### PR TITLE
featureflags: Introduce featureflags package

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy/ads"
+	"github.com/open-service-mesh/osm/pkg/featureflags"
 	"github.com/open-service-mesh/osm/pkg/httpserver"
 	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/injector"
@@ -50,6 +51,9 @@ var (
 	kubeConfigFile string
 	osmNamespace   string
 	injectorConfig injector.Config
+
+	// feature flag options
+	optionalFeatures featureflags.OptionalFeatures
 )
 
 var (
@@ -78,12 +82,16 @@ func init() {
 	flags.IntVar(&injectorConfig.ListenPort, "webhook-port", constants.InjectorWebhookPort, "Webhook port for sidecar-injector")
 	flags.StringVar(&injectorConfig.InitContainerImage, "init-container-image", "", "InitContainer image")
 	flags.StringVar(&injectorConfig.SidecarImage, "sidecar-image", "", "Sidecar proxy Container image")
+
+	// feature flags
+	flags.BoolVar(&optionalFeatures.Ingress, "enable-ingress", false, "Enable ingress in OSM")
 }
 
 func main() {
 	log.Trace().Msg("Starting ADS")
 	parseFlags()
 	logger.SetLogLevel(verbosity)
+	featureflags.Initialize(optionalFeatures)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -1,0 +1,32 @@
+package featureflags
+
+import (
+	"sync"
+
+	"github.com/open-service-mesh/osm/pkg/logger"
+)
+
+// OptionalFeatures is a struct to enable/disable optional features
+type OptionalFeatures struct {
+	Ingress bool
+}
+
+var (
+	// Features describes whether an optional feature is enabled
+	Features OptionalFeatures
+
+	once sync.Once
+	log  = logger.New("featureflags")
+)
+
+// Initialize initializes the feature flag options
+func Initialize(optionalFeatures OptionalFeatures) {
+	once.Do(func() {
+		Features = optionalFeatures
+	})
+}
+
+// IsIngressEnabled returns a boolean indicating if the ingress feature is enabled
+func IsIngressEnabled() bool {
+	return Features.Ingress
+}


### PR DESCRIPTION
This change introduces a simple package to manage feature flags
within OSM. The optional features are disabled by default and
turned on using cmd line args.
This change introduces a feature flag for ingress so that callers
can use `featureflags.IsIngressEnabled()` to check if the ingress
feature is enabled.