### PR TITLE
catalog: Implement Expected/Connected/Disconnected proxy sets

### DIFF
--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -9,17 +9,30 @@ import (
 
 // ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
 func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
-	mc.expectedProxies[cn] = expectedProxy{time.Now()}
+	mc.expectedProxiesLock.Lock()
+	mc.expectedProxies[cn] = expectedProxy{
+		certificateIssuedOn: time.Now(),
+	}
+	mc.expectedProxiesLock.Unlock()
 }
 
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
 func (mc *MeshCatalog) RegisterProxy(p *envoy.Proxy) {
-	mc.connectedProxies[p.CommonName] = connectedProxy{p, time.Now()}
+	mc.connectedProxiesLock.Lock()
+	mc.connectedProxies[p.CommonName] = connectedProxy{
+		proxy:       p,
+		connectedOn: time.Now(),
+	}
+	mc.connectedProxiesLock.Unlock()
 	log.Info().Msgf("Registered new proxy: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
 func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	delete(mc.connectedProxies, p.CommonName)
+	mc.disconnectedProxiesLock.Lock()
+	mc.disconnectedProxies[p.CommonName] = disconnectedProxy{
+		lastSeen: time.Now(),
+	}
+	mc.disconnectedProxiesLock.Unlock()
 	log.Info().Msgf("Unregistered proxy: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -40,6 +40,7 @@ func (mc *MeshCatalog) getCases() ([]reflect.SelectCase, []string) {
 }
 
 func (mc *MeshCatalog) broadcast(message interface{}) {
+	mc.connectedProxiesLock.Lock()
 	for _, connectedEnvoy := range mc.connectedProxies {
 		log.Debug().Msgf("[repeater] Broadcast announcement to envoy %s", connectedEnvoy.proxy.GetCommonName())
 		select {
@@ -48,4 +49,5 @@ func (mc *MeshCatalog) broadcast(message interface{}) {
 		default:
 		}
 	}
+	mc.connectedProxiesLock.Unlock()
 }


### PR DESCRIPTION
This PR augments current Mesh Catalog with `disconnectedProxies` in addition to `connectedProxies` and `expectedProxies`

Also adds mutexes for all these.

These will be used to debug the OSM controller -- allows us to ask the questions:
 - what proxies have been issued certificates but have never connected
 - what proxies are currently connected to OSM
 - what proxies have disconnected

Example of how this could be used:  https://github.com/open-service-mesh/osm/pull/784



This is work towards addressing https://github.com/open-service-mesh/osm/issues/822