### PR TITLE
ads: Do not dump raw ADS payload

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -108,8 +108,6 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 
 			if err := server.Send(resp); err != nil {
 				log.Error().Err(err).Msgf("Error sending DiscoveryResponse")
-			} else {
-				log.Debug().Msgf("Sent Discovery Response %s to proxy %s: %s", resp.TypeUrl, proxy, resp)
 			}
 
 		case <-proxy.GetAnnouncementsChannel():


### PR DESCRIPTION
Sending the raw ADS payload to stdout could lead to leaking of secrets. This is no longer needed at this stage of the project.