### PR TITLE
web: Adding health check and metrics web servers

### DIFF
--- a/demo/deploy-xds.sh
+++ b/demo/deploy-xds.sh
@@ -99,6 +99,19 @@ spec:
         subPath: root-cert.pem
         readOnly: false
 
+      readinessProbe:
+        httpGet:
+          path: /health/ready
+          port: 8888
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      livenessProbe:
+        httpGet:
+          path: /health/alive
+          port: 8888
+        initialDelaySeconds: 15
+        periodSeconds: 20
+
   volumes:
     - name: kubeconfig
       configMap:

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/rogpeppe/godef v1.1.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/axw/gocov v1.0.0/go.mod h1:LvQpEYiwwIb2nYkXY2fDWhg9/AsYqkhmrCshjlUJECE=
+github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/census-instrumentation/opencensus-proto v0.0.2-0.20180913191712-f303ae3f8d6a/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.0 h1:LzQXZOgg4CQfE6bFvXGM30YZL1WW/M337pXml+GrcZ4=
@@ -204,6 +205,7 @@ github.com/kubernetes-client/go v0.0.0-20190516163813-075b33afc74f/go.mod h1:ks4
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/matm/gocov-html v0.0.0-20160206185555-f6dd0fd0ebc7/go.mod h1:2amKdhwK7Jz2kRhLYmUH2NIOeBs6Tmhpy5UgDXhRbHc=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -249,14 +251,18 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 h1:D+CiwcpGTW6pL6bv6KI3KbyEyCKyS+1JWS2h8PNDnGA=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.2.0 h1:kUZDBDTdBVBYBj5Tmh2NZLlF60mfjA27rM34b+cVwNU=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1 h1:/K3IL0Z1quvmJ7X0A1AwNEK7CRkVK3YwfOU/QAL4WGg=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -35,3 +35,11 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 func (s *Server) DeltaAggregatedResources(server xds.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	panic("NotImplemented")
 }
+
+func (s *Server) Liveness() bool {
+	return true
+}
+
+func (s *Server) Readiness() bool {
+	return true
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,31 @@
+package health
+
+import "net/http"
+
+// Probe is a type alias for a function.
+type Probe func() bool
+
+// Probes is the interface for liveness and readiness probes
+type Probes interface {
+	Liveness() bool
+	Readiness() bool
+}
+
+func makeHandler(probe Probe) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(map[bool]int{
+			true:  http.StatusOK,
+			false: http.StatusServiceUnavailable,
+		}[probe()])
+	})
+}
+
+// ReadinessHandler returns readiness http handlers for health
+func ReadinessHandler(probe Probes) http.Handler {
+	return makeHandler(probe.Readiness)
+}
+
+// LivenessHandler returns readiness http handlers for health
+func LivenessHandler(probe Probes) http.Handler {
+	return makeHandler(probe.Liveness)
+}

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -1,0 +1,64 @@
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/deislabs/smc/pkg/health"
+	"github.com/deislabs/smc/pkg/metricsstore"
+)
+
+// HTTPServer serving probes and metrics
+type HTTPServer interface {
+	Start()
+	Stop()
+}
+
+type httpServer struct {
+	server *http.Server
+}
+
+// NewHealthMux makes a new *http.ServeMux
+func NewHealthMux(handlers map[string]http.Handler) *http.ServeMux {
+	router := http.NewServeMux()
+	for url, handler := range handlers {
+		router.Handle(url, handler)
+	}
+
+	return router
+}
+
+// NewHTTPServer creates a new api server
+func NewHTTPServer(somethingWithProbes health.Probes, metricStore metricsstore.MetricStore, apiPort string) HTTPServer {
+	return &httpServer{
+		server: &http.Server{
+			Addr: fmt.Sprintf(":%s", apiPort),
+			Handler: NewHealthMux(map[string]http.Handler{
+				"/health/ready": health.ReadinessHandler(somethingWithProbes),
+				"/health/alive": health.LivenessHandler(somethingWithProbes),
+				"/metrics":      metricStore.Handler(),
+			}),
+		},
+	}
+}
+
+func (s *httpServer) Start() {
+	go func() {
+		glog.Infof("Starting API Server on %s", s.server.Addr)
+		if err := s.server.ListenAndServe(); err != nil {
+			glog.Fatal("Failed to start API server", err)
+		}
+	}()
+}
+
+func (s *httpServer) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.server.Shutdown(ctx); err != nil {
+		glog.Error("Unable to shutdown API server gracefully", err)
+	}
+}

--- a/pkg/metricsstore/fake.go
+++ b/pkg/metricsstore/fake.go
@@ -1,0 +1,39 @@
+package metricsstore
+
+import (
+	"net/http"
+	"time"
+)
+
+// NewFakeMetricStore return a fake metric store
+func NewFakeMetricStore() MetricStore {
+	return &fakeMetricStore{}
+}
+
+type fakeMetricStore struct{}
+
+type fakeMetricHandler struct {
+	metric string
+}
+
+func (m *fakeMetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte(m.metric))
+}
+
+func (ms *fakeMetricStore) Start() {}
+
+func (ms *fakeMetricStore) Stop() {}
+
+func (ms *fakeMetricStore) Handler() http.Handler {
+	return &fakeMetricHandler{metric: "OK"}
+}
+
+func (ms *fakeMetricStore) SetUpdateLatencySec(dur time.Duration) {}
+
+func (ms *fakeMetricStore) IncArmAPIUpdateCallFailureCounter() {}
+
+func (ms *fakeMetricStore) IncArmAPIUpdateCallSuccessCounter() {}
+
+func (ms *fakeMetricStore) IncArmAPICallCounter() {}
+
+func (ms *fakeMetricStore) IncK8sAPIEventCounter() {}

--- a/pkg/metricsstore/metricstore.go
+++ b/pkg/metricsstore/metricstore.go
@@ -1,0 +1,88 @@
+package metricsstore
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/deislabs/smc/pkg/version"
+)
+
+// PrometheusNamespace is the Prometheus Namespace
+var PrometheusNamespace = "smc"
+
+// MetricStore is store maintaining all metrics
+type MetricStore interface {
+	Start()
+	Stop()
+	Handler() http.Handler
+	SetUpdateLatencySec(time.Duration)
+	IncK8sAPIEventCounter()
+}
+
+// SMCMetricsStore is store
+type SMCMetricsStore struct {
+	constLabels        prometheus.Labels
+	updateLatency      prometheus.Gauge
+	k8sAPIEventCounter prometheus.Counter
+
+	registry *prometheus.Registry
+}
+
+// NewMetricStore returns a new metric store
+func NewMetricStore(nameSpace string, podName string) MetricStore {
+	constLabels := prometheus.Labels{
+		"smc_namespace": nameSpace,
+		"smc_pod":       podName,
+		"smc_version":   fmt.Sprintf("%s/%s/%s", version.Version, version.GitCommit, version.BuildDate),
+	}
+	return &SMCMetricsStore{
+		constLabels: constLabels,
+		updateLatency: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace:   PrometheusNamespace,
+			ConstLabels: constLabels,
+			Name:        "update_latency_seconds",
+			Help:        "The time spent in updating Envoy proxies",
+		}),
+		k8sAPIEventCounter: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace:   PrometheusNamespace,
+			ConstLabels: constLabels,
+			Name:        "k8s_api_event_counter",
+			Help:        "This counter represents the number of events received from Kubernetes API Server",
+		}),
+		registry: prometheus.NewRegistry(),
+	}
+}
+
+// Start store
+func (ms *SMCMetricsStore) Start() {
+	ms.registry.MustRegister(ms.updateLatency)
+	ms.registry.MustRegister(ms.k8sAPIEventCounter)
+}
+
+// Stop store
+func (ms *SMCMetricsStore) Stop() {
+	ms.registry.Unregister(ms.updateLatency)
+	ms.registry.Unregister(ms.k8sAPIEventCounter)
+}
+
+// SetUpdateLatencySec updates latency
+func (ms *SMCMetricsStore) SetUpdateLatencySec(duration time.Duration) {
+	ms.updateLatency.Set(duration.Seconds())
+}
+
+// IncK8sAPIEventCounter increases the counter after recieving a k8s Event
+func (ms *SMCMetricsStore) IncK8sAPIEventCounter() {
+	ms.k8sAPIEventCounter.Inc()
+}
+
+// Handler return the registry
+func (ms *SMCMetricsStore) Handler() http.Handler {
+	return promhttp.InstrumentMetricHandler(
+		ms.registry,
+		promhttp.HandlerFor(ms.registry, promhttp.HandlerOpts{}),
+	)
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+import (
+	"fmt"
+	"os"
+)
+
+// BuildDate is the date when the binary was built
+var BuildDate string
+
+// GitCommit is the commit hash when the binary was built
+var GitCommit string
+
+// Version is the version of the compiled software
+var Version string
+
+// PrintVersionAndExit prints the version and exits
+func PrintVersionAndExit() {
+	fmt.Printf("Version: %s; Commit: %s; Date: %s\n", Version, GitCommit, BuildDate)
+	os.Exit(0)
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+ORG_PATH="github.com/deislabs"
+PROJECT_NAME="smc"
+REPO_PATH="${ORG_PATH}/${PROJECT_NAME}"
+
+VERSION_VAR="${REPO_PATH}/pkg/version.Version"
+VERSION=$(git describe --abbrev=0 --tags)
+
+DATE_VAR="${REPO_PATH}/pkg/version.BuildDate"
+BUILD_DATE=$(date +%Y-%m-%d-%H:%MT%z)
+
+COMMIT_VAR="${REPO_PATH}/pkg/version.GitCommit"
+GIT_HASH=$(git rev-parse --short HEAD)
+
+GOOS=linux GOBIN="$(pwd)/bin" go install -ldflags "-s -X ${VERSION_VAR}=${VERSION} -X ${DATE_VAR}=${BUILD_DATE} -X ${COMMIT_VAR}=${GIT_HASH}" -v ./cmd/ads
+


### PR DESCRIPTION
This PR introduces

  - a packages called `metricsstore` -- this is a stub of a package, which will keep track of internal SMC metrics and report to prometheus
  - `health` package, which introduces an interface and a way for xDS to report health and readiness
  - `httpserver` package, which is the web server w/ the endpoints for the metrics and liveness/readiness probes
 - took the opportunity to add the `version` package, which is a way to embed a version / git hash data into the binary

Credit: I'm re-using code we wrote already for [AGIC](https://github.com/Azure/application-gateway-kubernetes-ingress)

TODO: these are still stubs and will need more thought on what makes sense to be the actual liveness / readiness and metrics

Fixes #98