### PR TITLE
ads: Integrating Aggregated Discovery Service

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -18,7 +18,7 @@ import (
 	"github.com/deislabs/smc/pkg/catalog"
 	"github.com/deislabs/smc/pkg/constants"
 	"github.com/deislabs/smc/pkg/envoy/ads"
-	"github.com/deislabs/smc/pkg/log"
+	"github.com/deislabs/smc/pkg/log/level"
 	"github.com/deislabs/smc/pkg/smi"
 	"github.com/deislabs/smc/pkg/tresor"
 	"github.com/deislabs/smc/pkg/utils"
@@ -31,7 +31,7 @@ const (
 var (
 	flags          = pflag.NewFlagSet(`ads`, pflag.ExitOnError)
 	kubeConfigFile = flags.String("kubeconfig", "", "Path to Kubernetes config file.")
-	verbosity      = flags.Int("verbosity", int(log.LvlInfo), "Set log verbosity level")
+	verbosity      = flags.Int("verbosity", int(level.Info), "Set log verbosity level")
 	port           = flags.Int("port", 15128, "Clusters Discovery Service port number. (Default: 15128)")
 	namespace      = flags.String("namespace", "default", "Kubernetes namespace to watch for SMI Spec.")
 	certPem        = flags.String("certpem", "", fmt.Sprintf("Full path to the %s Certificate PEM file", serverType))

--- a/demo/config/bootstrap.yaml
+++ b/demo/config/bootstrap.yaml
@@ -6,24 +6,21 @@ admin:
       port_value: 15000
 
 dynamic_resources:
-  lds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
-        envoy_grpc:
-          cluster_name: lds
-
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: ads
+    set_node_on_first_message_only: true
   cds_config:
-    api_config_source:
-      api_type: GRPC
-      grpc_services:
-        envoy_grpc:
-          cluster_name: cds
+    ads: {}
+  lds_config:
+    ads: {}
 
 static_resources:
   clusters:
 
-  - name: sds
+  - name: ads
     connect_timeout: 0.25s
     type: LOGICAL_DNS
     http2_protocol_options: {}
@@ -37,103 +34,11 @@ static_resources:
           - certificate_chain: { filename: "/etc/ssl/certs/cert.pem" }
             private_key: { filename: "/etc/ssl/certs/key.pem" }
     load_assignment:
-      cluster_name: sds
+      cluster_name: ads
       endpoints:
       - lb_endpoints:
         - endpoint:
             address:
               socket_address:
-                address: sds.smc.svc.cluster.local
-                port_value: 15123
-
-  - name: eds
-    connect_timeout: 0.25s
-    type: LOGICAL_DNS
-    http2_protocol_options: {}
-    tls_context:
-      common_tls_context:
-        tls_params:
-          tls_minimum_protocol_version: TLSv1_2
-          tls_maximum_protocol_version: TLSv1_3
-          cipher_suites: "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
-        tls_certificates:
-          - certificate_chain: { filename: "/etc/ssl/certs/cert.pem" }
-            private_key: { filename: "/etc/ssl/certs/key.pem" }
-    load_assignment:
-      cluster_name: eds
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: eds.smc.svc.cluster.local
-                port_value: 15124
-
-  - name: cds
-    connect_timeout: 0.25s
-    type: LOGICAL_DNS
-    http2_protocol_options: {}
-    tls_context:
-      common_tls_context:
-        tls_params:
-          tls_minimum_protocol_version: TLSv1_2
-          tls_maximum_protocol_version: TLSv1_3
-          cipher_suites: "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
-        tls_certificates:
-          - certificate_chain: { filename: "/etc/ssl/certs/cert.pem" }
-            private_key: { filename: "/etc/ssl/certs/key.pem" }
-    load_assignment:
-      cluster_name: cds
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: cds.smc.svc.cluster.local
-                port_value: 15125
-
-  - name: rds
-    connect_timeout: 0.25s
-    type: LOGICAL_DNS
-    http2_protocol_options: {}
-    tls_context:
-      common_tls_context:
-        tls_params:
-          tls_minimum_protocol_version: TLSv1_2
-          tls_maximum_protocol_version: TLSv1_3
-          cipher_suites: "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
-        tls_certificates:
-          - certificate_chain: { filename: "/etc/ssl/certs/cert.pem" }
-            private_key: { filename: "/etc/ssl/certs/key.pem" }
-    load_assignment:
-      cluster_name: rds
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: rds.smc.svc.cluster.local
-                port_value: 15126
-
-  - name: lds
-    connect_timeout: 0.25s
-    type: LOGICAL_DNS
-    http2_protocol_options: {}
-    tls_context:
-      common_tls_context:
-        tls_params:
-          tls_minimum_protocol_version: TLSv1_2
-          tls_maximum_protocol_version: TLSv1_3
-          cipher_suites: "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]"
-        tls_certificates:
-          - certificate_chain: { filename: "/etc/ssl/certs/cert.pem" }
-            private_key: { filename: "/etc/ssl/certs/key.pem" }
-    load_assignment:
-      cluster_name: lds
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: lds.smc.svc.cluster.local
-                port_value: 15127
+                address: ads.smc.svc.cluster.local
+                port_value: 15128

--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -12,11 +12,7 @@ rm -rf ./certs
 
 make build-cert
 
-make docker-push-cds
-make docker-push-lds
-make docker-push-eds
-make docker-push-sds
-make docker-push-rds
+make docker-push-ads
 
 make docker-push-init
 make docker-push-bookbuyer
@@ -38,11 +34,7 @@ kubectl apply -f demo/AzureResource.yaml
 ./demo/deploy-bookstore.sh "bookstore-1"
 # ./demo/deploy-bookstore.sh bookstore-2
 
-./demo/deploy-cds.sh
-./demo/deploy-sds.sh
-./demo/deploy-eds.sh
-./demo/deploy-rds.sh
-./demo/deploy-lds.sh
+./demo/deploy-ads.sh
 
 ./demo/deploy-traffic-split.sh
 ./demo/deploy-traffic-spec.sh

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -3,5 +3,6 @@ package catalog
 import "errors"
 
 var (
-	errNotFound = errors.New("no such service found")
+	errNotFound        = errors.New("no such service found")
+	errUnregisterProxy = errors.New("unregister proxy")
 )

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -45,7 +45,6 @@ func (sc *MeshCatalog) broadcastAnnouncementToProxies() {
 		cases[i] = reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ch)}
 	}
 
-	// Keep receiving
 	for {
 		chosen, message, ok := reflect.Select(cases)
 

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -3,6 +3,7 @@ package ads
 import (
 	"context"
 	"fmt"
+	"github.com/deislabs/smc/pkg/log/level"
 	"time"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -11,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/deislabs/smc/pkg/envoy"
-	"github.com/deislabs/smc/pkg/log"
 	"github.com/deislabs/smc/pkg/utils"
 )
 
@@ -70,7 +70,7 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 			}
 
 		case <-proxy.GetAnnouncementsChannel():
-			glog.V(log.LvlInfo).Infof("[%s][stream] Change detected - update all Envoys.", serverName)
+			glog.V(level.Info).Infof("[%s][stream] Change detected - update all Envoys.", serverName)
 			s.sendAllResponses(proxy, server)
 		}
 	}
@@ -96,7 +96,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy envoy.Proxyer, request *v2
 	var err error
 	var response *v2.DiscoveryResponse
 
-	glog.V(log.LvlInfo).Infof("[%s][stream] Received discovery request: %s", serverName, request.TypeUrl)
+	glog.V(level.Info).Infof("[%s][stream] Received discovery request: %s", serverName, request.TypeUrl)
 
 	switch request.TypeUrl {
 	case envoy.TypeEDS:
@@ -110,7 +110,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy envoy.Proxyer, request *v2
 	case envoy.TypeCDS:
 		response, err = s.cdsServer.NewClusterDiscoveryResponse(proxy)
 	case envoy.TypeRDS:
-		glog.V(log.LvlInfo).Infof("[%s][stream] Received a change message! Updating all Envoy proxies.", serverName)
+		glog.V(level.Info).Infof("[%s][stream] Received a change message! Updating all Envoy proxies.", serverName)
 		trafficPolicies, err := s.catalog.ListTrafficRoutes("TBD")
 		if err != nil {
 			glog.Errorf("[%s][stream] Failed listing routes: %+v", serverName, err)
@@ -136,7 +136,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy envoy.Proxyer, request *v2
 	s.lastNonce = string(time.Now().Nanosecond())
 	response.Nonce = s.lastNonce
 	response.VersionInfo = fmt.Sprintf("v%d", s.lastVersion)
-	glog.V(log.LvlTrace).Infof("[%s] Constructed response: %+v", serverName, response)
+	glog.V(level.Trace).Infof("[%s] Constructed response: %+v", serverName, response)
 	return response, nil
 }
 

--- a/pkg/envoy/cds/errors.go
+++ b/pkg/envoy/cds/errors.go
@@ -1,13 +1,7 @@
 package cds
 
 import (
-	errors2 "errors"
-
 	"github.com/pkg/errors"
 )
 
-var errTooManyConnections = errors.New("too many connections")
-var errDiscoveryRequest = errors.New("discovery request error")
-var errInvalidDiscoveryRequest = errors.New("invalid discovery request with no node")
-var errGrpcClosed = errors2.New("grpc closed")
 var errUnknownTypeURL = errors.New("unknown TypeUrl")

--- a/pkg/envoy/cds/service.go
+++ b/pkg/envoy/cds/service.go
@@ -3,12 +3,13 @@ package cds
 import (
 	"time"
 
-	"github.com/deislabs/smc/pkg/envoy"
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
+
+	"github.com/deislabs/smc/pkg/envoy"
 )
 
 func getServiceClusterLocal(clusterName string) *xds.Cluster {
@@ -35,6 +36,7 @@ func getServiceClusterLocal(clusterName string) *xds.Cluster {
 					LbEndpoints: []*endpoint.LbEndpoint{{
 						HostIdentifier: &endpoint.LbEndpoint_Endpoint{
 							Endpoint: &endpoint.Endpoint{
+								// TODO(draychev): remove hard-coded values
 								Address: envoy.GetAddress("0.0.0.0", 80),
 							},
 						},

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -14,7 +14,7 @@ import (
 	"github.com/deislabs/smc/pkg/envoy/cla"
 )
 
-func (e *Server) NewEndpointDiscoveryResponse(allServices map[endpoint.ServiceName][]endpoint.WeightedService) (*v2.DiscoveryResponse, error) {
+func (s *Server) NewEndpointDiscoveryResponse(allServices map[endpoint.ServiceName][]endpoint.WeightedService) (*v2.DiscoveryResponse, error) {
 	var protos []*any.Any
 	for targetServiceName, weightedServices := range allServices {
 		loadAssignment := cla.NewClusterLoadAssignment(targetServiceName, weightedServices)
@@ -32,10 +32,10 @@ func (e *Server) NewEndpointDiscoveryResponse(allServices map[endpoint.ServiceNa
 		TypeUrl:   envoy.TypeEDS,
 	}
 
-	e.lastVersion = e.lastVersion + 1
-	e.lastNonce = string(time.Now().Nanosecond())
-	resp.Nonce = e.lastNonce
-	resp.VersionInfo = fmt.Sprintf("v%d", e.lastVersion)
+	s.lastVersion = s.lastVersion + 1
+	s.lastNonce = string(time.Now().Nanosecond())
+	resp.Nonce = s.lastNonce
+	resp.VersionInfo = fmt.Sprintf("v%d", s.lastVersion)
 
 	return resp, nil
 }

--- a/pkg/envoy/eds/server.go
+++ b/pkg/envoy/eds/server.go
@@ -21,11 +21,11 @@ func NewEDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec s
 }
 
 // FetchEndpoints implements envoy.EndpointDiscoveryServiceServer
-func (e *Server) FetchEndpoints(context.Context, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
+func (s *Server) FetchEndpoints(context.Context, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
 	panic("NotImplemented")
 }
 
 // DeltaEndpoints implements envoy.EndpointDiscoveryServiceServer
-func (e *Server) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) error {
+func (s *Server) DeltaEndpoints(xds.EndpointDiscoveryService_DeltaEndpointsServer) error {
 	panic("NotImplemented")
 }

--- a/pkg/envoy/eds/stream.go
+++ b/pkg/envoy/eds/stream.go
@@ -17,7 +17,7 @@ const (
 )
 
 // StreamEndpoints implements v2.EndpointDiscoveryService and handles streaming of Endpoint changes to the Envoy proxies connected.
-func (e *Server) StreamEndpoints(server v2.EndpointDiscoveryService_StreamEndpointsServer) error {
+func (s *Server) StreamEndpoints(server v2.EndpointDiscoveryService_StreamEndpointsServer) error {
 	glog.Infof("[%s] Starting StreamEndpoints", serverName)
 
 	// When a new Envoy proxy connects, ValidateClient would ensure that it has a valid certificate,
@@ -31,8 +31,8 @@ func (e *Server) StreamEndpoints(server v2.EndpointDiscoveryService_StreamEndpoi
 
 	// Register the newly connected proxy w/ the catalog.
 	ip := utils.GetIPFromContext(server.Context())
-	proxy := e.catalog.RegisterProxy(cn, ip)
-	defer e.catalog.UnregisterProxy(proxy.GetID())
+	proxy := s.catalog.RegisterProxy(cn, ip)
+	defer s.catalog.UnregisterProxy(proxy.GetID())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -57,13 +57,13 @@ func (e *Server) StreamEndpoints(server v2.EndpointDiscoveryService_StreamEndpoi
 				// NOTE(draychev): This is deliberately only focused on providing MVP tools to run a TrafficSplit demo.
 				glog.V(level.Info).Infof("[%s][stream] Received a change message! Updating all Envoy proxies.", serverName)
 				// TODO(draychev): flesh out the ClientIdentity
-				weightedServices, err := e.catalog.ListEndpoints("TBD")
+				weightedServices, err := s.catalog.ListEndpoints("TBD")
 				if err != nil {
 					glog.Errorf("[%s][stream] Failed listing endpoints: %+v", serverName, err)
 					return err
 				}
 				glog.Infof("[%s][stream] WeightedServices: %+v", serverName, weightedServices)
-				resp, err := e.NewEndpointDiscoveryResponse(weightedServices)
+				resp, err := s.NewEndpointDiscoveryResponse(weightedServices)
 				if err != nil {
 					glog.Errorf("[%s][stream] Failed composing a DiscoveryResponse: %+v", serverName, err)
 					return err

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -22,7 +22,7 @@ func getRdsHTTPClientConnectionFilter() *envoy_hcm.HttpConnectionManager {
 		}},
 		RouteSpecifier: &envoy_hcm.HttpConnectionManager_Rds{
 			Rds: &envoy_hcm.Rds{
-				ConfigSource:    envoy.GetGRPCSource(envoy.RDSClusterName),
+				ConfigSource:    envoy.GetGRPCSource(envoy.XDSClusterName),
 				RouteConfigName: route.SourceRouteConfig,
 			},
 		},
@@ -40,7 +40,7 @@ func getRdsHTTPServerConnectionFilter() *envoy_hcm.HttpConnectionManager {
 		}},
 		RouteSpecifier: &envoy_hcm.HttpConnectionManager_Rds{
 			Rds: &envoy_hcm.Rds{
-				ConfigSource:    envoy.GetGRPCSource(envoy.RDSClusterName),
+				ConfigSource:    envoy.GetGRPCSource(envoy.XDSClusterName),
 				RouteConfigName: route.DestinationRouteConfig,
 			},
 		},

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -14,7 +14,7 @@ import (
 	"github.com/deislabs/smc/pkg/log/level"
 )
 
-func (e *Server) NewRouteDiscoveryResponse(allTrafficPolicies []endpoint.TrafficTargetPolicies) (*v2.DiscoveryResponse, error) {
+func (s *Server) NewRouteDiscoveryResponse(allTrafficPolicies []endpoint.TrafficTargetPolicies) (*v2.DiscoveryResponse, error) {
 	resp := &v2.DiscoveryResponse{
 		TypeUrl: envoy.TypeRDS,
 	}
@@ -32,10 +32,12 @@ func (e *Server) NewRouteDiscoveryResponse(allTrafficPolicies []endpoint.Traffic
 			resp.Resources = append(resp.Resources, marshalledRouteConfig)
 		}
 	}
-	e.lastVersion = e.lastVersion + 1
-	e.lastNonce = string(time.Now().Nanosecond())
-	resp.Nonce = e.lastNonce
-	resp.VersionInfo = fmt.Sprintf("v%d", e.lastVersion)
+
+	s.lastVersion = s.lastVersion + 1
+	s.lastNonce = string(time.Now().Nanosecond())
+	resp.Nonce = s.lastNonce
+	resp.VersionInfo = fmt.Sprintf("v%d", s.lastVersion)
 	glog.V(level.Trace).Infof("[%s] Constructed response: %+v", serverName, resp)
+
 	return resp, nil
 }

--- a/pkg/envoy/rds/server.go
+++ b/pkg/envoy/rds/server.go
@@ -21,11 +21,11 @@ func NewRDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec s
 }
 
 // FetchRoutes implements envoy.RouteDiscoveryServiceServer
-func (r *Server) FetchRoutes(context.Context, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
+func (s *Server) FetchRoutes(context.Context, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
 	panic("NotImplemented")
 }
 
 // DeltaRoutes implements envoy.RouteDiscoveryServiceServer
-func (r *Server) DeltaRoutes(xds.RouteDiscoveryService_DeltaRoutesServer) error {
+func (s *Server) DeltaRoutes(xds.RouteDiscoveryService_DeltaRoutesServer) error {
 	panic("NotImplemented")
 }

--- a/pkg/envoy/rds/stream.go
+++ b/pkg/envoy/rds/stream.go
@@ -17,7 +17,7 @@ const (
 )
 
 // StreamRoutes handles streaming of route changes to the Envoy proxies connected
-func (e *Server) StreamRoutes(server xds.RouteDiscoveryService_StreamRoutesServer) error {
+func (s *Server) StreamRoutes(server xds.RouteDiscoveryService_StreamRoutesServer) error {
 	glog.Infof("[%s] Starting StreamRoutes", serverName)
 
 	// When a new Envoy proxy connects, ValidateClient would ensure that it has a valid certificate,
@@ -31,8 +31,8 @@ func (e *Server) StreamRoutes(server xds.RouteDiscoveryService_StreamRoutesServe
 
 	// Register the newly connected proxy w/ the catalog.
 	ip := utils.GetIPFromContext(server.Context())
-	proxy := e.catalog.RegisterProxy(cn, ip)
-	defer e.catalog.UnregisterProxy(proxy.GetID())
+	proxy := s.catalog.RegisterProxy(cn, ip)
+	defer s.catalog.UnregisterProxy(proxy.GetID())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -57,13 +57,13 @@ func (e *Server) StreamRoutes(server xds.RouteDiscoveryService_StreamRoutesServe
 				// NOTE: This is deliberately only focused on providing MVP tools to run a TrafficRoute demo.
 				glog.V(level.Info).Infof("[%s][stream] Received a change message! Updating all Envoy proxies.", serverName)
 				// TODO: flesh out the ClientIdentity for this similar to eds.go
-				trafficPolicies, err := e.catalog.ListTrafficRoutes("TBD")
+				trafficPolicies, err := s.catalog.ListTrafficRoutes("TBD")
 				if err != nil {
 					glog.Errorf("[%s][stream] Failed listing routes: %+v", serverName, err)
 					return err
 				}
 				glog.Infof("[%s][stream] trafficPolicies: %+v", serverName, trafficPolicies)
-				resp, err := e.NewRouteDiscoveryResponse(trafficPolicies)
+				resp, err := s.NewRouteDiscoveryResponse(trafficPolicies)
 				if err != nil {
 					glog.Errorf("[%s][stream] Failed composing a DiscoveryResponse: %+v", serverName, err)
 					return err

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -8,12 +8,12 @@ import (
 )
 
 const (
-	TypeADS = "type.googleapis.com/envoy.api.v2.Cluster"
-	TypeCDS = "type.googleapis.com/envoy.api.v2.Cluster"
-	TypeLDS = "type.googleapis.com/envoy.api.v2.Listener"
-	TypeRDS = "type.googleapis.com/envoy.api.v2.RouteConfiguration"
-	TypeSDS = "type.googleapis.com/envoy.api.v2.auth.Secret"
-	TypeEDS = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
+	baseURI = "type.googleapis.com/envoy.api.v2."
+	TypeCDS = baseURI + "Cluster"
+	TypeLDS = baseURI + "Listener"
+	TypeRDS = baseURI + "RouteConfiguration"
+	TypeSDS = baseURI + "auth.Secret"
+	TypeEDS = baseURI + "ClusterLoadAssignment"
 )
 
 type ProxyID string

--- a/pkg/envoy/xds.go
+++ b/pkg/envoy/xds.go
@@ -20,19 +20,8 @@ import (
 )
 
 const (
-	accessLogPath = "/dev/stdout"
-
-	SDSClusterName = "sds"
-	SDSAddress     = "sds.smc.svc.cluster.local"
-	SDSPort        = 15123
-
-	EDSClusterName = "eds"
-	EDSAddress     = "eds.smc.svc.cluster.local"
-	EDSPort        = 15124
-
-	RDSClusterName = "rds"
-	RDSAddress     = "rds.smc.svc.cluster.local"
-	RDSPort        = 15126
+	accessLogPath  = "/dev/stdout"
+	XDSClusterName = "ads"
 
 	// cipher suites
 	aes    = "ECDHE-ECDSA-AES128-GCM-SHA256"
@@ -176,12 +165,12 @@ func getTLSDownstream(certificateName string) *any.Any {
 			TlsParams: GetTLSParams(),
 			TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
 				Name:      certificateName,
-				SdsConfig: GetGRPCSource(SDSClusterName),
+				SdsConfig: GetGRPCSource(XDSClusterName),
 			}},
 			ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 					Name:      certificateName,
-					SdsConfig: GetGRPCSource(SDSClusterName),
+					SdsConfig: GetGRPCSource(XDSClusterName),
 				},
 			},
 		},
@@ -201,12 +190,12 @@ func getTLSUpstream(certificateName string) *any.Any {
 			TlsParams: GetTLSParams(),
 			TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
 				Name:      certificateName,
-				SdsConfig: GetGRPCSource(SDSClusterName),
+				SdsConfig: GetGRPCSource(XDSClusterName),
 			}},
 			ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 					Name:      certificateName,
-					SdsConfig: GetGRPCSource(SDSClusterName),
+					SdsConfig: GetGRPCSource(XDSClusterName),
 				},
 			},
 		},
@@ -254,7 +243,7 @@ func GetEDSCluster() *xds.Cluster_EdsClusterConfig {
 					GrpcServices: []*core.GrpcService{
 						{
 							TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
-								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: EDSClusterName},
+								EnvoyGrpc: &core.GrpcService_EnvoyGrpc{ClusterName: XDSClusterName},
 							},
 						},
 					},


### PR DESCRIPTION
This is the second piece of the changes needed to introduce ADS.
First step was made with https://github.com/deislabs/smc/pull/162.

In this PR we:
  - add the necessary Makefile targets
  - trim the Envoy YAML and point all clusters to the new ADS
  - update the `./demo/run-demo.sh` script (removing sds, lds, cds, rds, eds in lieu of ads)