### PR TITLE
xds: RegisterProxy and emit a log messages

### DIFF
--- a/pkg/envoy/eds/stream.go
+++ b/pkg/envoy/eds/stream.go
@@ -2,17 +2,15 @@ package eds
 
 import (
 	"context"
-	"net"
 	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
-	"github.com/deislabs/smc/pkg/certificate"
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/envoy/cla"
-	"github.com/deislabs/smc/pkg/logging"
+	log "github.com/deislabs/smc/pkg/logging"
 	"github.com/deislabs/smc/pkg/utils"
 )
 
@@ -34,15 +32,11 @@ func (e *Server) StreamEndpoints(server v2.EndpointDiscoveryService_StreamEndpoi
 	// TODO(draychev): Use the Subject Common Name to identify the Envoy proxy and determine what service it belongs to.
 	glog.Infof("[%s][stream] Client connected: Subject CN=%+v", serverName, cn)
 
-	// Register the newly connected Envoy proxy.
-	connectedProxyIPAddress := net.IP("TBD")
-	connectedProxyCertCommonName := certificate.CommonName("TBD")
-	proxy := envoy.NewProxy(connectedProxyCertCommonName, connectedProxyIPAddress)
-	e.catalog.RegisterProxy(proxy)
-
 	// Register the newly connected proxy w/ the catalog.
 	ip := utils.GetIPFromContext(server.Context())
-	e.catalog.RegisterProxy(envoy.NewProxy(cn, ip))
+	proxy := envoy.NewProxy(cn, ip)
+	e.catalog.RegisterProxy(proxy)
+	glog.Infof("[%s][stream] Client connected: Subject CN=%s", serverName, cn)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/envoy/sds/server.go
+++ b/pkg/envoy/sds/server.go
@@ -48,6 +48,7 @@ func (s *Server) FetchSecrets(ctx context.Context, discReq *v2.DiscoveryRequest)
 	ip := utils.GetIPFromContext(ctx)
 	proxy := envoy.NewProxy(cn, ip)
 	s.catalog.RegisterProxy(proxy)
+	glog.Infof("[%s][FetchSecrets] Client connected: Subject CN=%+v", serverName, cn)
 
 	glog.Infof("[%s][FetchSecrets] Responding to proxy %s", serverName, proxy.GetCommonName())
 	return s.newDiscoveryResponse(proxy)

--- a/pkg/envoy/sds/stream.go
+++ b/pkg/envoy/sds/stream.go
@@ -24,23 +24,12 @@ func (s *Server) StreamSecrets(server v2.SecretDiscoveryService_StreamSecretsSer
 	// Register the newly connected proxy w/ the catalog.
 	ip := utils.GetIPFromContext(server.Context())
 	proxy := envoy.NewProxy(cn, ip)
-	s.catalog.RegisterProxy(envoy.NewProxy(cn, ip))
-
-	// TODO(draychev): Use the Subject Common Name to identify the Envoy proxy and determine what service it belongs to.
-	glog.Infof("[%s][stream] Client connected: Subject CN=%s", serverName, cn)
+	s.catalog.RegisterProxy(proxy)
+	glog.Infof("[%s][stream] Client connected: Subject CN=%+v", serverName, cn)
 
 	if err := s.isConnectionAllowed(); err != nil {
 		return err
 	}
-
-	/*
-		// TODO(draychev): enable this once we have ServiceCatalog in s.
-			// Register the newly connected Envoy proxy.
-			connectedProxyIPAddress := net.IP("TBD")
-			connectedProxyCertCommonName := certificate.CommonName("TBD")
-			proxy := envoy.NewProxy(connectedProxyCertCommonName, connectedProxyIPAddress)
-			s.catalog.RegisterProxy(proxy)
-	*/
 
 	reqChannel := make(chan *envoyv2.DiscoveryRequest)
 	go receive(reqChannel, server)


### PR DESCRIPTION
This PR ensures that for the time being (while we have separate xDS and before the aggregation) we have the same log message emitted when a new Envoy proxy connects. Also we register the proxy with the catalog.