### PR TITLE
tresor: Create fake Cert Manager for testing

### DIFF
--- a/pkg/tresor/fake.go
+++ b/pkg/tresor/fake.go
@@ -1,0 +1,21 @@
+package tresor
+
+import (
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+)
+
+// NewFakeCertManager creates a fake CertManager used for testing.
+func NewFakeCertManager() *CertManager {
+	ca, err := NewCA(1 * time.Hour)
+	if err != nil {
+		log.Error().Err(err).Msg("Error creating CA for fake cert manager")
+	}
+	return &CertManager{
+		ca:            ca,
+		validity:      1 * time.Hour,
+		announcements: make(chan interface{}),
+		cache:         make(map[certificate.CommonName]Certificate),
+	}
+}


### PR DESCRIPTION
This PR adds `NewFakeCertManager()` to the `tresor` package, which creates a certificate manager mock.

This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).