### PR TITLE
Refactor announcements channels

### DIFF
--- a/cmd/rds/rds.go
+++ b/cmd/rds/rds.go
@@ -61,13 +61,13 @@ func main() {
 
 	observeNamespaces := getNamespaces()
 
-	stopChan := make(chan struct{})
-	meshTopologyClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, announcements, stopChan)
-	azureResourceClient := azureResource.NewClient(kubeConfig, observeNamespaces, announcements, stopChan)
+	stop := make(chan struct{})
+	meshTopologyClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, announcements, stop)
+	azureResourceClient := azureResource.NewClient(kubeConfig, observeNamespaces, announcements, stop)
 
 	endpointsProviders := []endpoint.Provider{
-		azure.NewProvider(*subscriptionID, *azureAuthFile, announcements, stopChan, meshTopologyClient, azureResourceClient, constants.AzureProviderName),
-		kube.NewProvider(kubeConfig, observeNamespaces, announcements, stopChan, constants.KubeProviderName),
+		azure.NewProvider(*subscriptionID, *azureAuthFile, announcements, stop, meshTopologyClient, azureResourceClient, constants.AzureProviderName),
+		kube.NewProvider(kubeConfig, observeNamespaces, announcements, stop, constants.KubeProviderName),
 	}
 
 	serviceCatalog := catalog.NewServiceCatalog(meshTopologyClient, endpointsProviders...)
@@ -81,7 +81,7 @@ func main() {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	<-sigChan
 
-	close(stopChan)
+	close(stop)
 	glog.Info("[RDS] Goodbye!")
 }
 

--- a/pkg/catalog/announcement.go
+++ b/pkg/catalog/announcement.go
@@ -1,6 +1,6 @@
 package catalog
 
 // GetAnnouncementChannel returns an instance of a channel, which notifies the system of an event requiring the execution of ListEndpoints.
-func (sc *MeshCatalog) GetAnnouncementChannel() chan struct{} {
+func (sc *MeshCatalog) GetAnnouncementChannel() chan interface{} {
 	return sc.announcements
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -15,7 +15,7 @@ import (
 type MeshCatalog struct {
 	sync.Mutex
 
-	announcements chan struct{}
+	announcements chan interface{}
 
 	endpointsProviders []endpoint.Provider
 	meshSpec           smi.MeshSpec
@@ -44,7 +44,7 @@ type MeshCataloger interface {
 	ListEndpointsProviders() []endpoint.Provider
 
 	// GetAnnouncementChannel returns an instance of a channel, which notifies the system of an event requiring the execution of ListEndpoints.
-	GetAnnouncementChannel() chan struct{}
+	GetAnnouncementChannel() chan interface{}
 
 	// RegisterProxy registers a newly connected proxy with the service mesh catalog.
 	RegisterProxy(envoy.Proxyer)

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -1,12 +1,12 @@
 package certificate
 
 type CertManager struct {
-	announcementsChan chan struct{}
+	announcements chan interface{}
 }
 
 func NewManager(stop chan struct{}) CertManager {
 	return CertManager{
-		announcementsChan: make(chan struct{}),
+		announcements: make(chan interface{}),
 	}
 }
 
@@ -16,6 +16,6 @@ func (m CertManager) IssueCertificate(cn CommonName) (Certificater, error) {
 	return newCertificate(cn)
 }
 
-func (m CertManager) GetSecretsChangeAnnouncementChan() <-chan struct{} {
-	return m.announcementsChan
+func (m CertManager) GetSecretsChangeAnnouncementChan() <-chan interface{} {
+	return m.announcements
 }

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -22,5 +22,5 @@ type Manager interface {
 	IssueCertificate(cn CommonName) (Certificater, error)
 
 	// GetSecretsChangeAnnouncementChan returns a channel, which is used to announce when changes have been made to the issued certificates.
-	GetSecretsChangeAnnouncementChan() <-chan struct{}
+	GetSecretsChangeAnnouncementChan() <-chan interface{}
 }

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -45,7 +45,7 @@ func NewMeshSpecClient(kubeConfig *rest.Config, namespaces []string, announcemen
 }
 
 // run executes informer collection.
-func (c *Client) run(stopCh <-chan struct{}) error {
+func (c *Client) run(stop <-chan struct{}) error {
 	glog.V(1).Infoln("SMI Client started")
 	var hasSynced []cache.InformerSynced
 
@@ -68,12 +68,12 @@ func (c *Client) run(stopCh <-chan struct{}) error {
 		}
 		names = append(names, name)
 		glog.Info("Starting informer: ", name)
-		go informer.Run(stopCh)
+		go informer.Run(stop)
 		hasSynced = append(hasSynced, informer.HasSynced)
 	}
 
 	glog.V(1).Infof("[SMI Client] Waiting informers cache sync: %+v", names)
-	if !cache.WaitForCacheSync(stopCh, hasSynced...) {
+	if !cache.WaitForCacheSync(stop, hasSynced...) {
 		return errSyncingCaches
 	}
 


### PR DESCRIPTION
This PR ensures that all `announcements` channels are `chan interface{}`
Also ensures that all stop channels are named `stop`