### PR TITLE
grpc: Enrich ADS trace messages with the proxy requesting xDS

### DIFF
--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -5,12 +5,13 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	xds "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/open-service-mesh/osm/pkg/envoy"
 )
 
-func receive(requests chan v2.DiscoveryRequest, server *xds.AggregatedDiscoveryService_StreamAggregatedResourcesServer) {
+func receive(requests chan v2.DiscoveryRequest, server *xds.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy) {
 	defer close(requests)
 	for {
 		var request *v2.DiscoveryRequest
@@ -24,9 +25,10 @@ func receive(requests chan v2.DiscoveryRequest, server *xds.AggregatedDiscoveryS
 			return
 		}
 		if request.TypeUrl != "" {
+			log.Trace().Msgf("[grpc] Received DiscoveryRequest from Envoy %s: %+v", proxy.GetCommonName(), request)
 			requests <- *request
 		} else {
-			log.Warn().Msgf("[grpc] Unknown resource: %s", request.String())
+			log.Warn().Msgf("[grpc] Unknown resource: %+v", request)
 		}
 	}
 }

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -40,7 +40,7 @@ func (s *Server) StreamAggregatedResources(server discovery.AggregatedDiscoveryS
 	defer cancel()
 
 	requests := make(chan v2.DiscoveryRequest)
-	go receive(requests, &server)
+	go receive(requests, &server, proxy)
 
 	for {
 		select {


### PR DESCRIPTION
This PR is part of the larger https://github.com/open-service-mesh/osm/pull/833

The goal of this to add a bit more context on what the proxy is that connected to ADS and is sending Discovery Requests.