### PR TITLE
Switch to apps/v1 API group for Deployment resource

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -42,7 +42,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bookbuyer

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -41,7 +41,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: $SVC

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -43,7 +43,7 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: bookthief

--- a/demo/metrics/prometheus/deploy-prometheusService.sh
+++ b/demo/metrics/prometheus/deploy-prometheusService.sh
@@ -7,13 +7,16 @@ source .env
 
 echo -e "Deploy $PROMETHEUS_SVC monitoring service"
 cat <<EOF | kubectl apply -f -
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "$PROMETHEUS_SVC-deployment"
   namespace: "$K8S_NAMESPACE"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app:  "$PROMETHEUS_SVC-server"
   strategy:
     type: Recreate
   template:
@@ -61,4 +64,3 @@ spec:
   ports:
     - port: 7070
 EOF
-      

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -7,8 +7,8 @@ import (
 
 	kubernetes2 "github.com/open-service-mesh/osm/pkg/kubernetes"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -30,7 +30,7 @@ func NewProvider(kubeConfig *rest.Config, namespaceController namespace.Controll
 
 	informerCollection := InformerCollection{
 		Endpoints:   informerFactory.Core().V1().Endpoints().Informer(),
-		Deployments: informerFactory.Extensions().V1beta1().Deployments().Informer(),
+		Deployments: informerFactory.Apps().V1().Deployments().Informer(),
 	}
 
 	cacheCollection := CacheCollection{
@@ -112,7 +112,7 @@ func (c Client) ListServicesForServiceAccount(svcAccount endpoint.NamespacedServ
 	deploymentsInterface := c.caches.Deployments.List()
 
 	for _, deployments := range deploymentsInterface {
-		if kubernetesDeployments := deployments.(*extensionsv1.Deployment); kubernetesDeployments != nil {
+		if kubernetesDeployments := deployments.(*appsv1.Deployment); kubernetesDeployments != nil {
 			if !c.namespaceController.IsMonitoredNamespace(kubernetesDeployments.Namespace) {
 				// Doesn't belong to namespaces we are observing
 				continue


### PR DESCRIPTION
As of K8s v.16, API group extensions/v1beta1 for Deployment
is deprecated. Use the apps/v1 API group which has been available
since v1.9 and is the recommended API group for Deployment.

Testing done:
- Demo works as expected
- Prometheus stats are visible