### PR TITLE
s/validity/validityPeriod/

### DIFF
--- a/cmd/ads/certificates.go
+++ b/cmd/ads/certificates.go
@@ -52,7 +52,7 @@ func getPossibleCertManagers() []string {
 }
 
 func getNewRootCertFromTresor(kubeClient kubernetes.Interface, namespace, caBundleSecretName string) certificate.Certificater {
-	rootCert, err := tresor.NewCA(constants.CertificationAuthorityCommonName, constants.CertificationAuthorityRootExpiration, rootCertCountry, rootCertLocality, rootCertOrganization)
+	rootCert, err := tresor.NewCA(constants.CertificationAuthorityCommonName, constants.CertificationAuthorityRootValidityPeriod, rootCertCountry, rootCertLocality, rootCertOrganization)
 
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to create new Certificate Authority with cert issuer %s", *certManagerKind)
@@ -84,13 +84,13 @@ func getTresorCertificateManager(kubeConfig *rest.Config) certificate.Manager {
 	// A non-empty caBundleSecretName indicates to the certificate issuer to
 	// load the CA from the given k8s secret within the namespace where OSM is install.d
 	// An empty string or nil value would not load or save/load CA.
-	if caBundleSecretName != nil || *caBundleSecretName != "" {
-		rootCert = getCertFromKubernetes(kubeClient, osmNamespace, *caBundleSecretName)
+	if caBundleSecretName != "" {
+		rootCert = getCertFromKubernetes(kubeClient, osmNamespace, caBundleSecretName)
 	}
 
 	if rootCert == nil {
 		// A non-empty caBundleSecretName will save the CA and its private key as a kubernetes secret.
-		rootCert = getNewRootCertFromTresor(kubeClient, osmNamespace, *caBundleSecretName)
+		rootCert = getNewRootCertFromTresor(kubeClient, osmNamespace, caBundleSecretName)
 	}
 
 	certManager, err := tresor.NewCertManager(rootCert, getServiceCertValidityPeriod(), rootCertOrganization)

--- a/demo/cmd/deploy/xds/config.go
+++ b/demo/cmd/deploy/xds/config.go
@@ -95,7 +95,7 @@ func generateXDSPod(namespace string) *apiv1.Pod {
 		"--vaultToken", os.Getenv("VAULT_TOKEN"),
 		"--vaultRole", os.Getenv("VAULT_ROLE"),
 		"--webhookName", fmt.Sprintf("osm-webhook-%s", osmID),
-		"--serviceCertValidityMinutes", "1", // Certificate validity length in minutes
+		"--serviceCertValidityMinutes", "1", // Certificate TTL in minutes
 	}
 
 	if os.Getenv(common.IsGithubEnvVar) != "true" {

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -15,7 +15,7 @@ import (
 )
 
 // NewCA creates a new Certificate Authority.
-func NewCA(cn certificate.CommonName, validity time.Duration, rootCertCountry, rootCertLocality, rootCertOrganization string) (certificate.Certificater, error) {
+func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCountry, rootCertLocality, rootCertOrganization string) (certificate.Certificater, error) {
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
 		return nil, errors.Wrap(err, errGeneratingSerialNumber.Error())
@@ -31,7 +31,7 @@ func NewCA(cn certificate.CommonName, validity time.Duration, rootCertCountry, r
 			Organization: []string{rootCertOrganization},
 		},
 		NotBefore:             now,
-		NotAfter:              now.Add(validity),
+		NotAfter:              now.Add(validityPeriod),
 		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		IsCA:                  true,

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -70,7 +70,7 @@ func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
 }
 
 // NewCertManager creates a new CertManager with the passed CA and CA Private Key
-func NewCertManager(ca certificate.Certificater, validity time.Duration, certificatesOrganization string) (*CertManager, error) {
+func NewCertManager(ca certificate.Certificater, validityPeriod time.Duration, certificatesOrganization string) (*CertManager, error) {
 	if ca == nil {
 		return nil, errNoIssuingCA
 	}
@@ -82,7 +82,7 @@ func NewCertManager(ca certificate.Certificater, validity time.Duration, certifi
 		ca: ca,
 
 		// Newly issued certificates will be valid for this duration
-		validityPeriod: validity,
+		validityPeriod: validityPeriod,
 
 		// Channel used to inform other components of cert changes (rotation etc.)
 		announcements: make(chan interface{}),

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -98,7 +98,7 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 }
 
 // IssueCertificate implements certificate.Manager and returns a newly issued certificate.
-func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validity *time.Duration) (certificate.Certificater, error) {
+func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPeriod *time.Duration) (certificate.Certificater, error) {
 	log.Info().Msgf("Issuing new certificate for CN=%s, which will expire in %+v", cn, cm.validityPeriod)
 
 	start := time.Now()
@@ -107,7 +107,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validity *tim
 		return cert, nil
 	}
 
-	cert, err := cm.issue(cn, validity)
+	cert, err := cm.issue(cn, validityPeriod)
 	if err != nil {
 		return cert, err
 	}

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -34,7 +34,7 @@ var (
 
 // CertManager implements certificate.Manager
 type CertManager struct {
-	// How long will newly issued certificates be valid for
+	// Period for which the newly issued certificate will be valid.
 	validityPeriod time.Duration
 
 	// The Certificate Authority root certificate to be used by this certificate manager

--- a/pkg/certificate/providers/vault/tools.go
+++ b/pkg/certificate/providers/vault/tools.go
@@ -7,8 +7,8 @@ import (
 	"github.com/open-service-mesh/osm/pkg/certificate"
 )
 
-func getDurationInMinutes(validity time.Duration) string {
-	return fmt.Sprintf("%dh", validity/time.Hour)
+func getDurationInMinutes(validityPeriod time.Duration) string {
+	return fmt.Sprintf("%dh", validityPeriod/time.Hour)
 }
 
 func getIssueURL(vaultRole string) string {
@@ -19,9 +19,9 @@ func getRoleConfigURL(vaultRole string) string {
 	return fmt.Sprintf("pki/roles/%s", vaultRole)
 }
 
-func getIssuanceData(cn certificate.CommonName, validity time.Duration) map[string]interface{} {
+func getIssuanceData(cn certificate.CommonName, validityPeriod time.Duration) map[string]interface{} {
 	return map[string]interface{}{
 		"common_name": cn.String(),
-		"ttl":         getDurationInMinutes(validity),
+		"ttl":         getDurationInMinutes(validityPeriod),
 	}
 }

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -11,7 +11,7 @@ import (
 // CertManager implements certificate.Manager and contains a Hashi Vault client instance.
 type CertManager struct {
 	// How long will newly issued certificates be valid for
-	validity time.Duration
+	validityPeriod time.Duration
 
 	// The Certificate Authority root certificate to be used by this certificate manager
 	ca certificate.Certificater

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -66,8 +66,8 @@ const (
 	// CertificationAuthorityCommonName is the CN used for the root certificate for OSM.
 	CertificationAuthorityCommonName = "Open Service Mesh Certification Authority"
 
-	// CertificationAuthorityRootExpiration is when the root certificate expires
-	CertificationAuthorityRootExpiration = 87600 * time.Hour // a decade
+	// CertificationAuthorityRootValidityPeriod is when the root certificate expires
+	CertificationAuthorityRootValidityPeriod = 87600 * time.Hour // a decade
 
 	// XDSCertificateValidityPeriod is the TTL of the certificates used for Envoy to xDS communication.
 	XDSCertificateValidityPeriod = 87600 * time.Hour // a decade


### PR DESCRIPTION
This PR consistently names `validity` into `validityPeriod` anywhere we use `validity` for the TTL of a certificate.