### PR TITLE
certificate: make rotation annoucements from CertManager

### DIFF
--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -93,16 +93,8 @@ func NewCertManager(ca certificate.Certificater, validityPeriod time.Duration, c
 		certificatesOrganization: certificatesOrganization,
 	}
 
-	// Instantiating a new certificate rotation mechanism will start a goroutine and return an announcement channel
-	// which we use to get notified when a cert has been rotated. From then we pass that onto whoever is listening
-	// to the announcement channel of pkg/tresor.
-	announcements := rotor.New(checkCertificateExpirationInterval, &certManager, &cache)
-	go func() {
-		for {
-			<-announcements
-			certManager.announcements <- nil
-		}
-	}()
+	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.
+	rotor.Start(checkCertificateExpirationInterval, &certManager, &cache)
 
 	return &certManager, nil
 }

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -143,6 +143,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	cm.cacheLock.Lock()
 	(*cm.cache)[cn] = cert
 	cm.cacheLock.Unlock()
+	cm.announcements <- nil
 
 	log.Info().Msgf("Rotating certificate CN=%s took %+v", cn, time.Since(start))
 

--- a/pkg/certificate/rotor/rotor.go
+++ b/pkg/certificate/rotor/rotor.go
@@ -21,17 +21,13 @@ const (
 type rotor struct {
 	certificates *map[certificate.CommonName]certificate.Certificater
 	certManager  certificate.Manager
-
-	// Announce to the outside world that a certificate has been rotated.
-	announcements chan interface{}
 }
 
-// New creates and starts a new facility for automatic certificate rotation.
-func New(checkInterval time.Duration, certManager certificate.Manager, certificates *map[certificate.CommonName]certificate.Certificater) <-chan interface{} {
+// Start creates and starts a new facility for automatic certificate rotation.
+func Start(checkInterval time.Duration, certManager certificate.Manager, certificates *map[certificate.CommonName]certificate.Certificater) {
 	rtr := rotor{
-		certificates:  certificates,
-		certManager:   certManager,
-		announcements: make(chan interface{}),
+		certificates: certificates,
+		certManager:  certManager,
 	}
 
 	// TODO(draychev): current implementation is the naive one - we iterate over a list of certificates we are given
@@ -43,8 +39,6 @@ func New(checkInterval time.Duration, certManager certificate.Manager, certifica
 			<-ticker.C
 		}
 	}()
-
-	return rtr.announcements
 }
 
 func (r *rotor) checkAndRotate() {
@@ -61,7 +55,6 @@ func (r *rotor) checkAndRotate() {
 				log.Error().Err(err).Msgf("Error rotating cert CN=%s", cn)
 				continue
 			}
-			r.announcements <- nil
 			log.Trace().Msgf("Rotated cert CN=%s", newCert.GetCommonName())
 		}
 	}

--- a/pkg/certificate/rotor/rotor_test.go
+++ b/pkg/certificate/rotor/rotor_test.go
@@ -51,9 +51,9 @@ var _ = Describe("Test Rotor", func() {
 			Expect(cache[cn]).To(Equal(certA))
 
 			start := time.Now()
-			announcements := rotor.New(360*time.Second, certManager, &cache)
+			rotor.Start(360*time.Second, certManager, &cache)
 			// Wait for one certificate rotation to be announced and terminate
-			<-announcements
+			<-certManager.GetAnnouncementsChannel()
 			close(done)
 
 			fmt.Printf("It took %+v to rotate certificate %s\n", time.Since(start), cn)


### PR DESCRIPTION
When certificates are rotated, rotor makes announcements on its
own announcement channel, followed by an announcment on the
CertManager's annoucement channel. Simplify this by making
announcements for cert rotation directly from the CertManager's
RotateCertificate() method.