### PR TITLE
tests: Remove unused symbols

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
-var uniqueness = Describe("UniqueLists", func() {
+var _ = Describe("UniqueLists", func() {
 	Context("Testing uniqueness of services", func() {
 		It("Returns unique list of services", func() {
 
@@ -51,7 +51,7 @@ var uniqueness = Describe("UniqueLists", func() {
 	})
 })
 
-var serviceToString = Describe("ServicesToString", func() {
+var _ = Describe("ServicesToString", func() {
 	Context("Testing servicesToString", func() {
 		It("Returns string list", func() {
 


### PR DESCRIPTION
Tests will still run if these are `_`, and linter won't complain that we are not using the variables anywhere.