### PR TITLE
tresor: Carve out constants

### DIFF
--- a/pkg/tresor/ca.go
+++ b/pkg/tresor/ca.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"math/big"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,7 +18,6 @@ func NewCA(org string, validity time.Duration) (pem.RootCertificate, pem.RootPri
 	notBefore := time.Now()
 	notAfter := notBefore.Add(validity)
 
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, errGeneratingSerialNumber.Error())

--- a/pkg/tresor/manager.go
+++ b/pkg/tresor/manager.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"math/big"
 	"time"
 
 	"github.com/pkg/errors"
@@ -32,7 +31,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName) (certificate.
 		return nil, errors.Wrap(err, errGeneratingPrivateKey.Error())
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, errors.Wrap(err, errGeneratingSerialNumber.Error())
 	}

--- a/pkg/tresor/types.go
+++ b/pkg/tresor/types.go
@@ -3,6 +3,7 @@ package tresor
 import (
 	"crypto/rsa"
 	"crypto/x509"
+	"math/big"
 	"time"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
@@ -23,12 +24,16 @@ const (
 	// How many bits to use for the RSA key
 	rsaBits = 4096
 
+	// How many bits in the certificate serial number
+	certSerialNumberBits = 128
+
 	// Organization field of certificates issued by Tresor
 	org = "Open Service Mesh Tresor"
 )
 
 var (
-	log = logger.New("tresor")
+	log               = logger.New("tresor")
+	serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), certSerialNumberBits)
 )
 
 // CertManager implements certificate.Manager


### PR DESCRIPTION
Follow up from https://github.com/open-service-mesh/osm/pull/423#discussion_r406415835 -- moving these constants in a central place.