### PR TITLE
Revert "Make the sidecar injector webhook's failurePolicy configurabl…

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -12,7 +12,7 @@ webhooks:
       namespace: {{.Release.Namespace}}
       path: /mutate
       port: 443
-  failurePolicy: {{.Values.OpenServiceMesh.sidecarInjectorWebhook.failurePolicy}}
+  failurePolicy: Fail
   matchPolicy: Exact
   namespaceSelector:
     matchLabels:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -28,5 +28,3 @@ OpenServiceMesh:
   enableDebugServer: false
   disableSMIAccessControlPolicy: false
   meshName: osm
-  sidecarInjectorWebhook:
-    failurePolicy: Fail

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -30,7 +30,7 @@ namespace does not exist, it will be created.
 Usage:
   $ osm install --namespace hello-world
 
-Each instance of the osm control plane installation is given a unqiue mesh
+Each instance of the osm control plane installation is given a unqiue mesh 
 name. A mesh name can be passed in via the --mesh-name flag or a default will
 be provided for you.
 The mesh name is used in various different ways by the control plane including
@@ -53,22 +53,21 @@ const (
 var chartTGZSource string
 
 type installCmd struct {
-	out                                 io.Writer
-	containerRegistry                   string
-	containerRegistrySecret             string
-	chartPath                           string
-	osmImageTag                         string
-	certManager                         string
-	vaultHost                           string
-	vaultProtocol                       string
-	vaultToken                          string
-	vaultRole                           string
-	serviceCertValidityMinutes          int
-	prometheusRetentionTime             string
-	enableDebugServer                   bool
-	disableSMIAccessControlPolicy       bool
-	meshName                            string
-	sidecarInjectorWebhookFailurePolicy string
+	out                           io.Writer
+	containerRegistry             string
+	containerRegistrySecret       string
+	chartPath                     string
+	osmImageTag                   string
+	certManager                   string
+	vaultHost                     string
+	vaultProtocol                 string
+	vaultToken                    string
+	vaultRole                     string
+	serviceCertValidityMinutes    int
+	prometheusRetentionTime       string
+	enableDebugServer             bool
+	disableSMIAccessControlPolicy bool
+	meshName                      string
 }
 
 func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
@@ -100,7 +99,6 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableDebugServer, "enable-debug-server", false, "Enable the debug HTTP server")
 	f.BoolVar(&inst.disableSMIAccessControlPolicy, "disable-smi-access-control-policy", false, "Disable SMI access control policy")
 	f.StringVar(&inst.meshName, "mesh-name", "osm", "Name of the service mesh")
-	f.StringVar(&inst.sidecarInjectorWebhookFailurePolicy, "sidecar-webhook-failure-policy", "Fail", "Failure policy for the sidecar injector webhook (Fail or Ignore)")
 
 	return cmd
 }
@@ -195,7 +193,6 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
 		fmt.Sprintf("OpenServiceMesh.disableSMIAccessControlPolicy=%t", i.disableSMIAccessControlPolicy),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
-		fmt.Sprintf("OpenServiceMesh.sidecarInjectorWebhook.failurePolicy=%s", i.sidecarInjectorWebhookFailurePolicy),
 	}
 
 	for _, val := range valuesConfig {

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -15,15 +15,14 @@ import (
 )
 
 var (
-	testRegistry                               = "test-registry"
-	testRegistrySecret                         = "test-registry-secret"
-	testOsmImageTag                            = "test-tag"
-	testVaultHost                              = "vault.osm.svc.cluster.local"
-	testVaultProtocol                          = "http"
-	testVaultToken                             = "token"
-	testVaultRole                              = "role"
-	testRetentionTime                          = "5d"
-	defaultSidecarInjectorWebhookFailurePolicy = "Fail"
+	testRegistry       = "test-registry"
+	testRegistrySecret = "test-registry-secret"
+	testOsmImageTag    = "test-tag"
+	testVaultHost      = "vault.osm.svc.cluster.local"
+	testVaultProtocol  = "http"
+	testVaultToken     = "token"
+	testVaultRole      = "role"
+	testRetentionTime  = "5d"
 )
 
 var _ = Describe("Running the install command", func() {
@@ -53,16 +52,15 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			installCmd := &installCmd{
-				out:                                 out,
-				chartPath:                           "testdata/test-chart",
-				containerRegistry:                   testRegistry,
-				containerRegistrySecret:             testRegistrySecret,
-				osmImageTag:                         testOsmImageTag,
-				certManager:                         "tresor",
-				serviceCertValidityMinutes:          1,
-				prometheusRetentionTime:             testRetentionTime,
-				meshName:                            "osm",
-				sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
+				out:                        out,
+				chartPath:                  "testdata/test-chart",
+				containerRegistry:          testRegistry,
+				containerRegistrySecret:    testRegistrySecret,
+				osmImageTag:                testOsmImageTag,
+				certManager:                "tresor",
+				serviceCertValidityMinutes: 1,
+				prometheusRetentionTime:    testRetentionTime,
+				meshName:                   "osm",
 			}
 
 			installClient := helm.NewInstall(config)
@@ -118,9 +116,6 @@ var _ = Describe("Running the install command", func() {
 							}},
 						"enableDebugServer":             false,
 						"disableSMIAccessControlPolicy": false,
-						"sidecarInjectorWebhook": map[string]interface{}{
-							"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
-						},
 					}}))
 			})
 
@@ -155,15 +150,14 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			installCmd := &installCmd{
-				out:                                 out,
-				containerRegistry:                   testRegistry,
-				containerRegistrySecret:             testRegistrySecret,
-				osmImageTag:                         testOsmImageTag,
-				certManager:                         "tresor",
-				serviceCertValidityMinutes:          1,
-				prometheusRetentionTime:             testRetentionTime,
-				meshName:                            "osm",
-				sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
+				out:                        out,
+				containerRegistry:          testRegistry,
+				containerRegistrySecret:    testRegistrySecret,
+				osmImageTag:                testOsmImageTag,
+				certManager:                "tresor",
+				serviceCertValidityMinutes: 1,
+				prometheusRetentionTime:    testRetentionTime,
+				meshName:                   "osm",
 			}
 
 			installClient := helm.NewInstall(config)
@@ -219,9 +213,6 @@ var _ = Describe("Running the install command", func() {
 							}},
 						"enableDebugServer":             false,
 						"disableSMIAccessControlPolicy": false,
-						"sidecarInjectorWebhook": map[string]interface{}{
-							"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
-						},
 					}}))
 			})
 
@@ -255,20 +246,19 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			installCmd := &installCmd{
-				out:                                 out,
-				chartPath:                           "testdata/test-chart",
-				containerRegistry:                   testRegistry,
-				containerRegistrySecret:             testRegistrySecret,
-				certManager:                         "vault",
-				vaultHost:                           testVaultHost,
-				vaultToken:                          testVaultToken,
-				vaultRole:                           testVaultRole,
-				vaultProtocol:                       "http",
-				osmImageTag:                         testOsmImageTag,
-				serviceCertValidityMinutes:          1,
-				prometheusRetentionTime:             testRetentionTime,
-				meshName:                            "osm",
-				sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
+				out:                        out,
+				chartPath:                  "testdata/test-chart",
+				containerRegistry:          testRegistry,
+				containerRegistrySecret:    testRegistrySecret,
+				certManager:                "vault",
+				vaultHost:                  testVaultHost,
+				vaultToken:                 testVaultToken,
+				vaultRole:                  testVaultRole,
+				vaultProtocol:              "http",
+				osmImageTag:                testOsmImageTag,
+				serviceCertValidityMinutes: 1,
+				prometheusRetentionTime:    testRetentionTime,
+				meshName:                   "osm",
 			}
 
 			installClient := helm.NewInstall(config)
@@ -325,9 +315,6 @@ var _ = Describe("Running the install command", func() {
 						},
 						"enableDebugServer":             false,
 						"disableSMIAccessControlPolicy": false,
-						"sidecarInjectorWebhook": map[string]interface{}{
-							"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
-						},
 					}}))
 			})
 
@@ -386,17 +373,16 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:                   testRegistry,
-			containerRegistrySecret:             testRegistrySecret,
-			certManager:                         "vault",
-			vaultHost:                           testVaultHost,
-			vaultProtocol:                       testVaultProtocol,
-			vaultToken:                          testVaultToken,
-			vaultRole:                           testVaultRole,
-			osmImageTag:                         testOsmImageTag,
-			serviceCertValidityMinutes:          1,
-			prometheusRetentionTime:             testRetentionTime,
-			sidecarInjectorWebhookFailurePolicy: defaultSidecarInjectorWebhookFailurePolicy,
+			containerRegistry:          testRegistry,
+			containerRegistrySecret:    testRegistrySecret,
+			certManager:                "vault",
+			vaultHost:                  testVaultHost,
+			vaultProtocol:              testVaultProtocol,
+			vaultToken:                 testVaultToken,
+			vaultRole:                  testVaultRole,
+			osmImageTag:                testOsmImageTag,
+			serviceCertValidityMinutes: 1,
+			prometheusRetentionTime:    testRetentionTime,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -434,67 +420,6 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				},
 				"enableDebugServer":             false,
 				"disableSMIAccessControlPolicy": false,
-				"sidecarInjectorWebhook": map[string]interface{}{
-					"failurePolicy": defaultSidecarInjectorWebhookFailurePolicy,
-				},
-			}}))
-	})
-})
-
-var _ = Describe("Resolving values for install command with sidecar injector webhook parameters", func() {
-	var (
-		vals map[string]interface{}
-		err  error
-	)
-
-	BeforeEach(func() {
-		installCmd := &installCmd{
-			containerRegistry:                   testRegistry,
-			containerRegistrySecret:             testRegistrySecret,
-			certManager:                         "tresor",
-			osmImageTag:                         testOsmImageTag,
-			serviceCertValidityMinutes:          1,
-			prometheusRetentionTime:             testRetentionTime,
-			sidecarInjectorWebhookFailurePolicy: "Ignore",
-		}
-
-		vals, err = installCmd.resolveValues()
-	})
-
-	It("should not error", func() {
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should resolve correctly", func() {
-		Expect(vals).To(BeEquivalentTo(map[string]interface{}{
-			"OpenServiceMesh": map[string]interface{}{
-				"certManager": "tresor",
-				"meshName":    "",
-				"image": map[string]interface{}{
-					"registry": testRegistry,
-					"tag":      testOsmImageTag,
-				},
-				"imagePullSecrets": []interface{}{
-					map[string]interface{}{
-						"name": testRegistrySecret,
-					},
-				},
-				"serviceCertValidityMinutes": int64(1),
-				"vault": map[string]interface{}{
-					"host":     "",
-					"protocol": "",
-					"token":    "",
-					"role":     "",
-				},
-				"prometheus": map[string]interface{}{
-					"retention": map[string]interface{}{
-						"time": "5d",
-					}},
-				"enableDebugServer":             false,
-				"disableSMIAccessControlPolicy": false,
-				"sidecarInjectorWebhook": map[string]interface{}{
-					"failurePolicy": "Ignore",
-				},
 			}}))
 	})
 })


### PR DESCRIPTION
This reverts commit 489f98d5ac8a16ccf3168137ee8c28dd60891493.

Allowing the failurePolicy to be set to Ignore opens the door
for the mesh state to be inconsistent from the desired state
when traffic should be denied by default. If the webhook fails,
then sidecars will not be injected and without the sidecar
traffic will not be intercepted for policy enforcement.