### PR TITLE
tresor: Delete unused code

### DIFF
--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -1,14 +1,10 @@
 package tresor
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"time"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
-	"github.com/open-service-mesh/osm/pkg/tresor/pem"
-	"github.com/pkg/errors"
 )
 
 // GetName implements certificate.Certificater and returns the CN of the cert.
@@ -69,58 +65,4 @@ func NewCertManager(ca *Certificate, validity time.Duration) (*CertManager, erro
 		cache:         make(map[certificate.CommonName]Certificate),
 	}
 	return &cm, nil
-}
-
-// NewCertManagerWithCAFromFile creates a new CertManager with the passed files containing the CA and CA Private Key
-// TODO(draychev): DELETEME
-func NewCertManagerWithCAFromFile(certFilePEM string, keyFilePEM string, org string, validity time.Duration) (*CertManager, error) {
-	ca, _, err := certFromFile(certFilePEM)
-	if err != nil {
-		return nil, err
-	}
-	rsaKey, _, err := privKeyFromFile(keyFilePEM)
-	if err != nil {
-		log.Error().Err(err).Msgf("Error loading private key from file %s", keyFilePEM)
-		return nil, err
-	}
-	return NewCertManagerWithCA(ca, rsaKey, org, validity)
-}
-
-// NewCertManagerWithCA creates a new CertManager with the passed CA and CA Private Key
-// TODO(draychev): DELETEME
-func NewCertManagerWithCA(ca *x509.Certificate, caPrivKey *rsa.PrivateKey, org string, validity time.Duration) (*CertManager, error) {
-	cm := CertManager{
-		ca: &Certificate{
-			name:     rootCertificateName,
-			x509Cert: ca,
-			rsaKey:   caPrivKey,
-		},
-		announcements: make(chan interface{}),
-		validity:      validity,
-		cache:         make(map[certificate.CommonName]Certificate),
-	}
-	return &cm, nil
-}
-
-// TODO(draychev): DELETEME
-func genCert(template, parent *x509.Certificate, certPrivKey, caPrivKey *rsa.PrivateKey) (pem.Certificate, pem.PrivateKey, error) {
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, parent, &certPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		log.Error().Err(err).Msgf("Error issuing x509.CreateCertificate command for CN=%s", template.Subject.CommonName)
-		return nil, nil, errors.Wrap(err, errCreateCert.Error())
-	}
-
-	certPEM, err := encodeCert(derBytes)
-	if err != nil {
-		log.Error().Err(err).Msgf("Error encoding certificate with CN=%s", template.Subject.CommonName)
-		return nil, nil, err
-	}
-
-	privKeyPEM, err := encodeKey(certPrivKey)
-	if err != nil {
-		log.Error().Err(err).Msgf("Error encoding private key for certificate with CN=%s", template.Subject.CommonName)
-		return nil, nil, err
-	}
-
-	return certPEM, privKeyPEM, nil
 }


### PR DESCRIPTION
With the refactoring of `pkg/tresor/...` we introduced new methods, which load root cert (https://github.com/open-service-mesh/osm/pull/422) and create a new CA.

This PR deletes the code that was obsoleted by the previous PRs: https://github.com/open-service-mesh/osm/pull/419, https://github.com/open-service-mesh/osm/pull/420, https://github.com/open-service-mesh/osm/pull/421, https://github.com/open-service-mesh/osm/pull/423, https://github.com/open-service-mesh/osm/pull/428, https://github.com/open-service-mesh/osm/pull/429, https://github.com/open-service-mesh/osm/pull/433,