### PR TITLE
tresor: Rename Certificate.name to Certificate.commonName

### DIFF
--- a/pkg/tresor/ca.go
+++ b/pkg/tresor/ca.go
@@ -10,6 +10,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// CertificationAuthorityCommonName is the CN used for the root certificate for OSM.
+const CertificationAuthorityCommonName = "Open Service Mesh Certification Authority"
+
 // NewCA creates a new Certificate Authority.
 func NewCA(validity time.Duration) (*Certificate, error) {
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
@@ -21,7 +24,7 @@ func NewCA(validity time.Duration) (*Certificate, error) {
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName:   "Azure Mesh RSA Certification Authority",
+			CommonName:   CertificationAuthorityCommonName,
 			Country:      []string{"US"},
 			Locality:     []string{"CA"},
 			Organization: []string{org},
@@ -59,11 +62,10 @@ func NewCA(validity time.Duration) (*Certificate, error) {
 	}
 
 	rootCertificate := Certificate{
-		name:       rootCertificateName,
+		commonName: rootCertificateName,
 		certChain:  pemCert,
 		privateKey: pemKey,
-		x509Cert:   template,
-		rsaKey:     rsaKey,
+		expiration: template.NotAfter,
 	}
 
 	return &rootCertificate, nil

--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -8,7 +8,7 @@ import (
 
 // GetName implements certificate.Certificater and returns the CN of the cert.
 func (c Certificate) GetName() string {
-	return c.name
+	return c.commonName
 }
 
 // GetCertificateChain implements certificate.Certificater and returns the certificate chain.
@@ -49,7 +49,7 @@ func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
 	}
 
 	rootCertificate := Certificate{
-		name:       rootCertificateName,
+		commonName: rootCertificateName,
 		certChain:  pemCert,
 		privateKey: pemKey,
 		x509Cert:   x509Cert,

--- a/pkg/tresor/manager.go
+++ b/pkg/tresor/manager.go
@@ -71,7 +71,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName) (certificate.
 	}
 
 	cert := Certificate{
-		name:       string(cn),
+		commonName: string(cn),
 		certChain:  certPEM,
 		privateKey: privKeyPEM,
 		ca:         cm.ca,

--- a/pkg/tresor/types.go
+++ b/pkg/tresor/types.go
@@ -18,7 +18,7 @@ const (
 	// TypePrivateKey is a string constant to be used in the generation of a private key for a certificate.
 	TypePrivateKey = "PRIVATE KEY"
 
-	// String constant used for the name of the root certificate
+	// String constant used for the commonName of the root certificate
 	rootCertificateName = "root-certificate"
 
 	// How many bits to use for the RSA key
@@ -53,8 +53,8 @@ type CertManager struct {
 
 // Certificate implements certificate.Certificater
 type Certificate struct {
-	// The name of the certificate
-	name string
+	// The commonName of the certificate
+	commonName string
 
 	// When the cert expires
 	expiration time.Time


### PR DESCRIPTION
This PR renames `Certificate.name` to `Certificate.commonName` and also changes the CN of the auto-generated root cert (removes 'Azure' mention).

This is a chunk from https://github.com/open-service-mesh/osm/pull/483 and one of the few PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).