### PR TITLE
interfaces: Rename SpecI to MeshTopology

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -11,5 +11,5 @@ type ServiceCatalog struct {
 	sync.Mutex
 	servicesCache    map[mesh.ServiceName][]mesh.IP
 	computeProviders []mesh.ComputeProviderI
-	meshSpec         mesh.SpecI
+	meshTopology     mesh.MeshTopology
 }

--- a/pkg/envoy/eds/server.go
+++ b/pkg/envoy/eds/server.go
@@ -16,7 +16,7 @@ import (
 type EDS struct {
 	ctx          context.Context // root context
 	catalog      mesh.ServiceCatalogI
-	meshSpec     mesh.SpecI
+	meshTopology mesh.MeshTopology
 	announceChan *channels.RingChannel
 }
 
@@ -31,12 +31,12 @@ func (e *EDS) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) 
 }
 
 // NewEDSServer creates a new EDS server
-func NewEDSServer(ctx context.Context, catalog mesh.ServiceCatalogI, meshSpec mesh.SpecI, announceChan *channels.RingChannel) *EDS {
+func NewEDSServer(ctx context.Context, catalog mesh.ServiceCatalogI, meshTopology mesh.MeshTopology, announceChan *channels.RingChannel) *EDS {
 	glog.Info("[EDS] Create NewEDSServer...")
 	return &EDS{
 		ctx:          ctx,
 		catalog:      catalog,
-		meshSpec:     meshSpec,
+		meshTopology: meshTopology,
 		announceChan: announceChan,
 	}
 }

--- a/pkg/mesh/types.go
+++ b/pkg/mesh/types.go
@@ -36,10 +36,15 @@ type ComputeProviderI interface {
 	Run(<-chan struct{}) error
 }
 
-// SpecI is an interface declaring what an SMI spec provider should implement.
-type SpecI interface {
+// MeshTopology is an interface declaring functions, which provide the topology of a service mesh declared with SMI.
+type MeshTopology interface {
+	// ListTrafficSplits lists TrafficSplit SMI resources.
 	ListTrafficSplits() []*v1alpha2.TrafficSplit
+
+	// ListServices fetches all services declared with SMI Spec.
 	ListServices() []ServiceName
+
+	// GetComputeIDForService is deprecated
 	GetComputeIDForService(ServiceName) []ComputeID
 }
 

--- a/pkg/providers/azure/client.go
+++ b/pkg/providers/azure/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 // newClient creates an Azure Client
-func newClient(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshSpec mesh.SpecI, providerIdent string) mesh.ComputeProviderI {
+func newClient(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshTopology mesh.MeshTopology, providerIdent string) mesh.ComputeProviderI {
 	var authorizer autorest.Authorizer
 	var err error
 	if authorizer, err = getAuthorizerWithRetry(azureAuthFile, maxAuthRetryCount, retryPause); err != nil {
@@ -35,7 +35,7 @@ func newClient(subscriptionID string, namespace string, azureAuthFile string, ma
 		ctx:               context.Background(),
 		authorizer:        authorizer,
 		announceChan:      announceChan,
-		mesh:              meshSpec,
+		meshTopology:      meshTopology,
 		providerIdent:     providerIdent,
 	}
 

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -12,15 +12,15 @@ import (
 )
 
 // NewProvider creates an Azure Client
-func NewProvider(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshSpec mesh.SpecI, providerIdent string) mesh.ComputeProviderI {
-	return newClient(subscriptionID, namespace, azureAuthFile, maxAuthRetryCount, retryPause, announceChan, meshSpec, providerIdent)
+func NewProvider(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshTopology mesh.MeshTopology, providerIdent string) mesh.ComputeProviderI {
+	return newClient(subscriptionID, namespace, azureAuthFile, maxAuthRetryCount, retryPause, announceChan, meshTopology, providerIdent)
 }
 
 // GetIPs returns the IP addresses for the given ServiceName Name
 // This function is required by the ComputeProviderI
 func (az Client) GetIPs(svc mesh.ServiceName) []mesh.IP {
 	var azureIPs []mesh.IP
-	clusters := az.mesh.GetComputeIDForService(svc)
+	clusters := az.meshTopology.GetComputeIDForService(svc)
 	for _, cluster := range clusters {
 		if cluster.AzureID == "" {
 			continue
@@ -65,7 +65,7 @@ func (az Client) GetID() string {
 }
 
 func parseAzureID(id mesh.AzureID) (resourceGroup, computeKind, computeName, error) {
-	// Sample URI: /resource/subscriptions/e3f0/resourceGroups/mesh-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz
+	// Sample URI: /resource/subscriptions/e3f0/resourceGroups/meshTopology-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz
 	chunks := strings.Split(string(id), "/")
 	if len(chunks) != 9 {
 		return "", "", "", errIncorrectAzureURI

--- a/pkg/providers/azure/provider_test.go
+++ b/pkg/providers/azure/provider_test.go
@@ -9,11 +9,11 @@ import (
 var _ = Describe("Azure Compute Provider", func() {
 	Describe("Testing Azure Compute Provider", func() {
 		Context("Testing parseAzureID", func() {
-			uri := mesh.AzureID("/subscriptions/e3f0/resourceGroups/mesh-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz")
+			uri := mesh.AzureID("/subscriptions/e3f0/resourceGroups/meshTopology-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz")
 			It("returns default value in absence of an env var", func() {
 				rg, kind, name, err := parseAzureID(uri)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(rg).To(Equal(resourceGroup("mesh-rg")))
+				Expect(rg).To(Equal(resourceGroup("meshTopology-rg")))
 				Expect(kind).To(Equal(computeKind("Microsoft.Compute/virtualMachineScaleSets")))
 				Expect(name).To(Equal(computeName(("baz"))))
 			})

--- a/pkg/providers/azure/types.go
+++ b/pkg/providers/azure/types.go
@@ -37,7 +37,7 @@ type Client struct {
 	subscriptionID    string
 	ctx               context.Context
 	announceChan      *channels.RingChannel
-	mesh              mesh.SpecI
+	meshTopology      mesh.MeshTopology
 
 	// Free-form string identifying the compute provider: Azure, Kubernetes etc.
 	// This is used in logs

--- a/pkg/providers/kube/mesh_spec.go
+++ b/pkg/providers/kube/mesh_spec.go
@@ -21,7 +21,7 @@ import (
 const kubernetesClientName = "MeshSpec"
 
 // NewMeshSpecClient creates the Kubernetes client, which retrieves SMI specific CRDs.
-func NewMeshSpecClient(kubeConfig *rest.Config, namespaces []string, resyncPeriod time.Duration, announceChan *channels.RingChannel, stopChan chan struct{}) mesh.SpecI {
+func NewMeshSpecClient(kubeConfig *rest.Config, namespaces []string, resyncPeriod time.Duration, announceChan *channels.RingChannel, stopChan chan struct{}) mesh.MeshTopology {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 	smiClientset := smiClient.NewForConfigOrDie(kubeConfig)
 	azureResourceClient := smcClient.NewForConfigOrDie(kubeConfig)


### PR DESCRIPTION
This PR only renames `mesh.SpecI` to `mesh.MeshTopology` and certain variables from `meshSpec...` to `meshTopology`

No functional code changes!