### PR TITLE
Adding ginkgo test runners for most packages

### DIFF
--- a/pkg/apis/suite_test.go
+++ b/pkg/apis/suite_test.go
@@ -1,0 +1,13 @@
+package apis
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/certificate/suite_test.go
+++ b/pkg/certificate/suite_test.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/constants/suite_test.go
+++ b/pkg/constants/suite_test.go
@@ -1,0 +1,13 @@
+package constants
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/endpoint/suite_test.go
+++ b/pkg/endpoint/suite_test.go
@@ -1,0 +1,13 @@
+package endpoint
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/ads/suite_test.go
+++ b/pkg/envoy/ads/suite_test.go
@@ -1,0 +1,13 @@
+package ads
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/cds/suite_test.go
+++ b/pkg/envoy/cds/suite_test.go
@@ -1,0 +1,13 @@
+package cds
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/eds/suite_test.go
+++ b/pkg/envoy/eds/suite_test.go
@@ -1,0 +1,13 @@
+package eds
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/lds/suite_test.go
+++ b/pkg/envoy/lds/suite_test.go
@@ -1,0 +1,13 @@
+package lds
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/rds/suite_test.go
+++ b/pkg/envoy/rds/suite_test.go
@@ -1,0 +1,13 @@
+package rds
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/sds/suite_test.go
+++ b/pkg/envoy/sds/suite_test.go
@@ -1,0 +1,13 @@
+package sds
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/envoy/suite_test.go
+++ b/pkg/envoy/suite_test.go
@@ -1,0 +1,13 @@
+package envoy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/health/suite_test.go
+++ b/pkg/health/suite_test.go
@@ -1,0 +1,13 @@
+package health
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/httpserver/suite_test.go
+++ b/pkg/httpserver/suite_test.go
@@ -1,0 +1,13 @@
+package httpserver
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/log/suite_test.go
+++ b/pkg/log/suite_test.go
@@ -1,0 +1,13 @@
+package log
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/metricsstore/suite_test.go
+++ b/pkg/metricsstore/suite_test.go
@@ -1,0 +1,13 @@
+package metricsstore
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/providers/suite_test.go
+++ b/pkg/providers/suite_test.go
@@ -1,0 +1,13 @@
+package providers
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/smi/suite_test.go
+++ b/pkg/smi/suite_test.go
@@ -1,0 +1,13 @@
+package smi
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/version/suite_test.go
+++ b/pkg/version/suite_test.go
@@ -1,0 +1,13 @@
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}


### PR DESCRIPTION
This PR adds the ginkgo test runner files necessary for the rest of our system to show % test coverage.

See: https://github.com/deislabs/smc/pull/202