### PR TITLE
cds/test: fix tests by unit testing each cluster

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,8 +42,8 @@ const (
 	// LocalhostIPAddress is the local host address.
 	LocalhostIPAddress = "127.0.0.1"
 
-	// EnvoyAdminCluster is the cluster name for Envoy's Admin
-	EnvoyAdminCluster = "envoy-admin-cluster"
+	// EnvoyMetricsCluster is the cluster name of the Prometheus metrics cluster
+	EnvoyMetricsCluster = "envoy-admin-cluster"
 
 	// EnvoyZipkinCluster is the name of the Zipkin cluster.
 	EnvoyZipkinCluster = "envoy-zipkin-cluster"

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/configurator"
-	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
@@ -75,7 +74,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 	}
 
 	if config.EnablePrometheus {
-		prometheusCluster := getPrometheusCluster(constants.EnvoyAdminCluster)
+		prometheusCluster := getPrometheusCluster()
 		marshalledCluster, err := ptypes.MarshalAny(&prometheusCluster)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed to marshal prometheus cluster for proxy %s", proxy.GetCommonName())

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -28,17 +28,19 @@ import (
 )
 
 var _ = Describe("CDS Response", func() {
+	kubeClient := testclient.NewSimpleClientset()
+	catalog := catalog.NewFakeMeshCatalog(kubeClient)
+	proxyServiceName := tests.BookbuyerServiceName
+	proxyServiceAccountName := tests.BookbuyerServiceAccountName
+	proxyService := tests.BookbuyerService
+	proxyServicePort := tests.ServicePort
+
 	Context("Test cds.NewResponse", func() {
 		It("Returns unique list of clusters for CDS", func() {
-			kubeClient := testclient.NewSimpleClientset()
 			smiClient := smi.NewFakeMeshSpecClient()
 
 			proxyUUID := fmt.Sprintf("proxy-0-%s", uuid.New())
 			podName := fmt.Sprintf("pod-0-%s", uuid.New())
-			proxyServiceName := tests.BookbuyerServiceName
-			proxyServiceAccountName := tests.BookbuyerServiceAccountName
-			proxyService := tests.BookbuyerService
-			proxyServicePort := tests.ServicePort
 
 			// The format of the CN matters
 			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
@@ -69,7 +71,7 @@ var _ = Describe("CDS Response", func() {
 				EnablePrometheus: true,
 				EnableTracing:    true,
 			}
-			resp, err := NewResponse(context.Background(), catalog.NewFakeMeshCatalog(kubeClient), smiClient, proxy, nil, config)
+			resp, err := NewResponse(context.Background(), catalog, smiClient, proxy, nil, config)
 			Expect(err).ToNot(HaveOccurred())
 
 			// There are to any.Any resources in the ClusterDiscoveryStruct (Clusters)
@@ -80,204 +82,209 @@ var _ = Describe("CDS Response", func() {
 			// 4. Zipkin cluster
 			numExpectedClusters := 4
 			Expect(len((*resp).Resources)).To(Equal(numExpectedClusters))
+		})
+	})
 
-			{
-				expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
-					ClusterName: "envoy-admin-cluster",
-					Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
-						{
-							Locality: nil,
-							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
-								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
-									Endpoint: &envoy_api_v2_endpoint.Endpoint{
-										Address: &envoy_api_v2_core.Address{
-											Address: &envoy_api_v2_core.Address_SocketAddress{
-												SocketAddress: &envoy_api_v2_core.SocketAddress{
-													Protocol: envoy_api_v2_core.SocketAddress_TCP,
-													Address:  "127.0.0.1",
-													PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
-														PortValue: uint32(15000),
-													},
+	Context("Test cds clusters", func() {
+		It("Returns a local cluster object", func() {
+			cluster, err := getServiceClusterLocal(catalog, proxyService, getLocalClusterName(proxyService))
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
+				ClusterName: getLocalClusterName(proxyService),
+				Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+					{
+						Locality: nil,
+						LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+							HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoy_api_v2_endpoint.Endpoint{
+									Address: &envoy_api_v2_core.Address{
+										Address: &envoy_api_v2_core.Address_SocketAddress{
+											SocketAddress: &envoy_api_v2_core.SocketAddress{
+												Protocol: envoy_api_v2_core.SocketAddress_TCP,
+												Address:  constants.WildcardIPAddr,
+												PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+													PortValue: uint32(proxyServicePort),
 												},
 											},
 										},
 									},
 								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 100,
+							},
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: constants.ClusterWeightAcceptAll,
+							},
+						}},
+					},
+				},
+			}
+			expectedCluster := xds.Cluster{
+				TransportSocketMatches: nil,
+				Name:                   getLocalClusterName(proxyService),
+				AltStatName:            getLocalClusterName(proxyService),
+				ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
+				EdsClusterConfig:       nil,
+				ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
+				LoadAssignment:         expectedClusterLoadAssignment,
+			}
+
+			Expect(cluster.Name).To(Equal(expectedCluster.Name))
+			Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
+			Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
+			Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+		})
+
+		It("Returns a remote cluster object", func() {
+			cluster, err := envoy.GetServiceCluster(proxyServiceName, proxyService)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
+				ClusterName: "envoy-admin-cluster",
+				Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+					{
+						Locality: nil,
+						LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+							HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoy_api_v2_endpoint.Endpoint{
+									Address: &envoy_api_v2_core.Address{
+										Address: &envoy_api_v2_core.Address_SocketAddress{
+											SocketAddress: &envoy_api_v2_core.SocketAddress{
+												Protocol: envoy_api_v2_core.SocketAddress_TCP,
+												Address:  "127.0.0.1",
+												PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+													PortValue: uint32(15000),
+												},
+											},
+										},
+									},
 								},
-							}},
+							},
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 100,
+							},
+						}},
+					},
+				},
+			}
+			expectedCluster := xds.Cluster{
+				TransportSocketMatches: nil,
+				Name:                   "default/bookstore",
+				AltStatName:            "",
+				ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_EDS},
+				EdsClusterConfig: &xds.Cluster_EdsClusterConfig{
+					EdsConfig: &envoy_api_v2_core.ConfigSource{
+						ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
+							Ads: &envoy_api_v2_core.AggregatedConfigSource{},
 						},
 					},
-				}
-				expectedCluster := xds.Cluster{
-					TransportSocketMatches: nil,
-					Name:                   "default/bookstore",
-					AltStatName:            "",
-					ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_EDS},
-					EdsClusterConfig: &xds.Cluster_EdsClusterConfig{
-						EdsConfig: &envoy_api_v2_core.ConfigSource{
+					ServiceName: "",
+				},
+				ConnectTimeout: ptypes.DurationProto(5 * time.Second),
+				TransportSocket: &envoy_api_v2_core.TransportSocket{
+					Name: envoy.TransportSocketTLS,
+					ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
+						TypedConfig: &any.Any{
+							TypeUrl: string(envoy.TypeUpstreamTLSContext),
+							Value:   []byte{10, 88, 10, 4, 8, 3, 16, 4, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 58, 42, 10, 36, 114, 111, 111, 116, 45, 99, 101, 114, 116, 45, 102, 111, 114, 45, 109, 116, 108, 115, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 18, 35, 98, 111, 111, 107, 98, 117, 121, 101, 114, 46, 100, 101, 102, 97, 117, 108, 116, 46, 115, 118, 99, 46, 99, 108, 117, 115, 116, 101, 114, 46, 108, 111, 99, 97, 108},
+						},
+					},
+				},
+				LoadAssignment: expectedClusterLoadAssignment,
+			}
+
+			Expect(cluster.ClusterDiscoveryType).To(Equal(expectedCluster.ClusterDiscoveryType))
+			Expect(cluster.EdsClusterConfig).To(Equal(expectedCluster.EdsClusterConfig))
+			Expect(cluster.ConnectTimeout).To(Equal(expectedCluster.ConnectTimeout))
+			Expect(cluster.TransportSocket).To(Equal(expectedCluster.TransportSocket))
+
+			// TODO(draychev): finish the rest
+			// Expect(cluster).To(Equal(expectedCluster))
+
+			upstreamTLSContext := envoy_api_v2_auth.UpstreamTlsContext{}
+			err = ptypes.UnmarshalAny(cluster.TransportSocket.GetTypedConfig(), &upstreamTLSContext)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedTLSContext := envoy_api_v2_auth.UpstreamTlsContext{
+				CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
+					TlsParams: &envoy_api_v2_auth.TlsParameters{
+						TlsMinimumProtocolVersion: 3,
+						TlsMaximumProtocolVersion: 4,
+					},
+					TlsCertificates: nil,
+					TlsCertificateSdsSecretConfigs: []*envoy_api_v2_auth.SdsSecretConfig{{
+						Name: "service-cert:default/bookstore",
+						SdsConfig: &envoy_api_v2_core.ConfigSource{
 							ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
 								Ads: &envoy_api_v2_core.AggregatedConfigSource{},
 							},
 						},
-						ServiceName: "",
-					},
-					ConnectTimeout: ptypes.DurationProto(5 * time.Second),
-					TransportSocket: &envoy_api_v2_core.TransportSocket{
-						Name: envoy.TransportSocketTLS,
-						ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
-							TypedConfig: &any.Any{
-								TypeUrl: string(envoy.TypeUpstreamTLSContext),
-								Value:   []byte{10, 88, 10, 4, 8, 3, 16, 4, 50, 36, 10, 30, 115, 101, 114, 118, 105, 99, 101, 45, 99, 101, 114, 116, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 58, 42, 10, 36, 114, 111, 111, 116, 45, 99, 101, 114, 116, 45, 102, 111, 114, 45, 109, 116, 108, 115, 58, 100, 101, 102, 97, 117, 108, 116, 47, 98, 111, 111, 107, 98, 117, 121, 101, 114, 18, 2, 26, 0, 18, 35, 98, 111, 111, 107, 98, 117, 121, 101, 114, 46, 100, 101, 102, 97, 117, 108, 116, 46, 115, 118, 99, 46, 99, 108, 117, 115, 116, 101, 114, 46, 108, 111, 99, 97, 108},
-							},
-						},
-					},
-					LoadAssignment: expectedClusterLoadAssignment,
-				}
-				cluster := xds.Cluster{}
-				err = ptypes.UnmarshalAny(resp.Resources[0], &cluster)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.ClusterDiscoveryType).To(Equal(expectedCluster.ClusterDiscoveryType))
-				Expect(cluster.EdsClusterConfig).To(Equal(expectedCluster.EdsClusterConfig))
-				Expect(cluster.ConnectTimeout).To(Equal(expectedCluster.ConnectTimeout))
-				Expect(cluster.TransportSocket).To(Equal(expectedCluster.TransportSocket))
-
-				// TODO(draychev): finish the rest
-				// Expect(cluster).To(Equal(expectedCluster))
-
-				upstreamTLSContext := envoy_api_v2_auth.UpstreamTlsContext{}
-				err = ptypes.UnmarshalAny(cluster.TransportSocket.GetTypedConfig(), &upstreamTLSContext)
-				Expect(err).ToNot(HaveOccurred())
-
-				expectedTLSContext := envoy_api_v2_auth.UpstreamTlsContext{
-					CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
-						TlsParams: &envoy_api_v2_auth.TlsParameters{
-							TlsMinimumProtocolVersion: 3,
-							TlsMaximumProtocolVersion: 4,
-						},
-						TlsCertificates: nil,
-						TlsCertificateSdsSecretConfigs: []*envoy_api_v2_auth.SdsSecretConfig{{
-							Name: "service-cert:default/bookstore",
+					}},
+					ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+						ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
+							Name: fmt.Sprintf("%s%s%s", envoy.RootCertTypeForMTLS, envoy.Separator, "default/bookstore"),
 							SdsConfig: &envoy_api_v2_core.ConfigSource{
 								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
 									Ads: &envoy_api_v2_core.AggregatedConfigSource{},
 								},
 							},
-						}},
-						ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
-							ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
-								Name: fmt.Sprintf("%s%s%s", envoy.RootCertTypeForMTLS, envoy.Separator, "default/bookstore"),
-								SdsConfig: &envoy_api_v2_core.ConfigSource{
-									ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
-										Ads: &envoy_api_v2_core.AggregatedConfigSource{},
+						},
+					},
+					AlpnProtocols: nil,
+				},
+				Sni:                "default/bookstore",
+				AllowRenegotiation: false,
+			}
+			Expect(upstreamTLSContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))
+			// TODO(draychev): finish the rest
+			// Expect(upstreamTLSContext).To(Equal(expectedTLSContext)
+		})
+
+		It("Returns a Prometheus cluster object", func() {
+			cluster := getPrometheusCluster()
+
+			expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
+				ClusterName: constants.EnvoyMetricsCluster,
+				Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
+					{
+						Locality: nil,
+						LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
+							HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoy_api_v2_endpoint.Endpoint{
+									Address: &envoy_api_v2_core.Address{
+										Address: &envoy_api_v2_core.Address_SocketAddress{
+											SocketAddress: &envoy_api_v2_core.SocketAddress{
+												Protocol: envoy_api_v2_core.SocketAddress_TCP,
+												Address:  "127.0.0.1",
+												PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
+													PortValue: uint32(15000),
+												},
+											},
+										},
 									},
 								},
 							},
-						},
-						AlpnProtocols: nil,
+							LoadBalancingWeight: &wrappers.UInt32Value{
+								Value: 100,
+							},
+						}},
 					},
-					Sni:                "default/bookstore",
-					AllowRenegotiation: false,
-				}
-				Expect(upstreamTLSContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))
-				// TODO(draychev): finish the rest
-				// Expect(upstreamTLSContext).To(Equal(expectedTLSContext)
+				},
 			}
-			{
-				expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
-					ClusterName: getLocalClusterName(proxyService),
-					Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
-						{
-							Locality: nil,
-							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
-								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
-									Endpoint: &envoy_api_v2_endpoint.Endpoint{
-										Address: &envoy_api_v2_core.Address{
-											Address: &envoy_api_v2_core.Address_SocketAddress{
-												SocketAddress: &envoy_api_v2_core.SocketAddress{
-													Protocol: envoy_api_v2_core.SocketAddress_TCP,
-													Address:  constants.WildcardIPAddr,
-													PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
-														PortValue: uint32(proxyServicePort),
-													},
-												},
-											},
-										},
-									},
-								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: constants.ClusterWeightAcceptAll,
-								},
-							}},
-						},
-					},
-				}
-				expectedCluster := xds.Cluster{
-					TransportSocketMatches: nil,
-					Name:                   getLocalClusterName(proxyService),
-					AltStatName:            getLocalClusterName(proxyService),
-					ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
-					EdsClusterConfig:       nil,
-					ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
-					LoadAssignment:         expectedClusterLoadAssignment,
-				}
-				cluster := xds.Cluster{}
-				err = ptypes.UnmarshalAny(resp.Resources[1], &cluster)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.Name).To(Equal(expectedCluster.Name))
-				Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
-				Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
-				Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+			expectedCluster := xds.Cluster{
+				TransportSocketMatches: nil,
+				Name:                   "envoy-admin-cluster",
+				AltStatName:            "envoy-admin-cluster",
+				ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
+				EdsClusterConfig:       nil,
+				ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
+				LoadAssignment:         expectedClusterLoadAssignment,
 			}
-			{
-				expectedClusterLoadAssignment := &xds.ClusterLoadAssignment{
-					ClusterName: "envoy-admin-cluster",
-					Endpoints: []*envoy_api_v2_endpoint.LocalityLbEndpoints{
-						{
-							Locality: nil,
-							LbEndpoints: []*envoy_api_v2_endpoint.LbEndpoint{{
-								HostIdentifier: &envoy_api_v2_endpoint.LbEndpoint_Endpoint{
-									Endpoint: &envoy_api_v2_endpoint.Endpoint{
-										Address: &envoy_api_v2_core.Address{
-											Address: &envoy_api_v2_core.Address_SocketAddress{
-												SocketAddress: &envoy_api_v2_core.SocketAddress{
-													Protocol: envoy_api_v2_core.SocketAddress_TCP,
-													Address:  "127.0.0.1",
-													PortSpecifier: &envoy_api_v2_core.SocketAddress_PortValue{
-														PortValue: uint32(15000),
-													},
-												},
-											},
-										},
-									},
-								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 100,
-								},
-							}},
-						},
-					},
-				}
-				expectedCluster := xds.Cluster{
-					TransportSocketMatches: nil,
-					Name:                   "envoy-admin-cluster",
-					AltStatName:            "envoy-admin-cluster",
-					ClusterDiscoveryType:   &xds.Cluster_Type{Type: xds.Cluster_STATIC},
-					EdsClusterConfig:       nil,
-					ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
-					LoadAssignment:         expectedClusterLoadAssignment,
-				}
-				cluster := xds.Cluster{}
-				err = ptypes.UnmarshalAny(resp.Resources[2], &cluster)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
-				Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
-				Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
-				Expect(cluster.LoadAssignment).To(Equal(expectedClusterLoadAssignment))
-				Expect(cluster).To(Equal(expectedCluster))
-			}
+
+			Expect(cluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
+			Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
+			Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+			Expect(cluster.LoadAssignment).To(Equal(expectedClusterLoadAssignment))
+			Expect(cluster).To(Equal(expectedCluster))
 		})
 	})
-
 })

--- a/pkg/envoy/cds/service.go
+++ b/pkg/envoy/cds/service.go
@@ -69,11 +69,11 @@ func getServiceClusterLocal(catalog catalog.MeshCataloger, proxyServiceName serv
 	return &xdsCluster, nil
 }
 
-func getPrometheusCluster(clusterName string) xds.Cluster {
+func getPrometheusCluster() xds.Cluster {
 	return xds.Cluster{
 		// The name must match the domain being cURLed in the demo
-		Name:           clusterName,
-		AltStatName:    clusterName,
+		Name:           constants.EnvoyMetricsCluster,
+		AltStatName:    constants.EnvoyMetricsCluster,
 		ConnectTimeout: ptypes.DurationProto(connectionTimeout),
 		ClusterDiscoveryType: &xds.Cluster_Type{
 			Type: xds.Cluster_STATIC,
@@ -81,7 +81,7 @@ func getPrometheusCluster(clusterName string) xds.Cluster {
 		LbPolicy: xds.Cluster_ROUND_ROBIN,
 		LoadAssignment: &xds.ClusterLoadAssignment{
 			// NOTE: results.ServiceName is the top level service that is cURLed.
-			ClusterName: clusterName,
+			ClusterName: constants.EnvoyMetricsCluster,
 			Endpoints: []*envoyEndpoint.LocalityLbEndpoints{
 				{
 					LbEndpoints: []*envoyEndpoint.LbEndpoint{{

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -101,7 +101,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 	}
 
 	// Build Prometheus listener config
-	prometheusConnManager := getPrometheusConnectionManager(prometheusListenerName, constants.PrometheusScrapePath, constants.EnvoyAdminCluster)
+	prometheusConnManager := getPrometheusConnectionManager(prometheusListenerName, constants.PrometheusScrapePath, constants.EnvoyMetricsCluster)
 	prometheusListener, err := buildPrometheusListener(prometheusConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error building Prometheus listener config for proxy %s", proxyServiceName)


### PR DESCRIPTION
This change refactors the CDS unit test to test each
cluster separately as opposed to testing all clusters
as a part of the CDS response. This allows to not
rely on ordering of resources in the serialized CDS
response, and instead unit tests each cluster separately.

Resolves #899

---

Unit testing this several times didn't result in intermittent failures:
```
$  for i in {1..20}; do go test ./pkg/envoy/cds/ -count=1; done
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	1.451s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	3.221s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	2.646s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	2.125s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	1.166s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	3.380s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	0.734s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	1.413s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	4.183s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	3.712s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	0.631s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	4.542s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	0.713s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	1.166s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	0.663s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	1.226s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	3.314s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	2.927s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	1.204s
ok  	github.com/open-service-mesh/osm/pkg/envoy/cds	5.072s
```