### PR TITLE
feat(cmd/osm): gen osm id + delete osm instance

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: ads
     spec:
-      serviceAccountName: {{ include "osm.serviceAccountName" . }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}-{{ .Values.osmID }}
       containers:
         - name: ads
           image: "{{ .Values.image.registry }}/ads:{{ .Chart.AppVersion }}"

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}-{{ .Values.osmID }}
 rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -36,17 +36,17 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}-{{ .Values.osmID }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}-{{ .Values.osmID }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.serviceAccount.name }}
+    name: {{ .Values.serviceAccount.name }}-{{ .Values.osmID }}
     namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}-{{ .Values.osmID }}
   apiGroup: rbac.authorization.k8s.io

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           name: prometheus-config-volume
         - mountPath: /prometheus/
           name: prometheus-storage-volume
-      serviceAccountName: {{.Values.prometheus.serviceName}}-serviceaccount
+      serviceAccountName: {{.Values.prometheus.serviceName}}-{{.Values.osmID}}-serviceaccount
       volumes:
       - name: prometheus-config-volume
         configMap:

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{.Values.prometheus.serviceName}}
+  name: {{.Values.prometheus.serviceName}}-{{.Values.osmID}}
 rules:
   - apiGroups: [""]
     resources: ["nodes", "node/proxy", "services", "endpoints", "pods"]
@@ -15,17 +15,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{.Values.prometheus.serviceName}}
+  name: {{.Values.prometheus.serviceName}}-{{.Values.osmID}}
 subjects:
   - kind: ServiceAccount
-    name: {{.Values.prometheus.serviceName}}-serviceaccount
+    name: {{.Values.prometheus.serviceName}}-{{.Values.osmID}}-serviceaccount
     namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{.Values.prometheus.serviceName}}
+  name: {{.Values.prometheus.serviceName}}-{{.Values.osmID}}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{.Values.prometheus.serviceName}}-serviceaccount
+  name: {{.Values.prometheus.serviceName}}-{{.Values.osmID}}-serviceaccount

--- a/cmd/osm/admin.go
+++ b/cmd/osm/admin.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+const adminDescription = `
+This command consists of multiple subcommands related to administrating instances
+of osm installations.
+
+`
+
+func newAdminCmd(config *action.Configuration, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "admin osm installs",
+		Long:  adminDescription,
+		Args:  require.NoArgs,
+	}
+	cmd.AddCommand(newAdminDelete(config, out))
+
+	return cmd
+}

--- a/cmd/osm/admin_delete.go
+++ b/cmd/osm/admin_delete.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+const adminDeleteOsmDescription = `
+This command will delete an instance of the osm control plane
+given the OSM ID and namespace of the control plane. It will
+not delete the namespace that the control plane components live
+in.
+
+Only use this in non-production and test environments.
+
+Usage:
+  $ osm admin delete-osm <osm-id> --namespace osm-system
+`
+
+type adminDeleteOsm struct {
+	out       io.Writer
+	osmID     string
+	namespace string
+	client    *action.Uninstall
+}
+
+func newAdminDelete(config *action.Configuration, out io.Writer) *cobra.Command {
+	del := &adminDeleteOsm{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "delete-osm",
+		Short: "delete osm instance",
+		Long:  adminDeleteOsmDescription,
+		Args:  require.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			del.osmID = args[0]
+			del.client = action.NewUninstall(config)
+			return del.run()
+		},
+	}
+
+	return cmd
+}
+
+func (d *adminDeleteOsm) run() error {
+
+	_, err := d.client.Run(d.osmID)
+	return err
+}

--- a/cmd/osm/install.go
+++ b/cmd/osm/install.go
@@ -12,10 +12,26 @@ import (
 
 const installDesc = `
 This command installs the osm control plane on the Kubernetes cluster.
+
+The osm control plane components get installed into the osm-system namespace
+by default. This can be overriden with the --namespace flag. If the give
+namespace does not exist, it will be created.
+
+Usage:
+  $ osm install --namespace hello-world
+
+Each instance of the osm control plane installation is given a unqiue ID
+referred to as the osm ID. An osm ID can be passed in via the --osm-id flag.
+The osm ID is used in various different ways by the control plane including
+the resource name for the MutatingWebhookConfiguration created by the control
+plane for sidecar injection of envoy proxies.
+
+Usage:
+  $ osm install --osm-id "hello-osm"
+
 `
 const (
-	defaultOSMChartPath    = "charts/osm"
-	defaultHelmReleaseName = "osm-cp"
+	defaultOSMChartPath = "charts/osm"
 )
 
 type installCmd struct {
@@ -23,6 +39,7 @@ type installCmd struct {
 	containerRegistry       string
 	containerRegistrySecret string
 	chartPath               string
+	osmID                   string
 }
 
 func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
@@ -44,12 +61,16 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.containerRegistry, "container-registry", "smctest.azurecr.io", "container registry that hosts control plane component images")
 	f.StringVar(&inst.containerRegistrySecret, "container-registry-secret", "acr-creds", "name of Kubernetes secret for container registry credentials to be created if it doesn't already exist")
 	f.StringVar(&inst.chartPath, "osm-chart-path", "", "path to osm chart to override default chart")
+	f.StringVar(&inst.osmID, "osm-id", "", "unique ID for an instance of the OSM control plane")
 
 	return cmd
 }
 
 func (i *installCmd) run(installClient *helm.Install) error {
-	installClient.ReleaseName = defaultHelmReleaseName
+	if i.osmID == "" {
+		i.osmID = "osm-cp-" + settings.Namespace()
+	}
+	installClient.ReleaseName = i.osmID
 	installClient.Namespace = settings.Namespace()
 	installClient.CreateNamespace = true
 
@@ -83,6 +104,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("image.registry=%s", i.containerRegistry),
 		fmt.Sprintf("imagePullSecrets[0].name=%s", i.containerRegistrySecret),
 		fmt.Sprintf("namespace=%s", settings.Namespace()),
+		fmt.Sprintf("osmID=%s", i.osmID),
 	}
 
 	for _, val := range valuesConfig {

--- a/cmd/osm/install_test.go
+++ b/cmd/osm/install_test.go
@@ -38,6 +38,7 @@ func TestInstallRun(t *testing.T) {
 		chartPath:               "testdata/test-chart",
 		containerRegistry:       testRegistry,
 		containerRegistrySecret: testRegistrySecret,
+		osmID:                   "testid-123",
 	}
 
 	installClient := helm.NewInstall(config)
@@ -51,9 +52,9 @@ func TestInstallRun(t *testing.T) {
 		t.Errorf("Expected %s, got %s", expectedOutput, result)
 	}
 
-	rel, err := config.Releases.Get(defaultHelmReleaseName, 1)
+	rel, err := config.Releases.Get(installCmd.osmID, 1)
 	if err != nil {
-		t.Errorf("Expected helm release %s, got err %s", defaultHelmReleaseName, err)
+		t.Errorf("Expected helm release %s, got err %s", installCmd.osmID, err)
 	}
 
 	//user did not set any values. Used same defaults from test-chart so this is empty.
@@ -67,6 +68,7 @@ func TestInstallRun(t *testing.T) {
 			},
 		},
 		"namespace": settings.Namespace(),
+		"osmID":     installCmd.osmID,
 	}
 	if !reflect.DeepEqual(rel.Config, expectedUserValues) {
 		t.Errorf("Expected helm release values to resolve as %#v\nbut got %#v", expectedUserValues, rel.Config)
@@ -83,6 +85,7 @@ func TestResolveValues(t *testing.T) {
 	installCmd := &installCmd{
 		containerRegistry:       testRegistry,
 		containerRegistrySecret: testRegistrySecret,
+		osmID:                   "helloworld",
 	}
 
 	vals, err := installCmd.resolveValues()
@@ -100,6 +103,7 @@ func TestResolveValues(t *testing.T) {
 			},
 		},
 		"namespace": settings.Namespace(),
+		"osmID":     installCmd.osmID,
 	}
 	if !reflect.DeepEqual(vals, expected) {
 		t.Errorf("Expected values to resolve as %#v\nbut got %#v", expected, vals)

--- a/cmd/osm/osm.go
+++ b/cmd/osm/osm.go
@@ -35,9 +35,10 @@ func newRootCmd(config *action.Configuration, out io.Writer, args []string) *cob
 
 	// Add subcommands here
 	cmd.AddCommand(
-		newInstallCmd(config, out),
+		newAdminCmd(config, out),
 		newConfigCmd(config, out),
 		newEnvCmd(out),
+		newInstallCmd(config, out),
 	)
 
 	flags.Parse(args)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/servicemeshinterface/smi-sdk-go v0.3.1-0.20200415150537-c8c381cb495f
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
+	github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/sys v0.0.0-20200107162124-548cf772de50 // indirect
 	gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -621,6 +621,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245 h1:DNVk+NIkGS0RbLkjQOLCJb/759yfCysThkMbl7EXxyY=
+github.com/technosophos/moniker v0.0.0-20180509230615-a5dbd03a2245/go.mod h1:O1c8HleITsZqzNZDjSNzirUGsMT0oGu9LhHKoJrqO+A=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
* Adds an osm-id flag to the install command.
It allows the user to specify an osm id to use. It one is not
specified, an osm id will be generated.
* Also adds an admin parent command to house administrative
actions. The first subcommand is the delete-osm subcommand.
It takes an osm id and deletes the helm release associated
with that osm ID

resolves #350 
depends on #608 (Please review #608 first)