### PR TITLE
ref(charts): rm NodePort service for ads

### DIFF
--- a/charts/osm/templates/osm-service.yaml
+++ b/charts/osm/templates/osm-service.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: ads
 spec:
-  type: NodePort
   ports:
     - name: ads-port
       port: 15128


### PR DESCRIPTION
* We don't need a NodePort service for ads bc
we do not need to access ads from outside the cluster.
Removing this line will allow the service type to
resolve to the default of ClusterIP