### PR TITLE
xds: Verify that ServiceAccount of Pod matches that of xDS Certificate

### DIFF
--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -3,9 +3,11 @@ package catalog
 import "errors"
 
 var (
-	errServiceNotFound               = errors.New("no such service found")
-	errInvalidCertificateCN          = errors.New("invalid cn")
-	errMoreThanOnePodForCertificate  = errors.New("found more than one pod for certificate")
-	errDidNotFindPodForCertificate   = errors.New("did not find pod for certificate")
-	errNoServicesFoundForCertificate = errors.New("no services found for certificate")
+	errServiceNotFound                       = errors.New("no such service found")
+	errInvalidCertificateCN                  = errors.New("invalid cn")
+	errMoreThanOnePodForCertificate          = errors.New("found more than one pod for certificate")
+	errDidNotFindPodForCertificate           = errors.New("did not find pod for certificate")
+	errNoServicesFoundForCertificate         = errors.New("no services found for certificate")
+	errServiceAccountDoesNotMatchCertificate = errors.New("service account does not match certificate")
+	errNamespaceDoesNotMatchCertificate      = errors.New("namespace does not match certificate")
 )

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -106,6 +106,7 @@ type connectedProxy struct {
 
 // certificateCommonNameMeta is the type that stores the metadata present in the CommonName field in a proxy's certificate
 type certificateCommonNameMeta struct {
-	ProxyID   string
-	Namespace string
+	ProxyID        string
+	ServiceAccount string
+	Namespace      string
 }

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -30,10 +30,10 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 
 	// Start patching the spec
 	var patches []JSONPatchOperation
-	log.Info().Msgf("Patching POD spec: service-account=%s, namespace=%s", pod.Spec.ServiceAccountName, namespace)
 
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
-	cn := catalog.NewCertCommonNameWithProxyID(proxyUUID, namespace)
+	cn := catalog.NewCertCommonNameWithProxyID(proxyUUID, pod.Spec.ServiceAccountName, namespace)
+	log.Info().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN=%s", pod.Spec.ServiceAccountName, namespace, cn)
 	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing bootstrap certificate for Envoy with CN=%s", cn)

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -202,6 +202,7 @@ func (wh *webhook) mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespo
 	}
 
 	// Create the patches for the spec
+	// We use req.Namespace because pod.Namespace is "" at this point
 	patchBytes, err := wh.createPatch(&pod, req.Namespace)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create patch")

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -189,7 +189,9 @@ func NewPodTestFixture(namespace string, podName string) corev1.Pod {
 				constants.EnvoyUniqueIDLabelName: EnvoyUID,
 			},
 		},
-		Spec: corev1.PodSpec{},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: BookbuyerServiceAccountName,
+		},
 	}
 }
 


### PR DESCRIPTION
This PR is a continuation of https://github.com/open-service-mesh/osm/pull/580 (where we changed the xDS certs issued to be based on the pod's UUID instead of a hard-coded pod Service name).

In this PR we:

  1. Add the `ServiceAccount` of the pod to the CN of the xDS certificate (at mutating webhook time).
  2. Verify the ServiceAccount matches that of the found pod when an Envoy connects to xDS.

This ensures that when an xDS certificate is somehow moved from one service account to another, we reject the Envoy using it.

# Lifecycle of a pod

1. Something attempts to create a pod
2. MutatingWebhookConfiguration captures that, blocks it, forwards the request to OSM
3. OSM injects an Envoy sidecar with an xDS certificate (used between Envoy and OSM only); This certificate has a CN with the following:  `Pod UUID`,  `Service Account`,  `Namespace`
4. Pod is created;  Envoy of sidecar connects to xDS and presents xDS certificate to OSM
5. Based on the pod UUID in the client certificate of the connected Envoy from #4 OSM:
  - finds the Pod
  - verifies that the matching pod is of the Service Account for which the cert was issued
  - determines the services the pod belongs to
  - programs Envoy 

# TODO
 - [ ] leverage Service Account token from pod to guarantee pod identity when it connects to xDS