### PR TITLE
tresor: Log cert serial as hexadecimal number

### DIFF
--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -88,7 +88,7 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Dur
 		expiration: template.NotAfter,
 	}
 
-	log.Info().Msgf("Created new certificate for CN=%s; validity=%+v; expires on %+v; serial: %+v", cn, validityPeriod, template.NotAfter, template.SerialNumber)
+	log.Info().Msgf("Created new certificate for CN=%s; validity=%+v; expires on %+v; serial: %x", cn, validityPeriod, template.NotAfter, template.SerialNumber)
 
 	return cert, nil
 }


### PR DESCRIPTION
This PR changes tresor so it logs the new cert's serial as hexadecimal, which matches what Envoy shows in /certs -- makes it easy (possible) to grep logs and search for certs