### PR TITLE
ci: reuse run-demo.sh in CI

### DIFF
--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -10,10 +10,11 @@ rm -rf ./certs
 
 ./demo/clean-kubernetes.sh
 
+echo "Create the bootstrap.yaml file"
+./demo/create-bootstrap-yaml.sh
+
 make build-cert
-
 make docker-push-ads
-
 make docker-push-init
 make docker-push-envoyproxy
 make docker-push-bookbuyer
@@ -21,17 +22,30 @@ make docker-push-bookstore
 
 # Create the proxy certificates
 ./demo/gen-ca.sh
-./demo/create-container-registry-creds.sh
 
-kubectl create configmap kubeconfig --from-file="$HOME/.kube/config" -n "$K8S_NAMESPACE"
+if [[ "$IS_GITHUB" != "true" ]]; then
+    ./demo/create-container-registry-creds.sh
+else
+    mkdir -p "$HOME/.kube"
+    touch "$HOME/.kube/config"
+    mkdir -p "$HOME/.azure"
+    touch "$HOME/.azure/azureAuth.json"
+    # This script is specifically for CI
+    ./ci/create-container-registry-creds.sh
+fi
+
+kubectl create configmap kubeconfig  --from-file="$HOME/.kube/config"          -n "$K8S_NAMESPACE"
 kubectl create configmap azureconfig --from-file="$HOME/.azure/azureAuth.json" -n "$K8S_NAMESPACE"
+./demo/deploy-envoyproxy-config.sh
+
+
 kubectl apply -f crd/AzureResource.yaml
-kubectl apply -f demo/AzureResource.yaml
+./demo/deploy-AzureResource.sh
 
 ./demo/deploy-bookbuyer.sh
 
 ./demo/deploy-bookstore.sh bookstore
-./demo/deploy-bookstore.sh "bookstore-1"
+./demo/deploy-bookstore.sh bookstore-1
 ./demo/deploy-bookstore.sh bookstore-2
 
 ./demo/deploy-xds.sh
@@ -40,4 +54,6 @@ kubectl apply -f demo/AzureResource.yaml
 ./demo/deploy-traffic-spec.sh
 ./demo/deploy-traffic-target.sh
 
-watch -n0.5 "kubectl get pods -n${K8S_NAMESPACE} -o wide"
+if [[ "$IS_GITHUB" != "true" ]]; then
+    watch -n0.5 "kubectl get pods -n${K8S_NAMESPACE} -o wide"
+fi


### PR DESCRIPTION
It would be wonderful to use in CI the same `./demo/run-demo.sh` script we use on our workstations.


This PR is a small piece of https://github.com/deislabs/smc/pull/208 

This PR requires:
  -  https://github.com/deislabs/smc/pull/222
  -  https://github.com/deislabs/smc/pull/223

