### PR TITLE
interfaces: Rename MeshTopology to Topology

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewServiceCatalog creates a new service catalog
-func NewServiceCatalog(meshTopology mesh.MeshTopology, stopChan chan struct{}, endpointsProviders ...mesh.EndpointsProvider) mesh.ServiceCataloger {
+func NewServiceCatalog(meshTopology mesh.Topology, stopChan chan struct{}, endpointsProviders ...mesh.EndpointsProvider) mesh.ServiceCataloger {
 	// Run each provider -- starting the pub/sub system, which leverages the announceChan channel
 	for _, provider := range endpointsProviders {
 		if err := provider.Run(stopChan); err != nil {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -11,5 +11,5 @@ type ServiceCatalog struct {
 	sync.Mutex
 	servicesCache      map[mesh.ServiceName][]mesh.IP
 	endpointsProviders []mesh.EndpointsProvider
-	meshTopology       mesh.MeshTopology
+	meshTopology       mesh.Topology
 }

--- a/pkg/envoy/eds/server.go
+++ b/pkg/envoy/eds/server.go
@@ -16,7 +16,7 @@ import (
 type EDS struct {
 	ctx          context.Context // root context
 	catalog      mesh.ServiceCataloger
-	meshTopology mesh.MeshTopology
+	meshTopology mesh.Topology
 	announceChan *channels.RingChannel
 }
 
@@ -31,7 +31,7 @@ func (e *EDS) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) 
 }
 
 // NewEDSServer creates a new EDS server
-func NewEDSServer(ctx context.Context, catalog mesh.ServiceCataloger, meshTopology mesh.MeshTopology, announceChan *channels.RingChannel) *EDS {
+func NewEDSServer(ctx context.Context, catalog mesh.ServiceCataloger, meshTopology mesh.Topology, announceChan *channels.RingChannel) *EDS {
 	glog.Info("[EDS] Create NewEDSServer...")
 	return &EDS{
 		ctx:          ctx,

--- a/pkg/mesh/types.go
+++ b/pkg/mesh/types.go
@@ -56,8 +56,8 @@ type EndpointsProvider interface {
 	Run(<-chan struct{}) error
 }
 
-// MeshTopology is an interface declaring functions, which provide the topology of a service mesh declared with SMI.
-type MeshTopology interface {
+// Topology is an interface declaring functions, which provide the topology of a service mesh declared with SMI.
+type Topology interface {
 	// ListTrafficSplits lists TrafficSplit SMI resources.
 	ListTrafficSplits() []*v1alpha2.TrafficSplit
 

--- a/pkg/providers/azure/client.go
+++ b/pkg/providers/azure/client.go
@@ -15,7 +15,7 @@ import (
 )
 
 // newClient creates an Azure Client
-func newClient(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshTopology mesh.MeshTopology, providerIdent string) mesh.EndpointsProvider {
+func newClient(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshTopology mesh.Topology, providerIdent string) mesh.EndpointsProvider {
 	var authorizer autorest.Authorizer
 	var err error
 	if authorizer, err = getAuthorizerWithRetry(azureAuthFile, maxAuthRetryCount, retryPause); err != nil {

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewProvider creates an Azure Client
-func NewProvider(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshTopology mesh.MeshTopology, providerIdent string) mesh.EndpointsProvider {
+func NewProvider(subscriptionID string, namespace string, azureAuthFile string, maxAuthRetryCount int, retryPause time.Duration, announceChan *channels.RingChannel, meshTopology mesh.Topology, providerIdent string) mesh.EndpointsProvider {
 	return newClient(subscriptionID, namespace, azureAuthFile, maxAuthRetryCount, retryPause, announceChan, meshTopology, providerIdent)
 }
 

--- a/pkg/providers/azure/types.go
+++ b/pkg/providers/azure/types.go
@@ -37,7 +37,7 @@ type Client struct {
 	subscriptionID    string
 	ctx               context.Context
 	announceChan      *channels.RingChannel
-	meshTopology      mesh.MeshTopology
+	meshTopology      mesh.Topology
 
 	// Free-form string identifying the compute provider: Azure, Kubernetes etc.
 	// This is used in logs

--- a/pkg/providers/kube/mesh_spec.go
+++ b/pkg/providers/kube/mesh_spec.go
@@ -21,7 +21,7 @@ import (
 const kubernetesClientName = "MeshSpec"
 
 // NewMeshSpecClient creates the Kubernetes client, which retrieves SMI specific CRDs.
-func NewMeshSpecClient(kubeConfig *rest.Config, namespaces []string, resyncPeriod time.Duration, announceChan *channels.RingChannel, stopChan chan struct{}) mesh.MeshTopology {
+func NewMeshSpecClient(kubeConfig *rest.Config, namespaces []string, resyncPeriod time.Duration, announceChan *channels.RingChannel, stopChan chan struct{}) mesh.Topology {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 	smiClientset := smiClient.NewForConfigOrDie(kubeConfig)
 	azureResourceClient := smcClient.NewForConfigOrDie(kubeConfig)


### PR DESCRIPTION
This PR renames `MeshTopology` to `Topology` per the Go linter's recommendation: `type name will be used as mesh.MeshTopology by other packages, and that stutters; consider calling this Topology`

(This is a subset of https://github.com/deislabs/smc/pull/32)