### PR TITLE
feat(*): Supporting domain specific routing on envoy

### DIFF
--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -40,6 +40,7 @@ func (sc *MeshCatalog) getWeightedEndpointsPerService(clientID endpoint.Namespac
 			log.Error().Msgf("TrafficSplit %s/%s has no Backends in Spec; Skipping...", trafficSplit.Namespace, trafficSplit.Name)
 			continue
 		}
+		domain := trafficSplit.Spec.Service
 		for _, trafficSplitBackend := range trafficSplit.Spec.Backends {
 			namespacedServiceName := endpoint.NamespacedService{
 				Namespace: trafficSplit.Namespace,
@@ -49,6 +50,7 @@ func (sc *MeshCatalog) getWeightedEndpointsPerService(clientID endpoint.Namespac
 			svcEp.WeightedService = endpoint.WeightedService{
 				ServiceName: namespacedServiceName,
 				Weight:      trafficSplitBackend.Weight,
+				Domain:      domain,
 			}
 			var err error
 			if svcEp.Endpoints, err = sc.listEndpointsForService(svcEp.WeightedService); err != nil {

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -11,40 +11,18 @@ var _ = Describe("UniqueLists", func() {
 		It("Returns unique list of services", func() {
 
 			services := []endpoint.NamespacedService{
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-1"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-1"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-2"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-3"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-2"},
+				{Namespace: "osm", Service: "booktore-1"},
+				{Namespace: "osm", Service: "booktore-1"},
+				{Namespace: "osm", Service: "booktore-2"},
+				{Namespace: "osm", Service: "booktore-3"},
+				{Namespace: "osm", Service: "booktore-2"},
 			}
 
 			actual := uniqueServices(services)
 			expected := []endpoint.NamespacedService{
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-1"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-2"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "booktore-3"},
-			}
-			Expect(actual).To(Equal(expected))
-		})
-	})
-
-	Context("Testing uniqueness of weighted clusters", func() {
-		It("Returns unique list of weighted clusters", func() {
-
-			weightedClusters := []endpoint.WeightedCluster{
-				{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-1-local"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-1-local"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 50},
-			}
-
-			actual := uniqueClusters(weightedClusters)
-			expected := []endpoint.WeightedCluster{
-				{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-1-local"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
-				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 50},
+				{Namespace: "osm", Service: "booktore-1"},
+				{Namespace: "osm", Service: "booktore-2"},
+				{Namespace: "osm", Service: "booktore-3"},
 			}
 			Expect(actual).To(Equal(expected))
 		})
@@ -56,8 +34,8 @@ var _ = Describe("ServicesToString", func() {
 		It("Returns string list", func() {
 
 			services := []endpoint.NamespacedService{
-				endpoint.NamespacedService{Namespace: "osm", Service: "bookstore-1"},
-				endpoint.NamespacedService{Namespace: "osm", Service: "bookstore-2"},
+				{Namespace: "osm", Service: "bookstore-1"},
+				{Namespace: "osm", Service: "bookstore-2"},
 			}
 
 			actual := servicesToString(services)

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -51,6 +51,12 @@ type MeshCataloger interface {
 
 	// GetServicesByServiceAccountName returns a list of services corresponding to a service account, and refreshes the cache if requested
 	GetServicesByServiceAccountName(endpoint.NamespacedServiceAccount, bool) []endpoint.NamespacedService
+
+	//GetDomainForService returns the domain name of a service
+	GetDomainForService(service endpoint.NamespacedService) (string, error)
+
+	//GetWeightedClusterForService returns the weighted cluster for a service
+	GetWeightedClusterForService(service endpoint.NamespacedService) (endpoint.WeightedCluster, error)
 }
 
 type announcementChannel struct {

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -70,10 +70,11 @@ func (ns NamespacedServiceAccount) String() string {
 // ClusterName is a type for a service name
 type ClusterName string
 
-//WeightedService is a struct of a service name and its weight
+//WeightedService is a struct of a service name, its weight and domain
 type WeightedService struct {
 	ServiceName NamespacedService `json:"service_name:omitempty"`
 	Weight      int               `json:"weight:omitempty"`
+	Domain      string            `json:"domain:omitempty"`
 }
 
 // WeightedServiceEndpoints is a struct of a weighted service and its endpoints
@@ -107,5 +108,10 @@ type TrafficPolicyResource struct {
 	ServiceAccount ServiceAccount      `json:"service_account:omitempty"`
 	Namespace      string              `json:"namespace:omitempty"`
 	Services       []NamespacedService `json:"services:omitempty"`
-	Clusters       []WeightedCluster   `json:"clusters:omitempty"`
+}
+
+//RoutePolicyWeightedClusters is a struct of a route and the weighted clusters on that route
+type RoutePolicyWeightedClusters struct {
+	RoutePolicy      RoutePolicy
+	WeightedClusters []WeightedCluster
 }

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -1,0 +1,143 @@
+package rds
+
+import (
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Route exists in routePolicyWeightedClustersList", func() {
+	Context("Testing a route is already in a given list of routes", func() {
+		It("Returns true and the index of route in the list", func() {
+
+			weightedClusters := []endpoint.WeightedCluster{
+				{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100},
+				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
+			}
+			routePolicy := endpoint.RoutePolicy{
+				PathRegex: "/books-bought",
+				Methods:   []string{"GET"},
+			}
+			routePolicyWeightedClustersList := []endpoint.RoutePolicyWeightedClusters{
+				{RoutePolicy: routePolicy, WeightedClusters: weightedClusters},
+			}
+			newRoutePolicy := endpoint.RoutePolicy{
+				PathRegex: "/books-bought",
+				Methods:   []string{"GET"},
+			}
+
+			index, routeExists := routeExits(routePolicyWeightedClustersList, newRoutePolicy)
+			Expect(index).To(Equal(0))
+			Expect(routeExists).To(Equal(true))
+		})
+	})
+
+	Context("Testing a route doesn't exist a given list of routes", func() {
+		It("Returns false and the index of -1", func() {
+
+			weightedClusters := []endpoint.WeightedCluster{
+				{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100},
+				{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
+			}
+			routePolicy := endpoint.RoutePolicy{
+				PathRegex: "/books-bought",
+				Methods:   []string{"GET"},
+			}
+			routeWeightedClustersList := []endpoint.RoutePolicyWeightedClusters{
+				{RoutePolicy: routePolicy, WeightedClusters: weightedClusters},
+			}
+			newRoutePolicy := endpoint.RoutePolicy{
+				PathRegex: "/buy-a-book",
+				Methods:   []string{"GET"},
+			}
+
+			index, routeExists := routeExits(routeWeightedClustersList, newRoutePolicy)
+			Expect(index).To(Equal(-1))
+			Expect(routeExists).To(Equal(false))
+		})
+	})
+})
+
+var _ = Describe("Construct RoutePolicyWeightedClusters object", func() {
+	Context("Testing the creating of a RoutePolicyWeightedClusters object", func() {
+		It("Returns RoutePolicyWeightedClusters", func() {
+
+			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}
+			routePolicy := endpoint.RoutePolicy{
+				PathRegex: "/books-bought",
+				Methods:   []string{"GET"},
+			}
+
+			routePolicyWeightedClusters := createRoutePolicyWeightedClusters(routePolicy, weightedCluster)
+			Expect(routePolicyWeightedClusters).NotTo(Equal(nil))
+			Expect(routePolicyWeightedClusters.RoutePolicy.PathRegex).To(Equal("/books-bought"))
+			Expect(routePolicyWeightedClusters.RoutePolicy.Methods).To(Equal([]string{"GET"}))
+			Expect(len(routePolicyWeightedClusters.WeightedClusters)).To(Equal(1))
+			Expect(string(routePolicyWeightedClusters.WeightedClusters[0].ClusterName)).To(Equal("osm/bookstore-1"))
+			Expect(routePolicyWeightedClusters.WeightedClusters[0].Weight).To(Equal(100))
+		})
+	})
+})
+
+var _ = Describe("AggregateRoutesByDomain", func() {
+	domainRoutesMap := make(map[string][]endpoint.RoutePolicyWeightedClusters)
+	Context("Building a map of routes by domain", func() {
+		It("Returns a new aggregated map of domain and routes", func() {
+
+			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}
+			routePolicies := []endpoint.RoutePolicy{
+				{PathRegex: "/books-bought", Methods: []string{"GET"}},
+				{PathRegex: "/buy-a-book", Methods: []string{"GET"}},
+			}
+
+			aggregateRoutesByDomain(domainRoutesMap, routePolicies, weightedCluster, "bookstore.mesh")
+			Expect(domainRoutesMap).NotTo(Equal(nil))
+			Expect(len(domainRoutesMap)).To(Equal(1))
+			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(2))
+			Expect(domainRoutesMap["bookstore.mesh"][0].RoutePolicy).To(Equal(endpoint.RoutePolicy{PathRegex: "/books-bought", Methods: []string{"GET"}}))
+			Expect(len(domainRoutesMap["bookstore.mesh"][0].WeightedClusters)).To(Equal(1))
+			Expect(domainRoutesMap["bookstore.mesh"][0].WeightedClusters[0]).To(Equal(endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}))
+			Expect(domainRoutesMap["bookstore.mesh"][1].RoutePolicy).To(Equal(endpoint.RoutePolicy{PathRegex: "/buy-a-book", Methods: []string{"GET"}}))
+			Expect(len(domainRoutesMap["bookstore.mesh"][1].WeightedClusters)).To(Equal(1))
+			Expect(domainRoutesMap["bookstore.mesh"][1].WeightedClusters[0]).To(Equal(endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}))
+		})
+	})
+
+	Context("Adding a route to existing domain in the map", func() {
+		It("Returns the map of with a new route on the domain", func() {
+
+			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}
+			routePolicies := []endpoint.RoutePolicy{
+				{PathRegex: "/update-books-bought", Methods: []string{"GET"}},
+			}
+
+			aggregateRoutesByDomain(domainRoutesMap, routePolicies, weightedCluster, "bookstore.mesh")
+			Expect(domainRoutesMap).NotTo(Equal(nil))
+			Expect(len(domainRoutesMap)).To(Equal(1))
+			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(3))
+			Expect(domainRoutesMap["bookstore.mesh"][2].RoutePolicy).To(Equal(endpoint.RoutePolicy{PathRegex: "/update-books-bought", Methods: []string{"GET"}}))
+			Expect(len(domainRoutesMap["bookstore.mesh"][2].WeightedClusters)).To(Equal(1))
+			Expect(domainRoutesMap["bookstore.mesh"][0].WeightedClusters[0]).To(Equal(endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}))
+		})
+	})
+
+	Context("Adding a cluster to an existing route to existing domain in the map", func() {
+		It("Returns the map of with a new weighted cluster on a route in the domain", func() {
+
+			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100}
+			routePolicies := []endpoint.RoutePolicy{
+				{PathRegex: "/update-books-bought", Methods: []string{"GET"}},
+			}
+
+			aggregateRoutesByDomain(domainRoutesMap, routePolicies, weightedCluster, "bookstore.mesh")
+			Expect(domainRoutesMap).NotTo(Equal(nil))
+			Expect(len(domainRoutesMap)).To(Equal(1))
+			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(3))
+			Expect(domainRoutesMap["bookstore.mesh"][2].RoutePolicy).To(Equal(endpoint.RoutePolicy{PathRegex: "/update-books-bought", Methods: []string{"GET", "GET"}}))
+			Expect(len(domainRoutesMap["bookstore.mesh"][2].WeightedClusters)).To(Equal(2))
+			Expect(domainRoutesMap["bookstore.mesh"][2].WeightedClusters[0]).To(Equal(endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}))
+			Expect(domainRoutesMap["bookstore.mesh"][2].WeightedClusters[1]).To(Equal(endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100}))
+		})
+	})
+})

--- a/pkg/envoy/rds/suite_test.go
+++ b/pkg/envoy/rds/suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestEndpoints(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "RDS Test Suite")
 }

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -181,6 +181,7 @@ func (c *Client) ListServices() []endpoint.WeightedService {
 	var services []endpoint.WeightedService
 	for _, splitIface := range c.caches.TrafficSplit.List() {
 		split := splitIface.(*split.TrafficSplit)
+		domain := split.Spec.Service
 		for _, backend := range split.Spec.Backends {
 			// The TrafficSplit SMI Spec does not allow providing a namespace for the backends,
 			// so we assume that the top level namespace for the TrafficSplit is the namespace
@@ -189,7 +190,7 @@ func (c *Client) ListServices() []endpoint.WeightedService {
 				Namespace: split.Namespace,
 				Service:   backend.Service,
 			}
-			services = append(services, endpoint.WeightedService{ServiceName: namespacedServiceName, Weight: backend.Weight})
+			services = append(services, endpoint.WeightedService{ServiceName: namespacedServiceName, Weight: backend.Weight, Domain: domain})
 		}
 	}
 	return services


### PR DESCRIPTION
This PR resolves the issue mentioned in #415

For the SMI Traffic Split version v1alpha2, the spec.Service provides the domain for all the backend services .
The route configuration is updated to contain multiple virtual hosts, where each host will contain routes to a specific domain only. Sample virtual host configuration after this change is as follows :

```
{
     "version_info": "1",
     "route_config": {
      "@type": "type.googleapis.com/envoy.api.v2.RouteConfiguration",
      "name": "RDS_Outbound",
      "virtual_hosts": [
       {
        "name": "outbound_virtualHost|bookstore.mesh",
        "domains": [
         "bookstore.mesh"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "exact_match": "GET"
            }
           ],
           "safe_regex": {
            "google_re2": {
             "max_program_size": 1024
            },
            "regex": "/books-bought"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore-ns/bookstore-1",
              "weight": 50
             }
            ],
            "total_weight": 50
           }
          }
         },
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "exact_match": "GET"
            }
           ],
           "safe_regex": {
            "google_re2": {
             "max_program_size": 1024
            },
            "regex": ".*a-book.*new"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore-ns/bookstore-2",
              "weight": 50
             }
            ],
            "total_weight": 50
           }
          }
         },
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "exact_match": "POST"
            }
           ],
           "safe_regex": {
            "google_re2": {
             "max_program_size": 1024
            },
            "regex": "/update-books-bought"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore-ns/bookstore-2",
              "weight": 50
             }
            ],
            "total_weight": 50
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": true
     },
     "last_updated": "2020-04-18T00:55:51.390Z"
    }
````
Some other changes related to this PR : 

- The process of building the route configuration has been simplified significantly, by first building a map of the routes on a domain and iterating through this map while constructing the configuration
- Unit test has been updated to support a scenario of multiple domains having the same routes, hence showing the creating of multiple virtual hosts

Both the demo and prometheus stat collection work with these changes