### PR TITLE
feat(*) : Decoupling traffic split from traffic target

### DIFF
--- a/demo/deploy-traffic-spec.sh
+++ b/demo/deploy-traffic-spec.sh
@@ -19,12 +19,18 @@ matches:
   pathRegex: /books-bought
   methods:
   - GET
+  headers:
+  - host: "bookstore-mesh.$BOOKSTORE_NAMESPACE"
 - name: buy-a-book
   pathRegex: ".*a-book.*new"
   methods: 
   - GET
+  headers:
+  - host: "bookstore-mesh.$BOOKSTORE_NAMESPACE"
 - name: update-books-bought
   pathRegex: /update-books-bought
   methods:
   - POST
+  headers:
+  - host: "bookstore-mesh.$BOOKSTORE_NAMESPACE"
 EOF

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -11,4 +11,5 @@ var (
 	errServiceAccountDoesNotMatchCertificate = errors.New("service account does not match certificate")
 	errNamespaceDoesNotMatchCertificate      = errors.New("namespace does not match certificate")
 	errServiceNotFoundForAnyProvider         = errors.New("no service found for service account with any of the mesh supported providers")
+	errDomainNotFoundForService              = errors.New("no host/domain found to configure service")
 )

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -63,6 +63,6 @@ func (mc *MeshCatalog) GetIngressRoutePoliciesPerDomain(service service.Namespac
 func (mc *MeshCatalog) GetIngressWeightedCluster(svc service.NamespacedService) (service.WeightedCluster, error) {
 	return service.WeightedCluster{
 		ClusterName: service.ClusterName(svc.String()),
-		Weight:      100,
+		Weight:      constants.WildcardClusterWeight,
 	}, nil
 }

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint"
 	"github.com/open-service-mesh/osm/pkg/ingress"
 	"github.com/open-service-mesh/osm/pkg/providers/kube"
-	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 	"github.com/open-service-mesh/osm/pkg/tests"
 	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
@@ -37,18 +36,6 @@ var _ = Describe("Catalog tests", func() {
 		})
 	})
 
-	Context("Test getActiveService", func() {
-		It("lists active services", func() {
-			actual, err := meshCatalog.getActiveService(tests.BookstoreService)
-			Expect(err).ToNot(HaveOccurred())
-			expected := &service.NamespacedService{
-				Namespace: "default",
-				Service:   "bookstore",
-			}
-			Expect(actual).To(Equal(expected))
-		})
-	})
-
 	Context("Test getTrafficPolicyPerRoute", func() {
 		It("lists traffic policies", func() {
 			allTrafficPolicies, err := getTrafficPolicyPerRoute(meshCatalog, tests.RoutePolicyMap, tests.BookstoreService)
@@ -66,7 +53,7 @@ var _ = Describe("Catalog tests", func() {
 					Namespace:      tests.Namespace,
 					Service:        tests.BookbuyerService,
 				},
-				Routes: []trafficpolicy.Route{{PathRegex: "", Methods: nil}},
+				Route: trafficpolicy.Route{PathRegex: "", Methods: nil},
 			}}
 
 			Expect(allTrafficPolicies).To(Equal(expected))
@@ -79,10 +66,18 @@ var _ = Describe("Catalog tests", func() {
 			actual, err := mc.getHTTPPathsPerRoute()
 			Expect(err).ToNot(HaveOccurred())
 
-			key := fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", tests.Namespace, tests.RouteGroupName, tests.MatchName)
+			keyBuy := fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", tests.Namespace, tests.RouteGroupName, tests.BuyBooksMatchName)
+			keySell := fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", tests.Namespace, tests.RouteGroupName, tests.SellBooksMatchName)
 			expected := map[string]trafficpolicy.Route{
-				key: {
+				keyBuy: {
 					PathRegex: tests.BookstoreBuyPath,
+					Methods:   []string{"GET"},
+					Headers: map[string]string{
+						"host": tests.Domain,
+					},
+				},
+				keySell: {
+					PathRegex: tests.BookstoreSellPath,
 					Methods:   []string{"GET"},
 				},
 			}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -6,7 +6,7 @@ import (
 )
 
 // GetServiceForServiceAccount returns a service corresponding to a service account
-func (mc *MeshCatalog) GetServiceForServiceAccount(sa service.NamespacedServiceAccount) (*service.NamespacedService, error) {
+func (mc *MeshCatalog) GetServiceForServiceAccount(sa service.NamespacedServiceAccount) (service.NamespacedService, error) {
 	for _, provider := range mc.endpointsProviders {
 		// TODO (#88) : remove this provider check once we have figured out the service account story for azure vms
 		if provider.GetID() != constants.AzureProviderName {
@@ -16,5 +16,5 @@ func (mc *MeshCatalog) GetServiceForServiceAccount(sa service.NamespacedServiceA
 			return service, err
 		}
 	}
-	return nil, errServiceNotFoundForAnyProvider
+	return service.NamespacedService{}, errServiceNotFoundForAnyProvider
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -67,10 +67,10 @@ type MeshCataloger interface {
 	UnregisterProxy(*envoy.Proxy)
 
 	// GetServiceForServiceAccount returns the service corresponding to a service account
-	GetServiceForServiceAccount(service.NamespacedServiceAccount) (*service.NamespacedService, error)
+	GetServiceForServiceAccount(service.NamespacedServiceAccount) (service.NamespacedService, error)
 
 	//GetDomainForService returns the domain name of a service
-	GetDomainForService(service service.NamespacedService) (string, error)
+	GetDomainForService(service service.NamespacedService, routeHeaders map[string]string) (string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.NamespacedService) (service.WeightedCluster, error)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -103,4 +103,7 @@ const (
 
 	// EnvVarHumanReadableLogMessages is an environment variable, which when set to "true" enables colorful human-readable log messages.
 	EnvVarHumanReadableLogMessages = "OSM_HUMAN_DEBUG_LOG"
+
+	// WildcardClusterWeight is the default wildcard cluster weight
+	WildcardClusterWeight = 100
 )

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -13,7 +13,7 @@ type Provider interface {
 	ListEndpointsForService(service.Name) []Endpoint
 
 	// Retrieve the namespaced service for a given service account
-	GetServiceForServiceAccount(service.NamespacedServiceAccount) (*service.NamespacedService, error)
+	GetServiceForServiceAccount(service.NamespacedServiceAccount) (service.NamespacedService, error)
 
 	// GetID returns the unique identifier of the EndpointsProvider.
 	GetID() string

--- a/pkg/providers/azure/provider.go
+++ b/pkg/providers/azure/provider.go
@@ -53,7 +53,7 @@ func (az Client) ListEndpointsForService(svc service.Name) []endpoint.Endpoint {
 }
 
 // GetServiceForServiceAccount retrieves the service for the given service account
-func (az Client) GetServiceForServiceAccount(svcAccount service.NamespacedServiceAccount) (*service.NamespacedService, error) {
+func (az Client) GetServiceForServiceAccount(svcAccount service.NamespacedServiceAccount) (service.NamespacedService, error) {
 	//TODO (snchh) : need to figure out the service account equivalnent for azure
 	panic("NotImplemented")
 }

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -109,7 +109,7 @@ func (c Client) ListEndpointsForService(svc service.Name) []endpoint.Endpoint {
 }
 
 // GetServiceForServiceAccount retrieves the service for the given service account
-func (c Client) GetServiceForServiceAccount(svcAccount service.NamespacedServiceAccount) (*service.NamespacedService, error) {
+func (c Client) GetServiceForServiceAccount(svcAccount service.NamespacedServiceAccount) (service.NamespacedService, error) {
 	log.Info().Msgf("[%s] Getting Services for service account %s on Kubernetes", c.providerIdent, svcAccount)
 	var services []service.NamespacedService
 	deploymentsInterface := c.caches.Deployments.List()
@@ -143,7 +143,7 @@ func (c Client) GetServiceForServiceAccount(svcAccount service.NamespacedService
 
 	if len(services) == 0 {
 		log.Error().Msgf("Did not find any service with serviceAccount = %s in namespace %s", svcAccount.ServiceAccount, svcAccount.Namespace)
-		return nil, errDidNotFindServiceForServiceAccount
+		return service.NamespacedService{}, errDidNotFindServiceForServiceAccount
 	}
 
 	// --- CONVENTION ---
@@ -152,14 +152,14 @@ func (c Client) GetServiceForServiceAccount(svcAccount service.NamespacedService
 	// When a servcie account has more than one service XDS will not apply any SMI policy for that service, leaving it out of the mesh.
 	if len(services) > 1 {
 		log.Error().Msgf("Found more than one service for serviceAccount %s in namespace %s; There should be only one!", svcAccount.ServiceAccount, svcAccount.Namespace)
-		return nil, errMoreThanServiceForServiceAccount
+		return service.NamespacedService{}, errMoreThanServiceForServiceAccount
 	}
 
 	service := services[0]
 	log.Trace().Msgf("Found service %s for serviceAccount %s in namespace %s", service.Service, svcAccount.ServiceAccount, svcAccount.Namespace)
 
 	log.Info().Msgf("[%s] Services %v observed on service account %s on Kubernetes", c.providerIdent, services, svcAccount)
-	return &service, nil
+	return service, nil
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the Kubernetes endpoints provider.

--- a/pkg/providers/kube/fake.go
+++ b/pkg/providers/kube/fake.go
@@ -15,16 +15,16 @@ func NewFakeProvider() endpoint.Provider {
 		endpoints: map[service.Name][]endpoint.Endpoint{
 			tests.NamespacedServiceName: {tests.Endpoint},
 		},
-		services: map[service.NamespacedServiceAccount]*service.NamespacedService{
-			tests.BookstoreServiceAccount: &tests.BookstoreService,
-			tests.BookbuyerServiceAccount: &tests.BookbuyerService,
+		services: map[service.NamespacedServiceAccount]service.NamespacedService{
+			tests.BookstoreServiceAccount: tests.BookstoreService,
+			tests.BookbuyerServiceAccount: tests.BookbuyerService,
 		},
 	}
 }
 
 type fakeClient struct {
 	endpoints map[service.Name][]endpoint.Endpoint
-	services  map[service.NamespacedServiceAccount]*service.NamespacedService
+	services  map[service.NamespacedServiceAccount]service.NamespacedService
 }
 
 // Retrieve the IP addresses comprising the given service.
@@ -35,7 +35,7 @@ func (f fakeClient) ListEndpointsForService(name service.Name) []endpoint.Endpoi
 	panic(fmt.Sprintf("You are asking for ServiceName=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", name, f.endpoints))
 }
 
-func (f fakeClient) GetServiceForServiceAccount(svcAccount service.NamespacedServiceAccount) (*service.NamespacedService, error) {
+func (f fakeClient) GetServiceForServiceAccount(svcAccount service.NamespacedServiceAccount) (service.NamespacedService, error) {
 	services, ok := f.services[svcAccount]
 	if !ok {
 		panic(fmt.Sprintf("You asked fake k8s provider's GetServiceForServiceAccount for a ServiceAccount=%s, but that's not in cache: %+v", svcAccount, f.services))

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -36,8 +36,11 @@ const (
 	// TrafficTargetName is the name of the traffic target SMI object.
 	TrafficTargetName = "bookbuyer-access-bookstore"
 
-	// MatchName is the name of the match object.
-	MatchName = "buy-books"
+	// BuyBooksMatchName is the name of the match object.
+	BuyBooksMatchName = "buy-books"
+
+	// SellBooksMatchName is the name of the match object.
+	SellBooksMatchName = "sell-books"
 
 	// Domain is a domain
 	Domain = "contoso.com"
@@ -50,6 +53,9 @@ const (
 
 	// BookstoreBuyPath is the path to the bookstore.
 	BookstoreBuyPath = "/buy"
+
+	// BookstoreSellPath is the path to the bookstore.
+	BookstoreSellPath = "/sell"
 
 	// SelectorKey is a Pod selector key constant.
 	SelectorKey = "app"
@@ -99,10 +105,13 @@ var (
 			Namespace:      Namespace,
 			Service:        BookbuyerService,
 		},
-		Routes: []trafficpolicy.Route{{
+		Route: trafficpolicy.Route{
 			PathRegex: BookstoreBuyPath,
 			Methods:   []string{"GET"},
-		}},
+			Headers: map[string]string{
+				"host": Domain,
+			},
+		},
 	}
 
 	// TrafficTarget is a traffic target SMI object.
@@ -134,7 +143,7 @@ var (
 
 	// RoutePolicyMap is a map of a key to a route policy SMI object.
 	RoutePolicyMap = map[string]trafficpolicy.Route{
-		fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", Namespace, TrafficTargetName, MatchName): RoutePolicy}
+		fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", Namespace, TrafficTargetName, BuyBooksMatchName): RoutePolicy}
 
 	// NamespacedServiceName is a namespaced service.
 	NamespacedServiceName = service.Name(fmt.Sprintf("%s/%s", BookstoreService.Namespace, BookstoreService.Service))
@@ -172,10 +181,18 @@ var (
 			Name:      RouteGroupName,
 		},
 		Matches: []spec.HTTPMatch{{
-			Name:      MatchName,
+			Name:      BuyBooksMatchName,
 			PathRegex: BookstoreBuyPath,
 			Methods:   []string{"GET"},
-		}},
+			Headers: map[string]string{
+				"host": Domain,
+			},
+		},
+			{
+				Name:      SellBooksMatchName,
+				PathRegex: BookstoreSellPath,
+				Methods:   []string{"GET"},
+			}},
 	}
 )
 

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -7,8 +7,9 @@ import (
 
 // Route is a struct of a path regex and the methods on a given route
 type Route struct {
-	PathRegex string   `json:"path_regex:omitempty"`
-	Methods   []string `json:"methods:omitempty"`
+	PathRegex string            `json:"path_regex:omitempty"`
+	Methods   []string          `json:"methods:omitempty"`
+	Headers   map[string]string `json:"headers:omitempty"`
 }
 
 // TrafficTarget is a struct of the allowed RoutePaths from sources to a destination
@@ -16,7 +17,7 @@ type TrafficTarget struct {
 	Name        string          `json:"name:omitempty"`
 	Destination TrafficResource `json:"destination:omitempty"`
 	Source      TrafficResource `json:"source:omitempty"`
-	Routes      []Route         `json:"route:omitempty"`
+	Route       Route           `json:"route:omitempty"`
 }
 
 //TrafficResource is a struct of the various resources of a source/destination in the TrafficPolicy


### PR DESCRIPTION
In OSM we had a dependency between traffic policy and traffic split whereby a policy was applied for a destination service only if there was a traffic split corresponding to that service. This PR removes that dependency by leveraging the host name provided in the traffic spec (referenced in the traffic policy).

With this PR the behaviors in OSM are as follows:

1. if there's no traffic policy and traffic split, `bookbuyer` cannot talk to `bookstore-v1` or `bookstore-v2`
2. if there's only a traffic policy as defined in `demo/deploy-traffic-target.sh`,  `bookbuyer` will talk to both `bookstore-v1` and `bookstore-v2` in a load balanced manner. This is because `demo/deploy-traffic-spec.sh` has the header `host:bookstore-mesh.$BOOKSTORE_NAMESPACE` . If there's no host the policy will fail to apply 
3. if there's a traffic policy as defined in `demo/deploy-traffic-target.sh` and a traffic split as defined in `demo/deploy-traffic-split.sh`,  `bookbuyer` will talk to both `bookstore-v1` and `bookstore-v2` with a split in the traffic based on the weights and domain ( `spec.Service`) provided in the split.
4. if there's no traffic policy but a traffic split only as defined in `demo/deploy-traffic-split.sh`, `bookbuyer` cannot talk to `bookstore-v1` or `bookstore-v2` as there's no policy (OSM as of today is default deny all)

I will work on improving the demo to depict the above scenarios in a future PR

This PR resolves #668 