### PR TITLE
feat(*) : Updating traffic access policy based on matches from TrafficSpec

### DIFF
--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -12,4 +12,5 @@ var (
 	errNamespaceDoesNotMatchCertificate      = errors.New("namespace does not match certificate")
 	errServiceNotFoundForAnyProvider         = errors.New("no service found for service account with any of the mesh supported providers")
 	errDomainNotFoundForService              = errors.New("no host/domain found to configure service")
+	errNoTrafficSpecFoundForTrafficPolicy    = errors.New("no traffic spec found for the traffic policy")
 )

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -53,7 +53,9 @@ var _ = Describe("Catalog tests", func() {
 					Namespace:      tests.Namespace,
 					Service:        tests.BookbuyerService,
 				},
-				Route: trafficpolicy.Route{PathRegex: "", Methods: nil},
+				Route: trafficpolicy.Route{PathRegex: tests.BookstoreBuyPath, Methods: []string{"GET"}, Headers: map[string]string{
+					"host": tests.Domain,
+				}},
 			}}
 
 			Expect(allTrafficPolicies).To(Equal(expected))
@@ -66,21 +68,19 @@ var _ = Describe("Catalog tests", func() {
 			actual, err := mc.getHTTPPathsPerRoute()
 			Expect(err).ToNot(HaveOccurred())
 
-			keyBuy := fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", tests.Namespace, tests.RouteGroupName, tests.BuyBooksMatchName)
-			keySell := fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", tests.Namespace, tests.RouteGroupName, tests.SellBooksMatchName)
-			expected := map[string]trafficpolicy.Route{
-				keyBuy: {
-					PathRegex: tests.BookstoreBuyPath,
-					Methods:   []string{"GET"},
-					Headers: map[string]string{
-						"host": tests.Domain,
-					},
-				},
-				keySell: {
-					PathRegex: tests.BookstoreSellPath,
-					Methods:   []string{"GET"},
-				},
-			}
+			specKey := fmt.Sprintf("HTTPRouteGroup/%s/%s", tests.Namespace, tests.RouteGroupName)
+			expected := map[string]map[string]trafficpolicy.Route{
+				specKey: map[string]trafficpolicy.Route{
+					tests.BuyBooksMatchName: {
+						PathRegex: tests.BookstoreBuyPath,
+						Methods:   []string{"GET"},
+						Headers: map[string]string{
+							"host": tests.Domain,
+						}},
+					tests.SellBooksMatchName: {
+						PathRegex: tests.BookstoreSellPath,
+						Methods:   []string{"GET"},
+					}}}
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -84,6 +84,9 @@ var (
 	RoutePolicy = trafficpolicy.Route{
 		PathRegex: BookstoreBuyPath,
 		Methods:   []string{"GET"},
+		Headers: map[string]string{
+			"host": Domain,
+		},
 	}
 
 	// Endpoint is an endpoint object.
@@ -125,25 +128,26 @@ var (
 			Namespace: "default",
 		},
 		Destination: target.IdentityBindingSubject{
-			Kind:      "BookstoreServiceAccount",
+			Kind:      "ServiceAccount",
 			Name:      BookstoreServiceAccountName,
 			Namespace: "default",
 		},
 		Sources: []target.IdentityBindingSubject{{
-			Kind:      "BookstoreServiceAccount",
+			Kind:      "ServiceAccount",
 			Name:      BookbuyerServiceAccountName,
 			Namespace: "default",
 		}},
 		Specs: []target.TrafficTargetSpec{{
 			Kind:    "HTTPRouteGroup",
 			Name:    RouteGroupName,
-			Matches: []string{"buy-books"},
+			Matches: []string{BuyBooksMatchName},
 		}},
 	}
 
 	// RoutePolicyMap is a map of a key to a route policy SMI object.
-	RoutePolicyMap = map[string]trafficpolicy.Route{
-		fmt.Sprintf("HTTPRouteGroup/%s/%s/%s", Namespace, TrafficTargetName, BuyBooksMatchName): RoutePolicy}
+	RoutePolicyMap = map[string]map[string]trafficpolicy.Route{
+		fmt.Sprintf("HTTPRouteGroup/%s/%s", Namespace, RouteGroupName): {
+			BuyBooksMatchName: RoutePolicy}}
 
 	// NamespacedServiceName is a namespaced service.
 	NamespacedServiceName = service.Name(fmt.Sprintf("%s/%s", BookstoreService.Namespace, BookstoreService.Service))
@@ -180,19 +184,21 @@ var (
 			Namespace: "default",
 			Name:      RouteGroupName,
 		},
-		Matches: []spec.HTTPMatch{{
-			Name:      BuyBooksMatchName,
-			PathRegex: BookstoreBuyPath,
-			Methods:   []string{"GET"},
-			Headers: map[string]string{
-				"host": Domain,
+		Matches: []spec.HTTPMatch{
+			{
+				Name:      BuyBooksMatchName,
+				PathRegex: BookstoreBuyPath,
+				Methods:   []string{"GET"},
+				Headers: map[string]string{
+					"host": Domain,
+				},
 			},
-		},
 			{
 				Name:      SellBooksMatchName,
 				PathRegex: BookstoreSellPath,
 				Methods:   []string{"GET"},
-			}},
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
As per the SMI Traffic policy : https://github.com/servicemeshinterface/smi-spec/blob/master/apis/traffic-access/v1alpha1/traffic-access.md ` The matches field is optional and if omitted, a rule is valid for all the matches in a traffic spec` 

This PR helps fulfilling this condition and applies either a specific `match` based on the `name` or applies all the matches for the `TrafficSpec` referenced in the `TrafficTarget` (policy).

This is a part of #449 