### PR TITLE
osm-rbac: add delete permission for mutatingwebhookconfiguration

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -30,7 +30,7 @@ rules:
     verbs: ["create", "update"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "create", "update"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
   - apiGroups: ["split.smi-spec.io"]
     resources: ["trafficsplits"]
     verbs: ["list", "get", "watch"]


### PR DESCRIPTION
OSM attempts to delete the webhook configuration with the same
name if one exists during creation.