### PR TITLE
namespace: Update NamespaceService cache w/ k8s events

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -5,29 +5,28 @@ import (
 	"reflect"
 
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/open-service-mesh/osm/pkg/namespace"
 )
 
+type namespaceFilter func(obj interface{}) bool
+
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
-func GetKubernetesEventHandlers(informerName string, providerName string, announcements chan interface{}, namespaceController namespace.Controller) cache.ResourceEventHandlerFuncs {
+func GetKubernetesEventHandlers(informerName string, providerName string, announcements chan interface{}, nsFilter namespaceFilter) cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    Add(informerName, providerName, announcements, namespaceController),
-		UpdateFunc: Update(informerName, providerName, announcements, namespaceController),
-		DeleteFunc: Delete(informerName, providerName, announcements, namespaceController),
+		AddFunc:    add(informerName, providerName, announcements, nsFilter),
+		UpdateFunc: upd(informerName, providerName, announcements, nsFilter),
+		DeleteFunc: del(informerName, providerName, announcements, nsFilter),
 	}
 }
 
-// Add a new item to Kubernetes caches from an incoming Kubernetes event.
-func Add(informerName string, providerName string, announce chan interface{}, namespaceController namespace.Controller) func(obj interface{}) {
+// add a new item to Kubernetes caches from an incoming Kubernetes event.
+func add(informerName string, providerName string, announce chan interface{}, nsFilter namespaceFilter) func(obj interface{}) {
 	return func(obj interface{}) {
-		ns := getNamespace(obj)
-		if !namespaceController.IsMonitoredNamespace(ns) {
-			log.Debug().Msgf("Not monitored: %s", ns)
+		if nsFilter != nil && !nsFilter(obj) {
+			log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring ADD event", getNamespace(obj))
 			return
 		}
 		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
-			log.Trace().Msgf("[%s][%s] Add event: %+v", providerName, informerName, obj)
+			log.Trace().Msgf("[%s][%s] add event: %+v", providerName, informerName, obj)
 		}
 		if announce != nil {
 			announce <- Event{
@@ -38,15 +37,15 @@ func Add(informerName string, providerName string, announce chan interface{}, na
 	}
 }
 
-// Update caches with an incoming Kubernetes event.
-func Update(informerName string, providerName string, announce chan interface{}, namespaceController namespace.Controller) func(oldObj, newObj interface{}) {
+// upd caches with an incoming Kubernetes event.
+func upd(informerName string, providerName string, announce chan interface{}, nsFilter namespaceFilter) func(oldObj, newObj interface{}) {
 	return func(oldObj, newObj interface{}) {
-		ns := getNamespace(newObj)
-		if !namespaceController.IsMonitoredNamespace(ns) {
+		if nsFilter != nil && !nsFilter(newObj) {
+			log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring UPDATE event", getNamespace(newObj))
 			return
 		}
 		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
-			log.Trace().Msgf("[%s][%s] Update event %+v", providerName, informerName, oldObj)
+			log.Trace().Msgf("[%s][%s] upd event %+v", providerName, informerName, oldObj)
 		}
 		if announce != nil {
 			announce <- Event{
@@ -57,15 +56,15 @@ func Update(informerName string, providerName string, announce chan interface{},
 	}
 }
 
-// Delete Kubernetes cache from an incoming Kubernetes event.
-func Delete(informerName string, providerName string, announce chan interface{}, namespaceController namespace.Controller) func(obj interface{}) {
+// delete Kubernetes cache from an incoming Kubernetes event.
+func del(informerName string, providerName string, announce chan interface{}, nsFilter namespaceFilter) func(obj interface{}) {
 	return func(obj interface{}) {
-		ns := getNamespace(obj)
-		if !namespaceController.IsMonitoredNamespace(ns) {
+		if nsFilter != nil && !nsFilter(obj) {
+			log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring DELETE event", getNamespace(obj))
 			return
 		}
 		if os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true" {
-			log.Trace().Msgf("[%s][%s] Delete event: %+v", providerName, informerName, obj)
+			log.Trace().Msgf("[%s][%s] delete event: %+v", providerName, informerName, obj)
 		}
 		if announce != nil {
 			announce <- Event{

--- a/pkg/namespace/types.go
+++ b/pkg/namespace/types.go
@@ -12,9 +12,10 @@ var (
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
-	informer    cache.SharedIndexInformer
-	cache       cache.Store
-	cacheSynced chan interface{}
+	informer      cache.SharedIndexInformer
+	cache         cache.Store
+	cacheSynced   chan interface{}
+	announcements chan interface{}
 }
 
 // Controller is the controller interface for K8s namespaces


### PR DESCRIPTION
We saw intermittent demo/ci failures. It seems to me that these may be related to inconsistent Namespaces cache.  The namespace controller needs `informer.AddEventHandler` added to it so that if the namespaces were tagged after this was started it will pick up the events and register the namespaces as being observed.

I discovered this by looking at ADS pod logs in one of the CI namespaces - noticed that ADS reported the bookstore/bookbuyer namespaces as "Not monitored: xxx", which is a reason for demo to not work.

### What's up with the `nsFilter` function?
We need to add `AddEventHandler` from our `pkg/kubernetes` into `pkg/namespace`, but then also `pkg/kubernetes` needs a function from `pkg/namespace` - so we endup with a cyclical import ∞.

To move this forward and fix CI I decided to create a generic filter function (could have been a variadic functions...).  The NamespaceController needs `AddEventHandler`, but it should NOT have a filter (because it will filter the namespace events, which it needs to watch to understand whether they are tagged to start watching the namespace events ↻)

So we make a `type namespaceFilter func(obj interface{}) bool` and let each Controller that needs to manage cache define their own filter.  NamespaceController should have no filters - so it passes `nil`.  Everybody else makes the same namespace filter function.