### PR TITLE
s/GetRootCertificate/GetIssuingCA/g

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -449,8 +449,8 @@ type Certificater interface {
 	// GetPrivateKey returns the private key.
 	GetPrivateKey() []byte
 
-	// GetRootCertificate returns the root certificate for the given cert.
-	GetRootCertificate() *x509.Certificate
+	// GetIssuingCA returns the root certificate for the given cert.
+	GetIssuingCA() *x509.Certificate
 }
 ```
 

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -21,8 +21,8 @@ type Certificater interface {
 	// GetPrivateKey returns the private key.
 	GetPrivateKey() []byte
 
-	// GetRootCertificate returns the root certificate for the given cert.
-	GetRootCertificate() *x509.Certificate
+	// GetIssuingCA returns the root certificate for the given cert.
+	GetIssuingCA() *x509.Certificate
 }
 
 // Manager is the interface declaring the methods for the Certificate Manager.

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -125,7 +125,7 @@ func getServiceCertSecret(cert certificate.Certificater, name string) (*auth.Sec
 }
 
 func getRootCert(cert certificate.Certificater, resourceName string) (*auth.Secret, error) {
-	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.GetRootCertificate().Raw}
+	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.GetIssuingCA().Raw}
 	var rootCert bytes.Buffer
 	err := pem.Encode(&rootCert, &block)
 	if err != nil {

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -83,7 +83,7 @@ type envoyBootstrapConfigMeta struct {
 
 func (wh *Webhook) createEnvoyTLSSecret(name string, namespace string, cert certificate.Certificater) (*corev1.Secret, error) {
 	// PEM encode the root certificate
-	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.GetRootCertificate().Raw}
+	block := pem.Block{Type: "CERTIFICATE", Bytes: cert.GetIssuingCA().Raw}
 	var rootCert bytes.Buffer
 	err := pem.Encode(&rootCert, &block)
 	if err != nil {

--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -22,8 +22,8 @@ func (c Certificate) GetPrivateKey() []byte {
 	return c.privateKey
 }
 
-// GetRootCertificate implements certificate.Certificater and returns the root certificate for the given cert.
-func (c Certificate) GetRootCertificate() *x509.Certificate {
+// GetIssuingCA implements certificate.Certificater and returns the root certificate for the given cert.
+func (c Certificate) GetIssuingCA() *x509.Certificate {
 	if c.ca == nil {
 		log.Info().Msgf("No root certificate available for certificate with CN=%s", c.x509Cert.Subject.CommonName)
 		return nil


### PR DESCRIPTION
Renaming `GetRootCertificate()` to `GetIssuingCA()` for clarity (inspired by Hashi's Vault API)

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).