### PR TITLE
tresor: Rename CertManager.validity -> CertManager.validityPeriod

### DIFF
--- a/pkg/tresor/certificate.go
+++ b/pkg/tresor/certificate.go
@@ -62,10 +62,10 @@ func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
 // NewCertManager creates a new CertManager with the passed CA and CA Private Key
 func NewCertManager(ca *Certificate, validity time.Duration) (*CertManager, error) {
 	cm := CertManager{
-		ca:                   ca,
-		certificatesValidFor: validity,
-		announcements:        make(chan interface{}),
-		cache:                make(map[certificate.CommonName]Certificate),
+		ca:             ca,
+		validityPeriod: validity,
+		announcements:  make(chan interface{}),
+		cache:          make(map[certificate.CommonName]Certificate),
 	}
 	return &cm, nil
 }

--- a/pkg/tresor/fake.go
+++ b/pkg/tresor/fake.go
@@ -13,9 +13,9 @@ func NewFakeCertManager() *CertManager {
 		log.Error().Err(err).Msg("Error creating CA for fake cert manager")
 	}
 	return &CertManager{
-		ca:                   ca,
-		certificatesValidFor: 1 * time.Hour,
-		announcements:        make(chan interface{}),
-		cache:                make(map[certificate.CommonName]Certificate),
+		ca:             ca,
+		validityPeriod: 1 * time.Hour,
+		announcements:  make(chan interface{}),
+		cache:          make(map[certificate.CommonName]Certificate),
 	}
 }

--- a/pkg/tresor/manager.go
+++ b/pkg/tresor/manager.go
@@ -45,7 +45,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName) (certificate.
 			Organization: []string{org},
 		},
 		NotBefore: now,
-		NotAfter:  now.Add(cm.certificatesValidFor),
+		NotAfter:  now.Add(cm.validityPeriod),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},

--- a/pkg/tresor/types.go
+++ b/pkg/tresor/types.go
@@ -39,7 +39,7 @@ var (
 // CertManager implements certificate.Manager
 type CertManager struct {
 	// How long will newly issued certificates be valid for
-	certificatesValidFor time.Duration
+	validityPeriod time.Duration
 
 	// The Certificate Authority root certificate to be used by this certificate manager
 	ca *Certificate


### PR DESCRIPTION
This PR renames `CertManager.validity` -> `CertManager.certificatesValidFor` for clarity