### PR TITLE
envoy: Use TLS for ingress

### DIFF
--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -1,0 +1,24 @@
+package lds
+
+import (
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/tests"
+)
+
+var _ = Describe("Test LDS response", func() {
+	Context("Test getInboundIngressFilterChain()", func() {
+		It("should return filter chain used for ingress", func() {
+			marshalledConnManager, err := envoy.MessageToAny(getHTTPConnectionManager("fake"))
+			Expect(err).ToNot(HaveOccurred())
+			filterChain, err := getInboundIngressFilterChain(tests.BookstoreService, marshalledConnManager)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(filterChain.FilterChainMatch.TransportProtocol).To(Equal(envoy.TransportProtocolTLS))
+			Expect(len(filterChain.Filters)).To(Equal(1))
+			Expect(filterChain.Filters[0].Name).To(Equal(wellknown.HTTPConnectionManager))
+		})
+	})
+})

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -38,6 +38,9 @@ const (
 
 	// ConnectionTimeout is the timeout duration used by Envoy to timeout connections
 	ConnectionTimeout = 5 * time.Second
+
+	// TransportProtocolTLS is the TLS transport protocol used in Envoy configurations
+	TransportProtocolTLS = "tls"
 )
 
 // GetAddress creates an Envoy Address struct.
@@ -147,11 +150,11 @@ func MessageToAny(pb proto.Message) (*any.Any, error) {
 }
 
 // GetDownstreamTLSContext creates a downstream Envoy TLS Context
-func GetDownstreamTLSContext(serviceName service.NamespacedService) *auth.DownstreamTlsContext {
+func GetDownstreamTLSContext(serviceName service.NamespacedService, mTLS bool) *auth.DownstreamTlsContext {
 	tlsConfig := &auth.DownstreamTlsContext{
 		CommonTlsContext: getCommonTLSContext(serviceName),
 		// When RequireClientCertificate is enabled trusted CA certs must be provided via ValidationContextType
-		RequireClientCertificate: &wrappers.BoolValue{Value: true},
+		RequireClientCertificate: &wrappers.BoolValue{Value: mTLS},
 	}
 	return tlsConfig
 }

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetDownstreamTLSContext()", func() {
 		It("should return TLS context", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreService)
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, true)
 
 			expectedTLSContext := envoy_api_v2_auth.DownstreamTlsContext{
 				CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
@@ -74,6 +74,20 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificateSdsSecretConfigs))
 			Expect(tlsContext.CommonTlsContext.ValidationContextType).To(Equal(expectedTLSContext.CommonTlsContext.ValidationContextType))
 			Expect(*tlsContext).To(Equal(expectedTLSContext))
+		})
+	})
+
+	Context("Test GetDownstreamTLSContext() for mTLS", func() {
+		It("should return TLS context with client certificate validation enabled", func() {
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, true)
+			Expect(*tlsContext.RequireClientCertificate).To(Equal(wrappers.BoolValue{Value: true}))
+		})
+	})
+
+	Context("Test GetDownstreamTLSContext() for TLS", func() {
+		It("should return TLS context with client certificate validation disabled", func() {
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, false)
+			Expect(*tlsContext.RequireClientCertificate).To(Equal(wrappers.BoolValue{Value: false}))
 		})
 	})
 


### PR DESCRIPTION
Previously envoy was configured to accept plaintext ingress
traffic. This change updates the ingress configuration to
only accept TLS traffic for ingress.

Part of #666