### PR TITLE
tresor: Moving pkg/keyvaultclient to pkg/certificate/providers/keyvault

### DIFF
--- a/pkg/certificate/providers/keyvault/client.go
+++ b/pkg/certificate/providers/keyvault/client.go
@@ -1,4 +1,4 @@
-package keyvaultclient
+package keyvault
 
 import (
 	"fmt"

--- a/pkg/certificate/providers/keyvault/types.go
+++ b/pkg/certificate/providers/keyvault/types.go
@@ -1,4 +1,4 @@
-package keyvaultclient
+package keyvault
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"


### PR DESCRIPTION
Much like https://github.com/open-service-mesh/osm/pull/594 this PR moves `pkg/keyvaultclient` to `pkg/certificate/providers/keyvault` (and renames `keyvaultclient` to `keyvault`)

The **proposal** is to have all certificate managers be under `pkg/certificate/providers/*`

No functional code changes.