### PR TITLE
certs: There is only one root cert and key

### DIFF
--- a/cmd/smc/config.go
+++ b/cmd/smc/config.go
@@ -135,9 +135,15 @@ func generateKubernetesConfig(name, namespace, containerRegistry, containerRegis
 									ReadOnly:  false,
 								},
 								{
-									Name:      fmt.Sprintf("ca-rootcertpemstore-%s", name),
+									Name:      "ca-rootcertpemstore",
 									MountPath: "/etc/ssl/certs/root-cert.pem",
 									SubPath:   "root-cert.pem",
+									ReadOnly:  false,
+								},
+								{
+									Name:      "ca-rootkeypemstore",
+									MountPath: "/etc/ssl/certs/root-key.pem",
+									SubPath:   "root-key.pem",
 									ReadOnly:  false,
 								},
 							},
@@ -165,11 +171,21 @@ func generateKubernetesConfig(name, namespace, containerRegistry, containerRegis
 							},
 						},
 						{
-							Name: fmt.Sprintf("ca-rootcertpemstore-%s", name),
+							Name: "ca-rootcertpemstore",
 							VolumeSource: apiv1.VolumeSource{
 								ConfigMap: &apiv1.ConfigMapVolumeSource{
 									LocalObjectReference: apiv1.LocalObjectReference{
-										Name: fmt.Sprintf("ca-rootcertpemstore-%s", name),
+										Name: "ca-rootcertpemstore",
+									},
+								},
+							},
+						},
+						{
+							Name: "ca-rootkeypemstore",
+							VolumeSource: apiv1.VolumeSource{
+								ConfigMap: &apiv1.ConfigMapVolumeSource{
+									LocalObjectReference: apiv1.LocalObjectReference{
+										Name: "ca-rootkeypemstore",
 									},
 								},
 							},

--- a/cmd/smc/install.go
+++ b/cmd/smc/install.go
@@ -105,7 +105,7 @@ func (i *installCmd) generateCerts(name string) error {
 		return err
 	}
 
-	configmap := generateCertConfig(fmt.Sprintf("ca-rootcertpemstore-%s", name), i.namespace, "root-cert.pem", i.rootcertpem)
+	configmap := generateCertConfig("ca-rootcertpemstore", i.namespace, "root-cert.pem", i.rootcertpem)
 	if _, err := i.kubeClient.CoreV1().ConfigMaps(i.namespace).Create(configmap); err != nil {
 		return err
 	}
@@ -116,6 +116,11 @@ func (i *installCmd) generateCerts(name string) error {
 	}
 
 	configmap = generateCertConfig(fmt.Sprintf("ca-keypemstore-%s", name), i.namespace, "key.pem", cert.GetPrivateKey())
+	if _, err := i.kubeClient.CoreV1().ConfigMaps(i.namespace).Create(configmap); err != nil {
+		return err
+	}
+
+	configmap = generateCertConfig("ca-rootkeypemstore", i.namespace, "root-key.pem", i.rootkeypem)
 	if _, err := i.kubeClient.CoreV1().ConfigMaps(i.namespace).Create(configmap); err != nil {
 		return err
 	}

--- a/demo/deploy-secrets.sh
+++ b/demo/deploy-secrets.sh
@@ -7,13 +7,11 @@ source .env
 
 NAME=${1:-unknown}
 
-echo -e "Delete old secrets: ca-certpemstore-${NAME}, ca-keypemstore-${NAME}, ca-rootcertpemstore-${NAME}"
+echo -e "Delete old secrets: ca-certpemstore-${NAME}, ca-keypemstore-${NAME}"
 kubectl -n "$K8S_NAMESPACE" \
         delete configmap \
         "ca-certpemstore-${NAME}" \
-        "ca-keypemstore-${NAME}" \
-        "ca-rootkeypemstore-${NAME}" \
-        "ca-rootcertpemstore-${NAME}" || true
+        "ca-keypemstore-${NAME}" || true
 
 echo -e "Generate certificates for ${NAME}"
 mkdir -p "./certificates/$NAME/"
@@ -25,7 +23,5 @@ mkdir -p "./certificates/$NAME/"
            --out "./certificates/$NAME/cert.pem"
 
 echo -e "Add secrets"
-kubectl -n "$K8S_NAMESPACE" create configmap "ca-rootcertpemstore-${NAME}" --from-file="./certificates/root-cert.pem"
-kubectl -n "$K8S_NAMESPACE" create configmap "ca-rootkeypemstore-${NAME}" --from-file="./certificates/root-key.pem"
 kubectl -n "$K8S_NAMESPACE" create configmap "ca-certpemstore-${NAME}" --from-file="./certificates/$NAME/cert.pem"
 kubectl -n "$K8S_NAMESPACE" create configmap "ca-keypemstore-${NAME}" --from-file="./certificates/$NAME/key.pem"

--- a/demo/deploy-xds.sh
+++ b/demo/deploy-xds.sh
@@ -88,11 +88,12 @@ spec:
         subPath: key.pem
         readOnly: false
 
-      - name: ca-rootcertpemstore-${NAME}
+      - name: ca-rootcertpemstore
         mountPath: /etc/ssl/certs/root-cert.pem
         subPath: root-cert.pem
         readOnly: false
-      - name: ca-rootkeypemstore-${NAME}
+
+      - name: ca-rootkeypemstore
         mountPath: /etc/ssl/certs/root-key.pem
         subPath: root-key.pem
         readOnly: false
@@ -120,12 +121,12 @@ spec:
     - name: ca-certpemstore-${NAME}
       configMap:
         name: ca-certpemstore-${NAME}
-    - name: ca-rootcertpemstore-${NAME}
+    - name: ca-rootcertpemstore
       configMap:
-        name: ca-rootcertpemstore-${NAME}
-    - name: ca-rootkeypemstore-${NAME}
+        name: ca-rootcertpemstore
+    - name: ca-rootkeypemstore
       configMap:
-        name: ca-rootkeypemstore-${NAME}
+        name: ca-rootkeypemstore
     - name: ca-keypemstore-${NAME}
       configMap:
         name: ca-keypemstore-${NAME}

--- a/demo/gen-ca.sh
+++ b/demo/gen-ca.sh
@@ -14,6 +14,9 @@ openssl req -x509 -sha256 -nodes -days 365 \
         -keyout "$KEY"  \
         -out "$CRT"
 
+kubectl -n "$K8S_NAMESPACE" create configmap "ca-rootcertpemstore" --from-file="$CRT"
+kubectl -n "$K8S_NAMESPACE" create configmap "ca-rootkeypemstore" --from-file="$KEY"
+
 exit 0
 
 ./bin/cert \


### PR DESCRIPTION
There should be only one root cert and key. We should not have many of these secrets.

This PR also moves the creation of `ca-rootkeypemstore` and `ca-rootcertpemstore` within `gen-ca.sh`

![image](https://user-images.githubusercontent.com/49918230/75501578-40bef400-5985-11ea-9c5b-a96a36f41757.png)
