### PR TITLE
ci: use a separate timeout for success

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,10 +150,10 @@ jobs:
         KUBECONFIG: ".kube/config"
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-        WAIT_FOR_OK_SECONDS: 120
+        CI_WAIT_FOR_OK_SECONDS: 60
         IS_GITHUB: true
         ACR: ${{ secrets.ACR }}
-        CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 30
+        CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 60
         CI_MIN_SUCCESS_THRESHOLD: 1
         OSM_HUMAN_DEBUG_LOG: ${{ secrets.OSM_HUMAN_DEBUG_LOG }}
         CERT_MANAGER: "tresor"
@@ -184,10 +184,10 @@ jobs:
         KUBECONFIG: ".kube/config"
         DOCKER_USER: ${{ secrets.DOCKER_USER }}
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-        WAIT_FOR_OK_SECONDS: 120
+        CI_WAIT_FOR_OK_SECONDS: 60
         IS_GITHUB: true
         ACR: ${{ secrets.ACR }}
-        CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 30
+        CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 60
         CI_MIN_SUCCESS_THRESHOLD: 1
         OSM_HUMAN_DEBUG_LOG: ${{ secrets.OSM_HUMAN_DEBUG_LOG }}
         CERT_MANAGER: "vault"  # enables Hashi Vault integration

--- a/ci/README.md
+++ b/ci/README.md
@@ -45,3 +45,4 @@ Set the variables in Github Secrets as `DOCKER_USER` and `DOCKER_PASS`
  - `OSM_HUMAN_DEBUG_LOG` - set it to `true` to show human-readable log lines (vs JSON blobs)
  - `VAULT_TOKEN` - (string) random string, which will be used as a Vault token in the CI Vault setup; example: `abcd`
  - `CI_MAX_WAIT_FOR_POD_TIME_SECONDS` - (integer) max number of seconds the CI system will wait for bookbuyer and bookthief pods to be ready / running; example: `15`
+ - `CI_WAIT_FOR_OK_SECONDS` - (integer) number of seconds the CI system will wait for bookbuyer and bookthief pods to poll for a success once the pods are ready; example: `15`

--- a/ci/cmd/maestro/types.go
+++ b/ci/cmd/maestro/types.go
@@ -37,6 +37,9 @@ const (
 
 	// WaitForPodTimeSecondsEnvVar is the environment variable for the time we will wait on the pod to be ready.
 	WaitForPodTimeSecondsEnvVar = "CI_MAX_WAIT_FOR_POD_TIME_SECONDS"
+
+	// WaitForOKSecondsEnvVar is the environment variable for the time to wait till a success is returned by the server.
+	WaitForOKSecondsEnvVar = "CI_WAIT_FOR_OK_SECONDS"
 )
 
 var (


### PR DESCRIPTION
This change uses the existing CI_WAIT_FOR_OK_SECONDS env variable
to configure the time the CI should wait for a success. Previously
the pod wait time was used to time out the success test as well.
This allows fine tuning of the pod wait time and success wait time.

Additionally the success wait time is increased to 60s to give the
CI more of a chance to succeed rather than timing out before a
potential success, which would cost more time due to having to
rerun the entire CI build again.