### PR TITLE
ingress: deprecate feature flag and enable by default

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -96,7 +96,6 @@ func init() {
 	flags.StringVar(&injectorConfig.SidecarImage, "sidecar-image", "", "Sidecar proxy Container image")
 
 	// feature flags
-	flags.BoolVar(&optionalFeatures.Ingress, "enable-ingress", false, "Enable ingress in OSM")
 	flags.BoolVar(&optionalFeatures.SMIAccessControlDisabled, "disable-smi-access-control-policy", false, "Disable SMI access control policies")
 }
 

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -9,7 +9,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
-	"github.com/open-service-mesh/osm/pkg/featureflags"
 	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
@@ -67,12 +66,10 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 		}
 	}
 
-	if featureflags.IsIngressEnabled() {
-		// Process ingress policy if applicable
-		clusterFactories, err = getIngressServiceCluster(proxyServiceName, catalog, clusterFactories)
-		if err != nil {
-			return nil, err
-		}
+	// Process ingress policy if applicable
+	clusterFactories, err = getIngressServiceCluster(proxyServiceName, catalog, clusterFactories)
+	if err != nil {
+		return nil, err
 	}
 	for _, cluster := range clusterFactories {
 		log.Debug().Msgf("Proxy service %s constructed ClusterConfiguration: %+v ", proxyServiceName, cluster)

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -10,7 +10,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/route"
-	"github.com/open-service-mesh/osm/pkg/featureflags"
 	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
@@ -64,11 +63,9 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		}
 	}
 
-	if featureflags.IsIngressEnabled() {
-		// Process ingress policy if applicable
-		if err = updateRoutesForIngress(proxyServiceName, catalog, destinationAggregatedRoutesByDomain); err != nil {
-			return nil, err
-		}
+	// Process ingress policy if applicable
+	if err = updateRoutesForIngress(proxyServiceName, catalog, destinationAggregatedRoutesByDomain); err != nil {
+		return nil, err
 	}
 
 	sourceRouteConfig = route.UpdateRouteConfiguration(sourceAggregatedRoutesByDomain, sourceRouteConfig, true, false)

--- a/pkg/featureflags/featureflags.go
+++ b/pkg/featureflags/featureflags.go
@@ -8,7 +8,6 @@ import (
 
 // OptionalFeatures is a struct to enable/disable optional features
 type OptionalFeatures struct {
-	Ingress                  bool
 	SMIAccessControlDisabled bool
 }
 
@@ -25,11 +24,6 @@ func Initialize(optionalFeatures OptionalFeatures) {
 	once.Do(func() {
 		Features = optionalFeatures
 	})
-}
-
-// IsIngressEnabled returns a boolean indicating if the ingress feature is enabled
-func IsIngressEnabled() bool {
-	return Features.Ingress
 }
 
 // IsSMIAccessControlDisabled returns a boolean indicating if access control is disabled


### PR DESCRIPTION
Ingress is no longer experimental. Deprecate the feature flag
to simplify the code.

Resolves #765