### PR TITLE
fix(charts): rm ":" before rentention time config

### DIFF
--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         args:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus/
-        - --storage.tsdb.retention.time=:{{.Values.prometheus.retention.time}}
+        - --storage.tsdb.retention.time={{.Values.prometheus.retention.time}}
         - --web.listen-address=:{{.Values.prometheus.port}}
         image: prom/prometheus:v2.18.1
         imagePullPolicy: Always


### PR DESCRIPTION
this is causing problems with starting the prometheus deployment