### PR TITLE
Use net.IP in lieu of type IP string

### DIFF
--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -1,5 +1,9 @@
 package endpoint
 
+import (
+	"net"
+)
+
 // Provider is an interface to be implemented by components abstracting Kubernetes, Azure, and other compute/cluster providers
 type Provider interface {
 	// Retrieve the IP addresses comprising the given service.
@@ -11,12 +15,9 @@ type Provider interface {
 
 // Endpoint is a tuple of IP and Port, representing an Envoy proxy, fronting an instance of a service
 type Endpoint struct {
-	IP   `json:"ip"`
-	Port `json:"port"`
+	net.IP `json:"ip"`
+	Port   `json:"port"`
 }
-
-// IP is an IP address
-type IP string
 
 // Port is a numerical port of an Envoy proxy
 type Port uint32

--- a/pkg/envoy/cla/cluster_load_assignment_test.go
+++ b/pkg/envoy/cla/cluster_load_assignment_test.go
@@ -1,6 +1,8 @@
 package cla
 
 import (
+	"net"
+
 	"github.com/deislabs/smc/pkg/endpoint"
 
 	. "github.com/onsi/ginkgo"
@@ -15,12 +17,12 @@ var _ = Describe("Cluster Load Assignment", func() {
 				weightedServices = append(weightedServices, endpoint.WeightedService{
 					ServiceName: endpoint.ServiceName("bookstore-1"),
 					Weight:      50,
-					Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: "0.0.0.0"}},
+					Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: net.IP("0.0.0.0")}},
 				})
 				weightedServices = append(weightedServices, endpoint.WeightedService{
 					ServiceName: endpoint.ServiceName("bookstore-2"),
 					Weight:      50,
-					Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: "0.0.0.1"}, endpoint.Endpoint{IP: "0.0.0.2"}},
+					Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: net.IP("0.0.0.1")}, endpoint.Endpoint{IP: net.IP("0.0.0.2")}},
 				})
 
 				cla := NewClusterLoadAssignment("bookstore", weightedServices)

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -2,14 +2,14 @@ package azure
 
 import (
 	"fmt"
+	"net"
 	"strings"
-
-	"github.com/deislabs/smc/pkg/endpoint"
 
 	"github.com/golang/glog"
 	v1 "k8s.io/api/core/v1"
 
 	smc "github.com/deislabs/smc/pkg/apis/azureresource/v1"
+	"github.com/deislabs/smc/pkg/endpoint"
 )
 
 // ListEndpointsForService returns the IP addresses and Ports for the given ServiceName Name.
@@ -33,7 +33,7 @@ func (az Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.En
 		}
 
 		if observer, ok := computeKindObserver[kind]; ok {
-			var ips []endpoint.IP
+			var ips []net.IP
 			var err error
 			ips, err = observer(resourceGroup, azID)
 			if err != nil {

--- a/pkg/providers/azure/types.go
+++ b/pkg/providers/azure/types.go
@@ -1,11 +1,12 @@
 package azure
 
 import (
+	"net"
+
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/deislabs/smc/pkg/endpoint"
 	"github.com/eapache/channels"
 
 	smc "github.com/deislabs/smc/pkg/apis/azureresource/v1"
@@ -26,7 +27,7 @@ type azureID string
 
 // computeObserver is a function which is specialized to a specific Azure compute and knows how to monitor this
 // for IP address changes. For instance: VM, VMSS.
-type computeObserver func(resourceGroup, azureID) ([]endpoint.IP, error)
+type computeObserver func(resourceGroup, azureID) ([]net.IP, error)
 
 type azureClients struct {
 	publicIPsClient network.PublicIPAddressesClient

--- a/pkg/providers/azure/vm.go
+++ b/pkg/providers/azure/vm.go
@@ -2,18 +2,17 @@ package azure
 
 import (
 	"context"
+	"net"
 	"time"
-
-	"github.com/deislabs/smc/pkg/endpoint"
 
 	"github.com/golang/glog"
 
 	"github.com/deislabs/smc/pkg/utils"
 )
 
-func (az *Client) getVM(rg resourceGroup, vmID azureID) ([]endpoint.IP, error) {
+func (az *Client) getVM(rg resourceGroup, vmID azureID) ([]net.IP, error) {
 	glog.V(7).Infof("[azure] Fetching IPS of VM for %s in resource group: %s", vmID, rg)
-	var ips []endpoint.IP
+	var ips []net.IP
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	list, err := az.vmClient.List(ctx, string(rg))
@@ -38,7 +37,7 @@ func (az *Client) getVM(rg resourceGroup, vmID azureID) ([]endpoint.IP, error) {
 
 		for _, ipConf := range *networkInterfaceName.IPConfigurations {
 			if ipConf.PrivateIPAddress != nil {
-				ips = append(ips, endpoint.IP(*ipConf.PrivateIPAddress))
+				ips = append(ips, net.IP(*ipConf.PrivateIPAddress))
 			}
 		}
 		cancel()

--- a/pkg/providers/azure/vmss.go
+++ b/pkg/providers/azure/vmss.go
@@ -2,16 +2,15 @@ package azure
 
 import (
 	"context"
+	"net"
 	"time"
-
-	"github.com/deislabs/smc/pkg/endpoint"
 
 	"github.com/golang/glog"
 )
 
-func (az *Client) getVMSS(rg resourceGroup, vmID azureID) ([]endpoint.IP, error) {
+func (az *Client) getVMSS(rg resourceGroup, vmID azureID) ([]net.IP, error) {
 	glog.V(7).Infof("[azure] Fetching IPS of VMSS for %s in resource group: %s", vmID, rg)
-	var ips []endpoint.IP
+	var ips []net.IP
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	glog.Info("[azure] List all VMSS for resource group: ", rg)

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"net"
 	"time"
 
 	"github.com/eapache/channels"
@@ -88,7 +89,7 @@ func (c Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.End
 		for _, kubernetesEndpoint := range kubernetesEndpoints.Subsets {
 			for _, address := range kubernetesEndpoint.Addresses {
 				ept := endpoint.Endpoint{
-					IP:   endpoint.IP(address.IP),
+					IP:   net.IP(address.IP),
 					Port: port,
 				}
 				endpoints = append(endpoints, ept)


### PR DESCRIPTION
No need to declare a custom `IP` type. We are going to reuse `net.IP`