### PR TITLE
ci: Shorter namespace; Longer wait time for pods; Disable FilterChainMatch temp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
         CTR_REGISTRY: ${{ secrets.CTR_REGISTRY }}
         CTR_REGISTRY_CREDS_NAME: ${{ secrets.CTR_REGISTRY_CREDS_NAME }}
-        K8S_NAMESPACE: "ci-${{ github.sha }}-${{ github.run_id }}-${{ github.run_number}}"
+        K8S_NAMESPACE: "ci-${{ github.run_id }}-${{ github.run_number}}"
         ACR_CREDS: ${{ secrets.ACR_CREDS }}
         KUBECONFIG: ".kube/config"
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
@@ -83,6 +83,7 @@ jobs:
         WAIT_FOR_OK_SECONDS: 120
         IS_GITHUB: true
         ACR: ${{ secrets.ACR }}
+        WAIT_FOR_POD_TIME_SECONDS: ${{ secrets.WAIT_FOR_POD_TIME_SECONDS }}
       run: |
         touch .env  # it is ok keep this empty
         echo "Creating Kubernetes namespace: $K8S_NAMESPACE"

--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,6 @@ docker-build-bookstore: build-bookstore
 docker-build-init:
 	docker build -t $(CTR_REGISTRY)/init -f dockerfiles/Dockerfile.init .
 
-.PHONY: docker-build-envoyproxy
-docker-build-envoyproxy:
-	docker build -t $(CTR_REGISTRY)/envoyproxy -f dockerfiles/Dockerfile.envoyproxy .
-
 .PHONY: docker-push-ads
 docker-push-ads: docker-build-ads
 	docker push "$(CTR_REGISTRY)/ads"
@@ -119,12 +115,8 @@ docker-push-bookstore: docker-build-bookstore
 docker-push-init: docker-build-init
 	docker push "$(CTR_REGISTRY)/init"
 
-.PHONY: docker-push-envoypoxy
-docker-push-envoyproxy: docker-build-envoyproxy
-	docker push "$(CTR_REGISTRY)/envoyproxy"
-
 .PHONY: docker-push
-docker-push: docker-push-init docker-push-envoyproxy docker-push-bookbuyer docker-push-bookstore docker-push-ads
+docker-push: docker-push-init docker-push-bookbuyer docker-push-bookstore docker-push-ads
 
 .PHONY: generate-crds
 generate-crds:

--- a/demo/build-push-images.sh
+++ b/demo/build-push-images.sh
@@ -9,8 +9,5 @@ IS_GITHUB="${IS_GITHUB:-default false}"
 make docker-push-ads
 
 make docker-push-init
-if [[ "$IS_GITHUB" != "true" ]]; then
-    make docker-push-envoyproxy
-fi
 make docker-push-bookbuyer
 make docker-push-bookstore

--- a/demo/deploy-traffic-split.sh
+++ b/demo/deploy-traffic-split.sh
@@ -7,8 +7,6 @@ source .env
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.2.0/crds/split.yaml
 
-kubectl create namespace "$K8S_NAMESPACE" || true
-
 kubectl apply -f - <<EOF
 apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit

--- a/demo/deploy-traffic-target-2.sh
+++ b/demo/deploy-traffic-target-2.sh
@@ -7,8 +7,6 @@ source .env
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.2.0/crds/access.yaml
 
-kubectl create namespace "$K8S_NAMESPACE" || true
-
 kubectl apply -f - <<EOF
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1

--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -7,8 +7,6 @@ source .env
 
 kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.2.0/crds/access.yaml
 
-kubectl create namespace "$K8S_NAMESPACE" || true
-
 kubectl apply -f - <<EOF
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1

--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -46,7 +46,7 @@ kubectl apply -f crd/AzureResource.yaml
 go run ./demo/cmd/deploy/xds.go
 
 # Wait for POD to be ready before
-while [ "$(kubectl get pods -n smc ads -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ];
+while [ "$(kubectl get pods -n "$K8S_NAMESPACE" ads -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ];
 do
   echo "waiting for pod ads to be ready" && sleep 2
 done

--- a/demo/webhook.yaml.template
+++ b/demo/webhook.yaml.template
@@ -2,6 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ .Name }}
+  namespace: {{ .Namespace }}
   labels:
     app: {{ .Name }}
 webhooks:

--- a/dockerfiles/Dockerfile.envoyproxy
+++ b/dockerfiles/Dockerfile.envoyproxy
@@ -1,5 +1,0 @@
-# Base image
-FROM envoyproxy/envoy-alpine-dev:latest
-
-# Update image with config
-ADD ./config/bootstrap.yaml /etc/envoy/bootstrap.yaml

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -76,12 +76,14 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 						},
 					},
 				},
+				/* --- This is commented out until we have a clear plan of how we are going to use FilterChainMatch ---
 				// Source: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener_components.proto
 				// The FilterChainMatch uses SNI from mTLS to match against the provided list of ServerNames.
 				// This ensures only clients authorized to talk to this listener are permitted to.
 				FilterChainMatch: &listener.FilterChainMatch{
 					ServerNames: []string{"smc/bookbuyer"}, // TODO(draychev): remove hard-coded demo value
 				},
+				*/
 				TransportSocket: &envoy_api_v2_core.TransportSocket{
 					Name: envoy.TransportSocketTLS,
 					ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{

--- a/pkg/injector/sidecar.go
+++ b/pkg/injector/sidecar.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	envoyProxyConfig          = "envoyproxy-config"
+	envoyProxyConfigPath      = "/etc/envoy"
 	envoySidecarContainerName = "envoyproxy"
 	envoyTLSCertPath          = "/etc/ssl/certs"
 	envoyBootstrapConfigFile  = "/etc/envoy/bootstrap.yaml"
@@ -34,6 +36,11 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, data *EnvoySidecarData) (core
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      envoyProxyConfig,
+				ReadOnly:  true,
+				MountPath: envoyProxyConfigPath,
+			},
 			{
 				Name:      envoyTLSVolume,
 				ReadOnly:  true,

--- a/pkg/injector/volumes.go
+++ b/pkg/injector/volumes.go
@@ -10,6 +10,16 @@ import (
 func getVolumeSpec(envoyTLSSecretName string) []corev1.Volume {
 	return []corev1.Volume{
 		{
+			Name: envoyProxyConfig,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: envoyProxyConfig,
+					},
+				},
+			},
+		},
+		{
 			// Envoy's TLS volume. This is sourced from the TLS secret
 			// references by 'envoyTLSSecretName'
 			Name: envoyTLSVolume,


### PR DESCRIPTION
Using the GitHub commit hash to create a *unique* Kubernetes namespace seems to cause issues later when we create a certificate, which contains the FQDN of a Kubernetes service, which has this namespace in it.

So dropping this from the NS; `run_id` and `run_number` should be sufficient.

Also temporarily disabling the `FilterChainMatch` (https://github.com/deislabs/smc/issues/300)

Removing scripts to create Envoy images -- will rely on public image.

CI running would also FIX #75 