### PR TITLE
fix(demo): Fix iptables rule for localhost

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: bookbuyer-serviceaccount
       automountServiceAccountToken: false
       hostAliases:
-      - ip: "127.0.0.1"
+      - ip: "127.0.0.2"
         hostnames:
         - "${K8S_NAMESPACE}.uswest.mesh"
         - "bookbuyer.mesh"

--- a/init-iptables.sh
+++ b/init-iptables.sh
@@ -41,8 +41,8 @@ iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT
 # Don't redirect Envoy traffic back ti itself for non-loopback traffic
 iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner "${PROXY_UID}" -j RETURN
 
-# TODO(shashank): Skip local container traffic
-#iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN
+# Skip localhost traffic
+iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN
 
 # Redirect remaining outbound traffic to Envou
 iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT


### PR DESCRIPTION
- Localhost traffic should not be proxied to envoy
- Use non-localhost `hostAlias` to avoid not being proxied to Envoy