### PR TITLE
mTLS: For certs found in cache - check if expired and rotate

### DIFF
--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/certificate/rotor"
 )
 
 func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Duration) (certificate.Certificater, error) {
@@ -96,7 +97,11 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 	cm.cacheLock.Lock()
 	defer cm.cacheLock.Unlock()
 	if cert, exists := (*cm.cache)[cn]; exists {
-		log.Trace().Msgf("Found in cache certificate with CN=%s", cn)
+		log.Trace().Msgf("Certificate found in cache CN=%s", cn)
+		if rotor.ShouldRotate(cert) {
+			log.Trace().Msgf("Certificate found in cache but has expired CN=%s", cn)
+			return nil
+		}
 		return cert
 	}
 	return nil

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -91,7 +91,11 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 	cm.cacheLock.Lock()
 	defer cm.cacheLock.Unlock()
 	if cert, exists := (*cm.cache)[cn]; exists {
-		log.Trace().Msgf("Found in cache certificate with CN=%s", cn)
+		log.Trace().Msgf("Certificate found in cache CN=%s", cn)
+		if rotor.ShouldRotate(cert) {
+			log.Trace().Msgf("Certificate found in cache but has expired CN=%s", cn)
+			return nil
+		}
 		return cert
 	}
 	return nil


### PR DESCRIPTION
When pulling certs from cache, check if the cert is expired.  Do not return expired certs.
When a cert is expired and we return nil, a new one will be issued (similar to rotating a cert)