### PR TITLE
ci: Tag Docker images per build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,5 @@ export BOOKTHIEF_NAMESPACE=bookthief-ns
 export AZURE_SUBSCRIPTION=abc
 export CTR_REGISTRY=your.azurecr.io/osm
 export CTR_REGISTRY_CREDS_NAME=acr-creds
+export CTR_TAG=latest
 export WAIT_SECONDS_FOR_200_OK=0  # 0 means wait forever for 200 OK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
         AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
         CTR_REGISTRY: ${{ secrets.CTR_REGISTRY }}
         CTR_REGISTRY_CREDS_NAME: ${{ secrets.CTR_REGISTRY_CREDS_NAME }}
+        CTR_TAG: "${{ github.run_id }}-${{ github.run_number}}"
         K8S_NAMESPACE: "ci-${{ github.run_id }}-${{ github.run_number}}"
         BOOKBUYER_NAMESPACE: "ci-bookbuyer-${{ github.run_id }}-${{ github.run_number}}"
         BOOKSTORE_NAMESPACE: "ci-bookstore-${{ github.run_id }}-${{ github.run_number}}"

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ go-test-coverage:
 
 .PHONY: docker-build-ads
 docker-build-ads: build-cross-ads
-	docker build --build-arg $(HOME)/go/ -t $(CTR_REGISTRY)/ads -f dockerfiles/Dockerfile.ads .
+	docker build --build-arg $(HOME)/go/ -t $(CTR_REGISTRY)/ads:$(CTR_TAG) -f dockerfiles/Dockerfile.ads .
 
 .PHONY: build-bookstore
 build-bookstore:
@@ -100,39 +100,39 @@ build-bookthief:
 
 .PHONY: docker-build-bookbuyer
 docker-build-bookbuyer: build-bookbuyer
-	docker build -t $(CTR_REGISTRY)/bookbuyer -f dockerfiles/Dockerfile.bookbuyer .
+	docker build -t $(CTR_REGISTRY)/bookbuyer:$(CTR_TAG) -f dockerfiles/Dockerfile.bookbuyer .
 
 .PHONY: docker-build-bookthief
 docker-build-bookthief: build-bookthief
-	docker build -t $(CTR_REGISTRY)/bookthief -f dockerfiles/Dockerfile.bookthief .
+	docker build -t $(CTR_REGISTRY)/bookthief:$(CTR_TAG) -f dockerfiles/Dockerfile.bookthief .
 
 .PHONY: docker-build-bookstore
 docker-build-bookstore: build-bookstore
-	docker build -t $(CTR_REGISTRY)/bookstore -f dockerfiles/Dockerfile.bookstore .
+	docker build -t $(CTR_REGISTRY)/bookstore:$(CTR_TAG) -f dockerfiles/Dockerfile.bookstore .
 
 .PHONY: docker-build-init
 docker-build-init:
-	docker build -t $(CTR_REGISTRY)/init -f dockerfiles/Dockerfile.init .
+	docker build -t $(CTR_REGISTRY)/init:$(CTR_TAG) -f dockerfiles/Dockerfile.init .
 
 .PHONY: docker-push-ads
 docker-push-ads: docker-build-ads
-	docker push "$(CTR_REGISTRY)/ads"
+	docker push "$(CTR_REGISTRY)/ads:$(CTR_TAG)"
 
 .PHONY: docker-push-bookbuyer
 docker-push-bookbuyer: docker-build-bookbuyer
-	docker push "$(CTR_REGISTRY)/bookbuyer"
+	docker push "$(CTR_REGISTRY)/bookbuyer:$(CTR_TAG)"
 
 .PHONY: docker-push-bookthief
 docker-push-bookthief: docker-build-bookthief
-	docker push "$(CTR_REGISTRY)/bookthief"
+	docker push "$(CTR_REGISTRY)/bookthief:$(CTR_TAG)"
 
 .PHONY: docker-push-bookstore
 docker-push-bookstore: docker-build-bookstore
-	docker push "$(CTR_REGISTRY)/bookstore"
+	docker push "$(CTR_REGISTRY)/bookstore:$(CTR_TAG)"
 
 .PHONY: docker-push-init
 docker-push-init: docker-build-init
-	docker push "$(CTR_REGISTRY)/init"
+	docker push "$(CTR_REGISTRY)/init:$(CTR_TAG)"
 
 .PHONY: docker-push
 docker-push: docker-push-init docker-push-bookbuyer docker-push-bookthief docker-push-bookstore docker-push-ads

--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -34,6 +34,9 @@ const (
 	// ContainerRegistryEnvVar is the name of the environment variable storing the container registry.
 	ContainerRegistryEnvVar = "CTR_REGISTRY"
 
+	// ContainerTag is the name of the environment variable storing the container tag for the images to be used.
+	ContainerTag = "CTR_TAG"
+
 	// AzureSubscription is the name of the env var storing the azure subscription to watch.
 	AzureSubscription = "AZURE_SUBSCRIPTION"
 

--- a/demo/cmd/deploy/xds.go
+++ b/demo/cmd/deploy/xds.go
@@ -19,6 +19,7 @@ const (
 
 func main() {
 	acr := os.Getenv(common.ContainerRegistryEnvVar)
+	adsVersion := os.Getenv(common.ContainerTag)
 	containerRegistryCredsName := os.Getenv(common.ContainerRegistryCredsEnvVar)
 	azureSubscription := os.Getenv(common.AzureSubscription)
 	initContainer := path.Join(acr, "init")
@@ -185,7 +186,7 @@ func main() {
 			InitContainers: nil,
 			Containers: []v1.Container{
 				{
-					Image:           fmt.Sprintf("%s/%s:latest", acr, common.AggregatedDiscoveryServiceName),
+					Image:           fmt.Sprintf("%s/%s:%s", acr, common.AggregatedDiscoveryServiceName, adsVersion),
 					ImagePullPolicy: "Always",
 					Name:            common.AggregatedDiscoveryServiceName,
 					Ports: []v1.ContainerPort{

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -70,7 +70,7 @@ spec:
       containers:
         # Main container with APP
         - name: bookbuyer
-          image: "${CTR_REGISTRY}/bookbuyer:latest"
+          image: "${CTR_REGISTRY}/bookbuyer:${CTR_TAG}"
           imagePullPolicy: Always
           command: ["/bookbuyer"]
 

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -63,7 +63,7 @@ spec:
       automountServiceAccountToken: false
       containers:
 
-        - image: "${CTR_REGISTRY}/bookstore:latest"
+        - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always
           name: $SVC
           ports:

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -70,7 +70,7 @@ spec:
       containers:
         # Main container with APP
         - name: bookthief
-          image: "${CTR_REGISTRY}/bookthief:latest"
+          image: "${CTR_REGISTRY}/bookthief:${CTR_TAG}"
           imagePullPolicy: Always
           command: ["/bookthief"]
 

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXT
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
Container images created by the CI system should be tagged appropriately so parallel builds don't conflict (one CI run installs `:latest` from another CI run)