### PR TITLE
fix(demo): wait for Zipkin Pod to be ready

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -145,6 +145,7 @@ fi
 wait_for_pod "osm-controller"
 wait_for_pod "osm-prometheus"
 wait_for_pod "osm-grafana"
+wait_for_pod "zipkin"
 
 ./demo/deploy-apps.sh
 


### PR DESCRIPTION
In the future, does it make sense to make the script wait for every Pod in the OSM namespace vs. ones with specific `app` labels that we have to continuously modify?