### PR TITLE
Introducing more unit tests

### DIFF
--- a/pkg/catalog/certificates_test.go
+++ b/pkg/catalog/certificates_test.go
@@ -8,29 +8,17 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
-	"github.com/open-service-mesh/osm/pkg/ingress"
-	"github.com/open-service-mesh/osm/pkg/smi"
 )
-
-func newMeshCatalog() *MeshCatalog {
-	meshSpec := smi.NewFakeMeshSpecClient()
-	certManager := tresor.NewFakeCertManager()
-	ingressMonitor := ingress.NewFakeIngressMonitor()
-	stop := make(<-chan struct{})
-	var endpointProviders []endpoint.Provider
-	return NewMeshCatalog(meshSpec, certManager, ingressMonitor, stop, endpointProviders...)
-}
 
 var _ = Describe("Test certificate tooling", func() {
 	Context("Testing DecodePEMCertificate along with GetCommonName and IssueCertificate", func() {
-		mc := newMeshCatalog()
+		namespacedService := endpoint.NamespacedService{
+			Namespace: "namespace-here",
+			Service:   "service-name-here",
+		}
+		mc := NewFakeMeshCatalog()
 		It("issues a PEM certificate with the correct CN", func() {
-			namespacedService := endpoint.NamespacedService{
-				Namespace: "namespace-here",
-				Service:   "service-name-here",
-			}
-
-			cert, err := mc.certManager.IssueCertificate(namespacedService.GetCommonName())
+			cert, err := mc.GetCertificateForService(namespacedService)
 			Expect(err).ToNot(HaveOccurred())
 
 			actual := cert.GetCertificateChain()

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -1,0 +1,21 @@
+package catalog
+
+import (
+	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/ingress"
+	"github.com/open-service-mesh/osm/pkg/providers/kube"
+	"github.com/open-service-mesh/osm/pkg/smi"
+)
+
+// NewFakeMeshCatalog creates a new struct implementing catalog.MeshCataloger interface used for testing.
+func NewFakeMeshCatalog() MeshCataloger {
+	meshSpec := smi.NewFakeMeshSpecClient()
+	certManager := tresor.NewFakeCertManager()
+	ingressMonitor := ingress.NewFakeIngressMonitor()
+	stop := make(<-chan struct{})
+	endpointProviders := []endpoint.Provider{
+		kube.NewFakeProvider(),
+	}
+	return NewMeshCatalog(meshSpec, certManager, ingressMonitor, stop, endpointProviders...)
+}

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -1,13 +1,24 @@
 package catalog
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/ingress"
+	"github.com/open-service-mesh/osm/pkg/providers/kube"
+	"github.com/open-service-mesh/osm/pkg/smi"
+	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
-var _ = Describe("UniqueLists", func() {
-	Context("Testing uniqueness of services", func() {
+var _ = Describe("Catalog tests", func() {
+	endpointProviders := []endpoint.Provider{kube.NewFakeProvider()}
+	meshCatalog := NewMeshCatalog(smi.NewFakeMeshSpecClient(), tresor.NewFakeCertManager(), ingress.NewFakeIngressMonitor(), make(<-chan struct{}), endpointProviders...)
+
+	Context("Testing UniqueLists", func() {
 		It("Returns unique list of services", func() {
 
 			services := []endpoint.NamespacedService{
@@ -27,9 +38,7 @@ var _ = Describe("UniqueLists", func() {
 			Expect(actual).To(Equal(expected))
 		})
 	})
-})
 
-var _ = Describe("ServicesToString", func() {
 	Context("Testing servicesToString", func() {
 		It("Returns string list", func() {
 
@@ -42,6 +51,85 @@ var _ = Describe("ServicesToString", func() {
 			expected := []string{
 				"osm/bookstore-1",
 				"osm/bookstore-2",
+			}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test ListTrafficPolicies", func() {
+		It("lists traffic policies", func() {
+			actual, err := meshCatalog.ListTrafficPolicies(tests.BookstoreService)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := []endpoint.TrafficPolicy{tests.TrafficPolicy}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test getActiveServices", func() {
+		It("lists active services", func() {
+			actual := meshCatalog.getActiveServices([]endpoint.NamespacedService{tests.BookstoreService})
+			expected := []endpoint.NamespacedService{{
+				Namespace: "default",
+				Service:   "bookstore",
+			}}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test getTrafficPolicyPerRoute", func() {
+		It("lists traffic policies", func() {
+			allTrafficPolicies, err := getTrafficPolicyPerRoute(meshCatalog, tests.RoutePolicyMap, tests.BookstoreService)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := []endpoint.TrafficPolicy{{
+				PolicyName: tests.TrafficTargetName,
+				Destination: endpoint.TrafficPolicyResource{
+					ServiceAccount: tests.BookstoreServiceAccountName,
+					Namespace:      tests.Namespace,
+					Services:       []endpoint.NamespacedService{tests.BookstoreService},
+				},
+				Source: endpoint.TrafficPolicyResource{
+					ServiceAccount: tests.BookbuyerServiceAccountName,
+					Namespace:      tests.Namespace,
+					Services:       []endpoint.NamespacedService{tests.BookbuyerService},
+				},
+				RoutePolicies: []endpoint.RoutePolicy{{PathRegex: "", Methods: nil}},
+			}}
+
+			Expect(allTrafficPolicies).To(Equal(expected))
+		})
+	})
+
+	Context("Test listServicesForServiceAccount", func() {
+		mc := MeshCatalog{
+			serviceAccountsCache: map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService{
+				tests.BookstoreServiceAccount: {tests.BookstoreService},
+			},
+		}
+		It("lists services for service account", func() {
+			actual, err := mc.listServicesForServiceAccount(tests.BookstoreServiceAccount)
+			Expect(err).ToNot(HaveOccurred())
+			expected := []endpoint.NamespacedService{{
+				Namespace: tests.Namespace,
+				Service:   tests.BookstoreServiceName,
+			}}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test getHTTPPathsPerRoute", func() {
+		mc := MeshCatalog{meshSpec: smi.NewFakeMeshSpecClient()}
+		It("constructs HTTP paths per route", func() {
+			actual, err := mc.getHTTPPathsPerRoute()
+			Expect(err).ToNot(HaveOccurred())
+
+			key := fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", tests.Namespace, tests.RouteGroupName, tests.MatchName)
+			expected := map[string]endpoint.RoutePolicy{
+				key: {
+					PathRegex: tests.BookstoreBuyPath,
+					Methods:   []string{"GET"},
+				},
 			}
 			Expect(actual).To(Equal(expected))
 		})

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -2,6 +2,10 @@ package cds
 
 import (
 	"context"
+	"fmt"
+	"time"
+
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
@@ -11,22 +15,14 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/open-service-mesh/osm/pkg/catalog"
-	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
+	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
-	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/smi"
+	"github.com/open-service-mesh/osm/pkg/tests"
 )
-
-func newMeshCatalog() catalog.MeshCataloger {
-	meshSpec := smi.NewFakeMeshSpecClient()
-	certManager := tresor.NewFakeCertManager()
-	ingressMonitor := ingress.NewFakeIngressMonitor()
-	stop := make(<-chan struct{})
-	var endpointProviders []endpoint.Provider
-	return catalog.NewMeshCatalog(meshSpec, certManager, ingressMonitor, stop, endpointProviders...)
-}
 
 var _ = Describe("UniqueLists", func() {
 	Context("Testing uniqueness of clusters", func() {
@@ -52,22 +48,21 @@ var _ = Describe("UniqueLists", func() {
 
 	Context("Test cds.NewResponse", func() {
 		It("Returns unique list of clusters for CDS", func() {
-			catalog := newMeshCatalog()
-			svc := endpoint.NamespacedService{
-				Namespace: "b",
-				Service:   "c",
-			}
-			proxy := envoy.NewProxy("blah", svc, nil)
-			meshSpec := smi.NewFakeMeshSpecClient()
-			resp, err := NewResponse(context.Background(), catalog, meshSpec, proxy, nil)
+			cn := certificate.CommonName("bookbuyer.openservicemesh.io")
+			proxy := envoy.NewProxy(cn, tests.BookbuyerService, nil)
+			resp, err := NewResponse(context.Background(), catalog.NewFakeMeshCatalog(), smi.NewFakeMeshSpecClient(), proxy, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := xds.DiscoveryResponse{
 				VersionInfo: "",
-				Resources: []*any.Any{{
-					TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
-					Value:   []byte{10, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 34, 2, 8, 1, 226, 1, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 138, 2, 49, 10, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 18, 26, 18, 24, 34, 2, 8, 100, 10, 18, 10, 16, 10, 14, 18, 9, 49, 50, 55, 46, 48, 46, 48, 46, 49, 24, 152, 117, 16, 0},
-				}},
+				Resources: []*any.Any{
+					{
+						TypeUrl: string(envoy.TypeCDS),
+						Value:   []byte{10, 17, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 115, 116, 111, 114, 101, 26, 4, 10, 2, 26, 0, 34, 2, 8, 5, 194, 1, 128, 2, 10, 27, 101, 110, 118, 111, 121, 46, 116, 114, 97, 110, 115, 112, 111, 114, 116, 95, 115, 111, 99, 107, 101, 116, 115, 46, 116, 108, 115, 26, 224, 1, 10, 56, 116, 121, 112, 101, 46, 103, 111, 111, 103, 108, 101, 97, 112, 105, 115, 46, 99, 111, 109, 47, 101, 110, 118, 111, 121, 46, 97, 112, 105, 46, 118, 50, 46, 97, 117, 116, 104, 46, 85, 112, 115, 116, 114, 101, 97, 109, 84, 108, 115, 67, 111, 110, 116, 101, 120, 116, 18, 163, 1, 10, 141, 1, 10, 66, 8, 3, 16, 4, 26, 29, 69, 67, 68, 72, 69, 45, 69, 67, 68, 83, 65, 45, 65, 69, 83, 49, 50, 56, 45, 71, 67, 77, 45, 83, 72, 65, 50, 53, 54, 26, 29, 69, 67, 68, 72, 69, 45, 69, 67, 68, 83, 65, 45, 67, 72, 65, 67, 72, 65, 50, 48, 45, 80, 79, 76, 89, 49, 51, 48, 53, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 58, 33, 10, 27, 114, 111, 111, 116, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 18, 17, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 16, 3},
+					}, {
+						TypeUrl: string(envoy.TypeCDS),
+						Value:   []byte{10, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 34, 2, 8, 1, 226, 1, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 138, 2, 49, 10, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 18, 26, 18, 24, 34, 2, 8, 100, 10, 18, 10, 16, 10, 14, 18, 9, 49, 50, 55, 46, 48, 46, 48, 46, 49, 24, 152, 117, 16, 0},
+					}},
 				Canary:  false,
 				TypeUrl: string(envoy.TypeCDS),
 				Nonce:   "",
@@ -103,24 +98,104 @@ var _ = Describe("UniqueLists", func() {
 				},
 			}
 
-			expectedCluster := xds.Cluster{
-				TransportSocketMatches: nil,
-				Name:                   "envoy-admin-cluster",
-				AltStatName:            "envoy-admin-cluster",
-				ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
-				EdsClusterConfig:       nil,
-				ConnectTimeout:         ptypes.DurationProto(connectionTimeout),
-				LoadAssignment:         expectedClusterLoadAssignment,
-			}
+			{
+				expectedCluster := xds.Cluster{
+					TransportSocketMatches: nil,
+					Name:                   "default/bookstore",
+					AltStatName:            "",
+					ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_EDS},
+					EdsClusterConfig: &xds.Cluster_EdsClusterConfig{
+						EdsConfig: &envoy_api_v2_core.ConfigSource{
+							ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+								Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+							},
+						},
+						ServiceName: "",
+					},
+					ConnectTimeout: ptypes.DurationProto(5 * time.Second),
+					TransportSocket: &envoy_api_v2_core.TransportSocket{
+						Name: envoy.TransportSocketTLS,
+						ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
+							TypedConfig: &any.Any{
+								TypeUrl: string(envoy.TypeUpstreamTLSContext),
+								Value:   []byte{10, 141, 1, 10, 66, 8, 3, 16, 4, 26, 29, 69, 67, 68, 72, 69, 45, 69, 67, 68, 83, 65, 45, 65, 69, 83, 49, 50, 56, 45, 71, 67, 77, 45, 83, 72, 65, 50, 53, 54, 26, 29, 69, 67, 68, 72, 69, 45, 69, 67, 68, 83, 65, 45, 67, 72, 65, 67, 72, 65, 50, 48, 45, 80, 79, 76, 89, 49, 51, 48, 53, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 58, 33, 10, 27, 114, 111, 111, 116, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 18, 17, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114},
+							},
+						},
+					},
+					LoadAssignment: expectedClusterLoadAssignment,
+				}
+				cluster := xds.Cluster{}
+				err = ptypes.UnmarshalAny(resp.Resources[0], &cluster)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.ClusterDiscoveryType).To(Equal(expectedCluster.ClusterDiscoveryType))
+				Expect(cluster.EdsClusterConfig).To(Equal(expectedCluster.EdsClusterConfig))
+				Expect(cluster.ConnectTimeout).To(Equal(expectedCluster.ConnectTimeout))
+				Expect(cluster.TransportSocket).To(Equal(expectedCluster.TransportSocket))
 
-			cluster := xds.Cluster{}
-			err = ptypes.UnmarshalAny(resp.Resources[0], &cluster)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
-			Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
-			Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
-			Expect(cluster.LoadAssignment).To(Equal(expectedClusterLoadAssignment))
-			Expect(cluster).To(Equal(expectedCluster))
+				// TODO(draychev): finish the rest
+				// Expect(cluster).To(Equal(expectedCluster))
+
+				upstreamTLSContext := envoy_api_v2_auth.UpstreamTlsContext{}
+				err = ptypes.UnmarshalAny(cluster.TransportSocket.GetTypedConfig(), &upstreamTLSContext)
+				Expect(err).ToNot(HaveOccurred())
+
+				expectedTLSContext := envoy_api_v2_auth.UpstreamTlsContext{
+					CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
+						TlsParams: &envoy_api_v2_auth.TlsParameters{
+							TlsMinimumProtocolVersion: 3,
+							TlsMaximumProtocolVersion: 4,
+							CipherSuites: []string{
+								"ECDHE-ECDSA-AES128-GCM-SHA256",
+								"ECDHE-ECDSA-CHACHA20-POLY1305",
+							},
+						},
+						TlsCertificates: nil,
+						TlsCertificateSdsSecretConfigs: []*envoy_api_v2_auth.SdsSecretConfig{{
+							Name: "service-cert:default/bookstore",
+							SdsConfig: &envoy_api_v2_core.ConfigSource{
+								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+									Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+								},
+							},
+						}},
+						ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+							ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
+								Name: fmt.Sprintf("%s%s%s", envoy.RootCertPrefix, envoy.Separator, "default/bookstore"),
+								SdsConfig: &envoy_api_v2_core.ConfigSource{
+									ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+										Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+									},
+								},
+							},
+						},
+						AlpnProtocols: nil,
+					},
+					Sni:                "default/bookstore",
+					AllowRenegotiation: false,
+				}
+				Expect(upstreamTLSContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))
+				// TODO(draychev): finish the rest
+				// Expect(upstreamTLSContext).To(Equal(expectedTLSContext)
+			}
+			{
+				expectedCluster := xds.Cluster{
+					TransportSocketMatches: nil,
+					Name:                   "envoy-admin-cluster",
+					AltStatName:            "envoy-admin-cluster",
+					ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
+					EdsClusterConfig:       nil,
+					ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
+					LoadAssignment:         expectedClusterLoadAssignment,
+				}
+				cluster := xds.Cluster{}
+				err = ptypes.UnmarshalAny(resp.Resources[1], &cluster)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
+				Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
+				Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+				Expect(cluster.LoadAssignment).To(Equal(expectedClusterLoadAssignment))
+				Expect(cluster).To(Equal(expectedCluster))
+			}
 		})
 	})
 

--- a/pkg/envoy/xds_test.go
+++ b/pkg/envoy/xds_test.go
@@ -1,10 +1,16 @@
 package envoy
 
 import (
-	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"fmt"
 
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
 var _ = Describe("Test Envoy tools", func() {
@@ -26,6 +32,61 @@ var _ = Describe("Test Envoy tools", func() {
 			}
 
 			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test GetUpstreamTLSContext()", func() {
+		It("should return TLS context", func() {
+			actual := GetUpstreamTLSContext(tests.BookstoreService)
+			expected := &any.Any{
+				TypeUrl: string(TypeUpstreamTLSContext),
+				Value:   []byte{10, 141, 1, 10, 66, 8, 3, 16, 4, 26, 29, 69, 67, 68, 72, 69, 45, 69, 67, 68, 83, 65, 45, 65, 69, 83, 49, 50, 56, 45, 71, 67, 77, 45, 83, 72, 65, 50, 53, 54, 26, 29, 69, 67, 68, 72, 69, 45, 69, 67, 68, 83, 65, 45, 67, 72, 65, 67, 72, 65, 50, 48, 45, 80, 79, 76, 89, 49, 51, 48, 53, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 115, 116, 111, 114, 101, 18, 2, 26, 0, 58, 33, 10, 27, 114, 111, 111, 116, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 115, 116, 111, 114, 101, 18, 2, 26, 0, 18, 17, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 115, 116, 111, 114, 101},
+			}
+			Expect(actual).To(Equal(expected))
+
+			tlsContext := envoy_api_v2_auth.UpstreamTlsContext{}
+			err := ptypes.UnmarshalAny(actual, &tlsContext)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedTLSContext := envoy_api_v2_auth.UpstreamTlsContext{
+				CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
+					TlsParams: &envoy_api_v2_auth.TlsParameters{
+						TlsMinimumProtocolVersion: 3,
+						TlsMaximumProtocolVersion: 4,
+						CipherSuites: []string{
+							"ECDHE-ECDSA-AES128-GCM-SHA256",
+							"ECDHE-ECDSA-CHACHA20-POLY1305",
+						},
+					},
+					TlsCertificates: nil,
+					TlsCertificateSdsSecretConfigs: []*envoy_api_v2_auth.SdsSecretConfig{{
+						Name: "service-cert:default/bookstore",
+						SdsConfig: &envoy_api_v2_core.ConfigSource{
+							ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+								Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+							},
+						},
+					}},
+					ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+						ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
+							Name: fmt.Sprintf("%s%s%s", RootCertPrefix, Separator, "default/bookstore"),
+							SdsConfig: &envoy_api_v2_core.ConfigSource{
+								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+									Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+								},
+							},
+						},
+					},
+					AlpnProtocols: nil,
+				},
+				Sni:                "default/bookstore",
+				AllowRenegotiation: false,
+			}
+			Expect(tlsContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))
+			Expect(tlsContext.CommonTlsContext.TlsCertificates).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificates))
+			Expect(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificateSdsSecretConfigs))
+			Expect(tlsContext.CommonTlsContext.ValidationContextType).To(Equal(expectedTLSContext.CommonTlsContext.ValidationContextType))
+			Expect(tlsContext).To(Equal(expectedTLSContext))
 		})
 	})
 })

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -1,18 +1,33 @@
 package smi
 
 import (
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
-type fakeMeshSpec struct{}
+type fakeMeshSpec struct {
+	routeGroups      []*spec.HTTPRouteGroup
+	trafficTargets   []*target.TrafficTarget
+	weightedServices []endpoint.WeightedService
+	serviceAccounts  []endpoint.NamespacedServiceAccount
+}
 
 // NewFakeMeshSpecClient creates a fake Mesh Spec used for testing.
 func NewFakeMeshSpecClient() MeshSpec {
-	return fakeMeshSpec{}
+	return fakeMeshSpec{
+		routeGroups:      []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
+		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
+		weightedServices: []endpoint.WeightedService{tests.WeightedService},
+		serviceAccounts: []endpoint.NamespacedServiceAccount{
+			tests.BookstoreServiceAccount,
+			tests.BookbuyerServiceAccount,
+		},
+	}
 }
 
 // ListTrafficSplits lists TrafficSplit SMI resources for the fake Mesh Spec.
@@ -22,12 +37,12 @@ func (f fakeMeshSpec) ListTrafficSplits() []*split.TrafficSplit {
 
 // ListServices fetches all services declared with SMI Spec for the fake Mesh Spec.
 func (f fakeMeshSpec) ListServices() []endpoint.WeightedService {
-	return nil
+	return f.weightedServices
 }
 
 // ListServiceAccounts fetches all service accounts declared with SMI Spec for the fake Mesh Spec.
 func (f fakeMeshSpec) ListServiceAccounts() []endpoint.NamespacedServiceAccount {
-	return nil
+	return f.serviceAccounts
 }
 
 // GetService fetches a specific service declared in SMI for the fake Mesh Spec.
@@ -37,12 +52,12 @@ func (f fakeMeshSpec) GetService(endpoint.ServiceName) (service *corev1.Service,
 
 // ListHTTPTrafficSpecs lists TrafficSpec SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup {
-	return nil
+	return f.routeGroups
 }
 
 // ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListTrafficTargets() []*target.TrafficTarget {
-	return nil
+	return f.trafficTargets
 }
 
 // GetAnnouncementsChannel returns the channel on which SMI makes announcements for the fake Mesh Spec.


### PR DESCRIPTION
This PR introduces new unit tests to ensure some/most of the functionality around generating Envoy config is tested.

These here are a prerequisite for the work happening in https://github.com/open-service-mesh/osm/pull/580

Fix #240