### PR TITLE
log: Remove [stream] tag from log messages

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -26,7 +26,7 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 
 	// TODO(draychev): check for envoy.ErrTooManyConnections
 
-	glog.Infof("[%s][stream] Client connected: Subject CN=%s", serverName, cn)
+	glog.Infof("[%s] Client connected: Subject CN=%s", serverName, cn)
 
 	// Register the newly connected proxy w/ the catalog.
 	ip := utils.GetIPFromContext(server.Context())
@@ -62,15 +62,15 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 			}
 			resp, err := s.newAggregatedDiscoveryResponse(proxy, &discoveryRequest)
 			if err != nil {
-				glog.Errorf("[%s][stream] Failed composing a DiscoveryResponse: %+v", serverName, err)
+				glog.Errorf("[%s] Failed composing a DiscoveryResponse: %+v", serverName, err)
 				return err
 			}
 			if err := server.Send(resp); err != nil {
-				glog.Errorf("[%s][stream] Error sending DiscoveryResponse: %+v", serverName, err)
+				glog.Errorf("[%s] Error sending DiscoveryResponse: %+v", serverName, err)
 			}
 
 		case <-proxy.GetAnnouncementsChannel():
-			glog.V(level.Info).Infof("[%s][stream] Change detected - update all Envoys.", serverName)
+			glog.V(level.Info).Infof("[%s] Change detected - update all Envoys.", serverName)
 			s.sendAllResponses(proxy, &server)
 		}
 	}
@@ -87,14 +87,14 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *discovery.Aggregat
 			continue
 		}
 		if err := (*server).Send(discoveryResponse); err != nil {
-			glog.Errorf("[%s][stream] Error sending DiscoveryResponse %s: %+v", serverName, uri, err)
+			glog.Errorf("[%s] Error sending DiscoveryResponse %s: %+v", serverName, uri, err)
 		}
 
 	}
 }
 
 func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *v2.DiscoveryRequest) (*v2.DiscoveryResponse, error) {
-	glog.V(level.Info).Infof("[%s][stream] Received discovery request: %s", serverName, request.TypeUrl)
+	glog.V(level.Info).Infof("[%s] Received discovery request: %s", serverName, request.TypeUrl)
 	handler, ok := s.xdsHandlers[envoy.TypeURI(request.TypeUrl)]
 	if !ok {
 		glog.Errorf("Responder for TypeUrl %s is not implemented", request.TypeUrl)

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -24,10 +24,10 @@ func svcLocal(clusterName string, _ string) *xds.Cluster {
 func (s *Server) NewClusterDiscoveryResponse(proxy *envoy.Proxy) (*xds.DiscoveryResponse, error) {
 	allServices, err := s.catalog.ListEndpoints("TBD")
 	if err != nil {
-		glog.Errorf("[%s][stream] Failed listing endpoints: %+v", serverName, err)
+		glog.Errorf("[%s] Failed listing endpoints: %+v", serverName, err)
 		return nil, err
 	}
-	glog.Infof("[%s][stream] WeightedServices: %+v", serverName, allServices)
+	glog.Infof("[%s] WeightedServices: %+v", serverName, allServices)
 	resp := &xds.DiscoveryResponse{
 		TypeUrl: string(envoy.TypeCDS),
 	}

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -20,10 +20,10 @@ const (
 func (s *Server) NewEndpointDiscoveryResponse(proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {
 	allServices, err := s.catalog.ListEndpoints("TBD")
 	if err != nil {
-		glog.Errorf("[%s][stream] Failed listing endpoints: %+v", serverName, err)
+		glog.Errorf("[%s] Failed listing endpoints: %+v", serverName, err)
 		return nil, err
 	}
-	glog.Infof("[%s][stream] WeightedServices: %+v", serverName, allServices)
+	glog.Infof("[%s] WeightedServices: %+v", serverName, allServices)
 	var protos []*any.Any
 	for targetServiceName, weightedServices := range allServices {
 		loadAssignment := cla.NewClusterLoadAssignment(targetServiceName, weightedServices)

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -20,10 +20,10 @@ const (
 func (s *Server) NewRouteDiscoveryResponse(proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {
 	allTrafficPolicies, err := s.catalog.ListTrafficRoutes("TBD")
 	if err != nil {
-		glog.Errorf("[%s][stream] Failed listing routes: %+v", serverName, err)
+		glog.Errorf("[%s] Failed listing routes: %+v", serverName, err)
 		return nil, err
 	}
-	glog.Infof("[%s][stream] trafficPolicies: %+v", serverName, allTrafficPolicies)
+	glog.Infof("[%s] trafficPolicies: %+v", serverName, allTrafficPolicies)
 
 	resp := &v2.DiscoveryResponse{
 		TypeUrl: string(envoy.TypeRDS),


### PR DESCRIPTION
Streaming is the only option (we don't use REST) - so no need to tag the log lines.