### PR TITLE
Use namespace from .env file for webhook server cert subject

### DIFF
--- a/demo/deploy-webhook-secrets.sh
+++ b/demo/deploy-webhook-secrets.sh
@@ -9,7 +9,7 @@ keydir="$basedir/webhook-certs"
 
 # Generate keys into a temporary directory.
 echo "Generating TLS keys ..."
-"${basedir}/gen-keys.sh" "$keydir"
+"${basedir}/gen-keys.sh" "$keydir" "$K8S_NAMESPACE"
 
 # Create the `smc` namespace. This cannot be part of the YAML file as we first need to create the TLS secret,
 # which would fail otherwise.

--- a/demo/gen-keys.sh
+++ b/demo/gen-keys.sh
@@ -3,6 +3,7 @@
 : ${1?'missing key directory'}
 
 key_dir="$1"
+namespace="$2"
 rm -rf "$key_dir"; mkdir -p "$key_dir"
 chmod 0700 "$key_dir"
 
@@ -12,5 +13,5 @@ openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -subj "/CN=SMC Sidecar 
 # Generate the private key for the webhook server
 openssl genrsa -out webhook-tls-certs.key 2048
 # Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
-openssl req -new -key webhook-tls-certs.key -subj "/CN=ads.smc.svc" \
+openssl req -new -key webhook-tls-certs.key -subj "/CN=ads.$namespace.svc" \
     | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -out webhook-tls-certs.crt


### PR DESCRIPTION
The server cert subject must be of the form: <svc_name>.<svc_namespace>.svc