### PR TITLE
ci: Webhook only applies to the namespace it is responsible for

### DIFF
--- a/demo/clean-kubernetes.sh
+++ b/demo/clean-kubernetes.sh
@@ -8,5 +8,6 @@ source .env
 kubectl delete mutatingwebhookconfiguration ads --ignore-not-found=true
 kubectl delete namespace "$K8S_NAMESPACE" || true
 kubectl create namespace "$K8S_NAMESPACE" || true
+kubectl label  namespaces "$K8S_NAMESPACE" osm="$K8S_NAMESPACE"
 kubectl delete clusterrole osm-xds || true
 kubectl delete clusterrolebinding osm-xds || true

--- a/demo/webhook.yaml.template
+++ b/demo/webhook.yaml.template
@@ -19,3 +19,6 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Fail
+    namespaceSelector:
+      matchLabels:
+        osm: {{ .Namespace }}


### PR DESCRIPTION
This PR scopes the operation of a given mutation webhook to a labelled namespace. This is expected to prevent conflicts between parallel CI runs.