### PR TITLE
Updating SMI Traffic Spec version

### DIFF
--- a/charts/osm/crds/specs.yaml
+++ b/charts/osm/crds/specs.yaml
@@ -4,7 +4,7 @@ metadata:
   name: httproutegroups.specs.smi-spec.io
 spec:
   group: specs.smi-spec.io
-  version: v1alpha1
+  version: v1alpha2
   scope: Namespaced 
   names:
     kind: HTTPRouteGroup
@@ -12,6 +12,57 @@ spec:
       - htr
     plural: httproutegroups
     singular: httproutegroup
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: false
+      storage: false
+  validation:
+    openAPIV3Schema:
+      required:
+        - matches
+      properties:
+        matches:
+          description: Match conditions of this route group.
+          type: array
+          items:
+            type: object
+            required:
+              - name
+            properties:
+              name:
+                description: Name of the HTTP route.
+                type: string
+              pathRegex:
+                description: URI path regex of the HTTP route.
+                type: string
+              methods:
+                description: The HTTP methods of this HTTP route.
+                type: array
+                items:
+                  type: string
+                  description: The HTTP method of this HTTP route.
+                  enum:
+                    - '*'
+                    - GET
+                    - HEAD
+                    - PUT
+                    - POST
+                    - DELETE
+                    - CONNECT
+                    - OPTIONS
+                    - TRACE
+                    - PATCH
+              headers:
+                description: Header match conditions of this route.
+                type: array
+                items:
+                  description: Header match condition of this route.
+                  type: object
+                  additionalProperties:
+                    type: string
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/demo/deploy-traffic-spec.sh
+++ b/demo/deploy-traffic-spec.sh
@@ -5,46 +5,11 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-echo "Deploy HTTPRouteGroup CRD"
-kubectl apply -f - <<EOF
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: httproutegroups.specs.smi-spec.io
-spec:
-  group: specs.smi-spec.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    kind: HTTPRouteGroup
-    shortNames:
-      - htr
-    plural: httproutegroups
-    singular: httproutegroup
-EOF
-
-echo "Deploy TCPRoute CRD"
-kubectl apply -f - <<EOF
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: tcproutes.specs.smi-spec.io
-spec:
-  group: specs.smi-spec.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    kind: TCPRoute
-    shortNames:
-      - tr
-    plural: tcproutes
-    singular: tcproute
-
-EOF
+kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.3.0/crds/specs.yaml
 
 echo "Create HTTPRouteGroup"
 kubectl apply -f - <<EOF
-apiVersion: specs.smi-spec.io/v1alpha1
+apiVersion: specs.smi-spec.io/v1alpha2
 kind: HTTPRouteGroup
 metadata:
   name: bookstore-service-routes
@@ -52,11 +17,14 @@ metadata:
 matches:
 - name: books-bought
   pathRegex: /books-bought
-  methods: ["GET"]
+  methods:
+  - GET
 - name: buy-a-book
   pathRegex: ".*a-book.*new"
-  methods: ["GET"]
+  methods: 
+  - GET
 - name: update-books-bought
   pathRegex: /update-books-bought
-  methods: ["POST"]
+  methods:
+  - POST
 EOF

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	smiTrafficTargetClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
 	smiTrafficTargetInformers "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/informers/externalversions"
@@ -104,7 +104,7 @@ func newSMIClient(kubeClient *kubernetes.Clientset, smiTrafficSplitClient *smiTr
 	informerCollection := InformerCollection{
 		Services:      informerFactory.Core().V1().Services().Informer(),
 		TrafficSplit:  smiTrafficSplitInformerFactory.Split().V1alpha2().TrafficSplits().Informer(),
-		TrafficSpec:   smiTrafficSpecInformerFactory.Specs().V1alpha1().HTTPRouteGroups().Informer(),
+		TrafficSpec:   smiTrafficSpecInformerFactory.Specs().V1alpha2().HTTPRouteGroups().Informer(),
 		TrafficTarget: smiTrafficTargetInformerFactory.Access().V1alpha1().TrafficTargets().Informer(),
 	}
 

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -2,7 +2,7 @@ package smi
 
 import (
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -2,7 +2,7 @@ package smi
 
 import (
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -6,7 +6,7 @@ import (
 
 	set "github.com/deckarep/golang-set"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha1"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -165,7 +165,7 @@ var (
 	// HTTPRouteGroup is the HTTP route group SMI object.
 	HTTPRouteGroup = spec.HTTPRouteGroup{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "specs.smi-spec.io/v1alpha1",
+			APIVersion: "specs.smi-spec.io/v1alpha2",
 			Kind:       "HTTPRouteGroup",
 		},
 		ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
This PR is one of the parts for #449, focusing only on updating the version of traffic spec to v1alpha2. 

The new features of this spec have not been used and will be in future PRs, hence no functional changes and only version upgrade. 