### PR TITLE
demo: fix traffic split usage

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -17,10 +17,12 @@ const (
 )
 
 func main() {
+	bookstoreNamespace := os.Getenv(common.BookstoreNamespaceEnvVar)
 	bookstoreService := os.Getenv("BOOKSTORE_SVC")
 	if bookstoreService == "" {
-		bookstoreService = "bookstore.mesh"
+		bookstoreService = "bookstore-v1"
 	}
+	bookstoreService = fmt.Sprintf("%s.%s", bookstoreService, bookstoreNamespace) // FQDN
 	booksBought := fmt.Sprintf("http://%s/books-bought", bookstoreService)
 	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -17,10 +17,12 @@ const (
 )
 
 func main() {
+	bookstoreNamespace := os.Getenv(common.BookstoreNamespaceEnvVar)
 	bookstoreService := os.Getenv("BOOKSTORE_SVC")
 	if bookstoreService == "" {
-		bookstoreService = "bookstore.mesh"
+		bookstoreService = "bookstore-v1"
 	}
+	bookstoreService = fmt.Sprintf("%s.%s", bookstoreService, bookstoreNamespace) // FQDN
 	booksBought := fmt.Sprintf("http://%s/books-bought", bookstoreService)
 	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()

--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -42,4 +42,7 @@ const (
 
 	// HumanReadableLogMessagesEnvVar is an environment variable, which when set to "true" enables colorful human-readable log messages.
 	HumanReadableLogMessagesEnvVar = "OSM_HUMAN_DEBUG_LOG"
+
+	// BookstoreNamespaceEnvVar is the environment variable for the Bookbuyer namespace.
+	BookstoreNamespaceEnvVar = "BOOKSTORE_NAMESPACE"
 )

--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -30,8 +30,8 @@ else
     ./ci/create-app-container-registry-creds.sh
 fi
 # Deploy bookstore
-./demo/deploy-bookstore.sh "bookstore-1"
-./demo/deploy-bookstore.sh "bookstore-2"
+./demo/deploy-bookstore.sh "v1"
+./demo/deploy-bookstore.sh "v2"
 # Deploy bookbuyer
 ./demo/deploy-bookbuyer.sh
 # Deploy bookthief

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -62,12 +62,6 @@ spec:
     spec:
       serviceAccountName: bookbuyer-serviceaccount
       automountServiceAccountToken: false
-      hostAliases:
-      - ip: "127.0.0.2"
-        hostnames:
-        - "${BOOKBUYER_NAMESPACE}.uswest.mesh"
-        - "bookbuyer.mesh"
-        - "bookstore.mesh"
 
       containers:
         # Main container with APP
@@ -79,6 +73,8 @@ spec:
           env:
             - name: "WAIT_FOR_OK_SECONDS"
               value: "$WAIT_FOR_OK_SECONDS"
+            - name: "BOOKSTORE_NAMESPACE"
+              value: "$BOOKSTORE_NAMESPACE"
 
 
       imagePullSecrets:

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -4,8 +4,8 @@ set -auexo pipefail
 
 # shellcheck disable=SC1091
 source .env
-
-SVC=${1:-bookstore}
+VERSION=${1:-v1}
+SVC="bookstore-$VERSION"
 
 kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  || true
 
@@ -51,11 +51,12 @@ spec:
   selector:
     matchLabels:
       app: $SVC
+      version: $VERSION
   template:
     metadata:
       labels:
         app: $SVC
-        version: v1
+        version: $VERSION
       annotations:
         "openservicemesh.io/sidecar-injection": "enabled"
         "openservicemesh.io/osm-service": "$SVC"

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -59,11 +59,6 @@ spec:
     spec:
       serviceAccountName: bookthief-serviceaccount
       automountServiceAccountToken: false
-      hostAliases:
-      - ip: "127.0.0.2"
-        hostnames:
-        - "${BOOKTHIEF_NAMESPACE}.uswest.mesh"
-        - "bookstore.mesh"
 
       containers:
         # Main container with APP
@@ -75,6 +70,8 @@ spec:
           env:
             - name: "WAIT_FOR_OK_SECONDS"
               value: "$WAIT_FOR_OK_SECONDS"
+            - name: "BOOKSTORE_NAMESPACE"
+              value: "$BOOKSTORE_NAMESPACE"
 
 
       imagePullSecrets:

--- a/demo/deploy-traffic-split.sh
+++ b/demo/deploy-traffic-split.sh
@@ -11,15 +11,15 @@ kubectl apply -f - <<EOF
 apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
-  name: bookstore.mesh
+  name: bookstore-split
   namespace: "$BOOKSTORE_NAMESPACE"
 spec:
-  service: bookstore.mesh
+  service: "bookstore-v1.$BOOKSTORE_NAMESPACE"
   backends:
 
-  - service: bookstore-1
+  - service: bookstore-v1
     weight: 50
-  - service: bookstore-2
+  - service: bookstore-v2
     weight: 50
 
 

--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -11,11 +11,11 @@ kubectl apply -f - <<EOF
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1
 metadata:
-  name: bookbuyer-access-bookstore-1
+  name: bookbuyer-access-bookstore-v1
   namespace: "$BOOKSTORE_NAMESPACE"
 destination:
   kind: ServiceAccount
-  name: bookstore-1-serviceaccount
+  name: bookstore-v1-serviceaccount
   namespace: "$BOOKSTORE_NAMESPACE"
 specs:
 - kind: HTTPRouteGroup
@@ -33,11 +33,11 @@ sources:
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1
 metadata:
-  name: bookbuyer-access-bookstore-2
+  name: bookbuyer-access-bookstore-v2
   namespace: "$BOOKSTORE_NAMESPACE"
 destination:
   kind: ServiceAccount
-  name: bookstore-2-serviceaccount
+  name: bookstore-v2-serviceaccount
   namespace: "$BOOKSTORE_NAMESPACE"
 specs:
 - kind: HTTPRouteGroup

--- a/demo/tail-bookstore.sh
+++ b/demo/tail-bookstore.sh
@@ -13,4 +13,4 @@ fi
 
 POD="$(kubectl get pods -n "$BOOKSTORE_NAMESPACE" --show-labels --selector app="$backend" --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
 
-kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c bookstore-1 --tail=100
+kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c "$backend" --tail=100


### PR DESCRIPTION
The demo has been interpreting SMI traffic split incorrectly.
Per the SMI traffic split policy, `spec.service` should be a
valid k8s service, and so should the leaf services specified
by `spec.backends[].service`. SMI does not impose any constraint
on what the leaf services should be other than the fact that
they belong to the same namespace as the root service in the Split.

The reason the root service `spec.service` is required to be a
valid k8s service is because `spec.service` is the FQDN that
apps use to communicate. This FQDN needs to be resolvable by
k8s, which would not be possible if `spec.service` is not a
k8s resource.

The demo has been using `bookstore.mesh` as the FQDN for the
bookstore service which is incorrect, but this has been working
because of a hack to statically resolve it to a random IP. Per
SMI (160), the FQDN should correspond to the root service in the
Split definition, obviating the need to statically configure
DNS in client pods.

This change fixes the demo to adhere to the SMI Split policy as
expected. One should note that since the demo deploys apps in
different namespaces, DNS queries for apps in different namespaces
should be of the form `service.namespace`. The demo uses
bookstore-v1 as the root bookstore service, with traffic split
between bookstore-v1 and bookstore-v2.