### PR TITLE
tresor: Simplify obtaining the CA for a certificate

### DIFF
--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -1,7 +1,5 @@
 package certificate
 
-import "crypto/x509"
-
 // CommonName is the Subject Common Name from a given SSL certificate.
 type CommonName string
 
@@ -22,7 +20,7 @@ type Certificater interface {
 	GetPrivateKey() []byte
 
 	// GetIssuingCA returns the root certificate for the given cert.
-	GetIssuingCA() *x509.Certificate
+	GetIssuingCA() []byte
 }
 
 // Manager is the interface declaring the methods for the Certificate Manager.

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -1,9 +1,7 @@
 package sds
 
 import (
-	"bytes"
 	"context"
-	"encoding/pem"
 	"fmt"
 	"strings"
 
@@ -125,12 +123,6 @@ func getServiceCertSecret(cert certificate.Certificater, name string) (*auth.Sec
 }
 
 func getRootCert(cert certificate.Certificater, resourceName string) (*auth.Secret, error) {
-	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.GetIssuingCA().Raw}
-	var rootCert bytes.Buffer
-	err := pem.Encode(&rootCert, &block)
-	if err != nil {
-		return nil, errors.Wrap(err, "error PEM encoding certificate")
-	}
 	secret := &auth.Secret{
 		// The Name field must match the tls_context.common_tls_context.tls_certificate_sds_secret_configs.name
 		Name: resourceName,
@@ -138,7 +130,7 @@ func getRootCert(cert certificate.Certificater, resourceName string) (*auth.Secr
 			ValidationContext: &auth.CertificateValidationContext{
 				TrustedCa: &core.DataSource{
 					Specifier: &core.DataSource_InlineBytes{
-						InlineBytes: rootCert.Bytes(),
+						InlineBytes: cert.GetIssuingCA(),
 					},
 				},
 				/*MatchSubjectAltNames: []*envoy_type_matcher.StringMatcher{{

--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -1,7 +1,6 @@
 package tresor
 
 import (
-	"crypto/x509"
 	"time"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
@@ -23,12 +22,16 @@ func (c Certificate) GetPrivateKey() []byte {
 }
 
 // GetIssuingCA implements certificate.Certificater and returns the root certificate for the given cert.
-func (c Certificate) GetIssuingCA() *x509.Certificate {
+func (c Certificate) GetIssuingCA() []byte {
 	if c.ca == nil {
 		log.Info().Msgf("No root certificate available for certificate with CN=%s", c.x509Cert.Subject.CommonName)
 		return nil
 	}
-	return c.ca.x509Cert
+	cert, err := encodeCertDERtoPEM(c.ca.x509Cert.Raw)
+	if err != nil {
+		log.Error().Err(err).Msg("Error PEM encoding root certificate")
+	}
+	return cert
 }
 
 // LoadCA loads the certificate and its key from the supplied PEM files.

--- a/pkg/tresor/types.go
+++ b/pkg/tresor/types.go
@@ -56,6 +56,9 @@ type Certificate struct {
 	// The name of the certificate
 	name string
 
+	// When the cert expires
+	expiration time.Time
+
 	// PEM encoded Certificate and Key (byte arrays)
 	certChain  pem.Certificate
 	privateKey pem.PrivateKey


### PR DESCRIPTION
Changing the return type of `GetIssuingCA()` to a PEM encoded certificate. (For compatibility leaving this as generic `[]byte`).

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).