### PR TITLE
Add Inbound and Outbound server names to MatchSubjectAltNames

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -279,8 +279,11 @@ type MeshCataloger interface {
 	// ListTrafficPolicies constructs a list of all the traffic policies /routes the given Envoy proxy should be aware of.
 	ListTrafficPolicies(endpoint.NamespacedService) ([]endpoint.TrafficPolicy, error)
 
-	// ListAllowedPeerServices lists the server names allowed to connect to the given downstream service.
-	ListAllowedPeerServices(service.NamespacedService) ([]service.NamespacedService, error) {
+	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
+	ListAllowedInboundServices(service.NamespacedService) ([]service.NamespacedService, error)
+
+	// ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
+	ListAllowedOutboundServices(service.NamespacedService) ([]service.NamespacedService, error)
 
 	// GetCertificateForService returns the SSL Certificate for the given service.
 	// This certificate will be used for service-to-service mTLS.

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -101,10 +101,10 @@ var _ = Describe("Catalog tests", func() {
 		})
 	})
 
-	Context("Test ListAllowedPeerServices()", func() {
+	Context("Test ListAllowedInboundServices()", func() {
 		It("returns the list of server names allowed to communicate with the hosted service", func() {
 			mc := NewFakeMeshCatalog(testclient.NewSimpleClientset())
-			actualList, err := mc.ListAllowedPeerServices(tests.BookstoreService)
+			actualList, err := mc.ListAllowedInboundServices(tests.BookstoreService)
 			Expect(err).ToNot(HaveOccurred())
 			expectedList := []service.NamespacedService{tests.BookbuyerService}
 			Expect(actualList).To(Equal(expectedList))
@@ -145,6 +145,17 @@ var _ = Describe("Catalog tests", func() {
 			Expect(cmp.Equal(trafficTarget.Destination, expectedDestinationTrafficResource)).To(BeTrue())
 			Expect(cmp.Equal(trafficTarget.Route.PathRegex, expectedRoute.PathRegex)).To(BeTrue())
 			Expect(cmp.Equal(trafficTarget.Route.Methods, expectedRoute.Methods)).To(BeTrue())
+		})
+	})
+
+	Context("Test ListAllowedOutboundServices()", func() {
+		It("returns the list of server names the given service is allowed to communicate with", func() {
+			mc := NewFakeMeshCatalog(testclient.NewSimpleClientset())
+			actualList, err := mc.ListAllowedOutboundServices(tests.BookbuyerService)
+			Expect(err).ToNot(HaveOccurred())
+			expectedList := []service.NamespacedService{tests.BookstoreService}
+			Expect(actualList).To(Equal(expectedList))
+
 		})
 	})
 })

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -51,8 +51,11 @@ type MeshCataloger interface {
 	// ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
 	ListTrafficPolicies(service.NamespacedService) ([]trafficpolicy.TrafficTarget, error)
 
-	// ListAllowedPeerServices lists the services allowed to connect to the given downstream service (argument to this function).
-	ListAllowedPeerServices(service.NamespacedService) ([]service.NamespacedService, error)
+	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
+	ListAllowedInboundServices(service.NamespacedService) ([]service.NamespacedService, error)
+
+	// ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
+	ListAllowedOutboundServices(service.NamespacedService) ([]service.NamespacedService, error)
 
 	// ListEndpointsForService returns the list of provider endpoints corresponding to a service
 	ListEndpointsForService(service.Name) ([]endpoint.Endpoint, error)
@@ -120,3 +123,10 @@ type certificateCommonNameMeta struct {
 	ServiceAccount string
 	Namespace      string
 }
+
+type direction string
+
+const (
+	inbound  direction = "inbound"
+	outbound direction = "outbound"
+)

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 		})
 
 		It("returns an error with an invalid CN", func() {
-			service, err := mc.GetServiceFromEnvoyCertificate("blah")
+			service, err := mc.GetServiceFromEnvoyCertificate("getAllowedDirectionalServices")
 			Expect(err).To(HaveOccurred())
 			Expect(service).To(BeNil())
 		})

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -117,7 +117,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 }
 
 func getInboundInMeshFilterChain(proxyServiceName service.NamespacedService, mc catalog.MeshCataloger, filterConfig *any.Any) (*listener.FilterChain, error) {
-	serverNames, err := mc.ListAllowedPeerServices(proxyServiceName)
+	serverNames, err := mc.ListAllowedInboundServices(proxyServiceName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting server names for connected client proxy %s", proxyServiceName)
 		return nil, err


### PR DESCRIPTION
With https://github.com/open-service-mesh/osm/pull/747 we added a `bookWarehouse`.  The `bookstore` gets inventory from the `bookwarehouse`.

Because of mTLS - when `bookstore` connects to `bookwarehouse`
  1. `bookstore` (**the client**) verifies that the warehouse certificate is signed with the root cert and is in the list of `MatchSubjectAltNames`
  2. `bookwarehouse` (**the server**) verifies that the `bookstore` cert is signed by the root cert and is in the `MatchSubjectAltNames`

We populate `MatchSubjectAltNames` using the `ListAllowedPeerServices` function, which lists services per **destination** only.

The connection between `bookstore` and `bookwarehouse` is currently not working.  We see the following error we see in the `bookstore` Envoy logs:
`[2020-06-04 23:04:21.291][14][debug][connection] [source/extensions/transport_sockets/tls/ssl_socket.cc:226] [C204] TLS error: 268435581:SSL routines:OPENSSL_internal:CERTIFICATE_VERIFY_FAILED`

See the following PR, which introduces a check of `bookwarehouse` in CI:  https://github.com/open-service-mesh/osm/pull/767  
The PR above will start passing once this here is merged.

The SSL verification error s is caused by the `MatchSubjectAltNames` on the `bookstore` pod, which fails to validate the certificate of the `bookwarehouse`.  We have a function `ListAllowedPeerServices` which lists all permitted inbound certs. Inbound means: on bookstore we allow bookbuyer. On warehouse we allow bookstore.  But we also need to allow warehouse on bookbuyer for mTLS (m for Mutual, where bookstore checks warehouse eventhough bookstore is the client). In other words `ListAllowedPeerServices` does not list the outbound.

To solve this:
  - renamed `ListAllowedPeerServices` to `ListAllowedInboundServices`
  - created `ListAllowedOutboundServices` 

This PR is stacked on https://github.com/open-service-mesh/osm/pull/767

Fix https://github.com/open-service-mesh/osm/issues/440