### PR TITLE
catalog: Rename all MeshCatalog receivers to mc

### DIFF
--- a/pkg/catalog/cache.go
+++ b/pkg/catalog/cache.go
@@ -5,15 +5,15 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
-func (sc *MeshCatalog) refreshCache() {
+func (mc *MeshCatalog) refreshCache() {
 	log.Info().Msg("Refresh cache...")
 	servicesCache := make(map[endpoint.WeightedService][]endpoint.Endpoint)
 	serviceAccountsCache := make(map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService)
 	// TODO(draychev): split the namespace from the service name -- non-K8s services won't have namespace
 
-	services := sc.meshSpec.ListServices()
+	services := mc.meshSpec.ListServices()
 	for _, service := range services {
-		for _, provider := range sc.endpointsProviders {
+		for _, provider := range mc.endpointsProviders {
 			endpoints := provider.ListEndpointsForService(endpoint.ServiceName(service.ServiceName.String()))
 			if len(endpoints) == 0 {
 				log.Info().Msgf("[%s] No IPs found for service=%s", provider.GetID(), service.ServiceName)
@@ -24,8 +24,8 @@ func (sc *MeshCatalog) refreshCache() {
 		}
 	}
 
-	for _, namespacesServiceAccounts := range sc.meshSpec.ListServiceAccounts() {
-		for _, provider := range sc.endpointsProviders {
+	for _, namespacesServiceAccounts := range mc.meshSpec.ListServiceAccounts() {
+		for _, provider := range mc.endpointsProviders {
 			// TODO (snchh) : remove this provider check once we have figured out the service account story for azure vms
 			if provider.GetID() != constants.AzureProviderName {
 				log.Trace().Msgf("[%s] Finding Services for servcie acccount =%s", provider.GetID(), namespacesServiceAccounts)
@@ -56,8 +56,8 @@ func (sc *MeshCatalog) refreshCache() {
 	}
 	log.Info().Msgf("Services cache: %+v", servicesCache)
 	log.Info().Msgf("ServiceAccounts cache: %+v", serviceAccountsCache)
-	sc.servicesMutex.Lock()
-	sc.servicesCache = servicesCache
-	sc.serviceAccountsCache = serviceAccountsCache
-	sc.servicesMutex.Unlock()
+	mc.servicesMutex.Lock()
+	mc.servicesCache = servicesCache
+	mc.serviceAccountsCache = serviceAccountsCache
+	mc.servicesMutex.Unlock()
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -41,7 +41,7 @@ func NewMeshCatalog(meshSpec smi.MeshSpec, certManager certificate.Manager, ingr
 }
 
 // GetDebugInfo returns an HTTP handler for OSM debug endpoint.
-func (sc *MeshCatalog) GetDebugInfo() http.Handler {
+func (mc *MeshCatalog) GetDebugInfo() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// TODO(draychev): convert to CLI flag
 		if value, ok := os.LookupEnv("OSM_ENABLE_DEBUG"); ok && value == "true" {
@@ -51,20 +51,20 @@ func (sc *MeshCatalog) GetDebugInfo() http.Handler {
 }
 
 // RegisterNewEndpoint adds a newly connected Envoy proxy to the list of self-announced endpoints for a service.
-func (sc *MeshCatalog) RegisterNewEndpoint(smi.ClientIdentity) {
+func (mc *MeshCatalog) RegisterNewEndpoint(smi.ClientIdentity) {
 	// TODO(draychev): implement
 	panic("NotImplemented")
 }
 
-func (sc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
+func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 	ticking := make(chan interface{})
 	announcementChannels := []announcementChannel{
-		{"MeshSpec", sc.meshSpec.GetAnnouncementsChannel()},
-		{"CertManager", sc.certManager.GetAnnouncementsChannel()},
-		{"IngressMonitor", sc.ingressMonitor.GetAnnouncementsChannel()},
+		{"MeshSpec", mc.meshSpec.GetAnnouncementsChannel()},
+		{"CertManager", mc.certManager.GetAnnouncementsChannel()},
+		{"IngressMonitor", mc.ingressMonitor.GetAnnouncementsChannel()},
 		{"Ticker", ticking},
 	}
-	for _, ep := range sc.endpointsProviders {
+	for _, ep := range mc.endpointsProviders {
 		annCh := announcementChannel{ep.GetID(), ep.GetAnnouncementsChannel()}
 		announcementChannels = append(announcementChannels, annCh)
 	}

--- a/pkg/catalog/certificates.go
+++ b/pkg/catalog/certificates.go
@@ -6,16 +6,16 @@ import (
 )
 
 // GetCertificateForService returns the certificate the given proxy uses for mTLS to the XDS server.
-func (sc *MeshCatalog) GetCertificateForService(service endpoint.NamespacedService) (certificate.Certificater, error) {
-	cert, exists := sc.certificateCache[service]
+func (mc *MeshCatalog) GetCertificateForService(service endpoint.NamespacedService) (certificate.Certificater, error) {
+	cert, exists := mc.certificateCache[service]
 	if exists {
 		return cert, nil
 	}
-	newCert, err := sc.certManager.IssueCertificate(service.GetCommonName())
+	newCert, err := mc.certManager.IssueCertificate(service.GetCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing a new certificate for service %s", service)
 		return nil, err
 	}
-	sc.certificateCache[service] = newCert
+	mc.certificateCache[service] = newCert
 	return newCert, nil
 }

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -7,21 +7,21 @@ import (
 )
 
 // ListTrafficSplitEndpoints constructs a map from service to weighted sub-services with all endpoints the given Envoy proxy should be aware of.
-func (sc *MeshCatalog) ListTrafficSplitEndpoints(clientID endpoint.NamespacedService) ([]endpoint.WeightedServiceEndpoints, error) {
+func (mc *MeshCatalog) ListTrafficSplitEndpoints(clientID endpoint.NamespacedService) ([]endpoint.WeightedServiceEndpoints, error) {
 	log.Info().Msgf("Listing Endpoints for client: %s", clientID.String())
-	return sc.getWeightedEndpointsPerService(clientID)
+	return mc.getWeightedEndpointsPerService(clientID)
 }
 
-func (sc *MeshCatalog) listEndpointsForService(service endpoint.WeightedService) ([]endpoint.Endpoint, error) {
+func (mc *MeshCatalog) listEndpointsForService(service endpoint.WeightedService) ([]endpoint.Endpoint, error) {
 	// TODO(draychev): split namespace from the service name -- for non-K8s services
 	// todo (sneha) : TBD if clientID is needed for filtering endpoints
 	log.Info().Msgf("listEndpointsForService %s", service.ServiceName)
-	if _, found := sc.servicesCache[service]; !found {
-		sc.refreshCache()
+	if _, found := mc.servicesCache[service]; !found {
+		mc.refreshCache()
 	}
 	var endpoints []endpoint.Endpoint
 	var found bool
-	if endpoints, found = sc.servicesCache[service]; !found {
+	if endpoints, found = mc.servicesCache[service]; !found {
 		log.Error().Msgf("Did not find any Endpoints for service %s", service.ServiceName)
 		return nil, errServiceNotFound
 	}
@@ -29,10 +29,10 @@ func (sc *MeshCatalog) listEndpointsForService(service endpoint.WeightedService)
 	return endpoints, nil
 }
 
-func (sc *MeshCatalog) getWeightedEndpointsPerService(clientID endpoint.NamespacedService) ([]endpoint.WeightedServiceEndpoints, error) {
+func (mc *MeshCatalog) getWeightedEndpointsPerService(clientID endpoint.NamespacedService) ([]endpoint.WeightedServiceEndpoints, error) {
 	var serviceEndpoints []endpoint.WeightedServiceEndpoints
 
-	for _, trafficSplit := range sc.meshSpec.ListTrafficSplits() {
+	for _, trafficSplit := range mc.meshSpec.ListTrafficSplits() {
 		log.Debug().Msgf("Discovered TrafficSplit resource: %s/%s", trafficSplit.Namespace, trafficSplit.Name)
 		if trafficSplit.Spec.Backends == nil {
 			log.Error().Msgf("TrafficSplit %s/%s has no Backends in Spec; Skipping...", trafficSplit.Namespace, trafficSplit.Name)
@@ -54,7 +54,7 @@ func (sc *MeshCatalog) getWeightedEndpointsPerService(clientID endpoint.Namespac
 				Domain:      domain,
 			}
 			var err error
-			if svcEp.Endpoints, err = sc.listEndpointsForService(svcEp.WeightedService); err != nil {
+			if svcEp.Endpoints, err = mc.listEndpointsForService(svcEp.WeightedService); err != nil {
 				log.Error().Err(err).Msgf("Error getting Endpoints for service %s", namespacedServiceName)
 				svcEp.Endpoints = []endpoint.Endpoint{}
 			}
@@ -75,9 +75,9 @@ func endpointsToString(endpoints []endpoint.Endpoint) string {
 }
 
 // ListEndpointsForService returns the list of provider endpoints corresponding to a service
-func (sc *MeshCatalog) ListEndpointsForService(service endpoint.ServiceName) ([]endpoint.Endpoint, error) {
+func (mc *MeshCatalog) ListEndpointsForService(service endpoint.ServiceName) ([]endpoint.Endpoint, error) {
 	var endpoints []endpoint.Endpoint
-	for _, provider := range sc.endpointsProviders {
+	for _, provider := range mc.endpointsProviders {
 		ep := provider.ListEndpointsForService(service)
 		if len(ep) == 0 {
 			log.Trace().Msgf("[%s] No endpoints found for service=%s", provider.GetID(), service)

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -8,18 +8,18 @@ import (
 )
 
 // ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
-func (sc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
-	sc.expectedProxies[cn] = expectedProxy{time.Now()}
+func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
+	mc.expectedProxies[cn] = expectedProxy{time.Now()}
 }
 
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
-func (sc *MeshCatalog) RegisterProxy(p *envoy.Proxy) {
-	sc.connectedProxies[p.CommonName] = connectedProxy{p, time.Now()}
+func (mc *MeshCatalog) RegisterProxy(p *envoy.Proxy) {
+	mc.connectedProxies[p.CommonName] = connectedProxy{p, time.Now()}
 	log.Info().Msgf("Registered new proxy: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
-func (sc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	delete(sc.connectedProxies, p.CommonName)
+func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
+	delete(mc.connectedProxies, p.CommonName)
 	log.Info().Msgf("Unregistered p: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }


### PR DESCRIPTION
Renaming `sc` (Service Catalog) to `mc` (Mesh Catalog)

No functional code changes