### PR TITLE
catalog: Adding Expected proxy

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -25,7 +25,8 @@ func NewMeshCatalog(meshSpec smi.MeshSpec, certManager certificate.Manager, ingr
 
 		servicesCache:        make(map[endpoint.WeightedService][]endpoint.Endpoint),
 		certificateCache:     make(map[endpoint.NamespacedService]certificate.Certificater),
-		connectedProxies:     mapset.NewSet(),
+		expectedProxies:      make(map[certificate.CommonName]expectedProxy),
+		connectedProxies:     make(map[certificate.CommonName]connectedProxy),
 		announcementChannels: mapset.NewSet(),
 		serviceAccountsCache: make(map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService),
 	}

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -1,17 +1,25 @@
 package catalog
 
 import (
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
 
+// ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
+func (sc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
+	sc.expectedProxies[cn] = expectedProxy{time.Now()}
+}
+
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
 func (sc *MeshCatalog) RegisterProxy(p *envoy.Proxy) {
-	sc.connectedProxies.Add(p)
+	sc.connectedProxies[p.CommonName] = connectedProxy{p, time.Now()}
 	log.Info().Msgf("Registered new proxy: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
 func (sc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	sc.connectedProxies.Remove(p)
+	delete(sc.connectedProxies, p.CommonName)
 	log.Info().Msgf("Unregistered p: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -3,8 +3,6 @@ package catalog
 import (
 	"reflect"
 	"time"
-
-	"github.com/open-service-mesh/osm/pkg/envoy"
 )
 
 const (
@@ -42,12 +40,11 @@ func (sc *MeshCatalog) getCases() ([]reflect.SelectCase, []string) {
 }
 
 func (sc *MeshCatalog) broadcast(message interface{}) {
-	for _, proxyInterface := range sc.connectedProxies.ToSlice() {
-		envoy := proxyInterface.(*envoy.Proxy)
-		log.Debug().Msgf("[repeater] Broadcast announcement to envoy %s", envoy.GetCommonName())
+	for _, connectedEnvoy := range sc.connectedProxies {
+		log.Debug().Msgf("[repeater] Broadcast announcement to envoy %s", connectedEnvoy.proxy.GetCommonName())
 		select {
 		// send the message if possible - do not block
-		case envoy.GetAnnouncementsChannel() <- message:
+		case connectedEnvoy.proxy.GetAnnouncementsChannel() <- message:
 		default:
 		}
 	}

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -38,6 +38,8 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 		return nil, err
 	}
 
+	wh.meshCatalog.ExpectProxy(cn)
+
 	// Create kube secret for Envoy bootstrap config
 	envoyBootstrapConfigName := fmt.Sprintf("envoy-bootstrap-config-%s", serviceName)
 	_, err = wh.createEnvoyBootstrapConfig(envoyBootstrapConfigName, namespace, wh.osmNamespace, bootstrapCertificate)


### PR DESCRIPTION
At some point I remember discussing the idea of accounting for certificates issued to Envoy proxies for XDS connections, and then comparing these to the actual proxies connected.

This would be extremely useful as part of the support tools -- the issued certificates minus connected proxies gives us the proxies that may have run into some trouble.

This not a finished product just yet.  I imagine we'll have a way to query for this data from the outside world (perhaps as part of our logging/metrics work).


Partially addresses https://github.com/open-service-mesh/osm/issues/582