### PR TITLE
cds: Simplify local cluster config

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -22,14 +22,14 @@ var _ = Describe("Test XDS certificate tooling", func() {
 	kubeClient := testclient.NewSimpleClientset()
 
 	mc := NewFakeMeshCatalog(kubeClient)
-	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.EnvoyUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.EnvoyUID, tests.BookstoreServiceAccountName, tests.Namespace))
 
 	Context("Test GetServiceFromEnvoyCertificate()", func() {
 		It("works as expected", func() {
-			pod := tests.NewPodTestFixture(tests.Namespace, "pod-name")
+			pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName)
 			_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pod.Spec.ServiceAccountName).To(Equal(tests.BookbuyerServiceAccountName))
+			Expect(pod.Spec.ServiceAccountName).To(Equal(tests.BookstoreServiceAccountName))
 
 			// Create the SERVICE
 			svcName := uuid.New().String()
@@ -75,7 +75,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			_, err = kubeClient.CoreV1().Services(namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			podCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, namespace))
+			podCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookstoreServiceAccountName, namespace))
 			nsService, err := getServiceFromCertificate(podCN, kubeClient)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -122,7 +122,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods.Items)).To(Equal(3))
 
-			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, namespace))
+			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookstoreServiceAccountName, namespace))
 			actualPod, err := GetPodFromCertificate(newCN, kubeClient)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -170,7 +170,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, namespace))
+			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookstoreServiceAccountName, namespace))
 			actualPod, err := GetPodFromCertificate(newCN, kubeClient)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(errMoreThanOnePodForCertificate))
@@ -191,7 +191,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newPod.Spec.ServiceAccountName).ToNot(Equal(randomServiceAccount))
-			Expect(newPod.Spec.ServiceAccountName).To(Equal(tests.BookbuyerServiceAccountName))
+			Expect(newPod.Spec.ServiceAccountName).To(Equal(tests.BookstoreServiceAccountName))
 
 			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, randomServiceAccount, namespace))
 			actualPod, err := GetPodFromCertificate(newCN, kubeClient)
@@ -214,7 +214,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, someOtherRandomNamespace))
+			newCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookstoreServiceAccountName, someOtherRandomNamespace))
 			actualPod, err := GetPodFromCertificate(newCN, kubeClient)
 			Expect(err).To(HaveOccurred())
 			// Since the namespace on the certificate is different than where the pod is...

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -13,7 +13,8 @@ func NewFakeProvider() endpoint.Provider {
 
 	return &fakeClient{
 		endpoints: map[service.Name][]endpoint.Endpoint{
-			tests.NamespacedServiceName: {tests.Endpoint},
+			service.Name(tests.BookstoreService.String()): {tests.Endpoint},
+			service.Name(tests.BookbuyerService.String()): {tests.Endpoint},
 		},
 		services: map[service.NamespacedServiceAccount]service.NamespacedService{
 			tests.BookstoreServiceAccount: tests.BookstoreService,

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -31,7 +31,9 @@ var _ = Describe("Test ADS response functions", func() {
 	kubeClient := testclient.NewSimpleClientset()
 	namespace := tests.Namespace
 	envoyUID := tests.EnvoyUID
-	serviceName := uuid.New().String()
+	serviceName := tests.BookstoreServiceName
+	serviceAccountName := tests.BookstoreServiceAccountName
+
 	labels := map[string]string{constants.EnvoyUniqueIDLabelName: tests.EnvoyUID}
 	mc := catalog.NewFakeMeshCatalog(kubeClient)
 
@@ -48,7 +50,7 @@ var _ = Describe("Test ADS response functions", func() {
 	It("should have created a service", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
-	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, tests.BookbuyerServiceAccountName, namespace))
+	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", envoyUID, serviceAccountName, namespace))
 	proxy := envoy.NewProxy(cn, nil)
 
 	expectedSecretOneName := fmt.Sprintf("service-cert:default/%s", serviceName)
@@ -76,7 +78,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 		cache := make(map[certificate.CommonName]certificate.Certificater)
 		certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
-		cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), tests.BookbuyerServiceAccountName, tests.Namespace))
+		cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), serviceAccountName, tests.Namespace))
 		certPEM, _ := certManager.IssueCertificate(cn, nil)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 		server, actualResponses := tests.NewFakeXDSServer(cert, nil, nil)

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
 
@@ -54,7 +55,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 
 	// Create a local cluster for the service.
 	// The local cluster will be used for incoming traffic.
-	localClusterName := fmt.Sprintf("%s%s", proxyServiceName, envoy.LocalClusterSuffix)
+	localClusterName := getLocalClusterName(proxyServiceName)
 	localCluster, err := getServiceClusterLocal(catalog, proxyServiceName, localClusterName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
@@ -80,4 +81,8 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 	}
 	resp.Resources = append(resp.Resources, marshalledCluster)
 	return resp, nil
+}
+
+func getLocalClusterName(proxyServiceName service.NamespacedService) string {
+	return fmt.Sprintf("%s%s", proxyServiceName, envoy.LocalClusterSuffix)
 }

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -34,14 +34,18 @@ var _ = Describe("CDS Response", func() {
 
 			proxyUUID := fmt.Sprintf("proxy-0-%s", uuid.New())
 			podName := fmt.Sprintf("pod-0-%s", uuid.New())
+			proxyServiceName := tests.BookbuyerServiceName
+			proxyServiceAccountName := tests.BookbuyerServiceAccountName
+			proxyService := tests.BookbuyerService
+			proxyServicePort := tests.ServicePort
 
 			// The format of the CN matters
-			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
 			proxy := envoy.NewProxy(xdsCertificate, nil)
 
 			{
 				// Create a pod to match the CN
-				pod := tests.NewPodTestFixture(tests.Namespace, podName)
+				pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, podName, proxyServiceAccountName)
 				pod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID // This is what links the Pod and the Certificate
 				_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -54,7 +58,7 @@ var _ = Describe("CDS Response", func() {
 					tests.SelectorKey: tests.SelectorValue,
 				}
 				// The serviceName must match the SMI
-				service := tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, selectors)
+				service := tests.NewServiceFixture(proxyServiceName, tests.Namespace, selectors)
 				_, err := kubeClient.CoreV1().Services(tests.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
@@ -62,86 +66,43 @@ var _ = Describe("CDS Response", func() {
 			resp, err := NewResponse(context.Background(), catalog.NewFakeMeshCatalog(kubeClient), smiClient, proxy, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			expected := xds.DiscoveryResponse{
-				VersionInfo: "",
-				Resources: []*any.Any{
-					{
-						TypeUrl: string(envoy.TypeCDS),
-						Value:   []byte{10, 17, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 115, 116, 111, 114, 101, 26, 4, 10, 2, 26, 0, 34, 2, 8, 5, 194, 1, 219, 1, 10, 27, 101, 110, 118, 111, 121, 46, 116, 114, 97, 110, 115, 112, 111, 114, 116, 95, 115, 111, 99, 107, 101, 116, 115, 46, 116, 108, 115, 26, 187, 1, 10, 56, 116, 121, 112, 101, 46, 103, 111, 111, 103, 108, 101, 97, 112, 105, 115, 46, 99, 111, 109, 47, 101, 110, 118, 111, 121, 46, 97, 112, 105, 46, 118, 50, 46, 97, 117, 116, 104, 46, 85, 112, 115, 116, 114, 101, 97, 109, 84, 108, 115, 67, 111, 110, 116, 101, 120, 116, 18, 127, 10, 88, 10, 4, 8, 3, 16, 4, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 58, 42, 10, 36, 114, 111, 111, 116, 45, 99, 101, 114, 116, 45, 102, 111, 114, 45, 109, 116, 108, 115, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 18, 35, 98, 111, 111, 107, 98, 117, 121, 101, 114, 46, 100, 101, 102, 97, 117, 108, 116, 46, 115, 118, 99, 46, 99, 108, 117, 115, 116, 101, 114, 46, 108, 111, 99, 97, 108, 16, 3},
-					}, {
-						TypeUrl: string(envoy.TypeCDS),
-						Value:   []byte{10, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 34, 2, 8, 1, 226, 1, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 138, 2, 49, 10, 19, 101, 110, 118, 111, 121, 45, 97, 100, 109, 105, 110, 45, 99, 108, 117, 115, 116, 101, 114, 18, 26, 18, 24, 34, 2, 8, 100, 10, 18, 10, 16, 10, 14, 18, 9, 49, 50, 55, 46, 48, 46, 48, 46, 49, 24, 152, 117, 16, 0},
-					}},
-				Canary:  false,
-				TypeUrl: string(envoy.TypeCDS),
-				Nonce:   "",
-			}
-
 			// There are to any.Any resources in the ClusterDiscoveryStruct (Clusters)
-			Expect(len((*resp).Resources)).To(Equal(2))
+			// There are 3 clusters we expect:
+			// 1. Destination cluster
+			// 2. Source cluster
+			// 3. Prometheus cluster
+			numExpectedClusters := 3
+			Expect(len((*resp).Resources)).To(Equal(numExpectedClusters))
 
-			expectedClusters := []xds.Cluster{
-				{
-					Name: "default/bookstore",
-					TransportSocket: &envoy_api_v2_core.TransportSocket{
-						Name: "envoy.transport_sockets.tls",
-						ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
-							TypedConfig: &any.Any{
-								TypeUrl: "type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext",
-								Value:   []byte{10, 88, 10, 4, 8, 3, 16, 4, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 58, 42, 10, 36, 114, 111, 111, 116, 45, 99, 101, 114, 116, 45, 102, 111, 114, 45, 109, 116, 108, 115, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 18, 35, 98, 111, 111, 107, 98, 117, 121, 101, 114, 46, 100, 101, 102, 97, 117, 108, 116, 46, 115, 118, 99, 46, 99, 108, 117, 115, 116, 101, 114, 46, 108, 111, 99, 97, 108},
-							},
-						},
-					},
-				},
-				{
-					Name: "envoy-admin-cluster",
-				},
-			}
-
-			for clusterIdx, expectedCluster := range expectedClusters {
-				// The first cluster is the route to the Bookstore
-				// Second cluster is the Envoy Admin
-				cluster := xds.Cluster{}
-				err = ptypes.UnmarshalAny(resp.Resources[clusterIdx], &cluster)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.Name).To(Equal(expectedCluster.Name))
-				Expect(cluster.TransportSocket).To(Equal(expectedCluster.TransportSocket))
-			}
-
-			Expect((*resp).Resources[0]).To(Equal(expected.Resources[0]))
-			Expect((*resp).Resources[1]).To(Equal(expected.Resources[1]))
-			Expect(*resp).To(Equal(expected))
-
-			expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
-				ClusterName: "envoy-admin-cluster",
-				Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
-					{
-						Locality: nil,
-						LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
-							HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
-								Endpoint: &envoy_api_v2_endpoint.Endpoint{
-									Address: &envoy_api_v2_core.Address{
-										Address: &envoy_api_v2_core.Address_SocketAddress{
-											SocketAddress: &envoy_api_v2_core.SocketAddress{
-												Protocol: envoy_api_v2_core.SocketAddress_TCP,
-												Address:  "127.0.0.1",
-												PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
-													PortValue: uint32(15000),
+			{
+				expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
+					ClusterName: "envoy-admin-cluster",
+					Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+						{
+							Locality: nil,
+							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+									Endpoint: &envoy_api_v2_endpoint.Endpoint{
+										Address: &envoy_api_v2_core.Address{
+											Address: &envoy_api_v2_core.Address_SocketAddress{
+												SocketAddress: &envoy_api_v2_core.SocketAddress{
+													Protocol: envoy_api_v2_core.SocketAddress_TCP,
+													Address:  "127.0.0.1",
+													PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+														PortValue: uint32(15000),
+													},
 												},
 											},
 										},
 									},
 								},
-							},
-							LoadBalancingWeight: &wrappers.UInt32Value{
-								Value: 100,
-							},
-						}},
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 100,
+								},
+							}},
+						},
 					},
-				},
-			}
-
-			{
+				}
 				expectedCluster := xds.Cluster{
 					TransportSocketMatches: nil,
 					Name:                   "default/bookstore",
@@ -217,6 +178,80 @@ var _ = Describe("CDS Response", func() {
 				// Expect(upstreamTLSContext).To(Equal(expectedTLSContext)
 			}
 			{
+				expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
+					ClusterName: getLocalClusterName(proxyService),
+					Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+						{
+							Locality: nil,
+							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+									Endpoint: &envoy_api_v2_endpoint.Endpoint{
+										Address: &envoy_api_v2_core.Address{
+											Address: &envoy_api_v2_core.Address_SocketAddress{
+												SocketAddress: &envoy_api_v2_core.SocketAddress{
+													Protocol: envoy_api_v2_core.SocketAddress_TCP,
+													Address:  constants.WildcardIPAddr,
+													PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+														PortValue: uint32(proxyServicePort),
+													},
+												},
+											},
+										},
+									},
+								},
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: constants.ClusterWeightAcceptAll,
+								},
+							}},
+						},
+					},
+				}
+				expectedCluster := xds.Cluster{
+					TransportSocketMatches: nil,
+					Name:                   getLocalClusterName(proxyService),
+					AltStatName:            getLocalClusterName(proxyService),
+					ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
+					EdsClusterConfig:       nil,
+					ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
+					LoadAssignment:         expectedClusterLoadAssignment,
+				}
+				cluster := xds.Cluster{}
+				err = ptypes.UnmarshalAny(resp.Resources[1], &cluster)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.Name).To(Equal(expectedCluster.Name))
+				Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
+				Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
+				Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+			}
+			{
+				expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
+					ClusterName: "envoy-admin-cluster",
+					Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+						{
+							Locality: nil,
+							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+									Endpoint: &envoy_api_v2_endpoint.Endpoint{
+										Address: &envoy_api_v2_core.Address{
+											Address: &envoy_api_v2_core.Address_SocketAddress{
+												SocketAddress: &envoy_api_v2_core.SocketAddress{
+													Protocol: envoy_api_v2_core.SocketAddress_TCP,
+													Address:  "127.0.0.1",
+													PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+														PortValue: uint32(15000),
+													},
+												},
+											},
+										},
+									},
+								},
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: 100,
+								},
+							}},
+						},
+					},
+				}
 				expectedCluster := xds.Cluster{
 					TransportSocketMatches: nil,
 					Name:                   "envoy-admin-cluster",
@@ -227,7 +262,7 @@ var _ = Describe("CDS Response", func() {
 					LoadAssignment:         expectedClusterLoadAssignment,
 				}
 				cluster := xds.Cluster{}
-				err = ptypes.UnmarshalAny(resp.Resources[1], &cluster)
+				err = ptypes.UnmarshalAny(resp.Resources[2], &cluster)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
 				Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -26,7 +26,7 @@ import (
 var _ = Describe("Test SDS response functions", func() {
 
 	prep := func(resourceNames []string, namespace, svcName string) (certificate.Certificater, *envoy.Proxy, catalog.MeshCataloger) {
-		serviceAccount := tests.BookbuyerServiceAccountName
+		serviceAccount := tests.BookstoreServiceAccountName
 		proxyID := uuid.New().String()
 		podName := uuid.New().String()
 
@@ -169,6 +169,7 @@ var _ = Describe("Test SDS response functions", func() {
 						MatchSubjectAltNames: []*envoy_type_matcher.StringMatcher{{
 							MatchPattern: &envoy_type_matcher.StringMatcher_Exact{
 								// The Certificates Subject Common Name will look like this: "bookbuyer.default.svc.cluster.local"
+								// BookbuyerService is an inbound service that is allowed.
 								Exact: tests.BookbuyerService.GetCommonName().String(),
 							}},
 						},

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -70,7 +70,10 @@ const (
 	EnvoyUID = "A-B-C-D"
 
 	// ServicePort is the port used by a service
-	ServicePort = 9999
+	ServicePort = 8888
+
+	// ServiceIP is the IP used by a service
+	ServiceIP = "8.8.8.8"
 )
 
 var (
@@ -97,8 +100,8 @@ var (
 
 	// Endpoint is an endpoint object.
 	Endpoint = endpoint.Endpoint{
-		IP:   net.ParseIP("8.8.8.8"),
-		Port: endpoint.Port(8888),
+		IP:   net.ParseIP(ServiceIP),
+		Port: endpoint.Port(ServicePort),
 	}
 
 	// TrafficPolicy is a traffic policy SMI object.
@@ -224,7 +227,24 @@ func NewPodTestFixture(namespace string, podName string) corev1.Pod {
 			},
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: BookbuyerServiceAccountName,
+			ServiceAccountName: BookstoreServiceAccountName,
+		},
+	}
+}
+
+// NewPodTestFixtureWithOptions creates a new Pod struct with options for testing.
+func NewPodTestFixtureWithOptions(namespace string, podName string, serviceAccountName string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				SelectorKey:                      SelectorValue,
+				constants.EnvoyUniqueIDLabelName: EnvoyUID,
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: serviceAccountName,
 		},
 	}
 }


### PR DESCRIPTION
This change always creates a local cluster for a service
to handle incoming traffic. The local cluster is used
for both in-mesh and ingress traffic to the service.
Even if a local cluster is created, only the presence of
a route ensures that the local cluster can be reached, so
there should be no downside to creating a local cluster
at all times. This simplifies the code and voids the need
to create a local cluster separately for ingress.

Also updates the xDS unit tests that were breaking due to 
incorrect assumptions. 