### PR TITLE
rbac: Adding pods/PortForward

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -17,6 +17,14 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "namespaces", "pods", "replicationcontrollers", "services", "secrets"]
     verbs: ["list", "get", "watch"]
+
+  # Port forwarding is needed for the OSM pod to be able to connect
+  # to participating Envoys and fetch their configuration.
+  # This is used by the OSM debugging system.
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/portforward"]
+    verbs: ["get", "list", "create"]
+
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
     verbs: ["create", "update"]


### PR DESCRIPTION
I'd like to allow the OSM pod to do pod/portforwarding.
This will allow OSM to connect to port 15000 on the sidecars and introspect Envoy configuration -- very useful thing for (auto)debugging the service mesh.

Example of how this is going to be used: https://github.com/open-service-mesh/osm/pull/784



This is work towards addressing https://github.com/open-service-mesh/osm/issues/822