### PR TITLE
feat(*) : Allowing all paths and methods if not specified in TrafficSpec with headers 

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -80,7 +80,14 @@ var _ = Describe("Catalog tests", func() {
 					trafficpolicy.TrafficSpecMatchName(tests.SellBooksMatchName): {
 						PathRegex: tests.BookstoreSellPath,
 						Methods:   []string{"GET"},
-					}}}
+					},
+					trafficpolicy.TrafficSpecMatchName(tests.WildcardWithHeadersMatchName): {
+						PathRegex: ".*",
+						Methods:   []string{"*"},
+						Headers: map[string]string{
+							"host": tests.Domain,
+						}}},
+			}
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -42,6 +42,9 @@ const (
 	// SellBooksMatchName is the name of the match object.
 	SellBooksMatchName = "sell-books"
 
+	// WildcardWithHeadersMatchName is the name of the match object.
+	WildcardWithHeadersMatchName = "allow-everything-on-header"
+
 	// Domain is a domain
 	Domain = "contoso.com"
 
@@ -197,6 +200,12 @@ var (
 				Name:      SellBooksMatchName,
 				PathRegex: BookstoreSellPath,
 				Methods:   []string{"GET"},
+			},
+			{
+				Name: WildcardWithHeadersMatchName,
+				Headers: map[string]string{
+					"host": Domain,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
According the the SMI TrafficSpec `When pathRegex and methods are not defined, the header filters are applied to any path and all HTTP methods` . This PR has changes to address this.

This is a part of the changes for #449 