### PR TITLE
demo: fix connection leaks while making HTTP requests

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -54,10 +54,10 @@ func GetBooks(participantName string, expectedResponseCode int) {
 	}
 
 	// Count how many times we have reached out to the bookstore
-	var iteration int64 = 0
+	var iteration int64
 
 	// Count how many times BOTH urls have returned the expected status code
-	var successCount int64 = 0
+	var successCount int64
 
 	// Keep state of the previous success/failure so we know when things regress
 	previouslySucceeded := false
@@ -134,9 +134,11 @@ func fetch(url string) (responseCode int) {
 	}
 	fmt.Printf("\nFetching %s\n", req.URL)
 	fmt.Printf("Request Headers: %v\n", req.Header)
-	if resp, err := client.Do(req); err != nil {
+	resp, err := client.Do(req)
+	if err != nil {
 		fmt.Printf("Error fetching %s: %s\n", url, err)
 	} else {
+		defer resp.Body.Close()
 		responseCode = resp.StatusCode
 		for _, hdr := range interestingHeaders {
 			fmt.Printf("%s: %s\n", hdr, getHeader(resp.Header, hdr))


### PR DESCRIPTION
There is a bug where http clients are not freeing connections,
resulting in connection leaks.
Per https://golang.org/pkg/net/http/#Client, http clients must
close the response body to free up the connection and associated
resoureces.

Without this, successful connections always remain active and
new connections will fail when max active connections are reached.
This was resulting in request failure when active connections in
Envoy (cx_active) reached the max of 512 connections.

Also fixes a linting issue.