### PR TITLE
Change OSM metrics port to 9091

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -143,7 +143,7 @@ func main() {
 	// TODO(draychev): figure out the NS and POD
 	metricsStore := metricsstore.NewMetricStore("TBD_NameSpace", "TBD_PodName")
 	// TODO(draychev): the port number should be configurable
-	httpServer := httpserver.NewHTTPServer(adsServer, metricsStore, "15000", meshCatalog.GetDebugInfo)
+	httpServer := httpserver.NewHTTPServer(adsServer, metricsStore, constants.MetricsServerPort, meshCatalog.GetDebugInfo)
 	httpServer.Start()
 
 	// Wait for exit handler signal

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -51,4 +51,7 @@ const (
 
 	// RootCertPath is the path too the root certificate
 	RootCertPath = "/etc/ssl/certs/root-cert.pem"
+
+	// MetricsServerPort is the port on which OSM exposes its own metrics server
+	MetricsServerPort = 9091
 )

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -37,10 +37,10 @@ func NewHealthMux(handlers map[string]http.Handler) *http.ServeMux {
 }
 
 // NewHTTPServer creates a new api server
-func NewHTTPServer(somethingWithProbes health.Probes, metricStore metricsstore.MetricStore, apiPort string, debugInfo func() http.Handler) HTTPServer {
+func NewHTTPServer(somethingWithProbes health.Probes, metricStore metricsstore.MetricStore, apiPort int32, debugInfo func() http.Handler) HTTPServer {
 	return &httpServer{
 		server: &http.Server{
-			Addr: fmt.Sprintf(":%s", apiPort),
+			Addr: fmt.Sprintf(":%d", apiPort),
 			Handler: NewHealthMux(map[string]http.Handler{
 				"/health/ready": health.ReadinessHandler(somethingWithProbes),
 				"/health/alive": health.LivenessHandler(somethingWithProbes),

--- a/scripts/port-forward-osm-metrics.sh
+++ b/scripts/port-forward-osm-metrics.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+source .env
+
+POD="$(kubectl get pods --selector app=ads -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+
+kubectl port-forward "$POD" -n "$K8S_NAMESPACE" 9091:9091
+


### PR DESCRIPTION
Its a bit confusing to use 15000 as the metrics port
because 15000 is used by Envoy's admin port. Use the 90xx range
for OSM ports.