### PR TITLE
ads: Simplify xds response handlers

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -12,7 +12,7 @@ const (
 	WildcardIpAddr = "0.0.0.0"
 
 	// Listener ports configured on Envoy for handling inbound and outbound traffic
-	EnvoyInboundListenerPort   = 15003
+	EnvoyInboundListenerPort  = 15003
 	EnvoyOutboundListenerPort = 15001
 
 	HttpPort = 80

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -3,9 +3,11 @@ package ads
 import (
 	"context"
 
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 
 	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/envoy/cds"
 	"github.com/deislabs/smc/pkg/envoy/eds"
 	"github.com/deislabs/smc/pkg/envoy/lds"
@@ -20,7 +22,7 @@ const (
 
 // NewADSServer creates a new CDS server
 func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
-	return &Server{
+	s := Server{
 		catalog: meshCatalog,
 
 		cdsServer: cds.NewCDSServer(meshCatalog),
@@ -29,6 +31,14 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 		ldsServer: lds.NewLDSServer(meshCatalog),
 		sdsServer: sds.NewSDSServer(meshCatalog),
 	}
+	s.xdsHandlers = map[envoy.TypeURI]func(envoy.Proxyer) (*envoy_api_v2.DiscoveryResponse, error){
+		envoy.TypeEDS: s.edsServer.NewEndpointDiscoveryResponse,
+		envoy.TypeCDS: s.cdsServer.NewClusterDiscoveryResponse,
+		envoy.TypeRDS: s.rdsServer.NewRouteDiscoveryResponse,
+		envoy.TypeLDS: s.ldsServer.NewListenerDiscoveryResponse,
+		envoy.TypeSDS: s.sdsServer.NewSecretDiscoveryResponse,
+	}
+	return &s
 }
 
 // DeltaAggregatedResources implements xds.AggregatedDiscoveryServiceServer

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -1,7 +1,10 @@
 package ads
 
 import (
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+
 	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/envoy/cds"
 	"github.com/deislabs/smc/pkg/envoy/eds"
 	"github.com/deislabs/smc/pkg/envoy/lds"
@@ -20,4 +23,6 @@ type Server struct {
 	ldsServer *lds.Server
 	sdsServer *sds.Server
 	cdsServer *cds.Server
+
+	xdsHandlers map[envoy.TypeURI]func(envoy.Proxyer) (*envoy_api_v2.DiscoveryResponse, error)
 }

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -28,7 +28,7 @@ func svcLocal(clusterName string, _ string) func() *xds.Cluster {
 func (s *Server) NewClusterDiscoveryResponse(proxy envoy.Proxyer) (*xds.DiscoveryResponse, error) {
 	glog.Infof("[%s] Composing Cluster Discovery Response for proxy: %s", serverName, proxy.GetCommonName())
 	resp := &xds.DiscoveryResponse{
-		TypeUrl: envoy.TypeCDS,
+		TypeUrl: string(envoy.TypeCDS),
 	}
 
 	clusterFactories := []func() *xds.Cluster{

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -22,7 +22,7 @@ const (
 func (s *Server) NewListenerDiscoveryResponse(proxy envoy.Proxyer) (*xds.DiscoveryResponse, error) {
 	glog.Infof("[%s] Composing listener Discovery Response for proxy: %s", serverName, proxy.GetCommonName())
 	resp := &xds.DiscoveryResponse{
-		TypeUrl: envoy.TypeLDS,
+		TypeUrl: string(envoy.TypeLDS),
 	}
 
 	clientConnManager, err := ptypes.MarshalAny(getRdsHTTPClientConnectionFilter())

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/ptypes"
 
-	"github.com/deislabs/smc/pkg/endpoint"
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/envoy/route"
 	"github.com/deislabs/smc/pkg/log/level"
@@ -18,9 +17,16 @@ const (
 	serverName = "RDS"
 )
 
-func (s *Server) NewRouteDiscoveryResponse(allTrafficPolicies []endpoint.TrafficTargetPolicies) (*v2.DiscoveryResponse, error) {
+func (s *Server) NewRouteDiscoveryResponse(proxy envoy.Proxyer) (*v2.DiscoveryResponse, error) {
+	allTrafficPolicies, err := s.catalog.ListTrafficRoutes("TBD")
+	if err != nil {
+		glog.Errorf("[%s][stream] Failed listing routes: %+v", serverName, err)
+		return nil, err
+	}
+	glog.Infof("[%s][stream] trafficPolicies: %+v", serverName, allTrafficPolicies)
+
 	resp := &v2.DiscoveryResponse{
-		TypeUrl: envoy.TypeRDS,
+		TypeUrl: string(envoy.TypeRDS),
 	}
 
 	for _, trafficPolicies := range allTrafficPolicies {

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -27,7 +27,7 @@ func (s *Server) NewSecretDiscoveryResponse(proxy envoy.Proxyer) (*v2.DiscoveryR
 	}
 
 	resp := &v2.DiscoveryResponse{
-		TypeUrl: envoy.TypeSDS,
+		TypeUrl: string(envoy.TypeSDS),
 	}
 
 	services := []string{

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -7,13 +7,14 @@ import (
 	"github.com/deislabs/smc/pkg/endpoint"
 )
 
+type TypeURI string
+
 const (
-	baseURI = "type.googleapis.com/envoy.api.v2."
-	TypeCDS = baseURI + "Cluster"
-	TypeLDS = baseURI + "Listener"
-	TypeRDS = baseURI + "RouteConfiguration"
-	TypeSDS = baseURI + "auth.Secret"
-	TypeEDS = baseURI + "ClusterLoadAssignment"
+	TypeSDS TypeURI = "type.googleapis.com/envoy.api.v2.auth.Secret"
+	TypeCDS TypeURI = "type.googleapis.com/envoy.api.v2.Cluster"
+	TypeLDS TypeURI = "type.googleapis.com/envoy.api.v2.Listener"
+	TypeRDS TypeURI = "type.googleapis.com/envoy.api.v2.RouteConfiguration"
+	TypeEDS TypeURI = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
 )
 
 type ProxyID string


### PR DESCRIPTION
This PR simplifies the *DS handlers by unifying their signatures.

Removed the `switch request.TypeUrl {` statement  --  now using a map lookup.