### PR TITLE
events: Wrap logging of k8s events with an env var (too noisy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ export WAIT_SECONDS_FOR_200_OK=0  # 0 means wait forever for 200 OK
 
 # Enable human readable logs
 export OSM_HUMAN_DEBUG_LOG=true
+
+# Enable logging of observed Kubernetes events (must have trace logging level enabled as well)
+export OSM_LOG_KUBERNETES_EVENTS=true

--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"os"
 	"reflect"
 
 	"k8s.io/client-go/tools/cache"
@@ -18,7 +19,9 @@ func GetKubernetesEventHandlers(informerName string, providerName string, announ
 // Add a new item to Kubernetes caches from an incoming Kubernetes event.
 func Add(informerName string, providerName string, announce chan interface{}) func(obj interface{}) {
 	return func(obj interface{}) {
-		log.Trace().Msgf("[%s][%s] Add event: %+v", providerName, informerName, obj)
+		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
+			log.Trace().Msgf("[%s][%s] Add event: %+v", providerName, informerName, obj)
+		}
 		if announce != nil {
 			announce <- Event{
 				Type:  CreateEvent,
@@ -31,7 +34,9 @@ func Add(informerName string, providerName string, announce chan interface{}) fu
 // Update caches with an incoming Kubernetes event.
 func Update(informerName string, providerName string, announce chan interface{}) func(oldObj, newObj interface{}) {
 	return func(oldObj, newObj interface{}) {
-		log.Trace().Msgf("[%s][%s] Update event %+v", providerName, informerName, oldObj)
+		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
+			log.Trace().Msgf("[%s][%s] Update event %+v", providerName, informerName, oldObj)
+		}
 		if reflect.DeepEqual(oldObj, newObj) {
 			return
 		}
@@ -47,7 +52,9 @@ func Update(informerName string, providerName string, announce chan interface{})
 // Delete Kubernetes cache from an incoming Kubernetes event.
 func Delete(informerName string, providerName string, announce chan interface{}) func(obj interface{}) {
 	return func(obj interface{}) {
-		log.Trace().Msgf("[%s][%s] Delete event: %+v", providerName, informerName, obj)
+		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
+			log.Trace().Msgf("[%s][%s] Delete event: %+v", providerName, informerName, obj)
+		}
 		if announce != nil {
 			announce <- Event{
 				Type:  DeleteEvent,


### PR DESCRIPTION
The logging of Kubernetes events is useful, but also terribly noisy and drowns other interesting logs.

I used this env var to disable it in one of my dev branches - this may actually be useful to add to the repo.
