### PR TITLE
route: Remove duplicate import

### DIFF
--- a/pkg/envoy/route/routeConfiguration.go
+++ b/pkg/envoy/route/routeConfiguration.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/open-service-mesh/osm/pkg/endpoint"
-	osmEndpoint "github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/log/level"
 )
@@ -24,7 +23,7 @@ const (
 )
 
 //UpdateRouteConfiguration consrtucts the Envoy construct necessary for TrafficTarget implementation
-func UpdateRouteConfiguration(trafficPolicies osmEndpoint.TrafficTargetPolicies, routeConfig v2.RouteConfiguration, isSourceService bool, isDestinationService bool) v2.RouteConfiguration {
+func UpdateRouteConfiguration(trafficPolicies endpoint.TrafficTargetPolicies, routeConfig v2.RouteConfiguration, isSourceService bool, isDestinationService bool) v2.RouteConfiguration {
 	glog.V(level.Trace).Infof("[RDS] Updating Route Configuration")
 	var routeConfiguration v2.RouteConfiguration
 	var isLocalCluster bool
@@ -40,7 +39,7 @@ func UpdateRouteConfiguration(trafficPolicies osmEndpoint.TrafficTargetPolicies,
 	return routeConfiguration
 }
 
-func updateRoutes(routePaths []osmEndpoint.RoutePaths, cluster []osmEndpoint.WeightedCluster, routeConfig v2.RouteConfiguration, isLocalCluster bool) v2.RouteConfiguration {
+func updateRoutes(routePaths []endpoint.RoutePaths, cluster []endpoint.WeightedCluster, routeConfig v2.RouteConfiguration, isLocalCluster bool) v2.RouteConfiguration {
 	allowedMethods := strings.Split(routeConfig.VirtualHosts[0].Cors.AllowMethods, ",")
 	for _, path := range routePaths {
 		routedMatched := false


### PR DESCRIPTION
Removing duplicated imports from `pkg/envoy/route/routeConfiguration.go`