### PR TITLE
Make the sidecar injector webhook's failurePolicy configurable

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: {{.Release.Namespace}}
       path: /mutate
       port: 443
-  failurePolicy: Fail
+  failurePolicy: {{.Values.OpenServiceMesh.sidecarInjectorWebhook.failurePolicy}}
   matchPolicy: Exact
   namespaceSelector:
     matchLabels:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -28,3 +28,5 @@ OpenServiceMesh:
   enableDebugServer: false
   disableSMIAccessControlPolicy: false
   meshName: osm
+  sidecarInjectorWebhook:
+    failurePolicy: Fail

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -30,7 +30,7 @@ namespace does not exist, it will be created.
 Usage:
   $ osm install --namespace hello-world
 
-Each instance of the osm control plane installation is given a unqiue mesh 
+Each instance of the osm control plane installation is given a unqiue mesh
 name. A mesh name can be passed in via the --mesh-name flag or a default will
 be provided for you.
 The mesh name is used in various different ways by the control plane including
@@ -53,21 +53,22 @@ const (
 var chartTGZSource string
 
 type installCmd struct {
-	out                           io.Writer
-	containerRegistry             string
-	containerRegistrySecret       string
-	chartPath                     string
-	osmImageTag                   string
-	certManager                   string
-	vaultHost                     string
-	vaultProtocol                 string
-	vaultToken                    string
-	vaultRole                     string
-	serviceCertValidityMinutes    int
-	prometheusRetentionTime       string
-	enableDebugServer             bool
-	disableSMIAccessControlPolicy bool
-	meshName                      string
+	out                                 io.Writer
+	containerRegistry                   string
+	containerRegistrySecret             string
+	chartPath                           string
+	osmImageTag                         string
+	certManager                         string
+	vaultHost                           string
+	vaultProtocol                       string
+	vaultToken                          string
+	vaultRole                           string
+	serviceCertValidityMinutes          int
+	prometheusRetentionTime             string
+	enableDebugServer                   bool
+	disableSMIAccessControlPolicy       bool
+	meshName                            string
+	sidecarInjectorWebhookFailurePolicy string
 }
 
 func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
@@ -99,6 +100,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableDebugServer, "enable-debug-server", false, "Enable the debug HTTP server")
 	f.BoolVar(&inst.disableSMIAccessControlPolicy, "disable-smi-access-control-policy", false, "Disable SMI access control policy")
 	f.StringVar(&inst.meshName, "mesh-name", "osm", "Name of the service mesh")
+	f.StringVar(&inst.sidecarInjectorWebhookFailurePolicy, "sidecar-webhook-failure-policy", "Fail", "Failure policy for the sidecar injector webhook (Fail or Ignore)")
 
 	return cmd
 }
@@ -193,6 +195,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
 		fmt.Sprintf("OpenServiceMesh.disableSMIAccessControlPolicy=%t", i.disableSMIAccessControlPolicy),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
+		fmt.Sprintf("OpenServiceMesh.sidecarInjectorWebhook.failurePolicy=%s", i.sidecarInjectorWebhookFailurePolicy),
 	}
 
 	for _, val := range valuesConfig {

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -15,14 +15,15 @@ import (
 )
 
 var (
-	testRegistry       = "test-registry"
-	testRegistrySecret = "test-registry-secret"
-	testOsmImageTag    = "test-tag"
-	testVaultHost      = "vault.osm.svc.cluster.local"
-	testVaultProtocol  = "http"
-	testVaultToken     = "token"
-	testVaultRole      = "role"
-	testRetentionTime  = "5d"
+	testRegistry                               = "test-registry"
+	testRegistrySecret                         = "test-registry-secret"
+	testOsmImageTag                            = "test-tag"
+	testVaultHost                              = "vault.osm.svc.cluster.local"
+	testVaultProtocol                          = "http"
+	testVaultToken                             = "token"
+	testVaultRole                              = "role"
+	testRetentionTime                          = "5d"
+	defaultSidecarInjectorWebhookFailurePolicy = "Fail"
 )
 
 var _ = Describe("Running the install command", func() {
@@ -52,15 +53,16 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			installCmd := &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				osmImageTag:                testOsmImageTag,
-				certManager:                "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   "osm",
+				out:                                 out,
+				chartPath:                           "testdata/test-chart",
+				containerRegistry:                   testRegistry,
+				containerRegistrySecret:             testRegistrySecret,
+				osmImageTag:                         testOsmImageTag,
+				certManager:                         "tresor",
+				serviceCertValidityMinutes:          1,
+				prometheusRetentionTime:             testRetentionTime,
+				meshName:                            "osm",
+				sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
 			}
 
 			installClient := helm.NewInstall(config)
@@ -116,6 +118,9 @@ var _ = Describe("Running the install command", func() {
 							}},
 						"enableDebugServer":             false,
 						"disableSMIAccessControlPolicy": false,
+						"sidecarInjectorWebhook": map[string]interface{}{
+							"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
+						},
 					}}))
 			})
 
@@ -150,14 +155,15 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			installCmd := &installCmd{
-				out:                        out,
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				osmImageTag:                testOsmImageTag,
-				certManager:                "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   "osm",
+				out:                                 out,
+				containerRegistry:                   testRegistry,
+				containerRegistrySecret:             testRegistrySecret,
+				osmImageTag:                         testOsmImageTag,
+				certManager:                         "tresor",
+				serviceCertValidityMinutes:          1,
+				prometheusRetentionTime:             testRetentionTime,
+				meshName:                            "osm",
+				sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
 			}
 
 			installClient := helm.NewInstall(config)
@@ -213,6 +219,9 @@ var _ = Describe("Running the install command", func() {
 							}},
 						"enableDebugServer":             false,
 						"disableSMIAccessControlPolicy": false,
+						"sidecarInjectorWebhook": map[string]interface{}{
+							"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
+						},
 					}}))
 			})
 
@@ -246,19 +255,20 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			installCmd := &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				certManager:                "vault",
-				vaultHost:                  testVaultHost,
-				vaultToken:                 testVaultToken,
-				vaultRole:                  testVaultRole,
-				vaultProtocol:              "http",
-				osmImageTag:                testOsmImageTag,
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   "osm",
+				out:                                 out,
+				chartPath:                           "testdata/test-chart",
+				containerRegistry:                   testRegistry,
+				containerRegistrySecret:             testRegistrySecret,
+				certManager:                         "vault",
+				vaultHost:                           testVaultHost,
+				vaultToken:                          testVaultToken,
+				vaultRole:                           testVaultRole,
+				vaultProtocol:                       "http",
+				osmImageTag:                         testOsmImageTag,
+				serviceCertValidityMinutes:          1,
+				prometheusRetentionTime:             testRetentionTime,
+				meshName:                            "osm",
+				sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
 			}
 
 			installClient := helm.NewInstall(config)
@@ -315,6 +325,9 @@ var _ = Describe("Running the install command", func() {
 						},
 						"enableDebugServer":             false,
 						"disableSMIAccessControlPolicy": false,
+						"sidecarInjectorWebhook": map[string]interface{}{
+							"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
+						},
 					}}))
 			})
 
@@ -373,16 +386,17 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:          testRegistry,
-			containerRegistrySecret:    testRegistrySecret,
-			certManager:                "vault",
-			vaultHost:                  testVaultHost,
-			vaultProtocol:              testVaultProtocol,
-			vaultToken:                 testVaultToken,
-			vaultRole:                  testVaultRole,
-			osmImageTag:                testOsmImageTag,
-			serviceCertValidityMinutes: 1,
-			prometheusRetentionTime:    testRetentionTime,
+			containerRegistry:                   testRegistry,
+			containerRegistrySecret:             testRegistrySecret,
+			certManager:                         "vault",
+			vaultHost:                           testVaultHost,
+			vaultProtocol:                       testVaultProtocol,
+			vaultToken:                          testVaultToken,
+			vaultRole:                           testVaultRole,
+			osmImageTag:                         testOsmImageTag,
+			serviceCertValidityMinutes:          1,
+			prometheusRetentionTime:             testRetentionTime,
+			sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -420,6 +434,67 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				},
 				"enableDebugServer":             false,
 				"disableSMIAccessControlPolicy": false,
+				"sidecarInjectorWebhook": map[string]interface{}{
+					"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
+				},
+			}}))
+	})
+})
+
+var _ = Describe("Resolving values for install command with sidecar injector webhook parameters", func() {
+	var (
+		vals map[string]interface{}
+		err  error
+	)
+
+	BeforeEach(func() {
+		installCmd := &installCmd{
+			containerRegistry:                   testRegistry,
+			containerRegistrySecret:             testRegistrySecret,
+			certManager:                         "tresor",
+			osmImageTag:                         testOsmImageTag,
+			serviceCertValidityMinutes:          1,
+			prometheusRetentionTime:             testRetentionTime,
+			sidecarInjectorWebhookFailurePolicy: "Ignore",
+		}
+
+		vals, err = installCmd.resolveValues()
+	})
+
+	It("should not error", func() {
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should resolve correctly", func() {
+		Expect(vals).To(BeEquivalentTo(map[string]interface{}{
+			"OpenServiceMesh": map[string]interface{}{
+				"certManager": "tresor",
+				"meshName":    "",
+				"image": map[string]interface{}{
+					"registry": testRegistry,
+					"tag":      testOsmImageTag,
+				},
+				"imagePullSecrets": []interface{}{
+					map[string]interface{}{
+						"name": testRegistrySecret,
+					},
+				},
+				"serviceCertValidityMinutes": int64(1),
+				"vault": map[string]interface{}{
+					"host":     "",
+					"protocol": "",
+					"token":    "",
+					"role":     "",
+				},
+				"prometheus": map[string]interface{}{
+					"retention": map[string]interface{}{
+						"time": "5d",
+					}},
+				"enableDebugServer":             false,
+				"disableSMIAccessControlPolicy": false,
+				"sidecarInjectorWebhook": map[string]interface{}{
+					"failurePolicy": "Ignore",
+				},
 			}}))
 	})
 })


### PR DESCRIPTION
By default, the failurePolicy is set to Fail to prevent pods
from being injected into the mesh if the sidecar injector webhook
fails. This is the desired behavior in most cases so as to get
instant feedback when a sidecar needs to be injected but fails.
However, it might be desirable in some environments to make the
failurePolicy configurable.

This change makes the webhook's failurePolicy configurable via the
install cli and Helm chart.

Resolves #908