### PR TITLE
tresor: Tests for the DecodePEMCertificate tool

### DIFF
--- a/pkg/tresor/ca_test.go
+++ b/pkg/tresor/ca_test.go
@@ -13,9 +13,13 @@ var _ = Describe("Test creation of a new CA", func() {
 		cert, err := NewCA(2 * time.Second)
 		It("should create a new CA", func() {
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cert.x509Cert.NotAfter.Sub(cert.x509Cert.NotBefore)).To(Equal(2 * time.Second))
-			Expect(cert.x509Cert.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
-			Expect(cert.x509Cert.IsCA).To(BeTrue())
+
+			x509Cert, err := DecodePEMCertificate(cert.GetCertificateChain())
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(x509Cert.NotAfter.Sub(x509Cert.NotBefore)).To(Equal(2 * time.Second))
+			Expect(x509Cert.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
+			Expect(x509Cert.IsCA).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
This PR introduces a test for the `DecodePEMCertificate` tool.

This is stacked on and will only pass CI with https://github.com/open-service-mesh/osm/pull/500 merged.

This is a chunk from https://github.com/open-service-mesh/osm/pull/483 and one of the few PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).