### PR TITLE
kube/client.go: Don't use net.ParseIP while creating endpoint

### DIFF
--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -89,7 +89,7 @@ func (c Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.End
 			for _, address := range kubernetesEndpoint.Addresses {
 				for _, port := range kubernetesEndpoint.Ports {
 					ept := endpoint.Endpoint{
-						IP:   net.ParseIP(address.IP),
+						IP:   net.IP(address.IP),
 						Port: endpoint.Port(port.Port),
 					}
 					endpoints = append(endpoints, ept)


### PR DESCRIPTION
This change fixes the demo which breaks when net.ParseIP is used
to create the endpoint object.
net.ParseIP has side-effects where it can return nil if the IP
is not valid. Suspect this to be causing encoding issues while
programming Envoy, as opposed to an empty string.

The demo works as expected with this change.