### PR TITLE
logging: Get the last chunk of slashed package name

### DIFF
--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -10,11 +10,12 @@ import (
 	"github.com/deislabs/smc/pkg/endpoint"
 	"github.com/deislabs/smc/pkg/log/level"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 func (sc *MeshCatalog) listEndpointsForService(namespacedServiceName endpoint.ServiceName) ([]endpoint.Endpoint, error) {
 	// TODO(draychev): split namespace from the service name -- for non-K8s services

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"reflect"
 
-	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
 
 	"github.com/deislabs/smc/pkg/catalog"
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 //Server implements the Envoy xDS Aggregate Discovery Services
 type Server struct {

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -12,11 +12,12 @@ import (
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/log/level"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 // NewResponse creates a new Cluster Discovery Response.
 func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy) (*xds.DiscoveryResponse, error) {

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -13,11 +13,12 @@ import (
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/envoy/cla"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 // NewResponse creates a new Endpoint Discovery Response.
 func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -15,11 +15,12 @@ import (
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/envoy/route"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 // NewResponse creates a new Listener Discovery Response.
 func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy) (*xds.DiscoveryResponse, error) {

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -13,11 +13,12 @@ import (
 	"github.com/deislabs/smc/pkg/envoy/route"
 	"github.com/deislabs/smc/pkg/log/level"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 // NewResponse creates a new Route Discovery Response.
 func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -14,11 +14,12 @@ import (
 	"github.com/deislabs/smc/pkg/certificate"
 	"github.com/deislabs/smc/pkg/envoy"
 	"github.com/deislabs/smc/pkg/smi"
+	"github.com/deislabs/smc/pkg/utils"
 )
 
 type empty struct{}
 
-var packageName = reflect.TypeOf(empty{}).PkgPath()
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
 
 // NewResponse creates a new Secrets Discovery Response.
 func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy) (*v2.DiscoveryResponse, error) {


### PR DESCRIPTION
Our logging system needs a major overhaul.  This PR is a slight improvement - it truncates the `[packageName]` tag (which I find very useful) to the last word of the package.
At the moment we may see logs like: `[github.com/deislabs/smc/pkg/tresor]`
This PR ensures this is always `[tresor]`