### PR TITLE
demo: Change bookstore service's default port to 8080

### DIFF
--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -18,7 +18,7 @@ import (
 
 var identity = flag.String("ident", "unidentified", "the identity of the container where this demo app is running (VM, K8s, etc)")
 
-var port = flag.Int("port", 80, "port on which this app is listening for incoming HTTP")
+var port = flag.Int("port", 8080, "port on which this app is listening for incoming HTTP")
 var path = flag.String("path", ".", "path to the HTML template")
 var booksBought int
 


### PR DESCRIPTION
By default the service should run on port 8080.