### PR TITLE
Use the new ./bin/cert binary to create CA

### DIFF
--- a/demo/gen-ca.sh
+++ b/demo/gen-ca.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+DIR="./certs"
+
+mkdir -p "$DIR"
+
+openssl req -x509 -sha256 -nodes -days 365 \
+        -newkey rsa:2048 \
+        -subj "/CN=$(uuidgen).azure.mesh/O=Az Mesh/C=US" \
+        -keyout $DIR/root-key.pem \
+        -out $DIR/root-cert.pem
+
+
+exit 0
+
+./bin/cert \
+    --caPEMFileOut="$DIR/root-cert.pem" \
+    --caKeyPEMFileOut="$DIR/root-key.pem" \
+    --org="Azure Mesh"


### PR DESCRIPTION
With https://github.com/deislabs/smc/pull/145 we made a new CLI tool for generating certificates.

This PR adds the necessary bash script to execute the tool and create new root certs.