### PR TITLE
Use service specific certs for secrets

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -31,7 +31,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 
 	clusterFactories := []*xds.Cluster{}
 	for targetedServiceName, weightedServices := range allServices {
-		remoteService := envoy.GetServiceCluster(string(targetedServiceName), string(targetedServiceName))
+		remoteService := envoy.GetServiceCluster(string(targetedServiceName), string(proxy.GetService()))
 		clusterFactories = append(clusterFactories, remoteService)
 		for _, localservice := range weightedServices {
 			clusterFactories = append(clusterFactories, getServiceClusterLocal(string(localservice.ServiceName)))

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -64,7 +64,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 					},
 				},
 				// TODO(draychev): enable "tls_context.require_client_certificate: true"
-				TransportSocket: envoy.GetTransportSocketForServiceDownstream(envoy.CertificateName),
+				TransportSocket: envoy.GetTransportSocketForServiceDownstream(string(proxy.GetService())),
 			},
 		},
 	}

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -32,32 +32,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		TypeUrl: string(envoy.TypeSDS),
 	}
 
-	allServices, err := catalog.ListEndpoints("TBD")
-	if err != nil {
-		glog.Errorf("[%s] Failed listing endpoints: %+v", serverName, err)
-		return nil, err
-	}
-
-	for targetedServiceName, weightedServices := range allServices {
-		secret := newSecret(cert, string(targetedServiceName))
-		marshalledSecret, err := ptypes.MarshalAny(secret)
-		if err != nil {
-			glog.Errorf("[%s] Failed to marshal secret for proxy %s: %v", serverName, proxy.GetCommonName(), err)
-			return nil, err
-		}
-		resp.Resources = append(resp.Resources, marshalledSecret)
-		for _, localservice := range weightedServices {
-			secret := newSecret(cert, string(localservice.ServiceName))
-			marshalledSecret, err := ptypes.MarshalAny(secret)
-			if err != nil {
-				glog.Errorf("[%s] Failed to marshal secret for proxy %s: %v", serverName, proxy.GetCommonName(), err)
-				return nil, err
-			}
-			resp.Resources = append(resp.Resources, marshalledSecret)
-		}
-	}
-	//Add server_cert
-	serverSecret := newSecret(cert, envoy.CertificateName)
+	serverSecret := newSecret(cert, string(proxy.GetService()))
 	marshalledSecret, err := ptypes.MarshalAny(serverSecret)
 	if err != nil {
 		glog.Errorf("[%s] Failed to marshal secret for proxy %s: %v", serverName, proxy.GetCommonName(), err)

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -22,9 +22,6 @@ const (
 	// TransportSocketTLS is an Envoy string constant.
 	TransportSocketTLS = "envoy.transport_sockets.tls"
 
-	// CertificateName is a string constant for a certificate name.
-	CertificateName = "server_cert"
-
 	accessLogPath = "/dev/stdout"
 
 	// cipher suites


### PR DESCRIPTION
Only program certs on an envoy instance based on the service
its fronting. For ex. envoy-A fronting service-A should only
get the certificate created for service-A and not other
services.

Co-authored-by: Sneha Chhabria <snchh@microsoft.com>