### PR TITLE
smi: Improving NewFakeMeshSpecClient() so it can be used in more unit tests

### DIFF
--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -1,18 +1,33 @@
 package smi
 
 import (
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
-type fakeMeshSpec struct{}
+type fakeMeshSpec struct {
+	routeGroups      []*spec.HTTPRouteGroup
+	trafficTargets   []*target.TrafficTarget
+	weightedServices []endpoint.WeightedService
+	serviceAccounts  []endpoint.NamespacedServiceAccount
+}
 
 // NewFakeMeshSpecClient creates a fake Mesh Spec used for testing.
 func NewFakeMeshSpecClient() MeshSpec {
-	return fakeMeshSpec{}
+	return fakeMeshSpec{
+		routeGroups:      []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
+		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
+		weightedServices: []endpoint.WeightedService{tests.WeightedService},
+		serviceAccounts: []endpoint.NamespacedServiceAccount{
+			tests.BookstoreServiceAccount,
+			tests.BookbuyerServiceAccount,
+		},
+	}
 }
 
 // ListTrafficSplits lists TrafficSplit SMI resources for the fake Mesh Spec.
@@ -22,12 +37,12 @@ func (f fakeMeshSpec) ListTrafficSplits() []*split.TrafficSplit {
 
 // ListServices fetches all services declared with SMI Spec for the fake Mesh Spec.
 func (f fakeMeshSpec) ListServices() []endpoint.WeightedService {
-	return nil
+	return f.weightedServices
 }
 
 // ListServiceAccounts fetches all service accounts declared with SMI Spec for the fake Mesh Spec.
 func (f fakeMeshSpec) ListServiceAccounts() []endpoint.NamespacedServiceAccount {
-	return nil
+	return f.serviceAccounts
 }
 
 // GetService fetches a specific service declared in SMI for the fake Mesh Spec.
@@ -37,12 +52,12 @@ func (f fakeMeshSpec) GetService(endpoint.ServiceName) (service *corev1.Service,
 
 // ListHTTPTrafficSpecs lists TrafficSpec SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup {
-	return nil
+	return f.routeGroups
 }
 
 // ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListTrafficTargets() []*target.TrafficTarget {
-	return nil
+	return f.trafficTargets
 }
 
 // GetAnnouncementsChannel returns the channel on which SMI makes announcements for the fake Mesh Spec.


### PR DESCRIPTION
This PR is a part of https://github.com/open-service-mesh/osm/pull/610

It introduces an improved `NewFakeMeshSpecClient()` to be used in unit tests.

Fix #240