### PR TITLE
Use a regex match all for wildcard HTTP method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,6 @@ require (
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20200107162124-548cf772de50 // indirect
-	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/appengine v1.6.2 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,4 +68,10 @@ const (
 
 	// CertificationAuthorityRootExpiration is when the root certificate expires
 	CertificationAuthorityRootExpiration = 87600 * time.Hour // a decade
+
+	// RegexMatchAll is a regex pattern match for all
+	RegexMatchAll = ".*"
+
+	// WildcardHTTPMethod is a wildcard for all HTTP methods
+	WildcardHTTPMethod = "*"
 )

--- a/pkg/envoy/route/routeConfiguration.go
+++ b/pkg/envoy/route/routeConfiguration.go
@@ -9,6 +9,7 @@ import (
 	matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
+	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
@@ -91,7 +92,7 @@ func createRoutes(routePolicyWeightedClustersList []endpoint.RoutePolicyWeighted
 							HeaderMatchSpecifier: &v2route.HeaderMatcher_SafeRegexMatch{
 								SafeRegexMatch: &matcher.RegexMatcher{
 									EngineType: regexEngine,
-									Regex:      method,
+									Regex:      getRegexForMethod(method),
 								},
 							},
 						},
@@ -148,8 +149,8 @@ func sanitizeHTTPMethods(allowedMethods []string) []string {
 	keys := make(map[string]interface{})
 	for _, method := range allowedMethods {
 		if method != "" {
-			if method == "*" {
-				newAllowedMethods = []string{"*"}
+			if method == constants.WildcardHTTPMethod {
+				newAllowedMethods = []string{constants.WildcardHTTPMethod}
 				return newAllowedMethods
 			}
 			if _, value := keys[method]; !value {
@@ -169,4 +170,12 @@ func NewRouteConfigurationStub(routeConfigName string) v2.RouteConfiguration {
 		ValidateClusters: &wrappers.BoolValue{Value: true},
 	}
 	return routeConfiguration
+}
+
+func getRegexForMethod(httpMethod string) string {
+	methodRegex := httpMethod
+	if httpMethod == constants.WildcardHTTPMethod {
+		methodRegex = constants.RegexMatchAll
+	}
+	return methodRegex
 }

--- a/pkg/envoy/route/routeConfiguration_test.go
+++ b/pkg/envoy/route/routeConfiguration_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
@@ -155,6 +156,19 @@ var _ = Describe("Route Configuration", func() {
 			Expect(sourceRouteConfig.VirtualHosts[0].Routes[0].Match.GetSafeRegex().Regex).To(Equal(routePolicy.PathRegex))
 			Expect(sourceRouteConfig.VirtualHosts[0].Routes[0].Match.GetHeaders()[0].GetSafeRegexMatch().Regex).To(Equal(routePolicy.Methods[0]))
 			Expect(len(sourceRouteConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters().GetClusters())).To(Equal(len(weightedClusters)))
+		})
+	})
+})
+
+var _ = Describe("Route Configuration", func() {
+	Context("Testing regex matches for HTTP methods", func() {
+		It("Tests that the wildcard HTTP method correctly translates to a match all regex", func() {
+			regex := getRegexForMethod("*")
+			Expect(regex).To(Equal(constants.RegexMatchAll))
+		})
+		It("Tests that a non wildcard HTTP method correctly translates to its corresponding regex", func() {
+			regex := getRegexForMethod("GET")
+			Expect(regex).To(Equal("GET"))
 		})
 	})
 })


### PR DESCRIPTION
For a traffic policy with a method * , use a match all
regex ".*", just * is not correct.

Resolves #521