### PR TITLE
debug: Create pkg/debugger & Debug HTTP Server

### DIFF
--- a/pkg/debugger/certificate.go
+++ b/pkg/debugger/certificate.go
@@ -1,0 +1,53 @@
+package debugger
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+)
+
+func (ds debugServer) getCertHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		certs := ds.certDebugger.ListIssuedCertificates()
+
+		sort.Slice(certs, func(i, j int) bool {
+			return certs[i].GetCommonName() < certs[j].GetCommonName()
+		})
+
+		for idx, cert := range certs {
+			ca := cert.GetIssuingCA()
+			chain := cert.GetCertificateChain()
+			x509, err := certificate.DecodePEMCertificate(chain)
+			if err != nil {
+				log.Error().Err(err).Msgf("Error decoding PEM to x509 CN=%s", cert.GetCommonName())
+			}
+
+			_, _ = fmt.Fprintf(w, "---[ %d ]---\n", idx)
+			_, _ = fmt.Fprintf(w, "\t Common Name: %q\n", cert.GetCommonName())
+			_, _ = fmt.Fprintf(w, "\t Valid Until: %+v (%+v remaining)\n", cert.GetExpiration(), time.Until(cert.GetExpiration()))
+			_, _ = fmt.Fprintf(w, "\t Issuing CA (SHA256): %x\n", sha256.Sum256(ca))
+			_, _ = fmt.Fprintf(w, "\t Cert Chain (SHA256): %x\n", sha256.Sum256(chain))
+
+			// Show only some x509 fields to keep the output clean
+			_, _ = fmt.Fprintf(w, "\t x509.SignatureAlgorithm: %+v\n", x509.SignatureAlgorithm)
+			_, _ = fmt.Fprintf(w, "\t x509.PublicKeyAlgorithm: %+v\n", x509.PublicKeyAlgorithm)
+			_, _ = fmt.Fprintf(w, "\t x509.Version: %+v\n", x509.Version)
+			_, _ = fmt.Fprintf(w, "\t x509.SerialNumber: %x\n", x509.SerialNumber)
+			_, _ = fmt.Fprintf(w, "\t x509.Issuer: %+v\n", x509.Issuer)
+			_, _ = fmt.Fprintf(w, "\t x509.Subject: %+v\n", x509.Subject)
+			_, _ = fmt.Fprintf(w, "\t x509.NotBefore (begin): %+v (%+v ago)\n", x509.NotBefore, time.Since(x509.NotBefore))
+			_, _ = fmt.Fprintf(w, "\t x509.NotAfter (end): %+v (%+v remaining)\n", x509.NotAfter, time.Until(x509.NotAfter))
+			_, _ = fmt.Fprintf(w, "\t x509.BasicConstraintsValid: %+v\n", x509.BasicConstraintsValid)
+			_, _ = fmt.Fprintf(w, "\t x509.IsCA: %+v\n", x509.IsCA)
+			_, _ = fmt.Fprintf(w, "\t x509.DNSNames: %+v\n", x509.DNSNames)
+
+			_, _ = fmt.Fprintf(w, "\t Cert struct expiration vs. x509.NotAfter: %+v\n", x509.NotAfter.Sub(cert.GetExpiration()))
+
+			_, _ = fmt.Fprint(w, "\n")
+		}
+	})
+}

--- a/pkg/debugger/index.go
+++ b/pkg/debugger/index.go
@@ -1,0 +1,14 @@
+package debugger
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (ds debugServer) getDebugIndex(handlers map[string]http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for url := range handlers {
+			_, _ = fmt.Fprintf(w, "%s\n", url)
+		}
+	})
+}

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -1,0 +1,52 @@
+package debugger
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/catalog"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+)
+
+const specificProxyQueryKey = "proxy"
+
+func (ds debugServer) getProxies() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if specificProxy, ok := r.URL.Query()[specificProxyQueryKey]; !ok {
+			printProxies(w, ds.meshCatalogDebugger.ListConnectedProxies(), "Connected")
+			printProxies(w, ds.meshCatalogDebugger.ListExpectedProxies(), "Expected")
+			printProxies(w, ds.meshCatalogDebugger.ListDisconnectedProxies(), "Disconnected")
+		} else {
+			ds.getProxy(certificate.CommonName(specificProxy[0]), w)
+		}
+	})
+}
+
+func printProxies(w http.ResponseWriter, proxies map[certificate.CommonName]time.Time, category string) {
+	var commonNames []string
+	for cn := range proxies {
+		commonNames = append(commonNames, cn.String())
+	}
+
+	sort.Strings(commonNames)
+
+	_, _ = fmt.Fprintf(w, "---| %s Proxies (%d):\n", category, len(proxies))
+	for idx, cn := range commonNames {
+		ts := proxies[certificate.CommonName(cn)]
+		_, _ = fmt.Fprintf(w, "\t%d: \t %s \t %+v \t(%+v ago)\n", idx, cn, ts, time.Since(ts))
+	}
+	_, _ = fmt.Fprint(w, "\n")
+}
+
+func (ds debugServer) getProxy(cn certificate.CommonName, w http.ResponseWriter) {
+	_, err := catalog.GetPodFromCertificate(cn, ds.kubeClient)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting pod with CN=%s", cn)
+	}
+	// TODO(draychev): get Envoy debug
+	envoyConfig := "TODO"
+	_, _ = fmt.Fprintf(w, "%s\n", envoyConfig)
+}

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -1,0 +1,33 @@
+package debugger
+
+import (
+	"net/http"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// GetHandlers implements DebugServer interface and returns the rist of URLs and the handling functions.
+func (ds debugServer) GetHandlers() map[string]http.Handler {
+	handlers := map[string]http.Handler{
+		"/debug/certs": ds.getCertHandler(),
+		"/debug/xds":   ds.getXDSHandler(),
+		"/debug/proxy": ds.getProxies(),
+	}
+
+	// provides an index of the available /debug endpoints
+	handlers["/debug"] = ds.getDebugIndex(handlers)
+
+	return handlers
+}
+
+// NewDebugServer returns an implementation of DebugServer interface.
+func NewDebugServer(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, kubeConfig *rest.Config) DebugServer {
+	return debugServer{
+		certDebugger:        certDebugger,
+		xdsDebugger:         xdsDebugger,
+		meshCatalogDebugger: meshCatalogDebugger,
+		kubeConfig:          kubeConfig,
+		kubeClient:          kubernetes.NewForConfigOrDie(kubeConfig),
+	}
+}

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -1,0 +1,55 @@
+package debugger
+
+import (
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/rest"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/logger"
+)
+
+var log = logger.New("debugger")
+
+// debugServer implements the DebugServer interface.
+type debugServer struct {
+	certDebugger        CertificateManagerDebugger
+	xdsDebugger         XDSDebugger
+	meshCatalogDebugger MeshCatalogDebugger
+	kubeConfig          *rest.Config
+	kubeClient          kubernetes.Interface
+}
+
+// CertificateManagerDebugger is an interface with methods for debugging certificate issuance.
+type CertificateManagerDebugger interface {
+	// ListIssuedCertificates returns the current list of certificates in OSM's cache.
+	ListIssuedCertificates() []certificate.Certificater
+}
+
+// MeshCatalogDebugger is an interface with methods for debugging Mesh Catalog.
+type MeshCatalogDebugger interface {
+	// ListExpectedProxies lists the Envoy proxies yet to connect and the time their XDS certificate was issued.
+	ListExpectedProxies() map[certificate.CommonName]time.Time
+
+	// ListConnectedProxies lists the Envoy proxies already connected and the time they first connected.
+	ListConnectedProxies() map[certificate.CommonName]time.Time
+
+	// ListDisconnectedProxies lists the Envoy proxies disconnected and the time last seen.
+	ListDisconnectedProxies() map[certificate.CommonName]time.Time
+}
+
+// XDSDebugger is an interface providing debugging server with methods introspecting XDS.
+type XDSDebugger interface {
+	// GetXDSLog returns a log of the XDS responses sent to Envoy proxies.
+	GetXDSLog() *map[certificate.CommonName]map[envoy.TypeURI][]time.Time
+}
+
+// DebugServer is the interface of the Debug HTTP server.
+type DebugServer interface {
+	// GetHandlers returns the HTTP handlers available for the debug server.
+	GetHandlers() map[string]http.Handler
+}

--- a/pkg/debugger/xds.go
+++ b/pkg/debugger/xds.go
@@ -1,0 +1,51 @@
+package debugger
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/envoy"
+)
+
+func (ds debugServer) getXDSHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		xdsLog := ds.xdsDebugger.GetXDSLog()
+
+		var proxies []string
+		for proxyCN := range *xdsLog {
+			proxies = append(proxies, proxyCN.String())
+		}
+
+		sort.Strings(proxies)
+
+		for _, proxyCN := range proxies {
+			xdsTypeWithTimestamps := (*xdsLog)[certificate.CommonName(proxyCN)]
+			_, _ = fmt.Fprintf(w, "---[ %s\n", proxyCN)
+
+			var xdsTypes []string
+			for xdsType := range xdsTypeWithTimestamps {
+				xdsTypes = append(xdsTypes, xdsType.String())
+			}
+
+			sort.Strings(xdsTypes)
+
+			for _, xdsType := range xdsTypes {
+				timeStamps := xdsTypeWithTimestamps[envoy.TypeURI(xdsType)]
+
+				_, _ = fmt.Fprintf(w, "\t %s (%d):\n", xdsType, len(timeStamps))
+
+				sort.Slice(timeStamps, func(i, j int) bool {
+					return timeStamps[i].After(timeStamps[j])
+				})
+				for _, timeStamp := range timeStamps {
+					_, _ = fmt.Fprintf(w, "\t\t%+v (%+v ago)\n", timeStamp, time.Since(timeStamp))
+				}
+				_, _ = fmt.Fprint(w, "\n")
+			}
+			_, _ = fmt.Fprint(w, "\n")
+		}
+	})
+}


### PR DESCRIPTION
This PR adds a new `pkg/debugger`, which, if initialized with the required functions/interfaces will provide extremely simple HTTP endpoints dumping OSM debug info in text text format:
 - certificates issued so far
 - expected/connected/disconnected Envoy proxies
 - xds responses sent w/ timestamps

This PR outlines the interfaces, which will have to be implemented by other OSM components.  Implementation will come with another PR (see https://github.com/open-service-mesh/osm/pull/784)

This PR is as a result of troubleshooting https://github.com/open-service-mesh/osm/issues/661

This debug server will be enabled/disabled via the `--enableDebugServer` introduced in https://github.com/open-service-mesh/osm/pull/785

The long term goal (done in the superset PR: https://github.com/open-service-mesh/osm/pull/784) would be to add more HTTP endpoints to the OSM web server:

 - `http://localhost:9091/debug/certs` - shows current certificates in cache
```
---[ 0 ]---
	 Common Name: "260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del"
	 Valid Until: 2030-06-07 02:37:48.201328482 +0000 UTC m=+315360021.333751977 (87587h3m52.639555249s remaining)
	 Issuing CA (SHA256): 79716f71136121c9ab03e5b4624e481a848818f4eaa90888d29e02ced2a16815
	 Cert Chain (SHA256): cf4fe9712a6e9808386222c2f8a043a91fd92489a75d45da418cd3b4be21b38e
	 x509.SignatureAlgorithm: SHA256-RSA
	 x509.PublicKeyAlgorithm: RSA
	 x509.Version: 3
	 x509.SerialNumber: 77a34d4834a95cc031303d5291d8e479
	 x509.Issuer: CN=Open Service Mesh Certification Authority,O=Open Service Mesh,L=CA,C=US
	 x509.Subject: CN=260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del,O=Open Service Mesh
	 x509.NotBefore (begin): 2020-06-09 02:37:48 +0000 UTC (12h56m7.561850232s ago)
	 x509.NotAfter (end): 2030-06-07 02:37:48 +0000 UTC (87587h3m52.438146668s remaining)
	 x509.BasicConstraintsValid: true
	 x509.IsCA: false
	 x509.DNSNames: [260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del]
	 Cert struct expiration vs. x509.NotAfter: -201.328482ms

```

 - `http://localhost:9091/debug/xds` - shows XDS stats per Envoy, per response type:
```
---[ 260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del
	 type.googleapis.com/envoy.api.v2.Cluster (3031):
		2020-06-09 15:34:19.932372962 +0000 UTC m=+46613.064796457 (7.363425032s ago)
		2020-06-09 15:34:07.021386902 +0000 UTC m=+46600.153810397 (20.274423392s ago)
		2020-06-09 15:33:55.591193511 +0000 UTC m=+46588.723616906 (31.704619283s ago)
		2020-06-09 15:33:39.41728115 +0000 UTC m=+46572.549704645 (47.878533844s ago)
		2020-06-09 15:33:28.35578677 +0000 UTC m=+46561.488210165 (58.940030524s ago)
		2020-06-09 15:33:14.006580337 +0000 UTC m=+46547.139003732 (1m13.289238757s ago)
```

- `http://localhost:9091/debug/proxy` - shows the list of expected, connected, disconnected proxies:
```
---| Connected Proxies (5):
	0: 	 260694cc-f30d-4257-956a-7aa6d3dacaf9.bookstore-v2-serviceaccount.bookstore-ns-del 	 2020-06-09 02:37:48.214728235 +0000 UTC m=+21.347151730 	(12h55m19.599218864s ago)
	1: 	 2699dabd-ae3a-4c2b-969b-5ac175919388.bookwarehouse-serviceaccount.bookwarehouse-ns-del 	 2020-06-09 02:37:56.382028312 +0000 UTC m=+29.514451807 	(12h55m11.431932287s ago)
	2: 	 b7297ae0-0d68-47f7-885c-dfc53979f6b2.bookthief-serviceaccount.bookthief-ns-del 	 2020-06-09 02:37:52.38367999 +0000 UTC m=+25.516103485 	(12h55m15.430283509s ago)
	3: 	 c061aeba-5c4d-4281-aa0e-ef9ccd6a322e.bookstore-v1-serviceaccount.bookstore-ns-del 	 2020-06-09 02:37:46.755456047 +0000 UTC m=+19.887879442 	(12h55m21.058509951s ago)
	4: 	 f41d916f-42ce-4ed0-958d-e7fc0e8817c5.bookbuyer-serviceaccount.bookbuyer-ns-del 	 2020-06-09 02:37:50.642670294 +0000 UTC m=+23.775093789 	(12h55m17.171297904s ago)

---| Expected Proxies (0):

---| Disconnected Proxies (0):
```

This PR is as a result of troubleshooting https://github.com/open-service-mesh/osm/issues/661

Context on how this is used:  https://github.com/open-service-mesh/osm/pull/784