### PR TITLE
catalog: Test certificate issuance for namespaced services

### DIFF
--- a/pkg/catalog/certificates_test.go
+++ b/pkg/catalog/certificates_test.go
@@ -1,0 +1,39 @@
+package catalog
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/smi"
+	"github.com/open-service-mesh/osm/pkg/tresor"
+)
+
+func newMeshCatalog() *MeshCatalog {
+	meshSpec := smi.NewFakeMeshSpecClient()
+	certManager := tresor.NewFakeCertManager()
+	stop := make(<-chan struct{})
+	var endpointProviders []endpoint.Provider
+	return NewMeshCatalog(meshSpec, certManager, stop, endpointProviders...)
+}
+
+var _ = Describe("Test certificate tooling", func() {
+	Context("Testing DecodePEMCertificate along with GetCommonName and IssueCertificate", func() {
+		mc := newMeshCatalog()
+		It("issues a PEM certificate with the correct CN", func() {
+			namespacedService := endpoint.NamespacedService{
+				Namespace: "namespace-here",
+				Service:   "service-name-here",
+			}
+			cert, err := mc.certManager.IssueCertificate(namespacedService.GetCommonName())
+			Expect(err).ToNot(HaveOccurred())
+			actual := cert.GetCertificateChain()
+			expected := []byte{45, 45, 45, 45, 45, 66, 69, 71, 73, 78, 32, 67, 69, 82, 84, 73, 70, 73, 67, 65, 84, 69, 45, 45, 45, 45, 45, 10, 77, 73, 73, 70, 49}
+			Expect(actual[:33]).To(Equal(expected))
+			x509Cert, _, err := tresor.DecodePEMCertificate(cert.GetCertificateChain())
+			Expect(err).ToNot(HaveOccurred())
+			expectedCN := "service-name-here.namespace-here.svc.cluster.local"
+			Expect(x509Cert.Subject.CommonName).To(Equal(expectedCN))
+		})
+	})
+})


### PR DESCRIPTION
This PR uses the code introduced in https://github.com/open-service-mesh/osm/pull/486 (`NamespacedService.GetCommonName()`), https://github.com/open-service-mesh/osm/pull/488 (creating a fake cert manager), and https://github.com/open-service-mesh/osm/pull/490 (creatin ga fake mesh spec client) to test the integration between all these components.

This PR ensures the certificates being issued by cert manager to the catalog have correct common names.


This is one of the many PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).