### PR TITLE
demo: Bookbuyer to wait up to N seconds for a 200 OK

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -3,38 +3,60 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const (
+	waitForEnvVar = "WAIT_FOR_OK_SECONDS"
+
 	counter = "http://bookstore.mesh/counter"
 	incremt = "http://bookstore.mesh/incrementcounter"
 )
 
 func main() {
+	waitForOK := getWaitForOK()
+	started := time.Now()
+	finishBy := started.Add(time.Duration(waitForOK) * time.Second)
 	iteration := 0
 	for {
-		iteration += 1
+		iteration++
 		fmt.Printf("---[ %d ]-----------------------------------------\n", iteration)
+		var responses []int
 		for _, url := range []string{counter, incremt} {
-			fetch(url)
+			response := fetch(url)
+			fmt.Println("")
+			responses = append(responses, response)
 		}
-		fmt.Println("")
+		if waitForOK != 0 {
+			if responses[0] == 200 {
+				fmt.Printf("Success")
+				os.Exit(0)
+			} else if time.Now().After(finishBy) {
+				fmt.Printf("It has been %v since we started the test. Response code from %s is %d. This test has failed.",
+					time.Now().Sub(started), counter, responses[0])
+				os.Exit(1)
+			}
+		}
+		fmt.Print("\n\n")
 		time.Sleep(3 * time.Second)
 	}
 }
 
-func fetch(url string) {
+func fetch(url string) (responseCode int) {
 	fmt.Printf("Fetching %s\n", url)
 	if resp, err := http.Get(url); err != nil {
 		fmt.Printf("Error fetching %s: %s\n", url, err)
 	} else {
+		responseCode = resp.StatusCode
 		for _, hdr := range []string{"Identity", "Counter", "Server", "Date"} {
 			fmt.Printf("%s: %s\n", hdr, getHeader(resp.Header, hdr))
 		}
-		fmt.Printf("Status: %d %s\n", resp.StatusCode, resp.Status)
+		fmt.Printf("Status: %s\n", resp.Status)
 	}
+	return responseCode
 }
 
 func getHeader(headers map[string][]string, header string) string {
@@ -43,4 +65,13 @@ func getHeader(headers map[string][]string, header string) string {
 		val = []string{"n/a"}
 	}
 	return strings.Join(val, ", ")
+}
+
+func getWaitForOK() int64 {
+	waitForOKString := os.Getenv(waitForEnvVar)
+	waitForOK, err := strconv.ParseInt(waitForOKString, 10, 64)
+	if err != nil {
+		waitForOK = 0
+	}
+	return waitForOK
 }


### PR DESCRIPTION
This PR augments the bookbuyer with environment variable `WAIT_FOR_OK_SECONDS`, which, when present:

  - will indicate to the `bookbuyer` that a `200 OK` within the `WAIT_FOR_OK_SECONDS` is a reason to exit 0

  - and on the other hand not getting `200 OK` by the `WAIT_FOR_OK_SECONDS` threshold is a reason to exit 1

This is going to be used in the integration test here:  https://github.com/deislabs/smc/pull/135

### Examples
```bash

$ WAIT_FOR_OK_SECONDS="2" ./demo/bin/bookbuyer; echo $?
---[ 1 ]-----------------------------------------
Fetching http://bookstore.mesh/counter
Error fetching http://bookstore.mesh/counter: Get http://bookstore.mesh/counter: dial tcp: lookup bookstore.mesh on 10.50.10.50:53: no such host

Fetching http://bookstore.mesh/incrementcounter
Error fetching http://bookstore.mesh/incrementcounter: Get http://bookstore.mesh/incrementcounter: dial tcp: lookup bookstore.mesh on 10.50.10.50:53: no such host


---[ 2 ]-----------------------------------------
Fetching http://bookstore.mesh/counter
Error fetching http://bookstore.mesh/counter: Get http://bookstore.mesh/counter: dial tcp: lookup bookstore.mesh on 10.50.10.50:53: no such host

Fetching http://bookstore.mesh/incrementcounter
Error fetching http://bookstore.mesh/incrementcounter: Get http://bookstore.mesh/incrementcounter: dial tcp: lookup bookstore.mesh on 10.50.10.50:53: no such host

It has been 3.1735574s since we started the test. Response for http://bookstore.mesh/counter is 0. This test has failed.1

```