### PR TITLE
namespace: Reuse Kubernetes event handlers for the Namespace informers

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -21,9 +21,11 @@ func GetKubernetesEventHandlers(informerName string, providerName string, announ
 func Add(informerName string, providerName string, announce chan interface{}) func(obj interface{}) {
 	return func(obj interface{}) {
 		glog.V(level.Trace).Infof("[%s][%s] Add event: %+v", providerName, informerName, obj)
-		announce <- Event{
-			Type:  CreateEvent,
-			Value: obj,
+		if announce != nil {
+			announce <- Event{
+				Type:  CreateEvent,
+				Value: obj,
+			}
 		}
 	}
 }
@@ -35,9 +37,11 @@ func Update(informerName string, providerName string, announce chan interface{})
 		if reflect.DeepEqual(oldObj, newObj) {
 			return
 		}
-		announce <- Event{
-			Type:  UpdateEvent,
-			Value: newObj,
+		if announce != nil {
+			announce <- Event{
+				Type:  UpdateEvent,
+				Value: newObj,
+			}
 		}
 	}
 }
@@ -46,9 +50,11 @@ func Update(informerName string, providerName string, announce chan interface{})
 func Delete(informerName string, providerName string, announce chan interface{}) func(obj interface{}) {
 	return func(obj interface{}) {
 		glog.V(level.Trace).Infof("[%s][%s] Delete event: %+v", providerName, informerName, obj)
-		announce <- Event{
-			Type:  DeleteEvent,
-			Value: obj,
+		if announce != nil {
+			announce <- Event{
+				Type:  DeleteEvent,
+				Value: obj,
+			}
 		}
 	}
 }

--- a/pkg/namespace/client.go
+++ b/pkg/namespace/client.go
@@ -37,13 +37,12 @@ func NewNamespaceController(kubeConfig *rest.Config, osmID string, stop chan str
 	informer := informerFactory.Core().V1().Namespaces().Informer()
 
 	client := Client{
-		informer:      informer,
-		cache:         informer.GetStore(),
-		cacheSynced:   make(chan interface{}),
-		announcements: make(chan interface{}),
+		informer:    informer,
+		cache:       informer.GetStore(),
+		cacheSynced: make(chan interface{}),
 	}
 
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Namespaces", "Kubernetes", client.announcements))
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Namespaces", "Kubernetes", nil))
 
 	if err := client.run(stop); err != nil {
 		glog.Fatal("Could not start Kubernetes Namespaces client", err)

--- a/pkg/namespace/types.go
+++ b/pkg/namespace/types.go
@@ -6,10 +6,9 @@ import (
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
-	informer      cache.SharedIndexInformer
-	cache         cache.Store
-	cacheSynced   chan interface{}
-	announcements chan interface{}
+	informer    cache.SharedIndexInformer
+	cache       cache.Store
+	cacheSynced chan interface{}
 }
 
 // Controller is the controller interface for K8s namespaces


### PR DESCRIPTION
This PR reuses the common package and Kubernetes event handler functions we created in https://github.com/open-service-mesh/osm/pull/371 to remove code duplication.