### PR TITLE
ads: No need for KUBECONFIG when in cluster

### DIFF
--- a/demo/deploy-xds.sh
+++ b/demo/deploy-xds.sh
@@ -58,8 +58,10 @@ spec:
 
       command: [ "/$NAME"]
       args:
-        - "--kubeconfig"
-        - "/kube/config"
+        - "--azureAuthFile"
+        - "/azure/azureAuth.json"
+        - "--subscriptionID"
+        - "$AZURE_SUBSCRIPTION"
         - "--verbosity"
         - "17"
         - "--namespace"


### PR DESCRIPTION
This is introducing what @michelleN did w/ *DS - removes the need for KUBECONFIG when SMC is running in a k8s cluster.

Also adding azureAuth so we can fetch VM IPs for the demo.


![image](https://user-images.githubusercontent.com/49918230/74885952-b8f53c00-532b-11ea-8530-8e2eeb0afb63.png)
