### PR TITLE
fix(service-cache): Skip adding empty endpoints

### DIFF
--- a/pkg/catalog/cache.go
+++ b/pkg/catalog/cache.go
@@ -11,10 +11,15 @@ func (sc *MeshCatalog) refreshCache() {
 	glog.Info("[catalog] Refresh cache...")
 	servicesCache := make(map[endpoint.ServiceName][]endpoint.Endpoint)
 	// TODO(draychev): split the namespace from the service name -- non-K8s services won't have namespace
+
 	for _, namespacedServiceName := range sc.meshSpec.ListServices() {
 		for _, provider := range sc.endpointsProviders {
 			newIps := provider.ListEndpointsForService(namespacedServiceName)
-			glog.V(log.LvlTrace).Infof("[catalog][%s] Found ips=%+v for service=%s", provider.GetID(), endpointsToString(newIps), namespacedServiceName)
+			if len(newIps) == 0 {
+				glog.Infof("[catalog][%s] No IPs found for service=%s", provider.GetID(), namespacedServiceName)
+				continue
+			}
+			glog.V(log.LvlTrace).Infof("[catalog][%s] Found IPs=%+v for service=%s", provider.GetID(), endpointsToString(newIps), namespacedServiceName)
 			if existingIps, exists := servicesCache[namespacedServiceName]; exists {
 				servicesCache[namespacedServiceName] = append(existingIps, newIps...)
 			} else {


### PR DESCRIPTION
    Adding empty endpoints to the service cache causes readers of the
    cache to assume the service name is resolved to one or more endpoints.
    Noticed that without this change, EDS was reporting invalid endpoints in
    the DiscoveryResponse message to envoy.
    
    The demo app would previously return 503 status code consistently, but
    with this change gives a 200 status code.
