### PR TITLE
injector: Use a Secret instead of a ConfigMap for Envoy bootstrap config

### DIFF
--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -43,7 +43,7 @@ func (wh *Webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 		return nil, err
 	}
 
-	// Create kube configMap for Envoy bootstrap config
+	// Create kube secret for Envoy bootstrap config
 	envoyBootstrapConfigName := fmt.Sprintf("envoy-bootstrap-config-%s", serviceName)
 	_, err = wh.createEnvoyBootstrapConfig(envoyBootstrapConfigName, namespace, wh.osmNamespace)
 	if err != nil {

--- a/pkg/injector/volumes.go
+++ b/pkg/injector/volumes.go
@@ -10,10 +10,8 @@ func getVolumeSpec(envoyBootstrapConfigName, envoyTLSSecretName string) []corev1
 		{
 			Name: envoyBootstrapConfigVolume,
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: envoyBootstrapConfigName,
-					},
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: envoyBootstrapConfigName,
 				},
 			},
 		},


### PR DESCRIPTION
This PR moves away from using a ConfigMap for the Envoy bootstrap config and uses a Kubernetes secret.

The following upcoming PR (stacked on this) https://github.com/open-service-mesh/osm/pull/528 will inline Envoy's bootstrap certificates inside the Envoy bootstrap YAML.  To secure these we need to stop using ConfigMap for Envoy bootstrap and switch to a k8s Secret.

This fixes https://github.com/open-service-mesh/osm/issues/256