### PR TITLE
feat(*) : Integrating TrafficSpec v1alpha2 features (http headers) with OSM 

### DIFF
--- a/demo/deploy-traffic-spec.sh
+++ b/demo/deploy-traffic-spec.sh
@@ -21,6 +21,8 @@ matches:
   - GET
   headers:
   - host: "bookstore-mesh.$BOOKSTORE_NAMESPACE"
+  - "user-agent": ".*-http-client/*.*"
+  - "client-app": "bookbuyer"
 - name: buy-a-book
   pathRegex: ".*a-book.*new"
   methods: 

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -12,8 +12,8 @@ const (
 	//HTTPTraffic specifies HTTP Traffic Policy
 	HTTPTraffic = "HTTPRouteGroup"
 
-	//HostHeader specifies the host header key
-	HostHeader = "host"
+	//HostHeaderKey specifies the host header key
+	HostHeaderKey = "host"
 )
 
 // ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
@@ -69,7 +69,7 @@ func (mc *MeshCatalog) GetDomainForService(nsService service.NamespacedService, 
 		}
 	}
 	//service not referenced in traffic split, check if the traffic policy has the host header as a part of the route spec
-	hostName, hostExists := routeHeaders[HostHeader]
+	hostName, hostExists := routeHeaders[HostHeaderKey]
 	if hostExists {
 		return hostName, nil
 	}


### PR DESCRIPTION
This PR has changes to configure OSM's envoy's with headers on the HTTP route based on what is specified in the SMI `TrafficSpec`

- The demo has been updated to make requests on `/books-bought ` with a custom header called `osm-custom-header` and the `./demo/deploy-traffic-spec.sh` has the same header (both key and value)  specified.
- Tests have been updated

With this PR we will finally resolve #449 