### PR TITLE
azure: Adding AzureResource client (Kubernetes) to the Azure EndpointsProvider

### DIFF
--- a/pkg/providers/azure/kubernetes/client.go
+++ b/pkg/providers/azure/kubernetes/client.go
@@ -1,0 +1,101 @@
+package azure
+
+import (
+	"time"
+
+	smc "github.com/deislabs/smc/pkg/apis/azureresource/v1"
+
+	"github.com/eapache/channels"
+	"github.com/golang/glog"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+
+	smcClient "github.com/deislabs/smc/pkg/smc_client/clientset/versioned"
+	smcInformers "github.com/deislabs/smc/pkg/smc_client/informers/externalversions"
+)
+
+const (
+	kubernetesClientName = "AzureResourceClient"
+)
+
+var resyncPeriod = 1 * time.Second
+
+// NewClient creates the Kubernetes client, which retrieves the AzureResource CRD and Services resources.
+func NewClient(kubeConfig *rest.Config, namespaces []string, announceChan *channels.RingChannel, stopChan chan struct{}) *Client {
+	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
+	azureResourceClient := smcClient.NewForConfigOrDie(kubeConfig)
+	k8sClient := newClient(kubeClient, azureResourceClient, namespaces, announceChan)
+	if err := k8sClient.Run(stopChan); err != nil {
+		glog.Fatalf("Could not start %s client: %s", kubernetesClientName, err)
+	}
+	return k8sClient
+}
+
+// newClient creates a provider based on a Kubernetes client instance.
+func newClient(kubeClient *kubernetes.Clientset, azureResourceClient *smcClient.Clientset, namespaces []string, announceChan *channels.RingChannel) *Client {
+	var options []smcInformers.SharedInformerOption
+	for _, namespace := range namespaces {
+		options = append(options, smcInformers.WithNamespace(namespace))
+	}
+	azureResourceFactory := smcInformers.NewSharedInformerFactoryWithOptions(azureResourceClient, resyncPeriod, options...)
+	informerCollection := InformerCollection{
+		AzureResource: azureResourceFactory.Smc().V1().AzureResources().Informer(),
+	}
+
+	cacheCollection := CacheCollection{
+		AzureResource: informerCollection.AzureResource.GetStore(),
+	}
+
+	client := Client{
+		providerIdent: kubernetesClientName,
+		kubeClient:    kubeClient,
+		informers:     &informerCollection,
+		caches:        &cacheCollection,
+		announceChan:  announceChan,
+		cacheSynced:   make(chan interface{}),
+	}
+
+	h := handlers{client}
+
+	resourceHandler := cache.ResourceEventHandlerFuncs{
+		AddFunc:    h.addFunc,
+		UpdateFunc: h.updateFunc,
+		DeleteFunc: h.deleteFunc,
+	}
+
+	informerCollection.AzureResource.AddEventHandler(resourceHandler)
+
+	return &client
+}
+
+// Run executes informer collection.
+func (c *Client) Run(stopCh <-chan struct{}) error {
+	glog.V(1).Infoln("Kubernetes Compute Provider started")
+	var hasSynced []cache.InformerSynced
+
+	glog.Info("Starting AzureResource informer")
+	go c.informers.AzureResource.Run(stopCh)
+	hasSynced = append(hasSynced, c.informers.AzureResource.HasSynced)
+
+	glog.V(1).Infof("Waiting AzureResource informer cache sync")
+	if !cache.WaitForCacheSync(stopCh, hasSynced...) {
+		return errSyncingCaches
+	}
+
+	// Closing the cacheSynced channel signals to the rest of the system that... caches have been synced.
+	close(c.cacheSynced)
+
+	glog.V(1).Info("Cache sync for AzureResource finished")
+	return nil
+}
+
+// ListAzureResources lists the AzureResource CRD resources.
+func (c *Client) ListAzureResources() []*smc.AzureResource {
+	var azureResources []*smc.AzureResource
+	for _, azureResourceInterface := range c.caches.AzureResource.List() {
+		azureResource := azureResourceInterface.(*smc.AzureResource)
+		azureResources = append(azureResources, azureResource)
+	}
+	return azureResources
+}

--- a/pkg/providers/azure/kubernetes/errors.go
+++ b/pkg/providers/azure/kubernetes/errors.go
@@ -1,0 +1,5 @@
+package azure
+
+import "errors"
+
+var errSyncingCaches = errors.New("syncing caches")

--- a/pkg/providers/azure/kubernetes/handlers.go
+++ b/pkg/providers/azure/kubernetes/handlers.go
@@ -1,0 +1,41 @@
+package azure
+
+import (
+	"reflect"
+
+	"github.com/golang/glog"
+
+	"github.com/Azure/application-gateway-kubernetes-ingress/pkg/events"
+)
+
+type handlers struct {
+	Client
+}
+
+// general resource handlers
+func (h handlers) addFunc(obj interface{}) {
+	glog.V(9).Infof("[%s] Add event: %+v", h.providerIdent, obj)
+	h.announceChan.In() <- events.Event{
+		Type:  events.Create,
+		Value: obj,
+	}
+}
+
+func (h handlers) updateFunc(oldObj, newObj interface{}) {
+	glog.V(9).Infof("[%s] Update event %+v", h.providerIdent, oldObj)
+	if reflect.DeepEqual(oldObj, newObj) {
+		return
+	}
+	h.announceChan.In() <- events.Event{
+		Type:  events.Update,
+		Value: newObj,
+	}
+}
+
+func (h handlers) deleteFunc(obj interface{}) {
+	glog.V(9).Infof("[%s] Delete event: %+v", h.providerIdent, obj)
+	h.announceChan.In() <- events.Event{
+		Type:  events.Delete,
+		Value: obj,
+	}
+}

--- a/pkg/providers/azure/kubernetes/types.go
+++ b/pkg/providers/azure/kubernetes/types.go
@@ -1,0 +1,27 @@
+package azure
+
+import (
+	"github.com/eapache/channels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// InformerCollection is a struct of the Kubernetes informers used in SMC
+type InformerCollection struct {
+	AzureResource cache.SharedIndexInformer
+}
+
+// CacheCollection is a struct of the Kubernetes caches used in SMC
+type CacheCollection struct {
+	AzureResource cache.Store
+}
+
+// Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
+type Client struct {
+	caches        *CacheCollection
+	cacheSynced   chan interface{}
+	kubeClient    kubernetes.Interface
+	informers     *InformerCollection
+	announceChan  *channels.RingChannel
+	providerIdent string
+}


### PR DESCRIPTION
This PR adds an `AzureResource` client to the `pkg/providers/azure` package.

We are deliberately leaking the storage implementation of SMI Spec into the Azure provider. This allows AzureProvider to resolve a service name (`webservice`) into an Azure URI of compute (`/subscription/abc/xyz/myVM`), which participates in the service mesh.

As of this PR this is dead code - not used anywhere else.
This PR is a subset of https://github.com/deislabs/smc/pull/32 -- chopping it up to make it digestable.