### PR TITLE
Support regex matching HTTP route paths

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -22,7 +22,7 @@ func main() {
 		bookstoreService = "bookstore.mesh"
 	}
 	booksBought := fmt.Sprintf("http://%s/books-bought", bookstoreService)
-	buyBook := fmt.Sprintf("http://%s/buy-a-book", bookstoreService)
+	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()
 	iteration := 0
 	for {

--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -96,7 +96,7 @@ func main() {
 	//endpoints
 	router.HandleFunc("/books-bought", getBooksBought).Methods("GET")
 	router.HandleFunc("/books-bought", updateBooksBought).Methods("POST")
-	router.HandleFunc("/buy-a-book", buyBook).Methods("GET")
+	router.HandleFunc("/buy-a-book/new", buyBook).Methods("GET")
 	http.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {})
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), router)
 	log.Fatal().Err(err).Msgf("Failed to start HTTP server on port %d", *port)

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -22,7 +22,7 @@ func main() {
 		bookstoreService = "bookstore.mesh"
 	}
 	booksBought := fmt.Sprintf("http://%s/books-bought", bookstoreService)
-	buyBook := fmt.Sprintf("http://%s/buy-a-book", bookstoreService)
+	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()
 	iteration := 0
 	for {

--- a/demo/deploy-traffic-spec.sh
+++ b/demo/deploy-traffic-spec.sh
@@ -50,7 +50,7 @@ matches:
   pathRegex: /books-bought
   methods: ["GET"]
 - name: buy-a-book
-  pathRegex: /buy-a-book
+  pathRegex: ".*a-book.*new"
   methods: ["GET"]
 - name: update-books-bought
   pathRegex: /update-books-bought

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
+github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=


### PR DESCRIPTION
SMI spec defines `pathRegex` for matching HTTP routes
based on a HTTP path that can be a regex. OSM has been
matching routes on prefixes instead of regex matching
on paths, which is fixed in this change.

This change extends the demo as follows:
- Expose a bookbuying service at buy-a-book/new
- Specify an SMI policy with a regex match for the above service

Resolves #451