### PR TITLE
Use NamespacedService* type while namespacing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -537,6 +537,7 @@ k8s.io/api v0.17.2 h1:NF1UFXcKN7/OOv1uxdRz3qfra8AHsPav5M93hlV9+Dc=
 k8s.io/apimachinery v0.0.0-20181127025237-2b1284ed4c93/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad h1:x1lITOfDEbnzt8D1cZJsPbdnx/hnv28FxY2GKkxmxgU=
 k8s.io/apimachinery v0.0.0-20190612125636-6a5db36e93ad/go.mod h1:I4A+glKBHiTgiEjQiCCQfCAIcIMFGt291SmsvcrFzJA=
+k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
 k8s.io/client-go v0.0.0-20190612125919-5c45477a8ae7 h1:LjXh7ChUmcT8ilhmqZ0ZSPQc06zsP4+pqJkKbcQ+g0k=
 k8s.io/client-go v0.0.0-20190612125919-5c45477a8ae7/go.mod h1:ElCnOBWqvEffJopQHDgJf1jrf7j/f2rNbGv6uUkuHrU=
 k8s.io/code-generator v0.0.0-20181114232248-ae218e241252/go.mod h1:IPqxl/YHk05nodzupwjke6ctMjyNRdV2zZ5/j3/F204=

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -38,7 +38,11 @@ func (sc *MeshCatalog) getWeightedEndpointsPerService() (map[endpoint.ServiceNam
 	backendWeight := make(map[string]int)
 
 	for _, trafficSplit := range sc.meshSpec.ListTrafficSplits() {
-		targetServiceName := endpoint.ServiceName(fmt.Sprintf("%s/%s", trafficSplit.Namespace, trafficSplit.Spec.Service))
+		namespacedTargerServiceName := endpoint.NamespacedService{
+			Namespace: trafficSplit.Namespace,
+			Service:   trafficSplit.Spec.Service,
+		}
+		targetServiceName := endpoint.ServiceName(namespacedTargerServiceName.String())
 		var services []endpoint.WeightedService
 		glog.V(level.Trace).Infof("[Server][catalog] Discovered TrafficSplit resource: %s/%s for service %s\n", trafficSplit.Namespace, trafficSplit.Name, targetServiceName)
 		if trafficSplit.Spec.Backends == nil {
@@ -48,14 +52,17 @@ func (sc *MeshCatalog) getWeightedEndpointsPerService() (map[endpoint.ServiceNam
 		for _, trafficSplitBackend := range trafficSplit.Spec.Backends {
 			// TODO(draychev): PULL THIS FROM SERVICE REGISTRY
 			// svcName := mesh.ServiceName(fmt.Sprintf("%s/%s", trafficSplit.Namespace, trafficSplitBackend.ServiceName))
-			namespaced := fmt.Sprintf("%s/%s", trafficSplit.Namespace, trafficSplitBackend.Service)
+			namespaced := endpoint.NamespacedService{
+				Namespace: trafficSplit.Namespace,
+				Service:   trafficSplitBackend.Service,
+			}
 			backendWeight[trafficSplitBackend.Service] = trafficSplitBackend.Weight
 			weightedService := endpoint.WeightedService{}
-			weightedService.ServiceName = endpoint.ServiceName(namespaced)
+			weightedService.ServiceName = endpoint.ServiceName(namespaced.String())
 			weightedService.Weight = trafficSplitBackend.Weight
 			var err error
-			if weightedService.Endpoints, err = sc.listEndpointsForService(endpoint.ServiceName(namespaced)); err != nil {
-				glog.Errorf("[catalog] Error getting Endpoints for service %s: %s", namespaced, err)
+			if weightedService.Endpoints, err = sc.listEndpointsForService(endpoint.ServiceName(namespaced.String())); err != nil {
+				glog.Errorf("[catalog] Error getting Endpoints for service %s: %s", namespaced.String(), err)
 				weightedService.Endpoints = []endpoint.Endpoint{}
 			}
 			services = append(services, weightedService)

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -116,16 +116,24 @@ func getTrafficPolicyPerRoute(sc *MeshCatalog, routes map[string]endpoint.RouteP
 			continue
 		}
 
-		destServices, destErr := sc.listServicesForServiceAccount(endpoint.ServiceAccount(fmt.Sprintf("%s/%s", trafficTargets.Destination.Namespace, trafficTargets.Destination.Name)))
+		dstNamespacedServiceAcc := endpoint.NamespacedServiceAccount{
+			Namespace:      trafficTargets.Destination.Namespace,
+			ServiceAccount: trafficTargets.Destination.Name,
+		}
+		destServices, destErr := sc.listServicesForServiceAccount(endpoint.ServiceAccount(dstNamespacedServiceAcc.String()))
 		if destErr != nil {
-			glog.Errorf("[catalog] TrafficSpec %s/%s could not get services for service account %s", trafficTargets.Namespace, trafficTargets.Name, fmt.Sprintf("%s/%s", trafficTargets.Destination.Namespace, trafficTargets.Destination.Name))
+			glog.Errorf("[catalog] TrafficSpec %s/%s could not get services for service account %s", trafficTargets.Namespace, trafficTargets.Name, dstNamespacedServiceAcc.String())
 			return nil, destErr
 		}
 
 		for _, trafficSources := range trafficTargets.Sources {
-			srcServices, srcErr := sc.listServicesForServiceAccount(endpoint.ServiceAccount(fmt.Sprintf("%s/%s", trafficSources.Namespace, trafficSources.Name)))
+			srcNamespacedServiceAcc := endpoint.NamespacedServiceAccount{
+				Namespace:      trafficSources.Namespace,
+				ServiceAccount: trafficSources.Name,
+			}
+			srcServices, srcErr := sc.listServicesForServiceAccount(endpoint.ServiceAccount(srcNamespacedServiceAcc.String()))
 			if srcErr != nil {
-				glog.Errorf("[catalog] TrafficSpec %s/%s could not get services for service account %s", trafficTargets.Namespace, trafficTargets.Name, fmt.Sprintf("%s/%s", trafficSources.Namespace, trafficSources.Name))
+				glog.Errorf("[catalog] TrafficSpec %s/%s could not get services for service account %s", trafficTargets.Namespace, trafficTargets.Name, srcNamespacedServiceAcc.String())
 				return nil, srcErr
 			}
 			trafficTargetPolicy := endpoint.TrafficTargetPolicies{}

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -1,6 +1,7 @@
 package endpoint
 
 import (
+	"fmt"
 	"net"
 )
 
@@ -31,8 +32,36 @@ type Port uint32
 // ServiceName is a type for a service name
 type ServiceName string
 
+func (s ServiceName) String() string {
+	return string(s)
+}
+
+// NamespacedService is a type for a namespaced service
+type NamespacedService struct {
+	Namespace string
+	Service   string
+}
+
+func (ns NamespacedService) String() string {
+	return fmt.Sprintf("%s/%s", ns.Namespace, ns.Service)
+}
+
 // ServiceAccount is a type for a service account
 type ServiceAccount string
+
+func (s ServiceAccount) String() string {
+	return string(s)
+}
+
+// NamespacedServiceAccount is a type for a namespaced service account
+type NamespacedServiceAccount struct {
+	Namespace      string
+	ServiceAccount string
+}
+
+func (ns NamespacedServiceAccount) String() string {
+	return fmt.Sprintf("%s/%s", ns.Namespace, ns.ServiceAccount)
+}
 
 // WeightedService is a struct of a delegated service backing a target service
 type WeightedService struct {

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -114,16 +113,22 @@ func (c Client) ListServicesForServiceAccount(svcAccount endpoint.ServiceAccount
 	for _, deployments := range deploymentsInterface {
 		if kubernetesDeployments := deployments.(*extensionsv1.Deployment); kubernetesDeployments != nil {
 			spec := kubernetesDeployments.Spec
-			namespacedSvcAccount := endpoint.ServiceAccount(fmt.Sprintf("%s/%s", kubernetesDeployments.Namespace, spec.Template.Spec.ServiceAccountName))
-			if svcAccount == namespacedSvcAccount {
+			namespacedSvcAccount := endpoint.NamespacedServiceAccount{
+				Namespace:      kubernetesDeployments.Namespace,
+				ServiceAccount: spec.Template.Spec.ServiceAccountName,
+			}
+			if svcAccount.String() == namespacedSvcAccount.String() {
 				var selectorLabel map[string]string
 				if spec.Selector != nil {
 					selectorLabel = spec.Selector.MatchLabels
 				} else {
 					selectorLabel = spec.Template.Labels
 				}
-				namespacedService := fmt.Sprintf("%s/%s", kubernetesDeployments.Namespace, selectorLabel["app"])
-				services = append(services, endpoint.ServiceName(namespacedService))
+				namespacedService := endpoint.NamespacedService{
+					Namespace: kubernetesDeployments.Namespace,
+					Service:   selectorLabel["app"],
+				}
+				services = append(services, endpoint.ServiceName(namespacedService.String()))
 			}
 		}
 	}

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -1,7 +1,6 @@
 package smi
 
 import (
-	"fmt"
 	"time"
 
 	target "github.com/deislabs/smi-sdk-go/pkg/apis/access/v1alpha1"
@@ -191,15 +190,21 @@ func (c *Client) ListServices() ([]endpoint.ServiceName, map[endpoint.ServiceNam
 	virtualServicesMap := make(map[endpoint.ServiceName][]endpoint.ServiceName)
 	for _, splitIface := range c.caches.TrafficSplit.List() {
 		split := splitIface.(*split.TrafficSplit)
-		namespacedServiceName := fmt.Sprintf("%s/%s", split.Namespace, split.Spec.Service)
-		services = append(services, endpoint.ServiceName(namespacedServiceName))
+		namespacedService := endpoint.NamespacedService{
+			Namespace: split.Namespace,
+			Service:   split.Spec.Service,
+		}
+		services = append(services, endpoint.ServiceName(namespacedService.String()))
 		var backends []endpoint.ServiceName
 		for _, backend := range split.Spec.Backends {
-			namespacedServiceName := fmt.Sprintf("%s/%s", split.Namespace, backend.Service)
-			services = append(services, endpoint.ServiceName(namespacedServiceName))
-			backends = append(backends, endpoint.ServiceName(namespacedServiceName))
+			namespacedService := endpoint.NamespacedService{
+				Namespace: split.Namespace,
+				Service:   backend.Service,
+			}
+			services = append(services, endpoint.ServiceName(namespacedService.String()))
+			backends = append(backends, endpoint.ServiceName(namespacedService.String()))
 		}
-		virtualServicesMap[endpoint.ServiceName(namespacedServiceName)] = backends
+		virtualServicesMap[endpoint.ServiceName(namespacedService.String())] = backends
 	}
 	return services, virtualServicesMap
 }
@@ -211,13 +216,19 @@ func (c *Client) ListServiceAccounts() []endpoint.ServiceAccount {
 	for _, targetIface := range c.caches.TrafficTarget.List() {
 		target := targetIface.(*target.TrafficTarget)
 		for _, sources := range target.Sources {
-			namespacedServiceAccount := fmt.Sprintf("%s/%s", sources.Namespace, sources.Name)
-			serviceAccounts = append(serviceAccounts, endpoint.ServiceAccount(namespacedServiceAccount))
+			namespacedServiceAccount := endpoint.NamespacedServiceAccount{
+				Namespace:      sources.Namespace,
+				ServiceAccount: sources.Name,
+			}
+			serviceAccounts = append(serviceAccounts, endpoint.ServiceAccount(namespacedServiceAccount.String()))
 		}
 
 		destination := target.Destination
-		namespacedServiceAccount := fmt.Sprintf("%s/%s", destination.Namespace, destination.Name)
-		serviceAccounts = append(serviceAccounts, endpoint.ServiceAccount(namespacedServiceAccount))
+		namespacedServiceAccount := endpoint.NamespacedServiceAccount{
+			Namespace:      destination.Namespace,
+			ServiceAccount: destination.Name,
+		}
+		serviceAccounts = append(serviceAccounts, endpoint.ServiceAccount(namespacedServiceAccount.String()))
 	}
 	return serviceAccounts
 }


### PR DESCRIPTION
- Currently fmt.Sprintf("%s/%s") is used throughout the
  code while namespacing services, service accounts.
  This can easily break due to bugs.
- Introduces a custom type for such references

This change will facilitate additional refactoring to prevent
loose semantics elsewhere in the code.