### PR TITLE
ads: Delete CLI param keepRootPrivateKeyInKubernetes

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -53,9 +53,6 @@ var (
 
 	injectorConfig injector.Config
 
-	// Enabling this will keep CA's private key in a K8s secret within the OSM namespace
-	keepRootPrivateKeyInKubernetes bool
-
 	// feature flag options
 	optionalFeatures featureflags.OptionalFeatures
 )
@@ -86,7 +83,6 @@ func init() {
 	flags.StringVar(&osmNamespace, "osmNamespace", "", "Namespace to which OSM belongs to.")
 	flags.StringVar(&webhookName, "webhookName", "", "Name of the MutatingWebhookConfiguration to be created by ADS")
 	flags.IntVar(&serviceCertValidityMinutes, "serviceCertValidityMinutes", defaultServiceCertValidityMinutes, "serviceCertValidityMinutes duration of a certificate in minutes")
-	flags.BoolVar(&keepRootPrivateKeyInKubernetes, "keepRootPrivateKeyInKubernetes", false, "Set to true to keep the CA's private key as a Kubernetes secret in the OSM's namespace")
 
 	// sidecar injector options
 	flags.BoolVar(&injectorConfig.DefaultInjection, "default-injection", true, "Enable sidecar injection by default")

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -81,14 +81,20 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 		"--osmNamespace", namespace,
 		"--init-container-image", initContainer,
 		"--sidecar-image", defaultEnvoyImage,
+
+		// A non-empty caBundleSecretName indicates that cert issuer
+		// should both read CA from and write CA to Kubernetes
+		// This also means that the root private key will be saved in a k8s secret.
+		// To disable this feature - delete this CLI param or set it to
+		// an empty string"".
 		"--caBundleSecretName", fmt.Sprintf("osm-ca-%s", osmID),
+
 		"--certmanager", os.Getenv("CERT_MANAGER"),
 		"--vaultHost", os.Getenv("VAULT_HOST"),
 		"--vaultProtocol", os.Getenv("VAULT_PROTOCOL"),
 		"--vaultToken", os.Getenv("VAULT_TOKEN"),
 		"--webhookName", fmt.Sprintf("osm-webhook-%s", osmID),
 		"--serviceCertValidityMinutes", "1", // Certificate validity length in minutes
-		"--keepRootPrivateKeyInKubernetes", "true",
 	}
 
 	if os.Getenv(common.IsGithubEnvVar) != "true" {

--- a/pkg/utils/certificate.go
+++ b/pkg/utils/certificate.go
@@ -1,1 +1,0 @@
-package utils


### PR DESCRIPTION
The goal of this PR is to simplify `ads` CLI.
Currently users have to supply `keepRootPrivateKeyInKubernetes=true` as well as non-empty `caBundleSecretName` to be able to save CA as a k8s secret.

This seems confusing.

This PR deletes `keepRootPrivateKeyInKubernetes` and relies on `caBundleSecretName` having a value or not to determine whether to enable the save-CA-to-k8s feature. 