### PR TITLE
Renaming stopChan to stop

### DIFF
--- a/cmd/eds/eds.go
+++ b/cmd/eds/eds.go
@@ -69,13 +69,13 @@ func main() {
 
 	observeNamespaces := getNamespaces()
 
-	stopChan := make(chan struct{})
-	meshSpecClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, announcements, stopChan)
-	azureResourceClient := azureResource.NewClient(kubeConfig, observeNamespaces, announcements, stopChan)
+	stop := make(chan struct{})
+	meshSpecClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, announcements, stop)
+	azureResourceClient := azureResource.NewClient(kubeConfig, observeNamespaces, announcements, stop)
 
 	endpointsProviders := []endpoint.Provider{
-		azure.NewProvider(*subscriptionID, *azureAuthFile, announcements, stopChan, meshSpecClient, azureResourceClient, azureProviderName),
-		kube.NewProvider(kubeConfig, observeNamespaces, announcements, stopChan, kubernetesProviderName),
+		azure.NewProvider(*subscriptionID, *azureAuthFile, announcements, stop, meshSpecClient, azureResourceClient, azureProviderName),
+		kube.NewProvider(kubeConfig, observeNamespaces, announcements, stop, kubernetesProviderName),
 	}
 
 	serviceCatalog := catalog.NewServiceCatalog(meshSpecClient, endpointsProviders...)
@@ -89,7 +89,7 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	close(stopChan)
+	close(stop)
 	glog.Info("[EDS] Goodbye!")
 }
 

--- a/pkg/providers/azure/client.go
+++ b/pkg/providers/azure/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 // NewProvider creates an Azure Client
-func NewProvider(subscriptionID string, azureAuthFile string, announcements *channels.RingChannel, stopChan chan struct{}, meshSpec smi.MeshSpec, azureResourceClient ResourceClient, providerIdent string) endpoint.Provider {
+func NewProvider(subscriptionID string, azureAuthFile string, announcements *channels.RingChannel, stop chan struct{}, meshSpec smi.MeshSpec, azureResourceClient ResourceClient, providerIdent string) endpoint.Provider {
 	var authorizer autorest.Authorizer
 	var err error
 	if authorizer, err = getAuthorizerWithRetry(azureAuthFile); err != nil {
@@ -59,7 +59,7 @@ func NewProvider(subscriptionID string, azureAuthFile string, announcements *cha
 			}
 	*/
 
-	if err := az.Run(stopChan); err != nil {
+	if err := az.Run(stop); err != nil {
 		glog.Fatal("[azure] Could not start Azure EndpointsProvider client", err)
 	}
 

--- a/pkg/providers/azure/kubernetes/client.go
+++ b/pkg/providers/azure/kubernetes/client.go
@@ -22,11 +22,11 @@ const (
 var resyncPeriod = 1 * time.Second
 
 // NewClient creates the Kubernetes client, which retrieves the AzureResource CRD and Services resources.
-func NewClient(kubeConfig *rest.Config, namespaces []string, announcements *channels.RingChannel, stopChan chan struct{}) *Client {
+func NewClient(kubeConfig *rest.Config, namespaces []string, announcements *channels.RingChannel, stop chan struct{}) *Client {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 	azureResourceClient := smcClient.NewForConfigOrDie(kubeConfig)
 	k8sClient := newClient(kubeClient, azureResourceClient, namespaces, announcements)
-	if err := k8sClient.Run(stopChan); err != nil {
+	if err := k8sClient.Run(stop); err != nil {
 		glog.Fatalf("Could not start %s client: %s", kubernetesClientName, err)
 	}
 	return k8sClient

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -18,7 +18,7 @@ import (
 var resyncPeriod = 1 * time.Second
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
-func NewProvider(kubeConfig *rest.Config, namespaces []string, announcements *channels.RingChannel, stopChan chan struct{}, providerIdent string) endpoint.Provider {
+func NewProvider(kubeConfig *rest.Config, namespaces []string, announcements *channels.RingChannel, stop chan struct{}, providerIdent string) endpoint.Provider {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 
 	var options []informers.SharedInformerOption
@@ -54,7 +54,7 @@ func NewProvider(kubeConfig *rest.Config, namespaces []string, announcements *ch
 
 	informerCollection.Endpoints.AddEventHandler(resourceHandler)
 
-	if err := client.Run(stopChan); err != nil {
+	if err := client.Run(stop); err != nil {
 		glog.Fatal("Could not start Kubernetes EndpointProvider client", err)
 	}
 


### PR DESCRIPTION
There's no need to indicate the type of the variable in the name of it -- renaming `stopChan` to `stop`