### PR TITLE
ingress: catalog changes for ingress routes and endpoints

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy/ads"
 	"github.com/open-service-mesh/osm/pkg/httpserver"
+	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/injector"
 	"github.com/open-service-mesh/osm/pkg/logger"
 	"github.com/open-service-mesh/osm/pkg/metricsstore"
@@ -142,7 +143,12 @@ func main() {
 		endpointsProviders = append(endpointsProviders, azure.NewProvider(
 			*azureSubscriptionID, azureAuthFile, stop, meshSpec, azureResourceClient, constants.AzureProviderName))
 	}
-	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, stop, endpointsProviders...)
+
+	ingressClient, err := ingress.NewIngressClient(kubeConfig, namespaceController, stop)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to initialize ingress client")
+	}
+	meshCatalog := catalog.NewMeshCatalog(meshSpec, certManager, ingressClient, stop, endpointsProviders...)
 
 	// Create the sidecar-injector webhook
 	webhook := injector.NewWebhook(injectorConfig, kubeConfig, certManager, meshCatalog, namespaceController, osmNamespace)

--- a/go.sum
+++ b/go.sum
@@ -481,6 +481,7 @@ k8s.io/api v0.17.4 h1:HbwOhDapkguO8lTAE8OX3hdF2qp8GtpC9CW/MQATXXo=
 k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
 k8s.io/api v0.18.0 h1:lwYk8Vt7rsVTwjRU6pzEsa9YNhThbmbocQlKvNBB4EQ=
 k8s.io/api v0.18.0/go.mod h1:q2HRQkfDzHMBZL9l/y9rH63PkQl4vae0xRT+8prbrK8=
+k8s.io/api v0.18.2 h1:wG5g5ZmSVgm5B+eHMIbI9EGATS2L8Z72rda19RIEgY8=
 k8s.io/apimachinery v0.17.4 h1:UzM+38cPUJnzqSQ+E1PY4YxMHIzQyCg29LOoGfo79Zw=
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.18.0 h1:fuPfYpk3cs1Okp/515pAf0dNhL66+8zk8RLbSX+EgAE=

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -10,16 +10,18 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
 // NewMeshCatalog creates a new service catalog
-func NewMeshCatalog(meshSpec smi.MeshSpec, certManager certificate.Manager, stop <-chan struct{}, endpointsProviders ...endpoint.Provider) *MeshCatalog {
+func NewMeshCatalog(meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop <-chan struct{}, endpointsProviders ...endpoint.Provider) *MeshCatalog {
 	log.Info().Msg("Create a new Service MeshCatalog.")
 	sc := MeshCatalog{
 		endpointsProviders: endpointsProviders,
 		meshSpec:           meshSpec,
 		certManager:        certManager,
+		ingressMonitor:     ingressMonitor,
 
 		servicesCache:        make(map[endpoint.WeightedService][]endpoint.Endpoint),
 		certificateCache:     make(map[endpoint.NamespacedService]certificate.Certificater),
@@ -58,6 +60,7 @@ func (sc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 	announcementChannels := []announcementChannel{
 		{"MeshSpec", sc.meshSpec.GetAnnouncementsChannel()},
 		{"CertManager", sc.certManager.GetAnnouncementsChannel()},
+		{"IngressMonitor", sc.ingressMonitor.GetAnnouncementsChannel()},
 		{"Ticker", ticking},
 	}
 	for _, ep := range sc.endpointsProviders {

--- a/pkg/catalog/certificates_test.go
+++ b/pkg/catalog/certificates_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/smi"
 	"github.com/open-service-mesh/osm/pkg/tresor"
 )
@@ -14,9 +15,10 @@ import (
 func newMeshCatalog() *MeshCatalog {
 	meshSpec := smi.NewFakeMeshSpecClient()
 	certManager := tresor.NewFakeCertManager()
+	ingressMonitor := ingress.NewFakeIngressMonitor()
 	stop := make(<-chan struct{})
 	var endpointProviders []endpoint.Provider
-	return NewMeshCatalog(meshSpec, certManager, stop, endpointProviders...)
+	return NewMeshCatalog(meshSpec, certManager, ingressMonitor, stop, endpointProviders...)
 }
 
 var _ = Describe("Test certificate tooling", func() {

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -72,3 +72,17 @@ func endpointsToString(endpoints []endpoint.Endpoint) string {
 	}
 	return strings.Join(epts, ",")
 }
+
+// ListEndpointsForService returns the list of provider endpoints corresponding to a service
+func (sc *MeshCatalog) ListEndpointsForService(service endpoint.ServiceName) ([]endpoint.Endpoint, error) {
+	var endpoints []endpoint.Endpoint
+	for _, provider := range sc.endpointsProviders {
+		ep := provider.ListEndpointsForService(service)
+		if len(ep) == 0 {
+			log.Trace().Msgf("[%s] No endpoints found for service=%s", provider.GetID(), service)
+			continue
+		}
+		endpoints = append(endpoints, ep...)
+	}
+	return endpoints, nil
+}

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -1,0 +1,67 @@
+package catalog
+
+import (
+	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+)
+
+// IsIngressService returns a boolean indicating if the service is a backend for an ingress resource
+func (mc *MeshCatalog) IsIngressService(service endpoint.NamespacedService) (bool, error) {
+	policies, err := mc.GetIngressRoutePoliciesPerDomain(service)
+	return len(policies) > 0, err
+}
+
+// GetIngressRoutePoliciesPerDomain returns the route policies per domain associated with an ingress service
+func (mc *MeshCatalog) GetIngressRoutePoliciesPerDomain(service endpoint.NamespacedService) (map[string][]endpoint.RoutePolicy, error) {
+	domainRoutesMap := make(map[string][]endpoint.RoutePolicy)
+	ingresses, err := mc.ingressMonitor.GetIngressResources(service)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to get ingress resources with backend %s", service)
+		return domainRoutesMap, err
+	}
+	if len(ingresses) == 0 {
+		return domainRoutesMap, err
+	}
+
+	for _, ingress := range ingresses {
+		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == service.Service {
+			// A default backend rule exists and will be used in
+			// case more specific rules are not specified
+			defaultRoutePolicy := endpoint.RoutePolicy{
+				PathRegex: constants.RegexMatchAll,
+				Methods:   []string{constants.RegexMatchAll},
+			}
+			domainRoutesMap[constants.WildcardHTTPMethod] = []endpoint.RoutePolicy{defaultRoutePolicy}
+		}
+		for _, rule := range ingress.Spec.Rules {
+			domain := rule.Host
+			if domain == "" {
+				domain = constants.WildcardHTTPMethod
+			}
+			for _, ingressPath := range rule.HTTP.Paths {
+				if ingressPath.Backend.ServiceName == service.Service {
+					var pathRegex string
+					if ingressPath.Path == "" {
+						pathRegex = constants.RegexMatchAll
+					} else {
+						pathRegex = ingressPath.Path
+					}
+					routePolicy := endpoint.RoutePolicy{
+						PathRegex: pathRegex,
+						Methods:   []string{constants.RegexMatchAll},
+					}
+					domainRoutesMap[domain] = append(domainRoutesMap[domain], routePolicy)
+				}
+			}
+		}
+	}
+	return domainRoutesMap, nil
+}
+
+// GetIngressWeightedCluster returns the weighted cluster for an ingress service
+func (mc *MeshCatalog) GetIngressWeightedCluster(service endpoint.NamespacedService) (endpoint.WeightedCluster, error) {
+	return endpoint.WeightedCluster{
+		ClusterName: endpoint.ClusterName(service.String()),
+		Weight:      100,
+	}, nil
+}

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -1,0 +1,163 @@
+package catalog
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/ingress"
+	"github.com/open-service-mesh/osm/pkg/smi"
+	"github.com/open-service-mesh/osm/pkg/tresor"
+)
+
+var (
+	fakeIngressService         = "fake-service"
+	fakeIngressNamespace       = "ingress-ns"
+	fakeIngressPort      int32 = 80
+
+	// fakeIngressPaths is a mapping of the fake ingress resource domains to its paths
+	fakeIngressPaths = map[string][]string{
+		"fake1.com": []string{"/fake1-path1", "/fake1-path2"},
+		"fake2.com": []string{"/fake2-path1"},
+		"*":         []string{".*"},
+	}
+)
+
+func newFakeMeshCatalog() *MeshCatalog {
+	meshSpec := smi.NewFakeMeshSpecClient()
+	certManager := tresor.NewFakeCertManager()
+	ingressMonitor := ingress.NewFakeIngressMonitor()
+	ingressMonitor.FakeIngresses = getFakeIngresses()
+	stop := make(<-chan struct{})
+	var endpointProviders []endpoint.Provider
+	return NewMeshCatalog(meshSpec, certManager, ingressMonitor, stop, endpointProviders...)
+}
+
+func getFakeIngresses() []*extensionsV1beta.Ingress {
+	return []*extensionsV1beta.Ingress{
+		&extensionsV1beta.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ingress-1",
+				Namespace: fakeIngressNamespace,
+				Annotations: map[string]string{
+					constants.OSMKubeResourceMonitorAnnotation: "enabled",
+				},
+			},
+			Spec: extensionsV1beta.IngressSpec{
+				Backend: &extensionsV1beta.IngressBackend{
+					ServiceName: fakeIngressService,
+					ServicePort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: fakeIngressPort,
+					},
+				},
+				Rules: []extensionsV1beta.IngressRule{
+					{
+						Host: "fake1.com",
+						IngressRuleValue: extensionsV1beta.IngressRuleValue{
+							HTTP: &extensionsV1beta.HTTPIngressRuleValue{
+								Paths: []extensionsV1beta.HTTPIngressPath{
+									{
+										Path: "/fake1-path1",
+										Backend: extensionsV1beta.IngressBackend{
+											ServiceName: fakeIngressService,
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: fakeIngressPort,
+											},
+										},
+									},
+									{
+										Path: "/fake1-path2",
+										Backend: extensionsV1beta.IngressBackend{
+											ServiceName: fakeIngressService,
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: fakeIngressPort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&extensionsV1beta.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ingress-2",
+				Namespace: fakeIngressNamespace,
+				Annotations: map[string]string{
+					constants.OSMKubeResourceMonitorAnnotation: "enabled",
+				},
+			},
+			Spec: extensionsV1beta.IngressSpec{
+				Rules: []extensionsV1beta.IngressRule{
+					{
+						Host: "fake2.com",
+						IngressRuleValue: extensionsV1beta.IngressRuleValue{
+							HTTP: &extensionsV1beta.HTTPIngressRuleValue{
+								Paths: []extensionsV1beta.HTTPIngressPath{
+									{
+										Path: "/fake2-path1",
+										Backend: extensionsV1beta.IngressBackend{
+											ServiceName: fakeIngressService,
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: fakeIngressPort,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func pathContains(allowed []string, path string) bool {
+	for _, p := range allowed {
+		if path == p {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = Describe("Test ingress route policies", func() {
+	Context("Testing GetIngressRoutePoliciesPerDomain", func() {
+		mc := newFakeMeshCatalog()
+		It("Gets the route policies per domain from multiple ingress resources corresponding to a service", func() {
+			fakeService := endpoint.NamespacedService{
+				Namespace: fakeIngressNamespace,
+				Service:   fakeIngressService,
+			}
+			domainRoutesMap, _ := mc.GetIngressRoutePoliciesPerDomain(fakeService)
+
+			for domain, routePolicies := range domainRoutesMap {
+				// The number of route policies per domain is the product of the number of rules and paths per rule
+				Expect(len(routePolicies)).To(Equal(len(fakeIngressPaths[domain])))
+				for _, routePolicy := range routePolicies {
+					// For each ingress path, all HTTP methods are allowed, which is a regex match all of '*'
+					Expect(len(routePolicy.Methods)).To(Equal(1))
+					Expect(routePolicy.Methods[0]).To(Equal(constants.RegexMatchAll))
+					// routePolicy.Path is the path specified in the ingress resource rule. Since the same service
+					// could be a backend for multiple ingress resources, we don't know which ingress resource
+					// this path corresponds to just from 'domainRoutesMap'. In order to not make assumptions
+					// on the implementation of 'GetIngressRoutePoliciesPerDomain()', we relax the check here
+					// to match on any of the ingress paths corresponding to the domain.
+					Expect(pathContains(fakeIngressPaths[domain], routePolicy.PathRegex)).To(BeTrue())
+				}
+			}
+		})
+
+	})
+})

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/logger"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
@@ -21,6 +22,7 @@ type MeshCatalog struct {
 	endpointsProviders []endpoint.Provider
 	meshSpec           smi.MeshSpec
 	certManager        certificate.Manager
+	ingressMonitor     ingress.Monitor
 
 	servicesCache        map[endpoint.WeightedService][]endpoint.Endpoint
 	servicesMutex        sync.Mutex
@@ -38,6 +40,9 @@ type MeshCataloger interface {
 
 	// ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
 	ListTrafficPolicies(endpoint.NamespacedService) ([]endpoint.TrafficPolicy, error)
+
+	// ListEndpointsForService returns the list of provider endpoints corresponding to a service
+	ListEndpointsForService(endpoint.ServiceName) ([]endpoint.Endpoint, error)
 
 	// GetCertificateForService returns the SSL Certificate for the given service.
 	// This certificate will be used for service-to-service mTLS.
@@ -57,6 +62,15 @@ type MeshCataloger interface {
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service endpoint.NamespacedService) (endpoint.WeightedCluster, error)
+
+	// IsIngressService returns a boolean indicating if the service is a backend for an ingress resource
+	IsIngressService(endpoint.NamespacedService) (bool, error)
+
+	// GetIngressRoutePoliciesPerDomain returns the route policies per domain associated with an ingress service
+	GetIngressRoutePoliciesPerDomain(endpoint.NamespacedService) (map[string][]endpoint.RoutePolicy, error)
+
+	// GetIngressWeightedCluster returns the weighted cluster for an ingress service
+	GetIngressWeightedCluster(endpoint.NamespacedService) (endpoint.WeightedCluster, error)
 }
 
 type announcementChannel struct {

--- a/pkg/ingress/fake.go
+++ b/pkg/ingress/fake.go
@@ -6,19 +6,23 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
-type fakeIngressMonitor struct{}
+// FakeIngressMonitor returns a fake ingress monitor object
+type FakeIngressMonitor struct {
+	FakeIngresses []*extensionsV1beta.Ingress
+	Monitor
+}
 
 // NewFakeIngressMonitor returns a fake ingress.Monitor used for testing
-func NewFakeIngressMonitor() Monitor {
-	return fakeIngressMonitor{}
+func NewFakeIngressMonitor() FakeIngressMonitor {
+	return FakeIngressMonitor{}
 }
 
 // GetIngressResources returns the ingress resources whose backends correspond to the service
-func (f fakeIngressMonitor) GetIngressResources(endpoint.NamespacedService) ([]*extensionsV1beta.Ingress, error) {
-	return nil, nil
+func (f FakeIngressMonitor) GetIngressResources(endpoint.NamespacedService) ([]*extensionsV1beta.Ingress, error) {
+	return f.FakeIngresses, nil
 }
 
 // GetAnnouncementsChannel returns the channel on which Ingress Monitor makes annoucements
-func (f fakeIngressMonitor) GetAnnouncementsChannel() <-chan interface{} {
+func (f FakeIngressMonitor) GetAnnouncementsChannel() <-chan interface{} {
 	return make(chan interface{})
 }


### PR DESCRIPTION
This change adds support for mesh catalog to consume ingress
resources from ingress monitor and convert them to route
policies per domain. It also adds an API in catalog to list
endpoints for a service, without having a dependency on the
service to be referenced in SMI. Ingress endpoints will not
have an SMI reference but will need to resolve to K8s provider
endpoints.

Also adds unit tets for the ingress route policies.