### PR TITLE
ads: Create CA bundle k8s secret

### DIFF
--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -85,6 +85,7 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 		"--rootkeypem", "/etc/ssl/certs/root-key.pem",
 		"--init-container-image", initContainer,
 		"--sidecar-image", defaultEnvoyImage,
+		"--caBundleSecretName", fmt.Sprintf("osm-ca-%s", osmID),
 	}
 
 	if os.Getenv(common.IsGithubEnvVar) != "true" {


### PR DESCRIPTION
This PR adds the ability to export the CA bundle when the ADS pod is created.
This will create an Opaque k8s secret with the key `ca.crt` and the PEM encoded public root.
This could then be used by Ingress controllers to bring mTLS encrypted traffic into the mesh and other similar purposes.

This PR solves some of the complexities around https://github.com/open-service-mesh/osm/pull/539 where we decided that we don't want to move creation of MutatingWebhookConfiguration from Helm chart to ADS pod.

Fixes https://github.com/open-service-mesh/osm/issues/555