### PR TITLE
catalog: Simplify certificates test

### DIFF
--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
+// NewFakeMeshCatalog creates a struct implementing catalog.Mesh to be used for tests.
 func NewFakeMeshCatalog() MeshCataloger {
 	meshSpec := smi.NewFakeMeshSpecClient()
 	certManager := tresor.NewFakeCertManager()

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 var _ = Describe("Test Kubernetes Provider", func() {
-
 	Context("Testing ListServicesForServiceAccount", func() {
 		It("returns empty list", func() {
 			c := NewFakeProvider()

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -155,8 +155,7 @@ var (
 			Name:      RouteGroupName,
 		},
 		Matches: []spec.HTTPMatch{{
-			Name: MatchName,
-
+			Name:      MatchName,
 			PathRegex: BookstoreBuyPath,
 			Methods:   []string{"GET"},
 		}},


### PR DESCRIPTION
This PR simplifies a unit test by reusing the `NewFakeMeshCatalog` introduced in https://github.com/open-service-mesh/osm/pull/616

This PR is stacked on https://github.com/open-service-mesh/osm/pull/616, which is stacked on https://github.com/open-service-mesh/osm/pull/615, which is stacked on https://github.com/open-service-mesh/osm/pull/615

This is a piece of https://github.com/open-service-mesh/osm/pull/610