### PR TITLE
docker: Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,6 @@
 **/*.dbmdl
 **/*.jfm
 **/azds.yaml
-**/bin
 **/charts
 **/docker-compose*
 **/Dockerfile*

--- a/dockerfiles/Dockerfile.eds
+++ b/dockerfiles/Dockerfile.eds
@@ -1,4 +1,3 @@
 FROM alpine:3.10.1
 ADD bin/linux-amd64/eds /eds
-ADD ./run-eds.sh /run-eds.sh
 RUN chmod +x /eds


### PR DESCRIPTION
An attempt to `make docker-push` failed with the following error:

```
docker build . --build-arg /home/de/go/ -t your.azurecr.io/smc/sds --file dockerfiles/Dockerfile.sds
Sending build context to Docker daemon  417.3kB
Step 1/6 : FROM alpine:3.10.1
 ---> b7b28af77ffe
Step 2/6 : ADD ./bin/linux-amd64/sds /
ADD failed: stat /var/lib/docker/tmp/docker-builder615982108/bin/linux-amd64/sds: no such file or directory
make: *** [GNUmakefile:82: docker-build-sds] Error 1
```

It turns out docker is ignoring contents of `./bin`, which results in this.
Using this opportunity to remove the `run-eds.sh` from the eds container, which is not used.