### PR TITLE
cds: Remove unused variable

### DIFF
--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var uniqueness = Describe("UniqueLists", func() {
+var _ = Describe("UniqueLists", func() {
 	Context("Testing uniqueness of clusters", func() {
 		It("Returns unique list of clusters for CDS", func() {
 


### PR DESCRIPTION
The Ginkgo tests will run with `_` instead of `uniqueness` as well. Removing `uniqueness` since it is unused.