### PR TITLE
eds: Adding pipefail to run-eds.sh

### DIFF
--- a/scripts/run-eds.sh
+++ b/scripts/run-eds.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -aueo pipefail
+
 rm -rf ./bin/eds
 
 if [ ! -f ".env" ]; then

--- a/scripts/run-envoy.sh
+++ b/scripts/run-envoy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -aueo pipefail
+
 envoy \
     --log-level debug \
     -c ./demo/config/localhost-eds.yaml


### PR DESCRIPTION
This PR ensures all `./scripts/run-*.sh` bash scripts have pipefail enabled