### PR TITLE
debugger: Implement tresor.ListIssuedCertificates()

### DIFF
--- a/pkg/certificate/providers/tresor/debugger.go
+++ b/pkg/certificate/providers/tresor/debugger.go
@@ -1,0 +1,14 @@
+package tresor
+
+import "github.com/open-service-mesh/osm/pkg/certificate"
+
+// ListIssuedCertificates implements CertificateDebugger interface and returns the list of issued certificates.
+func (cm *CertManager) ListIssuedCertificates() []certificate.Certificater {
+	var certs []certificate.Certificater
+	cm.cacheLock.Lock()
+	defer cm.cacheLock.Unlock()
+	for _, cert := range *cm.cache {
+		certs = append(certs, cert)
+	}
+	return certs
+}

--- a/pkg/certificate/providers/tresor/debugger_test.go
+++ b/pkg/certificate/providers/tresor/debugger_test.go
@@ -1,0 +1,34 @@
+package tresor
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/certificate/pem"
+)
+
+var _ = Describe("Test Tresor Debugger", func() {
+	Context("test ListIssuedCertificates()", func() {
+		cert := &Certificate{
+			privateKey: pem.PrivateKey("yy"),
+			certChain:  pem.Certificate("xx"),
+			expiration: time.Now(),
+			commonName: "foo.bar.co.uk",
+		}
+		cert.issuingCA = cert
+		cache := map[certificate.CommonName]certificate.Certificater{
+			"foo": cert,
+		}
+		cm := CertManager{
+			cache: &cache,
+		}
+		It("lists all issued certificets", func() {
+			actual := cm.ListIssuedCertificates()
+			expeced := []certificate.Certificater{cert}
+			Expect(actual).To(Equal(expeced))
+		})
+	})
+})


### PR DESCRIPTION
This PR implements `ListIssuedCertificates()` for the tresor package

This is work towards addressing https://github.com/open-service-mesh/osm/issues/822