### PR TITLE
Remove deprecated appNamespaces references

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -38,7 +38,6 @@ var (
 	osmID          string // An ID that uniquely identifies an OSM instance
 	azureAuthFile  string
 	kubeConfigFile string
-	appNamespaces  string // comma separated list of namespaces to observe
 	osmNamespace   string
 	injectorConfig injector.Config
 )
@@ -59,7 +58,6 @@ func init() {
 	flags.StringVar(&osmID, "osmID", "", "OSM instance ID")
 	flags.StringVar(&azureAuthFile, "azureAuthFile", "", "Path to Azure Auth File")
 	flags.StringVar(&kubeConfigFile, "kubeconfig", "", "Path to Kubernetes config file.")
-	flags.StringVar(&appNamespaces, "appNamespaces", "", "List of comma separated application namespaces OSM should manage.")
 	flags.StringVar(&osmNamespace, "osmNamespace", "", "Namespace to which OSM belongs to.")
 
 	// sidecar injector options

--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -13,9 +13,6 @@ const (
 	// KubeNamespaceEnvVar is the environment variable with the k8s namespace
 	KubeNamespaceEnvVar = "K8S_NAMESPACE"
 
-	// AppNamespacesEnvVar is the environment variable for a comma separated list of application namespaces
-	AppNamespacesEnvVar = "APP_NAMESPACES"
-
 	// OsmIDEnvVar is the environment variable for the namespace an OSM instance belongs to
 	OsmIDEnvVar = "OSM_ID"
 

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -71,7 +71,6 @@ func generateXdsPod(namespace string) *apiv1.Pod {
 	containerRegistryCredsName := os.Getenv(common.ContainerRegistryCredsEnvVar)
 	azureSubscription := os.Getenv(common.AzureSubscription)
 	initContainer := path.Join(acr, "init")
-	appNamespaces := os.Getenv(common.AppNamespacesEnvVar)
 	osmID := os.Getenv(common.OsmIDEnvVar)
 
 	meta := getXdsLabelMeta(namespace)
@@ -81,7 +80,6 @@ func generateXdsPod(namespace string) *apiv1.Pod {
 		"--verbosity", "trace",
 		"--osmID", osmID,
 		"--osmNamespace", namespace,
-		"--appNamespaces", appNamespaces,
 		"--certpem", "/etc/ssl/certs/cert.pem",
 		"--keypem", "/etc/ssl/certs/key.pem",
 		"--rootcertpem", "/etc/ssl/certs/root-cert.pem",

--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -43,9 +43,6 @@ for ns in "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE"; 
     kubectl create namespace "$ns"
     kubectl label  namespaces "$ns" openservicemesh.io/monitor="$OSM_ID"
 done
-# APP_NAMESPACES is a comma separated list of namespaces that informs OSM of the
-# namespaces it should observe.
-export APP_NAMESPACES="$BOOKBUYER_NAMESPACE,$BOOKSTORE_NAMESPACE,$BOOKTHIEF_NAMESPACE"
 
 make build-cert
 


### PR DESCRIPTION
OSM dynamically monitors namespaces and statically
passing the app namespaces is not required anymore.