### PR TITLE
Document the choice to error out on a pod belonging to more than one service

### DIFF
--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -85,9 +85,9 @@ func getPodFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Inte
 	}
 
 	// --- CONVENTION ---
-	// Open Service Mesh by convention restricts the number of services a pod can belong to to 1
-	// This is a limitation we set in place in order to make the mesh easy to reason about.
-	// When a pod belongs to more than one service XDS will not program the Envoy proxy.
+	// By Open Service Mesh convention the number of services a pod can belong to is 1
+	// This is a limitation we set in place in order to make the mesh easy to understand and reason about.
+	// When a pod belongs to more than one service XDS will not program the Envoy proxy, leaving it out of the mesh.
 	if len(pods) > 1 {
 		log.Error().Msgf("Found more than one pod with label %s = %s in namespace %s; There should be only one!", constants.EnvoyUniqueIDLabelName, cnMeta.ProxyID, cnMeta.Namespace)
 		return nil, errMoreThanOnePodForCertificate


### PR DESCRIPTION
This PR documents the choice to error out on a pod belonging to more than one service