### PR TITLE
trafficpolicy: remove unused field for TrafficResource

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -177,13 +177,11 @@ func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[trafficpolicy.T
 			policy := trafficpolicy.TrafficTarget{}
 			policy.Name = trafficTargets.Name
 			policy.Destination = trafficpolicy.TrafficResource{
-				ServiceAccount: service.Account(trafficTargets.Destination.Name),
-				Namespace:      trafficTargets.Destination.Namespace,
-				Service:        destService}
+				Namespace: trafficTargets.Destination.Namespace,
+				Service:   destService}
 			policy.Source = trafficpolicy.TrafficResource{
-				ServiceAccount: service.Account(trafficSources.Name),
-				Namespace:      trafficSources.Namespace,
-				Service:        srcServices}
+				Namespace: trafficSources.Namespace,
+				Service:   srcServices}
 
 			for _, trafficTargetSpecs := range trafficTargets.Specs {
 				if trafficTargetSpecs.Kind != HTTPTraffic {

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -44,14 +44,12 @@ var _ = Describe("Catalog tests", func() {
 			expected := []trafficpolicy.TrafficTarget{{
 				Name: tests.TrafficTargetName,
 				Destination: trafficpolicy.TrafficResource{
-					ServiceAccount: tests.BookstoreServiceAccountName,
-					Namespace:      tests.Namespace,
-					Service:        tests.BookstoreService,
+					Namespace: tests.Namespace,
+					Service:   tests.BookstoreService,
 				},
 				Source: trafficpolicy.TrafficResource{
-					ServiceAccount: tests.BookbuyerServiceAccountName,
-					Namespace:      tests.Namespace,
-					Service:        tests.BookbuyerService,
+					Namespace: tests.Namespace,
+					Service:   tests.BookbuyerService,
 				},
 				Route: trafficpolicy.Route{PathRegex: tests.BookstoreBuyPath, Methods: []string{"GET"}, Headers: map[string]string{
 					"host": tests.Domain,

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -102,14 +102,12 @@ var (
 	TrafficPolicy = trafficpolicy.TrafficTarget{
 		Name: TrafficTargetName,
 		Destination: trafficpolicy.TrafficResource{
-			ServiceAccount: BookstoreServiceAccountName,
-			Namespace:      Namespace,
-			Service:        BookstoreService,
+			Namespace: Namespace,
+			Service:   BookstoreService,
 		},
 		Source: trafficpolicy.TrafficResource{
-			ServiceAccount: BookbuyerServiceAccountName,
-			Namespace:      Namespace,
-			Service:        BookbuyerService,
+			Namespace: Namespace,
+			Service:   BookbuyerService,
 		},
 		Route: trafficpolicy.Route{
 			PathRegex: BookstoreBuyPath,

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -28,9 +28,8 @@ type TrafficTarget struct {
 
 //TrafficResource is a struct of the various resources of a source/destination in the TrafficPolicy
 type TrafficResource struct {
-	ServiceAccount service.Account           `json:"service_account:omitempty"`
-	Namespace      string                    `json:"namespace:omitempty"`
-	Service        service.NamespacedService `json:"services:omitempty"`
+	Namespace string                    `json:"namespace:omitempty"`
+	Service   service.NamespacedService `json:"services:omitempty"`
 }
 
 //RouteWeightedClusters is a struct of a route and the weighted clusters on that route


### PR DESCRIPTION
ServiceAccount is not required in a TrafficResource and is unused while
applying traffic policies.