### PR TITLE
Make k8s event eventually consistent

### DIFF
--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -2,7 +2,6 @@ package ingress
 
 import (
 	"strings"
-	"time"
 
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/informers"
@@ -16,15 +15,11 @@ import (
 	"github.com/open-service-mesh/osm/pkg/namespace"
 )
 
-var (
-	resyncPeriod = 60 * time.Second
-)
-
 // NewIngressClient implements ingress.Monitor and creates the Kubernetes client to monitor Ingress resources.
 func NewIngressClient(kubeConfig *rest.Config, namespaceController namespace.Controller, stop chan struct{}) (Monitor, error) {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 
-	informerFactory := informers.NewSharedInformerFactory(kubeClient, resyncPeriod)
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
 	informer := informerFactory.Extensions().V1beta1().Ingresses().Informer()
 
 	client := Client{

--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -45,9 +45,6 @@ func Update(informerName string, providerName string, announce chan interface{},
 		if !namespaceController.IsMonitoredNamespace(ns) {
 			return
 		}
-		if reflect.DeepEqual(oldObj, newObj) {
-			return
-		}
 		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
 			log.Trace().Msgf("[%s][%s] Update event %+v", providerName, informerName, oldObj)
 		}

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"time"
+
 	"github.com/open-service-mesh/osm/pkg/logger"
 )
 
@@ -20,6 +22,11 @@ const (
 
 	// DeleteEvent is a type of a Kubernetes API event.
 	DeleteEvent
+)
+
+const (
+	// DefaultKubeEventResyncInterval is the default resync interval for k8s events
+	DefaultKubeEventResyncInterval = 30 * time.Second
 )
 
 // Event is the combined type and actual object we received from Kubernetes

--- a/pkg/namespace/client.go
+++ b/pkg/namespace/client.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	resyncPeriod = 10 * time.Second
+	resyncPeriod = 30 * time.Second
 )
 
 // NewNamespaceController implements namespace.Controller and creates the Kubernetes client to manage namespaces.

--- a/pkg/providers/azure/kubernetes/client.go
+++ b/pkg/providers/azure/kubernetes/client.go
@@ -1,8 +1,6 @@
 package azure
 
 import (
-	"time"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -19,8 +17,6 @@ const (
 	kubernetesClientName = "AzureResourceClient"
 )
 
-var resyncPeriod = 10 * time.Second
-
 // NewClient creates the Kubernetes client, which retrieves the AzureResource CRD and Services resources.
 func NewClient(kubeConfig *rest.Config, namespaceController namespace.Controller, stop chan struct{}) *Client {
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
@@ -35,7 +31,7 @@ func NewClient(kubeConfig *rest.Config, namespaceController namespace.Controller
 
 // newClient creates a provider based on a Kubernetes client instance.
 func newClient(kubeClient *kubernetes.Clientset, azureResourceClient *osmClient.Clientset, namespaceController namespace.Controller) *Client {
-	azureResourceFactory := osmInformers.NewSharedInformerFactory(azureResourceClient, resyncPeriod)
+	azureResourceFactory := osmInformers.NewSharedInformerFactory(azureResourceClient, k8s.DefaultKubeEventResyncInterval)
 	informerCollection := InformerCollection{
 		AzureResource: azureResourceFactory.Osm().V1().AzureResources().Informer(),
 	}

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -2,7 +2,6 @@ package smi
 
 import (
 	"strings"
-	"time"
 
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 
@@ -24,8 +23,6 @@ import (
 	k8s "github.com/open-service-mesh/osm/pkg/kubernetes"
 	"github.com/open-service-mesh/osm/pkg/namespace"
 )
-
-var resyncPeriod = 10 * time.Second
 
 // We have a few different k8s clients. This identifies these in logs.
 const kubernetesClientName = "MeshSpec"
@@ -99,10 +96,10 @@ func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
 
 // newClient creates a provider based on a Kubernetes client instance.
 func newSMIClient(kubeClient *kubernetes.Clientset, smiTrafficSplitClient *smiTrafficSplitClient.Clientset, smiTrafficSpecClient *smiTrafficSpecClient.Clientset, smiTrafficTargetClient *smiTrafficTargetClient.Clientset, osmNamespace string, namespaceController namespace.Controller, providerIdent string) *Client {
-	informerFactory := informers.NewSharedInformerFactory(kubeClient, resyncPeriod)
-	smiTrafficSplitInformerFactory := smiTrafficSplitInformers.NewSharedInformerFactory(smiTrafficSplitClient, resyncPeriod)
-	smiTrafficSpecInformerFactory := smiTrafficSpecInformers.NewSharedInformerFactory(smiTrafficSpecClient, resyncPeriod)
-	smiTrafficTargetInformerFactory := smiTrafficTargetInformers.NewSharedInformerFactory(smiTrafficTargetClient, resyncPeriod)
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
+	smiTrafficSplitInformerFactory := smiTrafficSplitInformers.NewSharedInformerFactory(smiTrafficSplitClient, k8s.DefaultKubeEventResyncInterval)
+	smiTrafficSpecInformerFactory := smiTrafficSpecInformers.NewSharedInformerFactory(smiTrafficSpecClient, k8s.DefaultKubeEventResyncInterval)
+	smiTrafficTargetInformerFactory := smiTrafficTargetInformers.NewSharedInformerFactory(smiTrafficTargetClient, k8s.DefaultKubeEventResyncInterval)
 
 	informerCollection := InformerCollection{
 		Services:      informerFactory.Core().V1().Services().Informer(),


### PR DESCRIPTION
Updates for k8s events were ignored if the old and new
objects are the same. This breaks the eventual consistency model
where an event could be missed/lost by the system due to network
faults, consumers being down etc. This change processes k8s update
events for monitored namespaces based on the default resync interval.
The point of even having resync interval for events is to achieve
eventual consistency.