### PR TITLE
tests: Adding common test fixtures

### DIFF
--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -65,7 +65,7 @@ var (
 
 	// Endpoint is an endpoint object.
 	Endpoint = endpoint.Endpoint{
-		IP:   net.IP("8.8.8.8"),
+		IP:   net.ParseIP("8.8.8.8"),
 		Port: endpoint.Port(8888),
 	}
 


### PR DESCRIPTION
Adding common objects to be reused in tests between many of the packages in this repo.

This is a piece of https://github.com/open-service-mesh/osm/pull/610

Fix #240