### PR TITLE
bookthief: No need to deploy secrets

### DIFF
--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -8,8 +8,6 @@ WAIT_FOR_OK_SECONDS="${WAIT_FOR_OK_SECONDS:-default 120}"
 
 echo "WAIT_FOR_OK_SECONDS = ${WAIT_FOR_OK_SECONDS}"
 
-./demo/deploy-secrets.sh "bookthief"
-
 kubectl delete deployment bookthief -n "$BOOKTHIEF_NAMESPACE"  || true
 
 echo -e "Deploy BookThief demo service"


### PR DESCRIPTION
Turns out we don't need `./demo/deploy-secrets.sh "bookthief"` -- the certificates are provided by the sidecar injector, which generates the bootstrap YAML and inlines the certs there.