### PR TITLE
Tag experimental branch for CI suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - experimental
   pull_request:
     branches:
       - master
+      - experimental
 env:
   KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
   AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}


### PR DESCRIPTION
The `experimental` branch is being used for experimental changes
that should not interfere with the `main` branch. While we commit
changes to the `experimental` branch, make sure the CI suite passes.