### PR TITLE
Use correct root CA key in ADS

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -50,6 +50,7 @@ var (
 	certPem        = flags.String("certpem", "", "Full path to the xDS Certificate PEM file")
 	keyPem         = flags.String("keypem", "", "Full path to the xDS Key PEM file")
 	rootCertPem    = flags.String("rootcertpem", "", "Full path to the Root Certificate PEM file")
+	rootKeyPem     = flags.String("rootkeypem", "", "Full path to the Root Key PEM file")
 )
 
 func init() {
@@ -83,7 +84,7 @@ func main() {
 	stop := make(chan struct{})
 
 	meshSpec := smi.NewMeshSpecClient(kubeConfig, observeNamespaces, stop)
-	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *keyPem, "Acme", 1*time.Hour)
+	certManager, err := tresor.NewCertManagerWithCAFromFile(*rootCertPem, *rootKeyPem, "Acme", 1*time.Hour)
 	if err != nil {
 		glog.Fatal("Could not instantiate Certificate Manager: ", err)
 	}

--- a/demo/deploy-secrets.sh
+++ b/demo/deploy-secrets.sh
@@ -12,6 +12,7 @@ kubectl -n "$K8S_NAMESPACE" \
         delete configmap \
         "ca-certpemstore-${NAME}" \
         "ca-keypemstore-${NAME}" \
+        "ca-rootkeypemstore-${NAME}" \
         "ca-rootcertpemstore-${NAME}" || true
 
 echo -e "Generate certificates for ${NAME}"
@@ -25,5 +26,6 @@ mkdir -p "./certificates/$NAME/"
 
 echo -e "Add secrets"
 kubectl -n "$K8S_NAMESPACE" create configmap "ca-rootcertpemstore-${NAME}" --from-file="./certificates/root-cert.pem"
+kubectl -n "$K8S_NAMESPACE" create configmap "ca-rootkeypemstore-${NAME}" --from-file="./certificates/root-key.pem"
 kubectl -n "$K8S_NAMESPACE" create configmap "ca-certpemstore-${NAME}" --from-file="./certificates/$NAME/cert.pem"
 kubectl -n "$K8S_NAMESPACE" create configmap "ca-keypemstore-${NAME}" --from-file="./certificates/$NAME/key.pem"

--- a/demo/deploy-xds.sh
+++ b/demo/deploy-xds.sh
@@ -68,6 +68,8 @@ spec:
         - "/etc/ssl/certs/key.pem"
         - "--rootcertpem"
         - "/etc/ssl/certs/root-cert.pem"
+        - "--rootkeypem"
+        - "/etc/ssl/certs/root-key.pem"
 
       volumeMounts:
       - name: kubeconfig
@@ -89,6 +91,10 @@ spec:
       - name: ca-rootcertpemstore-${NAME}
         mountPath: /etc/ssl/certs/root-cert.pem
         subPath: root-cert.pem
+        readOnly: false
+      - name: ca-rootkeypemstore-${NAME}
+        mountPath: /etc/ssl/certs/root-key.pem
+        subPath: root-key.pem
         readOnly: false
 
       readinessProbe:
@@ -117,6 +123,9 @@ spec:
     - name: ca-rootcertpemstore-${NAME}
       configMap:
         name: ca-rootcertpemstore-${NAME}
+    - name: ca-rootkeypemstore-${NAME}
+      configMap:
+        name: ca-rootkeypemstore-${NAME}
     - name: ca-keypemstore-${NAME}
       configMap:
         name: ca-keypemstore-${NAME}


### PR DESCRIPTION
Previously, the ADS key was used as the root key while generating
certs. Certificate manager (tresor) needs to use the root key
along with the root cert while generating certs instead.