### PR TITLE
tresor: Emit the serial number of the newly issued certificate

### DIFF
--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -87,7 +87,7 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Dur
 		expiration: template.NotAfter,
 	}
 
-	log.Info().Msgf("Created new certificate for CN=%s, which will expire in %+v on %+v", cn, validityPeriod, template.NotAfter)
+	log.Info().Msgf("Created new certificate for CN=%s; validity=%+v; expires on %+v; serial: %+v", cn, validityPeriod, template.NotAfter, template.SerialNumber)
 
 	return cert, nil
 }
@@ -119,7 +119,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	(*cm.cache)[cn] = cert
 	cm.cacheLock.Unlock()
 
-	log.Info().Msgf("Issuing new certificate for CN=%s took %+v", cn, time.Since(start))
+	log.Info().Msgf("It took %+v to issue certificate with CN=%s", time.Since(start), cn)
 
 	return cert, nil
 }


### PR DESCRIPTION
This PR augments 2 log messages in the certificate issuance domain.

We need to see the serial number of the certificate issued to a proxy to be able to verify that this indeed is on the proxy itself.

This PR is as a result of troubleshooting https://github.com/open-service-mesh/osm/issues/661