### PR TITLE
catalog: Issue certificates for services based on GetCommonName (not the service name)

### DIFF
--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -53,10 +53,6 @@ func (ns NamespacedService) String() string {
 	return fmt.Sprintf("%s/%s", ns.Namespace, ns.Service)
 }
 
-func (ns NamespacedService) GetCommonName() certificate.CommonName {
-	return certificate.CommonName(strings.Join([]string{ns.Service, ns.Namespace, "svc", "cluster", "local"}, "."))
-}
-
 // ServiceAccount is a type for a service account
 type ServiceAccount string
 
@@ -82,10 +78,11 @@ func (ns NamespacedServiceAccount) String() string {
 // ClusterName is a type for a service name
 type ClusterName string
 
-//WeightedService is a struct of a service name and its weight
+//WeightedService is a struct of a service name, its weight and domain
 type WeightedService struct {
 	ServiceName NamespacedService `json:"service_name:omitempty"`
 	Weight      int               `json:"weight:omitempty"`
+	Domain      string            `json:"domain:omitempty"`
 }
 
 // WeightedServiceEndpoints is a struct of a weighted service and its endpoints
@@ -119,5 +116,10 @@ type TrafficPolicyResource struct {
 	ServiceAccount ServiceAccount      `json:"service_account:omitempty"`
 	Namespace      string              `json:"namespace:omitempty"`
 	Services       []NamespacedService `json:"services:omitempty"`
-	Clusters       []WeightedCluster   `json:"clusters:omitempty"`
+}
+
+//RoutePolicyWeightedClusters is a struct of a route and the weighted clusters on that route
+type RoutePolicyWeightedClusters struct {
+	RoutePolicy      RoutePolicy
+	WeightedClusters []WeightedCluster
 }

--- a/pkg/endpoint/types_test.go
+++ b/pkg/endpoint/types_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 var _ = Describe("Test NamespacedService methods", func() {
-
 	Context("Testing GetCommonName", func() {
 		It("should return DNS-1123 of the NamespacedService struct", func() {
 			namespacedService := NamespacedService{


### PR DESCRIPTION
When the service mesh catalog requests for a new certificate to be issued, it needs to come up with the CN for the certificate.  The CN is currently generated based on the namespace and the name of the service for which the certificate is issued.  The `namespace/service` is not a correct `DNS-1123` FQDN. For that reason we added GetCommonName (via https://github.com/open-service-mesh/osm/pull/486) and in this PR we are using it to issue a correct certificate.

Without this correction certain certificate issuers (such as Hashi Vault) would not be able to issue certs (error out w/ incorrect CN).

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).