### PR TITLE
debug: Provide a way for OSM pod to port forward from a side car to OSM

### DIFF
--- a/pkg/debugger/envoy.go
+++ b/pkg/debugger/envoy.go
@@ -1,0 +1,54 @@
+package debugger
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+)
+
+func (ds debugServer) getEnvoyConfig(pod *v1.Pod, cn certificate.CommonName) string {
+	log.Info().Msgf("Getting Envoy config for CN=%s, podIP=%s", cn, pod.Status.PodIP)
+
+	minPort := 16000
+	maxPort := 18000
+	portFwdRequest := portForward{
+		Pod:       pod,
+		LocalPort: rand.Intn(maxPort-minPort) + minPort,
+		PodPort:   15000,
+		Stop:      make(chan struct{}),
+		Ready:     make(chan struct{}),
+	}
+	go ds.forwardPort(portFwdRequest)
+
+	<-portFwdRequest.Ready
+
+	client := &http.Client{}
+	resp, err := client.Get(fmt.Sprintf("http://%s:%d/certs", "localhost", portFwdRequest.LocalPort))
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting pod with CN=%s and podIP=%s", cn, pod.Status.PodIP)
+		return fmt.Sprintf("Error: %s", err)
+	}
+
+	defer func() {
+		portFwdRequest.Stop <- struct{}{}
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Error().Msgf("Error getting Envoy config for Pod with CN=%s and IP=%s; HTTP Error %d", cn, pod.Status.PodIP, resp.StatusCode)
+		portFwdRequest.Stop <- struct{}{}
+		return fmt.Sprintf("Error: %s", err)
+	}
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting pod with CN=%s", cn)
+		return fmt.Sprintf("Error: %s", err)
+	}
+
+	return string(bodyBytes)
+}

--- a/pkg/debugger/port_forward.go
+++ b/pkg/debugger/port_forward.go
@@ -1,0 +1,62 @@
+package debugger
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+type portForward struct {
+	// Pod for which port forwarding is done.
+	Pod *v1.Pod
+
+	// LocalPort is port on local host, which will be used.
+	LocalPort int
+
+	// PodPort is the port on the target Pod, which will be forwarded.
+	PodPort int
+
+	// Stop is a channel managing the port forward lifecycle.
+	Stop chan struct{}
+
+	// Ready is a channel informing us when the tunnel is ready.
+	Ready chan struct{}
+}
+
+func (ds debugServer) forwardPort(req portForward) {
+	log.Info().Msgf("Start port forward to podIP=%s on PodPort=%d to LocalPort=%d", req.Pod.Status.PodIP, req.PodPort, req.LocalPort)
+	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward", req.Pod.Namespace, req.Pod.Name)
+	hostIP := strings.TrimLeft(ds.kubeConfig.Host, "htps:/")
+
+	transport, upgrader, err := spdy.RoundTripperFor(ds.kubeConfig)
+	if err != nil {
+		log.Error().Err(err)
+	}
+
+	client := &http.Client{Transport: transport}
+	u := &url.URL{Scheme: "https", Path: path, Host: hostIP}
+	streams := genericclioptions.IOStreams{}
+	fw, err := portforward.New(
+		spdy.NewDialer(upgrader, client, http.MethodPost, u),
+		[]string{fmt.Sprintf("%d:%d", req.LocalPort, req.PodPort)},
+		req.Stop,
+		req.Ready,
+		streams.Out,
+		streams.ErrOut,
+	)
+	if err != nil {
+		log.Error().Err(err)
+	}
+
+	if err = fw.ForwardPorts(); err != nil {
+		log.Error().Err(err)
+	}
+
+}

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -41,11 +41,10 @@ func printProxies(w http.ResponseWriter, proxies map[certificate.CommonName]time
 }
 
 func (ds debugServer) getProxy(cn certificate.CommonName, w http.ResponseWriter) {
-	_, err := catalog.GetPodFromCertificate(cn, ds.kubeClient)
+	pod, err := catalog.GetPodFromCertificate(cn, ds.kubeClient)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error getting pod with CN=%s", cn)
+		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
 	}
-	// TODO(draychev): get Envoy debug
-	envoyConfig := "TODO"
+	envoyConfig := ds.getEnvoyConfig(pod, cn)
 	_, _ = fmt.Fprintf(w, "%s\n", envoyConfig)
 }


### PR DESCRIPTION
The Envoy proxies in Open Service Mesh expose an admin port 15000, which has a few endpoints allowing us to get Envoy's current config, certificates etc.

Typically we troubleshoot service mesh issues by using `kubectl port-forward` and then browsing `localhost:15000`

It would be great if the OSM pod itself had access to that information for each Envoy proxy.  This would be very useful to compare state of what OSM sent to the proxy and what the proxy's current config is.

For instance -- it would be terrific to be able to see what certificates are in OSM Pod's cache and what certs are currently on an Envoy. (Compare on cert's serial number for instance.)

It is not possible for the OSM pod to directly query the Envoy pods on 15000, but it is possible to port forward that to the OSM pod.

This PR adds the ability to port forward from a given Envoy to the OSM pod and introspect Envoy's config.  This is an experimental feature. It is very helpful, but we should consider eventually moving it into a different pod.  This is only enabled when the `-enable-debug-server` flag is on (off by default)

This is the last PR from the series:
 - https://github.com/open-service-mesh/osm/pull/813
 - https://github.com/open-service-mesh/osm/pull/812
 - https://github.com/open-service-mesh/osm/pull/811
 - https://github.com/open-service-mesh/osm/pull/806
 - https://github.com/open-service-mesh/osm/pull/799
 - https://github.com/open-service-mesh/osm/pull/798 
 - https://github.com/open-service-mesh/osm/pull/794

This will fix https://github.com/open-service-mesh/osm/issues/822