### PR TITLE
ref(demo): remove NodePort references

### DIFF
--- a/cmd/osm/config.go
+++ b/cmd/osm/config.go
@@ -62,7 +62,6 @@ func generateKubernetesConfig(name, namespace, serviceAccountName, containerRegi
 				},
 			},
 			Selector: map[string]string{"app": name},
-			Type:     apiv1.ServiceTypeNodePort,
 		},
 	}
 	deployment := &appsv1.Deployment{

--- a/demo/cmd/deploy/metrics/config.go
+++ b/demo/cmd/deploy/metrics/config.go
@@ -103,7 +103,6 @@ func generatePrometheusService(svc string, namespace string) *apiv1.Service {
 			Selector: map[string]string{
 				"app": fmt.Sprintf("%s-server", svc),
 			},
-			Type: apiv1.ServiceTypeNodePort,
 			Ports: []apiv1.ServicePort{
 				{Port: prometheusPort},
 			},

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -59,7 +59,6 @@ func generateXDSService(namespace string) *apiv1.Service {
 			Selector: map[string]string{
 				"app": constants.AggregatedDiscoveryServiceName,
 			},
-			Type: apiv1.ServiceTypeNodePort,
 		},
 	}
 	return service

--- a/demo/deploy-AzureResource.sh
+++ b/demo/deploy-AzureResource.sh
@@ -23,7 +23,6 @@ spec:
     name: app-port
   selector:
     app: $SVC
-  type: NodePort
 ---
 
 apiVersion: osm.osm.k8s.io/v1

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -38,8 +38,6 @@ spec:
 
   selector:
     app: bookbuyer
-
-  type: NodePort
 EOF
 
 echo -e "Deploy BookBuyer Deployment"

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -37,8 +37,6 @@ spec:
 
   selector:
     app: $SVC
-
-  type: NodePort
 EOF
 
 echo -e "Deploy $SVC Deployment"

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -39,8 +39,6 @@ spec:
   selector:
     app: bookthief
 
-  type: NodePort
-
 ---
 
 apiVersion: apps/v1

--- a/demo/metrics/prometheus/deploy-prometheusService.sh
+++ b/demo/metrics/prometheus/deploy-prometheusService.sh
@@ -60,7 +60,6 @@ metadata:
 spec:
   selector:
     app: "$PROMETHEUS_SVC-server"
-  type: NodePort
   ports:
     - port: 7070
 EOF


### PR DESCRIPTION
NodePort is a way to get external traffic to
your service. We don't need it because our
services are only communicating with services
inside the cluster and we can rely on the default
service type, clusterIP (service type that other
apps inside your cluster can access)