### PR TITLE
ads: Adding the Aggregated Discovery Service Server

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	xds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/constants"
+	"github.com/deislabs/smc/pkg/envoy/ads"
+	"github.com/deislabs/smc/pkg/log"
+	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/tresor"
+	"github.com/deislabs/smc/pkg/utils"
+)
+
+const (
+	serverType = "ADS"
+)
+
+var (
+	flags          = pflag.NewFlagSet(`ads`, pflag.ExitOnError)
+	kubeConfigFile = flags.String("kubeconfig", "", "Path to Kubernetes config file.")
+	verbosity      = flags.Int("verbosity", int(log.LvlInfo), "Set log verbosity level")
+	port           = flags.Int("port", 15128, "Clusters Discovery Service port number. (Default: 15128)")
+	namespace      = flags.String("namespace", "default", "Kubernetes namespace to watch for SMI Spec.")
+	certPem        = flags.String("certpem", "", fmt.Sprintf("Full path to the %s Certificate PEM file", serverType))
+	keyPem         = flags.String("keypem", "", fmt.Sprintf("Full path to the %s Key PEM file", serverType))
+	rootCertPem    = flags.String("rootcertpem", "", "Full path to the Root Certificate PEM file")
+)
+
+func main() {
+	defer glog.Flush()
+	parseFlags()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", *kubeConfigFile)
+	if err != nil {
+		glog.Fatalf("[%s] Error fetching Kubernetes config. Ensure correctness of CLI argument 'kubeconfig=%s': %s", serverType, *kubeConfigFile, err)
+	}
+
+	observeNamespaces := getNamespaces()
+	stop := make(chan struct{})
+
+	meshSpec := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
+	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *keyPem, "Acme", 1*time.Hour)
+	if err != nil {
+		glog.Fatal("Could not instantiate Certificate Manager: ", err)
+	}
+	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop)
+	adsServer := ads.NewADSServer(ctx, meshCatalog, meshSpec)
+
+	grpcServer, lis := utils.NewGrpc(serverType, *port, *certPem, *keyPem, *rootCertPem)
+	xds.RegisterAggregatedDiscoveryServiceServer(grpcServer, adsServer)
+
+	go utils.GrpcServe(ctx, grpcServer, lis, cancel, serverType)
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	close(stop)
+	glog.Infof("[%s] Goodbye!", serverType)
+}
+
+func parseFlags() {
+	// TODO(draychev): consolidate parseFlags - shared between ads.go and eds.go
+	if err := flags.Parse(os.Args); err != nil {
+		glog.Error(err)
+	}
+	_ = flag.CommandLine.Parse([]string{})
+	_ = flag.Lookup("v").Value.Set(fmt.Sprintf("%d", *verbosity))
+	_ = flag.Lookup("logtostderr").Value.Set("true")
+}
+
+func getNamespaces() []string {
+	var namespaces []string
+	if namespace == nil {
+		defaultNS := constants.DefaultKubeNamespace
+		namespaces = []string{defaultNS}
+	} else {
+		namespaces = []string{*namespace}
+	}
+	glog.Infof("[%s] Observing namespaces: %s", serverType, strings.Join(namespaces, ","))
+	return namespaces
+}

--- a/demo/deploy-ads.sh
+++ b/demo/deploy-ads.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+NAME="ads"
+PORT=15128
+
+./demo/deploy-xds.sh $NAME $PORT

--- a/demo/tail-ads-logs.sh
+++ b/demo/tail-ads-logs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+POD="$(kubectl get pods -n "$K8S_NAMESPACE" --selector app=ads --no-headers | awk '{print $1}' | head -n1)"
+
+kubectl logs "${POD}" -n "$K8S_NAMESPACE" -f

--- a/dockerfiles/Dockerfile.ads
+++ b/dockerfiles/Dockerfile.ads
@@ -1,0 +1,4 @@
+FROM alpine:3.10.1
+
+ADD bin/linux-amd64/ads /ads
+RUN chmod +x /ads

--- a/pkg/envoy/ads/errors.go
+++ b/pkg/envoy/ads/errors.go
@@ -1,0 +1,11 @@
+package ads
+
+import (
+	"github.com/pkg/errors"
+)
+
+var errUnknownTypeURL = errors.New("unknown TypeUrl")
+var errCreatingResponse = errors.New("creating response")
+var errTooManyConnections = errors.New("too many connections")
+var errEnvoyError = errors.New("Envoy error")
+var errGrpcClosed = errors.New("grpc closed")

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -1,0 +1,30 @@
+package ads
+
+import (
+	"io"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	xds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func receive(requests chan *v2.DiscoveryRequest, server xds.AggregatedDiscoveryService_StreamAggregatedResourcesServer) {
+	defer close(requests)
+	for {
+		var request *v2.DiscoveryRequest
+		request, recvErr := server.Recv()
+		if recvErr != nil {
+			if status.Code(recvErr) == codes.Canceled || recvErr == io.EOF {
+				glog.Errorf("[%s][grpc] Connection terminated: %+v", serverName, recvErr)
+				return
+			}
+			glog.Errorf("[%s][grpc] Connection terminated with error: %+v", serverName, recvErr)
+			return
+		}
+		glog.Infof("[%s][grpc] Done!", serverName)
+		requests <- request
+	}
+}

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -1,0 +1,37 @@
+package ads
+
+import (
+	"context"
+
+	xds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+
+	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/envoy/cds"
+	"github.com/deislabs/smc/pkg/envoy/eds"
+	"github.com/deislabs/smc/pkg/envoy/lds"
+	"github.com/deislabs/smc/pkg/envoy/rds"
+	"github.com/deislabs/smc/pkg/envoy/sds"
+	"github.com/deislabs/smc/pkg/smi"
+)
+
+const (
+	serverName = "ADS"
+)
+
+// NewADSServer creates a new CDS server
+func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
+	return &Server{
+		catalog: meshCatalog,
+
+		cdsServer: cds.NewCDSServer(meshCatalog),
+		rdsServer: rds.NewRDSServer(ctx, meshCatalog, meshSpec),
+		edsServer: eds.NewEDSServer(ctx, meshCatalog, meshSpec),
+		ldsServer: lds.NewLDSServer(meshCatalog),
+		sdsServer: sds.NewSDSServer(meshCatalog),
+	}
+}
+
+// DeltaAggregatedResources implements xds.AggregatedDiscoveryServiceServer
+func (s *Server) DeltaAggregatedResources(server xds.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+	panic("NotImplemented")
+}

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -1,0 +1,145 @@
+package ads
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"github.com/deislabs/smc/pkg/envoy"
+	"github.com/deislabs/smc/pkg/log"
+	"github.com/deislabs/smc/pkg/utils"
+)
+
+// StreamAggregates handles streaming of the clusters to the connected Envoy proxies
+func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+	glog.Infof("[%s] Starting StreamAggregates", serverName)
+
+	// When a new Envoy proxy connects, ValidateClient would ensure that it has a valid certificate,
+	// and the Subject CN is in the allowedCommonNames set.
+	cn, err := utils.ValidateClient(server.Context(), nil, serverName)
+	if err != nil {
+		return errors.Wrap(err, "[%s] Could not start stream")
+	}
+
+	glog.Infof("[%s][stream] Client connected: Subject CN=%s", serverName, cn)
+
+	// Register the newly connected proxy w/ the catalog.
+	ip := utils.GetIPFromContext(server.Context())
+	proxy := s.catalog.RegisterProxy(cn, ip)
+	defer s.catalog.UnregisterProxy(proxy.GetID())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requests := make(chan *v2.DiscoveryRequest)
+	go receive(requests, server)
+
+	s.sendAllResponses(proxy, server)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case discoveryRequest, ok := <-requests:
+			glog.Infof("[%s][incoming] Discovery Request %s from Envoy %s", serverName, discoveryRequest.TypeUrl, proxy.GetCommonName())
+			if !ok {
+				glog.Errorf("[%s] Proxy %s closed GRPC", serverName, proxy.GetCommonName())
+				return errGrpcClosed
+			}
+			if discoveryRequest.ErrorDetail != nil {
+				glog.Errorf("[%s] Discovery request error from proxy %s: %s", serverName, proxy.GetCommonName(), discoveryRequest.ErrorDetail)
+				return errEnvoyError
+			}
+			if len(s.lastNonce) > 0 && discoveryRequest.ResponseNonce == s.lastNonce {
+				glog.Warningf("[%s] Nothing changed", serverName)
+				continue
+			}
+			resp, err := s.newAggregatedDiscoveryResponse(proxy, discoveryRequest)
+			if err != nil {
+				glog.Errorf("[%s][stream] Failed composing a DiscoveryResponse: %+v", serverName, err)
+				return err
+			}
+			if err := server.Send(resp); err != nil {
+				glog.Errorf("[%s][stream] Error sending DiscoveryResponse: %+v", serverName, err)
+			}
+
+		case <-proxy.GetAnnouncementsChannel():
+			glog.V(log.LvlInfo).Infof("[%s][stream] Change detected - update all Envoys.", serverName)
+			s.sendAllResponses(proxy, server)
+		}
+	}
+}
+
+func (s *Server) sendAllResponses(proxy envoy.Proxyer, server discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer) {
+	// Order is important
+	uris := []string{envoy.TypeCDS, envoy.TypeEDS, envoy.TypeLDS, envoy.TypeRDS, envoy.TypeSDS}
+	for _, uri := range uris {
+		request := &v2.DiscoveryRequest{TypeUrl: uri}
+		if discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, request); err != nil {
+			glog.Error(err)
+			continue
+		} else {
+			if err := server.Send(discoveryResponse); err != nil {
+				glog.Errorf("[%s][stream] Error sending DiscoveryResponse %s: %+v", serverName, uri, err)
+			}
+		}
+	}
+}
+
+func (s *Server) newAggregatedDiscoveryResponse(proxy envoy.Proxyer, request *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
+	var err error
+	var response *v2.DiscoveryResponse
+
+	glog.V(log.LvlInfo).Infof("[%s][stream] Received discovery request: %s", serverName, request.TypeUrl)
+
+	switch request.TypeUrl {
+	case envoy.TypeEDS:
+		weightedServices, err := s.catalog.ListEndpoints("TBD")
+		if err != nil {
+			glog.Errorf("[%s][stream] Failed listing endpoints: %+v", serverName, err)
+			return nil, err
+		}
+		glog.Infof("[%s][stream] WeightedServices: %+v", serverName, weightedServices)
+		response, err = s.edsServer.NewEndpointDiscoveryResponse(weightedServices)
+	case envoy.TypeCDS:
+		response, err = s.cdsServer.NewClusterDiscoveryResponse(proxy)
+	case envoy.TypeRDS:
+		glog.V(log.LvlInfo).Infof("[%s][stream] Received a change message! Updating all Envoy proxies.", serverName)
+		trafficPolicies, err := s.catalog.ListTrafficRoutes("TBD")
+		if err != nil {
+			glog.Errorf("[%s][stream] Failed listing routes: %+v", serverName, err)
+			return nil, err
+		}
+		glog.Infof("[%s][stream] trafficPolicies: %+v", serverName, trafficPolicies)
+		response, err = s.rdsServer.NewRouteDiscoveryResponse(trafficPolicies)
+	case envoy.TypeLDS:
+		response, err = s.ldsServer.NewListenerDiscoveryResponse(proxy)
+	case envoy.TypeSDS:
+		response, err = s.sdsServer.NewSecretDiscoveryResponse(proxy)
+	default:
+		glog.Errorf("Responder for TypeUrl %s is not implemented", request.TypeUrl)
+		return nil, errUnknownTypeURL
+	}
+
+	if err != nil {
+		glog.Errorf("Error creating %s response: %s", request.TypeUrl, err)
+		return nil, errCreatingResponse
+	}
+
+	s.lastVersion = s.lastVersion + 1
+	s.lastNonce = string(time.Now().Nanosecond())
+	response.Nonce = s.lastNonce
+	response.VersionInfo = fmt.Sprintf("v%d", s.lastVersion)
+	glog.V(log.LvlTrace).Infof("[%s] Constructed response: %+v", serverName, response)
+	return response, nil
+}
+
+func makeEverything() *v2.DiscoveryResponse {
+	return &v2.DiscoveryResponse{}
+}

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -1,0 +1,23 @@
+package ads
+
+import (
+	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/envoy/cds"
+	"github.com/deislabs/smc/pkg/envoy/eds"
+	"github.com/deislabs/smc/pkg/envoy/lds"
+	"github.com/deislabs/smc/pkg/envoy/rds"
+	"github.com/deislabs/smc/pkg/envoy/sds"
+)
+
+//Server implements the Envoy xDS Aggregate Discovery Services
+type Server struct {
+	catalog     catalog.MeshCataloger
+	lastVersion uint64
+	lastNonce   string
+
+	rdsServer *rds.Server
+	edsServer *eds.Server
+	ldsServer *lds.Server
+	sdsServer *sds.Server
+	cdsServer *cds.Server
+}

--- a/pkg/envoy/cla/cluster_load_assignment.go
+++ b/pkg/envoy/cla/cluster_load_assignment.go
@@ -15,7 +15,7 @@ import (
 const (
 	zone = "zone"
 
-	// TypeCLA is the string constant of the Cluster Load Assignment URI
+	// TypeEDS is the string constant of the Cluster Load Assignment URI
 
 )
 

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -21,7 +21,7 @@ func (e *Server) NewEndpointDiscoveryResponse(allServices map[endpoint.ServiceNa
 
 		proto, err := ptypes.MarshalAny(&loadAssignment)
 		if err != nil {
-			glog.Errorf("[catalog] Error marshalling TypeCLA %+v: %s", loadAssignment, err)
+			glog.Errorf("[catalog] Error marshalling TypeEDS %+v: %s", loadAssignment, err)
 			continue
 		}
 		protos = append(protos, proto)
@@ -29,7 +29,7 @@ func (e *Server) NewEndpointDiscoveryResponse(allServices map[endpoint.ServiceNa
 
 	resp := &v2.DiscoveryResponse{
 		Resources: protos,
-		TypeUrl:   envoy.TypeCLA,
+		TypeUrl:   envoy.TypeEDS,
 	}
 
 	e.lastVersion = e.lastVersion + 1

--- a/pkg/envoy/eds/stream.go
+++ b/pkg/envoy/eds/stream.go
@@ -43,7 +43,7 @@ func (e *Server) StreamEndpoints(server v2.EndpointDiscoveryService_StreamEndpoi
 			return errors.Wrap(err, "recv")
 		}
 
-		if request.TypeUrl != envoy.TypeCLA {
+		if request.TypeUrl != envoy.TypeEDS {
 			glog.Errorf("[%s][stream] Unknown TypeUrl: %s", serverName, request.TypeUrl)
 			return errUnknownTypeURL
 		}

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -13,7 +13,7 @@ const (
 	TypeLDS = "type.googleapis.com/envoy.api.v2.Listener"
 	TypeRDS = "type.googleapis.com/envoy.api.v2.RouteConfiguration"
 	TypeSDS = "type.googleapis.com/envoy.api.v2.auth.Secret"
-	TypeCLA = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
+	TypeEDS = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
 )
 
 type ProxyID string


### PR DESCRIPTION
This PR introduces an Aggregated Discovery Service.
It follows the pattern that currently exists w/ EDS, CDS, LDS, RDS, and SDS.
Once this is fully merged and working -- the `./cmd/?ds` components will be removed. The bootstrap YAML file will be simplified as well. (Coming in a separate PR)