### PR TITLE
Move ServiceCataloger interface to the Catalog package

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -12,7 +12,7 @@ import (
 )
 
 // NewServiceCatalog creates a new service catalog
-func NewServiceCatalog(meshTopology mesh.Topology, stopChan chan struct{}, endpointsProviders ...mesh.EndpointsProvider) mesh.ServiceCataloger {
+func NewServiceCatalog(meshTopology mesh.Topology, stopChan chan struct{}, endpointsProviders ...mesh.EndpointsProvider) ServiceCataloger {
 	// Run each provider -- starting the pub/sub system, which leverages the announceChan channel
 	for _, provider := range endpointsProviders {
 		if err := provider.Run(stopChan); err != nil {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -3,6 +3,8 @@ package catalog
 import (
 	"sync"
 
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
 	"github.com/deislabs/smc/pkg/mesh"
 )
 
@@ -12,4 +14,28 @@ type ServiceCatalog struct {
 	servicesCache      map[mesh.ServiceName][]mesh.IP
 	endpointsProviders []mesh.EndpointsProvider
 	meshTopology       mesh.Topology
+}
+
+// ServiceCataloger is the mechanism by which the Service Mesh controller discovers all Envoy proxies connected to the catalog.
+type ServiceCataloger interface {
+
+	// GetWeightedServices is deprecated
+	// Deprecated: this needs to be removed
+	GetWeightedServices() (map[mesh.ServiceName][]mesh.WeightedService, error)
+
+	// ListEndpoints constructs a DescoveryResponse with all endpoints the given Envoy proxy should be aware of.
+	// The bool return value indicates whether there have been any changes since the last invocation of this function.
+	ListEndpoints(mesh.ClientIdentity) (v2.DiscoveryResponse, bool, error)
+
+	// RegisterNewEndpoint adds a newly connected Envoy proxy to the list of self-announced endpoints for a service.
+	RegisterNewEndpoint(mesh.ClientIdentity)
+
+	// ListEndpointsProviders retrieves the full list of endpoints providers registered with Service Catalog so far.
+	ListEndpointsProviders() []mesh.EndpointsProvider
+
+	// RegisterEndpointsProvider adds a new endpoints provider to the list within the Service Catalog.
+	RegisterEndpointsProvider(mesh.EndpointsProvider) error
+
+	// GetAnnouncementChannel returns an instance of a channel, which notifies the system of an event requiring the execution of ListEndpoints.
+	GetAnnouncementChannel() chan struct{}
 }

--- a/pkg/envoy/eds/server.go
+++ b/pkg/envoy/eds/server.go
@@ -5,17 +5,17 @@ import (
 	"time"
 
 	"github.com/eapache/channels"
-
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/glog"
 
+	"github.com/deislabs/smc/pkg/catalog"
 	"github.com/deislabs/smc/pkg/mesh"
 )
 
 // EDS implements the Envoy xDS Endpoint Discovery Service
 type EDS struct {
 	ctx          context.Context // root context
-	catalog      mesh.ServiceCataloger
+	catalog      catalog.ServiceCataloger
 	meshTopology mesh.Topology
 	announceChan *channels.RingChannel
 }
@@ -31,7 +31,7 @@ func (e *EDS) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) 
 }
 
 // NewEDSServer creates a new EDS server
-func NewEDSServer(ctx context.Context, catalog mesh.ServiceCataloger, meshTopology mesh.Topology, announceChan *channels.RingChannel) *EDS {
+func NewEDSServer(ctx context.Context, catalog catalog.ServiceCataloger, meshTopology mesh.Topology, announceChan *channels.RingChannel) *EDS {
 	glog.Info("[EDS] Create NewEDSServer...")
 	return &EDS{
 		ctx:          ctx,

--- a/pkg/mesh/types.go
+++ b/pkg/mesh/types.go
@@ -2,34 +2,9 @@ package mesh
 
 import (
 	"github.com/deislabs/smi-sdk-go/pkg/apis/split/v1alpha2"
-	envoy "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
 type ClientIdentity string
-
-// ServiceCataloger is the mechanism by which the Service Mesh controller discovers all Envoy proxies connected to the catalog.
-type ServiceCataloger interface {
-
-	// GetWeightedServices is deprecated
-	// Deprecated: this needs to be removed
-	GetWeightedServices() (map[ServiceName][]WeightedService, error)
-
-	// ListEndpoints constructs a DescoveryResponse with all endpoints the given Envoy proxy should be aware of.
-	// The bool return value indicates whether there have been any changes since the last invocation of this function.
-	ListEndpoints(ClientIdentity) (envoy.DiscoveryResponse, bool, error)
-
-	// RegisterNewEndpoint adds a newly connected Envoy proxy to the list of self-announced endpoints for a service.
-	RegisterNewEndpoint(ClientIdentity)
-
-	// ListEndpointsProviders retrieves the full list of endpoints providers registered with Service Catalog so far.
-	ListEndpointsProviders() []EndpointsProvider
-
-	// RegisterEndpointsProvider adds a new endpoints provider to the list within the Service Catalog.
-	RegisterEndpointsProvider(EndpointsProvider) error
-
-	// GetAnnouncementChannel returns an instance of a channel, which notifies the system of an event requiring the execution of ListEndpoints.
-	GetAnnouncementChannel() chan struct{}
-}
 
 // ServiceName is a type for a service name
 type ServiceName string


### PR DESCRIPTION
It is time to move the `ServiceCataloger` interface to the `catalog` package. (Thank you @snehachhabria for making the suggestion)