### PR TITLE
events: Optional Debug log statements

### DIFF
--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Testing event handlers", func() {
 		It("Should add the event to the announcement channel", func() {
 			announcements := make(chan interface{}, 1)
 			pod := tests.NewPodTestFixture(testNamespace, "pod-name")
-			add(testInformer, testProvider, announcements, shouldObserve)(&pod)
+			addEvent(testInformer, testProvider, announcements, shouldObserve, "ADD")(&pod)
 			Expect(len(announcements)).To(Equal(1))
 			<-announcements
 		})
@@ -37,7 +37,7 @@ var _ = Describe("Testing event handlers", func() {
 			announcements := make(chan interface{}, 1)
 			var pod corev1.Pod
 			pod.Namespace = "not-a-monitored-namespace"
-			add(testInformer, testProvider, announcements, shouldObserve)(&pod)
+			addEvent(testInformer, testProvider, announcements, shouldObserve, "ADD")(&pod)
 			Expect(len(announcements)).To(Equal(0))
 		})
 	})


### PR DESCRIPTION
Moving the Trace and Debug statements into separate functions to DRY this up a bit.

Wrapping the DEBUG statements with the same env var `OSM_LOG_KUBERNETES_EVENTS` to remove log noise -- gives us ability to optionally toggle these.

In a separate PR will move `OSM_LOG_KUBERNETES_EVENTS` into constants.go (see https://github.com/open-service-mesh/osm/pull/672)

---

Here is an example of the "... is not observed by OSM ..." messages, which make it difficult to get to the log lines that could be causing issues:

![image](https://user-images.githubusercontent.com/49918230/82483622-86272500-9a8d-11ea-864f-355467301458.png)
