### PR TITLE
Fix formatting while printing endpoints

### DIFF
--- a/pkg/catalog/cache.go
+++ b/pkg/catalog/cache.go
@@ -22,7 +22,7 @@ func (sc *MeshCatalog) refreshCache() {
 				glog.Infof("[%s][%s] No IPs found for service=%s", packageName, provider.GetID(), service.ServiceName)
 				continue
 			}
-			glog.V(level.Trace).Infof("[%s][%s] Found Endpoints=%v for service=%s", packageName, provider.GetID(), endpointsToString(endpoints), service.ServiceName)
+			glog.V(level.Trace).Infof("[%s][%s] Found Endpoints=%s for service=%s", packageName, provider.GetID(), endpointsToString(endpoints), service.ServiceName)
 			servicesCache[service] = endpoints
 		}
 	}

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/golang/glog"
 
@@ -71,10 +72,11 @@ func (sc *MeshCatalog) getWeightedEndpointsPerService(clientID endpoint.Namespac
 	return serviceEndpoints, nil
 }
 
-func endpointsToString(endpoints []endpoint.Endpoint) []string {
+// endpointsToString stringifies a list of endpoints to a readable form
+func endpointsToString(endpoints []endpoint.Endpoint) string {
 	var epts []string
-	for _, ept := range endpoints {
-		epts = append(epts, fmt.Sprintf("%s:%d", string(ept.IP[:]), ept.Port))
+	for _, ep := range endpoints {
+		epts = append(epts, fmt.Sprintf("%s", ep))
 	}
-	return epts
+	return strings.Join(epts, ",")
 }

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("Endpoints To String", func() {
 	Context("Testing endpointsToString", func() {
-		It("Returns string list", func() {
+		It("Returns string representation of a list of endpoints", func() {
 
 			endpoints := []endpoint.Endpoint{
 				{
@@ -25,10 +25,7 @@ var _ = Describe("Endpoints To String", func() {
 			}
 
 			actual := endpointsToString(endpoints)
-			expected := []string{
-				"10.20.30.1:10",
-				"210.220.230.21:202",
-			}
+			expected := "(ip=10.20.30.1, port=10),(ip=210.220.230.21, port=202)"
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -26,6 +26,10 @@ type Endpoint struct {
 	Port   `json:"port"`
 }
 
+func (ep Endpoint) String() string {
+	return fmt.Sprintf("(ip=%s, port=%d)", ep.IP, ep.Port)
+}
+
 // Port is a numerical port of an Envoy proxy
 type Port uint32
 

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -89,7 +89,7 @@ func (c Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.End
 			for _, address := range kubernetesEndpoint.Addresses {
 				for _, port := range kubernetesEndpoint.Ports {
 					ept := endpoint.Endpoint{
-						IP:   net.IP(address.IP),
+						IP:   net.ParseIP(address.IP),
 						Port: endpoint.Port(port.Port),
 					}
 					endpoints = append(endpoints, ept)


### PR DESCRIPTION
Since endpoint.IP is a byte array, endpoints are not formatted
as expected to a string while logging. Fix this and make
it more readable.