### PR TITLE
tresor: With --keepRootPrivateKeyInKubernetes keep root cert in Kubernetes secret

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -463,6 +463,9 @@ type Certificater interface {
 
 	// GetIssuingCA returns the root certificate for the given cert.
 	GetIssuingCA() Certificater
+
+	// GetExpiration() returns the expiration of the certificate
+	GetExpiration() time.Time
 }
 ```
 

--- a/cmd/ads/certificates.go
+++ b/cmd/ads/certificates.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"context"
+	"encoding/base64"
 	"fmt"
 	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
@@ -22,10 +28,13 @@ const (
 
 	// Hashi Vault integration; OSM is pointed to an external Vault; signing of certs happens on Vault
 	vaultKind = "vault"
+
+	// Name of the Kubernetes secret where we store the Root certificate for the service mesh
+	rootCertSecretName = "root-cert"
 )
 
 // Functions we can call to create a Certificate Manager for each kind of supported certificate issuer
-var certManagers = map[certificateManagerKind]func() certificate.Manager{
+var certManagers = map[certificateManagerKind]func(kubeConfig *rest.Config) certificate.Manager{
 	tresorKind:   getTresorCertificateManager,
 	keyVaultKind: getAzureKeyVaultCertManager,
 	vaultKind:    getHashiVaultCertManager,
@@ -40,14 +49,42 @@ func getPossibleCertManagers() []string {
 	return possible
 }
 
-func getTresorCertificateManager() certificate.Manager {
-	rootCert, err := tresor.NewCA(constants.CertificationAuthorityCommonName, getServiceCertValidityPeriod())
+func getNewRootCertFromTresor(kubeClient kubernetes.Interface, namespace, rootCertSecretName string, saveRootPrivateKeyInKubernetes bool) certificate.Certificater {
+	rootCert, err := tresor.NewCA(constants.CertificationAuthorityCommonName, constants.CertificationAuthorityRootExpiration)
+
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to create new Certificate Authority with cert issuer %s", *certManagerKind)
 	}
 
 	if rootCert == nil {
 		log.Fatal().Msgf("Invalid root certificate created by cert issuer %s", *certManagerKind)
+	}
+
+	if rootCert.GetPrivateKey() == nil {
+		log.Fatal().Err(err).Msg("Root cert does not have a private key")
+	}
+
+	if saveRootPrivateKeyInKubernetes {
+		if err := saveSecretToKubernetes(kubeClient, rootCert, namespace, rootCertSecretName, rootCert.GetPrivateKey()); err != nil {
+			log.Error().Err(err).Msgf("Error exporting CA bundle into Kubernetes secret with name %s", rootCertSecretName)
+		}
+	}
+
+	return rootCert
+}
+
+func getTresorCertificateManager(kubeConfig *rest.Config) certificate.Manager {
+	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
+
+	var err error
+	var rootCert certificate.Certificater
+	if keepRootPrivateKeyInKubernetes {
+		rootCert = getCertFromKubernetes(kubeClient, osmNamespace, rootCertSecretName)
+		if rootCert == nil {
+			rootCert = getNewRootCertFromTresor(kubeClient, osmNamespace, rootCertSecretName, keepRootPrivateKeyInKubernetes)
+		}
+	} else {
+		rootCert = getNewRootCertFromTresor(kubeClient, osmNamespace, rootCertSecretName, keepRootPrivateKeyInKubernetes)
 	}
 
 	certManager, err := tresor.NewCertManager(rootCert, getServiceCertValidityPeriod())
@@ -58,13 +95,72 @@ func getTresorCertificateManager() certificate.Manager {
 	return certManager
 }
 
-func getAzureKeyVaultCertManager() certificate.Manager {
+func getCertFromKubernetes(kubeClient kubernetes.Interface, namespace, secretName string) certificate.Certificater {
+	secrets, err := kubeClient.CoreV1().Secrets(namespace).List(context.Background(), v1.ListOptions{})
+	if err != nil {
+		log.Error().Err(err).Msgf("Error listing secrets in namespace %q", namespace)
+	}
+	found := false
+	for _, secret := range secrets.Items {
+		if secret.Name == secretName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	rootCertSecret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), secretName, v1.GetOptions{})
+	if err != nil {
+		log.Warn().Msgf("Error retrieving root certificate rootCertSecret %q from namespace %q; Will create a new one", secretName, osmNamespace)
+		return nil
+	}
+
+	pemCert, ok := rootCertSecret.Data[constants.KubernetesOpaqueSecretCAKey]
+	if !ok {
+		log.Error().Msgf("Opaque k8s secret %s/%s does not have required field %q", osmNamespace, secretName, constants.KubernetesOpaqueSecretCAKey)
+		return nil
+	}
+
+	pemKey, ok := rootCertSecret.Data[constants.KubernetesOpaqueSecretRootPrivateKeyKey]
+	if !ok {
+		log.Error().Msgf("Opaque k8s secret %s/%s does not have required field %q", osmNamespace, secretName, constants.KubernetesOpaqueSecretRootPrivateKeyKey)
+		return nil
+	}
+
+	expirationBytes, ok := rootCertSecret.Data[constants.KubernetesOpaqueSecretCAExpiration]
+	if !ok {
+		log.Error().Msgf("Opaque k8s secret %s/%s does not have required field %q", osmNamespace, secretName, constants.KubernetesOpaqueSecretCAExpiration)
+		return nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(string(expirationBytes))
+	if err != nil {
+		log.Error().Err(err).Msgf("Error decoding base64 encoded CA expiration %q from Kubernetes rootCertSecret %q from namespace %q", expirationBytes, secretName, osmNamespace)
+	}
+
+	expirationString := string(decoded)
+	expiration, err := time.Parse(constants.TimeDateLayout, expirationString)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error parsing CA expiration %q from Kubernetes rootCertSecret %q from namespace %q", expirationString, secretName, osmNamespace)
+	}
+
+	rootCert, err := tresor.NewCertificateFromPEM(pemCert, pemKey, expiration)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Failed to create new Certificate Authority with cert issuer %s", *certManagerKind)
+	}
+	return rootCert
+}
+
+func getAzureKeyVaultCertManager(_ *rest.Config) certificate.Manager {
 	// TODO(draychev): implement: https://github.com/open-service-mesh/osm/issues/577
 	log.Fatal().Msg("Azure Key Vault certificate manager is not implemented")
 	return nil
 }
 
-func getHashiVaultCertManager() certificate.Manager {
+func getHashiVaultCertManager(_ *rest.Config) certificate.Manager {
 	if _, ok := map[string]interface{}{"http": nil, "https": nil}[*vaultProtocol]; !ok {
 		log.Fatal().Msgf("Value %s is not a valid Hashi Vault protocol", *vaultProtocol)
 	}
@@ -85,5 +181,13 @@ func getHashiVaultCertManager() certificate.Manager {
 }
 
 func getServiceCertValidityPeriod() time.Duration {
-	return time.Duration(validity) * time.Minute
+	return time.Duration(serviceCertValidityMinutes) * time.Minute
+}
+
+func encodeExpiration(expiration time.Time) []byte {
+	// Serialize CA expiration
+	expirationString := expiration.Format(constants.TimeDateLayout)
+	b64Encoded := make([]byte, base64.StdEncoding.EncodedLen(len(expirationString)))
+	base64.StdEncoding.Encode(b64Encoded, []byte(expirationString))
+	return b64Encoded
 }

--- a/cmd/ads/certificates_test.go
+++ b/cmd/ads/certificates_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
+	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor/pem"
+	"github.com/open-service-mesh/osm/pkg/constants"
+)
+
+var _ = Describe("Test CMD tools", func() {
+
+	Context("Testing encodeExpiration", func() {
+		It("serialized expiration date", func() {
+			expiration, err := time.Parse(constants.TimeDateLayout, "2020-05-07T14:25:18.677Z")
+			Expect(err).ToNot(HaveOccurred())
+
+			actual := encodeExpiration(expiration)
+			expected := []byte("MjAyMC0wNS0wN1QxNDoyNToxOC42Nzda")
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Testing getCertFromKubernetes", func() {
+		It("obtained root cert from k8s", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			certPEM := []byte(uuid.New().String())
+			keyPEM := []byte(uuid.New().String())
+
+			secret := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					constants.KubernetesOpaqueSecretCAKey:             certPEM,
+					constants.KubernetesOpaqueSecretCAExpiration:      []byte("MjAyMC0wNS0wN1QxNDoyNToxOC42Nzda"),
+					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
+				},
+			}
+
+			_, err := kubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, v1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			actual := getCertFromKubernetes(kubeClient, ns, secretName)
+
+			expectedCert := pem.Certificate(certPEM)
+			expectedKey := pem.PrivateKey(keyPEM)
+			expiration, err := time.Parse(constants.TimeDateLayout, "2020-05-07T14:25:18.677Z")
+			Expect(err).ToNot(HaveOccurred())
+
+			expected, err := tresor.NewCertificateFromPEM(expectedCert, expectedKey, expiration)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Testing saveSecretToKubernetes", func() {
+		It("saves root cert to k8s", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			certPEM := []byte(uuid.New().String())
+			keyPEM := []byte(uuid.New().String())
+
+			expected := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					constants.KubernetesOpaqueSecretCAKey:             certPEM,
+					constants.KubernetesOpaqueSecretCAExpiration:      []byte("MjAyMC0wNS0wN1QxNDoyNToxOC42Nzda"),
+					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
+				},
+			}
+
+			expectedCert := pem.Certificate(certPEM)
+			expectedKey := pem.PrivateKey(keyPEM)
+			expiration, err := time.Parse(constants.TimeDateLayout, "2020-05-07T14:25:18.677Z")
+			Expect(err).ToNot(HaveOccurred())
+			cert, err := tresor.NewCertificateFromPEM(expectedCert, expectedKey, expiration)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = saveSecretToKubernetes(kubeClient, cert, ns, secretName, keyPEM)
+			Expect(err).ToNot(HaveOccurred())
+
+			actual, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, v1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(*actual).To(Equal(*expected))
+		})
+	})
+
+	Context("Testing getNewRootCertFromTresor", func() {
+		It("saves root cert to k8s and returns it", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			cert := getNewRootCertFromTresor(kubeClient, ns, secretName, true)
+
+			expected := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					constants.KubernetesOpaqueSecretCAKey:             cert.GetCertificateChain(),
+					constants.KubernetesOpaqueSecretCAExpiration:      encodeExpiration(cert.GetExpiration()),
+					constants.KubernetesOpaqueSecretRootPrivateKeyKey: cert.GetPrivateKey(),
+				},
+			}
+
+			actual, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, v1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(*actual).To(Equal(*expected))
+		})
+	})
+
+})

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -87,7 +87,8 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 		"--vaultProtocol", os.Getenv("VAULT_PROTOCOL"),
 		"--vaultToken", os.Getenv("VAULT_TOKEN"),
 		"--webhookName", fmt.Sprintf("osm-webhook-%s", osmID),
-		"--validity", "1", // Certificate validity length in minutes
+		"--serviceCertValidityMinutes", "1", // Certificate validity length in minutes
+		"--keepRootPrivateKeyInKubernetes", "true",
 	}
 
 	if os.Getenv(common.IsGithubEnvVar) != "true" {

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -7,6 +7,8 @@ import (
 	"crypto/x509/pkix"
 	"time"
 
+	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor/pem"
+
 	"github.com/open-service-mesh/osm/pkg/certificate"
 
 	"github.com/pkg/errors"
@@ -66,6 +68,22 @@ func NewCA(cn certificate.CommonName, validity time.Duration) (certificate.Certi
 		privateKey: pemKey,
 		expiration: template.NotAfter,
 	}
+
+	rootCertificate.issuingCA = rootCertificate
+
+	return &rootCertificate, nil
+}
+
+// NewCertificateFromPEM is a helper returning a certificate.Certificater from the PEM components given.
+func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expiration time.Time) (certificate.Certificater, error) {
+	rootCertificate := Certificate{
+		commonName: rootCertificateName,
+		certChain:  pemCert,
+		privateKey: pemKey,
+		expiration: expiration,
+	}
+
+	rootCertificate.issuingCA = rootCertificate
 
 	return &rootCertificate, nil
 }

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -36,7 +36,7 @@ func (c Certificate) GetIssuingCA() []byte {
 	return c.issuingCA.GetCertificateChain()
 }
 
-// GetExpiration returns the time the given certificate expires.
+// GetExpiration implements certificate.Certificater and returns the time the given certificate expires.
 func (c Certificate) GetExpiration() time.Time {
 	return c.expiration
 }

--- a/pkg/certificate/providers/tresor/manager.go
+++ b/pkg/certificate/providers/tresor/manager.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/certificate"
 )
 
-// IssueCertificate implements certificate.Manager and returns a newly issued certificate.
 func (cm *CertManager) issue(cn certificate.CommonName) (certificate.Certificater, error) {
 	if cm.ca == nil {
 		log.Error().Msgf("Invalid CA provided for issuance of certificate with CN=%s", cn)
@@ -97,7 +96,7 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 
 // IssueCertificate implements certificate.Manager and returns a newly issued certificate.
 func (cm *CertManager) IssueCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
-	log.Info().Msgf("Issuing new certificate for CN=%s", cn)
+	log.Info().Msgf("Issuing new certificate for CN=%s, which will expire in %+v", cn, cm.validityPeriod)
 
 	start := time.Now()
 

--- a/pkg/certificate/providers/vault/client.go
+++ b/pkg/certificate/providers/vault/client.go
@@ -173,7 +173,7 @@ func (c Certificate) GetIssuingCA() []byte {
 	return c.issuingCA
 }
 
-// GetExpiration returns the time the given certificate expires.
+// GetExpiration implements certificate.Certificater and returns the time the given certificate expires.
 func (c Certificate) GetExpiration() time.Time {
 	return c.expiration
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,6 +81,15 @@ const (
 	// KubernetesOpaqueSecretCAKey is the key which holds the CA bundle in a Kubernetes secret.
 	KubernetesOpaqueSecretCAKey = "ca.crt"
 
+	// KubernetesOpaqueSecretRootPrivateKeyKey is the key which holds the CA's private key in a Kubernetes secret.
+	KubernetesOpaqueSecretRootPrivateKeyKey = "private.key"
+
+	// KubernetesOpaqueSecretCAExpiration is the key which holds the CA's expiration in a Kubernetes secret.
+	KubernetesOpaqueSecretCAExpiration = "expiration"
+
 	// EnvoyUniqueIDLabelName is the label applied to pods with the unique ID of the Envoy sidecar.
 	EnvoyUniqueIDLabelName = "osm-envoy-uid"
+
+	// TimeDateLayout is the layout for time.Parse used in this repo
+	TimeDateLayout = "2006-01-02T15:04:05.000Z"
 )


### PR DESCRIPTION
This PR introduces `--keepRootPrivateKeyInKubernetes`, which when  set to `true` will make it so OSM saves `pkg/tresor` issued certificates saved in a Kubernetes secret within the OSM namespace.

(This will not affect Hashi Vault - it will not save root in k8s)

Without `--keepRootPrivateKeyInKubernetes=true`, when the ADS pod restarts, CA will change, causing connectivity issues.

With `----keepRootPrivateKeyInKubernetes=true` restarting the ADS pod will allow us to resume work with the same CA.

Fix https://github.com/open-service-mesh/osm/issues/599
Fix https://github.com/open-service-mesh/osm/issues/524
Fix https://github.com/open-service-mesh/osm/issues/633