### PR TITLE
catalog: Fill catalog cache as soon as possible

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -36,6 +36,8 @@ func NewMeshCatalog(meshSpec smi.MeshSpec, certManager certificate.Manager, ingr
 
 	}
 
+	sc.refreshCache()
+
 	go sc.repeater()
 	return &sc
 }


### PR DESCRIPTION
Warm the Mesh Catalog cache as soon as a new mesh catalog is instantiated.

This is a piece of https://github.com/open-service-mesh/osm/pull/610