### PR TITLE
interfaces: Extending ServiceCataloger interface

### DIFF
--- a/cmd/eds/eds.go
+++ b/cmd/eds/eds.go
@@ -68,15 +68,15 @@ func main() {
 	}
 
 	stopChan := make(chan struct{})
-	meshSpec := kube.NewMeshSpecClient(kubeConfig, getNamespaces(), 1*time.Second, announceChan, stopChan)
+	meshTopologyClient := kube.NewMeshSpecClient(kubeConfig, getNamespaces(), 1*time.Second, announceChan, stopChan)
 	kubernetesProvider := kube.NewProvider(kubeConfig, getNamespaces(), 1*time.Second, announceChan, kubernetesProviderName)
-	azureProvider := azure.NewProvider(*subscriptionID, *namespace, *azureAuthFile, maxAuthRetryCount, retryPause, announceChan, meshSpec, azureProvidername)
+	azureProvider := azure.NewProvider(*subscriptionID, *namespace, *azureAuthFile, maxAuthRetryCount, retryPause, announceChan, meshTopologyClient, azureProvidername)
 
 	// ServiceName Catalog is the facility, which we query to get the list of services, weights for traffic split etc.
-	serviceCatalog := catalog.NewServiceCatalog(meshSpec, stopChan, kubernetesProvider, azureProvider)
+	serviceCatalog := catalog.NewServiceCatalog(meshTopologyClient, stopChan, kubernetesProvider, azureProvider)
 
 	grpcServer, lis := utils.NewGrpc(serverType, *port)
-	eds := edsServer.NewEDSServer(ctx, serviceCatalog, meshSpec, announceChan)
+	eds := edsServer.NewEDSServer(ctx, serviceCatalog, meshTopologyClient, announceChan)
 	envoyControlPlane.RegisterEndpointDiscoveryServiceServer(grpcServer, eds)
 	go utils.GrpcServe(ctx, grpcServer, lis, cancel, serverType)
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -5,13 +5,14 @@ import (
 	"strings"
 	"time"
 
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/glog"
 
 	"github.com/deislabs/smc/pkg/mesh"
 )
 
 // NewServiceCatalog creates a new service catalog
-func NewServiceCatalog(meshTopology mesh.MeshTopology, stopChan chan struct{}, endpointsProviders ...mesh.EndpointsProvider) mesh.ServiceCatalogI {
+func NewServiceCatalog(meshTopology mesh.MeshTopology, stopChan chan struct{}, endpointsProviders ...mesh.EndpointsProvider) mesh.ServiceCataloger {
 	// Run each provider -- starting the pub/sub system, which leverages the announceChan channel
 	for _, provider := range endpointsProviders {
 		if err := provider.Run(stopChan); err != nil {
@@ -143,4 +144,35 @@ func ipsToString(meshIPs []mesh.IP) []string {
 		ips = append(ips, string(ip))
 	}
 	return ips
+}
+
+// ListEndpoints constructs a DiscoveryResponse with all endpoints the given Envoy proxy should be aware of.
+// The bool return value indicates whether there have been any changes since the last invocation of this function.
+func (sc *ServiceCatalog) ListEndpoints(mesh.ClientIdentity) (envoy.DiscoveryResponse, bool, error) {
+	// TODO(draychev): implement
+	panic("NotImplemented")
+}
+
+// RegisterNewEndpoint adds a newly connected Envoy proxy to the list of self-announced endpoints for a service.
+func (sc *ServiceCatalog) RegisterNewEndpoint(mesh.ClientIdentity) {
+	// TODO(draychev): implement
+	panic("NotImplemented")
+}
+
+// ListEndpointsProviders retrieves the full list of endpoints providers registered with Service Catalog so far.
+func (sc *ServiceCatalog) ListEndpointsProviders() []mesh.EndpointsProvider {
+	// TODO(draychev): implement
+	panic("NotImplemented")
+}
+
+// RegisterEndpointsProvider adds a new endpoints provider to the list within the Service Catalog.
+func (sc *ServiceCatalog) RegisterEndpointsProvider(mesh.EndpointsProvider) error {
+	// TODO(draychev): implement
+	panic("NotImplemented")
+}
+
+// GetAnnouncementChannel returns an instance of a channel, which notifies the system of an event requiring the execution of ListEndpoints.
+func (sc *ServiceCatalog) GetAnnouncementChannel() chan struct{} {
+	// TODO(draychev): implement
+	panic("NotImplemented")
 }

--- a/pkg/envoy/eds/server.go
+++ b/pkg/envoy/eds/server.go
@@ -15,7 +15,7 @@ import (
 // EDS implements the Envoy xDS Endpoint Discovery Service
 type EDS struct {
 	ctx          context.Context // root context
-	catalog      mesh.ServiceCatalogI
+	catalog      mesh.ServiceCataloger
 	meshTopology mesh.MeshTopology
 	announceChan *channels.RingChannel
 }
@@ -31,7 +31,7 @@ func (e *EDS) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) 
 }
 
 // NewEDSServer creates a new EDS server
-func NewEDSServer(ctx context.Context, catalog mesh.ServiceCatalogI, meshTopology mesh.MeshTopology, announceChan *channels.RingChannel) *EDS {
+func NewEDSServer(ctx context.Context, catalog mesh.ServiceCataloger, meshTopology mesh.MeshTopology, announceChan *channels.RingChannel) *EDS {
 	glog.Info("[EDS] Create NewEDSServer...")
 	return &EDS{
 		ctx:          ctx,

--- a/pkg/mesh/types.go
+++ b/pkg/mesh/types.go
@@ -2,13 +2,33 @@ package mesh
 
 import (
 	"github.com/deislabs/smi-sdk-go/pkg/apis/split/v1alpha2"
+	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
-// ServiceCatalogI is an interface w/ requirements to implement a service catalog
-type ServiceCatalogI interface {
-	GetServiceIPs(svcName ServiceName) ([]IP, error)
-	GetWeightedService(svcName ServiceName) ([]WeightedService, error)
+type ClientIdentity string
+
+// ServiceCataloger is the mechanism by which the Service Mesh controller discovers all Envoy proxies connected to the catalog.
+type ServiceCataloger interface {
+
+	// GetWeightedServices is deprecated
+	// Deprecated: this needs to be removed
 	GetWeightedServices() (map[ServiceName][]WeightedService, error)
+
+	// ListEndpoints constructs a DescoveryResponse with all endpoints the given Envoy proxy should be aware of.
+	// The bool return value indicates whether there have been any changes since the last invocation of this function.
+	ListEndpoints(ClientIdentity) (envoy.DiscoveryResponse, bool, error)
+
+	// RegisterNewEndpoint adds a newly connected Envoy proxy to the list of self-announced endpoints for a service.
+	RegisterNewEndpoint(ClientIdentity)
+
+	// ListEndpointsProviders retrieves the full list of endpoints providers registered with Service Catalog so far.
+	ListEndpointsProviders() []EndpointsProvider
+
+	// RegisterEndpointsProvider adds a new endpoints provider to the list within the Service Catalog.
+	RegisterEndpointsProvider(EndpointsProvider) error
+
+	// GetAnnouncementChannel returns an instance of a channel, which notifies the system of an event requiring the execution of ListEndpoints.
+	GetAnnouncementChannel() chan struct{}
 }
 
 // ServiceName is a type for a service name
@@ -45,6 +65,7 @@ type MeshTopology interface {
 	ListServices() []ServiceName
 
 	// GetComputeIDForService is deprecated
+	// Deprecated: this needs to be removed
 	GetComputeIDForService(ServiceName) []ComputeID
 }
 


### PR DESCRIPTION
Adding the following functions to `ServiceCataloger` interface:

- ListEndpoints 
- RegisterNewEndpoint 
- ListEndpointsProviders 
- RegisterEndpointsProvider 
- GetAnnouncementChannel 

See: https://github.com/deislabs/smc/pull/22