### PR TITLE
ads: Fatal on failing to load a root certificate

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -108,12 +108,13 @@ func main() {
 
 	namespaceController := namespace.NewNamespaceController(kubeConfig, osmID, stop)
 	meshSpec := smi.NewMeshSpecClient(kubeConfig, osmNamespace, namespaceController, stop)
-	cert, err := tresor.LoadCA(*rootCertPem, *rootKeyPem)
-	if err != nil {
-		log.Fatal().Msgf("Error loading CA from files %s and %s", *rootCertPem, *rootKeyPem)
+	ca, err := tresor.LoadCA(*rootCertPem, *rootKeyPem)
+	if ca == nil || err != nil {
+		log.Fatal().Err(err).Msgf("Error loading CA from files %s and %s", *rootCertPem, *rootKeyPem)
 	}
-	log.Info().Msgf("Loaded CA root %s cert from files %s and %s", cert.GetName(), *rootCertPem, *rootKeyPem)
-	certManager, err := tresor.NewCertManager(cert, 1*time.Hour)
+
+	log.Info().Msgf("Loaded CA root certificate from files %s and %s", *rootCertPem, *rootKeyPem)
+	certManager, err := tresor.NewCertManager(ca, 1*time.Hour)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to instantiate Certificate Manager")
 	}


### PR DESCRIPTION
This PR is a small refactor of the ADS launcher, which will Fatal if it failed to load the root cert and private key.

This is a chunk from https://github.com/open-service-mesh/osm/pull/483 and one of the few PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).