### PR TITLE
ci: Trim logs fetched from demo pods on failure

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/open-service-mesh/osm/ci/cmd/maestro"
+	"github.com/open-service-mesh/osm/demo/cmd/common"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/logger"
 )
@@ -113,8 +115,8 @@ func main() {
 
 	bookBuyerLogs := maestro.GetPodLogs(kubeClient, bookbuyerNS, bookBuyerPodName, bookBuyerLabel, maestro.FailureLogsFromTimeSince)
 	bookThiefLogs := maestro.GetPodLogs(kubeClient, bookthiefNS, bookThiefPodName, bookThiefLabel, maestro.FailureLogsFromTimeSince)
-	fmt.Println("-------- Bookbuyer LOGS --------\n", bookBuyerLogs)
-	fmt.Println("-------- Bookthief LOGS --------\n", bookThiefLogs)
+	fmt.Println("-------- Bookbuyer LOGS --------\n", cutIt(bookBuyerLogs))
+	fmt.Println("-------- Bookthief LOGS --------\n", cutIt(bookThiefLogs))
 
 	osmPodName, err := maestro.GetPodName(kubeClient, osmNamespace, adsPodSelector)
 	if err != nil {
@@ -124,6 +126,22 @@ func main() {
 	fmt.Println("-------- ADS LOGS --------\n", maestro.GetPodLogs(kubeClient, osmNamespace, osmPodName, "", maestro.FailureLogsFromTimeSince))
 
 	os.Exit(1)
+}
+
+func cutItAt(logs string, at string) string {
+	firstOccurrence := strings.Index(logs, at)
+	if firstOccurrence == -1 {
+		return logs
+	}
+	return logs[:firstOccurrence+len(at)]
+}
+
+func cutIt(logs string) string {
+	firstSuccess := strings.Index(logs, common.Success)
+	if firstSuccess == -1 {
+		return cutItAt(logs, common.Failure)
+	}
+	return cutItAt(logs, common.Success)
 }
 
 func maxWait() time.Duration {

--- a/ci/cmd/maestro_test.go
+++ b/ci/cmd/maestro_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/demo/cmd/common"
+)
+
+var _ = Describe("Test maestro", func() {
+
+	Context("Test cutIt", func() {
+		It("cuts it at success", func() {
+			str := fmt.Sprintf("foo bar %s baz", common.Success)
+			actual := cutIt(str)
+			expected := fmt.Sprintf("foo bar %s", common.Success)
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("cuts it at failure", func() {
+			str := fmt.Sprintf("foo bar %s baz baz", common.Failure)
+			actual := cutIt(str)
+			expected := fmt.Sprintf("foo bar %s", common.Failure)
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+})

--- a/ci/cmd/suite_test.go
+++ b/ci/cmd/suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Maestro Test Suite")
+}


### PR DESCRIPTION
We know that when `common.Success` or `common.Failure` are emitted in `stdout` by `bookbuyer` or `bookthief` - this is all we care about - the logs after that do not matter much.

So let's cut these out to lower the amount of logs we show in CI and make this easier to scroll through.