### PR TITLE
logger: Adding a new pkg/logger

### DIFF
--- a/pkg/azure/auth.go
+++ b/pkg/azure/auth.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/rs/zerolog/log"
+
+	"github.com/open-service-mesh/osm/pkg/logger"
 )
 
 const (
@@ -17,6 +18,8 @@ const (
 
 // ErrUnableToObtainArmAuth is the error returned when GetAuthorizerWithRetry has not been able to authorize with ARM
 var ErrUnableToObtainArmAuth = errors.New("unable to obtain ARM authorizer")
+
+var log = logger.New("azure")
 
 // GetAuthorizerWithRetry obtains an Azure Resource Manager authorizer.
 func GetAuthorizerWithRetry(azureAuthFile string, baseURI string) (autorest.Authorizer, error) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,25 @@
+package logger
+
+import (
+	"os"
+	"path"
+	"runtime"
+
+	"github.com/rs/zerolog"
+)
+
+// CallerHook implements zerolog.Hook interface.
+type CallerHook struct{}
+
+// Run adds additional context
+func (h CallerHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+	if _, file, line, ok := runtime.Caller(3); ok {
+		e.Str("file", path.Base(file)).Int("line", line)
+	}
+}
+
+// New creates a new zerolog.Logger
+func New(name string) zerolog.Logger {
+	l := zerolog.New(os.Stdout).With().Timestamp().Str("logger", name).Logger().Hook(CallerHook{})
+	return l.Output(zerolog.ConsoleWriter{Out: os.Stdout})
+}


### PR DESCRIPTION
While working on Azure Key Vault integration I realized I need a bit more information from our zerolog implementation.  Decided to create `pkg/logging` and set-up what's needed (file and line number).

This is very minimal - just exploratory at this point. We can start with this and grow it as needed.

I understand `zerolog.ConsoleWriter` - we should be able to change this w/ a CLI param.


What this looks like: 
![image](https://user-images.githubusercontent.com/49918230/78190257-865d5980-7428-11ea-8798-d5ebc5c8f56d.png)
