### PR TITLE
injector: Reformat Envoy config template

### DIFF
--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -33,7 +33,7 @@ dynamic_resources:
     grpc_services:
     - envoy_grpc:
         cluster_name: '{{.XDSClusterName}}'
-    set_node_on_first_message_only: "true"
+    set_node_on_first_message_only: true
   cds_config:
     ads: {}
   lds_config:


### PR DESCRIPTION
This PR reformats the Envoy YAML multi-line string template so it is a sorted all-YAML string (no mixing of JSON and YAML)

NO functional code changes!

Stacked on top of this PR is https://github.com/open-service-mesh/osm/pull/527, which switches from static string to Go struct -> Template generation.

And the final destination is https://github.com/open-service-mesh/osm/pull/528, where we switch to using Envoy's `inline_bytes`.