### PR TITLE
injector: Add detail to log message

### DIFF
--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -29,7 +29,7 @@ func (wh *Webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 	cn := utils.NewCertCommonNameWithUUID(pod.Spec.ServiceAccountName, namespace, subDomain)
 	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to issue TLS certificate for Envoy")
+		log.Error().Err(err).Msgf("Error issuing bootstrap certificate for Envoy with CN=%s", cn)
 		return nil, err
 	}
 


### PR DESCRIPTION
Adding the CN of the certificate we attempt to issue to this injector log message.

This is a chunk from https://github.com/open-service-mesh/osm/pull/483 and one of the few PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).