### PR TITLE
Pass kubeconfig to ADS

### DIFF
--- a/demo/deploy-xds.sh
+++ b/demo/deploy-xds.sh
@@ -52,6 +52,8 @@ spec:
 
       command: [ "/$NAME"]
       args:
+        - "--kubeconfig"
+        - "/kube/config"
         - "--azureAuthFile"
         - "/azure/azureAuth.json"
         - "--subscriptionID"


### PR DESCRIPTION
Without this, in cluster config is used and is failing in some
environments. Continue to use kubeconfig till the issue is root
caused and addressed.