### PR TITLE
s/defaultNamespace/defaultKubernetesNamespace/g

### DIFF
--- a/cmd/cds/cds.go
+++ b/cmd/cds/cds.go
@@ -25,7 +25,7 @@ import (
 const (
 	serverType = "CDS"
 
-	defaultNamespace = "default"
+	defaultKubernetesNamespace = "default"
 )
 
 var (
@@ -93,7 +93,7 @@ func parseFlags() {
 func getNamespaces() []string {
 	var namespaces []string
 	if namespace == nil {
-		defaultNS := defaultNamespace
+		defaultNS := defaultKubernetesNamespace
 		namespaces = []string{defaultNS}
 	} else {
 		namespaces = []string{*namespace}

--- a/cmd/eds/eds.go
+++ b/cmd/eds/eds.go
@@ -28,7 +28,7 @@ import (
 const (
 	serverType = "EDS"
 
-	defaultNamespace = "default"
+	defaultKubernetesNamespace = "default"
 
 	// These strings identify the participating clusters / endpoint providers.
 	// Ideally these should be not only the type of compute but also a unique identifier, like the FQDN of the cluster,
@@ -106,7 +106,7 @@ func parseFlags() {
 func getNamespaces() []string {
 	var namespaces []string
 	if namespace == nil {
-		defaultNS := defaultNamespace
+		defaultNS := defaultKubernetesNamespace
 		namespaces = []string{defaultNS}
 	} else {
 		namespaces = []string{*namespace}


### PR DESCRIPTION
This PR renames `defaultNamespace` to `defaultKubernetesNamespace` for clarity.

No functional code changes.