### PR TITLE
tests: Cleanup tests

### DIFF
--- a/pkg/envoy/cla/cluster_load_assignment_test.go
+++ b/pkg/envoy/cla/cluster_load_assignment_test.go
@@ -9,31 +9,29 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Cluster Load Assignment", func() {
-	Describe("Testing Cluster Load Assignment", func() {
-		Context("Testing NewClusterLoadAssignemnt", func() {
-			It("Returns cluster load assignment", func() {
-				weightedServices := []endpoint.WeightedService{}
-				weightedServices = append(weightedServices, endpoint.WeightedService{
-					ServiceName: endpoint.ServiceName("bookstore-1"),
-					Weight:      50,
-					Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: net.IP("0.0.0.0")}},
-				})
-				weightedServices = append(weightedServices, endpoint.WeightedService{
-					ServiceName: endpoint.ServiceName("bookstore-2"),
-					Weight:      50,
-					Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: net.IP("0.0.0.1")}, endpoint.Endpoint{IP: net.IP("0.0.0.2")}},
-				})
-
-				cla := NewClusterLoadAssignment("bookstore", weightedServices)
-				Expect(cla).NotTo(Equal(nil))
-				Expect(cla.ClusterName).To(Equal("bookstore"))
-				Expect(len(cla.Endpoints)).To(Equal(1))
-				Expect(len(cla.Endpoints[0].LbEndpoints)).To(Equal(3))
-				Expect(cla.Endpoints[0].LbEndpoints[0].GetLoadBalancingWeight().Value).To(Equal(uint32(50)))
-				Expect(cla.Endpoints[0].LbEndpoints[1].GetLoadBalancingWeight().Value).To(Equal(uint32(25)))
-				Expect(cla.Endpoints[0].LbEndpoints[2].GetLoadBalancingWeight().Value).To(Equal(uint32(25)))
+var _ = Describe("Testing Cluster Load Assignment", func() {
+	Context("Testing NewClusterLoadAssignemnt", func() {
+		It("Returns cluster load assignment", func() {
+			weightedServices := []endpoint.WeightedService{}
+			weightedServices = append(weightedServices, endpoint.WeightedService{
+				ServiceName: endpoint.ServiceName("bookstore-1"),
+				Weight:      50,
+				Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: net.IP("0.0.0.0")}},
 			})
+			weightedServices = append(weightedServices, endpoint.WeightedService{
+				ServiceName: endpoint.ServiceName("bookstore-2"),
+				Weight:      50,
+				Endpoints:   []endpoint.Endpoint{endpoint.Endpoint{IP: net.IP("0.0.0.1")}, endpoint.Endpoint{IP: net.IP("0.0.0.2")}},
+			})
+
+			cla := NewClusterLoadAssignment("bookstore", weightedServices)
+			Expect(cla).NotTo(Equal(nil))
+			Expect(cla.ClusterName).To(Equal("bookstore"))
+			Expect(len(cla.Endpoints)).To(Equal(1))
+			Expect(len(cla.Endpoints[0].LbEndpoints)).To(Equal(3))
+			Expect(cla.Endpoints[0].LbEndpoints[0].GetLoadBalancingWeight().Value).To(Equal(uint32(50)))
+			Expect(cla.Endpoints[0].LbEndpoints[1].GetLoadBalancingWeight().Value).To(Equal(uint32(25)))
+			Expect(cla.Endpoints[0].LbEndpoints[2].GetLoadBalancingWeight().Value).To(Equal(uint32(25)))
 		})
 	})
 })

--- a/pkg/providers/azure/provider_test.go
+++ b/pkg/providers/azure/provider_test.go
@@ -9,49 +9,45 @@ import (
 	v12 "github.com/deislabs/smc/pkg/apis/azureresource/v1"
 )
 
-var _ = Describe("Azure Compute Provider", func() {
-	Describe("Testing Azure Compute Provider", func() {
-		Context("Testing parseAzureID", func() {
-			uri := azureID("/subscriptions/e3f0/resourceGroups/meshSpec-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz")
-			It("returns default value in absence of an env var", func() {
-				rg, kind, name, err := parseAzureID(uri)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(rg).To(Equal(resourceGroup("meshSpec-rg")))
-				Expect(kind).To(Equal(computeKind("Microsoft.Compute/virtualMachineScaleSets")))
-				Expect(name).To(Equal(computeName(("baz"))))
-			})
+var _ = Describe("Testing Azure Compute Provider", func() {
+	Context("Testing parseAzureID", func() {
+		uri := azureID("/subscriptions/e3f0/resourceGroups/meshSpec-rg/providers/Microsoft.Compute/virtualMachineScaleSets/baz")
+		It("returns default value in absence of an env var", func() {
+			rg, kind, name, err := parseAzureID(uri)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(rg).To(Equal(resourceGroup("meshSpec-rg")))
+			Expect(kind).To(Equal(computeKind("Microsoft.Compute/virtualMachineScaleSets")))
+			Expect(name).To(Equal(computeName(("baz"))))
 		})
 	})
 })
 
-var _ = Describe("Azure Compute Provider", func() {
-	Describe("Testing Azure Compute Provider", func() {
-		Context("Testing parseAzureID", func() {
-			It("returns default value in absence of an env var", func() {
-				svc := corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"k": "v",
-							"a": "b",
-						},
+var _ = Describe("Testing Azure Compute Provider", func() {
+	Context("Testing parseAzureID", func() {
+		It("returns default value in absence of an env var", func() {
+			svc := corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"k": "v",
+						"a": "b",
 					},
-				}
-				azureResources := []*v12.AzureResource{{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							"k": "v",
-							"a": "b",
-							"x": "y",
-						},
+				},
+			}
+			azureResources := []*v12.AzureResource{{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"k": "v",
+						"a": "b",
+						"x": "y",
 					},
-					Spec: v12.AzureResourceSpec{
-						ResourceID: "/one/two/three",
-					},
-				}}
-				azID := matchServiceAzureResource(&svc, azureResources)
-				expectedAzureID := []azureID{"/one/two/three"}
-				Expect(azID).To(Equal(expectedAzureID))
-			})
+				},
+				Spec: v12.AzureResourceSpec{
+					ResourceID: "/one/two/three",
+				},
+			}}
+			azID := matchServiceAzureResource(&svc, azureResources)
+			expectedAzureID := []azureID{"/one/two/three"}
+			Expect(azID).To(Equal(expectedAzureID))
 		})
 	})
 })

--- a/pkg/providers/azure/suite_test.go
+++ b/pkg/providers/azure/suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Environment Suite")
+	RunSpecs(t, "Azure Endpoints Provider Suite")
 }

--- a/pkg/utils/json_test.go
+++ b/pkg/utils/json_test.go
@@ -5,17 +5,15 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Utils", func() {
-	Describe("Testing utils helpers", func() {
-		Context("Test PrettyJSON", func() {
-			It("should return pretty JSON and no error", func() {
-				prettyJSON, err := PrettyJSON([]byte("{\"name\":\"baba yaga\"}"), "--prefix--")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(prettyJSON).To(Equal([]byte(`{
+var _ = Describe("Testing utils helpers", func() {
+	Context("Test PrettyJSON", func() {
+		It("should return pretty JSON and no error", func() {
+			prettyJSON, err := PrettyJSON([]byte("{\"name\":\"baba yaga\"}"), "--prefix--")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prettyJSON).To(Equal([]byte(`{
 --prefix--    "name": "baba yaga"
 --prefix--}`)))
-			})
 		})
-
 	})
+
 })

--- a/pkg/utils/strings_test.go
+++ b/pkg/utils/strings_test.go
@@ -5,16 +5,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Utils", func() {
-	Describe("Testing utils helpers", func() {
-		Context("Test GetLastNOfDotted", func() {
-			It("Should return the last slice of a string split on a slash.", func() {
-				Expect(GetLastNOfDotted("a.b.c", 2)).To(Equal("b.c"))
-			})
+var _ = Describe("Testing utils helpers", func() {
+	Context("Test GetLastNOfDotted", func() {
+		It("Should return the last slice of a string split on a slash.", func() {
+			Expect(GetLastNOfDotted("a.b.c", 2)).To(Equal("b.c"))
+		})
 
-			It("Should return the full string when there are no slashes.", func() {
-				Expect(GetLastChunkOfSlashed("abc")).To(Equal("abc"))
-			})
+		It("Should return the full string when there are no slashes.", func() {
+			Expect(GetLastChunkOfSlashed("abc")).To(Equal("abc"))
 		})
 	})
 })

--- a/pkg/utils/suite_test.go
+++ b/pkg/utils/suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Environment Suite")
+	RunSpecs(t, "Utils Test Suite")
 }

--- a/pkg/utils/uri_test.go
+++ b/pkg/utils/uri_test.go
@@ -5,16 +5,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Utils", func() {
-	Describe("Testing utils helpers", func() {
-		Context("Test GetLastChunkOfSlashed", func() {
-			It("Should return the last slice of a string split on a slash.", func() {
-				Expect(GetLastChunkOfSlashed("a/b/c")).To(Equal("c"))
-			})
+var _ = Describe("Testing utils helpers", func() {
+	Context("Test GetLastChunkOfSlashed", func() {
+		It("Should return the last slice of a string split on a slash.", func() {
+			Expect(GetLastChunkOfSlashed("a/b/c")).To(Equal("c"))
+		})
 
-			It("Should return the full string when there are no slashes.", func() {
-				Expect(GetLastChunkOfSlashed("abc")).To(Equal("abc"))
-			})
+		It("Should return the full string when there are no slashes.", func() {
+			Expect(GetLastChunkOfSlashed("abc")).To(Equal("abc"))
 		})
 	})
 })


### PR DESCRIPTION
Cosmetic fixes to our minimal tests:

  - removing the double `Describe` wrapping
  - renaming the `RunSpecs`


No functional code changes!