### PR TITLE
Make the sidecar injector webhook's failurePolicy configurable

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: {{.Release.Namespace}}
       path: /mutate
       port: 443
-  failurePolicy: Fail
+  failurePolicy: {{.Values.OpenServiceMesh.sidecarInjectorWebhook.failurePolicy}}
   matchPolicy: Exact
   namespaceSelector:
     matchLabels:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -28,3 +28,5 @@ OpenServiceMesh:
   enableDebugServer: false
   disableSMIAccessControlPolicy: false
   meshName: osm
+  sidecarInjectorWebhook:
+    failurePolicy: Fail

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -30,7 +30,7 @@ namespace does not exist, it will be created.
 Usage:
   $ osm install --namespace hello-world
 
-Each instance of the osm control plane installation is given a unqiue mesh 
+Each instance of the osm control plane installation is given a unqiue mesh
 name. A mesh name can be passed in via the --mesh-name flag or a default will
 be provided for you.
 The mesh name is used in various different ways by the control plane including
@@ -53,21 +53,22 @@ const (
 var chartTGZSource string
 
 type installCmd struct {
-	out                           io.Writer
-	containerRegistry             string
-	containerRegistrySecret       string
-	chartPath                     string
-	osmImageTag                   string
-	certManager                   string
-	vaultHost                     string
-	vaultProtocol                 string
-	vaultToken                    string
-	vaultRole                     string
-	serviceCertValidityMinutes    int
-	prometheusRetentionTime       string
-	enableDebugServer             bool
-	disableSMIAccessControlPolicy bool
-	meshName                      string
+	out                                 io.Writer
+	containerRegistry                   string
+	containerRegistrySecret             string
+	chartPath                           string
+	osmImageTag                         string
+	certManager                         string
+	vaultHost                           string
+	vaultProtocol                       string
+	vaultToken                          string
+	vaultRole                           string
+	serviceCertValidityMinutes          int
+	prometheusRetentionTime             string
+	enableDebugServer                   bool
+	disableSMIAccessControlPolicy       bool
+	meshName                            string
+	sidecarInjectorWebhookFailurePolicy string
 }
 
 func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
@@ -99,6 +100,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableDebugServer, "enable-debug-server", false, "Enable the debug HTTP server")
 	f.BoolVar(&inst.disableSMIAccessControlPolicy, "disable-smi-access-control-policy", false, "Disable SMI access control policy")
 	f.StringVar(&inst.meshName, "mesh-name", "osm", "Name of the service mesh")
+	f.StringVar(&inst.sidecarInjectorWebhookFailurePolicy, "sidecar-webhook-failure-policy", "Fail", "Failure policy for the sidecar injector webhook (Fail or Ignore)")
 
 	return cmd
 }
@@ -193,6 +195,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
 		fmt.Sprintf("OpenServiceMesh.disableSMIAccessControlPolicy=%t", i.disableSMIAccessControlPolicy),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
+		fmt.Sprintf("OpenServiceMesh.sidecarInjectorWebhook.failurePolicy=%s", i.sidecarInjectorWebhookFailurePolicy),
 	}
 
 	for _, val := range valuesConfig {


### PR DESCRIPTION
By default, the failurePolicy is set to Fail to prevent pods
from being injected into the mesh if the sidecar injector webhook
fails. This is the desired behavior in most cases so as to get
instant feedback when a sidecar needs to be injected but fails.
However, this setting is not suitable in all environments, AKS
being one of them where the requirement is for the failurePolicy
to be set to Ignore due to limitations in how AKS handles webhook
failures.

This change makes the webhook's failurePolicy configurable via the
install cli and Helm chart.

Resolves #908