### PR TITLE
envoy: Adding UpstreamTlsContext to types

### DIFF
--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -31,6 +31,9 @@ const (
 	// TypeEDS is the EDS type URI.
 	TypeEDS TypeURI = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
 
+	// TypeUpstreamTLSContext is an Envoy type URI.
+	TypeUpstreamTLSContext TypeURI = "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext"
+
 	// TransportSocketTLS is an Envoy string constant.
 	TransportSocketTLS = "envoy.transport_sockets.tls"
 


### PR DESCRIPTION
This PR is part of https://github.com/open-service-mesh/osm/pull/610

This adds `UpstreamTlsContext` to the types of URIs OSM can deal with.

(This is going to be used in one of the follow-up PRs via  https://github.com/open-service-mesh/osm/pull/610)