### PR TITLE
xds: Streamline all discovery services: same fn signatures

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -4,11 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/deislabs/smc/pkg/constants"
-	"github.com/deislabs/smc/pkg/endpoint"
-	"github.com/deislabs/smc/pkg/providers/azure"
-	"github.com/deislabs/smc/pkg/providers/kube"
-	"k8s.io/client-go/rest"
 	"os"
 	"os/signal"
 	"strings"
@@ -18,14 +13,19 @@ import (
 	xds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/constants"
+	"github.com/deislabs/smc/pkg/endpoint"
 	"github.com/deislabs/smc/pkg/envoy/ads"
 	"github.com/deislabs/smc/pkg/httpserver"
 	"github.com/deislabs/smc/pkg/log/level"
 	"github.com/deislabs/smc/pkg/metricsstore"
+	"github.com/deislabs/smc/pkg/providers/azure"
 	azureResource "github.com/deislabs/smc/pkg/providers/azure/kubernetes"
+	"github.com/deislabs/smc/pkg/providers/kube"
 	"github.com/deislabs/smc/pkg/smi"
 	"github.com/deislabs/smc/pkg/tresor"
 	"github.com/deislabs/smc/pkg/utils"
@@ -47,8 +47,8 @@ var (
 	verbosity      = flags.Int("verbosity", int(level.Info), "Set log verbosity level")
 	port           = flags.Int("port", 15128, "Clusters Discovery Service port number.")
 	namespace      = flags.String("namespace", "default", "Kubernetes namespace to watch for SMI Spec.")
-	certPem        = flags.String("certpem", "", fmt.Sprintf("Full path to the %s Certificate PEM file", serverType))
-	keyPem         = flags.String("keypem", "", fmt.Sprintf("Full path to the %s Key PEM file", serverType))
+	certPem        = flags.String("certpem", "", "Full path to the xDS Certificate PEM file")
+	keyPem         = flags.String("keypem", "", "Full path to the xDS Key PEM file")
 	rootCertPem    = flags.String("rootcertpem", "", "Full path to the Root Certificate PEM file")
 )
 
@@ -140,6 +140,6 @@ func getNamespaces() []string {
 	} else {
 		namespaces = []string{*namespace}
 	}
-	glog.Infof("[%s] Observing namespaces: %s", serverType, strings.Join(namespaces, ","))
+	glog.Infof("Observing namespaces: %s", strings.Join(namespaces, ","))
 	return namespaces
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -1,9 +1,5 @@
 package ads
 
-
-
-
-
 import (
 	"fmt"
 	"time"

--- a/pkg/envoy/cds/server.go
+++ b/pkg/envoy/cds/server.go
@@ -7,13 +7,11 @@ import (
 	"github.com/deislabs/smc/pkg/smi"
 )
 
-const (
-	serverName = "CDS"
-)
-
 // NewCDSServer creates a new CDS server
 func NewCDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
 	return &Server{
-		catalog: catalog,
+		ctx:      ctx,
+		catalog:  catalog,
+		meshSpec: meshSpec,
 	}
 }

--- a/pkg/envoy/cds/types.go
+++ b/pkg/envoy/cds/types.go
@@ -1,10 +1,18 @@
 package cds
 
 import (
+	"context"
 	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/smi"
+)
+
+const (
+	serverName = "CDS"
 )
 
 //Server implements the Envoy xDS Cluster Discovery Services
 type Server struct {
-	catalog catalog.MeshCataloger
+	ctx      context.Context
+	catalog  catalog.MeshCataloger
+	meshSpec smi.MeshSpec
 }

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -10,10 +10,6 @@ import (
 	"github.com/deislabs/smc/pkg/envoy/cla"
 )
 
-const (
-	serverName = "EDS"
-)
-
 // NewDiscoveryResponse creates a new Endpoint Discovery Response.
 func (s *Server) NewDiscoveryResponse(proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {
 	allServices, err := s.catalog.ListEndpoints("TBD")

--- a/pkg/envoy/eds/types.go
+++ b/pkg/envoy/eds/types.go
@@ -7,6 +7,10 @@ import (
 	"github.com/deislabs/smc/pkg/smi"
 )
 
+const (
+	serverName = "EDS"
+)
+
 // Server implements the Envoy xDS Endpoint Discovery Services
 type Server struct {
 	ctx      context.Context

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -11,10 +11,6 @@ import (
 	"github.com/deislabs/smc/pkg/envoy"
 )
 
-const (
-	serverName = "LDS"
-)
-
 // NewDiscoveryResponse creates a new Listener Discovery Response.
 func (s *Server) NewDiscoveryResponse(proxy *envoy.Proxy) (*xds.DiscoveryResponse, error) {
 	glog.Infof("[%s] Composing listener Discovery Response for proxy: %s", serverName, proxy.GetCommonName())
@@ -46,7 +42,7 @@ func (s *Server) NewDiscoveryResponse(proxy *envoy.Proxy) (*xds.DiscoveryRespons
 
 	serverConnManager, err := ptypes.MarshalAny(getRdsHTTPServerConnectionFilter())
 	if err != nil {
-		glog.Error("[LDS] Could not construct inbound listener FilterChain: ", err)
+		glog.Errorf("[%s] Could not construct inbound listener FilterChain: %s", serverName, err)
 		return nil, err
 	}
 

--- a/pkg/envoy/lds/server.go
+++ b/pkg/envoy/lds/server.go
@@ -10,8 +10,8 @@ import (
 // NewLDSServer creates a new LDS server
 func NewLDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
 	return &Server{
-		connectionNum: 0,
-		catalog:       catalog,
-		closing:       make(chan bool),
+		ctx:      ctx,
+		catalog:  catalog,
+		meshSpec: meshSpec,
 	}
 }

--- a/pkg/envoy/lds/types.go
+++ b/pkg/envoy/lds/types.go
@@ -1,10 +1,18 @@
 package lds
 
-import "github.com/deislabs/smc/pkg/catalog"
+import (
+	"context"
+	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/smi"
+)
+
+const (
+	serverName = "LDS"
+)
 
 // Server is the ClusterDiscoveryService server struct
 type Server struct {
-	connectionNum int
-	catalog       catalog.MeshCataloger
-	closing       chan bool
+	ctx      context.Context
+	catalog  catalog.MeshCataloger
+	meshSpec smi.MeshSpec
 }

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -10,10 +10,6 @@ import (
 	"github.com/deislabs/smc/pkg/log/level"
 )
 
-const (
-	serverName = "RDS"
-)
-
 // NewDiscoveryResponse creates a new Route Discovery Response.
 func (s *Server) NewDiscoveryResponse(proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {
 	allTrafficPolicies, err := s.catalog.ListTrafficRoutes("TBD")

--- a/pkg/envoy/rds/server.go
+++ b/pkg/envoy/rds/server.go
@@ -3,15 +3,12 @@ package rds
 import (
 	"context"
 
-	"github.com/golang/glog"
-
 	"github.com/deislabs/smc/pkg/catalog"
 	"github.com/deislabs/smc/pkg/smi"
 )
 
 // NewRDSServer creates a new RDS server
 func NewRDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
-	glog.Info("[RDS] Create NewRDSServer")
 	return &Server{
 		ctx:      ctx,
 		catalog:  catalog,

--- a/pkg/envoy/rds/types.go
+++ b/pkg/envoy/rds/types.go
@@ -7,6 +7,10 @@ import (
 	"github.com/deislabs/smc/pkg/smi"
 )
 
+const (
+	serverName = "RDS"
+)
+
 // Server implements the Envoy xDS Endpoint Discovery Services
 type Server struct {
 	ctx      context.Context

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -10,10 +10,6 @@ import (
 	"github.com/deislabs/smc/pkg/envoy"
 )
 
-const (
-	serverName = "SDS"
-)
-
 // NewDiscoveryResponse creates a new Secrets Discovery Response.
 func (s *Server) NewDiscoveryResponse(proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {
 	glog.Infof("[%s] Composing SDS Discovery Response for proxy: %s", serverName, proxy.GetCommonName())

--- a/pkg/envoy/sds/server.go
+++ b/pkg/envoy/sds/server.go
@@ -10,8 +10,8 @@ import (
 // NewSDSServer creates a new SDS server
 func NewSDSServer(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
 	return &Server{
-		connectionNum: 0,
-		catalog:       catalog,
-		closing:       make(chan bool),
+		ctx:      ctx,
+		catalog:  catalog,
+		meshSpec: meshSpec,
 	}
 }

--- a/pkg/envoy/sds/types.go
+++ b/pkg/envoy/sds/types.go
@@ -1,12 +1,18 @@
 package sds
 
 import (
+	"context"
 	"github.com/deislabs/smc/pkg/catalog"
+	"github.com/deislabs/smc/pkg/smi"
+)
+
+const (
+	serverName = "SDS"
 )
 
 // Server is the SDS server struct
 type Server struct {
-	connectionNum int
-	catalog       catalog.MeshCataloger
-	closing       chan bool
+	ctx      context.Context
+	catalog  catalog.MeshCataloger
+	meshSpec smi.MeshSpec
 }


### PR DESCRIPTION
This PR takes one step further to unifying the instantiation of xDS -- use similar structs.  Removing unused struct members.