### PR TITLE
demo: create a top level bookstore-mesh service

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -18,10 +18,12 @@ const (
 )
 
 func main() {
+	bookstoreNamespace := os.Getenv(common.BookstoreNamespaceEnvVar)
 	bookstoreService := os.Getenv("BOOKSTORE_SVC")
 	if bookstoreService == "" {
-		bookstoreService = "bookstore.mesh"
+		bookstoreService = "bookstore-mesh"
 	}
+	bookstoreService = fmt.Sprintf("%s.%s", bookstoreService, bookstoreNamespace) // FQDN
 	booksBought := fmt.Sprintf("http://%s/books-bought", bookstoreService)
 	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -18,10 +18,12 @@ const (
 )
 
 func main() {
+	bookstoreNamespace := os.Getenv(common.BookstoreNamespaceEnvVar)
 	bookstoreService := os.Getenv("BOOKSTORE_SVC")
 	if bookstoreService == "" {
-		bookstoreService = "bookstore.mesh"
+		bookstoreService = "bookstore-mesh"
 	}
+	bookstoreService = fmt.Sprintf("%s.%s", bookstoreService, bookstoreNamespace) // FQDN
 	booksBought := fmt.Sprintf("http://%s/books-bought", bookstoreService)
 	buyBook := fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	waitForOK := getWaitForOK()

--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -39,4 +39,7 @@ const (
 
 	// PrometheusVar is the environment variable for promethues service name
 	PrometheusVar = "PROMETHEUS_SVC"
+
+	// BookstoreNamespaceEnvVar is the environment variable for the Bookbuyer namespace.
+	BookstoreNamespaceEnvVar = "BOOKSTORE_NAMESPACE"
 )

--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -30,8 +30,8 @@ else
     ./ci/create-app-container-registry-creds.sh
 fi
 # Deploy bookstore
-./demo/deploy-bookstore.sh "bookstore-1"
-./demo/deploy-bookstore.sh "bookstore-2"
+./demo/deploy-bookstore.sh "v1"
+./demo/deploy-bookstore.sh "v2"
 # Deploy bookbuyer
 ./demo/deploy-bookbuyer.sh
 # Deploy bookthief

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -60,12 +60,6 @@ spec:
     spec:
       serviceAccountName: bookbuyer-serviceaccount
       automountServiceAccountToken: false
-      hostAliases:
-      - ip: "127.0.0.2"
-        hostnames:
-        - "${BOOKBUYER_NAMESPACE}.uswest.mesh"
-        - "bookbuyer.mesh"
-        - "bookstore.mesh"
 
       containers:
         # Main container with APP
@@ -77,6 +71,8 @@ spec:
           env:
             - name: "WAIT_FOR_OK_SECONDS"
               value: "$WAIT_FOR_OK_SECONDS"
+            - name: "BOOKSTORE_NAMESPACE"
+              value: "$BOOKSTORE_NAMESPACE"
 
 
       imagePullSecrets:

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -57,11 +57,6 @@ spec:
     spec:
       serviceAccountName: bookthief-serviceaccount
       automountServiceAccountToken: false
-      hostAliases:
-      - ip: "127.0.0.2"
-        hostnames:
-        - "${BOOKTHIEF_NAMESPACE}.uswest.mesh"
-        - "bookstore.mesh"
 
       containers:
         # Main container with APP
@@ -73,6 +68,8 @@ spec:
           env:
             - name: "WAIT_FOR_OK_SECONDS"
               value: "$WAIT_FOR_OK_SECONDS"
+            - name: "BOOKSTORE_NAMESPACE"
+              value: "$BOOKSTORE_NAMESPACE"
 
 
       imagePullSecrets:

--- a/demo/deploy-traffic-split.sh
+++ b/demo/deploy-traffic-split.sh
@@ -11,15 +11,15 @@ kubectl apply -f - <<EOF
 apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
-  name: bookstore.mesh
+  name: bookstore-split
   namespace: "$BOOKSTORE_NAMESPACE"
 spec:
-  service: bookstore.mesh
+  service: "bookstore-mesh.$BOOKSTORE_NAMESPACE"
   backends:
 
-  - service: bookstore-1
+  - service: bookstore-v1
     weight: 50
-  - service: bookstore-2
+  - service: bookstore-v2
     weight: 50
 
 

--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -11,11 +11,11 @@ kubectl apply -f - <<EOF
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1
 metadata:
-  name: bookbuyer-access-bookstore-1
+  name: bookbuyer-access-bookstore-v1
   namespace: "$BOOKSTORE_NAMESPACE"
 destination:
   kind: ServiceAccount
-  name: bookstore-1-serviceaccount
+  name: bookstore-v1-serviceaccount
   namespace: "$BOOKSTORE_NAMESPACE"
 specs:
 - kind: HTTPRouteGroup
@@ -33,11 +33,11 @@ sources:
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1
 metadata:
-  name: bookbuyer-access-bookstore-2
+  name: bookbuyer-access-bookstore-v2
   namespace: "$BOOKSTORE_NAMESPACE"
 destination:
   kind: ServiceAccount
-  name: bookstore-2-serviceaccount
+  name: bookstore-v2-serviceaccount
   namespace: "$BOOKSTORE_NAMESPACE"
 specs:
 - kind: HTTPRouteGroup

--- a/demo/tail-bookstore.sh
+++ b/demo/tail-bookstore.sh
@@ -13,4 +13,4 @@ fi
 
 POD="$(kubectl get pods -n "$BOOKSTORE_NAMESPACE" --show-labels --selector app="$backend" --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
 
-kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c bookstore-1 --tail=100
+kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c "$backend" --tail=100


### PR DESCRIPTION
A top level bookstore-mesh service is created
to avoid statically configuring DNS on client pods.
Also versions the backends as bookstore-v1 and
bookstore-v2.