### PR TITLE
demo: Adding tail-vault.sh helper

### DIFF
--- a/demo/tail-vault.sh
+++ b/demo/tail-vault.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+POD="$(kubectl get pods -n "$K8S_NAMESPACE" --selector app=vault --no-headers | awk '{print $1}' | head -n1)"
+
+kubectl logs "${POD}" -n "$K8S_NAMESPACE" -f


### PR DESCRIPTION
Adding a helper script to assist with tailing the logs of the Vault pod.

This is part of the work around https://github.com/open-service-mesh/osm/issues/588

This PR is a chunk from https://github.com/open-service-mesh/osm/pull/706