### PR TITLE
tresor: Pass the CN to NewCA()

### DIFF
--- a/pkg/tresor/ca.go
+++ b/pkg/tresor/ca.go
@@ -7,14 +7,13 @@ import (
 	"crypto/x509/pkix"
 	"time"
 
+	"github.com/open-service-mesh/osm/pkg/certificate"
+
 	"github.com/pkg/errors"
 )
 
-// CertificationAuthorityCommonName is the CN used for the root certificate for OSM.
-const CertificationAuthorityCommonName = "Open Service Mesh Certification Authority"
-
 // NewCA creates a new Certificate Authority.
-func NewCA(validity time.Duration) (*Certificate, error) {
+func NewCA(cn certificate.CommonName, validity time.Duration) (*Certificate, error) {
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, errors.Wrap(err, errGeneratingSerialNumber.Error())
@@ -24,7 +23,7 @@ func NewCA(validity time.Duration) (*Certificate, error) {
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
-			CommonName:   CertificationAuthorityCommonName,
+			CommonName:   cn.String(),
 			Country:      []string{"US"},
 			Locality:     []string{"CA"},
 			Organization: []string{org},

--- a/pkg/tresor/ca_test.go
+++ b/pkg/tresor/ca_test.go
@@ -10,7 +10,7 @@ import (
 
 var _ = Describe("Test creation of a new CA", func() {
 	Context("Create a new CA", func() {
-		cert, err := NewCA(2 * time.Second)
+		cert, err := NewCA("Tresor CA for Testing", 2*time.Second)
 		It("should create a new CA", func() {
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/tresor/fake.go
+++ b/pkg/tresor/fake.go
@@ -8,7 +8,7 @@ import (
 
 // NewFakeCertManager creates a fake CertManager used for testing.
 func NewFakeCertManager() *CertManager {
-	ca, err := NewCA(1 * time.Hour)
+	ca, err := NewCA("Fake Tresor CN", 1*time.Hour)
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating CA for fake cert manager")
 	}

--- a/pkg/tresor/manager_test.go
+++ b/pkg/tresor/manager_test.go
@@ -3,6 +3,8 @@ package tresor
 import (
 	"time"
 
+	"github.com/open-service-mesh/osm/pkg/certificate"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -57,7 +59,8 @@ var _ = Describe("Test Certificate Manager", func() {
 		validity := 3 * time.Second
 		rootCertPem := "sample_certificate.pem"
 		rootKeyPem := "sample_private_key.pem"
-		rootCert, err := NewCA(1 * time.Hour)
+		cn := certificate.CommonName("Test CA")
+		rootCert, err := NewCA(cn, 1*time.Hour)
 		if err != nil {
 			log.Fatal().Err(err).Msgf("Error loading CA from files %s and %s", rootCertPem, rootKeyPem)
 		}
@@ -83,7 +86,7 @@ var _ = Describe("Test Certificate Manager", func() {
 			pemRootCert := cert.GetIssuingCA()
 			xRootCert, err := DecodePEMCertificate(pemRootCert)
 			Expect(err).ToNot(HaveOccurred(), string(pemRootCert))
-			Expect(xRootCert.Subject.CommonName).To(Equal(CertificationAuthorityCommonName))
+			Expect(xRootCert.Subject.CommonName).To(Equal(cn.String()))
 		})
 	})
 })


### PR DESCRIPTION
Tiny refactor of tresor package to accommodate for `NewCA` with the same signature as the one from Hashi Vault package.

This PR is from the Vault integration series (https://github.com/open-service-mesh/osm/issues/426).