### PR TITLE
util: Delete unused getNamespacedService() fn

### DIFF
--- a/pkg/envoy/util.go
+++ b/pkg/envoy/util.go
@@ -1,8 +1,6 @@
 package envoy
 
 import (
-	"strings"
-
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
@@ -14,17 +12,4 @@ func Contains(proxyService endpoint.NamespacedService, services []endpoint.Names
 		}
 	}
 	return false
-}
-
-func getNamespacedService(serviceName string) endpoint.NamespacedService {
-	split := strings.Split(serviceName, "/")
-	var namespacedService endpoint.NamespacedService
-	if len(split) == 0 {
-		namespacedService.Namespace = "default"
-		namespacedService.Service = split[0]
-	} else {
-		namespacedService.Namespace = split[0]
-		namespacedService.Service = split[1]
-	}
-	return namespacedService
 }


### PR DESCRIPTION
We are no longer using `getNamespacedService()` - I propose we delete it.