### PR TITLE
demo: change bookstore port to 8080

### DIFF
--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -32,7 +32,7 @@ metadata:
     app: $SVC
 spec:
   ports:
-  - port: 80
+  - port: 8080
     name: bookstore-port
 
   selector:
@@ -62,15 +62,14 @@ spec:
       serviceAccountName: "$SVC-serviceaccount"
       automountServiceAccountToken: false
       containers:
-
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always
           name: $SVC
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: web
           command: ["/bookstore"]
-          args: ["--path", "./", "--port", "80"]
+          args: ["--path", "./", "--port", "8080"]
           env:
             - name: IDENTITY
               value: ${SVC}--${GIT_HASH}

--- a/dockerfiles/Dockerfile.bookstore
+++ b/dockerfiles/Dockerfile.bookstore
@@ -4,5 +4,5 @@ RUN apk add --no-cache iptables
 ADD ./demo/bin/bookstore /
 ADD ./demo/bookstore.html.template /
 WORKDIR /
-EXPOSE 80
+EXPOSE 8080
 RUN chmod +x bookstore


### PR DESCRIPTION
Port 80 is typically used for HTTP - while the bookstore service
is running an HTTP service, clients access it over HTTPS via
proxy sidecars. Azure AGIC does not allow exposing an HTTPS
backend over port 80 with ingress, so use a different port for the demo app.

Part of #66