### PR TITLE
ref(*) : Renaming certificate.GetName() to certificate.GetCommonName()

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -444,8 +444,8 @@ Additionally we define an interface for the `Certificate` object, which requires
 // Certificater is the interface declaring methods each Certificate object must have.
 type Certificater interface {
 
-	// GetName retrieves the name of the certificate.
-	GetName() string
+	// GetCommonName retrieves the name of the certificate.
+	GetCommonName() string
 
 	// GetCertificateChain retrieves the cert chain.
 	GetCertificateChain() []byte

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -11,8 +11,8 @@ const (
 	checkCertificateExpirationInterval = 5 * time.Second
 )
 
-// GetName implements certificate.Certificater and returns the CN of the cert.
-func (c Certificate) GetName() string {
+// GetCommonName implements certificate.Certificater and returns the CN of the cert.
+func (c Certificate) GetCommonName() string {
 	return c.commonName.String()
 }
 

--- a/pkg/certificate/providers/tresor/manager_test.go
+++ b/pkg/certificate/providers/tresor/manager_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Test Certificate Manager", func() {
 
 			cert, err := m.IssueCertificate(serviceFQDN)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(cert.GetName()).To(Equal(serviceFQDN))
+			Expect(cert.GetCommonName()).To(Equal(serviceFQDN))
 
 			x509RootCert, err := DecodePEMCertificate(rootCert.GetCertificateChain())
 			Expect(err).ToNot(HaveOccurred())
@@ -69,7 +69,7 @@ var _ = Describe("Test Certificate Manager", func() {
 			Expect(newCertError).ToNot(HaveOccurred())
 			cert, issueCerterror := m.IssueCertificate(serviceFQDN)
 			Expect(issueCerterror).ToNot(HaveOccurred())
-			Expect(cert.GetName()).To(Equal(serviceFQDN))
+			Expect(cert.GetCommonName()).To(Equal(serviceFQDN))
 
 			x509Cert, err := DecodePEMCertificate(rootCert.GetCertificateChain())
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/certificate/providers/vault/client.go
+++ b/pkg/certificate/providers/vault/client.go
@@ -153,8 +153,8 @@ type Certificate struct {
 	issuingCA pem.RootCertificate
 }
 
-// GetName returns the common name of the given certificate.
-func (c Certificate) GetName() string {
+// GetCommonName returns the common name of the given certificate.
+func (c Certificate) GetCommonName() string {
 	return c.commonName.String()
 }
 

--- a/pkg/certificate/rotor/rotor.go
+++ b/pkg/certificate/rotor/rotor.go
@@ -59,7 +59,7 @@ func (r *rotor) checkAndRotate() {
 				continue
 			}
 			r.announcements <- nil
-			log.Trace().Msgf("Rotated cert CN=%s", newCert.GetName())
+			log.Trace().Msgf("Rotated cert CN=%s", newCert.GetCommonName())
 		}
 	}
 }

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -12,8 +12,8 @@ func (cn CommonName) String() string {
 // Certificater is the interface declaring methods each Certificate object must have.
 type Certificater interface {
 
-	// GetName retrieves the name of the certificate.
-	GetName() string
+	// GetCommonName retrieves the name of the certificate.
+	GetCommonName() string
 
 	// GetCertificateChain retrieves the cert chain.
 	GetCertificateChain() []byte


### PR DESCRIPTION
PR resolves #497 