### PR TITLE
debug: Adding a helper script to port forward OSM's debug facility to localhost

### DIFF
--- a/scripts/port-forward-osm-debug.sh
+++ b/scripts/port-forward-osm-debug.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+set -aueo pipefail
+
+source .env
+
+OSM_POD=$(kubectl get pods -n "$K8S_NAMESPACE" --no-headers  --selector app=ads | awk '{print $1}')
+
+kubectl port-forward -n "$K8S_NAMESPACE" "$OSM_POD"  9091:9091


### PR DESCRIPTION
This PR adds a bash helper script to easily find the OSM pod and forward the debug HTTP server's port to localhost.

Like this:  
![image](https://user-images.githubusercontent.com/49918230/84205353-ca409080-aa61-11ea-850f-b336ad7ee2a0.png)



This is work towards addressing https://github.com/open-service-mesh/osm/issues/822