### PR TITLE
deploy/xds: Use upstream Envoy image

### DIFF
--- a/demo/cmd/deploy/xds.go
+++ b/demo/cmd/deploy/xds.go
@@ -13,12 +13,15 @@ import (
 	"github.com/open-service-mesh/osm/pkg/constants"
 )
 
+const (
+	defaultEnvoyImage = "envoyproxy/envoy-alpine:latest" // v1.13.1 currently
+)
+
 func main() {
 	acr := os.Getenv(common.ContainerRegistryEnvVar)
 	containerRegistryCredsName := os.Getenv(common.ContainerRegistryCredsEnvVar)
 	azureSubscription := os.Getenv(common.AzureSubscription)
 	initContainer := path.Join(acr, "init")
-	envoyContainer := path.Join(acr, "envoyproxy:latest")
 	namespace := os.Getenv(common.KubeNamespaceEnvVar)
 	appNamespaces := os.Getenv(common.AppNamespacesEnvVar)
 	osmID := os.Getenv(common.OsmIDEnvVar)
@@ -87,7 +90,7 @@ func main() {
 		"--rootcertpem", "/etc/ssl/certs/root-cert.pem",
 		"--rootkeypem", "/etc/ssl/certs/root-key.pem",
 		"--init-container-image", initContainer,
-		"--sidecar-image", envoyContainer,
+		"--sidecar-image", defaultEnvoyImage,
 	}
 
 	if os.Getenv(common.IsGithubEnvVar) != "true" {


### PR DESCRIPTION
Currently a cached image from a container registry defined
by CTR_REGISTRY env variable is used for the envoy image. This
is unintentional.

This change fixes this to use the latest envoyproxy/envoy-alpine
image. Although we should pin the version before releasing, tagging
on latest helps us quickly find incompatibilities with a released
envoy version. We already know the current released version is
v.1.13.1 on envoy-alpine, so if things break we can simply revert
to using this version.