### PR TITLE
simplify: Removing type friendlyName - using string

### DIFF
--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -157,12 +157,12 @@ func (c *Client) run(stop <-chan struct{}) error {
 		return errInitInformers
 	}
 
-	sharedInformers := map[friendlyName]cache.SharedInformer{
+	sharedInformers := map[string]cache.SharedInformer{
 		"Endpoints":   c.informers.Endpoints,
 		"Deployments": c.informers.Deployments,
 	}
 
-	var names []friendlyName
+	var names []string
 	for name, informer := range sharedInformers {
 		// Depending on the use-case, some Informers from the collection may not have been initialized.
 		if informer == nil {

--- a/pkg/providers/kube/types.go
+++ b/pkg/providers/kube/types.go
@@ -10,8 +10,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/utils"
 )
 
-type friendlyName string
-
 type empty struct{}
 
 var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -55,14 +55,14 @@ func (c *Client) run(stop <-chan struct{}) error {
 		return errInitInformers
 	}
 
-	sharedInformers := map[friendlyName]cache.SharedInformer{
+	sharedInformers := map[string]cache.SharedInformer{
 		"TrafficSplit":  c.informers.TrafficSplit,
 		"Services":      c.informers.Services,
 		"TrafficSpec":   c.informers.TrafficSpec,
 		"TrafficTarget": c.informers.TrafficTarget,
 	}
 
-	var names []friendlyName
+	var names []string
 	for name, informer := range sharedInformers {
 		// Depending on the use-case, some Informers from the collection may not have been initialized.
 		if informer == nil {

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -12,8 +12,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/namespace"
 )
 
-type friendlyName string
-
 // InformerCollection is a struct of the Kubernetes informers used in OSM
 type InformerCollection struct {
 	Services      cache.SharedIndexInformer


### PR DESCRIPTION
I regret adding the `friendlyName` type - it seemed helpful to know what the keys of this map are... but now it seems silly. Makes logging actually harder (have to convert `[]friendlyName` to `[]string`)