### PR TITLE
certificates: Adding Certificate Manager

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -1,0 +1,58 @@
+package certificate
+
+import (
+	"io/ioutil"
+
+	"github.com/golang/glog"
+)
+
+const (
+	keysDefaultDirectory = "/etc/ssl/certs/"
+	certFileName         = "cert.pem"
+	keyFileName          = "key.pem"
+)
+
+type Certificate struct {
+	name             string
+	certificateChain []byte
+	privateKey       []byte
+}
+
+// GetName implements Certificater
+func (c Certificate) GetName() string {
+	return c.name
+}
+
+// GetCertificateChain implements Certificater
+func (c Certificate) GetCertificateChain() []byte {
+	return c.certificateChain
+}
+
+// GetPrivateKey implements Certificater
+func (c Certificate) GetPrivateKey() []byte {
+	return c.privateKey
+}
+
+func newCertificate(cn CommonName) (*Certificate, error) {
+	glog.V(7).Infof("[certificate] Creating a certificate for CN=%s", cn)
+	// TODO(draychev): Temporarily read certificates from file until we integrate w/ KeyVault
+	certificateChain, err := ioutil.ReadFile(keysDefaultDirectory + certFileName)
+	if err != nil {
+		glog.Infof("[certificate] Failed to read certificateChain chain from %s: %s", keysDefaultDirectory+certFileName, err)
+		return nil, err
+	}
+	privateKey, err := ioutil.ReadFile(keysDefaultDirectory + keyFileName)
+	if err != nil {
+		glog.Info("[certificate] Failed to read private privateKey", err)
+		return nil, err
+	}
+
+	secret := &Certificate{
+		// TODO(draychev): what makes sense for the Name?
+		name:             string(cn),
+		certificateChain: certificateChain,
+		privateKey:       privateKey,
+	}
+
+	return secret, nil
+}

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -1,0 +1,21 @@
+package certificate
+
+type CertManager struct {
+	announcementsChan chan struct{}
+}
+
+func NewManager(stop chan struct{}) CertManager {
+	return CertManager{
+		announcementsChan: make(chan struct{}),
+	}
+}
+
+// IssueCertificate implements Manager interface
+func (m CertManager) IssueCertificate(cn CommonName) (Certificater, error) {
+	// TODO(draychev): implement this function (and remove the shim below)
+	return newCertificate(cn)
+}
+
+func (m CertManager) GetSecretsChangeAnnouncementChan() <-chan struct{} {
+	return m.announcementsChan
+}

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -2,3 +2,25 @@ package certificate
 
 // CommonName is the Subject Common Name from a given SSL certificate.
 type CommonName string
+
+// Certificater is the interface declaring methods each Certificate object must have.
+type Certificater interface {
+
+	// GetName retrieves the name of the cerificate.
+	GetName() string
+
+	// GetCertificateChain retrieves the cert chain.
+	GetCertificateChain() []byte
+
+	// GetPrivateKey returns the private key.
+	GetPrivateKey() []byte
+}
+
+// Manager is the interface declaring the methods for the Certificate Maneger.
+type Manager interface {
+	// IssueCertificate issues a new certificate.
+	IssueCertificate(cn CommonName) (Certificater, error)
+
+	// GetSecretsChangeAnnouncementChan returns a channel, which is used to announce when changes have been made to the issued certificates.
+	GetSecretsChangeAnnouncementChan() <-chan struct{}
+}


### PR DESCRIPTION
This PR proposes a `certificate.Manager`, which will be additionally discussed in the Design Document here https://github.com/deislabs/smc/pull/51

This implementation of a `Certificate Manager` relies on hard-coded PEMs on disk.

At a later stage the implementation will change.