### PR TITLE
ref(cmd/osm): update delete-osm cmd, silence usage

### DIFF
--- a/cmd/osm/admin.go
+++ b/cmd/osm/admin.go
@@ -17,7 +17,7 @@ of osm installations.
 func newAdminCmd(config *action.Configuration, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "admin",
-		Short: "admin osm installs",
+		Short: "manage osm installations",
 		Long:  adminDescription,
 		Args:  require.NoArgs,
 	}

--- a/cmd/osm/osm.go
+++ b/cmd/osm/osm.go
@@ -24,9 +24,10 @@ var settings = cli.New()
 
 func newRootCmd(config *action.Configuration, out io.Writer, args []string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "osm",
-		Short: "Install and manage open service mesh",
-		Long:  globalUsage,
+		Use:          "osm",
+		Short:        "Install and manage open service mesh",
+		Long:         globalUsage,
+		SilenceUsage: true,
 	}
 
 	cmd.PersistentFlags().AddGoFlagSet(goflag.CommandLine)

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -84,10 +84,10 @@ make build-osm
 
 if [[ "$IS_GITHUB" != "true" ]]; then
     # In Github CI we always use a new namespace - so this is not necessary
-    bin/osm admin delete-osm "$OSM_ID" || true
+    bin/osm admin delete-osm --namespace "$K8S_NAMESPACE" || true
     ./demo/clean-kubernetes.sh
 else
-    bin/osm admin delete-osm "$OSM_ID" || true
+    bin/osm admin delete-osm --namespace "$K8S_NAMESPACE" || true
 fi
 
 # The demo uses osm's namespace as defined by environment variables, K8S_NAMESPACE


### PR DESCRIPTION
* remove reference to to osm id for `osm admin delete-osm`
cmd, replace with namespace flag
* silence usage help text on every error (distracts from err)
* update demo where delete-osm command is used