### PR TITLE
ci: poll for success for a period of time

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -14,6 +14,7 @@ import (
 const (
 	waitForEnvVar                = "WAIT_FOR_OK_SECONDS"
 	sleepDurationBetweenRequests = 3 * time.Second
+	minSuccessThreshold          = 10
 )
 
 func main() {
@@ -25,22 +26,35 @@ func main() {
 	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()
 	iteration := 0
+	successCount := 0
+	hasSucceeded := false
+	urlSuccessMap := map[string]bool{booksBought: false, buyBook: false}
 	for {
 		iteration++
 		fmt.Printf("---Bookbuyer:[ %d ]-----------------------------------------\n", iteration)
-		var responses []int
 		for _, url := range []string{booksBought, buyBook} {
 			response := fetch(url)
 			fmt.Println("")
-			responses = append(responses, response)
-		}
-		if waitForOK != 0 {
-			if responses[0] == http.StatusOK {
-				fmt.Printf(common.Success)
-			} else {
-				fmt.Printf("Error, response code = %d", responses[0])
+			if waitForOK != 0 {
+				if response == http.StatusOK {
+					urlSuccessMap[url] = true
+					if urlSuccessMap[booksBought] == true && urlSuccessMap[buyBook] == true {
+						// All the queries have succeeded, test should succeed from this point
+						hasSucceeded = true
+					}
+					successCount++
+					if successCount >= minSuccessThreshold {
+						fmt.Println(common.Success)
+					}
+				} else {
+					fmt.Printf("Error, response code = %d\n", response)
+					if hasSucceeded {
+						fmt.Println(common.Failure)
+					}
+				}
 			}
 		}
+
 		fmt.Print("\n\n")
 		time.Sleep(sleepDurationBetweenRequests)
 	}

--- a/demo/cmd/tail/tail.go
+++ b/demo/cmd/tail/tail.go
@@ -172,6 +172,7 @@ func main() {
 	for {
 		if time.Since(startedWaiting) >= totalWaitSeconds {
 			// failure
+			fmt.Println("Timed out waiting for success")
 			break
 		}
 		bookBuyerLogs := getPodLogs(bookbuyerNS, bookBuyerPodName, bookBuyerContainerName, false, pollLogsFromTimeSince)
@@ -182,6 +183,10 @@ func main() {
 			deleteNamespaces(clientset, namespaces...)
 			deleteWebhook(clientset, webhookName)
 			os.Exit(0)
+		} else if strings.Contains(bookBuyerLogs, common.Failure) || strings.Contains(bookThiefLogs, common.Failure) {
+			// failure
+			fmt.Println("One of bookbuyer, bookthief failed")
+			break
 		}
 	}
 


### PR DESCRIPTION
This change attempts to make the CI more strict by ensuring
the test is marked as success only if the success count reaches
a minimum threshold for success. Additionally, if a failure
is seen after a previously seen success, the test is marked
as a failure.

Resolves #625