### PR TITLE
s/meshSpecClient/meshSpec/g

### DIFF
--- a/cmd/cds/cds.go
+++ b/cmd/cds/cds.go
@@ -54,12 +54,12 @@ func main() {
 	observeNamespaces := getNamespaces()
 	stop := make(chan struct{})
 
-	meshSpecClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
+	meshSpec := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
 	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *keyPem, "Acme", 1*time.Hour)
 	if err != nil {
 		glog.Fatal("Could not instantiate Certificate Manager: ", err)
 	}
-	meshCatalog := catalog.NewMeshCatalog(meshSpecClient, certManager, stop)
+	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop)
 	cdsServer := cds.NewCDSServer(meshCatalog)
 
 	grpcServer, lis := utils.NewGrpc(serverType, *port, *certPem, *keyPem, *rootCertPem)

--- a/cmd/eds/eds.go
+++ b/cmd/eds/eds.go
@@ -60,19 +60,19 @@ func main() {
 	observeNamespaces := getNamespaces()
 
 	stop := make(chan struct{})
-	meshSpecClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
+	meshSpec := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
 	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *keyPem, "Acme", 1*time.Hour)
 	if err != nil {
 		glog.Fatal("Could not instantiate Certificate Manager: ", err)
 	}
 	azureResourceClient := azureResource.NewClient(kubeConfig, observeNamespaces, stop)
 	endpointsProviders := []endpoint.Provider{
-		azure.NewProvider(*subscriptionID, *azureAuthFile, stop, meshSpecClient, azureResourceClient, constants.AzureProviderName),
+		azure.NewProvider(*subscriptionID, *azureAuthFile, stop, meshSpec, azureResourceClient, constants.AzureProviderName),
 		kube.NewProvider(kubeConfig, observeNamespaces, stop, constants.KubeProviderName),
 	}
 
-	meshCatalog := catalog.NewMeshCatalog(meshSpecClient, certManager, stop, endpointsProviders...)
-	edsServer := eds.NewEDSServer(ctx, meshCatalog, meshSpecClient)
+	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop, endpointsProviders...)
+	edsServer := eds.NewEDSServer(ctx, meshCatalog, meshSpec)
 
 	grpcServer, lis := utils.NewGrpc(serverType, *port, *certPem, *keyPem, *rootCertPem)
 	xds.RegisterEndpointDiscoveryServiceServer(grpcServer, edsServer)

--- a/cmd/lds/lds.go
+++ b/cmd/lds/lds.go
@@ -54,12 +54,12 @@ func main() {
 	observeNamespaces := getNamespaces()
 
 	stop := make(chan struct{})
-	meshSpecClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
+	meshSpec := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
 	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *keyPem, "Acme", 1*time.Hour)
 	if err != nil {
 		glog.Fatal("Could not instantiate Certificate Manager: ", err)
 	}
-	meshCatalog := catalog.NewMeshCatalog(meshSpecClient, certManager, stop)
+	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop)
 	ldsServer := lds.NewLDSServer(meshCatalog)
 
 	grpcServer, lis := utils.NewGrpc(serverType, *port, *certPem, *keyPem, *rootCertPem)

--- a/cmd/sds/sds.go
+++ b/cmd/sds/sds.go
@@ -54,12 +54,12 @@ func main() {
 	observeNamespaces := getNamespaces()
 
 	stop := make(chan struct{})
-	meshSpecClient := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
+	meshSpec := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
 	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *keyPem, "Acme", 1*time.Hour)
 	if err != nil {
 		glog.Fatal("Could not instantiate Certificate Manager: ", err)
 	}
-	meshCatalog := catalog.NewMeshCatalog(meshSpecClient, certManager, stop)
+	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop)
 	sdsServer := sds.NewSDSServer(meshCatalog)
 
 	grpcServer, lis := utils.NewGrpc(serverType, *port, *certPem, *keyPem, *rootCertPem)


### PR DESCRIPTION
Renaming `meshSpecClient` to `meshSpec` for consistency.