### PR TITLE
keyvault: Leverage existing GetAuthorizerWithRetry to create KeyVault client

### DIFF
--- a/pkg/keyvaultclient/client.go
+++ b/pkg/keyvaultclient/client.go
@@ -1,0 +1,38 @@
+package keyvaultclient
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	az "github.com/Azure/go-autorest/autorest/azure"
+	"github.com/rs/zerolog/log"
+
+	"github.com/open-service-mesh/osm/pkg/azure"
+)
+
+const (
+	azureKeyVaultBaseURI   = "vault.azure.net"
+	pollingDurationTimeout = 15 * time.Minute
+)
+
+func newKeyVaultClient(keyVaultName string, azureAuthFile string) (*client, error) {
+	authorizer, err := azure.GetAuthorizerWithRetry(azureAuthFile, azureKeyVaultBaseURI)
+	if err != nil {
+		log.Error().Err(err).Msgf("[%s] Error getting Azure Key Vault authorizer", packageName)
+		return nil, err
+	}
+
+	keyVaultClient := keyvault.New()
+	keyVaultClient.Authorizer = authorizer
+	keyVaultClient.PollingDuration = pollingDurationTimeout
+	return &client{
+		client:        &keyVaultClient,
+		vaultURL:      getKeyVaultURL(keyVaultName),
+		announcements: make(chan interface{}),
+	}, nil
+}
+
+func getKeyVaultURL(keyVaultName string) string {
+	return fmt.Sprintf("https://%s.%s", keyVaultName, az.PublicCloud.KeyVaultDNSSuffix)
+}

--- a/pkg/keyvaultclient/types.go
+++ b/pkg/keyvaultclient/types.go
@@ -1,0 +1,18 @@
+package keyvaultclient
+
+import (
+	"reflect"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+	"github.com/open-service-mesh/osm/pkg/utils"
+)
+
+type empty struct{}
+
+var packageName = utils.GetLastChunkOfSlashed(reflect.TypeOf(empty{}).PkgPath())
+
+type client struct {
+	client        *keyvault.BaseClient
+	vaultURL      string
+	announcements chan interface{}
+}

--- a/pkg/providers/azure/client.go
+++ b/pkg/providers/azure/client.go
@@ -16,7 +16,7 @@ func NewProvider(subscriptionID string, azureAuthFile string, stop chan struct{}
 	var authorizer autorest.Authorizer
 	var err error
 
-	if authorizer, err = azure.GetAuthorizerWithRetry(azureAuthFile); err != nil {
+	if authorizer, err = azure.GetAuthorizerWithRetry(azureAuthFile, n.DefaultBaseURI); err != nil {
 		log.Fatal().Err(err).Msg("Failed obtaining authentication token for Azure Resource Manager")
 	}
 


### PR DESCRIPTION
This PR is stacked on https://github.com/open-service-mesh/osm/pull/391 

Here we introduce:

  - `pkg/keyvaultclient` package
  - `newKeyVaultClient()` which is not *yet* used;  leverages the `GetAuthorizerWithRetry()` introduced in https://github.com/open-service-mesh/osm/pull/391

