### PR TITLE
Use service port instead of proxy port for endpoints

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -33,9 +33,8 @@ metadata:
 spec:
   ports:
 
-  - port: 15000
-    targetPort: admin-port
-    name: bookbuyer-envoy-admin-port
+  - port: 9999
+    name: dummy-unused-port
 
   selector:
     app: bookbuyer

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -33,13 +33,8 @@ metadata:
     app: $SVC
 spec:
   ports:
-  - port: 89
-    targetPort: 15000
-    name: admin-port
-
-  - port: 83
-    targetPort: 15003
-    name: mtls-port
+  - port: 80
+    name: bookstore-port
 
   selector:
     app: $SVC

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/deislabs/smc/pkg/constants"
 	"github.com/deislabs/smc/pkg/endpoint"
 	"github.com/deislabs/smc/pkg/log/level"
 )
@@ -87,17 +86,17 @@ func (c Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.End
 		return endpoints
 	}
 
-	// TODO(draychev): get the port number from the service
-	port := endpoint.Port(constants.EnvoyInboundListenerPort)
-
 	if kubernetesEndpoints := endpointsInterface.(*corev1.Endpoints); kubernetesEndpoints != nil {
 		for _, kubernetesEndpoint := range kubernetesEndpoints.Subsets {
 			for _, address := range kubernetesEndpoint.Addresses {
-				ept := endpoint.Endpoint{
-					IP:   net.IP(address.IP),
-					Port: port,
+				for _, port := range kubernetesEndpoint.Ports {
+					ept := endpoint.Endpoint{
+						IP:   net.IP(address.IP),
+						Port: endpoint.Port(port.Port),
+					}
+					endpoints = append(endpoints, ept)
 				}
-				endpoints = append(endpoints, ept)
+
 			}
 		}
 	}


### PR DESCRIPTION
- Envoy doesn't need its own port to be set as the DST port
  while proxying traffic. Iptables takes care of redirecting
  incoming traffic to Envoy.

- Also users may not want their traffic to be using magic port
  numbers on the wire, in case they want to apply service specific
  policies on the traffic (eg. a third party firewall).

- Also removes bookbuyer service definition since its not an actual
  service (no ports required).