### PR TITLE
ref(*): update smi crds for traffictarget

### DIFF
--- a/charts/osm/crds/access.yaml
+++ b/charts/osm/crds/access.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traffictargets.access.smi-spec.io
 spec:
   group: access.smi-spec.io
-  scope: Namespaced 
+  scope: Namespaced
   names:
     kind: TrafficTarget
     shortNames:
@@ -27,7 +27,6 @@ spec:
           required:
             - name
             - kind
-            - port
           properties:
             kind:
               description: Kind of the destination.

--- a/demo/deploy-traffic-spec.sh
+++ b/demo/deploy-traffic-spec.sh
@@ -5,8 +5,6 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.3.0/crds/specs.yaml
-
 echo "Create Bookstore HTTPRouteGroup"
 kubectl apply -f - <<EOF
 apiVersion: specs.smi-spec.io/v1alpha2

--- a/demo/deploy-traffic-split.sh
+++ b/demo/deploy-traffic-split.sh
@@ -5,8 +5,6 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.2.0/crds/split.yaml
-
 kubectl apply -f - <<EOF
 apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit

--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -5,8 +5,6 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-kubectl apply -f https://raw.githubusercontent.com/deislabs/smi-sdk-go/v0.2.0/crds/access.yaml
-
 kubectl apply -f - <<EOF
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha1

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -108,11 +108,6 @@ for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPAC
     kubectl label  namespaces "$ns" openservicemesh.io/monitored-by="$MESH_NAME"
 done
 
-# Apply SMI policies
-./demo/deploy-traffic-split.sh
-./demo/deploy-traffic-spec.sh
-./demo/deploy-traffic-target.sh
-
 # Deploys Xds and Prometheus
 echo "Certificate Manager in use: $CERT_MANAGER"
 if [ "$CERT_MANAGER" = "vault" ]; then
@@ -140,6 +135,12 @@ else
       --enable-debug-server \
       $optionalInstallArgs
 fi
+
+# Apply SMI policies
+./demo/deploy-traffic-split.sh
+./demo/deploy-traffic-spec.sh
+./demo/deploy-traffic-target.sh
+
 
 wait_for_osm_pods
 


### PR DESCRIPTION
* TrafficTarget CRD now matches what is in smi-sdk-go
v0.3.0 where it does not require port
* Move SMI policy deployment to after control plane install
* Remove manual apply of SMI CRDs now that CRD creation is
streamlined in helm chart