### PR TITLE
demo: Splitting the YAML applied in smaller sections

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -aueo pipefail
+set -auexo pipefail
 
 # shellcheck disable=SC1091
 source .env
@@ -11,7 +11,7 @@ echo "WAIT_FOR_OK_SECONDS = ${WAIT_FOR_OK_SECONDS}"
 kubectl create namespace "$BOOKBUYER_NAMESPACE" || true
 kubectl delete deployment bookbuyer -n "$BOOKBUYER_NAMESPACE"  || true
 
-echo -e "Deploy BookBuyer demo service"
+echo -e "Deploy BookBuyer Service Account"
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ServiceAccount
@@ -19,9 +19,10 @@ metadata:
   name: bookbuyer-serviceaccount
   namespace: $BOOKBUYER_NAMESPACE
 automountServiceAccountToken: false
+EOF
 
----
-
+echo -e "Deploy BookBuyer Service"
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Service
 metadata:
@@ -39,9 +40,10 @@ spec:
     app: bookbuyer
 
   type: NodePort
+EOF
 
----
-
+echo -e "Deploy BookBuyer Deployment"
+cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -aueo pipefail
+set -auexo pipefail
 
 # shellcheck disable=SC1091
 source .env
@@ -11,7 +11,7 @@ kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  || true
 
 GIT_HASH=$(git rev-parse --short HEAD)
 
-echo -e "Deploy $SVC demo service"
+echo -e "Deploy $SVC Namespace"
 cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ServiceAccount
@@ -19,9 +19,10 @@ metadata:
   name: "$SVC-serviceaccount"
   namespace: $BOOKSTORE_NAMESPACE
 automountServiceAccountToken: false
+EOF
 
----
-
+echo -e "Deploy $SVC Service"
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: Service
 metadata:
@@ -38,9 +39,10 @@ spec:
     app: $SVC
 
   type: NodePort
+EOF
 
----
-
+echo -e "Deploy $SVC Deployment"
+cat <<EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/demo/deploy-traffic-spec.sh
+++ b/demo/deploy-traffic-spec.sh
@@ -5,6 +5,7 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
+echo "Deploy HTTPRouteGroup CRD"
 kubectl apply -f - <<EOF
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -20,9 +21,10 @@ spec:
       - htr
     plural: httproutegroups
     singular: httproutegroup
+EOF
 
----
-
+echo "Deploy TCPRoute CRD"
+kubectl apply -f - <<EOF
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -38,8 +40,10 @@ spec:
     plural: tcproutes
     singular: tcproute
 
----
+EOF
 
+echo "Create HTTPRouteGroup"
+kubectl apply -f - <<EOF
 apiVersion: specs.smi-spec.io/v1alpha1
 kind: HTTPRouteGroup
 metadata:


### PR DESCRIPTION
This PR splits large YAML blobs into smaller sub-commands with some comments so it is easier to understand what happens during Demo deployment.

No functional code changes.

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426)