### PR TITLE
Deploy ADS pod as a Deployment w/ replica=2;  Rename ADS to OSM

### DIFF
--- a/demo/cmd/deploy/control-plane.go
+++ b/demo/cmd/deploy/control-plane.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/open-service-mesh/osm/demo/cmd/common"
+	"github.com/open-service-mesh/osm/demo/cmd/deploy/metrics"
+	"github.com/open-service-mesh/osm/demo/cmd/deploy/osm"
+)
+
+func main() {
+	namespace := os.Getenv(common.KubeNamespaceEnvVar)
+	if namespace == "" {
+		fmt.Println("Empty namespace")
+		os.Exit(1)
+	}
+	clientset := common.GetClient()
+	err := osm.DeployOSM(clientset, namespace)
+	if err != nil {
+		fmt.Println("Error creating osm: ", err)
+		os.Exit(1)
+	}
+	err = metrics.DeployPrometheus(clientset, namespace)
+	if err != nil {
+		fmt.Println("Error creating prometheus: ", err)
+		os.Exit(1)
+	}
+}

--- a/demo/cmd/deploy/osm/config.go
+++ b/demo/cmd/deploy/osm/config.go
@@ -1,0 +1,184 @@
+package osm
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	v1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/open-service-mesh/osm/demo/cmd/common"
+	"github.com/open-service-mesh/osm/pkg/constants"
+)
+
+const (
+	defaultEnvoyImage          = "envoyproxy/envoy-alpine:v1.14.1"
+
+	sidecarInjectorWebhookPort = 443
+)
+
+var labels = map[string]string{
+	"app": constants.AggregatedDiscoveryServiceName,
+}
+
+func getOSMLabelMeta(namespace string) metav1.ObjectMeta {
+
+	meta := metav1.ObjectMeta{
+		Name:      constants.AggregatedDiscoveryServiceName,
+		Namespace: namespace,
+		Labels:    labels,
+	}
+	return meta
+}
+
+func generateOSMService(namespace string) *apiv1.Service {
+	meta := getOSMLabelMeta(namespace)
+	service := &apiv1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: meta,
+		Spec: apiv1.ServiceSpec{
+			Ports: []apiv1.ServicePort{
+				{
+					Name: fmt.Sprintf("%s-port", constants.AggregatedDiscoveryServiceName),
+					Port: constants.AggregatedDiscoveryServicePort,
+					TargetPort: intstr.IntOrString{
+						IntVal: constants.AggregatedDiscoveryServicePort,
+					},
+				},
+				{
+					Name: "sidecar-injector",
+					Port: sidecarInjectorWebhookPort,
+					TargetPort: intstr.IntOrString{
+						IntVal: constants.InjectorWebhookPort,
+					},
+				},
+			},
+			Selector: map[string]string{
+				"app": constants.AggregatedDiscoveryServiceName,
+			},
+		},
+	}
+	return service
+}
+
+func generateOSMDeployment(namespace string) *v1.Deployment {
+	acr := os.Getenv(common.ContainerRegistryEnvVar)
+	adsVersion := os.Getenv(common.ContainerTag)
+	containerRegistryCredsName := os.Getenv(common.ContainerRegistryCredsEnvVar)
+	initContainer := path.Join(acr, "init")
+	osmID := os.Getenv(common.OsmIDEnvVar)
+
+	meta := getOSMLabelMeta(namespace)
+	args := []string{
+		"--kubeconfig", "/kube/config",
+		"--verbosity", "trace",
+		"--osmID", osmID,
+		"--osmNamespace", namespace,
+		"--init-container-image", initContainer,
+		"--sidecar-image", defaultEnvoyImage,
+		"--caBundleSecretName", fmt.Sprintf("osm-ca-%s", osmID),
+		"--certmanager", os.Getenv("CERT_MANAGER"),
+		"--vaultHost", os.Getenv("VAULT_HOST"),
+		"--vaultProtocol", os.Getenv("VAULT_PROTOCOL"),
+		"--vaultToken", os.Getenv("VAULT_TOKEN"),
+		"--webhookName", fmt.Sprintf("osm-webhook-%s", osmID),
+		"--serviceCertValidityMinutes", "1", // Certificate validity length in minutes
+		"--keepRootPrivateKeyInKubernetes", "true",
+	}
+
+	pod := &apiv1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "",
+			APIVersion: "",
+		},
+		ObjectMeta: meta,
+		Spec: apiv1.PodSpec{
+			Volumes: []apiv1.Volume{
+				{
+					Name: "kubeconfig",
+					VolumeSource: apiv1.VolumeSource{
+						ConfigMap: &apiv1.ConfigMapVolumeSource{
+							LocalObjectReference: apiv1.LocalObjectReference{
+								Name: "kubeconfig",
+							},
+						},
+					},
+				},
+			},
+			ImagePullSecrets: []apiv1.LocalObjectReference{
+				{
+					Name: containerRegistryCredsName,
+				},
+			},
+			InitContainers: nil,
+			Containers: []apiv1.Container{
+				{
+					Image:           fmt.Sprintf("%s/%s:%s", acr, constants.AggregatedDiscoveryServiceName, adsVersion),
+					ImagePullPolicy: apiv1.PullAlways,
+					Name:            constants.AggregatedDiscoveryServiceName,
+					Ports: []apiv1.ContainerPort{
+						{
+							ContainerPort: constants.AggregatedDiscoveryServicePort,
+							Name:          fmt.Sprintf("%s-port", constants.AggregatedDiscoveryServiceName),
+						},
+					},
+					Command: []string{
+						"/ads",
+					},
+					Env: []apiv1.EnvVar{{
+						Name:  common.HumanReadableLogMessagesEnvVar,
+						Value: os.Getenv(common.HumanReadableLogMessagesEnvVar),
+					}},
+					Args: args,
+					VolumeMounts: []apiv1.VolumeMount{
+						{
+							Name:      "kubeconfig",
+							MountPath: "/kube",
+						},
+					},
+					// ReadinessProbe
+					ReadinessProbe: &apiv1.Probe{
+						InitialDelaySeconds: 1,
+						Handler: apiv1.Handler{
+							HTTPGet: &apiv1.HTTPGetAction{
+								Scheme: apiv1.URISchemeHTTPS,
+								Path:   "/health/ready",
+								Port: intstr.IntOrString{
+									IntVal: constants.InjectorWebhookPort,
+								},
+							},
+						},
+					},
+					// LivenessProbe
+				},
+			},
+		},
+	}
+
+	deployment := &v1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.OSMDeploymentName,
+		},
+		Spec: v1.DeploymentSpec{
+			Replicas: to.Int32Ptr(2),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: pod.Spec,
+			},
+		},
+	}
+
+	return deployment
+}

--- a/demo/cmd/deploy/osm/osm.go
+++ b/demo/cmd/deploy/osm/osm.go
@@ -1,0 +1,36 @@
+package osm
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DeployOSM deploys various components of OSM service
+func DeployOSM(clientSet *kubernetes.Clientset, namespace string) error {
+	if err := deployOSMService(clientSet, namespace); err != nil {
+		return fmt.Errorf("Unable to deploy osm service : %v", err)
+	}
+	if err := applyOSMDeployment(clientSet, namespace); err != nil {
+		return fmt.Errorf("Unable to deploy osm pod : %v", err)
+	}
+	return nil
+}
+
+func deployOSMService(clientSet *kubernetes.Clientset, namespace string) error {
+	service := generateOSMService(namespace)
+	if _, err := clientSet.CoreV1().Services(namespace).Create(context.Background(), service, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyOSMDeployment(clientSet *kubernetes.Clientset, namespace string) error {
+	deployment := generateOSMDeployment(namespace)
+	if _, err := clientSet.AppsV1().Deployments(namespace).Create(context.Background(), deployment, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,6 +73,12 @@ const (
 	// OSMControllerPort is the port on which XDS listens for new connections.
 	OSMControllerPort = 15128
 
+	// OSMDeploymentName is the name of the OSM Kubernetes Deployment
+	OSMDeploymentName = "osm-deployment"
+
+	// AggregatedDiscoveryServicePort is the port on which XDS listens for new connections.
+	AggregatedDiscoveryServicePort = 15128
+
 	// PrometheusScrapePath is the path for prometheus to scrap envoy metrics from
 	PrometheusScrapePath = "/stats/prometheus"
 


### PR DESCRIPTION
In this PR:

  - primary goal - convert OSM to a Kubernetes deployment - set replica count to 2
  - rename ADS (pod) to OSM
  - remove azure config stuff (will eventually come back)