### PR TITLE
osm-rbac: add backpressure policy to RBAC policies

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -38,6 +38,9 @@ rules:
   - apiGroups: ["specs.smi-spec.io"]
     resources: ["httproutegroups"]
     verbs: ["list", "get", "watch"]
+  - apiGroups: ["policy.openservicemesh.io"]
+    resources: ["backpressures"]
+    verbs: ["list", "get", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This is required for OSM to be able to access the `backpressures` resource
in the `policy.openservicemesh.io` API group.