### PR TITLE
Adding vaultRole CLI parameter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ export OSM_LOG_KUBERNETES_EVENTS=true
 # optional: Token to be shared between components (and used by the temporary instance of Vault)
 export VAULT_TOKEN=abcd
 
+# optional: Name of the Vault role dedicated to OSM
+export VAULT_ROLE=open-service-mesh
+
 ### The section below configures certificates management
 ### OSM has 2 ways to manage certificates
 ### Set CERT_MANAGER to "tresor" to use the internal system (relies on k8s secrets)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,7 @@ jobs:
         VAULT_PROTOCOL: "http"
         VAULT_PORT: "8200"
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+        VAULT_ROLE: "open-service-mesh"
       run: |
         touch .env  # it is ok keep this empty
         echo "Ensure K8s namespace $K8S_NAMESPACE is clean from previous runs"

--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -73,6 +73,7 @@ var (
 	vaultHost     = flags.String("vaultHost", "vault.default.svc.cluster.local", "Host name of the Hashi Vault")
 	vaultPort     = flags.Int("vaultPort", 8200, "Port of the Hashi Vault")
 	vaultToken    = flags.String("vaultToken", "", "Secret token for the the Hashi Vault")
+	vaultRole     = flags.String("vaultRole", "open-service-mesh", "Name of the Vault role dedicated to Open Service Mesh")
 )
 
 func init() {

--- a/cmd/ads/certificates.go
+++ b/cmd/ads/certificates.go
@@ -173,7 +173,7 @@ func getHashiVaultCertManager(_ *rest.Config) certificate.Manager {
 
 	// A Vault address would have the following shape: "http://vault.default.svc.cluster.local:8200"
 	vaultAddr := fmt.Sprintf("%s://%s:%d", *vaultProtocol, *vaultHost, *vaultPort)
-	vaultCertManager, err := vault.NewCertManager(vaultAddr, *vaultToken, getServiceCertValidityPeriod())
+	vaultCertManager, err := vault.NewCertManager(vaultAddr, *vaultToken, getServiceCertValidityPeriod(), *vaultRole)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error instantiating Hashicorp Vault as a Certificate Manager")
 	}

--- a/cmd/osm/install.go
+++ b/cmd/osm/install.go
@@ -49,6 +49,7 @@ type installCmd struct {
 	vaultHost               string
 	vaultProtocol           string
 	vaultToken              string
+	vaultRole               string
 }
 
 func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
@@ -75,6 +76,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.vaultHost, "vault-host", "", "Hashicorp Vault host/service - where Vault is installed")
 	f.StringVar(&inst.vaultProtocol, "vault-protocol", defaultVaultProtocol, "protocol to use to connect to Vault")
 	f.StringVar(&inst.vaultToken, "vault-token", "", "token that should be used to connect to Vault")
+	f.StringVar(&inst.vaultRole, "vault-role", "open-service-mesh", "Vault role to be used by Open Service Mesh")
 
 	return cmd
 }

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -93,6 +93,7 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 		"--vaultHost", os.Getenv("VAULT_HOST"),
 		"--vaultProtocol", os.Getenv("VAULT_PROTOCOL"),
 		"--vaultToken", os.Getenv("VAULT_TOKEN"),
+		"--vaultRole", os.Getenv("VAULT_ROLE"),
 		"--webhookName", fmt.Sprintf("osm-webhook-%s", osmID),
 		"--serviceCertValidityMinutes", "1", // Certificate validity length in minutes
 	}

--- a/pkg/certificate/providers/vault/ca.go
+++ b/pkg/certificate/providers/vault/ca.go
@@ -10,8 +10,7 @@ import (
 )
 
 const (
-	vaultRole = "open-service-mesh"
-	maxTTL    = 3 * time.Minute
+	maxTTL = 3 * time.Minute
 )
 
 // NewCA creates a new certification authority within Hashi Vault. Returns the new root certificate WITHOUT the private key.
@@ -31,12 +30,12 @@ func (cm *CertManager) NewCA(cn certificate.CommonName, validity time.Duration) 
 		"max_ttl":           getDurationInMinutes(maxTTL),
 	}
 
-	if _, err := cm.client.Logical().Write(getRoleConfigURL(), options); err != nil {
+	if _, err := cm.client.Logical().Write(getRoleConfigURL(cm.vaultRole), options); err != nil {
 		return nil, err
 	}
 
 	// Ensure cert generation has been initialized correctly
-	secret, err := cm.client.Logical().Write(getIssueURL(), getIssuanceData("localhost", cm.validity))
+	secret, err := cm.client.Logical().Write(getIssueURL(cm.vaultRole), getIssuanceData("localhost", cm.validity))
 	if err != nil {
 		log.Error().Err(err).Msg("Error creating a test certificate with the newly instantiated Hashi Vault client")
 		return nil, err

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -23,12 +23,13 @@ const (
 )
 
 // NewCertManager implements certificate.Manager and wraps a Hashi Vault with methods to allow easy certificate issuance.
-func NewCertManager(vaultAddr, token string, validity time.Duration) (*CertManager, error) {
+func NewCertManager(vaultAddr, token string, validity time.Duration, vaultRole string) (*CertManager, error) {
 	cache := make(map[certificate.CommonName]certificate.Certificater)
 	c := &CertManager{
 		validity:      validity,
 		announcements: make(chan interface{}),
 		cache:         &cache,
+		vaultRole:     vaultRole,
 	}
 	config := api.DefaultConfig()
 	config.Address = vaultAddr
@@ -69,7 +70,7 @@ func NewCertManager(vaultAddr, token string, validity time.Duration) (*CertManag
 }
 
 func (cm *CertManager) issue(cn certificate.CommonName, validity *time.Duration) (certificate.Certificater, error) {
-	secret, err := cm.client.Logical().Write(getIssueURL(), getIssuanceData(cn, cm.validity))
+	secret, err := cm.client.Logical().Write(getIssueURL(cm.vaultRole), getIssuanceData(cn, cm.validity))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing new certificate for CN=%s", cn)
 		return nil, err

--- a/pkg/certificate/providers/vault/tools.go
+++ b/pkg/certificate/providers/vault/tools.go
@@ -11,11 +11,11 @@ func getDurationInMinutes(validity time.Duration) string {
 	return fmt.Sprintf("%dh", validity/time.Hour)
 }
 
-func getIssueURL() string {
+func getIssueURL(vaultRole string) string {
 	return fmt.Sprintf("pki/issue/%+v", vaultRole)
 }
 
-func getRoleConfigURL() string {
+func getRoleConfigURL(vaultRole string) string {
 	return fmt.Sprintf("pki/roles/%s", vaultRole)
 }
 

--- a/pkg/certificate/providers/vault/tools_test.go
+++ b/pkg/certificate/providers/vault/tools_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -10,6 +11,8 @@ import (
 )
 
 var _ = Describe("Test tools", func() {
+	vaultRole := "open-service-mesh"
+
 	Context("Test converting duration into Vault recognizable string", func() {
 		It("converts 36 hours into correct string representation", func() {
 			actual := getDurationInMinutes(2160 * time.Minute)
@@ -20,16 +23,16 @@ var _ = Describe("Test tools", func() {
 
 	Context("Test cert issuance URL", func() {
 		It("creates the URL for issuing a new certificate", func() {
-			actual := getIssueURL()
-			expected := "pki/issue/open-service-mesh"
+			actual := getIssueURL(vaultRole)
+			expected := fmt.Sprintf("pki/issue/%s", vaultRole)
 			Expect(actual).To(Equal(expected))
 		})
 	})
 
 	Context("Test role config URL", func() {
 		It("creates the URL for role configuration", func() {
-			actual := getRoleConfigURL()
-			expected := "pki/roles/open-service-mesh"
+			actual := getRoleConfigURL(vaultRole)
+			expected := fmt.Sprintf("pki/roles/%s", vaultRole)
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -25,4 +25,7 @@ type CertManager struct {
 
 	// Hashicorp Vault client
 	client *api.Client
+
+	// The Vault role configured for OSM and passed as a CLI.
+	vaultRole string
 }


### PR DESCRIPTION
We have `vaultRole` hard coded as `"open-service-mesh"`

To provide flexibility and prepare for launch - we are moving `vaultRole` to a configurable optional CLI param with a reasonable default.

The Vault role would be created and configured by the Vault administrator - typically security team of some sort.  In our demo and CI cases - we have `deploy-vault.sh` script, which creates the Vault pod, creates CA and **role** and configures these. (See: https://github.com/open-service-mesh/osm/pull/707/files#diff-ce34bd1610bf53ea01b2899e19a35c96R54)

This is part of the work around https://github.com/open-service-mesh/osm/issues/588

This PR is a chunk from https://github.com/open-service-mesh/osm/pull/706