### PR TITLE
ads: Seed NewFakeXDSServer() with a certificate to test mTLS as well

### DIFF
--- a/pkg/tests/address.go
+++ b/pkg/tests/address.go
@@ -1,0 +1,23 @@
+package tests
+
+import "net"
+
+type netAddr struct {
+	address string
+}
+
+// Network implements net.Addr interface
+func (a *netAddr) Network() string {
+	return "mockNetwork"
+}
+
+func (a *netAddr) String() string {
+	return a.address
+}
+
+// NewMockAddress creates a new net.Addr
+func NewMockAddress(address string) net.Addr {
+	return &netAddr{
+		address: address,
+	}
+}

--- a/pkg/tests/mtls.go
+++ b/pkg/tests/mtls.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// NewMockAuthInfo creates a new credentials.AuthInfo
+func NewMockAuthInfo(cert *x509.Certificate) credentials.AuthInfo {
+	return credentials.TLSInfo{
+		State: tls.ConnectionState{
+			ServerName:     "server.name",
+			VerifiedChains: [][]*x509.Certificate{{cert}}},
+	}
+}


### PR DESCRIPTION
This PR changes the signature of `NewFakeXDSServer()` to make it possible to pass a certificate to the XDS server.

This PR is part of https://github.com/open-service-mesh/osm/pull/833 where we actually use this XDS certificate in tests.