### PR TITLE
ads: Get correct IP address of proxy connected to ADS pod

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -25,10 +25,6 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 
 	// TODO(draychev): check for envoy.ErrTooManyConnections
 
-	log.Info().Msgf("Client connected: Subject CN=%s", cn)
-
-	// Register the newly connected proxy w/ the catalog.
-	// TODO(draychev): this does not produce the correct IP address
 	ip := utils.GetIPFromContext(server.Context())
 
 	// TODO: Need a better way to map a proxy to a service. This
@@ -39,7 +35,7 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 		Namespace: cnMeta.Namespace,
 		Service:   cnMeta.ServiceName,
 	}
-	log.Info().Msgf("cert: cn=%s, service=%s", cn, namespacedService)
+	log.Info().Msgf("Client %s connected: Subject CN=%s; Service=%s", ip, cn, namespacedService)
 
 	proxy := envoy.NewProxy(cn, namespacedService, ip)
 	s.catalog.RegisterProxy(proxy)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -13,7 +13,7 @@ import (
 // This should at some point have a 1:1 match to an Endpoint (which is a member of a meshed service).
 type Proxy struct {
 	certificate.CommonName
-	net.IP
+	net.Addr
 	ServiceName   endpoint.NamespacedService
 	announcements chan interface{}
 
@@ -76,8 +76,8 @@ func (p Proxy) GetCommonName() certificate.CommonName {
 }
 
 // GetIP returns the IP address of the Envoy proxy connected to xDS.
-func (p Proxy) GetIP() net.IP {
-	return p.IP
+func (p Proxy) GetIP() net.Addr {
+	return p.Addr
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the given Envoy proxy.
@@ -86,10 +86,10 @@ func (p Proxy) GetAnnouncementsChannel() chan interface{} {
 }
 
 // NewProxy creates a new instance of an Envoy proxy connected to the xDS servers.
-func NewProxy(cn certificate.CommonName, namespacedService endpoint.NamespacedService, ip net.IP) *Proxy {
+func NewProxy(cn certificate.CommonName, namespacedService endpoint.NamespacedService, ip net.Addr) *Proxy {
 	return &Proxy{
 		CommonName:         cn,
-		IP:                 ip,
+		Addr:               ip,
 		ServiceName:        namespacedService,
 		announcements:      make(chan interface{}),
 		lastNonce:          make(map[TypeURI]string),

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -2,7 +2,6 @@ package envoy
 
 import (
 	"fmt"
-	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,7 +27,7 @@ var _ = Describe("Test proxy methods", func() {
 				Service:   svc,
 			}
 
-			proxy := NewProxy(cn, namespacedSvc, net.IP{})
+			proxy := NewProxy(cn, namespacedSvc, nil)
 
 			actualCN := proxy.GetCommonName()
 			Expect(actualCN).To(Equal(certificate.CommonName(commonNameForProxy)))

--- a/pkg/utils/userip.go
+++ b/pkg/utils/userip.go
@@ -3,12 +3,14 @@ package utils
 import (
 	"context"
 	"net"
+
+	"google.golang.org/grpc/peer"
 )
 
-const userIPKey int = 0
-
 // GetIPFromContext obtains the IP address of the caller from the context.
-func GetIPFromContext(ctx context.Context) net.IP {
-	userIP, _ := ctx.Value(userIPKey).(net.IP)
-	return userIP
+func GetIPFromContext(ctx context.Context) net.Addr {
+	if clientPeer, ok := peer.FromContext(ctx); ok {
+		return clientPeer.Addr
+	}
+	return nil
 }


### PR DESCRIPTION
This PR corrects how we obtain the IP address of the Envoy proxy connected to the ADS pod.

Log line will look like this now:
```
11:08PM INF Client 10.244.1.32:37410 connected: Subject CN=c3c301a6-5bf1-4067-b315-1573b26aa1e7.bookthief.bookthief-ns-1.osm.mesh; Service=bookthief-ns-1/bookthief component=envoy/ads file=stream.go:38
```