### PR TITLE
providers/client: Use the same resync interval for informers

### DIFF
--- a/pkg/providers/azure/kubernetes/client.go
+++ b/pkg/providers/azure/kubernetes/client.go
@@ -18,7 +18,7 @@ const (
 	kubernetesClientName = "AzureResourceClient"
 )
 
-var resyncPeriod = 1 * time.Second
+var resyncPeriod = 10 * time.Second
 
 // NewClient creates the Kubernetes client, which retrieves the AzureResource CRD and Services resources.
 func NewClient(kubeConfig *rest.Config, namespaces []string, stop chan struct{}) *Client {

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -15,7 +15,7 @@ import (
 	"github.com/deislabs/smc/pkg/log/level"
 )
 
-var resyncPeriod = 1 * time.Second
+var resyncPeriod = 10 * time.Second
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
 func NewProvider(kubeConfig *rest.Config, namespaces []string, stop chan struct{}, providerIdent string) *Client {


### PR DESCRIPTION
A resync interval of 1s is too aggressive, change this to 10s
to be consistent with SMI informers.