### PR TITLE
Map a proxy instance to a service instead of service account

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -59,6 +59,8 @@ spec:
       labels:
         app: bookbuyer
         version: v1
+      annotations:
+        "openservicemesh.io/osm-service": "bookbuyer"
     spec:
       serviceAccountName: bookbuyer-serviceaccount
       automountServiceAccountToken: false

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -60,6 +60,7 @@ spec:
         version: v1
       annotations:
         "openservicemesh.io/sidecar-injection": "enabled"
+        "openservicemesh.io/osm-service": "$SVC"
     spec:
       serviceAccountName: "$SVC-serviceaccount"
       automountServiceAccountToken: false

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -2,7 +2,6 @@ package ads
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -36,17 +35,10 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 	// is primarly required because envoy configurations are programmed
 	// per service.
 	cnMeta := utils.GetCertificateCommonNameMeta(cn)
-	namespacedSvcAcc := endpoint.NamespacedServiceAccount{
-		Namespace:      cnMeta.Namespace,
-		ServiceAccount: cnMeta.ServiceAccountName,
+	namespacedService := endpoint.NamespacedService{
+		Namespace: cnMeta.Namespace,
+		Service:   cnMeta.ServiceName,
 	}
-	services := s.catalog.GetServicesByServiceAccountName(namespacedSvcAcc, true)
-	if len(services) == 0 {
-		// No services found for this service account, don't patch
-		return fmt.Errorf("No service found for service account %q", namespacedSvcAcc)
-	}
-	// TODO: Don't assume a service account maps to a single service
-	namespacedService := services[0]
 	log.Info().Msgf("cert: cn=%s, service=%s", cn, namespacedService)
 
 	proxy := envoy.NewProxy(cn, namespacedService, ip)

--- a/pkg/injector/sidecar.go
+++ b/pkg/injector/sidecar.go
@@ -56,8 +56,8 @@ func getEnvoySidecarContainerSpec(data *EnvoySidecarData) corev1.Container {
 		Args: []string{
 			"--log-level", "debug", // TODO: remove
 			"--config-path", envoyBootstrapConfigFile,
-			"--service-node", data.ServiceAccount,
-			"--service-cluster", data.ServiceAccount,
+			"--service-node", data.Service,
+			"--service-cluster", data.Service,
 		},
 	}
 

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -10,6 +10,10 @@ import (
 )
 
 const (
+	// OSM Annotations
+	annotationInject  = "openservicemesh.io/sidecar-injection"
+	annotationService = "openservicemesh.io/osm-service"
+
 	envoyTLSVolume             = "envoy-tls-volume"
 	envoyBootstrapConfigVolume = "envoy-bootstrap-config-volume"
 )
@@ -59,7 +63,7 @@ type InitContainerData struct {
 
 // EnvoySidecarData is the type used to represent information about the Envoy sidecar
 type EnvoySidecarData struct {
-	Name           string
-	Image          string
-	ServiceAccount string
+	Name    string
+	Image   string
+	Service string
 }

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -27,9 +27,6 @@ const (
 	tlsDir      = `/run/secrets/tls`
 	tlsCertFile = `tls.crt`
 	tlsKeyFile  = `tls.key`
-
-	// Annotations
-	annotationInject = "openservicemesh.io/sidecar-injection"
 )
 
 var (

--- a/pkg/utils/certificate.go
+++ b/pkg/utils/certificate.go
@@ -11,17 +11,17 @@ const (
 )
 
 // NewCertCommonNameWithUUID returns a newly generated CommonName for a certificate of the form: <UUID>.<domain>
-func NewCertCommonNameWithUUID(serviceAccountName, namespace, subDomain string) certificate.CommonName {
-	return certificate.CommonName(strings.Join([]string{NewUUIDStr(), serviceAccountName, namespace, subDomain}, domainDelimiter))
+func NewCertCommonNameWithUUID(serviceName, namespace, subDomain string) certificate.CommonName {
+	return certificate.CommonName(strings.Join([]string{NewUUIDStr(), serviceName, namespace, subDomain}, domainDelimiter))
 }
 
 // GetCertificateCommonNameMeta returns the metadata information in the CommonName of a certificate
 func GetCertificateCommonNameMeta(cn certificate.CommonName) CertificateCommonNameMeta {
 	chunks := strings.Split(cn.String(), domainDelimiter)
 	return CertificateCommonNameMeta{
-		UUID:               chunks[0],
-		ServiceAccountName: chunks[1],
-		Namespace:          chunks[2],
-		SubDomain:          strings.Join(chunks[3:], domainDelimiter),
+		UUID:        chunks[0],
+		ServiceName: chunks[1],
+		Namespace:   chunks[2],
+		SubDomain:   strings.Join(chunks[3:], domainDelimiter),
 	}
 }

--- a/pkg/utils/certificate_test.go
+++ b/pkg/utils/certificate_test.go
@@ -10,17 +10,17 @@ import (
 )
 
 const (
-	testServiceAccountName = "test-service-account"
-	testNamespace          = "test-namespace"
-	testSubDomain          = "foo.test.mesh"
+	testServiceName = "test-service"
+	testNamespace   = "test-namespace"
+	testSubDomain   = "foo.test.mesh"
 )
 
 var _ = Describe("Testing utils helpers", func() {
 	Context("Test NewCertCommonNameWithUUID", func() {
 		It("Should return the the CommonName of the form <uuid>;<service_account_name>.<namespace>.<sub_domain>.", func() {
-			cn := NewCertCommonNameWithUUID(testServiceAccountName, testNamespace, testSubDomain)
+			cn := NewCertCommonNameWithUUID(testServiceName, testNamespace, testSubDomain)
 			cnMeta := GetCertificateCommonNameMeta(cn)
-			expected := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", cnMeta.UUID, cnMeta.ServiceAccountName, cnMeta.Namespace, cnMeta.SubDomain))
+			expected := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", cnMeta.UUID, cnMeta.ServiceName, cnMeta.Namespace, cnMeta.SubDomain))
 			Expect(cn).To(Equal(expected))
 		})
 	})
@@ -29,13 +29,13 @@ var _ = Describe("Testing utils helpers", func() {
 var _ = Describe("Testing utils helpers", func() {
 	Context("Test GetCertificateCommonNameMeta", func() {
 		It("Should return the the Certificate's Common Name metadata correctly.", func() {
-			cn := NewCertCommonNameWithUUID(testServiceAccountName, testNamespace, testSubDomain)
+			cn := NewCertCommonNameWithUUID(testServiceName, testNamespace, testSubDomain)
 			cnMeta := GetCertificateCommonNameMeta(cn)
-			Expect(cnMeta.ServiceAccountName).To(Equal(testServiceAccountName))
+			Expect(cnMeta.ServiceName).To(Equal(testServiceName))
 			Expect(IsValidUUID(cnMeta.UUID)).To(BeTrue())
 			Expect(cnMeta.Namespace).To(Equal(testNamespace))
 			Expect(cnMeta.SubDomain).To(Equal(testSubDomain))
-			expected := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", cnMeta.UUID, cnMeta.ServiceAccountName, cnMeta.Namespace, cnMeta.SubDomain))
+			expected := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", cnMeta.UUID, cnMeta.ServiceName, cnMeta.Namespace, cnMeta.SubDomain))
 			Expect(cn).To(Equal(expected))
 		})
 

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -10,8 +10,8 @@ var (
 
 // CertificateCommonNameMeta is the type that stores the metadata present in the CommonName field in a proxy's certificate
 type CertificateCommonNameMeta struct {
-	UUID               string
-	ServiceAccountName string
-	Namespace          string
-	SubDomain          string
+	UUID        string
+	ServiceName string
+	Namespace   string
+	SubDomain   string
 }


### PR DESCRIPTION
This change (#515) is part of a broader issue (#514) to constrain a service
running in a mesh to a single service account. It encodes the service name
in the proxy's certificate instead of its service account. The allows
to remove the hack to pick the first service in the service account
while creating the proxy instance in ADS.

In order to map 1 proxy -- 1 service -- 1 service account, this change
does the following:
1. Uses openservicemesh.io/osm-service annotation as an explicit way
   to infer a service running on the POD
2. If the annotation is not present, assumes the service and service
   account have the same name.

With 1., service and service accounts can have different names as in
the demo setup.
With 2., service and service accounts should have the same name.

This change does not constrain 1 service -- 1 service account mapping,
which would be the responsibility of pre-OSM install checks or
validation webhooks.