### PR TITLE
Simplify building listeners

### DIFF
--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/cla"
 	"github.com/open-service-mesh/osm/pkg/service"
-
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -19,7 +19,7 @@ func buildOutboundListener(connManager *envoy_hcm.HttpConnectionManager) (*xds.L
 		return nil, err
 	}
 
-	listener := &xds.Listener{
+	return &xds.Listener{
 		Name:             outboundListenerName,
 		Address:          envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyOutboundListenerPort),
 		TrafficDirection: envoy_api_v2_core.TrafficDirection_OUTBOUND,
@@ -35,12 +35,11 @@ func buildOutboundListener(connManager *envoy_hcm.HttpConnectionManager) (*xds.L
 				},
 			},
 		},
-	}
-	return listener, nil
+	}, nil
 }
 
-func buildInboundListener() (*xds.Listener, error) {
-	listener := &xds.Listener{
+func buildInboundListener() *xds.Listener {
+	return &xds.Listener{
 		Name:             inboundListenerName,
 		Address:          envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyInboundListenerPort),
 		TrafficDirection: envoy_api_v2_core.TrafficDirection_INBOUND,
@@ -51,7 +50,6 @@ func buildInboundListener() (*xds.Listener, error) {
 			},
 		},
 	}
-	return listener, nil
 }
 
 func buildPrometheusListener(connManager *envoy_hcm.HttpConnectionManager) (*xds.Listener, error) {

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Construct inbound listener object", func() {
 
 	Context("Testing the creating of inbound listener", func() {
 		It("Returns an inbound listener config", func() {
-			listener, _ := buildInboundListener()
+			listener := buildInboundListener()
 			Expect(listener.Address).To(Equal(envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyInboundListenerPort)))
 			Expect(len(listener.ListenerFilters)).To(Equal(1)) // tls-inpsector listener filter
 			Expect(listener.ListenerFilters[0].Name).To(Equal(wellknown.TlsInspector))

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -63,11 +63,8 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		log.Error().Err(err).Msgf("Error marshalling inbound HttpConnectionManager object for proxy %s", proxyServiceName)
 		return nil, err
 	}
-	inboundListener, err := buildInboundListener()
-	if err != nil {
-		log.Error().Err(err).Msgf("Error building inbound listener config for proxy %s", proxyServiceName)
-		return nil, err
-	}
+
+	inboundListener := buildInboundListener()
 	meshFilterChain, err := getInboundInMeshFilterChain(proxyServiceName, catalog, marshalledInboundConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to construct in-mesh filter chain for proxy %s", proxy.GetCommonName())


### PR DESCRIPTION
Tweaking the signature of `buildInboundListener` to remove an error, which is always `nil`