### PR TITLE
tresor: Export simplified LoadCertificateFromFile and LoadPrivateKeyFromFile helpers

### DIFF
--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -8,7 +8,7 @@ import (
 
 // GetName implements certificate.Certificater and returns the CN of the cert.
 func (c Certificate) GetName() string {
-	return c.name
+	return c.commonName.String()
 }
 
 // GetCertificateChain implements certificate.Certificater and returns the certificate chain.
@@ -23,49 +23,59 @@ func (c Certificate) GetPrivateKey() []byte {
 
 // GetIssuingCA implements certificate.Certificater and returns the root certificate for the given cert.
 func (c Certificate) GetIssuingCA() []byte {
-	if c.ca == nil {
-		log.Info().Msgf("No root certificate available for certificate with CN=%s", c.x509Cert.Subject.CommonName)
+	if c.issuingCA == nil {
+		log.Fatal().Msgf("No issuing CA available for cert %s", c.commonName)
 		return nil
 	}
-	cert, err := encodeCertDERtoPEM(c.ca.x509Cert.Raw)
-	if err != nil {
-		log.Error().Err(err).Msg("Error PEM encoding root certificate")
-	}
-	return cert
+
+	return c.issuingCA.GetCertificateChain()
 }
 
 // LoadCA loads the certificate and its key from the supplied PEM files.
 func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
-	x509Cert, pemCert, err := certFromFile(certFilePEM)
+	pemCert, err := LoadCertificateFromFile(certFilePEM)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error loading certificate from file %s", certFilePEM)
 		return nil, err
 	}
 
-	rsaKey, pemKey, err := privKeyFromFile(keyFilePEM)
+	pemKey, err := LoadPrivateKeyFromFile(keyFilePEM)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error loading private key from file %s", keyFilePEM)
 		return nil, err
 	}
 
+	x509RootCert, err := DecodePEMCertificate(pemCert)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error converting certificate from PEM to x509 - CN=%s", rootCertificateName)
+	}
+
 	rootCertificate := Certificate{
-		name:       rootCertificateName,
+		commonName: rootCertificateName,
 		certChain:  pemCert,
 		privateKey: pemKey,
-		x509Cert:   x509Cert,
-		rsaKey:     rsaKey,
-		ca:         nil, // this is the CA itself
+		expiration: x509RootCert.NotAfter,
 	}
 	return &rootCertificate, nil
 }
 
 // NewCertManager creates a new CertManager with the passed CA and CA Private Key
 func NewCertManager(ca *Certificate, validity time.Duration) (*CertManager, error) {
-	cm := CertManager{
-		ca:            ca,
-		validity:      validity,
-		announcements: make(chan interface{}),
-		cache:         make(map[certificate.CommonName]Certificate),
+	if ca == nil {
+		return nil, errNoIssuingCA
 	}
-	return &cm, nil
+
+	return &CertManager{
+		// The root certificate signing all newly issued certificates
+		ca: ca,
+
+		// Newly issued certificates will be valid for this duration
+		certificatesValidFor: validity,
+
+		// Channel used to inform other components of cert changes (rotation etc.)
+		announcements: make(chan interface{}),
+
+		// Certificate cache
+		cache: make(map[certificate.CommonName]Certificate),
+	}, nil
 }

--- a/pkg/tresor/file.go
+++ b/pkg/tresor/file.go
@@ -1,10 +1,7 @@
 package tresor
 
 import (
-	"crypto/rsa"
-	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 
 	"github.com/pkg/errors"
@@ -12,48 +9,45 @@ import (
 	tresorPem "github.com/open-service-mesh/osm/pkg/tresor/pem"
 )
 
-func certFromFile(caPEMFile string) (*x509.Certificate, tresorPem.Certificate, error) {
+// LoadCertificateFromFile loads a certificate from a PEM file.
+func LoadCertificateFromFile(caPEMFile string) (tresorPem.Certificate, error) {
 	if caPEMFile == "" {
-		return nil, nil, errors.Wrap(errInvalidFileName, caPEMFile)
+		return nil, errors.Wrap(errInvalidFileName, caPEMFile)
 	}
 
 	caPEM, err := ioutil.ReadFile(caPEMFile)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, fmt.Sprintf("failed reading file: %+v", caPEMFile))
+		log.Error().Err(err).Msgf("Error reading file: %+v", caPEMFile)
+		return nil, err
 	}
 
 	caBlock, _ := pem.Decode(caPEM)
 	if caBlock == nil || caBlock.Type != TypeCertificate {
-		return nil, nil, errDecodingPEMBlock
+		log.Error().Err(err).Msgf("Certificate not found in file: %+v", caPEMFile)
+		return nil, errDecodingPEMBlock
 	}
 
-	ca, err := x509.ParseCertificate(caBlock.Bytes)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, fmt.Sprintf("failed parsing certificate loaded from %+v", caPEMFile))
-	}
-
-	return ca, caBlock.Bytes, nil
+	return pem.EncodeToMemory(caBlock), nil
 }
 
-func privKeyFromFile(caKeyPEMFile string) (*rsa.PrivateKey, tresorPem.PrivateKey, error) {
+// LoadPrivateKeyFromFile loads a private key from a PEM file.
+func LoadPrivateKeyFromFile(caKeyPEMFile string) (tresorPem.PrivateKey, error) {
 	if caKeyPEMFile == "" {
-		return nil, nil, errors.Wrap(errInvalidFileName, caKeyPEMFile)
+		log.Error().Msgf("Invalid file for private key: %s", caKeyPEMFile)
+		return nil, errInvalidFileName
 	}
 
 	caKeyPEM, err := ioutil.ReadFile(caKeyPEMFile)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, fmt.Sprintf("faled reading file: %+v", caKeyPEMFile))
+		log.Error().Err(err).Msgf("Error reading file: %+v", caKeyPEMFile)
+		return nil, err
 	}
 
 	caKeyBlock, _ := pem.Decode(caKeyPEM)
 	if caKeyBlock == nil || caKeyBlock.Type != TypePrivateKey {
-		return nil, nil, err
+		log.Error().Err(err).Msgf("Private Key not found in file: %+v", caKeyPEMFile)
+		return nil, err
 	}
 
-	caKeyInterface, err := x509.ParsePKCS8PrivateKey(caKeyBlock.Bytes)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, fmt.Sprintf("failed parsing private key loaded from %+v", caKeyPEMFile))
-	}
-
-	return caKeyInterface.(*rsa.PrivateKey), caKeyBlock.Bytes, nil
+	return pem.EncodeToMemory(caKeyBlock), nil
 }


### PR DESCRIPTION
This PR refactors/removes `certFromFile` and `privKeyFromFile` in lieu of `LoadCertificateFromFile` and 
`LoadPrivateKeyFromFile`

This is stacked on https://github.com/open-service-mesh/osm/pull/502

This is a chunk from https://github.com/open-service-mesh/osm/pull/483 and one of the few PRs in the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).