### PR TITLE
Program HTTP methods for a route instead of virtual host

### DIFF
--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -43,6 +43,7 @@ specs:
   name: bookstore-service-routes
   matches:
   - buy-a-book
+  - update-books-bought
 sources:
 - kind: ServiceAccount
   name: bookbuyer-serviceaccount

--- a/pkg/envoy/route/routeConfiguration_test.go
+++ b/pkg/envoy/route/routeConfiguration_test.go
@@ -63,8 +63,8 @@ var _ = Describe("Route Configuration", func() {
 			Expect(len(sourceRouteConfig.VirtualHosts)).To(Equal(1))
 			Expect(len(sourceRouteConfig.VirtualHosts[0].Routes)).To(Equal(1))
 			Expect(sourceRouteConfig.VirtualHosts[0].Routes[0].Match.GetSafeRegex().Regex).To(Equal("/books-bought"))
+			Expect(sourceRouteConfig.VirtualHosts[0].Routes[0].Match.GetHeaders()[0].GetExactMatch()).To(Equal("GET"))
 			Expect(sourceRouteConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters()).To(Equal(&destWeightedClusters))
-			Expect(sourceRouteConfig.VirtualHosts[0].Cors.AllowMethods).To(Equal("GET"))
 			//Validating the inbound clusters and routes
 			destinationRouteConfig := NewInboundRouteConfiguration()
 			destinationRouteConfig = UpdateRouteConfiguration(trafficPolicies, destinationRouteConfig, false, true)
@@ -73,8 +73,8 @@ var _ = Describe("Route Configuration", func() {
 			Expect(len(destinationRouteConfig.VirtualHosts)).To(Equal(1))
 			Expect(len(destinationRouteConfig.VirtualHosts[0].Routes)).To(Equal(1))
 			Expect(destinationRouteConfig.VirtualHosts[0].Routes[0].Match.GetSafeRegex().Regex).To(Equal("/books-bought"))
+			Expect(sourceRouteConfig.VirtualHosts[0].Routes[0].Match.GetHeaders()[0].GetExactMatch()).To(Equal("GET"))
 			Expect(destinationRouteConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters()).To(Equal(&srcWeightedClusters))
-			Expect(destinationRouteConfig.VirtualHosts[0].Cors.AllowMethods).To(Equal("GET"))
 		})
 	})
 })
@@ -134,7 +134,11 @@ var _ = Describe("Route Action weighted clusters", func() {
 				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
 			}
 
-			route1 := createRoute("books-bought", weightedClusters, false)
+			routePath := endpoint.RoutePaths{
+				RoutePathRegex: "books-bought",
+				RouteMethods:   []string{"GET", "POST"},
+			}
+			route1 := createRoute(&routePath, weightedClusters, false)
 			rt := []*route.Route{&route1}
 			updatedAction := updateRouteActionWeightedClusters(*rt[0].GetRoute().GetWeightedClusters(), newWeightedClusters, false)
 			Expect(updatedAction.Route.GetWeightedClusters().TotalWeight).To(Equal(&wrappers.UInt32Value{Value: uint32(200)}))


### PR DESCRIPTION
In the SMI HTTPRouterGroup spec, a domain could have multiple
HTTP method access policies and hence multiple associated routes.
Currently OSM programs the allowed methods on the top level
virtual host instead of the specific routes within a virtual host.
This will not work when #415 is fixed, where a virtual host will
be associated with a domain. An access policy for a route takes
precedence over the virtual host policy, so program the allowed
method associated with a route as a part of the route matching
for a route within a virtual host.

Also updates the traffic spec to include multiple HTTP methods
for sanity purpose and the import identifier for envoy's route
package to avoid conflicts.

Resolves #455