### PR TITLE
demo/ci: add support to test allow-all scenario

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,14 @@ export VAULT_ROLE=open-service-mesh
 # optional: Retention time for the data scraped by Prometheus service. Default is 15d
 export PROMETHEUS_RETENTION_TIME=5d
 
+# optional: Name of the bookstore service bookbuyer and bookthief make requests to.
+# Default: bookstore-mesh
+export BOOKSTORE_SVC=bookstore-mesh
+
+# optional: Expected response code when bookthief makes reqeusts to bookstore
+# Default: 404
+export BOOKTHIEF_EXPECTED_RESPONSE_CODE=404
+
 ### The section below configures certificates management
 ### OSM has 2 ways to manage certificates
 ### Set CERT_MANAGER to "tresor" to use the internal system (relies on k8s secrets)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
         mkdir coverage
         gocov-html < coverage.json > coverage/index.html
 
-    - name: Integration Test with Tresor
+    - name: Integration Test with Tresor and SMI traffic policies
       env:
         KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
         AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
@@ -157,6 +157,8 @@ jobs:
         CI_MIN_SUCCESS_THRESHOLD: 1
         OSM_HUMAN_DEBUG_LOG: ${{ secrets.OSM_HUMAN_DEBUG_LOG }}
         CERT_MANAGER: "tresor"
+        BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
+        BOOKSTORE_SVC: "bookstore-mesh"
       run: |
         touch .env  # it is ok keep this empty
         echo "Ensure K8s namespace $K8S_NAMESPACE is clean from previous runs"
@@ -168,7 +170,7 @@ jobs:
         ./demo/run-osm-demo.sh
         go run ./ci/cmd/maestro.go
 
-    - name: Integration Test with Hashi Vault
+    - name: Integration Test with Hashi Vault and Allow-all traffic policy
       env:
         KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
         AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}
@@ -196,6 +198,8 @@ jobs:
         VAULT_PORT: "8200"
         VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
         VAULT_ROLE: "open-service-mesh"
+        BOOKTHIEF_EXPECTED_RESPONSE_CODE: "200"
+        BOOKSTORE_SVC: "bookstore-v1"
       run: |
         touch .env  # it is ok keep this empty
         echo "Ensure K8s namespace $K8S_NAMESPACE is clean from previous runs"
@@ -204,5 +208,5 @@ jobs:
         mkdir -p ".kube"
         echo "$KUBE_CONFIG" | base64 -d > "$KUBECONFIG"
         echo "$DOCKER_PASS" | docker login "$ACR" -u "$DOCKER_USER" --password-stdin
-        ./demo/run-osm-demo.sh
+        ./demo/run-osm-demo.sh --disable-smi-access-control-policy
         go run ./ci/cmd/maestro.go

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -1,18 +1,16 @@
 package main
 
 import (
-	"net/http"
-
 	"github.com/open-service-mesh/osm/demo/cmd/common"
 )
 
 const (
-	participantName = "bookthief"
+	participantName    = "bookthief"
+	httpStatusNotFound = "404"
 )
 
 func main() {
-
 	// This is the book thief.  When it tries to get books from the bookstore - it will see 404 responses!
-	expectedResponseCode := http.StatusNotFound
+	expectedResponseCode := common.GetExpectedResponseCodeFromEnvVar(common.BookthiefExpectedResponseCodeEnvVar, httpStatusNotFound)
 	common.GetBooks(participantName, expectedResponseCode)
 }

--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -216,3 +216,13 @@ func getEnvVars(participantName string) (minSuccessThreshold int64, maxIteration
 
 	return minSuccessThreshold, maxIterations, time.Duration(sleepDurationBetweenRequestsInt) * time.Second
 }
+
+// GetExpectedResponseCodeFromEnvVar returns the expected response code based on the given environment variable
+func GetExpectedResponseCodeFromEnvVar(envVar, defaultValue string) int {
+	expectedRespCodeStr := GetEnv(envVar, defaultValue)
+	expectedRespCode, err := strconv.ParseInt(expectedRespCodeStr, 10, 0)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Could not convert environment variable %s='%s' to int", envVar, expectedRespCodeStr)
+	}
+	return int(expectedRespCode)
+}

--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -45,4 +45,7 @@ const (
 
 	// BookwarehouseNamespaceEnvVar is the environment variable for the Bookwarehouse namespace.
 	BookwarehouseNamespaceEnvVar = "BOOKWAREHOUSE_NAMESPACE"
+
+	// BookthiefExpectedResponseCodeEnvVar is the environment variable for Bookthief's expected HTTP response code
+	BookthiefExpectedResponseCodeEnvVar = "BOOKTHIEF_EXPECTED_RESPONSE_CODE"
 )

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -4,6 +4,7 @@ set -auexo pipefail
 
 # shellcheck disable=SC1091
 source .env
+BOOKSTORE_SVC="${BOOKSTORE_SVC:-bookstore-mesh}"
 
 kubectl create namespace "$BOOKBUYER_NAMESPACE" || true
 kubectl delete deployment bookbuyer -n "$BOOKBUYER_NAMESPACE"  || true
@@ -70,6 +71,8 @@ spec:
               value: "$BOOKSTORE_NAMESPACE"
             - name: "OSM_HUMAN_DEBUG_LOG"
               value: "true"
+            - name: "BOOKSTORE_SVC"
+              value: "$BOOKSTORE_SVC"
 
       imagePullSecrets:
         - name: "$CTR_REGISTRY_CREDS_NAME"

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -4,6 +4,8 @@ set -aueo pipefail
 
 # shellcheck disable=SC1091
 source .env
+BOOKSTORE_SVC="${BOOKSTORE_SVC:-bookstore-mesh}"
+BOOKTHIEF_EXPECTED_RESPONSE_CODE="${BOOKTHIEF_EXPECTED_RESPONSE_CODE:-404}"
 
 kubectl delete deployment bookthief -n "$BOOKTHIEF_NAMESPACE"  || true
 
@@ -67,7 +69,10 @@ spec:
               value: "$BOOKSTORE_NAMESPACE"
             - name: "OSM_HUMAN_DEBUG_LOG"
               value: "true"
-
+            - name: "BOOKSTORE_SVC"
+              value: "$BOOKSTORE_SVC"
+            - name: "BOOKTHIEF_EXPECTED_RESPONSE_CODE"
+              value: "$BOOKTHIEF_EXPECTED_RESPONSE_CODE"
 
       imagePullSecrets:
         - name: "$CTR_REGISTRY_CREDS_NAME"

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -4,7 +4,8 @@ set -aueo pipefail
 
 # shellcheck disable=SC1091
 source .env
-IS_GITHUB="${IS_GITHUB:-default false}"
+IS_GITHUB="${IS_GITHUB:-false}"
+optionalInstallArgs=$*
 
 exit_error() {
     error="$1"
@@ -121,6 +122,7 @@ done
 # Deploys Xds and Prometheus
 echo "Certificate Manager in use: $CERT_MANAGER"
 if [ "$CERT_MANAGER" = "vault" ]; then
+  # shellcheck disable=SC2086
   bin/osm install \
       --namespace "$K8S_NAMESPACE" \
       --cert-manager="$CERT_MANAGER" \
@@ -130,14 +132,17 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --container-registry "$CTR_REGISTRY" \
       --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
       --osm-image-tag "$CTR_TAG" \
-      --enable-debug-server
+      --enable-debug-server \
+      $optionalInstallArgs
 else
+  # shellcheck disable=SC2086
   bin/osm install \
       --namespace "$K8S_NAMESPACE" \
       --container-registry "$CTR_REGISTRY" \
       --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
       --osm-image-tag "$CTR_TAG" \
-      --enable-debug-server
+      --enable-debug-server \
+      $optionalInstallArgs
 fi
 
 wait_for_pod "ads"


### PR DESCRIPTION
This change updates the CI to run 2 scenarios:
- SMI policy with Tresor cert manager
- Allow-all policy with Vault cert manager

To support allow-all policy as a part of the demo:
- An existing BOOKSTORE_SVC env variable is used
  to configure the name of the bookstore service.
  By default, bookbuyer and bookthief make requests
  to the bookstore-mesh root service with SMI policies.
  The bookstore-mesh service is only used as a root
  level service for resolving the service DNS and doesn't
  have actual backends, with SMI policies defining how
  traffic is routed.
  With allow-all, since there are no SMI policies to
  define traffic routing, traffic should be routed
  similar to native k8s networking with the destination
  service having actual backends (bookstore-v1, bookstore-v2).

- The expected HTTP response code for bookthief is made
  configurable, defaulting to 404. With allow-all, bookthief
  should get a 200 response code when accessing the bookstore.

- Optional arguments to osm-install cli are exposed via the
  run-osm-demo.sh script to configure allow-all policy.

Resolves #817