### PR TITLE
catalog: fix pod lookup for proxy certificate

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -875,6 +875,7 @@ k8s.io/apimachinery v0.17.4 h1:UzM+38cPUJnzqSQ+E1PY4YxMHIzQyCg29LOoGfo79Zw=
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.18.0 h1:fuPfYpk3cs1Okp/515pAf0dNhL66+8zk8RLbSX+EgAE=
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
 k8s.io/cli-runtime v0.18.0 h1:jG8XpSqQ5TrV0N+EZ3PFz6+gqlCk71dkggWCCq9Mq34=
 k8s.io/cli-runtime v0.18.0/go.mod h1:1eXfmBsIJosjn9LjEBUd2WVPoPAY9XGTqTFcPMIBsUQ=

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -70,11 +70,11 @@ func getPodFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Inte
 		return nil, err
 	}
 
-	var pods []*v1.Pod
+	var pods []v1.Pod
 	for _, pod := range podList.Items {
 		for labelKey, labelValue := range pod.Labels {
 			if labelKey == constants.EnvoyUniqueIDLabelName && labelValue == cnMeta.ProxyID {
-				pods = append(pods, &pod)
+				pods = append(pods, pod)
 			}
 		}
 	}
@@ -90,6 +90,7 @@ func getPodFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Inte
 	}
 
 	pod := pods[0]
+	log.Trace().Msgf("Found pod %s for proxyID %s", pod.Name, cnMeta.ProxyID)
 
 	// Ensure the Namespace encoded in the certificate matches that of the Pod
 	if pod.Namespace != cnMeta.Namespace {
@@ -104,7 +105,7 @@ func getPodFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Inte
 		return nil, errServiceAccountDoesNotMatchCertificate
 	}
 
-	return pod, nil
+	return &pod, nil
 }
 
 func mapStringStringToSet(m map[string]string) mapset.Set {


### PR DESCRIPTION
There is a bug where the pod being matched to a proxy
certificate is taking the address of the loop variable,
which is the same for each iteration of the loop. While the
pointer is the same in each iteration, the object being
pointed to is overwritten in each iteration, causing
the pointer to hold the value of the last iteration.

This was basically resulting in a matched pod being
overwritten with the value of the loop variable
from the last iteration.

Resolves #633