### PR TITLE
constants: Consolidate names of environment variables

### DIFF
--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -39,7 +39,4 @@ const (
 
 	// PrometheusVar is the environment variable for promethues service name
 	PrometheusVar = "PROMETHEUS_SVC"
-
-	// HumanReadableLogMessagesEnvVar is an environment variable, which when set to "true" enables colorful human-readable log messages.
-	HumanReadableLogMessagesEnvVar = "OSM_HUMAN_DEBUG_LOG"
 )

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -147,8 +147,8 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 						"/ads",
 					},
 					Env: []apiv1.EnvVar{{
-						Name:  common.HumanReadableLogMessagesEnvVar,
-						Value: os.Getenv(common.HumanReadableLogMessagesEnvVar),
+						Name:  constants.EnvVarHumanReadableLogMessages,
+						Value: os.Getenv(constants.EnvVarHumanReadableLogMessages),
 					}},
 					Args: args,
 					VolumeMounts: []apiv1.VolumeMount{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -92,4 +92,12 @@ const (
 
 	// TimeDateLayout is the layout for time.Parse used in this repo
 	TimeDateLayout = "2006-01-02T15:04:05.000Z"
+
+	// ----- Environment Variables
+
+	// EnvVarLogKubernetesEvents is the name of the env var instructing the event handlers whether to log at all (true/false)
+	EnvVarLogKubernetesEvents = "OSM_LOG_KUBERNETES_EVENTS"
+
+	// EnvVarHumanReadableLogMessages is an environment variable, which when set to "true" enables colorful human-readable log messages.
+	EnvVarHumanReadableLogMessages = "OSM_HUMAN_DEBUG_LOG"
 )

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/open-service-mesh/osm/pkg/constants"
 )
 
 // CallerHook implements zerolog.Hook interface.
@@ -24,7 +26,7 @@ func (h CallerHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 // New creates a new zerolog.Logger
 func New(component string) zerolog.Logger {
 	l := log.With().Str("component", component).Logger().Hook(CallerHook{})
-	if os.Getenv("OSM_HUMAN_DEBUG_LOG") == "true" {
+	if os.Getenv(constants.EnvVarHumanReadableLogMessages) == "true" {
 		return l.Output(zerolog.ConsoleWriter{Out: os.Stdout})
 	}
 	return l


### PR DESCRIPTION
We have a few places where we use environment variables.
This PR starts to move these into constants.go