### PR TITLE
debugging:  Create DebugServer package;  Adding /debug/* API endpoints

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,9 +1,6 @@
 package catalog
 
 import (
-	"fmt"
-	"net/http"
-	"os"
 	"time"
 
 	set "github.com/deckarep/golang-set"
@@ -44,16 +41,6 @@ func NewMeshCatalog(kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, cert
 
 	go sc.repeater()
 	return &sc
-}
-
-// GetDebugInfo returns an HTTP handler for OSM debug endpoint.
-func (mc *MeshCatalog) GetDebugInfo() http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO(draychev): convert to CLI flag
-		if value, ok := os.LookupEnv("OSM_ENABLE_DEBUG"); ok && value == "true" {
-			_, _ = fmt.Fprintf(w, "hello\n")
-		}
-	})
 }
 
 // RegisterNewEndpoint adds a newly connected Envoy proxy to the list of self-announced endpoints for a service.

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
-
 	"github.com/open-service-mesh/osm/pkg/certificate"
 )
 

--- a/pkg/envoy/ads/debugger.go
+++ b/pkg/envoy/ads/debugger.go
@@ -1,0 +1,13 @@
+package ads
+
+import (
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/envoy"
+)
+
+// GetXDSLog implements XDSDebugger interface and a log of the XDS responses sent to Envoy proxies.
+func (s Server) GetXDSLog() *map[certificate.CommonName]map[envoy.TypeURI][]time.Time {
+	return &s.xdsLog
+}

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -2,6 +2,7 @@ package ads
 
 import (
 	"strconv"
+	"time"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_service_discovery_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
@@ -31,6 +32,13 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *env
 	if !ok {
 		log.Error().Msgf("Responder for TypeUrl %s is not implemented", request.TypeUrl)
 		return nil, errUnknownTypeURL
+	}
+
+	if s.enableDebug {
+		if _, ok := s.xdsLog[proxy.GetCommonName()]; !ok {
+			s.xdsLog[proxy.GetCommonName()] = make(map[envoy.TypeURI][]time.Time)
+		}
+		s.xdsLog[proxy.GetCommonName()][typeURL] = append(s.xdsLog[proxy.GetCommonName()][typeURL], time.Now())
 	}
 
 	log.Trace().Msgf("Invoking handler for %s with request: %+v", typeURL, request)

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -2,11 +2,13 @@ package ads
 
 import (
 	"context"
+	"time"
 
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_service_discovery_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
+	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/cds"
 	"github.com/open-service-mesh/osm/pkg/envoy/eds"
@@ -17,8 +19,8 @@ import (
 )
 
 // NewADSServer creates a new Aggregated Discovery Service server
-func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSpec smi.MeshSpec) *Server {
-	return &Server{
+func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSpec smi.MeshSpec, enableDebug bool) *Server {
+	server := Server{
 		catalog:  meshCatalog,
 		ctx:      ctx,
 		meshSpec: meshSpec,
@@ -29,7 +31,14 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 			envoy.TypeLDS: lds.NewResponse,
 			envoy.TypeSDS: sds.NewResponse,
 		},
+		enableDebug: enableDebug,
 	}
+
+	if enableDebug {
+		server.xdsLog = make(map[certificate.CommonName]map[envoy.TypeURI][]time.Time)
+	}
+
+	return &server
 }
 
 // DeltaAggregatedResources implements envoy_service_discovery_v2.AggregatedDiscoveryServiceServer

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -2,10 +2,12 @@ package ads
 
 import (
 	"context"
+	"time"
 
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
+	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/logger"
 	"github.com/open-service-mesh/osm/pkg/smi"
@@ -15,10 +17,12 @@ var (
 	log = logger.New("envoy/ads")
 )
 
-//Server implements the Envoy xDS Aggregate Discovery Services
+// Server implements the Envoy xDS Aggregate Discovery Services
 type Server struct {
 	ctx         context.Context
 	catalog     catalog.MeshCataloger
 	meshSpec    smi.MeshSpec
 	xdsHandlers map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error)
+	xdsLog      map[certificate.CommonName]map[envoy.TypeURI][]time.Time
+	enableDebug bool
 }


### PR DESCRIPTION
This PR adds a new `pkg/debugger`, which exposes facilities to introspect OSM and provide debugging information via an HTTP server.

This PR outlines the interfaces, which will have to be implemented by other OSM components.  Implementation will come with another PR (see https://github.com/open-service-mesh/osm/pull/784)

This PR is as a result of troubleshooting https://github.com/open-service-mesh/osm/issues/661

This debug server will be enabled/disabled via the `--enableDebugServer` introduced in https://github.com/open-service-mesh/osm/pull/785

The long term goal (done in the superset PR: https://github.com/open-service-mesh/osm/pull/784) would be to add more HTTP endpoints to the OSM web server:

 - `http://localhost:9091/debug/certs` - shows current certificates in cache
```
---[ 0 ]---
	 Common Name: "260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del"
	 Valid Until: 2030-06-07 02:37:48.201328482 +0000 UTC m=+315360021.333751977 (87587h3m52.639555249s remaining)
	 Issuing CA (SHA256): 79716f71136121c9ab03e5b4624e481a848818f4eaa90888d29e02ced2a16815
	 Cert Chain (SHA256): cf4fe9712a6e9808386222c2f8a043a91fd92489a75d45da418cd3b4be21b38e
	 x509.SignatureAlgorithm: SHA256-RSA
	 x509.PublicKeyAlgorithm: RSA
	 x509.Version: 3
	 x509.SerialNumber: 77a34d4834a95cc031303d5291d8e479
	 x509.Issuer: CN=Open Service Mesh Certification Authority,O=Open Service Mesh,L=CA,C=US
	 x509.Subject: CN=260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del,O=Open Service Mesh
	 x509.NotBefore (begin): 2020-06-09 02:37:48 +0000 UTC (12h56m7.561850232s ago)
	 x509.NotAfter (end): 2030-06-07 02:37:48 +0000 UTC (87587h3m52.438146668s remaining)
	 x509.BasicConstraintsValid: true
	 x509.IsCA: false
	 x509.DNSNames: [260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del]
	 Cert struct expiration vs. x509.NotAfter: -201.328482ms

```

 - `http://localhost:9091/debug/xds` - shows XDS stats per Envoy, per response type:
```
---[ 260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del
	 type.googleapis.com/envoy.api.v2.Cluster (3031):
		2020-06-09 15:34:19.932372962 +0000 UTC m=+46613.064796457 (7.363425032s ago)
		2020-06-09 15:34:07.021386902 +0000 UTC m=+46600.153810397 (20.274423392s ago)
		2020-06-09 15:33:55.591193511 +0000 UTC m=+46588.723616906 (31.704619283s ago)
		2020-06-09 15:33:39.41728115 +0000 UTC m=+46572.549704645 (47.878533844s ago)
		2020-06-09 15:33:28.35578677 +0000 UTC m=+46561.488210165 (58.940030524s ago)
		2020-06-09 15:33:14.006580337 +0000 UTC m=+46547.139003732 (1m13.289238757s ago)
```

- `http://localhost:9091/debug/proxy` - shows the list of expected, connected, disconnected proxies:
```
---| Connected Proxies (5):
	0: 	 260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del 	 2020-06-09 02:37:48.214728235 +0000 UTC m=+21.347151730 	(12h55m19.599218864s ago)
	1: 	 2699dabd-ae3a-4c2b-969b-5ac175919388.bookwarehouse-serviceaccount.bookwarehouse-ns-del 	 2020-06-09 02:37:56.382028312 +0000 UTC m=+29.514451807 	(12h55m11.431932287s ago)
	2: 	 b7297ae0-0d68-47f7-885c-dfc53979f6b2.bookthief-serviceaccount.bookthief-ns-del 	 2020-06-09 02:37:52.38367999 +0000 UTC m=+25.516103485 	(12h55m15.430283509s ago)
	3: 	 c061aeba-5c4d-4281-aa0e-ef9ccd6a322e.bookstore-v1-serviceaccount.bookstore-ns-del 	 2020-06-09 02:37:46.755456047 +0000 UTC m=+19.887879442 	(12h55m21.058509951s ago)
	4: 	 f41d916f-42ce-4ed0-958d-e7fc0e8817c5.bookbuyer-serviceaccount.bookbuyer-ns-del 	 2020-06-09 02:37:50.642670294 +0000 UTC m=+23.775093789 	(12h55m17.171297904s ago)

---| Expected Proxies (0):

---| Disconnected Proxies (0):
```

This PR is as a result of troubleshooting https://github.com/open-service-mesh/osm/issues/661

## Security implications
 - as of this PR this is guarded with a flag `--enableDebugServer` defaulted to `false`
 - when the debug server is enabled - one has to port-forward to the pod to get the data - this is an unauthenticated end-point atm

## Going forward
 - immediate term - we should continue to add `/debug/xyz` endpoints - listing all SMI objects, services, list service accounts, errors, inconsistencies etc.
 - we could keep these endpoints as they are - returning plain text
 - we could convert them to HTML and hyperlink certain items (like certs pointing to Envoys etc) to make it easier
 - we could convert these endpoints to JSON or GraphQL and add a ReactJS etc frontend - perhaps longer term