### PR TITLE
ci: Tail BookWarehouse logs for success

### DIFF
--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -20,8 +20,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/open-service-mesh/osm/demo/cmd/common"
 )
 
 // We are going to wait for the Pod certain amount of time if it is in one of these statuses
@@ -113,7 +111,7 @@ func GetPodName(kubeClient kubernetes.Interface, namespace, selector string) (st
 
 // SearchLogsForSuccess tails logs until success enum is found.
 // The pod/container we are observing is responsible for sending the SUCCESS/FAIL token based on local heuristic.
-func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, podName string, containerName string, totalWait time.Duration, result chan TestResult) {
+func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, podName string, containerName string, totalWait time.Duration, result chan TestResult, successToken, failureToken string) {
 	sinceTime := metav1.NewTime(time.Now().Add(-PollLogsFromTimeSince))
 	options := &corev1.PodLogOptions{
 		Container: containerName,
@@ -160,14 +158,14 @@ func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, pod
 			// The container itself has the heuristic on when to emit these.
 			default:
 
-				if strings.Contains(line, common.Success) {
-					log.Info().Msgf("[%s] Found %s", containerName, common.Success)
+				if strings.Contains(line, successToken) {
+					log.Info().Msgf("[%s] Found %s", containerName, successToken)
 					result <- TestsPassed
 					return
 				}
 
-				if strings.Contains(line, common.Failure) {
-					log.Info().Msgf("[%s] Found %s", containerName, common.Failure)
+				if strings.Contains(line, failureToken) {
+					log.Info().Msgf("[%s] Found %s", containerName, failureToken)
 					result <- TestsFailed
 					return
 				}

--- a/ci/cmd/maestro/types.go
+++ b/ci/cmd/maestro/types.go
@@ -35,6 +35,9 @@ const (
 	// BookstoreNamespaceEnvVar is the environment variable for the Bookbuyer namespace.
 	BookstoreNamespaceEnvVar = "BOOKSTORE_NAMESPACE"
 
+	// BookWarehouseNamespaceEnvVar is the environment variable for the BookWarehouse namespace.
+	BookWarehouseNamespaceEnvVar = "BOOKWAREHOUSE_NAMESPACE"
+
 	// WaitForPodTimeSecondsEnvVar is the environment variable for the time we will wait on the pod to be ready.
 	WaitForPodTimeSecondsEnvVar = "CI_MAX_WAIT_FOR_POD_TIME_SECONDS"
 

--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -72,7 +72,6 @@ func updateBooksBought(w http.ResponseWriter, r *http.Request) {
 
 // buyBook increments the value of the booksBought
 func buyBook(w http.ResponseWriter, r *http.Request) {
-
 	booksBought++
 	setHeaders(w)
 	renderTemplate(w)


### PR DESCRIPTION
This PR makes sure our CI system checks whether BookWarehouse logs indicate successful restocking.

We will consider the job of the pod `BookWarehouse` successful when we find the following string in its logs: `Restocking bookstore with 1 new books; Total so far: 3 ` -- this indicates that there were a total of 3 books restocked.

Fix https://github.com/open-service-mesh/osm/issues/440