### PR TITLE
fix(*) : fixing issue for namespaces not being observed by osm

### DIFF
--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -31,11 +31,11 @@ func NewIngressClient(kubeConfig *rest.Config, namespaceController namespace.Con
 		namespaceController: namespaceController,
 	}
 
-	nsFilter := func(obj interface{}) bool {
+	shouldObserve := func(obj interface{}) bool {
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return namespaceController.IsMonitoredNamespace(ns)
 	}
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", client.announcements, nsFilter))
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", client.announcements, shouldObserve))
 
 	if err := client.run(stop); err != nil {
 		log.Error().Err(err).Msg("Could not start Kubernetes Ingress client")

--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -7,21 +7,26 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type namespaceFilter func(obj interface{}) bool
+// observeFilter returns true for YES observe and false for NO do not pay attention to this
+// This filter could be added optionally by anything using GetKubernetesEventHandlers()
+type observeFilter func(obj interface{}) bool
 
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
-func GetKubernetesEventHandlers(informerName string, providerName string, announcements chan interface{}, nsFilter namespaceFilter) cache.ResourceEventHandlerFuncs {
+func GetKubernetesEventHandlers(informerName string, providerName string, announcements chan interface{}, shouldObserve observeFilter) cache.ResourceEventHandlerFuncs {
+	if shouldObserve == nil {
+		shouldObserve = func(obj interface{}) bool { return true }
+	}
 	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    add(informerName, providerName, announcements, nsFilter),
-		UpdateFunc: update(informerName, providerName, announcements, nsFilter),
-		DeleteFunc: delete(informerName, providerName, announcements, nsFilter),
+		AddFunc:    add(informerName, providerName, announcements, shouldObserve),
+		UpdateFunc: update(informerName, providerName, announcements, shouldObserve),
+		DeleteFunc: delete(informerName, providerName, announcements, shouldObserve),
 	}
 }
 
 // add a new item to Kubernetes caches from an incoming Kubernetes event.
-func add(informerName string, providerName string, announce chan interface{}, nsFilter namespaceFilter) func(obj interface{}) {
+func add(informerName string, providerName string, announce chan interface{}, shouldObserve observeFilter) func(obj interface{}) {
 	return func(obj interface{}) {
-		if nsFilter == nil || !nsFilter(obj) {
+		if !shouldObserve(obj) {
 			log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring ADD event", getNamespace(obj))
 			return
 		}
@@ -38,9 +43,9 @@ func add(informerName string, providerName string, announce chan interface{}, ns
 }
 
 // update caches with an incoming Kubernetes event.
-func update(informerName string, providerName string, announce chan interface{}, nsFilter namespaceFilter) func(oldObj, newObj interface{}) {
+func update(informerName string, providerName string, announce chan interface{}, shouldObserve observeFilter) func(oldObj, newObj interface{}) {
 	return func(oldObj, newObj interface{}) {
-		if nsFilter == nil || !nsFilter(newObj) {
+		if !shouldObserve(newObj) {
 			log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring UPDATE event", getNamespace(newObj))
 			return
 		}
@@ -57,9 +62,9 @@ func update(informerName string, providerName string, announce chan interface{},
 }
 
 // delete Kubernetes cache from an incoming Kubernetes event.
-func delete(informerName string, providerName string, announce chan interface{}, nsFilter namespaceFilter) func(obj interface{}) {
+func delete(informerName string, providerName string, announce chan interface{}, shouldObserve observeFilter) func(obj interface{}) {
 	return func(obj interface{}) {
-		if nsFilter == nil || !nsFilter(obj) {
+		if !shouldObserve(obj) {
 			log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring DELETE event", getNamespace(obj))
 			return
 		}

--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -20,7 +20,7 @@ const (
 
 var _ = Describe("Testing event handlers", func() {
 	Context("Test add on a monitored namespace", func() {
-		nsFilter := func(obj interface{}) bool {
+		shouldObserve := func(obj interface{}) bool {
 			ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 			return ns == testNamespace
 		}
@@ -28,7 +28,7 @@ var _ = Describe("Testing event handlers", func() {
 		It("Should add the event to the announcement channel", func() {
 			announcements := make(chan interface{}, 1)
 			pod := tests.NewPodTestFixture(testNamespace, "pod-name")
-			add(testInformer, testProvider, announcements, nsFilter)(&pod)
+			add(testInformer, testProvider, announcements, shouldObserve)(&pod)
 			Expect(len(announcements)).To(Equal(1))
 			<-announcements
 		})
@@ -37,7 +37,7 @@ var _ = Describe("Testing event handlers", func() {
 			announcements := make(chan interface{}, 1)
 			var pod corev1.Pod
 			pod.Namespace = "not-a-monitored-namespace"
-			add(testInformer, testProvider, announcements, nsFilter)(&pod)
+			add(testInformer, testProvider, announcements, shouldObserve)(&pod)
 			Expect(len(announcements)).To(Equal(0))
 		})
 	})

--- a/pkg/providers/azure/kubernetes/client.go
+++ b/pkg/providers/azure/kubernetes/client.go
@@ -52,11 +52,11 @@ func newClient(kubeClient *kubernetes.Clientset, azureResourceClient *osmClient.
 		namespaceController: namespaceController,
 	}
 
-	nsFilter := func(obj interface{}) bool {
+	shouldObserve := func(obj interface{}) bool {
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return namespaceController.IsMonitoredNamespace(ns)
 	}
-	informerCollection.AzureResource.AddEventHandler(k8s.GetKubernetesEventHandlers("AzureResource", "Azure", client.announcements, nsFilter))
+	informerCollection.AzureResource.AddEventHandler(k8s.GetKubernetesEventHandlers("AzureResource", "Azure", client.announcements, shouldObserve))
 
 	return &client
 }

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -46,12 +46,12 @@ func NewProvider(kubeConfig *rest.Config, namespaceController namespace.Controll
 		namespaceController: namespaceController,
 	}
 
-	nsFilter := func(obj interface{}) bool {
+	shouldObserve := func(obj interface{}) bool {
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return namespaceController.IsMonitoredNamespace(ns)
 	}
-	informerCollection.Endpoints.AddEventHandler(k8s.GetKubernetesEventHandlers("Endpoints", "Kubernetes", client.announcements, nsFilter))
-	informerCollection.Deployments.AddEventHandler(k8s.GetKubernetesEventHandlers("Deployments", "Kubernetes", client.announcements, nsFilter))
+	informerCollection.Endpoints.AddEventHandler(k8s.GetKubernetesEventHandlers("Endpoints", "Kubernetes", client.announcements, shouldObserve))
+	informerCollection.Deployments.AddEventHandler(k8s.GetKubernetesEventHandlers("Deployments", "Kubernetes", client.announcements, shouldObserve))
 
 	if err := client.run(stop); err != nil {
 		log.Fatal().Err(err).Msg("Could not start Kubernetes EndpointProvider client")

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -126,14 +126,14 @@ func newSMIClient(kubeClient *kubernetes.Clientset, smiTrafficSplitClient *smiTr
 		namespaceController: namespaceController,
 	}
 
-	nsFilter := func(obj interface{}) bool {
+	shouldObserve := func(obj interface{}) bool {
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return namespaceController.IsMonitoredNamespace(ns)
 	}
-	informerCollection.Services.AddEventHandler(k8s.GetKubernetesEventHandlers("Services", "SMI", client.announcements, nsFilter))
-	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", client.announcements, nsFilter))
-	informerCollection.TrafficSpec.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSpec", "SMI", client.announcements, nsFilter))
-	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", client.announcements, nsFilter))
+	informerCollection.Services.AddEventHandler(k8s.GetKubernetesEventHandlers("Services", "SMI", client.announcements, shouldObserve))
+	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", client.announcements, shouldObserve))
+	informerCollection.TrafficSpec.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSpec", "SMI", client.announcements, shouldObserve))
+	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", client.announcements, shouldObserve))
 
 	return &client
 }


### PR DESCRIPTION
The demo was repeatedly failing with a 404 and the ads logs showed that the bookbuyer, bookstore namespaces weren't being added/updated or deleted by the event handler.

On debugging, the cached has the correct/required namespaces and they were all being monitored correctly it was the nsFilter conditional check that was incorrect. This PR updates and fixes that 

Demo run locally returns a 200 finally.