### PR TITLE
Pin envoy image to v1.14.1

### DIFF
--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultEnvoyImage          = "envoyproxy/envoy-alpine:latest" // v1.13.1 currently
+	defaultEnvoyImage          = "envoyproxy/envoy-alpine:v1.14.1"
 	sidecarInjectorWebhookPort = 443
 )
 


### PR DESCRIPTION
latest tag is missing for the image, so pin to the latest working
version.
Resolves #390