### PR TITLE
lint: Removing ineffectual err assignment

### DIFF
--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -69,10 +69,10 @@ func (wh *Webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 		Image:          wh.config.SidecarImage,
 		ServiceAccount: pod.Spec.ServiceAccountName,
 	}
-	envoySidecarSpec, err := getEnvoySidecarContainerSpec(pod, &envoySidecarData)
+
 	patches = append(patches, addContainer(
 		pod.Spec.Containers,
-		[]corev1.Container{envoySidecarSpec},
+		[]corev1.Container{getEnvoySidecarContainerSpec(pod, &envoySidecarData)},
 		"/spec/containers")...,
 	)
 

--- a/pkg/injector/sidecar.go
+++ b/pkg/injector/sidecar.go
@@ -13,7 +13,7 @@ const (
 	envoyBootstrapConfigFile  = "/etc/envoy/bootstrap.yaml"
 )
 
-func getEnvoySidecarContainerSpec(pod *corev1.Pod, data *EnvoySidecarData) (corev1.Container, error) {
+func getEnvoySidecarContainerSpec(pod *corev1.Pod, data *EnvoySidecarData) corev1.Container {
 	container := corev1.Container{
 		Name:            data.Name,
 		Image:           data.Image,
@@ -57,5 +57,5 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, data *EnvoySidecarData) (core
 		},
 	}
 
-	return container, nil
+	return container
 }


### PR DESCRIPTION
Lint complained about an ineffectual err assignment. It seems that we are not emitting an error, or using the err variable. So this PR proposes we remove it.