### PR TITLE
certificates: Change format of Common Name to UUID.svc.namespace

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,9 +1,6 @@
 package constants
 
 const (
-	// DefaultKubeNamespace is the default Kubernetes namespace.
-	DefaultKubeNamespace = "default"
-
 	// AzureProviderName is the string constant used for the ID of the Azure endpoints provider.
 	// These strings identify the participating clusters / endpoint providers.
 	// Ideally these should be not only the type of compute but also a unique identifier, like the FQDN of the cluster,
@@ -49,20 +46,8 @@ const (
 	// EnvoyPrometheusInboundListenerPort is Envoy's inbound listener port number for prometheus
 	EnvoyPrometheusInboundListenerPort = 15010
 
-	// CertCommonNameUUIDServiceDelimiter is the character used to delimit the UUID and service name in the certificate's CommonName
-	CertCommonNameUUIDServiceDelimiter = ";"
-
-	// NamespaceServiceDelimiter is the character used to delimit a namespace and a service name when used together
-	NamespaceServiceDelimiter = "/"
-
 	// InjectorWebhookPort is the port on which the sidecar injection webhook listens
 	InjectorWebhookPort = 9090
-
-	// RootCertPemStoreName is the name of the root certificate config store
-	RootCertPemStoreName = "ca-rootcertpemstore"
-
-	// RootCertPath is the path too the root certificate
-	RootCertPath = "/etc/ssl/certs/root-cert.pem"
 
 	// MetricsServerPort is the port on which OSM exposes its own metrics server
 	MetricsServerPort = 9091

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -35,7 +35,7 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 	// TODO: Need a better way to map a proxy to a service. This
 	// is primarly required because envoy configurations are programmed
 	// per service.
-	cnMeta := utils.GetCertificateCommonNameMeta(cn.String())
+	cnMeta := utils.GetCertificateCommonNameMeta(cn)
 	namespacedSvcAcc := endpoint.NamespacedServiceAccount{
 		Namespace:      cnMeta.Namespace,
 		ServiceAccount: cnMeta.ServiceAccountName,

--- a/pkg/utils/certificate.go
+++ b/pkg/utils/certificate.go
@@ -1,55 +1,27 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/certificate"
 )
 
 const (
 	domainDelimiter = "."
 )
 
-// NewCertCommonNameWithUUID returns a newly generated CommonName for a certificate of the form: <UUID>;<domain>
-func NewCertCommonNameWithUUID(serviceAccountName, namespace, subDomain string) string {
-	return fmt.Sprintf("%s%s%s.%s.%s", NewUUIDStr(), constants.CertCommonNameUUIDServiceDelimiter, serviceAccountName, namespace, subDomain)
+// NewCertCommonNameWithUUID returns a newly generated CommonName for a certificate of the form: <UUID>.<domain>
+func NewCertCommonNameWithUUID(serviceAccountName, namespace, subDomain string) certificate.CommonName {
+	return certificate.CommonName(strings.Join([]string{NewUUIDStr(), serviceAccountName, namespace, subDomain}, domainDelimiter))
 }
 
 // GetCertificateCommonNameMeta returns the metadata information in the CommonName of a certificate
-func GetCertificateCommonNameMeta(cn string) CertificateCommonNameMeta {
-	var cnMeta CertificateCommonNameMeta
-	var cnWithUUIDStripped string
-
-	if strings.Contains(cn, constants.CertCommonNameUUIDServiceDelimiter) {
-		tmp := strings.Split(cn, constants.CertCommonNameUUIDServiceDelimiter)
-		cnMeta.UUID = tmp[0]
-		cnWithUUIDStripped = tmp[1]
-	} else {
-		cnWithUUIDStripped = cn
+func GetCertificateCommonNameMeta(cn certificate.CommonName) CertificateCommonNameMeta {
+	chunks := strings.Split(cn.String(), domainDelimiter)
+	return CertificateCommonNameMeta{
+		UUID:               chunks[0],
+		ServiceAccountName: chunks[1],
+		Namespace:          chunks[2],
+		SubDomain:          strings.Join(chunks[3:], domainDelimiter),
 	}
-
-	maxSplits := 3 // <service_account_name>.<namespace>.<sub_domain>
-	tmp := strings.SplitN(cnWithUUIDStripped, domainDelimiter, maxSplits)
-	if len(tmp) != maxSplits {
-		panic("Certificate Common Name domain should be of the form <service_account_name>.<namespace>.<sub_domain>")
-	}
-
-	cnMeta.ServiceAccountName = tmp[0]
-	cnMeta.Namespace = tmp[1]
-	cnMeta.SubDomain = tmp[2]
-
-	return cnMeta
-
-}
-
-// GetCertCommonNameWithoutUUID returns the CommonName with the UUID stripped if the UUID delimiter exists, otherwise returns the existing name
-func GetCertCommonNameWithoutUUID(cn string) string {
-	if strings.Contains(cn, constants.CertCommonNameUUIDServiceDelimiter) {
-		tmp := strings.Split(cn, constants.CertCommonNameUUIDServiceDelimiter)
-		cnWithUUIDStripped := tmp[1]
-		return cnWithUUIDStripped
-	}
-
-	return cn
 }

--- a/pkg/utils/certificate_test.go
+++ b/pkg/utils/certificate_test.go
@@ -3,10 +3,10 @@ package utils
 import (
 	"fmt"
 
+	"github.com/open-service-mesh/osm/pkg/certificate"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/open-service-mesh/osm/pkg/constants"
 )
 
 const (
@@ -20,7 +20,8 @@ var _ = Describe("Testing utils helpers", func() {
 		It("Should return the the CommonName of the form <uuid>;<service_account_name>.<namespace>.<sub_domain>.", func() {
 			cn := NewCertCommonNameWithUUID(testServiceAccountName, testNamespace, testSubDomain)
 			cnMeta := GetCertificateCommonNameMeta(cn)
-			Expect(cn).To(Equal(fmt.Sprintf("%s%s%s.%s.%s", cnMeta.UUID, constants.CertCommonNameUUIDServiceDelimiter, cnMeta.ServiceAccountName, cnMeta.Namespace, cnMeta.SubDomain)))
+			expected := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", cnMeta.UUID, cnMeta.ServiceAccountName, cnMeta.Namespace, cnMeta.SubDomain))
+			Expect(cn).To(Equal(expected))
 		})
 	})
 })
@@ -34,29 +35,17 @@ var _ = Describe("Testing utils helpers", func() {
 			Expect(IsValidUUID(cnMeta.UUID)).To(BeTrue())
 			Expect(cnMeta.Namespace).To(Equal(testNamespace))
 			Expect(cnMeta.SubDomain).To(Equal(testSubDomain))
-			Expect(cn).To(Equal(fmt.Sprintf("%s%s%s.%s.%s", cnMeta.UUID, constants.CertCommonNameUUIDServiceDelimiter, cnMeta.ServiceAccountName, cnMeta.Namespace, cnMeta.SubDomain)))
+			expected := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", cnMeta.UUID, cnMeta.ServiceAccountName, cnMeta.Namespace, cnMeta.SubDomain))
+			Expect(cn).To(Equal(expected))
 		})
 
 		It("Should panic because Certificate's Common Name doesn't have the correct format.", func() {
 			CausePanic := func() {
-				invalidCN := "ab.c"
+				invalidCN := certificate.CommonName("ab.c")
 				GetCertificateCommonNameMeta(invalidCN)
 			}
 
 			Expect(CausePanic).To(Panic())
-		})
-	})
-})
-
-var _ = Describe("Testing utils helpers", func() {
-	Context("Test GetCertCommonNameWithoutUUID", func() {
-		It("Should return the the CommonName without UUID if present.", func() {
-			cnWithoutUUID := "svca.ns.osm.mesh"
-			cnWithUUID := fmt.Sprintf("4507ae67-a401-404e-aa93-cc5ee3edfd6e%s%s", constants.CertCommonNameUUIDServiceDelimiter, cnWithoutUUID)
-			cn := GetCertCommonNameWithoutUUID(cnWithUUID)
-			Expect(cn).To(Equal(cnWithoutUUID))
-			cn = GetCertCommonNameWithoutUUID(cnWithoutUUID)
-			Expect(cn).To(Equal(cnWithoutUUID))
 		})
 	})
 })


### PR DESCRIPTION
The goal of this PR is to remove the usage of a `;` in separating the UUID of the cert from the rest of the CN.
A `;` character makes the CN format unfriendly with Hashi Vault (and presumably other cert managers)
With this change we use `.` as a separator between the pieces forming the CN

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426)
