### PR TITLE
demo: Enable Debug Server

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -129,7 +129,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --container-registry "$CTR_REGISTRY" \
       --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
       --osm-image-tag "$CTR_TAG" \
-      -enable-debug-server
+      --enable-debug-server
 else
   bin/osm install \
       --namespace "$K8S_NAMESPACE" \


### PR DESCRIPTION
Enable the debug server in CI and in local demo with `-enableDebugServer`: https://github.com/open-service-mesh/osm/blob/de9138ecf5174d93cab6d08a219a5966e37fae14/cmd/ads/ads.go#L89



This is work towards addressing https://github.com/open-service-mesh/osm/issues/822