### PR TITLE
demo: Modify AzureResource.yaml for bookstore service running on VM

### DIFF
--- a/demo/AzureResource.yaml
+++ b/demo/AzureResource.yaml
@@ -1,9 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore-vm
+  namespace: smc
+  labels:
+    app: bookstore-vm
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    name: app-port
+  selector:
+    app: bookstore-vm
+  type: NodePort
+---
+
 apiVersion: smc.osm.k8s.io/v1
 kind: AzureResource
 metadata:
   name: bookstore
   namespace: smc
   labels:
-    app: bookstore-1
+    app: bookstore-vm
 spec:
-  resourceid: /subscriptions/abc/resourcegroups/xyz/providers/Microsoft.Compute/virtualMachines/myVM
+  resourceid: /subscriptions/your-subscription-id/resourceGroups/your-resource-group-name/providers/Microsoft.Compute/virtualMachines/vm-name


### PR DESCRIPTION
Adds a bookstore-vm service for a bookstore service running on an
Azure VM.
Updates 'resoucreId': s/resourcegroups/resourceGroups