### PR TITLE
ref(demo): remove duplicate cert gen step

### DIFF
--- a/demo/gen-ca.sh
+++ b/demo/gen-ca.sh
@@ -8,14 +8,6 @@ CRT="$DIR/root-cert.pem"
 
 mkdir -p "$DIR"
 
-openssl req -x509 -sha256 -nodes -days 365 \
-        -newkey rsa:2048 \
-        -subj "/CN=$(uuidgen).azure.mesh/O=Az Mesh/C=US" \
-        -keyout "$KEY"  \
-        -out "$CRT"
-
-exit 0
-
 ./bin/cert \
     --caPEMFileOut="$CRT" \
     --caKeyPEMFileOut="$KEY" \


### PR DESCRIPTION
If I'm understanding the code correctly, then `bin/cert` now generates the root key and cert and using `openssl req` is no longer necessary and those files get overwritten anyway. Deleting the `openssl req` step to remove duplication.