### PR TITLE
ref(*): Moving unrelated structs out of the endpoint types

### DIFF
--- a/pkg/catalog/cache.go
+++ b/pkg/catalog/cache.go
@@ -2,12 +2,12 @@ package catalog
 
 import (
 	"github.com/open-service-mesh/osm/pkg/constants"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 func (mc *MeshCatalog) refreshCache() {
 	log.Info().Msg("Refresh cache...")
-	serviceAccountToServicesCache := make(map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService)
+	serviceAccountToServicesCache := make(map[service.NamespacedServiceAccount][]service.NamespacedService)
 	for _, namespacesServiceAccounts := range mc.meshSpec.ListServiceAccounts() {
 		for _, provider := range mc.endpointsProviders {
 			// TODO (snchh) : remove this provider check once we have figured out the service account story for azure vms

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"time"
 
-	mapset "github.com/deckarep/golang-set"
+	set "github.com/deckarep/golang-set"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/ingress"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
@@ -24,11 +25,11 @@ func NewMeshCatalog(kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, cert
 		certManager:        certManager,
 		ingressMonitor:     ingressMonitor,
 
-		certificateCache:              make(map[endpoint.NamespacedService]certificate.Certificater),
+		certificateCache:              make(map[service.NamespacedService]certificate.Certificater),
 		expectedProxies:               make(map[certificate.CommonName]expectedProxy),
 		connectedProxies:              make(map[certificate.CommonName]connectedProxy),
-		announcementChannels:          mapset.NewSet(),
-		serviceAccountToServicesCache: make(map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService),
+		announcementChannels:          set.NewSet(),
+		serviceAccountToServicesCache: make(map[service.NamespacedServiceAccount][]service.NamespacedService),
 
 		// Kubernetes needed to determine what Services a pod that connects to XDS belongs to.
 		// In multicluster scenarios this would be a map of cluster ID to Kubernetes client.

--- a/pkg/catalog/certificates.go
+++ b/pkg/catalog/certificates.go
@@ -2,20 +2,20 @@ package catalog
 
 import (
 	"github.com/open-service-mesh/osm/pkg/certificate"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 // GetCertificateForService returns the certificate the given proxy uses for mTLS to the XDS server.
-func (mc *MeshCatalog) GetCertificateForService(service endpoint.NamespacedService) (certificate.Certificater, error) {
-	cert, exists := mc.certificateCache[service]
+func (mc *MeshCatalog) GetCertificateForService(nsService service.NamespacedService) (certificate.Certificater, error) {
+	cert, exists := mc.certificateCache[nsService]
 	if exists {
 		return cert, nil
 	}
-	newCert, err := mc.certManager.IssueCertificate(service.GetCommonName())
+	newCert, err := mc.certManager.IssueCertificate(nsService.GetCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error issuing a new certificate for service %s", service)
+		log.Error().Err(err).Msgf("Error issuing a new certificate for service %s", nsService)
 		return nil, err
 	}
-	mc.certificateCache[service] = newCert
+	mc.certificateCache[nsService] = newCert
 	return newCert, nil
 }

--- a/pkg/catalog/certificates_test.go
+++ b/pkg/catalog/certificates_test.go
@@ -9,12 +9,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 var _ = Describe("Test certificate tooling", func() {
 	Context("Testing DecodePEMCertificate along with GetCommonName and IssueCertificate", func() {
-		namespacedService := endpoint.NamespacedService{
+		namespacedService := service.NamespacedService{
 			Namespace: "namespace-here",
 			Service:   "service-name-here",
 		}

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -2,15 +2,16 @@ package catalog
 
 import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 // ListEndpointsForService returns the list of provider endpoints corresponding to a service
-func (mc *MeshCatalog) ListEndpointsForService(service endpoint.ServiceName) ([]endpoint.Endpoint, error) {
+func (mc *MeshCatalog) ListEndpointsForService(svc service.Name) ([]endpoint.Endpoint, error) {
 	var endpoints []endpoint.Endpoint
 	for _, provider := range mc.endpointsProviders {
-		ep := provider.ListEndpointsForService(endpoint.ServiceName(service.String()))
+		ep := provider.ListEndpointsForService(service.Name(svc.String()))
 		if len(ep) == 0 {
-			log.Trace().Msgf("[%s] No endpoints found for service=%s", provider.GetID(), service)
+			log.Trace().Msgf("[%s] No endpoints found for service=%s", provider.GetID(), svc)
 			continue
 		}
 		endpoints = append(endpoints, ep...)

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/ingress"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
@@ -143,7 +144,7 @@ var _ = Describe("Test ingress route policies", func() {
 	Context("Testing GetIngressRoutePoliciesPerDomain", func() {
 		mc := newFakeMeshCatalog()
 		It("Gets the route policies per domain from multiple ingress resources corresponding to a service", func() {
-			fakeService := endpoint.NamespacedService{
+			fakeService := service.NamespacedService{
 				Namespace: fakeIngressNamespace,
 				Service:   fakeIngressService,
 			}

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -5,7 +5,8 @@ import (
 
 	set "github.com/deckarep/golang-set"
 
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
+	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
 )
 
 const (
@@ -14,7 +15,7 @@ const (
 )
 
 // ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
-func (mc *MeshCatalog) ListTrafficPolicies(service endpoint.NamespacedService) ([]endpoint.TrafficPolicy, error) {
+func (mc *MeshCatalog) ListTrafficPolicies(service service.NamespacedService) ([]trafficpolicy.TrafficTarget, error) {
 	log.Info().Msgf("Listing Routes for service: %s", service)
 	allRoutes, err := mc.getHTTPPathsPerRoute()
 	if err != nil {
@@ -30,7 +31,7 @@ func (mc *MeshCatalog) ListTrafficPolicies(service endpoint.NamespacedService) (
 	return allTrafficPolicies, nil
 }
 
-func (mc *MeshCatalog) listServicesForServiceAccount(namespacedServiceAccount endpoint.NamespacedServiceAccount) (set.Set, error) {
+func (mc *MeshCatalog) listServicesForServiceAccount(namespacedServiceAccount service.NamespacedServiceAccount) (set.Set, error) {
 	// TODO(draychev): split namespace from the service name -- for non-K8s services
 	log.Info().Msgf("Listing services for ServiceAccount: %s", namespacedServiceAccount)
 	if _, found := mc.serviceAccountToServicesCache[namespacedServiceAccount]; !found {
@@ -50,29 +51,29 @@ func (mc *MeshCatalog) listServicesForServiceAccount(namespacedServiceAccount en
 }
 
 //GetWeightedClusterForService returns the weighted cluster for a given service
-func (mc *MeshCatalog) GetWeightedClusterForService(service endpoint.NamespacedService) (endpoint.WeightedCluster, error) {
+func (mc *MeshCatalog) GetWeightedClusterForService(nsService service.NamespacedService) (service.WeightedCluster, error) {
 	// TODO(draychev): split namespace from the service name -- for non-K8s services
-	log.Info().Msgf("Finding weighted cluster for service %s", service)
+	log.Info().Msgf("Finding weighted cluster for service %s", nsService)
 	servicesList := mc.meshSpec.ListServices()
 	for _, activeService := range servicesList {
-		if activeService.ServiceName == service {
-			return endpoint.WeightedCluster{
-				ClusterName: endpoint.ClusterName(activeService.ServiceName.String()),
+		if activeService.ServiceName == nsService {
+			return service.WeightedCluster{
+				ClusterName: service.ClusterName(activeService.ServiceName.String()),
 				Weight:      activeService.Weight,
 			}, nil
 		}
 	}
-	log.Error().Msgf("Did not find WeightedCluster for service %q", service)
-	return endpoint.WeightedCluster{}, errServiceNotFound
+	log.Error().Msgf("Did not find WeightedCluster for service %q", nsService)
+	return service.WeightedCluster{}, errServiceNotFound
 }
 
 //GetDomainForService returns the domain name of a service
-func (mc *MeshCatalog) GetDomainForService(service endpoint.NamespacedService) (string, error) {
-	log.Info().Msgf("Finding domain for service %s", service)
+func (mc *MeshCatalog) GetDomainForService(nsService service.NamespacedService) (string, error) {
+	log.Info().Msgf("Finding domain for service %s", nsService)
 	var domain string
 	servicesList := mc.meshSpec.ListServices()
 	for _, activeService := range servicesList {
-		if activeService.ServiceName == service {
+		if activeService.ServiceName == nsService {
 			return activeService.Domain, nil
 		}
 	}
@@ -90,8 +91,8 @@ func (mc *MeshCatalog) getActiveServices(services set.Set) set.Set {
 	return activeServices.Intersect(services)
 }
 
-func (mc *MeshCatalog) getHTTPPathsPerRoute() (map[string]endpoint.RoutePolicy, error) {
-	routePolicies := make(map[string]endpoint.RoutePolicy)
+func (mc *MeshCatalog) getHTTPPathsPerRoute() (map[string]trafficpolicy.Route, error) {
+	routePolicies := make(map[string]trafficpolicy.Route)
 	for _, trafficSpecs := range mc.meshSpec.ListHTTPTrafficSpecs() {
 		log.Debug().Msgf("Discovered TrafficSpec resource: %s/%s \n", trafficSpecs.Namespace, trafficSpecs.Name)
 		if trafficSpecs.Matches == nil {
@@ -101,7 +102,7 @@ func (mc *MeshCatalog) getHTTPPathsPerRoute() (map[string]endpoint.RoutePolicy, 
 		// since this method gets only specs related to HTTPRouteGroups added HTTPTraffic to the specKey by default
 		specKey := fmt.Sprintf("%s/%s/%s", HTTPTraffic, trafficSpecs.Namespace, trafficSpecs.Name)
 		for _, trafficSpecsMatches := range trafficSpecs.Matches {
-			serviceRoute := endpoint.RoutePolicy{}
+			serviceRoute := trafficpolicy.Route{}
 			serviceRoute.PathRegex = trafficSpecsMatches.PathRegex
 			serviceRoute.Methods = trafficSpecsMatches.Methods
 			routePolicies[fmt.Sprintf("%s/%s", specKey, trafficSpecsMatches.Name)] = serviceRoute
@@ -111,8 +112,8 @@ func (mc *MeshCatalog) getHTTPPathsPerRoute() (map[string]endpoint.RoutePolicy, 
 	return routePolicies, nil
 }
 
-func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[string]endpoint.RoutePolicy, service endpoint.NamespacedService) ([]endpoint.TrafficPolicy, error) {
-	var trafficPolicies []endpoint.TrafficPolicy
+func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[string]trafficpolicy.Route, nsService service.NamespacedService) ([]trafficpolicy.TrafficTarget, error) {
+	var trafficPolicies []trafficpolicy.TrafficTarget
 	for _, trafficTargets := range mc.meshSpec.ListTrafficTargets() {
 		log.Debug().Msgf("Discovered TrafficTarget resource: %s/%s \n", trafficTargets.Namespace, trafficTargets.Name)
 		if trafficTargets.Specs == nil || len(trafficTargets.Specs) == 0 {
@@ -120,7 +121,7 @@ func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[string]endpoint
 			continue
 		}
 
-		dstNamespacedServiceAcc := endpoint.NamespacedServiceAccount{
+		dstNamespacedServiceAcc := service.NamespacedServiceAccount{
 			Namespace:      trafficTargets.Destination.Namespace,
 			ServiceAccount: trafficTargets.Destination.Name,
 		}
@@ -136,7 +137,7 @@ func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[string]endpoint
 			continue
 		}
 		for _, trafficSources := range trafficTargets.Sources {
-			namespacedServiceAccount := endpoint.NamespacedServiceAccount{
+			namespacedServiceAccount := service.NamespacedServiceAccount{
 				Namespace:      trafficSources.Namespace,
 				ServiceAccount: trafficSources.Name,
 			}
@@ -146,14 +147,14 @@ func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[string]endpoint
 				log.Error().Msgf("TrafficSpec %s/%s could not get source services for service account %s", trafficTargets.Namespace, trafficTargets.Name, fmt.Sprintf("%s/%s", trafficSources.Namespace, trafficSources.Name))
 				return nil, srcErr
 			}
-			trafficPolicy := endpoint.TrafficPolicy{}
-			trafficPolicy.PolicyName = trafficTargets.Name
-			trafficPolicy.Destination = endpoint.TrafficPolicyResource{
-				ServiceAccount: endpoint.ServiceAccount(trafficTargets.Destination.Name),
+			trafficPolicy := trafficpolicy.TrafficTarget{}
+			trafficPolicy.Name = trafficTargets.Name
+			trafficPolicy.Destination = trafficpolicy.TrafficResource{
+				ServiceAccount: service.Account(trafficTargets.Destination.Name),
 				Namespace:      trafficTargets.Destination.Namespace,
 				Services:       activeDestServices}
-			trafficPolicy.Source = endpoint.TrafficPolicyResource{
-				ServiceAccount: endpoint.ServiceAccount(trafficSources.Name),
+			trafficPolicy.Source = trafficpolicy.TrafficResource{
+				ServiceAccount: service.Account(trafficSources.Name),
 				Namespace:      trafficSources.Namespace,
 				Services:       srcServices}
 
@@ -162,16 +163,16 @@ func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[string]endpoint
 					log.Error().Msgf("TrafficTarget %s/%s has Spec Kind %s which isn't supported for now; Skipping...", trafficTargets.Namespace, trafficTargets.Name, trafficTargetSpecs.Kind)
 					continue
 				}
-				trafficPolicy.RoutePolicies = []endpoint.RoutePolicy{}
+				trafficPolicy.Routes = []trafficpolicy.Route{}
 
 				for _, specMatches := range trafficTargetSpecs.Matches {
 					routeKey := fmt.Sprintf("%s/%s/%s/%s", trafficTargetSpecs.Kind, trafficTargets.Namespace, trafficTargetSpecs.Name, specMatches)
 					routePolicy := routePolicies[routeKey]
-					trafficPolicy.RoutePolicies = append(trafficPolicy.RoutePolicies, routePolicy)
+					trafficPolicy.Routes = append(trafficPolicy.Routes, routePolicy)
 				}
 			}
 			// append a traffic policy only if it corresponds to the service
-			if trafficPolicy.Source.Services.Contains(service) || trafficPolicy.Destination.Services.Contains(service) {
+			if trafficPolicy.Source.Services.Contains(nsService) || trafficPolicy.Destination.Services.Contains(nsService) {
 				trafficPolicies = append(trafficPolicies, trafficPolicy)
 			}
 		}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -1,11 +1,11 @@
 package catalog
 
 import (
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 // GetServicesByServiceAccountName returns a list of services corresponding to a service account, and refreshes the cache if requested
-func (mc *MeshCatalog) GetServicesByServiceAccountName(sa endpoint.NamespacedServiceAccount, refreshCache bool) []endpoint.NamespacedService {
+func (mc *MeshCatalog) GetServicesByServiceAccountName(sa service.NamespacedServiceAccount, refreshCache bool) []service.NamespacedService {
 	if refreshCache {
 		mc.refreshCache()
 	}

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -7,12 +7,12 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/service"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 )
 
 // GetServiceFromEnvoyCertificate returns the single service given Envoy is a member of based on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
-func (mc *MeshCatalog) GetServiceFromEnvoyCertificate(cn certificate.CommonName) (*endpoint.NamespacedService, error) {
+func (mc *MeshCatalog) GetServiceFromEnvoyCertificate(cn certificate.CommonName) (*service.NamespacedService, error) {
 	service, err := getServiceFromCertificate(cn, mc.kubeClient)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (mc *MeshCatalog) GetServiceFromEnvoyCertificate(cn certificate.CommonName)
 	return service, nil
 }
 
-func getServiceFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Interface) (*endpoint.NamespacedService, error) {
+func getServiceFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Interface) (*service.NamespacedService, error) {
 	pod, err := getPodFromCertificate(cn, kubeClient)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func getServiceFromCertificate(cn certificate.CommonName, kubeClient kubernetes.
 		return nil, err
 	}
 
-	return &endpoint.NamespacedService{
+	return &service.NamespacedService{
 		Namespace: cnMeta.Namespace,
 		Service:   services[0].Name,
 	}, nil

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/constants"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
@@ -38,13 +38,13 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			_, err = kubeClient.CoreV1().Services(tests.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			service, err := mc.GetServiceFromEnvoyCertificate(cn)
+			nsService, err := mc.GetServiceFromEnvoyCertificate(cn)
 			Expect(err).ToNot(HaveOccurred())
-			expected := endpoint.NamespacedService{
+			expected := service.NamespacedService{
 				Namespace: tests.Namespace,
 				Service:   svcName,
 			}
-			Expect(service).To(Equal(&expected))
+			Expect(nsService).To(Equal(&expected))
 		})
 
 		It("returns an error with an invalid CN", func() {
@@ -76,14 +76,14 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			podCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, namespace))
-			service, err := getServiceFromCertificate(podCN, kubeClient)
+			nsService, err := getServiceFromCertificate(podCN, kubeClient)
 			Expect(err).ToNot(HaveOccurred())
 
-			expected := endpoint.NamespacedService{
+			expected := service.NamespacedService{
 				Namespace: namespace,
 				Service:   svcName,
 			}
-			Expect(service).To(Equal(&expected))
+			Expect(nsService).To(Equal(&expected))
 		})
 	})
 

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -3,20 +3,17 @@ package endpoint
 import (
 	"fmt"
 	"net"
-	"strings"
 
-	set "github.com/deckarep/golang-set"
-
-	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 // Provider is an interface to be implemented by components abstracting Kubernetes, Azure, and other compute/cluster providers
 type Provider interface {
 	// Retrieve the IP addresses comprising the given service.
-	ListEndpointsForService(ServiceName) []Endpoint
+	ListEndpointsForService(service.Name) []Endpoint
 
 	// Retrieve the namespaced services for a given service account
-	ListServicesForServiceAccount(NamespacedServiceAccount) []NamespacedService
+	ListServicesForServiceAccount(service.NamespacedServiceAccount) []service.NamespacedService
 
 	// GetID returns the unique identifier of the EndpointsProvider.
 	GetID() string
@@ -37,85 +34,3 @@ func (ep Endpoint) String() string {
 
 // Port is a numerical port of an Envoy proxy
 type Port uint32
-
-// ServiceName is a type for a service name
-type ServiceName string
-
-func (s ServiceName) String() string {
-	return string(s)
-}
-
-// NamespacedService is a type for a namespaced service
-type NamespacedService struct {
-	Namespace string
-	Service   string
-}
-
-func (ns NamespacedService) String() string {
-	return fmt.Sprintf("%s/%s", ns.Namespace, ns.Service)
-}
-
-// ServiceAccount is a type for a service account
-type ServiceAccount string
-
-func (s ServiceAccount) String() string {
-	return string(s)
-}
-
-// GetCommonName returns the Subject CN for the NamespacedService to be used for its certificate.
-func (ns NamespacedService) GetCommonName() certificate.CommonName {
-	return certificate.CommonName(strings.Join([]string{ns.Service, ns.Namespace, "svc", "cluster", "local"}, "."))
-}
-
-// NamespacedServiceAccount is a type for a namespaced service account
-type NamespacedServiceAccount struct {
-	Namespace      string
-	ServiceAccount string
-}
-
-func (ns NamespacedServiceAccount) String() string {
-	return fmt.Sprintf("%s/%s", ns.Namespace, ns.ServiceAccount)
-}
-
-// ClusterName is a type for a service name
-type ClusterName string
-
-//WeightedService is a struct of a service name, its weight and domain
-type WeightedService struct {
-	ServiceName NamespacedService `json:"service_name:omitempty"`
-	Weight      int               `json:"weight:omitempty"`
-	Domain      string            `json:"domain:omitempty"`
-}
-
-// RoutePolicy is a struct of a path regex and the methods on a given route
-type RoutePolicy struct {
-	PathRegex string   `json:"path_regex:omitempty"`
-	Methods   []string `json:"methods:omitempty"`
-}
-
-// TrafficPolicy is a struct of the allowed RoutePaths from sources to a destination
-type TrafficPolicy struct {
-	PolicyName    string                `json:"policy_name:omitempty"`
-	Destination   TrafficPolicyResource `json:"destination:omitempty"`
-	Source        TrafficPolicyResource `json:"source:omitempty"`
-	RoutePolicies []RoutePolicy         `json:"route_policies:omitempty"`
-}
-
-// WeightedCluster is a struct of a cluster and is weight that is backing a service
-type WeightedCluster struct {
-	ClusterName ClusterName `json:"cluster_name:omitempty"`
-	Weight      int         `json:"weight:omitempty"`
-}
-
-//TrafficPolicyResource is a struct of the various resources of a source/destination in the TrafficPolicy
-type TrafficPolicyResource struct {
-	ServiceAccount ServiceAccount `json:"service_account:omitempty"`
-	Namespace      string         `json:"namespace:omitempty"`
-	Services       set.Set        `json:"services:omitempty"`
-}
-
-//RoutePolicyWeightedClusters is a struct of a route and the weighted clusters on that route
-type RoutePolicyWeightedClusters struct {
-	RoutePolicy      RoutePolicy `json:"route_policy:omitempty"`
-	WeightedClusters set.Set     `json:"weighted_clusters:omitempty"`
-}

--- a/pkg/endpoint/types_test.go
+++ b/pkg/endpoint/types_test.go
@@ -5,12 +5,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 var _ = Describe("Test NamespacedService methods", func() {
 	Context("Testing GetCommonName", func() {
 		It("should return DNS-1123 of the NamespacedService struct", func() {
-			namespacedService := NamespacedService{
+			namespacedService := service.NamespacedService{
 				Namespace: "namespace-here",
 				Service:   "service-name-here",
 			}

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/constants"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/featureflags"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
@@ -33,7 +33,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 		isDestinationService := trafficPolicies.Destination.Services.Contains(proxyServiceName)
 		//iterate through only destination services here since envoy is programmed by destination
 		for serviceInterface := range trafficPolicies.Destination.Services.Iter() {
-			service := serviceInterface.(endpoint.NamespacedService)
+			service := serviceInterface.(service.NamespacedService)
 			if isSourceService {
 				cluster, err := catalog.GetWeightedClusterForService(service)
 				if err != nil {
@@ -86,7 +86,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 	return resp, nil
 }
 
-func getIngressServiceCluster(proxyServiceName endpoint.NamespacedService, catalog catalog.MeshCataloger, clusters map[string]xds.Cluster) (map[string]xds.Cluster, error) {
+func getIngressServiceCluster(proxyServiceName service.NamespacedService, catalog catalog.MeshCataloger, clusters map[string]xds.Cluster) (map[string]xds.Cluster, error) {
 	isIngress, err := catalog.IsIngressService(proxyServiceName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error checking service %s for ingress", proxyServiceName)

--- a/pkg/envoy/cds/service.go
+++ b/pkg/envoy/cds/service.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/constants"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 const (
@@ -20,7 +20,7 @@ const (
 	connectionTimeout time.Duration = 1 * time.Second
 )
 
-func getServiceClusterLocal(catalog catalog.MeshCataloger, proxyServiceName endpoint.NamespacedService, clusterName string) (*xds.Cluster, error) {
+func getServiceClusterLocal(catalog catalog.MeshCataloger, proxyServiceName service.NamespacedService, clusterName string) (*xds.Cluster, error) {
 	xdsCluster := xds.Cluster{
 		// The name must match the domain being cURLed in the demo
 		Name:                          clusterName,
@@ -42,7 +42,7 @@ func getServiceClusterLocal(catalog catalog.MeshCataloger, proxyServiceName endp
 		},
 	}
 
-	endpoints, err := catalog.ListEndpointsForService(endpoint.ServiceName(proxyServiceName.String()))
+	endpoints, err := catalog.ListEndpointsForService(service.Name(proxyServiceName.String()))
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get endpoints for service %s", proxyServiceName)
 		return nil, err

--- a/pkg/envoy/cla/cluster_load_assignment.go
+++ b/pkg/envoy/cla/cluster_load_assignment.go
@@ -8,6 +8,7 @@ import (
 
 	osmEndpoint "github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 const (
@@ -15,7 +16,7 @@ const (
 )
 
 // NewClusterLoadAssignment constructs the Envoy struct necessary for TrafficSplit implementation.
-func NewClusterLoadAssignment(serviceName osmEndpoint.NamespacedService, serviceEndpoints []osmEndpoint.Endpoint) v2.ClusterLoadAssignment {
+func NewClusterLoadAssignment(serviceName service.NamespacedService, serviceEndpoints []osmEndpoint.Endpoint) v2.ClusterLoadAssignment {
 	cla := v2.ClusterLoadAssignment{
 		ClusterName: serviceName.String(),
 		Endpoints: []*endpoint.LocalityLbEndpoints{

--- a/pkg/envoy/cla/cluster_load_assignment_test.go
+++ b/pkg/envoy/cla/cluster_load_assignment_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,12 +14,12 @@ var _ = Describe("Testing Cluster Load Assignment", func() {
 	Context("Testing NewClusterLoadAssignemnt", func() {
 		It("Returns cluster load assignment", func() {
 
-			namespacedServices := []endpoint.NamespacedService{
+			namespacedServices := []service.NamespacedService{
 				{Namespace: "osm", Service: "bookstore-1"},
 				{Namespace: "osm", Service: "bookstore-2"},
 			}
 
-			allServiceEndpoints := map[endpoint.NamespacedService][]endpoint.Endpoint{
+			allServiceEndpoints := map[service.NamespacedService][]endpoint.Endpoint{
 				namespacedServices[0]: {
 					{IP: net.IP("0.0.0.0")},
 				},

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/cla"
+	"github.com/open-service-mesh/osm/pkg/service"
 
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
@@ -24,13 +25,13 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		return nil, err
 	}
 
-	allServicesEndpoints := make(map[endpoint.NamespacedService][]endpoint.Endpoint)
+	allServicesEndpoints := make(map[service.NamespacedService][]endpoint.Endpoint)
 	for _, trafficPolicy := range allTrafficPolicies {
 		isSourceService := trafficPolicy.Source.Services.Contains(proxyServiceName)
 		if isSourceService {
 			for serviceInterface := range trafficPolicy.Destination.Services.Iter() {
-				destService := serviceInterface.(endpoint.NamespacedService)
-				serviceEndpoints, err := catalog.ListEndpointsForService(endpoint.ServiceName(destService.String()))
+				destService := serviceInterface.(service.NamespacedService)
+				serviceEndpoints, err := catalog.ListEndpointsForService(service.Name(destService.String()))
 				if err != nil {
 					log.Error().Err(err).Msgf("Failed listing endpoints")
 					return nil, err

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/constants"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/route"
 	"github.com/open-service-mesh/osm/pkg/featureflags"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
@@ -142,7 +142,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 	return resp, nil
 }
 
-func getFilterChainMatchServerNames(proxyServiceName endpoint.NamespacedService, catalog catalog.MeshCataloger) ([]string, error) {
+func getFilterChainMatchServerNames(proxyServiceName service.NamespacedService, catalog catalog.MeshCataloger) ([]string, error) {
 	serverNamesMap := make(map[string]interface{})
 	var serverNames []string
 
@@ -156,7 +156,7 @@ func getFilterChainMatchServerNames(proxyServiceName endpoint.NamespacedService,
 		isDestinationService := trafficPolicies.Destination.Services.Contains(proxyServiceName)
 		if isDestinationService {
 			for sourceInterface := range trafficPolicies.Source.Services.Iter() {
-				source := sourceInterface.(endpoint.NamespacedService)
+				source := sourceInterface.(service.NamespacedService)
 				if _, server := serverNamesMap[source.String()]; !server {
 					serverNamesMap[source.String()] = nil
 					serverNames = append(serverNames, source.String())
@@ -168,7 +168,7 @@ func getFilterChainMatchServerNames(proxyServiceName endpoint.NamespacedService,
 	return serverNames, nil
 }
 
-func getInboundInMeshFilterChain(proxyServiceName endpoint.NamespacedService, mc catalog.MeshCataloger, filterConfig *any.Any) (*listener.FilterChain, error) {
+func getInboundInMeshFilterChain(proxyServiceName service.NamespacedService, mc catalog.MeshCataloger, filterConfig *any.Any) (*listener.FilterChain, error) {
 	serverNames, err := getFilterChainMatchServerNames(proxyServiceName, mc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get client server names for proxy %s", proxyServiceName)

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 // Proxy is a representation of an Envoy proxy connected to the xDS server.
@@ -14,7 +14,7 @@ import (
 type Proxy struct {
 	certificate.CommonName
 	net.Addr
-	ServiceName   endpoint.NamespacedService
+	ServiceName   service.NamespacedService
 	announcements chan interface{}
 
 	lastSentVersion    map[TypeURI]uint64
@@ -66,7 +66,7 @@ func (p Proxy) String() string {
 
 // GetService determines the meshed service this endpoint should support based on the mTLS certificate.
 // From "a.b.c" returns "b.c". By convention "a" is the ID of the proxy. Remaining "b.c" is the name of the service.
-func (p Proxy) GetService() endpoint.NamespacedService {
+func (p Proxy) GetService() service.NamespacedService {
 	return p.ServiceName
 }
 
@@ -86,7 +86,7 @@ func (p Proxy) GetAnnouncementsChannel() chan interface{} {
 }
 
 // NewProxy creates a new instance of an Envoy proxy connected to the xDS servers.
-func NewProxy(cn certificate.CommonName, namespacedService endpoint.NamespacedService, ip net.Addr) *Proxy {
+func NewProxy(cn certificate.CommonName, namespacedService service.NamespacedService, ip net.Addr) *Proxy {
 	return &Proxy{
 		CommonName:         cn,
 		Addr:               ip,

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 const (
@@ -22,7 +22,7 @@ var _ = Describe("Test proxy methods", func() {
 			commonNameForService := fmt.Sprintf("%s.%s.svc.cluster.local", svc, ns)
 			cn := certificate.CommonName(commonNameForProxy)
 
-			namespacedSvc := endpoint.NamespacedService{
+			namespacedSvc := service.NamespacedService{
 				Namespace: ns,
 				Service:   svc,
 			}

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -2,7 +2,8 @@ package rds
 
 import (
 	set "github.com/deckarep/golang-set"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
+	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,17 +14,17 @@ var _ = Describe("Route exists in routePolicyWeightedClustersList", func() {
 		It("Returns true and the index of route in the list", func() {
 
 			weightedClusters := set.NewSetFromSlice([]interface{}{
-				endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100},
-				endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
+				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100},
+				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2"), Weight: 100},
 			})
-			routePolicy := endpoint.RoutePolicy{
+			routePolicy := trafficpolicy.Route{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 			}
-			routePolicyWeightedClustersList := []endpoint.RoutePolicyWeightedClusters{
-				{RoutePolicy: routePolicy, WeightedClusters: weightedClusters},
+			routePolicyWeightedClustersList := []trafficpolicy.RouteWeightedClusters{
+				{Route: routePolicy, WeightedClusters: weightedClusters},
 			}
-			newRoutePolicy := endpoint.RoutePolicy{
+			newRoutePolicy := trafficpolicy.Route{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 			}
@@ -38,17 +39,17 @@ var _ = Describe("Route exists in routePolicyWeightedClustersList", func() {
 		It("Returns false and the index of -1", func() {
 
 			weightedClusters := set.NewSetFromSlice([]interface{}{
-				endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100},
-				endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100},
+				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100},
+				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2"), Weight: 100},
 			})
-			routePolicy := endpoint.RoutePolicy{
+			routePolicy := trafficpolicy.Route{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 			}
-			routeWeightedClustersList := []endpoint.RoutePolicyWeightedClusters{
-				{RoutePolicy: routePolicy, WeightedClusters: weightedClusters},
+			routeWeightedClustersList := []trafficpolicy.RouteWeightedClusters{
+				{Route: routePolicy, WeightedClusters: weightedClusters},
 			}
-			newRoutePolicy := endpoint.RoutePolicy{
+			newRoutePolicy := trafficpolicy.Route{
 				PathRegex: "/buy-a-book",
 				Methods:   []string{"GET"},
 			}
@@ -64,32 +65,32 @@ var _ = Describe("Construct RoutePolicyWeightedClusters object", func() {
 	Context("Testing the creating of a RoutePolicyWeightedClusters object", func() {
 		It("Returns RoutePolicyWeightedClusters", func() {
 
-			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}
-			routePolicy := endpoint.RoutePolicy{
+			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100}
+			routePolicy := trafficpolicy.Route{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 			}
 
 			routePolicyWeightedClusters := createRoutePolicyWeightedClusters(routePolicy, weightedCluster)
 			Expect(routePolicyWeightedClusters).NotTo(Equal(nil))
-			Expect(routePolicyWeightedClusters.RoutePolicy.PathRegex).To(Equal("/books-bought"))
-			Expect(routePolicyWeightedClusters.RoutePolicy.Methods).To(Equal([]string{"GET"}))
+			Expect(routePolicyWeightedClusters.Route.PathRegex).To(Equal("/books-bought"))
+			Expect(routePolicyWeightedClusters.Route.Methods).To(Equal([]string{"GET"}))
 			Expect(routePolicyWeightedClusters.WeightedClusters.Cardinality()).To(Equal(1))
 			routePolicyWeightedClustersSlice := routePolicyWeightedClusters.WeightedClusters.ToSlice()
-			Expect(string(routePolicyWeightedClustersSlice[0].(endpoint.WeightedCluster).ClusterName)).To(Equal("osm/bookstore-1"))
-			Expect(routePolicyWeightedClustersSlice[0].(endpoint.WeightedCluster).Weight).To(Equal(100))
+			Expect(string(routePolicyWeightedClustersSlice[0].(service.WeightedCluster).ClusterName)).To(Equal("osm/bookstore-1"))
+			Expect(routePolicyWeightedClustersSlice[0].(service.WeightedCluster).Weight).To(Equal(100))
 		})
 	})
 })
 
 var _ = Describe("AggregateRoutesByDomain", func() {
-	domainRoutesMap := make(map[string][]endpoint.RoutePolicyWeightedClusters)
+	domainRoutesMap := make(map[string][]trafficpolicy.RouteWeightedClusters)
 	weightedClustersMap := set.NewSet()
 	Context("Building a map of routes by domain", func() {
 		It("Returns a new aggregated map of domain and routes", func() {
 
-			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}
-			routePolicies := []endpoint.RoutePolicy{
+			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100}
+			routePolicies := []trafficpolicy.Route{
 				{PathRegex: "/books-bought", Methods: []string{"GET"}},
 				{PathRegex: "/buy-a-book", Methods: []string{"GET"}},
 			}
@@ -101,7 +102,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(2))
 
 			for j := range domainRoutesMap["bookstore.mesh"] {
-				Expect(domainRoutesMap["bookstore.mesh"][j].RoutePolicy).To(Equal(routePolicies[j]))
+				Expect(domainRoutesMap["bookstore.mesh"][j].Route).To(Equal(routePolicies[j]))
 				Expect(domainRoutesMap["bookstore.mesh"][j].WeightedClusters.Cardinality()).To(Equal(1))
 				Expect(domainRoutesMap["bookstore.mesh"][j].WeightedClusters.Equal(weightedClustersMap)).To(Equal(true))
 			}
@@ -111,8 +112,8 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 	Context("Adding a route to existing domain in the map", func() {
 		It("Returns the map of with a new route on the domain", func() {
 
-			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-1"), Weight: 100}
-			routePolicies := []endpoint.RoutePolicy{
+			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100}
+			routePolicies := []trafficpolicy.Route{
 				{PathRegex: "/update-books-bought", Methods: []string{"GET"}},
 			}
 			weightedClustersMap.Add(weightedCluster)
@@ -121,7 +122,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 			Expect(domainRoutesMap).NotTo(Equal(nil))
 			Expect(len(domainRoutesMap)).To(Equal(1))
 			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(3))
-			Expect(domainRoutesMap["bookstore.mesh"][2].RoutePolicy).To(Equal(routePolicies[0]))
+			Expect(domainRoutesMap["bookstore.mesh"][2].Route).To(Equal(routePolicies[0]))
 			Expect(domainRoutesMap["bookstore.mesh"][2].WeightedClusters.Cardinality()).To(Equal(1))
 			Expect(domainRoutesMap["bookstore.mesh"][2].WeightedClusters.Equal(weightedClustersMap)).To(Equal(true))
 		})
@@ -130,8 +131,8 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 	Context("Adding a cluster to an existing route to existing domain in the map", func() {
 		It("Returns the map of with a new weighted cluster on a route in the domain", func() {
 
-			weightedCluster := endpoint.WeightedCluster{ClusterName: endpoint.ClusterName("osm/bookstore-2"), Weight: 100}
-			routePolicies := []endpoint.RoutePolicy{
+			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2"), Weight: 100}
+			routePolicies := []trafficpolicy.Route{
 				{PathRegex: "/update-books-bought", Methods: []string{"GET"}},
 			}
 			weightedClustersMap.Add(weightedCluster)
@@ -140,7 +141,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 			Expect(domainRoutesMap).NotTo(Equal(nil))
 			Expect(len(domainRoutesMap)).To(Equal(1))
 			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(3))
-			Expect(domainRoutesMap["bookstore.mesh"][2].RoutePolicy).To(Equal(endpoint.RoutePolicy{PathRegex: "/update-books-bought", Methods: []string{"GET", "GET"}}))
+			Expect(domainRoutesMap["bookstore.mesh"][2].Route).To(Equal(trafficpolicy.Route{PathRegex: "/update-books-bought", Methods: []string{"GET", "GET"}}))
 			Expect(domainRoutesMap["bookstore.mesh"][2].WeightedClusters.Cardinality()).To(Equal(2))
 			Expect(domainRoutesMap["bookstore.mesh"][2].WeightedClusters.Equal(weightedClustersMap)).To(Equal(true))
 		})

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/certificate"
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
@@ -69,8 +69,8 @@ func getTasks(proxy *envoy.Proxy, request *xds.DiscoveryRequest) []task {
 	for _, resourceName := range request.ResourceNames {
 		if strings.HasPrefix(resourceName, serviceCertPrefix) {
 			// this is a request for a service certificate
-			requestFor := endpoint.ServiceName(resourceName[len(serviceCertPrefix):])
-			if endpoint.ServiceName(proxyServiceName.String()) != requestFor {
+			requestFor := service.Name(resourceName[len(serviceCertPrefix):])
+			if service.Name(proxyServiceName.String()) != requestFor {
 				log.Error().Msgf("Proxy %s (service %s) requested service certificate %s; this is not allowed", proxy.GetCommonName(), proxy.GetService(), requestFor)
 				continue
 			}
@@ -82,7 +82,7 @@ func getTasks(proxy *envoy.Proxy, request *xds.DiscoveryRequest) []task {
 			// this is a request for a root certificate
 			// proxies need this to verify other proxies certificates
 			requestFor := getServiceName(resourceName, envoy.RootCertPrefix)
-			if endpoint.ServiceName(proxyServiceName.String()) != requestFor {
+			if service.Name(proxyServiceName.String()) != requestFor {
 				log.Error().Msgf("Proxy %s (service %s) requested root certificate %s; this is not allowed", proxy.GetCommonName(), proxy.GetService(), requestFor)
 				continue
 			}
@@ -145,7 +145,7 @@ func getRootCert(cert certificate.Certificater, resourceName string) (*auth.Secr
 	return secret, nil
 }
 
-func getServiceName(resourceName string, prefix string) endpoint.ServiceName {
+func getServiceName(resourceName string, prefix string) service.Name {
 	rootCertPrefix := fmt.Sprintf("%s%s", prefix, envoy.Separator)
-	return endpoint.ServiceName(resourceName[len(rootCertPrefix):])
+	return service.Name(resourceName[len(rootCertPrefix):])
 }

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -15,7 +15,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 const (
@@ -112,7 +112,7 @@ func pbStringValue(v string) *structpb.Value {
 	}
 }
 
-func getCommonTLSContext(serviceName endpoint.NamespacedService) *auth.CommonTlsContext {
+func getCommonTLSContext(serviceName service.NamespacedService) *auth.CommonTlsContext {
 	return &auth.CommonTlsContext{
 		TlsParams: GetTLSParams(),
 		TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
@@ -129,7 +129,7 @@ func getCommonTLSContext(serviceName endpoint.NamespacedService) *auth.CommonTls
 }
 
 // GetDownstreamTLSContext creates a downstream Envoy TLS Context.
-func GetDownstreamTLSContext(serviceName endpoint.NamespacedService) *any.Any {
+func GetDownstreamTLSContext(serviceName service.NamespacedService) *any.Any {
 	tlsConfig := &auth.DownstreamTlsContext{
 		CommonTlsContext: getCommonTLSContext(serviceName),
 
@@ -146,7 +146,7 @@ func GetDownstreamTLSContext(serviceName endpoint.NamespacedService) *any.Any {
 }
 
 // GetUpstreamTLSContext creates an upstream Envoy TLS Context.
-func GetUpstreamTLSContext(serviceName endpoint.NamespacedService) *any.Any {
+func GetUpstreamTLSContext(serviceName service.NamespacedService) *any.Any {
 	tlsConfig := &auth.UpstreamTlsContext{
 		CommonTlsContext: getCommonTLSContext(serviceName),
 		Sni:              serviceName.String(),
@@ -161,7 +161,7 @@ func GetUpstreamTLSContext(serviceName endpoint.NamespacedService) *any.Any {
 }
 
 // GetServiceCluster creates an Envoy Cluster struct.
-func GetServiceCluster(clusterName string, serviceName endpoint.NamespacedService) xds.Cluster {
+func GetServiceCluster(clusterName string, serviceName service.NamespacedService) xds.Cluster {
 	return xds.Cluster{
 		Name:                 clusterName,
 		ConnectTimeout:       ptypes.DurationProto(ConnectionTimeout),

--- a/pkg/ingress/fake.go
+++ b/pkg/ingress/fake.go
@@ -1,9 +1,8 @@
 package ingress
 
 import (
+	"github.com/open-service-mesh/osm/pkg/service"
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
-
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 )
 
 // FakeIngressMonitor returns a fake ingress monitor object
@@ -18,7 +17,7 @@ func NewFakeIngressMonitor() FakeIngressMonitor {
 }
 
 // GetIngressResources returns the ingress resources whose backends correspond to the service
-func (f FakeIngressMonitor) GetIngressResources(endpoint.NamespacedService) ([]*extensionsV1beta.Ingress, error) {
+func (f FakeIngressMonitor) GetIngressResources(service.NamespacedService) ([]*extensionsV1beta.Ingress, error) {
 	return f.FakeIngresses, nil
 }
 

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -4,9 +4,9 @@ import (
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/logger"
 	"github.com/open-service-mesh/osm/pkg/namespace"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 var (
@@ -25,7 +25,7 @@ type Client struct {
 // Monitor is the client interface for K8s Ingress resource
 type Monitor interface {
 	// GetIngressResources returns the ingress resources whose backends correspond to the service
-	GetIngressResources(endpoint.NamespacedService) ([]*extensionsV1beta.Ingress, error)
+	GetIngressResources(service.NamespacedService) ([]*extensionsV1beta.Ingress, error)
 
 	// GetAnnouncementsChannel returns the channel on which Ingress Monitor makes annoucements
 	GetAnnouncementsChannel() <-chan interface{}

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -10,10 +10,11 @@ import (
 	osm "github.com/open-service-mesh/osm/pkg/apis/azureresource/v1"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 // ListEndpointsForService implements endpoints.Provider interface and returns the IP addresses and Ports for the given ServiceName Name.
-func (az Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.Endpoint {
+func (az Client) ListEndpointsForService(svc service.Name) []endpoint.Endpoint {
 	var endpoints []endpoint.Endpoint
 
 	// TODO(draychev): resolve the actual port number of this service
@@ -52,7 +53,7 @@ func (az Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.En
 }
 
 // ListServicesForServiceAccount retrieves the list of Services for the given service account
-func (az Client) ListServicesForServiceAccount(svcAccount endpoint.NamespacedServiceAccount) []endpoint.NamespacedService {
+func (az Client) ListServicesForServiceAccount(svcAccount service.NamespacedServiceAccount) []service.NamespacedService {
 	//TODO (snchh) : need to figure out the service account equivalnent for azure
 	panic("NotImplemented")
 }
@@ -87,7 +88,7 @@ func parseAzureID(id azureID) (resourceGroup, computeKind, computeName, error) {
 	return resGroup, kind, name, nil
 }
 
-func (az *Client) resolveService(svc endpoint.ServiceName) []azureID {
+func (az *Client) resolveService(svc service.Name) []azureID {
 	log.Trace().Msgf("Resolving service %s to an Azure URI", svc)
 	var azureIDs []azureID
 	service, exists, err := az.meshSpec.GetService(svc)

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	k8s "github.com/open-service-mesh/osm/pkg/kubernetes"
+	"github.com/open-service-mesh/osm/pkg/service"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ func (c *Client) GetID() string {
 }
 
 // ListEndpointsForService retrieves the list of IP addresses for the given service
-func (c Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.Endpoint {
+func (c Client) ListEndpointsForService(svc service.Name) []endpoint.Endpoint {
 	log.Info().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
 	var endpoints []endpoint.Endpoint
 	endpointsInterface, exist, err := c.caches.Endpoints.GetByKey(string(svc))
@@ -108,9 +109,9 @@ func (c Client) ListEndpointsForService(svc endpoint.ServiceName) []endpoint.End
 }
 
 // ListServicesForServiceAccount retrieves the list of Services for the given service account
-func (c Client) ListServicesForServiceAccount(svcAccount endpoint.NamespacedServiceAccount) []endpoint.NamespacedService {
+func (c Client) ListServicesForServiceAccount(svcAccount service.NamespacedServiceAccount) []service.NamespacedService {
 	log.Info().Msgf("[%s] Getting Services for service account %s on Kubernetes", c.providerIdent, svcAccount)
-	var services []endpoint.NamespacedService
+	var services []service.NamespacedService
 	deploymentsInterface := c.caches.Deployments.List()
 
 	for _, deployments := range deploymentsInterface {
@@ -120,7 +121,7 @@ func (c Client) ListServicesForServiceAccount(svcAccount endpoint.NamespacedServ
 				continue
 			}
 			spec := kubernetesDeployments.Spec
-			namespacedSvcAccount := endpoint.NamespacedServiceAccount{
+			namespacedSvcAccount := service.NamespacedServiceAccount{
 				Namespace:      kubernetesDeployments.Namespace,
 				ServiceAccount: spec.Template.Spec.ServiceAccountName,
 			}
@@ -131,7 +132,7 @@ func (c Client) ListServicesForServiceAccount(svcAccount endpoint.NamespacedServ
 				} else {
 					selectorLabel = spec.Template.Labels
 				}
-				namespacedService := endpoint.NamespacedService{
+				namespacedService := service.NamespacedService{
 					Namespace: kubernetesDeployments.Namespace,
 					Service:   selectorLabel[namespaceSelectorLabel],
 				}

--- a/pkg/providers/kube/fake.go
+++ b/pkg/providers/kube/fake.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
@@ -11,10 +12,10 @@ import (
 func NewFakeProvider() endpoint.Provider {
 
 	return &fakeClient{
-		endpoints: map[endpoint.ServiceName][]endpoint.Endpoint{
+		endpoints: map[service.Name][]endpoint.Endpoint{
 			tests.NamespacedServiceName: {tests.Endpoint},
 		},
-		services: map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService{
+		services: map[service.NamespacedServiceAccount][]service.NamespacedService{
 			tests.BookstoreServiceAccount: {tests.BookstoreService},
 			tests.BookbuyerServiceAccount: {tests.BookbuyerService},
 		},
@@ -22,12 +23,12 @@ func NewFakeProvider() endpoint.Provider {
 }
 
 type fakeClient struct {
-	endpoints map[endpoint.ServiceName][]endpoint.Endpoint
-	services  map[endpoint.NamespacedServiceAccount][]endpoint.NamespacedService
+	endpoints map[service.Name][]endpoint.Endpoint
+	services  map[service.NamespacedServiceAccount][]service.NamespacedService
 }
 
 // Retrieve the IP addresses comprising the given service.
-func (f fakeClient) ListEndpointsForService(name endpoint.ServiceName) []endpoint.Endpoint {
+func (f fakeClient) ListEndpointsForService(name service.Name) []endpoint.Endpoint {
 	if svc, ok := f.endpoints[name]; ok {
 		return svc
 	}
@@ -35,7 +36,7 @@ func (f fakeClient) ListEndpointsForService(name endpoint.ServiceName) []endpoin
 }
 
 // Retrieve the service for a given service account
-func (f fakeClient) ListServicesForServiceAccount(account endpoint.NamespacedServiceAccount) []endpoint.NamespacedService {
+func (f fakeClient) ListServicesForServiceAccount(account service.NamespacedServiceAccount) []service.NamespacedService {
 	services, ok := f.services[account]
 	if !ok {
 		panic(fmt.Sprintf("You asked fake k8s provider's ListServicesForServiceAccount for a ServiceAccount=%s, but that's not in cache: %+v", account, f.services))

--- a/pkg/service/suite_test.go
+++ b/pkg/service/suite_test.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,0 +1,63 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+)
+
+// Name is a type for a service name
+type Name string
+
+func (s Name) String() string {
+	return string(s)
+}
+
+// NamespacedService is a type for a namespaced service
+type NamespacedService struct {
+	Namespace string
+	Service   string
+}
+
+func (ns NamespacedService) String() string {
+	return fmt.Sprintf("%s/%s", ns.Namespace, ns.Service)
+}
+
+// Account is a type for a service account
+type Account string
+
+func (s Account) String() string {
+	return string(s)
+}
+
+// GetCommonName returns the Subject CN for the NamespacedService to be used for its certificate.
+func (ns NamespacedService) GetCommonName() certificate.CommonName {
+	return certificate.CommonName(strings.Join([]string{ns.Service, ns.Namespace, "svc", "cluster", "local"}, "."))
+}
+
+// NamespacedServiceAccount is a type for a namespaced service account
+type NamespacedServiceAccount struct {
+	Namespace      string
+	ServiceAccount string
+}
+
+func (ns NamespacedServiceAccount) String() string {
+	return fmt.Sprintf("%s/%s", ns.Namespace, ns.ServiceAccount)
+}
+
+// ClusterName is a type for a service name
+type ClusterName string
+
+//WeightedService is a struct of a service name, its weight and domain
+type WeightedService struct {
+	ServiceName NamespacedService `json:"service_name:omitempty"`
+	Weight      int               `json:"weight:omitempty"`
+	Domain      string            `json:"domain:omitempty"`
+}
+
+// WeightedCluster is a struct of a cluster and is weight that is backing a service
+type WeightedCluster struct {
+	ClusterName ClusterName `json:"cluster_name:omitempty"`
+	Weight      int         `json:"weight:omitempty"`
+}

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -6,15 +6,15 @@ import (
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/tests"
 )
 
 type fakeMeshSpec struct {
 	routeGroups      []*spec.HTTPRouteGroup
 	trafficTargets   []*target.TrafficTarget
-	weightedServices []endpoint.WeightedService
-	serviceAccounts  []endpoint.NamespacedServiceAccount
+	weightedServices []service.WeightedService
+	serviceAccounts  []service.NamespacedServiceAccount
 }
 
 // NewFakeMeshSpecClient creates a fake Mesh Spec used for testing.
@@ -22,8 +22,8 @@ func NewFakeMeshSpecClient() MeshSpec {
 	return fakeMeshSpec{
 		routeGroups:      []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
-		weightedServices: []endpoint.WeightedService{tests.WeightedService},
-		serviceAccounts: []endpoint.NamespacedServiceAccount{
+		weightedServices: []service.WeightedService{tests.WeightedService},
+		serviceAccounts: []service.NamespacedServiceAccount{
 			tests.BookstoreServiceAccount,
 			tests.BookbuyerServiceAccount,
 		},
@@ -36,17 +36,17 @@ func (f fakeMeshSpec) ListTrafficSplits() []*split.TrafficSplit {
 }
 
 // ListServices fetches all services declared with SMI Spec for the fake Mesh Spec.
-func (f fakeMeshSpec) ListServices() []endpoint.WeightedService {
+func (f fakeMeshSpec) ListServices() []service.WeightedService {
 	return f.weightedServices
 }
 
 // ListServiceAccounts fetches all service accounts declared with SMI Spec for the fake Mesh Spec.
-func (f fakeMeshSpec) ListServiceAccounts() []endpoint.NamespacedServiceAccount {
+func (f fakeMeshSpec) ListServiceAccounts() []service.NamespacedServiceAccount {
 	return f.serviceAccounts
 }
 
 // GetService fetches a specific service declared in SMI for the fake Mesh Spec.
-func (f fakeMeshSpec) GetService(endpoint.ServiceName) (service *corev1.Service, exists bool, err error) {
+func (f fakeMeshSpec) GetService(service.Name) (service *corev1.Service, exists bool, err error) {
 	return nil, false, nil
 }
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -8,9 +8,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/logger"
 	"github.com/open-service-mesh/osm/pkg/namespace"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 var (
@@ -53,13 +53,13 @@ type MeshSpec interface {
 	ListTrafficSplits() []*split.TrafficSplit
 
 	// ListServices fetches all services declared with SMI Spec.
-	ListServices() []endpoint.WeightedService
+	ListServices() []service.WeightedService
 
 	// ListServiceAccounts fetches all service accounts declared with SMI Spec.
-	ListServiceAccounts() []endpoint.NamespacedServiceAccount
+	ListServiceAccounts() []service.NamespacedServiceAccount
 
 	// GetService fetches a specific service declared in SMI.
-	GetService(endpoint.ServiceName) (service *corev1.Service, exists bool, err error)
+	GetService(service.Name) (service *corev1.Service, exists bool, err error)
 
 	// ListHTTPTrafficSpecs lists TrafficSpec SMI resources.
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/endpoint"
+	"github.com/open-service-mesh/osm/pkg/service"
+	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
 )
 
 const (
@@ -62,19 +64,19 @@ const (
 
 var (
 	// BookstoreService is the bookstore service.
-	BookstoreService = endpoint.NamespacedService{
+	BookstoreService = service.NamespacedService{
 		Namespace: Namespace,
 		Service:   BookstoreServiceName,
 	}
 
 	// BookbuyerService is the bookbuyer service.
-	BookbuyerService = endpoint.NamespacedService{
+	BookbuyerService = service.NamespacedService{
 		Namespace: Namespace,
 		Service:   BookbuyerServiceName,
 	}
 
 	// RoutePolicy is a route policy.
-	RoutePolicy = endpoint.RoutePolicy{
+	RoutePolicy = trafficpolicy.Route{
 		PathRegex: BookstoreBuyPath,
 		Methods:   []string{"GET"},
 	}
@@ -86,19 +88,19 @@ var (
 	}
 
 	// TrafficPolicy is a traffic policy SMI object.
-	TrafficPolicy = endpoint.TrafficPolicy{
-		PolicyName: TrafficTargetName,
-		Destination: endpoint.TrafficPolicyResource{
+	TrafficPolicy = trafficpolicy.TrafficTarget{
+		Name: TrafficTargetName,
+		Destination: trafficpolicy.TrafficResource{
 			ServiceAccount: BookstoreServiceAccountName,
 			Namespace:      Namespace,
 			Services:       set.NewSet(BookstoreService),
 		},
-		Source: endpoint.TrafficPolicyResource{
+		Source: trafficpolicy.TrafficResource{
 			ServiceAccount: BookbuyerServiceAccountName,
 			Namespace:      Namespace,
 			Services:       set.NewSet(BookbuyerService),
 		},
-		RoutePolicies: []endpoint.RoutePolicy{{
+		Routes: []trafficpolicy.Route{{
 			PathRegex: BookstoreBuyPath,
 			Methods:   []string{"GET"},
 		}},
@@ -132,27 +134,27 @@ var (
 	}
 
 	// RoutePolicyMap is a map of a key to a route policy SMI object.
-	RoutePolicyMap = map[string]endpoint.RoutePolicy{
+	RoutePolicyMap = map[string]trafficpolicy.Route{
 		fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", Namespace, TrafficTargetName, MatchName): RoutePolicy}
 
 	// NamespacedServiceName is a namespaced service.
-	NamespacedServiceName = endpoint.ServiceName(fmt.Sprintf("%s/%s", BookstoreService.Namespace, BookstoreService.Service))
+	NamespacedServiceName = service.Name(fmt.Sprintf("%s/%s", BookstoreService.Namespace, BookstoreService.Service))
 
 	// BookstoreServiceAccount is a namespaced service account.
-	BookstoreServiceAccount = endpoint.NamespacedServiceAccount{
+	BookstoreServiceAccount = service.NamespacedServiceAccount{
 		Namespace:      Namespace,
 		ServiceAccount: BookstoreServiceAccountName,
 	}
 
 	// BookbuyerServiceAccount is a namespaced bookbuyer account.
-	BookbuyerServiceAccount = endpoint.NamespacedServiceAccount{
+	BookbuyerServiceAccount = service.NamespacedServiceAccount{
 		Namespace:      Namespace,
 		ServiceAccount: BookbuyerServiceAccountName,
 	}
 
 	// WeightedService is a service with a weight used for traffic split.
-	WeightedService = endpoint.WeightedService{
-		ServiceName: endpoint.NamespacedService{
+	WeightedService = service.WeightedService{
+		ServiceName: service.NamespacedService{
 			Namespace: Namespace,
 			Service:   BookstoreServiceName,
 		},

--- a/pkg/trafficpolicy/suite_test.go
+++ b/pkg/trafficpolicy/suite_test.go
@@ -1,0 +1,13 @@
+package trafficpolicy
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTrafficPolicy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -1,0 +1,33 @@
+package trafficpolicy
+
+import (
+	set "github.com/deckarep/golang-set"
+	"github.com/open-service-mesh/osm/pkg/service"
+)
+
+// Route is a struct of a path regex and the methods on a given route
+type Route struct {
+	PathRegex string   `json:"path_regex:omitempty"`
+	Methods   []string `json:"methods:omitempty"`
+}
+
+// TrafficTarget is a struct of the allowed RoutePaths from sources to a destination
+type TrafficTarget struct {
+	Name        string          `json:"name:omitempty"`
+	Destination TrafficResource `json:"destination:omitempty"`
+	Source      TrafficResource `json:"source:omitempty"`
+	Routes      []Route         `json:"route:omitempty"`
+}
+
+//TrafficResource is a struct of the various resources of a source/destination in the TrafficPolicy
+type TrafficResource struct {
+	ServiceAccount service.Account `json:"service_account:omitempty"`
+	Namespace      string          `json:"namespace:omitempty"`
+	Services       set.Set         `json:"services:omitempty"`
+}
+
+//RouteWeightedClusters is a struct of a route and the weighted clusters on that route
+type RouteWeightedClusters struct {
+	Route            Route   `json:"route:omitempty"`
+	WeightedClusters set.Set `json:"weighted_clusters:omitempty"`
+}


### PR DESCRIPTION
The `types.go` for the package `endpoint` was over loaded whereby it had structs related to a Service and TrafficPolicy in it. 

This PR helps remove those structs from the endpoint package and creates a separate package called `service` and `policy` for the structs related to a service (`Name`, `Account`, `NamespacedServiceAccount`, `WeightedCluster`) and TrafficPolicies (`RoutePolicy`, `TrafficPolicy`, `TrafficPolicyResource`) respectively

No functional changes only refactoring