### PR TITLE
ads/grpc: skip discovery requests without a valid TypeUrl

### DIFF
--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -23,6 +23,10 @@ func receive(requests chan v2.DiscoveryRequest, server *xds.AggregatedDiscoveryS
 			log.Error().Msgf("[grpc] Connection terminated with error: %+v", recvErr)
 			return
 		}
-		requests <- *request
+		if request.TypeUrl != "" {
+			requests <- *request
+		} else {
+			log.Warn().Msgf("[grpc] Unknown resource: %s", request.String())
+		}
 	}
 }


### PR DESCRIPTION
The TypeUrl in the DiscoveryRequest to ADS is empty in cases where
the request is corresponding to a response_nonce. ADS does not
deal with discovery requests relating to ACK/NACK for a discovery response,
so this is not to be treated as an error.

Resolves #444