### PR TITLE
Move PEM certificate types to a pem package

### DIFF
--- a/cmd/cert/cert.go
+++ b/cmd/cert/cert.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/deislabs/smc/pkg/certificate"
 	"github.com/deislabs/smc/pkg/tresor"
+	"github.com/deislabs/smc/pkg/tresor/pem"
 )
 
 var (
@@ -31,8 +32,8 @@ func main() {
 	defer glog.Flush()
 	parseFlags()
 
-	var caPEM tresor.CA
-	var caKeyPEM tresor.CAPrivateKey
+	var caPEM pem.RootCertificate
+	var caKeyPEM pem.RootPrivateKey
 	var certManager *tresor.CertManager
 	var err error
 

--- a/pkg/tresor/ca.go
+++ b/pkg/tresor/ca.go
@@ -4,11 +4,12 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"github.com/deislabs/smc/pkg/tresor/pem"
 	"time"
 )
 
 // NewCA creates a new Certificate Authority.
-func NewCA(org string, validity time.Duration) (CA, CAPrivateKey, *x509.Certificate, *rsa.PrivateKey, error) {
+func NewCA(org string, validity time.Duration) (pem.RootCertificate, pem.RootPrivateKey, *x509.Certificate, *rsa.PrivateKey, error) {
 	template, err := makeTemplate("", org, validity)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -22,5 +23,5 @@ func NewCA(org string, validity time.Duration) (CA, CAPrivateKey, *x509.Certific
 		return nil, nil, nil, nil, err
 	}
 	caCert, caKey, err := genCert(template, template, caPrivKey, caPrivKey)
-	return CA(caCert), CAPrivateKey(caKey), template, caPrivKey, err
+	return pem.RootCertificate(caCert), pem.RootPrivateKey(caKey), template, caPrivKey, err
 }

--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"github.com/deislabs/smc/pkg/certificate"
+	"github.com/deislabs/smc/pkg/tresor/pem"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"time"
@@ -52,7 +53,7 @@ func NewCertManagerWithCA(ca *x509.Certificate, caPrivKey *rsa.PrivateKey, org s
 }
 
 // NewSelfSignedCert creates a new self-signed certificate.
-func NewSelfSignedCert(host string, org string, validity time.Duration) (CertPEM, CertPrivKeyPEM, error) {
+func NewSelfSignedCert(host string, org string, validity time.Duration) (pem.Certificate, pem.PrivateKey, error) {
 	glog.Infof("Generating a new certificate for host: %s", host)
 	if host == "" {
 		return nil, nil, errInvalidHost
@@ -68,7 +69,7 @@ func NewSelfSignedCert(host string, org string, validity time.Duration) (CertPEM
 	return genCert(template, template, privateKey, privateKey)
 }
 
-func genCert(template, parent *x509.Certificate, certPrivKey, caPrivKey *rsa.PrivateKey) (CertPEM, CertPrivKeyPEM, error) {
+func genCert(template, parent *x509.Certificate, certPrivKey, caPrivKey *rsa.PrivateKey) (pem.Certificate, pem.PrivateKey, error) {
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, parent, &certPrivKey.PublicKey, caPrivKey)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, errCreateCert.Error())

--- a/pkg/tresor/pem/types.go
+++ b/pkg/tresor/pem/types.go
@@ -1,0 +1,7 @@
+package pem
+
+type Certificate []byte
+type PrivateKey []byte
+
+type RootCertificate []byte
+type RootPrivateKey []byte

--- a/pkg/tresor/tools.go
+++ b/pkg/tresor/tools.go
@@ -6,28 +6,29 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
+	pemEnc "encoding/pem"
 	"math/big"
 	"time"
 
+	"github.com/deislabs/smc/pkg/tresor/pem"
 	"github.com/pkg/errors"
 )
 
-func encodeCert(derBytes []byte) (CertPEM, error) {
+func encodeCert(derBytes []byte) (pem.Certificate, error) {
 	certOut := &bytes.Buffer{}
-	if err := pem.Encode(certOut, &pem.Block{Type: TypeCertificate, Bytes: derBytes}); err != nil {
+	if err := pemEnc.Encode(certOut, &pemEnc.Block{Type: TypeCertificate, Bytes: derBytes}); err != nil {
 		return nil, errors.Wrap(err, errEncodeCert.Error())
 	}
 	return certOut.Bytes(), nil
 }
 
-func encodeKey(priv *rsa.PrivateKey) (CertPrivKeyPEM, error) {
+func encodeKey(priv *rsa.PrivateKey) (pem.PrivateKey, error) {
 	keyOut := &bytes.Buffer{}
 	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
 		return nil, errors.Wrap(err, errMarshalPrivateKey.Error())
 	}
-	if err := pem.Encode(keyOut, &pem.Block{Type: TypePrivateKey, Bytes: privBytes}); err != nil {
+	if err := pemEnc.Encode(keyOut, &pemEnc.Block{Type: TypePrivateKey, Bytes: privBytes}); err != nil {
 		return nil, errors.Wrap(err, errEncodeKey.Error())
 	}
 	return keyOut.Bytes(), nil

--- a/pkg/tresor/types.go
+++ b/pkg/tresor/types.go
@@ -8,11 +8,6 @@ import (
 	"github.com/deislabs/smc/pkg/certificate"
 )
 
-type CA []byte
-type CAPrivateKey []byte
-type CertPEM []byte
-type CertPrivKeyPEM []byte
-
 const (
 	TypeCertificate = "CERTIFICATE"
 	TypePrivateKey  = "PRIVATE KEY"


### PR DESCRIPTION
I really disliked the `CertPEM` type.  I believe `pem.Certificate` reads better than `CertPEM`

This PR moves the PEM related certificate, root, private key types into a `./pkg/tresor/pem` package.

No functional code changes.