### PR TITLE
demo: Make Ads logs human readable during demo runs

### DIFF
--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -39,4 +39,7 @@ const (
 
 	// PrometheusVar is the environment variable for promethues service name
 	PrometheusVar = "PROMETHEUS_SVC"
+
+	// HumanReadableLogMessagesEnvVar is an environment variable, which when set to "true" enables colorful human-readable log messages.
+	HumanReadableLogMessagesEnvVar = "OSM_HUMAN_DEBUG_LOG"
 )

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -193,8 +193,8 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 						"/ads",
 					},
 					Env: []apiv1.EnvVar{{
-						Name:  "OSM_HUMAN_DEBUG_LOG",
-						Value: "true",
+						Name:  common.HumanReadableLogMessagesEnvVar,
+						Value: os.Getenv(common.HumanReadableLogMessagesEnvVar),
 					}},
 					Args: args,
 					VolumeMounts: []apiv1.VolumeMount{


### PR DESCRIPTION
This will enable human readable and colorful logs in ADS, which I personally find 10x faster to grok.

This is only for running the demo and parsing logs to troubleshoot issues.
I do not suggest we run this in production.