### PR TITLE
ref(*): add webhook config to chart

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -1,0 +1,19 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app: ads
+  name: osm-webhook-{{.Release.Name}}
+webhooks:
+- name: osm-inject.k8s.io
+  clientConfig:
+    service:
+      name: ads
+      namespace: {{.Release.Namespace}}
+      path: /mutate
+      port: 443
+  failurePolicy: Fail
+  matchPolicy: Exact
+  namespaceSelector:
+    matchLabels:
+      openservicemesh.io/monitor: {{.Release.Name}}

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -30,7 +30,7 @@ rules:
     verbs: ["create", "update"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "create", "update", "delete"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["split.smi-spec.io"]
     resources: ["trafficsplits"]
     verbs: ["list", "get", "watch"]

--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -84,7 +84,7 @@ func init() {
 	flags.StringVar(&azureAuthFile, "azureAuthFile", "", "Path to Azure Auth File")
 	flags.StringVar(&kubeConfigFile, "kubeconfig", "", "Path to Kubernetes config file.")
 	flags.StringVar(&osmNamespace, "osmNamespace", "", "Namespace to which OSM belongs to.")
-	flags.StringVar(&webhookName, "webhookName", "", "Name of the MutatingWebhookConfiguration to be created by ADS")
+	flags.StringVar(&webhookName, "webhookName", "", "Name of the MutatingWebhookConfiguration to be configured by ADS")
 	flags.IntVar(&serviceCertValidityMinutes, "serviceCertValidityMinutes", defaultServiceCertValidityMinutes, "Certificate validityPeriod duration in minutes")
 	flags.StringVar(&caBundleSecretName, caBundleSecretNameCLIParam, "", "Name of the Kubernetes Secret for the OSM CA bundle")
 	flags.BoolVar(&enableDebugServer, "enableDebugServer", false, "Enable OSM debug HTTP server")

--- a/demo/clean-kubernetes.sh
+++ b/demo/clean-kubernetes.sh
@@ -5,9 +5,6 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-WEBHOOK_NAME="osm-webhook-$K8S_NAMESPACE"
-
-kubectl delete mutatingwebhookconfiguration "$WEBHOOK_NAME" --ignore-not-found=true
 for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" "$K8S_NAMESPACE"; do
     kubectl delete namespace "$ns" || true
 done

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -9,13 +9,13 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/Azure/go-autorest/autorest/to"
 	"k8s.io/api/admission/v1beta1"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -36,11 +36,8 @@ var (
 )
 
 const (
-	osmWebhookName        = "osm-inject.k8s.io"
-	osmWebhookLabelKey    = "app"
-	osmWebhookServiceName = constants.AggregatedDiscoveryServiceName
-	osmWebhookLabelValue  = constants.AggregatedDiscoveryServiceName
-	osmWebhookMutatePath  = "/mutate"
+	osmWebhookName       = "osm-inject.k8s.io"
+	osmWebhookMutatePath = "/mutate"
 )
 
 // NewWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
@@ -65,9 +62,9 @@ func NewWebhook(config Config, kubeConfig *rest.Config, certManager certificate.
 
 	go wh.run(stop)
 
-	err = createMutatingWebhookConfiguration(cert, osmID, osmNamespace, webhookName, wh.kubeClient)
+	err = patchMutatingWebhookConfiguration(cert, osmID, osmNamespace, webhookName, wh.kubeClient)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Error creating MutatingWebhookConfiguration")
+		log.Fatal().Err(err).Msg("Error configuring MutatingWebhookConfiguration")
 	}
 
 	return nil
@@ -80,7 +77,7 @@ func (wh *webhook) run(stop <-chan struct{}) {
 	mux := http.DefaultServeMux
 	// HTTP handlers
 	mux.HandleFunc("/health/ready", wh.healthReadyHandler)
-	mux.HandleFunc("/mutate", wh.mutateHandler)
+	mux.HandleFunc(osmWebhookMutatePath, wh.mutateHandler)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", wh.config.ListenPort),
@@ -281,28 +278,18 @@ func patchAdmissionResponse(resp *v1beta1.AdmissionResponse, patchBytes []byte) 
 	}()
 }
 
-func createMutatingWebhookConfiguration(cert certificate.Certificater, osmID, osmNamespace, webhookName string, clientSet kubernetes.Interface) error {
-	fail := admissionv1beta1.Fail
-	webhook := admissionv1beta1.MutatingWebhookConfiguration{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "",
-			APIVersion: "",
-		},
+func patchMutatingWebhookConfiguration(cert certificate.Certificater, osmID, osmNamespace, webhookName string, clientSet kubernetes.Interface) error {
+	if err := hookExists(clientSet, webhookName); err != nil {
+		log.Error().Err(err).Msgf("Error getting webhook %s", webhookName)
+	}
+	updatedWH := admissionv1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookName,
-			Labels: map[string]string{
-				osmWebhookLabelKey: osmWebhookLabelValue,
-			},
 		},
 		Webhooks: []admissionv1beta1.MutatingWebhook{
 			{
 				Name: osmWebhookName,
 				ClientConfig: admissionv1beta1.WebhookClientConfig{
-					Service: &admissionv1beta1.ServiceReference{
-						Namespace: osmNamespace,
-						Name:      osmWebhookServiceName,
-						Path:      to.StringPtr(osmWebhookMutatePath),
-					},
 					CABundle: cert.GetCertificateChain(),
 				},
 				Rules: []admissionv1beta1.RuleWithOperations{
@@ -315,44 +302,26 @@ func createMutatingWebhookConfiguration(cert certificate.Certificater, osmID, os
 						},
 					},
 				},
-				FailurePolicy: &fail,
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						namespace.MonitorLabel: osmID,
-					},
-				},
 			},
 		},
 	}
-
-	exists, err := hookExists(clientSet, webhookName)
+	data, err := json.Marshal(updatedWH)
 	if err != nil {
 		return err
 	}
-	if exists {
-		opts := metav1.DeleteOptions{
-			GracePeriodSeconds: to.Int64Ptr(0),
-		}
-		if err := clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.Background(), webhook.Name, opts); err != nil {
-			log.Error().Err(err).Msgf("Error deleting webhook %s", webhookName)
-		}
-	}
-	if _, err := clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.Background(), &webhook, metav1.CreateOptions{}); err != nil {
+
+	_, err = clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Patch(
+		context.Background(), webhookName, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		log.Error().Err(err).Msgf("Error configuring webhook %s", webhookName)
 		return err
 	}
-	log.Info().Msgf("Created MutatingWebhookConfiguration %s", webhookName)
+
+	log.Info().Msgf("Configured MutatingWebhookConfiguration %s", webhookName)
 	return nil
 }
 
-func hookExists(clientSet kubernetes.Interface, webhookName string) (bool, error) {
-	webhooks, err := clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		return false, err
-	}
-	for _, webhook := range webhooks.Items {
-		if webhook.Name == webhookName {
-			return true, nil
-		}
-	}
-	return false, nil
+func hookExists(clientSet kubernetes.Interface, webhookName string) error {
+	_, err := clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.Background(), webhookName, metav1.GetOptions{})
+	return err
 }

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -2,56 +2,94 @@ package injector
 
 import (
 	"context"
-
-	"github.com/open-service-mesh/osm/pkg/namespace"
-
-	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
-	// v12 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
 )
 
-var _ = Describe("Test MutatingWebhookConfiguration creation", func() {
-	Context("create webhook", func() {
-
-		cert := tresor.Certificate{}
+var _ = Describe("Test MutatingWebhookConfiguration patch", func() {
+	Context("find and patches webhook", func() {
+		//cert := tresor.Certificate{}
+		cert := mockCertificate{}
 		osmID := "--osmID--"
 		osmNamespace := "--namespace--"
 		webhookName := "--webhookName--"
-		kubeClient := testclient.NewSimpleClientset()
-
-		It("creates a webhook", func() {
-			err := createMutatingWebhookConfiguration(cert, osmID, osmNamespace, webhookName, kubeClient)
-			Expect(err).ToNot(HaveOccurred())
-
+		//TODO:seed a test webhook
+		testWebhookServiceNamespace := "test-namespace"
+		testWebhookServiceName := "test-service-name"
+		testWebhookServicePath := "/path"
+		kubeClient := fake.NewSimpleClientset(&admissionv1beta1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: webhookName,
+			},
+			Webhooks: []admissionv1beta1.MutatingWebhook{
+				{
+					Name: osmWebhookName,
+					ClientConfig: admissionv1beta1.WebhookClientConfig{
+						Service: &admissionv1beta1.ServiceReference{
+							Namespace: testWebhookServiceNamespace,
+							Name:      testWebhookServiceName,
+							Path:      &testWebhookServicePath,
+						},
+					},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"some-key": "some-value",
+						},
+					},
+				},
+			},
 		})
 
 		It("checks if the hook exists", func() {
-			actual, err := hookExists(kubeClient, webhookName)
+			err := hookExists(kubeClient, webhookName)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(BeTrue())
 		})
 
 		It("checks if a non existent hook exists", func() {
-			actual, err := hookExists(kubeClient, webhookName+"blah")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual).To(BeFalse())
+			err := hookExists(kubeClient, webhookName+"blah")
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("only one webhook is created", func() {
-			webhooks, err := kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.TODO(), v1.ListOptions{})
+		It("patches a webhook", func() {
+			err := patchMutatingWebhookConfiguration(cert, osmID, osmNamespace, webhookName, kubeClient)
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+
+		It("ensures webhook is configured correctly", func() {
+			webhooks, err := kubeClient.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(webhooks.Items)).To(Equal(1))
 
 			webhook := webhooks.Items[0]
 			Expect(len(webhook.Webhooks)).To(Equal(1))
-			Expect(webhook.Webhooks[0].NamespaceSelector.MatchLabels[namespace.MonitorLabel]).To(Equal(osmID))
-			Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(osmNamespace))
-			Expect(webhook.Webhooks[0].ClientConfig.Service.Name).To(Equal(osmWebhookServiceName))
-			Expect(*(webhook.Webhooks[0].ClientConfig.Service.Path)).To(Equal(osmWebhookMutatePath))
+			Expect(webhook.Webhooks[0].NamespaceSelector.MatchLabels["some-key"]).To(Equal("some-value"))
+			Expect(webhook.Webhooks[0].ClientConfig.Service.Namespace).To(Equal(testWebhookServiceNamespace))
+			Expect(webhook.Webhooks[0].ClientConfig.Service.Name).To(Equal(testWebhookServiceName))
+			Expect(webhook.Webhooks[0].ClientConfig.Service.Path).To(Equal(&testWebhookServicePath))
+			Expect(webhook.Webhooks[0].ClientConfig.CABundle).To(Equal([]byte("chain")))
+			Expect(len(webhook.Webhooks[0].Rules)).To(Equal(1))
+			rule := webhook.Webhooks[0].Rules[0]
+			Expect(len(rule.Operations)).To(Equal(1))
+			Expect(rule.Operations[0]).To(Equal(admissionv1beta1.Create))
+			Expect(rule.Rule.APIGroups).To(Equal([]string{""}))
+			Expect(rule.Rule.APIVersions).To(Equal([]string{"v1"}))
+			Expect(rule.Rule.Resources).To(Equal([]string{"pods"}))
 		})
 	})
 })
+
+type mockCertificate struct{}
+
+func (mc mockCertificate) GetCommonName() certificate.CommonName { return "" }
+func (mc mockCertificate) GetCertificateChain() []byte           { return []byte("chain") }
+func (mc mockCertificate) GetPrivateKey() []byte                 { return []byte("key") }
+func (mc mockCertificate) GetIssuingCA() []byte                  { return []byte("ca") }
+func (mc mockCertificate) GetExpiration() time.Time              { return time.Now() }


### PR DESCRIPTION
This PR adds the MutatingWebhookConfiguration to our helm chart. Ads then updates the configuration with a `caBundle` and `Rules`. Because it is part of the helm installation, it can also be tracked and deleted by helm as well and in turn as part of the `osm admin delete-osm` command. We don't need to have separate logic or steps to delete the object anymore.