### PR TITLE
demo: remove bookthief traffic target policy

### DIFF
--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -49,26 +49,3 @@ sources:
   name: bookbuyer-serviceaccount
   namespace: "$BOOKBUYER_NAMESPACE"
 EOF
-
-# To remove this, annotate the POD and also update the test to not
-# expect a 404. This is because if an SMI policy is not defined but sidecar
-# is injected, the gRPC xDS stream will be dropped by ADS because there is
-# no service/service-account associated with the service.
-kubectl apply -f - <<EOF
-kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha1
-metadata:
-  name: bookthief-access-bookstore-1
-  namespace: "$BOOKSTORE_NAMESPACE"
-destination:
-  kind: ServiceAccount
-  name: bookstore-1-serviceaccount
-  namespace: "$BOOKSTORE_NAMESPACE"
-specs:
-- kind: HTTPRouteGroup
-  name: bookstore-service-routes
-sources:
-- kind: ServiceAccount
-  name: bookthief-serviceaccount
-  namespace: "$BOOKTHIEF_NAMESPACE"
-EOF


### PR DESCRIPTION
This is not required because there is no dependency on
a service account for the proxy. Previously a proxy was
mapped to a service account, but after PR #516 a proxy
is mapped to a service.

Resolves #529