### PR TITLE
demo: Adding the script needed to deploy a Vault for the demo

### DIFF
--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -79,7 +79,7 @@ spec:
     protocol: TCP
 EOF
 
-kubectl logs -f $(kubectl get pods --selector app=vault --no-headers=true | awk '{print $1}')
+kubectl logs -f "$(kubectl get pods --selector app=vault --no-headers=true | awk '{print $1}')"
 
 
 exit 0


### PR DESCRIPTION
This scripts deploys an insecure, non-HA version of Vault to a K8s cluster with hard-coded token.
This is going to be used to demo the integration, and also test the integration via CI.

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426)