### PR TITLE
ref(helm) : Updating values.yaml for the helm charts

### DIFF
--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -48,7 +48,7 @@ data:
         # <int> org id. will default to orgId 1 if not specified
         orgId: 1
         # <string> url
-        url: http://osm-prometheus.{{.Release.Name}}.svc:{{.Values.prometheus.port}}
+        url: http://osm-prometheus.{{.Release.Name}}.svc:{{.Values.OpenServiceMesh.prometheus.port}}
         version: 1
         # <bool> allow users to edit datasources from the UI.
         editable: true

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -40,7 +40,7 @@ spec:
               mountPath: /etc/grafana/provisioning/dashboards/dataplane
               readOnly: true
           ports:
-            - containerPort: {{.Values.grafana.port}}
+            - containerPort: {{.Values.OpenServiceMesh.grafana.port}}
       volumes:
         - name: osm-grafana-config
           configMap:

--- a/charts/osm/templates/grafana-svc.yaml
+++ b/charts/osm/templates/grafana-svc.yaml
@@ -6,6 +6,6 @@ metadata:
     app: osm-grafana
 spec:
   ports:
-    - port: {{.Values.grafana.port}}
+    - port: {{.Values.OpenServiceMesh.grafana.port}}
   selector:
     app: osm-grafana

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: osm-controller
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.OpenServiceMesh.replicaCount }}
   selector:
     matchLabels:
       app: osm-controller
@@ -17,8 +17,8 @@ spec:
       serviceAccountName: {{ .Release.Name }}
       containers:
         - name: osm-controller
-          image: "{{ .Values.image.registry }}/osm-controller:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.OpenServiceMesh.image.registry }}/osm-controller:{{ .Values.OpenServiceMesh.image.tag }}"
+          imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}
           ports:
             - name: "admin-port"
               containerPort: 15000
@@ -29,19 +29,19 @@ spec:
             "--verbosity", "trace",
             "--osmNamespace", "{{.Release.Namespace}}",
             "--osmID", "{{.Release.Namespace}}",
-            "--init-container-image", "{{.Values.image.registry}}/init:{{ .Values.image.tag }}",
-            "--sidecar-image", "{{.Values.sidecarImage}}",
+            "--init-container-image", "{{.Values.OpenServiceMesh.image.registry}}/init:{{ .Values.OpenServiceMesh.image.tag }}",
+            "--sidecar-image", "{{.Values.OpenServiceMesh.sidecarImage}}",
             "--webhookName", "osm-webhook-{{.Release.Namespace}}",
             "--caBundleSecretName", "osm-ca-bundle",
-            "--certmanager", "{{.Values.certManager}}",
-            "--vaultHost", "{{.Values.vault.host}}",
-            "--vaultProtocol", "{{.Values.vault.protocol}}",
-            "--vaultToken", "{{.Values.vault.token}}",
-            "--serviceCertValidityMinutes", "{{.Values.serviceCertValidityMinutes}}",
-            {{- if .Values.enableDebugServer }}
+            "--certmanager", "{{.Values.OpenServiceMesh.certManager}}",
+            "--vaultHost", "{{.Values.OpenServiceMesh.vault.host}}",
+            "--vaultProtocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
+            "--vaultToken", "{{.Values.OpenServiceMesh.vault.token}}",
+            "--serviceCertValidityMinutes", "{{.Values.OpenServiceMesh.serviceCertValidityMinutes}}",
+            {{- if .Values.OpenServiceMesh.enableDebugServer }}
             "--enableDebugServer",
             {{- end }}
-            {{- if .Values.disableSMIAccessControlPolicy }}
+            {{- if .Values.OpenServiceMesh.disableSMIAccessControlPolicy }}
             "--disable-smi-access-control-policy",
             {{- end }}
           ]
@@ -51,7 +51,7 @@ spec:
               scheme: HTTPS
               path: /health/ready
               port: 9090
-    {{- with .Values.imagePullSecrets }}
+    {{- with .Values.OpenServiceMesh.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -6,7 +6,7 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
     verbs: ["list", "get", "watch"]
-{{- if .Values.features.ingressv1alpha1.enabled }}
+{{- if .Values.OpenServiceMesh.features.ingressv1alpha1.enabled }}
   - apiGroups: ["extensions"]
     resources: ["ingresses"]
     verbs: ["list", "get", "watch"]

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -17,12 +17,12 @@ spec:
       containers:
       - name: prometheus
         ports:
-        - containerPort: {{.Values.prometheus.port}}
+        - containerPort: {{.Values.OpenServiceMesh.prometheus.port}}
         args:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus/
-        - --storage.tsdb.retention.time={{.Values.prometheus.retention.time}}
-        - --web.listen-address=:{{.Values.prometheus.port}}
+        - --storage.tsdb.retention.time={{.Values.OpenServiceMesh.prometheus.retention.time}}
+        - --web.listen-address=:{{.Values.OpenServiceMesh.prometheus.port}}
         image: prom/prometheus:v2.18.1
         imagePullPolicy: Always
         volumeMounts:

--- a/charts/osm/templates/prometheus-svc.yaml
+++ b/charts/osm/templates/prometheus-svc.yaml
@@ -3,12 +3,12 @@ kind: Service
 metadata:
   name: osm-prometheus
   annotations:
-    prometheus.io/port: "{{.Values.prometheus.port}}"
+    prometheus.io/port: "{{.Values.OpenServiceMesh.prometheus.port}}"
     prometheus.io/scrape: "true"
 spec:
   ports:
-  - port: {{.Values.prometheus.port}}
+  - port: {{.Values.OpenServiceMesh.prometheus.port}}
     protocol: TCP
-    targetPort: {{.Values.prometheus.port}}
+    targetPort: {{.Values.OpenServiceMesh.prometheus.port}}
   selector:
     app: osm-prometheus

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -1,43 +1,31 @@
 # Default values for osm.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-# TODO: rename ads pod/deployment/service to osm
-name: ads
-
-replicaCount: 1
-
-image:
-  registry: smctest.azurecr.io
-  pullPolicy: Always
-  tag: latest
-
-imagePullSecrets:
-  - name: acr-creds
-
-initContainer: smctest.azurecr.io/init
-sidecarImage: envoyproxy/envoy-alpine:v1.14.1
-
-features:
-  ingressv1alpha1:
-    enabled: true
-
-prometheus:
-  port: 7070
-  retention:
-    time: 15d
-
-certManager: tresor
-
-vault:
-  host:
-  protocol: http
-  token:
-
-serviceCertValidityMinutes: 1
-
-grafana:
-  port: 3000
-
-enableDebugServer: false
-disableSMIAccessControlPolicy: false
+OpenServiceMesh:
+  replicaCount: 1
+  image:
+    registry: smctest.azurecr.io
+    pullPolicy: Always
+    tag: latest
+  imagePullSecrets:
+    - name: acr-creds
+  initContainer: smctest.azurecr.io/init
+  sidecarImage: envoyproxy/envoy-alpine:v1.14.1
+  features:
+    ingressv1alpha1:
+      enabled: true
+  prometheus:
+    port: 7070
+    retention:
+      time: 15d
+  certManager: tresor
+  vault:
+    host:
+    protocol: http
+    token:
+    role: open-service-mesh
+  serviceCertValidityMinutes: 1
+  grafana:
+    port: 3000
+  enableDebugServer: false
+  disableSMIAccessControlPolicy: false

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -140,17 +140,18 @@ func (i *installCmd) run(installClient *helm.Install) error {
 func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 	finalValues := map[string]interface{}{}
 	valuesConfig := []string{
-		fmt.Sprintf("image.registry=%s", i.containerRegistry),
-		fmt.Sprintf("image.tag=%s", i.osmImageTag),
-		fmt.Sprintf("imagePullSecrets[0].name=%s", i.containerRegistrySecret),
-		fmt.Sprintf("certManager=%s", i.certManager),
-		fmt.Sprintf("vault.host=%s", i.vaultHost),
-		fmt.Sprintf("vault.protocol=%s", i.vaultProtocol),
-		fmt.Sprintf("vault.token=%s", i.vaultToken),
-		fmt.Sprintf("serviceCertValidityMinutes=%d", i.serviceCertValidityMinutes),
-		fmt.Sprintf("prometheus.retention.time=%s", i.prometheusRetentionTime),
-		fmt.Sprintf("enableDebugServer=%t", i.enableDebugServer),
-		fmt.Sprintf("disableSMIAccessControlPolicy=%t", i.disableSMIAccessControlPolicy),
+		fmt.Sprintf("OpenServiceMesh.image.registry=%s", i.containerRegistry),
+		fmt.Sprintf("OpenServiceMesh.image.tag=%s", i.osmImageTag),
+		fmt.Sprintf("OpenServiceMesh.imagePullSecrets[0].name=%s", i.containerRegistrySecret),
+		fmt.Sprintf("OpenServiceMesh.certManager=%s", i.certManager),
+		fmt.Sprintf("OpenServiceMesh.vault.host=%s", i.vaultHost),
+		fmt.Sprintf("OpenServiceMesh.vault.protocol=%s", i.vaultProtocol),
+		fmt.Sprintf("OpenServiceMesh.vault.token=%s", i.vaultToken),
+		fmt.Sprintf("OpenServiceMesh.vault.role=%s", i.vaultRole),
+		fmt.Sprintf("OpenServiceMesh.serviceCertValidityMinutes=%d", i.serviceCertValidityMinutes),
+		fmt.Sprintf("OpenServiceMesh.prometheus.retention.time=%s", i.prometheusRetentionTime),
+		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
+		fmt.Sprintf("OpenServiceMesh.disableSMIAccessControlPolicy=%t", i.disableSMIAccessControlPolicy),
 	}
 
 	for _, val := range valuesConfig {

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -21,6 +21,7 @@ var (
 	testVaultHost      = "vault.osm.svc.cluster.local"
 	testVaultProtocol  = "http"
 	testVaultToken     = "token"
+	testVaultRole      = "role"
 	testRetentionTime  = "5d"
 )
 
@@ -89,29 +90,31 @@ var _ = Describe("Running the install command", func() {
 
 			It("should have the correct values", func() {
 				Expect(rel.Config).To(BeEquivalentTo(map[string]interface{}{
-					"certManager": "tresor",
-					"image": map[string]interface{}{
-						"registry": testRegistry,
-						"tag":      testOsmImageTag,
-					},
-					"imagePullSecrets": []interface{}{
-						map[string]interface{}{
-							"name": testRegistrySecret,
+					"OpenServiceMesh": map[string]interface{}{
+						"certManager": "tresor",
+						"image": map[string]interface{}{
+							"registry": testRegistry,
+							"tag":      testOsmImageTag,
 						},
-					},
-					"serviceCertValidityMinutes": int64(1),
-					"vault": map[string]interface{}{
-						"host":     "",
-						"protocol": "",
-						"token":    "",
-					},
-					"prometheus": map[string]interface{}{
-						"retention": map[string]interface{}{
-							"time": "5d",
-						}},
-					"enableDebugServer":             false,
-					"disableSMIAccessControlPolicy": false,
-				}))
+						"imagePullSecrets": []interface{}{
+							map[string]interface{}{
+								"name": testRegistrySecret,
+							},
+						},
+						"serviceCertValidityMinutes": int64(1),
+						"vault": map[string]interface{}{
+							"host":     "",
+							"protocol": "",
+							"token":    "",
+							"role":     "",
+						},
+						"prometheus": map[string]interface{}{
+							"retention": map[string]interface{}{
+								"time": "5d",
+							}},
+						"enableDebugServer":             false,
+						"disableSMIAccessControlPolicy": false,
+					}}))
 			})
 
 			It("should be installed in the correct namespace", func() {
@@ -182,29 +185,31 @@ var _ = Describe("Running the install command", func() {
 
 			It("should have the correct values", func() {
 				Expect(rel.Config).To(BeEquivalentTo(map[string]interface{}{
-					"certManager": "tresor",
-					"image": map[string]interface{}{
-						"registry": testRegistry,
-						"tag":      testOsmImageTag,
-					},
-					"imagePullSecrets": []interface{}{
-						map[string]interface{}{
-							"name": testRegistrySecret,
+					"OpenServiceMesh": map[string]interface{}{
+						"certManager": "tresor",
+						"image": map[string]interface{}{
+							"registry": testRegistry,
+							"tag":      testOsmImageTag,
 						},
-					},
-					"serviceCertValidityMinutes": int64(1),
-					"vault": map[string]interface{}{
-						"host":     "",
-						"protocol": "",
-						"token":    "",
-					},
-					"prometheus": map[string]interface{}{
-						"retention": map[string]interface{}{
-							"time": "5d",
-						}},
-					"enableDebugServer":             false,
-					"disableSMIAccessControlPolicy": false,
-				}))
+						"imagePullSecrets": []interface{}{
+							map[string]interface{}{
+								"name": testRegistrySecret,
+							},
+						},
+						"serviceCertValidityMinutes": int64(1),
+						"vault": map[string]interface{}{
+							"host":     "",
+							"protocol": "",
+							"token":    "",
+							"role":     "",
+						},
+						"prometheus": map[string]interface{}{
+							"retention": map[string]interface{}{
+								"time": "5d",
+							}},
+						"enableDebugServer":             false,
+						"disableSMIAccessControlPolicy": false,
+					}}))
 			})
 
 			It("should be installed in the correct namespace", func() {
@@ -244,6 +249,7 @@ var _ = Describe("Running the install command", func() {
 				certManager:                "vault",
 				vaultHost:                  testVaultHost,
 				vaultToken:                 testVaultToken,
+				vaultRole:                  testVaultRole,
 				vaultProtocol:              "http",
 				osmImageTag:                testOsmImageTag,
 				serviceCertValidityMinutes: 1,
@@ -278,30 +284,32 @@ var _ = Describe("Running the install command", func() {
 
 			It("should have the correct values", func() {
 				Expect(rel.Config).To(BeEquivalentTo(map[string]interface{}{
-					"certManager": "vault",
-					"image": map[string]interface{}{
-						"registry": testRegistry,
-						"tag":      testOsmImageTag,
-					},
-					"imagePullSecrets": []interface{}{
-						map[string]interface{}{
-							"name": testRegistrySecret,
+					"OpenServiceMesh": map[string]interface{}{
+						"certManager": "vault",
+						"image": map[string]interface{}{
+							"registry": testRegistry,
+							"tag":      testOsmImageTag,
 						},
-					},
-					"serviceCertValidityMinutes": int64(1),
-					"vault": map[string]interface{}{
-						"host":     testVaultHost,
-						"protocol": "http",
-						"token":    testVaultToken,
-					},
-					"prometheus": map[string]interface{}{
-						"retention": map[string]interface{}{
-							"time": "5d",
+						"imagePullSecrets": []interface{}{
+							map[string]interface{}{
+								"name": testRegistrySecret,
+							},
 						},
-					},
-					"enableDebugServer":             false,
-					"disableSMIAccessControlPolicy": false,
-				}))
+						"serviceCertValidityMinutes": int64(1),
+						"vault": map[string]interface{}{
+							"host":     testVaultHost,
+							"protocol": "http",
+							"token":    testVaultToken,
+							"role":     testVaultRole,
+						},
+						"prometheus": map[string]interface{}{
+							"retention": map[string]interface{}{
+								"time": "5d",
+							},
+						},
+						"enableDebugServer":             false,
+						"disableSMIAccessControlPolicy": false,
+					}}))
 			})
 
 			It("should be installed in the correct namespace", func() {
@@ -365,6 +373,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			vaultHost:                  testVaultHost,
 			vaultProtocol:              testVaultProtocol,
 			vaultToken:                 testVaultToken,
+			vaultRole:                  testVaultRole,
 			osmImageTag:                testOsmImageTag,
 			serviceCertValidityMinutes: 1,
 			prometheusRetentionTime:    testRetentionTime,
@@ -379,29 +388,31 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 
 	It("should resolve correctly", func() {
 		Expect(vals).To(BeEquivalentTo(map[string]interface{}{
-			"certManager": "vault",
-			"image": map[string]interface{}{
-				"registry": testRegistry,
-				"tag":      testOsmImageTag,
-			},
-			"imagePullSecrets": []interface{}{
-				map[string]interface{}{
-					"name": testRegistrySecret,
+			"OpenServiceMesh": map[string]interface{}{
+				"certManager": "vault",
+				"image": map[string]interface{}{
+					"registry": testRegistry,
+					"tag":      testOsmImageTag,
 				},
-			},
-			"serviceCertValidityMinutes": int64(1),
-			"vault": map[string]interface{}{
-				"host":     testVaultHost,
-				"protocol": "http",
-				"token":    testVaultToken,
-			},
-			"prometheus": map[string]interface{}{
-				"retention": map[string]interface{}{
-					"time": "5d",
+				"imagePullSecrets": []interface{}{
+					map[string]interface{}{
+						"name": testRegistrySecret,
+					},
 				},
-			},
-			"enableDebugServer":             false,
-			"disableSMIAccessControlPolicy": false,
-		}))
+				"serviceCertValidityMinutes": int64(1),
+				"vault": map[string]interface{}{
+					"host":     testVaultHost,
+					"protocol": "http",
+					"token":    testVaultToken,
+					"role":     testVaultRole,
+				},
+				"prometheus": map[string]interface{}{
+					"retention": map[string]interface{}{
+						"time": "5d",
+					},
+				},
+				"enableDebugServer":             false,
+				"disableSMIAccessControlPolicy": false,
+			}}))
 	})
 })

--- a/cmd/cli/testdata/test-chart/templates/deployment.yaml
+++ b/cmd/cli/testdata/test-chart/templates/deployment.yaml
@@ -14,14 +14,14 @@ spec:
       labels:
         testing: test
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.OpenServiceMesh.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end}}
       containers:
         - name: test
-          image: "{{ .Values.image.registry }}/test:{{ .Chart.AppVersion}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.OpenServiceMesh.image.registry }}/test:{{ .Chart.AppVersion}}"
+          imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 80

--- a/cmd/cli/testdata/test-chart/values.yaml
+++ b/cmd/cli/testdata/test-chart/values.yaml
@@ -1,10 +1,8 @@
 # Default values for test-chart.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-
-namespace: test-namespace
-
-image:
-  registry: test-registry-default
-
-imagePullSecrets: []
+OpenServiceMesh:
+  namespace: test-namespace
+  image:
+    registry: test-registry-default
+  imagePullSecrets: []


### PR DESCRIPTION
This PR adds a tag/key OpenServiceMesh to the values.yaml file needed for the creation of helm charts. The main purpose of this change is to make the nature of this file consistent with what the values file will look like for the AKS add-on. 

Other minute changes are deleting some environment variables that are no longer used 