### PR TITLE
kube/client: Return client's announcements channel

### DIFF
--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -143,9 +143,7 @@ func (c Client) ListServicesForServiceAccount(svcAccount endpoint.NamespacedServ
 
 // GetAnnouncementsChannel returns the announcement channel for the Kubernetes endpoints provider.
 func (c Client) GetAnnouncementsChannel() <-chan interface{} {
-	// return c.announcements
-	// TODO(draychev): implement
-	return make(chan interface{})
+	return c.announcements
 }
 
 // run executes informer collection.


### PR DESCRIPTION
Now that we actually have an announcement channel in the `Client{}` struct - we can return that. Removing TODO.