### PR TITLE
tresor: Create new x509 cert template dedicated to CA creation

### DIFF
--- a/pkg/tresor/ca.go
+++ b/pkg/tresor/ca.go
@@ -4,25 +4,52 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/open-service-mesh/osm/pkg/tresor/pem"
 )
 
 // NewCA creates a new Certificate Authority.
 func NewCA(org string, validity time.Duration) (pem.RootCertificate, pem.RootPrivateKey, *x509.Certificate, *rsa.PrivateKey, error) {
-	template, err := makeTemplate("", org, validity)
+	// Validity duration of the certificate
+	notBefore := time.Now()
+	notAfter := notBefore.Add(validity)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, errors.Wrap(err, errGeneratingSerialNumber.Error())
 	}
 
-	template.IsCA = true
-	template.KeyUsage |= x509.KeyUsageCertSign
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "Azure Mesh RSA Certification Authority",
+			Country:      []string{"US"},
+			Locality:     []string{"CA"},
+			Organization: []string{org},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
 
 	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
+		log.Error().Err(err).Msgf("Error generating key for CA for org %s", org)
 		return nil, nil, nil, nil, err
 	}
+
 	caCert, caKey, err := genCert(template, template, caPrivKey, caPrivKey)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error generating certificate for CA for org %s", org)
+		return nil, nil, nil, nil, err
+	}
 	return pem.RootCertificate(caCert), pem.RootPrivateKey(caKey), template, caPrivKey, err
 }


### PR DESCRIPTION
We have `makeTemplate()` https://github.com/open-service-mesh/osm/blob/b428834f1bade1f2279127358676b225c43e6640/pkg/tresor/tools.go#L48-L61 , which we will continue to use for leaf-node certificates.
For the creation of root cert and intermediaries I'd like to use a dedicated template.