### PR TITLE
Move ClusterLoadAssignment to pkg/eds/cla

### DIFF
--- a/pkg/envoy/cla/cluster_load_assignment.go
+++ b/pkg/envoy/cla/cluster_load_assignment.go
@@ -1,4 +1,4 @@
-package eds
+package cla
 
 import (
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -11,10 +11,11 @@ import (
 )
 
 const (
-	zone = "zone"
+	zone                     = "zone"
+	ClusterLoadAssignmentURI = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
 )
 
-func newClusterLoadAssignment(targetServiceName mesh.ServiceName, weightedServices []mesh.WeightedService) v2.ClusterLoadAssignment {
+func NewClusterLoadAssignment(targetServiceName mesh.ServiceName, weightedServices []mesh.WeightedService) v2.ClusterLoadAssignment {
 	cla := v2.ClusterLoadAssignment{
 		// NOTE: results.ServiceName is the top level service that is cURLed.
 		ClusterName: string(targetServiceName),

--- a/pkg/envoy/eds/stream.go
+++ b/pkg/envoy/eds/stream.go
@@ -9,6 +9,8 @@ import (
 	protobufTypes "github.com/gogo/protobuf/types"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
+	"github.com/deislabs/smc/pkg/envoy/cla"
 )
 
 type edsStreamHandler struct {
@@ -29,7 +31,7 @@ func (e *edsStreamHandler) run(ctx context.Context, server envoy.EndpointDiscove
 			return errors.Wrap(err, "recv")
 		}
 
-		if request.TypeUrl != clusterLoadAssignment {
+		if request.TypeUrl != cla.ClusterLoadAssignmentURI {
 			glog.Errorf("unknown TypeUrl %s", request.TypeUrl)
 			return errUnknownTypeURL
 		}
@@ -62,10 +64,10 @@ func (e *edsStreamHandler) updateEnvoyProxies(server envoy.EndpointDiscoveryServ
 	}
 
 	for targetServiceName, weightedServices := range allServices {
-		cla := newClusterLoadAssignment(targetServiceName, weightedServices)
+		loadAssignment := cla.NewClusterLoadAssignment(targetServiceName, weightedServices)
 		var protos []*protobufTypes.Any
-		if proto, err := protobufTypes.MarshalAny(&cla); err != nil {
-			glog.Errorf("Error marshalling ClusterLoadAssignment %+v: %s", cla, err)
+		if proto, err := protobufTypes.MarshalAny(&loadAssignment); err != nil {
+			glog.Errorf("Error marshalling ClusterLoadAssignment %+v: %s", loadAssignment, err)
 		} else {
 			protos = append(protos, proto)
 		}

--- a/pkg/envoy/eds/types.go
+++ b/pkg/envoy/eds/types.go
@@ -1,5 +1,1 @@
 package eds
-
-const (
-	clusterLoadAssignment = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
-)


### PR DESCRIPTION
This PR moves `newClusterLoadAssignment` into `pkg/eds/cla` package and exports the function so it is usable from anywhere.

This is a subset of https://github.com/deislabs/smc/pull/32 to make https://github.com/deislabs/smc/pull/32 more palatable.