### PR TITLE
injector: Move envoyBootstrapConfigTmpl to test

### DIFF
--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -21,57 +21,6 @@ const (
 	tlsKeyFileKey      = "key.pem"
 )
 
-const envoyBootstrapConfigTmpl = `
-admin:
-  access_log_path: /dev/stdout
-  address:
-    socket_address:
-      address: 0.0.0.0
-      port_value: '{{.EnvoyAdminPort}}'
-dynamic_resources:
-  ads_config:
-    api_type: GRPC
-    grpc_services:
-    - envoy_grpc:
-        cluster_name: '{{.XDSClusterName}}'
-    set_node_on_first_message_only: true
-  cds_config:
-    ads: {}
-  lds_config:
-    ads: {}
-static_resources:
-  clusters:
-  - connect_timeout: 0.25s
-    http2_protocol_options: {}
-    load_assignment:
-      cluster_name: '{{.XDSClusterName}}'
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: '{{.XDSHost}}'
-                port_value: '{{.XDSPort}}'
-    name: '{{.XDSClusterName}}'
-    tls_context:
-      common_tls_context:
-        alpn_protocols:
-        - h2
-        tls_certificates:
-        - certificate_chain:
-            filename: '{{.CertPath}}'
-          private_key:
-            filename: '{{.KeyPath}}'
-        tls_params:
-          cipher_suites: '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-          tls_maximum_protocol_version: TLSv1_3
-          tls_minimum_protocol_version: TLSv1_2
-        validation_context:
-          trusted_ca:
-            filename: '{{.RootCertPath}}'
-    type: LOGICAL_DNS
-`
-
 func getEnvoyConfigYAML() string {
 	m := map[interface{}]interface{}{
 		"admin": map[string]interface{}{

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -5,6 +5,57 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const envoyBootstrapConfigTmpl = `
+admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: '{{.EnvoyAdminPort}}'
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: '{{.XDSClusterName}}'
+    set_node_on_first_message_only: true
+  cds_config:
+    ads: {}
+  lds_config:
+    ads: {}
+static_resources:
+  clusters:
+  - connect_timeout: 0.25s
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: '{{.XDSClusterName}}'
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: '{{.XDSHost}}'
+                port_value: '{{.XDSPort}}'
+    name: '{{.XDSClusterName}}'
+    tls_context:
+      common_tls_context:
+        alpn_protocols:
+        - h2
+        tls_certificates:
+        - certificate_chain:
+            filename: '{{.CertPath}}'
+          private_key:
+            filename: '{{.KeyPath}}'
+        tls_params:
+          cipher_suites: '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+          tls_maximum_protocol_version: TLSv1_3
+          tls_minimum_protocol_version: TLSv1_2
+        validation_context:
+          trusted_ca:
+            filename: '{{.RootCertPath}}'
+    type: LOGICAL_DNS
+`
+
 var _ = Describe("Test Envoy configuration creation", func() {
 	Context("create envoy config", func() {
 		It("creates envoy config", func() {


### PR DESCRIPTION
This PR is a follow up from https://github.com/open-service-mesh/osm/pull/526 and https://github.com/open-service-mesh/osm/pull/527 where we moved from string literal to a Go struct.

In this PR we simply move the location of the `envoyBootstrapConfigTmpl ` to be closer to where this is used -- in the `config_test.go` file