### PR TITLE
ads: Send auth.Secret to all Envoys on announcement

### DIFF
--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -1,28 +1,63 @@
 package ads
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
 	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoy_service_discovery_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 
+	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
 
 func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *envoy_service_discovery_v2.AggregatedDiscoveryService_StreamAggregatedResourcesServer) {
+	log.Trace().Msgf("A change announcement triggered *DS update for proxy with CN=%s", proxy.GetCommonName())
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
-	for _, uri := range envoy.XDSResponseOrder {
-		request := &envoy_api_v2.DiscoveryRequest{TypeUrl: string(uri)}
+	for idx, typeURI := range envoy.XDSResponseOrder {
+		prefix := fmt.Sprintf("[*DS %d/%d]", idx+1, len(envoy.XDSResponseOrder))
+		log.Trace().Msgf("%s Creating %s response for proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
+
+		// For SDS we need to add ResourceNames
+		var request *envoy_api_v2.DiscoveryRequest
+		if typeURI == envoy.TypeSDS {
+			request = makeRequestForAllSecrets(proxy, s.catalog)
+			if request == nil {
+				continue
+			}
+		} else {
+			request = &envoy_api_v2.DiscoveryRequest{TypeUrl: string(typeURI)}
+		}
+
 		discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, request)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to create ADS discovery response")
+			log.Error().Err(err).Msgf("%s Failed to create %s discovery response for proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
 			continue
 		}
 		if err := (*server).Send(discoveryResponse); err != nil {
-			log.Error().Err(err).Msgf("Error sending DiscoveryResponse %s", uri)
+			log.Error().Err(err).Msgf("%s Error sending %s to proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
 		}
+	}
+}
+
+// makeRequestForAllSecrets constructs an SDS request AS IF an Envoy proxy sent it.
+// This request will result in the rest of the system creating an SDS response with the certificates
+// required by this proxy. The proxy itself did not ask for these. We know it needs them - so we send them.
+func makeRequestForAllSecrets(proxy *envoy.Proxy, catalog catalog.MeshCataloger) *envoy_api_v2.DiscoveryRequest {
+	serviceForProxy, err := catalog.GetServiceFromEnvoyCertificate(proxy.GetCommonName())
+	if err != nil {
+		log.Error().Err(err).Msgf("Error looking up Service for Envoy with CN=%q", proxy.GetCommonName())
+		return nil
+	}
+
+	return &envoy_api_v2.DiscoveryRequest{
+		ResourceNames: []string{
+			fmt.Sprintf("%s%s%s", envoy.ServiceCertType, envoy.Separator, serviceForProxy),
+			fmt.Sprintf("%s%s%s", envoy.RootCertType, envoy.Separator, serviceForProxy),
+		},
+		TypeUrl: string(envoy.TypeSDS),
 	}
 }
 

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -1,0 +1,114 @@
+package ads
+
+import (
+	"context"
+	"fmt"
+
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-service-mesh/osm/pkg/catalog"
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/smi"
+	"github.com/open-service-mesh/osm/pkg/tests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/open-service-mesh/osm/pkg/envoy"
+)
+
+var _ = Describe("Test ADS response functions", func() {
+
+	// --- setup
+	kubeClient := testclient.NewSimpleClientset()
+	namespace := tests.Namespace
+	envoyUID := tests.EnvoyUID
+	serviceName := uuid.New().String()
+	labels := map[string]string{constants.EnvoyUniqueIDLabelName: tests.EnvoyUID}
+	mc := catalog.NewFakeMeshCatalog(kubeClient)
+
+	// Create a Pod
+	pod := tests.NewPodTestFixture(namespace, fmt.Sprintf("pod-0-%s", uuid.New()))
+	pod.Labels[constants.EnvoyUniqueIDLabelName] = envoyUID
+	_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+	It("should have created a pod", func() {
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	service := tests.NewServiceFixture(serviceName, namespace, labels)
+	_, err = kubeClient.CoreV1().Services(namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+	It("should have created a service", func() {
+		Expect(err).ToNot(HaveOccurred())
+	})
+	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, namespace))
+	proxy := envoy.NewProxy(cn, nil)
+
+	expectedSecretOneName := fmt.Sprintf("service-cert:default/%s", serviceName)
+	expectedSecretTwoName := fmt.Sprintf("root-cert:default/%s", serviceName)
+
+	Context("Test getRequestedCertType()", func() {
+		It("returns service cert", func() {
+
+			actual := makeRequestForAllSecrets(proxy, mc)
+			expected := envoy_api_v2.DiscoveryRequest{
+				TypeUrl: string(envoy.TypeSDS),
+				ResourceNames: []string{
+					expectedSecretOneName,
+					expectedSecretTwoName,
+				},
+			}
+			Expect(actual).ToNot(BeNil())
+			Expect(*actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test sendAllResponses()", func() {
+		server, actualResponses := tests.NewFakeXDSServer()
+		It("returns Aggregated Discovery Service response", func() {
+			s := Server{
+				ctx:         context.TODO(),
+				catalog:     mc,
+				meshSpec:    smi.NewFakeMeshSpecClient(),
+				xdsHandlers: getHandlers(),
+			}
+
+			s.sendAllResponses(proxy, &server)
+
+			Expect(actualResponses).ToNot(BeNil())
+			Expect(len(*actualResponses)).To(Equal(5))
+
+			Expect((*actualResponses)[0].VersionInfo).To(Equal("1"))
+			Expect((*actualResponses)[0].TypeUrl).To(Equal(string(envoy.TypeCDS)))
+
+			Expect((*actualResponses)[1].VersionInfo).To(Equal("1"))
+			Expect((*actualResponses)[1].TypeUrl).To(Equal(string(envoy.TypeEDS)))
+
+			Expect((*actualResponses)[2].VersionInfo).To(Equal("1"))
+			Expect((*actualResponses)[2].TypeUrl).To(Equal(string(envoy.TypeLDS)))
+
+			Expect((*actualResponses)[3].VersionInfo).To(Equal("1"))
+			Expect((*actualResponses)[3].TypeUrl).To(Equal(string(envoy.TypeRDS)))
+
+			Expect((*actualResponses)[4].VersionInfo).To(Equal("1"))
+			Expect((*actualResponses)[4].TypeUrl).To(Equal(string(envoy.TypeSDS)))
+			Expect(len((*actualResponses)[4].Resources)).To(Equal(2))
+
+			secretOne := envoy_api_v2_auth.Secret{}
+			firstSecret := (*actualResponses)[4].Resources[0]
+			err = ptypes.UnmarshalAny(firstSecret, &secretOne)
+			Expect(secretOne.Name).To(Equal(expectedSecretOneName))
+
+			secretTwo := envoy_api_v2_auth.Secret{}
+			secondSecret := (*actualResponses)[4].Resources[1]
+			err = ptypes.UnmarshalAny(secondSecret, &secretTwo)
+			Expect(secretTwo.Name).To(Equal(expectedSecretTwoName))
+
+		})
+	})
+})

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -21,16 +21,10 @@ import (
 // NewADSServer creates a new Aggregated Discovery Service server
 func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSpec smi.MeshSpec, enableDebug bool) *Server {
 	server := Server{
-		catalog:  meshCatalog,
-		ctx:      ctx,
-		meshSpec: meshSpec,
-		xdsHandlers: map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error){
-			envoy.TypeEDS: eds.NewResponse,
-			envoy.TypeCDS: cds.NewResponse,
-			envoy.TypeRDS: rds.NewResponse,
-			envoy.TypeLDS: lds.NewResponse,
-			envoy.TypeSDS: sds.NewResponse,
-		},
+		catalog:     meshCatalog,
+		ctx:         ctx,
+		meshSpec:    meshSpec,
+		xdsHandlers: getHandlers(),
 		enableDebug: enableDebug,
 	}
 
@@ -39,6 +33,16 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 	}
 
 	return &server
+}
+
+func getHandlers() map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error) {
+	return map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest) (*xds.DiscoveryResponse, error){
+		envoy.TypeEDS: eds.NewResponse,
+		envoy.TypeCDS: cds.NewResponse,
+		envoy.TypeRDS: rds.NewResponse,
+		envoy.TypeLDS: lds.NewResponse,
+		envoy.TypeSDS: sds.NewResponse,
+	}
 }
 
 // DeltaAggregatedResources implements envoy_service_discovery_v2.AggregatedDiscoveryServiceServer

--- a/pkg/tests/stream.go
+++ b/pkg/tests/stream.go
@@ -1,0 +1,100 @@
+package tests
+
+import (
+	"context"
+
+	envoy_service_discovery_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"google.golang.org/grpc/metadata"
+)
+
+// XDSServer implements AggregatedDiscoveryService_StreamAggregatedResourcesServer
+type XDSServer struct {
+	responses []*v2.DiscoveryResponse
+}
+
+// NewFakeXDSServer returns a new XDSServer and implements AggregatedDiscoveryService_StreamAggregatedResourcesServer
+func NewFakeXDSServer() (envoy_service_discovery_v2.AggregatedDiscoveryService_StreamAggregatedResourcesServer, *[]*v2.DiscoveryResponse) {
+	server := XDSServer{}
+	return &server, &server.responses
+}
+
+// Send implements AggregatedDiscoveryService_StreamAggregatedResourcesServer
+func (s *XDSServer) Send(r *v2.DiscoveryResponse) error {
+	s.responses = append(s.responses, r)
+	return nil
+}
+
+// Recv implements AggregatedDiscoveryService_StreamAggregatedResourcesServer
+func (s *XDSServer) Recv() (*v2.DiscoveryRequest, error) {
+	r := v2.DiscoveryRequest{
+		VersionInfo:          "",
+		Node:                 nil,
+		ResourceNames:        nil,
+		TypeUrl:              "",
+		ResponseNonce:        "",
+		ErrorDetail:          nil,
+		XXX_NoUnkeyedLiteral: struct{}{},
+		XXX_unrecognized:     nil,
+		XXX_sizecache:        0,
+	}
+	return &r, nil
+}
+
+// SetHeader sets the header metadata. It may be called multiple times.
+// When call multiple times, all the provided metadata will be merged.
+// All the metadata will be sent out when one of the following happens:
+//  - ServerStream.SendHeader() is called;
+//  - The first response is sent out;
+//  - An RPC status is sent out (error or success).
+func (s *XDSServer) SetHeader(metadata.MD) error {
+	return nil
+}
+
+// SendHeader sends the header metadata.
+// The provided md and headers set by SetHeader() will be sent.
+// It fails if called multiple times.
+func (s *XDSServer) SendHeader(metadata.MD) error {
+	return nil
+}
+
+// SetTrailer sets the trailer metadata which will be sent with the RPC status.
+// When called more than once, all the provided metadata will be merged.
+func (s *XDSServer) SetTrailer(metadata.MD) {
+}
+
+// Context returns the context for this stream.
+func (s *XDSServer) Context() context.Context {
+	return nil
+}
+
+// SendMsg sends a message. On error, SendMsg aborts the stream and the
+// error is returned directly.
+//
+// SendMsg blocks until:
+//   - There is sufficient flow control to schedule m with the transport, or
+//   - The stream is done, or
+//   - The stream breaks.
+//
+// SendMsg does not wait until the message is received by the client. An
+// untimely stream closure may result in lost messages.
+//
+// It is safe to have a goroutine calling SendMsg and another goroutine
+// calling RecvMsg on the same stream at the same time, but it is not safe
+// to call SendMsg on the same stream in different goroutines.
+func (s *XDSServer) SendMsg(m interface{}) error {
+	return nil
+}
+
+// RecvMsg blocks until it receives a message into m or the stream is
+// done. It returns io.EOF when the client has performed a CloseSend. On
+// any non-EOF error, the stream is aborted and the error contains the
+// RPC status.
+//
+// It is safe to have a goroutine calling SendMsg and another goroutine
+// calling RecvMsg on the same stream at the same time, but it is not
+// safe to call RecvMsg on the same stream in different goroutines.
+func (s *XDSServer) RecvMsg(m interface{}) error {
+	return nil
+}


### PR DESCRIPTION
This PR fixes a bug **pushing** SDS messages to Envoys (when not requested).

This PR creates a proper SDS request (instead of a blank struct) and passes that to `sds.NewResponse()` -> `sds.getEnvoySDSSecrets()`.  This informs `getEnvoySDSSecrets` what certificates to place in the SDS response.

Before this PR - OSM pushing SDS responses / refreshes to Envoy proxies contained NO certificates.  Envoys would have to request new certs.

### Context
gRPC streams to/from Envoy proxies is handled by the following function satisfying an xDS interface:
https://github.com/open-service-mesh/osm/blob/0e8203964323b3c6e9ae49834fa7db8bbbce7aed/pkg/envoy/ads/stream.go#L15-L17

This is bidirectional: 
  - an Envoy makes a request for certain resource
  - OSM sends resources when an Envoy needs to be updated


When an Envoy needs to be updated (as a result of something somewhere sending an announcement message) the following block within 'StreamAggregatedResources' is executed, which regenerates all (CDS, EDS, LDS, RD, SDS) responses for the given Envoy unique proxy:
https://github.com/open-service-mesh/osm/blob/0e8203964323b3c6e9ae49834fa7db8bbbce7aed/pkg/envoy/ads/stream.go#L104-L107


Regardless of whether an Envoy requested it or OSM is pushing (unrequested) - we reuse the same function to create response and send:
https://github.com/open-service-mesh/osm/blob/d9104bf552011d6296d80a7068299bb75ad5b7f5/pkg/envoy/ads/response.go#L29-L31


`newAggregatedDiscoveryResponse` iterates through all the xDS request handlers and creates responses based on the SMI + Kubernetes context: 
https://github.com/open-service-mesh/osm/blob/c54e1d114b3f3f04bc3594af5436b5acb428f3e3/pkg/envoy/ads/server.go#L25-L31


The list of responses (CDS, EDS, LDS, RD, SDS) is combined into an Aggregated Discovery Service response (ADS) and is sent via gRPC to the Envoy: https://github.com/open-service-mesh/osm/blob/d9104bf552011d6296d80a7068299bb75ad5b7f5/pkg/envoy/ads/response.go#L23

Reusing the same xDS handlers for requests from Envoy (properly formatted from Envoy) and for OSM pushes to Envoys causes issues. SDS's handler https://github.com/open-service-mesh/osm/blob/0f4721c74d9780cc8018d8cbd12fc345cff9eac6/pkg/envoy/sds/response.go#L33
assumes that the request for secrets contains the kind of secret that needs to be sent.

The `sendAllResponses` function does not prepare a SDS request.  When the SDS response is created it is blank since it appears that nothing in particular was requested:
  - an Envoy can request a secret / certificate for a service:  https://github.com/open-service-mesh/osm/blob/0f4721c74d9780cc8018d8cbd12fc345cff9eac6/pkg/envoy/sds/response.go#L140
  - or the root cert: https://github.com/open-service-mesh/osm/blob/0f4721c74d9780cc8018d8cbd12fc345cff9eac6/pkg/envoy/sds/response.go#L162


To correct this - we create a proper SDS request when asking the SDS handler to generate an sds response.  We figure out what certificates need to be sent the Envoy and tell sds.NewResponse().