### PR TITLE
Update cmd option name: s/subscriptionID/azureSubscriptionID/

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -45,14 +45,14 @@ var (
 )
 
 var (
-	flags          = pflag.NewFlagSet(`ads`, pflag.ExitOnError)
-	subscriptionID = flags.String("subscriptionID", "", "Azure Subscription")
-	port           = flags.Int("port", constants.AggregatedDiscoveryServicePort, "Aggregated Discovery Service port number.")
-	certPem        = flags.String("certpem", "", "Full path to the xDS Certificate PEM file")
-	keyPem         = flags.String("keypem", "", "Full path to the xDS Key PEM file")
-	rootCertPem    = flags.String("rootcertpem", "", "Full path to the Root Certificate PEM file")
-	rootKeyPem     = flags.String("rootkeypem", "", "Full path to the Root Key PEM file")
-	log            = logger.New("ads/main")
+	flags               = pflag.NewFlagSet(`ads`, pflag.ExitOnError)
+	azureSubscriptionID = flags.String("azureSubscriptionID", "", "Azure Subscription ID")
+	port                = flags.Int("port", constants.AggregatedDiscoveryServicePort, "Aggregated Discovery Service port number.")
+	certPem             = flags.String("certpem", "", "Full path to the xDS Certificate PEM file")
+	keyPem              = flags.String("keypem", "", "Full path to the xDS Key PEM file")
+	rootCertPem         = flags.String("rootcertpem", "", "Full path to the Root Certificate PEM file")
+	rootKeyPem          = flags.String("rootkeypem", "", "Full path to the Root Key PEM file")
+	log                 = logger.New("ads/main")
 )
 
 func init() {
@@ -123,7 +123,7 @@ func main() {
 	if azureAuthFile != "" {
 		azureResourceClient := azureResource.NewClient(kubeConfig, namespaceController, stop)
 		endpointsProviders = append(endpointsProviders, azure.NewProvider(
-			*subscriptionID, azureAuthFile, stop, meshSpec, azureResourceClient, constants.AzureProviderName))
+			*azureSubscriptionID, azureAuthFile, stop, meshSpec, azureResourceClient, constants.AzureProviderName))
 	}
 	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop, endpointsProviders...)
 

--- a/demo/cmd/deploy/xds.go
+++ b/demo/cmd/deploy/xds.go
@@ -82,7 +82,7 @@ func main() {
 
 	args := []string{
 		"--kubeconfig", "/kube/config",
-		"--subscriptionID", azureSubscription,
+		"--azureSubscriptionID", azureSubscription,
 		"--verbosity", "trace",
 		"--osmID", osmID,
 		"--osmNamespace", namespace,


### PR DESCRIPTION
The subscriptionID is used for Azure, so call the variable as such.
Although the construct of subscriptionID but me relevant to other
cloud providers, its better to not overload the argument for providers
other than Azure.