### PR TITLE
Change terminology for cluster accepting all traffic

### DIFF
--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -63,6 +63,6 @@ func (mc *MeshCatalog) GetIngressRoutePoliciesPerDomain(service service.Namespac
 func (mc *MeshCatalog) GetIngressWeightedCluster(svc service.NamespacedService) (service.WeightedCluster, error) {
 	return service.WeightedCluster{
 		ClusterName: service.ClusterName(svc.String()),
-		Weight:      constants.WildcardClusterWeight,
+		Weight:      constants.ClusterWeightAcceptAll,
 	}, nil
 }

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -337,6 +337,6 @@ func getHostHeaderFromRouteHeaders(routeHeaders map[string]string) (string, erro
 func getDefaultWeightedClusterForService(nsService service.NamespacedService) service.WeightedCluster {
 	return service.WeightedCluster{
 		ClusterName: service.ClusterName(nsService.String()),
-		Weight:      constants.WildcardClusterWeight,
+		Weight:      constants.ClusterWeightAcceptAll,
 	}
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -104,8 +104,8 @@ const (
 	// EnvVarHumanReadableLogMessages is an environment variable, which when set to "true" enables colorful human-readable log messages.
 	EnvVarHumanReadableLogMessages = "OSM_HUMAN_DEBUG_LOG"
 
-	// WildcardClusterWeight is the default wildcard cluster weight
-	WildcardClusterWeight = 100
+	// ClusterWeightAcceptAll is the weight for a cluster that accepts 100 percent of traffic sent to it
+	ClusterWeightAcceptAll = 100
 
 	// PrometheusDefaultRetentionTime is the default days for which data is retained in prometheus
 	PrometheusDefaultRetentionTime = "15d"

--- a/pkg/envoy/cds/service.go
+++ b/pkg/envoy/cds/service.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	weightAcceptAll   uint32        = 100
 	connectionTimeout time.Duration = 1 * time.Second
 )
 
@@ -60,7 +59,7 @@ func getServiceClusterLocal(catalog catalog.MeshCataloger, proxyServiceName serv
 					},
 				},
 				LoadBalancingWeight: &wrappers.UInt32Value{
-					Value: weightAcceptAll, // Local cluster accepts all traffic
+					Value: constants.ClusterWeightAcceptAll, // Local cluster accepts all traffic
 				},
 			}},
 		}
@@ -92,7 +91,7 @@ func getPrometheusCluster(clusterName string) xds.Cluster {
 							},
 						},
 						LoadBalancingWeight: &wrappers.UInt32Value{
-							Value: weightAcceptAll,
+							Value: constants.ClusterWeightAcceptAll,
 						},
 					}},
 				},

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -83,7 +83,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 	Context("Adding a route to existing domain in the map", func() {
 		It("Returns the map of with a new route on the domain", func() {
 
-			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: constants.WildcardClusterWeight}
+			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: constants.ClusterWeightAcceptAll}
 			routePolicy := trafficpolicy.Route{
 				PathRegex: "/update-books-bought",
 				Methods:   []string{"GET"},
@@ -107,7 +107,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 	Context("Adding a cluster to an existing route to existing domain in the map", func() {
 		It("Returns the map of with a new weighted cluster on a route in the domain", func() {
 
-			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2"), Weight: constants.WildcardClusterWeight}
+			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2"), Weight: constants.ClusterWeightAcceptAll}
 			routePolicy := trafficpolicy.Route{
 				PathRegex: "/update-books-bought",
 				Methods:   []string{"GET"},


### PR DESCRIPTION
A weight of 100 implies the cluster accepts all traffic
it receives. This is used for local clusters accepting
100 percent of traffic destined to it.