### PR TITLE
eds: Rename EDS struct to Server

### DIFF
--- a/pkg/envoy/eds/server.go
+++ b/pkg/envoy/eds/server.go
@@ -15,8 +15,8 @@ const (
 	serverName = "EDS"
 )
 
-// EDS implements the Envoy xDS Endpoint Discovery Services
-type EDS struct {
+// Server implements the Envoy xDS Endpoint Discovery Services
+type Server struct {
 	ctx           context.Context // root context
 	catalog       catalog.MeshCataloger
 	meshSpec      smi.MeshSpec
@@ -24,19 +24,19 @@ type EDS struct {
 }
 
 // FetchEndpoints implements envoy.EndpointDiscoveryServiceServer
-func (e *EDS) FetchEndpoints(context.Context, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
+func (e *Server) FetchEndpoints(context.Context, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
 	panic("NotImplemented")
 }
 
 // DeltaEndpoints implements envoy.EndpointDiscoveryServiceServer
-func (e *EDS) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) error {
+func (e *Server) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) error {
 	panic("NotImplemented")
 }
 
 // NewEDSServer creates a new EDS server
-func NewEDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, announcements *channels.RingChannel) *EDS {
+func NewEDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, announcements *channels.RingChannel) *Server {
 	glog.Info("[EDS] Create NewEDSServer")
-	return &EDS{
+	return &Server{
 		ctx:           ctx,
 		catalog:       catalog,
 		meshSpec:      meshSpec,

--- a/pkg/envoy/eds/stream.go
+++ b/pkg/envoy/eds/stream.go
@@ -21,11 +21,11 @@ type edsStreamHandler struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	*EDS
+	*Server
 }
 
 // StreamEndpoints implements envoy.EndpointDiscoveryServiceServer and handles streaming of Endpoint changes to the Envoy proxies connected
-func (e *EDS) StreamEndpoints(server envoy.EndpointDiscoveryService_StreamEndpointsServer) error {
+func (e *Server) StreamEndpoints(server envoy.EndpointDiscoveryService_StreamEndpointsServer) error {
 	glog.Infof("[%s] Starting StreamEndpoints", serverName)
 
 	// Register the newly connected Envoy proxy.
@@ -38,7 +38,7 @@ func (e *EDS) StreamEndpoints(server envoy.EndpointDiscoveryService_StreamEndpoi
 	handler := &edsStreamHandler{
 		ctx:    ctx,
 		cancel: cancel,
-		EDS:    e,
+		Server: e,
 	}
 
 	// Periodic Updates -- useful for debugging


### PR DESCRIPTION
Renaming `eds.EDS` to `eds.Server` -- following the convention we started:

sds:  https://github.com/deislabs/smc/blob/065ef3602d60ca2170089f73015af7a859e1bd7c/pkg/envoy/sds/server.go#L42-L43

cds:  https://github.com/deislabs/smc/blob/065ef3602d60ca2170089f73015af7a859e1bd7c/pkg/envoy/cds/types.go#L5-L6