### PR TITLE
events: Move env var string literal to consts

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-service-mesh/osm/pkg/constants"
 )
 
 const (
@@ -13,7 +15,7 @@ const (
 	eventDelete = "DELETE"
 )
 
-var emitLogs = os.Getenv("OSM_LOG_KUBERNETES_EVENTS") == "true"
+var emitLogs = os.Getenv(constants.EnvVarLogKubernetesEvents) == "true"
 
 // observeFilter returns true for YES observe and false for NO do not pay attention to this
 // This filter could be added optionally by anything using GetKubernetesEventHandlers()


### PR DESCRIPTION
This PR is part 2 of https://github.com/open-service-mesh/osm/pull/672 and https://github.com/open-service-mesh/osm/pull/671 -- reusing the const in lieu of the string literal.