### PR TITLE
ci: Delete stale webhooks

### DIFF
--- a/ci/cmd/cleanup-namespaces.go
+++ b/ci/cmd/cleanup-namespaces.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/glog"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -18,42 +17,58 @@ import (
 const (
 	// KubeConfigEnvVar is the environment variable name for KUBECONFIG
 	KubeConfigEnvVar = "KUBECONFIG"
-
-	// KubeNamespaceEnvVar is the environment variable name for the K8s namespace
-	KubeNamespaceEnvVar = "K8S_NAMESPACE"
 )
 
 var (
-	staleIfOlderThan = 5 * time.Minute
+	staleIfOlderThan = 24 * time.Hour
 )
 
 func main() {
 	clientset := getClient()
 
+	webHooks, err := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(metav1.ListOptions{})
+	if err != nil {
+		glog.Error("Error listing mutating webhooks: ", err)
+	}
 	namespaces, err := clientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
-		fmt.Println("Error listing namespaces: ", err)
+		glog.Error("Error listing namespaces: ", err)
 		os.Exit(1)
 	}
 
 	var namespacesToDelete []v1.Namespace
 	for _, ns := range namespaces.Items {
-		isStale := time.Now().Sub(ns.CreationTimestamp.UTC()) > staleIfOlderThan
+		isStale := time.Since(ns.CreationTimestamp.UTC()) > staleIfOlderThan
 		if isStale && strings.HasPrefix(ns.Name, "ci-") {
 			namespacesToDelete = append(namespacesToDelete, ns)
 		}
 	}
 
 	if len(namespacesToDelete) == 0 {
-		fmt.Println("No stale namespaces to cleanup.")
+		glog.Info("No stale namespaces to cleanup.")
 		return
 	}
 
+	deleteOptions := &metav1.DeleteOptions{
+		GracePeriodSeconds: to.Int64Ptr(0),
+	}
+
 	for _, ns := range namespacesToDelete {
-		if err = clientset.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{GracePeriodSeconds: to.Int64Ptr(0)}); err != nil {
+		if err = clientset.CoreV1().Namespaces().Delete(ns.Name, deleteOptions); err != nil {
 			glog.Errorf("Error deleting namespace %s: %s", ns.Name, err)
 		}
 		glog.Infof("Deleted namespace: %s", ns.Name)
+		for _, webhook := range webHooks.Items {
+			// Convention is - the webhook name is prefixed with the namespace where OSM is.
+			if !strings.HasPrefix(webhook.Name, ns.Name) {
+				continue
+			}
+			opts := metav1.DeleteOptions{}
+			if err = clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(webhook.Name, &opts); err != nil {
+				glog.Errorf("Error deleting webhook %s: %s", webhook.Name, err)
+			}
+			glog.Infof("Deleted mutating webhook: %s", webhook.Name)
+		}
 	}
 }
 
@@ -64,22 +79,19 @@ func getClient() *kubernetes.Clientset {
 	if kubeConfigFile != "" {
 		kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeConfigFile)
 		if err != nil {
-			fmt.Printf("Error fetching Kubernetes config. Ensure correctness of CLI argument 'kubeconfig=%s': %s", kubeConfigFile, err)
-			os.Exit(1)
+			glog.Errorf("Error fetching Kubernetes config. Ensure correctness of CLI argument 'kubeconfig=%s': %s", kubeConfigFile, err)
 		}
 	} else {
 		// creates the in-cluster config
 		kubeConfig, err = rest.InClusterConfig()
 		if err != nil {
-			fmt.Printf("Error generating Kubernetes config: %s", err)
-			os.Exit(1)
+			glog.Errorf("Error generating Kubernetes config: %s", err)
 		}
 	}
 
 	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		fmt.Println("error in getting access to K8S")
-		os.Exit(1)
+		glog.Error("error in getting access to K8S")
 	}
 	return clientset
 }


### PR DESCRIPTION
This PR introduces another tiny improvement to CI - when a stale namespace of a previous CI run is deleted, we delete the associated mutating webhook as well.

By convention - the webhook is prefixed with the Kubernetes namespace in which the CI ran.