### PR TITLE
ref(chart): add resource limits/requests for other osm-system pods

### DIFF
--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -21,6 +21,13 @@ spec:
         - name: grafana
           image: "grafana/grafana:7.0.1"
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128M
+            requests:
+              cpu: 100m
+              memory: 64M
           volumeMounts:
             - name: osm-grafana-config
               mountPath: "/etc/grafana/grafana.ini"

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -25,6 +25,13 @@ spec:
         - --web.listen-address=:{{.Values.OpenServiceMesh.prometheus.port}}
         image: prom/prometheus:v2.18.1
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512M
+          requests:
+            cpu: 100m
+            memory: 256M
         volumeMounts:
         - mountPath: /etc/prometheus/
           name: prometheus-config-volume

--- a/charts/osm/templates/zipkin-deployment.yaml
+++ b/charts/osm/templates/zipkin-deployment.yaml
@@ -19,3 +19,10 @@ spec:
         image: openzipkin/zipkin:2.21.4
         ports:
         - containerPort: {{.Values.OpenServiceMesh.grafana.port}}
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512M
+          requests:
+            cpu: 100m
+            memory: 256M


### PR DESCRIPTION
Same exercise as #894 for the other Pods in the OSM control-plane namespace.

![image](https://user-images.githubusercontent.com/16093815/85797665-b5225d80-b701-11ea-8f63-b9ca424001cc.png)
