### PR TITLE
Add a readiness probe for the injector webhook

### DIFF
--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -161,6 +161,18 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 						},
 					},
 					// ReadinessProbe
+					ReadinessProbe: &apiv1.Probe{
+						InitialDelaySeconds: 1,
+						Handler: apiv1.Handler{
+							HTTPGet: &apiv1.HTTPGetAction{
+								Scheme: apiv1.URISchemeHTTPS,
+								Path:   "/health/ready",
+								Port: intstr.IntOrString{
+									IntVal: constants.InjectorWebhookPort,
+								},
+							},
+						},
+					},
 					// LivenessProbe
 				},
 			},

--- a/demo/run-demo.sh
+++ b/demo/run-demo.sh
@@ -67,8 +67,7 @@ kubectl apply -f crd/AzureResource.yaml
 # Deploys Xds and Prometheus
 go run ./demo/cmd/deploy/control-plane.go
 
-# Wait for POD to be ready before deploying the webhook config.
-# K8s API server will probe on the webhook port when the config is deployed.
+# Wait for POD to be ready before deploying the apps.
 while [ "$(kubectl get pods -n "$K8S_NAMESPACE" ads -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ];
 do
   echo "waiting for pod ads to be ready" && sleep 5


### PR DESCRIPTION
It has been observed that in some cases the sidecar injection
webhook is not invoked for pods being deployed around the same
time as ADS. To rule out such race conditions in the demo, add
a readiness probe for the webhook so that we are guaranteed that
the webhook is ready by the time ADS pod is marked as ready by K8s.
The demo ensures the ADS pod is ready before deploying the apps.

Could potentially fix #627