### PR TITLE
Moving CI_MIN_SUCCESS_THRESHOLD from github secrets to in-repo workflow/main.yaml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
         IS_GITHUB: true
         ACR: ${{ secrets.ACR }}
         CI_MAX_WAIT_FOR_POD_TIME_SECONDS: ${{ secrets.CI_MAX_WAIT_FOR_POD_TIME_SECONDS }}
-        CI_MIN_SUCCESS_THRESHOLD: ${{ secrets.CI_MIN_SUCCESS_THRESHOLD }}
+        CI_MIN_SUCCESS_THRESHOLD: 1
         OSM_HUMAN_DEBUG_LOG: ${{ secrets.OSM_HUMAN_DEBUG_LOG }}
         CERT_MANAGER: "tresor"
       run: |
@@ -188,7 +188,7 @@ jobs:
         IS_GITHUB: true
         ACR: ${{ secrets.ACR }}
         CI_MAX_WAIT_FOR_POD_TIME_SECONDS: ${{ secrets.CI_MAX_WAIT_FOR_POD_TIME_SECONDS }}
-        CI_MIN_SUCCESS_THRESHOLD: ${{ secrets.CI_MIN_SUCCESS_THRESHOLD }}
+        CI_MIN_SUCCESS_THRESHOLD: 1
         OSM_HUMAN_DEBUG_LOG: ${{ secrets.OSM_HUMAN_DEBUG_LOG }}
         CERT_MANAGER: "vault"  # enables Hashi Vault integration
         VAULT_HOST: "vault.ci-${{ github.run_id }}-${{ github.run_number}}-hashivault.svc.cluster.local"


### PR DESCRIPTION
Last week we added `CI_MIN_SUCCESS_THRESHOLD` as a Github secret.  This is/was set to 1.
Because it is in a Github secret - every time we see a `1` in stdout of the CI system - it gets rewritten to `***`

It should not be a problem to move this variable inside `.github/workflows/main.yml` and tweak it from there by submitting PRs.