### PR TITLE
demo: Only exit on failure for bookbuyer and bookthief

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -38,7 +38,6 @@ func main() {
 		if waitForOK != 0 {
 			if responses[0] == 200 {
 				fmt.Printf(common.Success)
-				os.Exit(0)
 			} else if time.Now().After(finishBy) {
 				fmt.Printf("It has been %v since we started the test. Response code from %s is %d. This test has failed.",
 					time.Now().Sub(started), counter, responses[0])

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -39,7 +39,6 @@ func main() {
 			//since bookthief doesn't have any traffic policies setup to talk to bookstore it will get a 404
 			if responses[0] == 404 {
 				fmt.Printf(common.Success)
-				os.Exit(0)
 			} else if time.Now().After(finishBy) {
 				fmt.Printf("It has been %v since we started the test. Response code from %s is %d. This test has failed.",
 					time.Now().Sub(started), counter, responses[0])


### PR DESCRIPTION
It has been observed that when the bookstore POD is ready
before the bookbuyer POD, the bookbuyer HTTP GET calls to
the bookstore service might succeed too soon. While this
is expected, it causes the bookbuyer container to exit
causing a CrashLoopBackoff of the POD in K8s.
This change avoids this scenario by only exiting on failure.
Also fixes the POD waiting logic.

Resolves #331