### PR TITLE
ads: Use AggregatedConfigSource where ConfigSource is needed

### DIFF
--- a/pkg/envoy/consts.go
+++ b/pkg/envoy/consts.go
@@ -1,6 +1,0 @@
-package envoy
-
-const (
-	TransportSocketTLS = "envoy.transport_sockets.tls"
-	CertificateName    = "server_cert"
-)

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -22,7 +22,7 @@ func getRdsHTTPClientConnectionFilter() *envoy_hcm.HttpConnectionManager {
 		}},
 		RouteSpecifier: &envoy_hcm.HttpConnectionManager_Rds{
 			Rds: &envoy_hcm.Rds{
-				ConfigSource:    envoy.GetGRPCSource(envoy.XDSClusterName),
+				ConfigSource:    envoy.GetADSConfigSource(),
 				RouteConfigName: route.SourceRouteConfig,
 			},
 		},
@@ -40,7 +40,7 @@ func getRdsHTTPServerConnectionFilter() *envoy_hcm.HttpConnectionManager {
 		}},
 		RouteSpecifier: &envoy_hcm.HttpConnectionManager_Rds{
 			Rds: &envoy_hcm.Rds{
-				ConfigSource:    envoy.GetGRPCSource(envoy.XDSClusterName),
+				ConfigSource:    envoy.GetADSConfigSource(),
 				RouteConfigName: route.DestinationRouteConfig,
 			},
 		},

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -8,4 +8,13 @@ const (
 	TypeLDS TypeURI = "type.googleapis.com/envoy.api.v2.Listener"
 	TypeRDS TypeURI = "type.googleapis.com/envoy.api.v2.RouteConfiguration"
 	TypeEDS TypeURI = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
+
+	TransportSocketTLS = "envoy.transport_sockets.tls"
+	CertificateName    = "server_cert"
+
+	accessLogPath = "/dev/stdout"
+
+	// cipher suites
+	aes    = "ECDHE-ECDSA-AES128-GCM-SHA256"
+	chacha = "ECDHE-ECDSA-CHACHA20-POLY1305"
 )


### PR DESCRIPTION
This PR removes the last remaining references in Go code to the *DS components and uses the ADS server.

![image](https://user-images.githubusercontent.com/49918230/74881529-59def980-5322-11ea-802d-afaad08b30a3.png)
