### PR TITLE
Adding catalog debugger; Fixing disconnectedProxies; Adding tests

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -28,6 +28,7 @@ func NewMeshCatalog(kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, cert
 		certificateCache:     make(map[service.NamespacedService]certificate.Certificater),
 		expectedProxies:      make(map[certificate.CommonName]expectedProxy),
 		connectedProxies:     make(map[certificate.CommonName]connectedProxy),
+		disconnectedProxies:  make(map[certificate.CommonName]disconnectedProxy),
 		announcementChannels: set.NewSet(),
 
 		// Kubernetes needed to determine what Services a pod that connects to XDS belongs to.

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -1,0 +1,79 @@
+package catalog
+
+import (
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/envoy"
+)
+
+var _ = Describe("Test catalog proxy register/unregister", func() {
+	Context("Test register/unregister proxies", func() {
+		mc := NewFakeMeshCatalog(testclient.NewSimpleClientset())
+		cn := certificate.CommonName("foo")
+		proxy := envoy.NewProxy(cn, nil)
+
+		It("no proxies expected, connected or disconnected", func() {
+			expectedProxies := mc.ListExpectedProxies()
+			Expect(len(expectedProxies)).To(Equal(0))
+
+			connectedProxies := mc.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(0))
+
+			disconnectedProxies := mc.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(0))
+		})
+
+		It("expect one proxy to connect", func() {
+			// mc.RegisterProxy(proxy)
+			mc.ExpectProxy(cn)
+
+			expectedProxies := mc.ListExpectedProxies()
+			Expect(len(expectedProxies)).To(Equal(1))
+
+			connectedProxies := mc.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(0))
+
+			disconnectedProxies := mc.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(0))
+
+			_, ok := expectedProxies[cn]
+			Expect(ok).To(BeTrue())
+		})
+
+		It("one proxy connected to OSM", func() {
+			mc.RegisterProxy(proxy)
+
+			expectedProxies := mc.ListExpectedProxies()
+			Expect(len(expectedProxies)).To(Equal(0))
+
+			connectedProxies := mc.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(1))
+
+			disconnectedProxies := mc.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(0))
+
+			_, ok := connectedProxies[cn]
+			Expect(ok).To(BeTrue())
+		})
+
+		It("one proxy disconnected from OSM", func() {
+			mc.UnregisterProxy(proxy)
+
+			expectedProxies := mc.ListExpectedProxies()
+			Expect(len(expectedProxies)).To(Equal(0))
+
+			connectedProxies := mc.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(0))
+
+			disconnectedProxies := mc.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(1))
+
+			_, ok := disconnectedProxies[cn]
+			Expect(ok).To(BeTrue())
+		})
+	})
+})

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -1,0 +1,55 @@
+package catalog
+
+import (
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+)
+
+// ListExpectedProxies lists the Envoy proxies yet to connect and the time their XDS certificate was issued.
+func (mc *MeshCatalog) ListExpectedProxies() map[certificate.CommonName]time.Time {
+	proxies := make(map[certificate.CommonName]time.Time)
+	mc.expectedProxiesLock.Lock()
+	mc.connectedProxiesLock.Lock()
+	mc.disconnectedProxiesLock.Lock()
+	for cn, props := range mc.expectedProxies {
+		if _, ok := mc.connectedProxies[cn]; ok {
+			continue
+		}
+		if _, ok := mc.disconnectedProxies[cn]; ok {
+			continue
+		}
+		proxies[cn] = props.certificateIssuedAt
+	}
+	mc.disconnectedProxiesLock.Unlock()
+	mc.connectedProxiesLock.Unlock()
+	mc.expectedProxiesLock.Unlock()
+	return proxies
+}
+
+// ListConnectedProxies lists the Envoy proxies already connected and the time they first connected.
+func (mc *MeshCatalog) ListConnectedProxies() map[certificate.CommonName]time.Time {
+	proxies := make(map[certificate.CommonName]time.Time)
+	mc.connectedProxiesLock.Lock()
+	mc.disconnectedProxiesLock.Lock()
+	for cn, props := range mc.connectedProxies {
+		if _, ok := mc.disconnectedProxies[cn]; ok {
+			continue
+		}
+		proxies[cn] = props.connectedAt
+	}
+	mc.disconnectedProxiesLock.Unlock()
+	mc.connectedProxiesLock.Unlock()
+	return proxies
+}
+
+// ListDisconnectedProxies lists the Envoy proxies disconnected and the time last seen.
+func (mc *MeshCatalog) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
+	proxies := make(map[certificate.CommonName]time.Time)
+	mc.disconnectedProxiesLock.Lock()
+	for cn, props := range mc.disconnectedProxies {
+		proxies[cn] = props.lastSeen
+	}
+	mc.disconnectedProxiesLock.Unlock()
+	return proxies
+}

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -14,7 +14,7 @@ import (
 )
 
 // NewFakeMeshCatalog creates a new struct implementing catalog.MeshCataloger interface used for testing.
-func NewFakeMeshCatalog(kubeClient kubernetes.Interface) MeshCataloger {
+func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	meshSpec := smi.NewFakeMeshSpecClient()
 	cache := make(map[certificate.CommonName]certificate.Certificater)
 	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -11,7 +11,7 @@ import (
 func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
 	mc.expectedProxiesLock.Lock()
 	mc.expectedProxies[cn] = expectedProxy{
-		certificateIssuedOn: time.Now(),
+		certificateIssuedAt: time.Now(),
 	}
 	mc.expectedProxiesLock.Unlock()
 }
@@ -21,7 +21,7 @@ func (mc *MeshCatalog) RegisterProxy(p *envoy.Proxy) {
 	mc.connectedProxiesLock.Lock()
 	mc.connectedProxies[p.CommonName] = connectedProxy{
 		proxy:       p,
-		connectedOn: time.Now(),
+		connectedAt: time.Now(),
 	}
 	mc.connectedProxiesLock.Unlock()
 	log.Info().Msgf("Registered new proxy: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -101,7 +101,7 @@ type announcementChannel struct {
 
 type expectedProxy struct {
 	// The time the certificate, identified by CN, for the expected proxy was issued on
-	certificateIssuedOn time.Time
+	certificateIssuedAt time.Time
 }
 
 type connectedProxy struct {
@@ -109,7 +109,7 @@ type connectedProxy struct {
 	proxy *envoy.Proxy
 
 	// When the proxy connected to the XDS control plane
-	connectedOn time.Time
+	connectedAt time.Time
 }
 
 type disconnectedProxy struct {


### PR DESCRIPTION
This PR fixes a bug with disconnectedProxies being uninitialized.
Also adds the following to MeshCatalog:
 - `ListExpectedProxies`
 - `ListConnectedProxies`
 - `ListDisconnectedProxies`

These are also very useful for testing Mesh catalog and re/deregistration of proxies (added tests)



This is work towards addressing https://github.com/open-service-mesh/osm/issues/822