### PR TITLE
@certResource, moving it out xdsutils

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRq
 github.com/Azure/azure-sdk-for-go v16.2.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v34.0.0+incompatible h1:4uQN/1HmJCkxYOnK3MUBUhHW7dxWUABOOr/LgxkkYKM=
 github.com/Azure/azure-sdk-for-go v34.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.8.1+incompatible h1:u0jVQf+a6k6x8A+sT60l6EY9XZu+kHdnZVPAYqpVRo0=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -57,7 +58,9 @@ github.com/Masterminds/sprig/v3 v3.1.0/go.mod h1:ONGMf7UfYGAbMXCZmQLy8x3lCDIPrEZ
 github.com/Masterminds/squirrel v1.2.0 h1:K1NhbTO21BWG47IVR0OnIZuE0LZcXAYqywrC3Ko53KI=
 github.com/Masterminds/squirrel v1.2.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/vcs v1.13.1/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
+github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5 h1:ygIc8M6trr62pF5DucadTWGdEB4mEyvzi0e2nbcmcyA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
+github.com/Microsoft/hcsshim v0.8.7 h1:ptnOoufxGSzauVTsdE+wMYnCWA301PdoN4xg5oRdZpg=
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -108,6 +111,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
+github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -419,6 +423,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -670,6 +675,7 @@ go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
+go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -817,6 +823,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.2 h1:j8RI1yW0SkI+paT6uGwMlrMI/6zwYA6/CFil8rxOzGI=
 google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/pkg/certresource/certresource.go
+++ b/pkg/certresource/certresource.go
@@ -1,0 +1,127 @@
+package certresource
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/copier"
+	"github.com/open-service-mesh/osm/pkg/service"
+)
+
+// CertType is a type of a certificate requested by an Envoy proxy via SDS.
+type CertType string
+
+// Direction is a type to identify TLS certificate connectivity direction.
+type Direction string
+
+// CertResource is only used to interface the naming and related functions to Marshal/Unmarshal a resource name,
+// this avoids having sprintf/parsing logic all over the place
+type CertResource struct {
+	// Service is a namespaced service struct
+	Service service.NamespacedService
+	// CertType is the certificate type
+	CertType CertType
+}
+
+func (ct CertType) String() string {
+	return string(ct)
+}
+
+const (
+	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:webservice"
+	ServiceCertType CertType = "service-cert"
+
+	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate resource name for upstream connectivity. Example: "root-cert-for-mtls-outbound:webservice"
+	RootCertTypeForMTLSOutbound CertType = "root-cert-for-mtls-outbound"
+
+	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate resource name for downstream connectivity. Example: "root-cert-for-mtls-inbound:webservice"
+	RootCertTypeForMTLSInbound CertType = "root-cert-for-mtls-inbound"
+
+	// RootCertTypeForHTTPS is the prefix for the HTTPS root certificate resource name. Example: "root-cert-https:webservice"
+	RootCertTypeForHTTPS CertType = "root-cert-https"
+
+	// Outbound refers to Envoy upstream connectivity direction for TLS certs
+	Outbound Direction = "outbound"
+
+	// Inbound refers to Envoy downstream connectivity direction for TLS certs
+	Inbound Direction = "inbound"
+
+	// NoDirection for resources that do not specify a direction implied with the cert resource type
+	NoDirection Direction = "no-direction"
+
+	// Separator is the separator between the prefix and the name of the certificate.
+	separator = ":"
+)
+
+// Defines valid cert types
+var validCertTypes = map[CertType]interface{}{
+	ServiceCertType:             nil,
+	RootCertTypeForMTLSOutbound: nil,
+	RootCertTypeForMTLSInbound:  nil,
+	RootCertTypeForHTTPS:        nil,
+}
+
+// UnmarshalCertResource parses and returns Certificate type and Namespaced Service name given a
+// correctly formatted string, otherwise returns error
+func UnmarshalCertResource(str string) (*CertResource, error) {
+	var svc *service.NamespacedService
+	var ret CertResource
+
+	// Check separators, ignore empty string fields
+	slices := strings.Split(str, separator)
+	if len(slices) != 2 {
+		return nil, errInvalidCertFormat
+	}
+
+	// Make sure the slices are not empty. Split might actually leave empty slices.
+	for _, sep := range slices {
+		if len(sep) == 0 {
+			return nil, errInvalidCertFormat
+		}
+	}
+
+	// Check valid certType
+	ret.CertType = CertType(slices[0])
+	if _, ok := validCertTypes[ret.CertType]; !ok {
+		return nil, errInvalidCertFormat
+	}
+
+	// Check valid namespace'd service name
+	svc, err := service.UnmarshalNamespacedService(slices[1])
+	if err != nil {
+		return nil, err
+	}
+	err = copier.Copy(&ret.Service, &svc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret, nil
+
+}
+
+// String is a common facility/interface to generate a string resource name out of a SDSCert
+// This is to keep the sprintf logic and/or separators used agnostic to other modules
+func (sdsc CertResource) String() string {
+	return fmt.Sprintf("%s%s%s",
+		sdsc.CertType.String(),
+		separator,
+		sdsc.Service.String())
+}
+
+// Direction returns direction (Direction type) of a certificate, or error
+// if the specific type has not direction implied
+func (sdsc CertResource) Direction() Direction {
+	switch sdsc.CertType {
+	case RootCertTypeForMTLSOutbound:
+		return Outbound
+	case RootCertTypeForMTLSInbound:
+		return Inbound
+	default:
+		return NoDirection
+	}
+}
+
+func (dir Direction) String() string {
+	return string(dir)
+}

--- a/pkg/certresource/certresource_test.go
+++ b/pkg/certresource/certresource_test.go
@@ -1,0 +1,106 @@
+package certresource
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/open-service-mesh/osm/pkg/service"
+)
+
+var _ = Describe("Test certresource", func() {
+
+	Context("Test CertName interface", func() {
+		It("Interface marshals and unmarshals preserving the exact same data", func() {
+			InitialObj := CertResource{
+				CertType: ServiceCertType,
+				Service: service.NamespacedService{
+					Namespace: "test-namespace",
+					Service:   "test-service",
+				},
+			}
+
+			// Marshal/stringify it
+			marshaledStr := InitialObj.String()
+
+			// Unmarshal it back from the string
+			finalObj, _ := UnmarshalCertResource(marshaledStr)
+
+			// First and final object must be equal
+			Expect(*finalObj).To(Equal(InitialObj))
+		})
+	})
+
+	Context("Test getRequestedCertType()", func() {
+		It("returns service cert", func() {
+			actual, err := UnmarshalCertResource("service-cert:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(ServiceCertType))
+			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
+			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
+		})
+		It("returns root cert for mTLS", func() {
+			actual, err := UnmarshalCertResource("root-cert-for-mtls-outbound:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(RootCertTypeForMTLSOutbound))
+			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
+			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
+		})
+
+		It("returns root cert for non-mTLS", func() {
+			actual, err := UnmarshalCertResource("root-cert-https:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(RootCertTypeForHTTPS))
+			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
+			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
+		})
+
+		It("returns an error (invalid formatting)", func() {
+			_, err := UnmarshalCertResource("blahBlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid formatting)", func() {
+			_, err := UnmarshalCertResource("blahBlahBlahCert:moreblabla/amazingservice:bla")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (missing cert type)", func() {
+			_, err := UnmarshalCertResource("blahBlahBlahCert/service")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (service is not namespaced)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:blahBlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid namespace formatting)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:blah/BlahBl/ahCert")
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns an error (empty left-side namespace)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:/ahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (empty cert type)", func() {
+			_, err := UnmarshalCertResource(":ns/svc")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (empty slice on right/wrong number of slices)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:aaa/ahCert:")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid serv type)", func() {
+			_, err := UnmarshalCertResource("revoked-cert:blah/BlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid mtls cert type)", func() {
+			_, err := UnmarshalCertResource("oot-cert-for-mtls-diagonalstream:blah/BlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+})

--- a/pkg/certresource/errors.go
+++ b/pkg/certresource/errors.go
@@ -1,0 +1,9 @@
+package certresource
+
+import (
+	"errors"
+)
+
+var (
+	errInvalidCertFormat = errors.New("invalid certificate string resource format")
+)

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -9,6 +9,7 @@ import (
 	envoy_service_discovery_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
+	"github.com/open-service-mesh/osm/pkg/certresource"
 	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
@@ -55,21 +56,21 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, catalog catalog.MeshCataloger)
 
 	return &envoy_api_v2.DiscoveryRequest{
 		ResourceNames: []string{
-			envoy.SDSCert{
+			certresource.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.ServiceCertType,
+				CertType: certresource.ServiceCertType,
 			}.String(),
-			envoy.SDSCert{
+			certresource.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.RootCertTypeForMTLSOutbound,
+				CertType: certresource.RootCertTypeForMTLSOutbound,
 			}.String(),
-			envoy.SDSCert{
+			certresource.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: certresource.RootCertTypeForMTLSInbound,
 			}.String(),
-			envoy.SDSCert{
+			certresource.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: certresource.RootCertTypeForHTTPS,
 			}.String(),
 		},
 		TypeUrl: string(envoy.TypeSDS),

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/certificate"
 	"github.com/open-service-mesh/osm/pkg/certificate/providers/tresor"
+	"github.com/open-service-mesh/osm/pkg/certresource"
 	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
@@ -66,21 +67,21 @@ var _ = Describe("Test ADS response functions", func() {
 			expected := envoy_api_v2.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					envoy.SDSCert{
+					certresource.CertResource{
 						Service:  nsService,
-						CertType: envoy.ServiceCertType,
+						CertType: certresource.ServiceCertType,
 					}.String(),
-					envoy.SDSCert{
+					certresource.CertResource{
 						Service:  nsService,
-						CertType: envoy.RootCertTypeForMTLSOutbound,
+						CertType: certresource.RootCertTypeForMTLSOutbound,
 					}.String(),
-					envoy.SDSCert{
+					certresource.CertResource{
 						Service:  nsService,
-						CertType: envoy.RootCertTypeForMTLSInbound,
+						CertType: certresource.RootCertTypeForMTLSInbound,
 					}.String(),
-					envoy.SDSCert{
+					certresource.CertResource{
 						Service:  nsService,
-						CertType: envoy.RootCertTypeForHTTPS,
+						CertType: certresource.RootCertTypeForHTTPS,
 					}.String(),
 				},
 			}
@@ -134,33 +135,33 @@ var _ = Describe("Test ADS response functions", func() {
 			secretOne := envoy_api_v2_auth.Secret{}
 			firstSecret := (*actualResponses)[4].Resources[0]
 			err = ptypes.UnmarshalAny(firstSecret, &secretOne)
-			Expect(secretOne.Name).To(Equal(envoy.SDSCert{
+			Expect(secretOne.Name).To(Equal(certresource.CertResource{
 				Service:  nsService,
-				CertType: envoy.ServiceCertType,
+				CertType: certresource.ServiceCertType,
 			}.String()))
 
 			secretTwo := envoy_api_v2_auth.Secret{}
 			secondSecret := (*actualResponses)[4].Resources[1]
 			err = ptypes.UnmarshalAny(secondSecret, &secretTwo)
-			Expect(secretTwo.Name).To(Equal(envoy.SDSCert{
+			Expect(secretTwo.Name).To(Equal(certresource.CertResource{
 				Service:  nsService,
-				CertType: envoy.RootCertTypeForMTLSOutbound,
+				CertType: certresource.RootCertTypeForMTLSOutbound,
 			}.String()))
 
 			secretThree := envoy_api_v2_auth.Secret{}
 			thirdSecret := (*actualResponses)[4].Resources[2]
 			err = ptypes.UnmarshalAny(thirdSecret, &secretThree)
-			Expect(secretThree.Name).To(Equal(envoy.SDSCert{
+			Expect(secretThree.Name).To(Equal(certresource.CertResource{
 				Service:  nsService,
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: certresource.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			secretFour := envoy_api_v2_auth.Secret{}
 			forthSecret := (*actualResponses)[4].Resources[3]
 			err = ptypes.UnmarshalAny(forthSecret, &secretFour)
-			Expect(secretFour.Name).To(Equal(envoy.SDSCert{
+			Expect(secretFour.Name).To(Equal(certresource.CertResource{
 				Service:  nsService,
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: certresource.RootCertTypeForHTTPS,
 			}.String()))
 		})
 	})

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/certresource"
 	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 	"github.com/open-service-mesh/osm/pkg/tests"
 )
@@ -223,7 +225,13 @@ var _ = Describe("CDS Response", func() {
 					}},
 					ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
-							Name: fmt.Sprintf("%s%s%s", envoy.RootCertTypeForMTLSOutbound, envoy.Separator, "default/bookstore"),
+							Name: certresource.CertResource{
+								Service: service.NamespacedService{
+									Namespace: "default",
+									Service:   "bookstore",
+								},
+								CertType: certresource.RootCertTypeForMTLSOutbound,
+							}.String(),
 							SdsConfig: &envoy_api_v2_core.ConfigSource{
 								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
 									Ads: &envoy_api_v2_core.AggregatedConfigSource{},

--- a/pkg/envoy/errors.go
+++ b/pkg/envoy/errors.go
@@ -1,9 +1,3 @@
 package envoy
 
-import (
-	"errors"
-)
-
-var (
-	errInvalidCertFormat = errors.New("invalid certificate string resource format")
-)
+var ()

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -12,17 +12,12 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/certresource"
 	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 )
-
-// Used mainly for logging/translation purposes
-var directionMap = map[envoy.SDSCertType]string{
-	envoy.RootCertTypeForMTLSInbound:  "inbound",
-	envoy.RootCertTypeForMTLSOutbound: "outbound",
-}
 
 // NewResponse creates a new Secrets Discovery Response.
 func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, config *configurator.Config) (*xds.DiscoveryResponse, error) {
@@ -78,7 +73,7 @@ func getEnvoySDSSecrets(cert certificate.Certificater, proxy *envoy.Proxy, reque
 	// The Envoy makes a request for a list of resources (aka certificates), which we will send as a response to the SDS request.
 	for _, requestedCertificate := range requestedCerts {
 		// requestedCertType could be either "service-cert" or "root-cert"
-		sdsCert, err := envoy.UnmarshalSDSCert(requestedCertificate)
+		sdsCert, err := certresource.UnmarshalCertResource(requestedCertificate)
 		if err != nil {
 			log.Error().Err(err).Msgf("Invalid resource kind requested: %q", requestedCertificate)
 			continue
@@ -90,7 +85,7 @@ func getEnvoySDSSecrets(cert certificate.Certificater, proxy *envoy.Proxy, reque
 		}
 
 		switch sdsCert.CertType {
-		case envoy.ServiceCertType:
+		case certresource.ServiceCertType:
 			log.Info().Msgf("proxy %s (member of service %s) requested %s", proxy.GetCommonName(), serviceForProxy.String(), requestedCertificate)
 			envoySecret, err := getServiceCertSecret(cert, requestedCertificate)
 			if err != nil {
@@ -99,16 +94,17 @@ func getEnvoySDSSecrets(cert certificate.Certificater, proxy *envoy.Proxy, reque
 			}
 			envoySecrets = append(envoySecrets, envoySecret)
 
-		case envoy.RootCertTypeForMTLSInbound:
+		case certresource.RootCertTypeForMTLSInbound:
 			fallthrough
-		case envoy.RootCertTypeForMTLSOutbound:
+		case certresource.RootCertTypeForMTLSOutbound:
 			fallthrough
-		case envoy.RootCertTypeForHTTPS:
+		case certresource.RootCertTypeForHTTPS:
 			log.Info().Msgf("proxy %s (member of service %s) requested %s", proxy.GetCommonName(), serviceForProxy.String(), requestedCertificate)
 			envoySecret, err := getRootCert(cert, *sdsCert, serviceForProxy, catalog)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error creating cert %s for proxy %s for service %s", requestedCertificate, proxy.GetCommonName(), serviceForProxy.String())
 				continue
+
 			}
 			envoySecrets = append(envoySecrets, envoySecret)
 		}
@@ -140,7 +136,7 @@ func getServiceCertSecret(cert certificate.Certificater, name string) (*auth.Sec
 	return secret, nil
 }
 
-func getRootCert(cert certificate.Certificater, sdscert envoy.SDSCert, proxyServiceName service.NamespacedService, mc catalog.MeshCataloger) (*auth.Secret, error) {
+func getRootCert(cert certificate.Certificater, sdscert certresource.CertResource, proxyServiceName service.NamespacedService, mc catalog.MeshCataloger) (*auth.Secret, error) {
 	secret := &auth.Secret{
 		// The Name field must match the tls_context.common_tls_context.tls_certificate_sds_secret_configs.name
 		Name: sdscert.String(),
@@ -156,16 +152,16 @@ func getRootCert(cert certificate.Certificater, sdscert envoy.SDSCert, proxyServ
 	}
 
 	switch sdscert.CertType {
-	case envoy.RootCertTypeForMTLSOutbound:
+	case certresource.RootCertTypeForMTLSOutbound:
 		fallthrough
-	case envoy.RootCertTypeForMTLSInbound:
+	case certresource.RootCertTypeForMTLSInbound:
 		var matchSANs []*envoy_type_matcher.StringMatcher
 		var serverNames []service.NamespacedService
 		var err error
 
 		// This block constructs a list of Server Names (peers) that are allowed to connect to the given service.
 		// The allowed list is derived from SMI's Traffic Policy.
-		if sdscert.CertType == envoy.RootCertTypeForMTLSOutbound {
+		if sdscert.CertType == certresource.RootCertTypeForMTLSOutbound {
 			// Outbound
 			serverNames, err = mc.ListAllowedOutboundServices(proxyServiceName)
 		} else {
@@ -174,7 +170,7 @@ func getRootCert(cert certificate.Certificater, sdscert envoy.SDSCert, proxyServ
 		}
 
 		if err != nil {
-			log.Error().Err(err).Msgf("Error getting server names for %s allowed Services %s", directionMap[sdscert.CertType], proxyServiceName)
+			log.Error().Err(err).Msgf("Error getting server names for %s allowed Services %s", sdscert.Direction(), proxyServiceName)
 			return nil, err
 		}
 
@@ -189,7 +185,7 @@ func getRootCert(cert certificate.Certificater, sdscert envoy.SDSCert, proxyServ
 			matchSANs = append(matchSANs, &match)
 		}
 
-		log.Trace().Msgf("Proxy for service %s will only allow %s SANs exactly matching: %+v", proxyServiceName, directionMap[sdscert.CertType], matchingCerts)
+		log.Trace().Msgf("Proxy for service %s will only allow %s SANs exactly matching: %+v", proxyServiceName, sdscert.Direction(), matchingCerts)
 
 		// Ensure the Subject Alternate Names (SAN) added by CertificateManager.IssueCertificate()
 		// matches what is allowed to connect to the downstream service as defined in TrafficPolicy.

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-service-mesh/osm/pkg/certresource"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/service"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,9 +72,9 @@ var _ = Describe("Test SDS response functions", func() {
 				Service:   "svc",
 			}
 
-			sdsc := envoy.SDSCert{
+			sdsc := certresource.CertResource{
 				Service:  svc,
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: certresource.RootCertTypeForMTLSInbound,
 			}
 
 			resourceName := sdsc.String()
@@ -122,9 +123,9 @@ var _ = Describe("Test SDS response functions", func() {
 				Service:   serviceName,
 			}
 
-			sdsc := envoy.SDSCert{
+			sdsc := certresource.CertResource{
 				Service:  svc,
-				CertType: envoy.RootCertTypeForMTLSOutbound,
+				CertType: certresource.RootCertTypeForMTLSOutbound,
 			}
 			resourceNames := []string{sdsc.String()}
 			cert, proxy, mc := prep(resourceNames, namespace, serviceName)

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -1,8 +1,6 @@
 package envoy
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -16,114 +14,18 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/jinzhu/copier"
 
+	"github.com/open-service-mesh/osm/pkg/certresource"
 	"github.com/open-service-mesh/osm/pkg/service"
 )
 
-// SDSCertType is a type of a certificate requested by an Envoy proxy via SDS.
-type SDSCertType string
-
-// SDSDirection is a type to identify TLS certificate connectivity direction.
-type SDSDirection bool
-
-// SDSCert is only used to interface the naming and related functions to Marshal/Unmarshal a resource name,
-// this avoids having sprintf/parsing logic all over the place
-type SDSCert struct {
-	// Service is a namespaced service struct
-	Service service.NamespacedService
-	// CertType is the certificate type
-	CertType SDSCertType
-}
-
-func (ct SDSCertType) String() string {
-	return string(ct)
-}
-
 const (
-	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:webservice"
-	ServiceCertType SDSCertType = "service-cert"
-
-	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate resource name for upstream connectivity. Example: "root-cert-for-mtls-outbound:webservice"
-	RootCertTypeForMTLSOutbound SDSCertType = "root-cert-for-mtls-outbound"
-
-	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate resource name for downstream connectivity. Example: "root-cert-for-mtls-inbound:webservice"
-	RootCertTypeForMTLSInbound SDSCertType = "root-cert-for-mtls-inbound"
-
-	// RootCertTypeForHTTPS is the prefix for the HTTPS root certificate resource name. Example: "root-cert-https:webservice"
-	RootCertTypeForHTTPS SDSCertType = "root-cert-https"
-
-	// Outbound refers to Envoy upstream connectivity direction for TLS certs
-	Outbound SDSDirection = true
-
-	// Inbound refers to Envoy downstream connectivity direction for TLS certs
-	Inbound SDSDirection = false
-
-	// Separator is the separator between the prefix and the name of the certificate.
-	Separator = ":"
-
 	// ConnectionTimeout is the timeout duration used by Envoy to timeout connections
 	ConnectionTimeout = 5 * time.Second
 
 	// TransportProtocolTLS is the TLS transport protocol used in Envoy configurations
 	TransportProtocolTLS = "tls"
 )
-
-// Defines valid cert types
-var validCertTypes = map[SDSCertType]interface{}{
-	ServiceCertType:             nil,
-	RootCertTypeForMTLSOutbound: nil,
-	RootCertTypeForMTLSInbound:  nil,
-	RootCertTypeForHTTPS:        nil,
-}
-
-// UnmarshalSDSCert parses and returns Certificate type and Namespaced Service name given a
-// correctly formatted string, otherwise returns error
-func UnmarshalSDSCert(str string) (*SDSCert, error) {
-	var svc *service.NamespacedService
-	var ret SDSCert
-
-	// Check separators, ignore empty string fields
-	slices := strings.Split(str, Separator)
-	if len(slices) != 2 {
-		return nil, errInvalidCertFormat
-	}
-
-	// Make sure the slices are not empty. Split might actually leave empty slices.
-	for _, sep := range slices {
-		if len(sep) == 0 {
-			return nil, errInvalidCertFormat
-		}
-	}
-
-	// Check valid certType
-	ret.CertType = SDSCertType(slices[0])
-	if _, ok := validCertTypes[ret.CertType]; !ok {
-		return nil, errInvalidCertFormat
-	}
-
-	// Check valid namespace'd service name
-	svc, err := service.UnmarshalNamespacedService(slices[1])
-	if err != nil {
-		return nil, err
-	}
-	err = copier.Copy(&ret.Service, &svc)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ret, nil
-
-}
-
-// String is a common facility/interface to generate a string resource name out of a SDSCert
-// This is to keep the sprintf logic and/or separators used agnostic to other modules
-func (sdsc SDSCert) String() string {
-	return fmt.Sprintf("%s%s%s",
-		sdsc.CertType.String(),
-		Separator,
-		sdsc.Service.String())
-}
 
 // GetAddress creates an Envoy Address struct.
 func GetAddress(address string, port uint32) *core.Address {
@@ -204,35 +106,35 @@ func pbStringValue(v string) *structpb.Value {
 	}
 }
 
-func getCommonTLSContext(serviceName service.NamespacedService, mTLS bool, dir SDSDirection) *auth.CommonTlsContext {
-	var certType SDSCertType
+func getCommonTLSContext(serviceName service.NamespacedService, mTLS bool, dir certresource.Direction) *auth.CommonTlsContext {
+	var certType certresource.CertType
 
 	// Define root cert type
 	if mTLS {
 		switch dir {
-		case Outbound:
-			certType = RootCertTypeForMTLSOutbound
-		case Inbound:
-			certType = RootCertTypeForMTLSInbound
+		case certresource.Outbound:
+			certType = certresource.RootCertTypeForMTLSOutbound
+		case certresource.Inbound:
+			certType = certresource.RootCertTypeForMTLSInbound
 		}
 	} else {
-		certType = RootCertTypeForHTTPS
+		certType = certresource.RootCertTypeForHTTPS
 	}
 
 	return &auth.CommonTlsContext{
 		TlsParams: GetTLSParams(),
 		TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
 			// Example ==> Name: "service-cert:NameSpaceHere/ServiceNameHere"
-			Name: SDSCert{
+			Name: certresource.CertResource{
 				Service:  serviceName,
-				CertType: ServiceCertType,
+				CertType: certresource.ServiceCertType,
 			}.String(),
 			SdsConfig: GetADSConfigSource(),
 		}},
 		ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 			ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 				// Example ==> Name: "root-cert<type>:NameSpaceHere/ServiceNameHere"
-				Name: SDSCert{
+				Name: certresource.CertResource{
 					Service:  serviceName,
 					CertType: certType,
 				}.String(),
@@ -254,7 +156,7 @@ func MessageToAny(pb proto.Message) (*any.Any, error) {
 // GetDownstreamTLSContext creates a downstream Envoy TLS Context
 func GetDownstreamTLSContext(serviceName service.NamespacedService, mTLS bool) *auth.DownstreamTlsContext {
 	tlsConfig := &auth.DownstreamTlsContext{
-		CommonTlsContext: getCommonTLSContext(serviceName, mTLS, Inbound),
+		CommonTlsContext: getCommonTLSContext(serviceName, mTLS, certresource.Inbound),
 		// When RequireClientCertificate is enabled trusted CA certs must be provided via ValidationContextType
 		RequireClientCertificate: &wrappers.BoolValue{Value: mTLS},
 	}
@@ -264,7 +166,7 @@ func GetDownstreamTLSContext(serviceName service.NamespacedService, mTLS bool) *
 // GetUpstreamTLSContext creates an upstream Envoy TLS Context
 func GetUpstreamTLSContext(serviceName service.NamespacedService) *auth.UpstreamTlsContext {
 	tlsConfig := &auth.UpstreamTlsContext{
-		CommonTlsContext: getCommonTLSContext(serviceName, true /* mTLS */, Outbound),
+		CommonTlsContext: getCommonTLSContext(serviceName, true /* mTLS */, certresource.Outbound),
 
 		// The Sni field is going to be used to do FilterChainMatch in getInboundInMeshFilterChain()
 		// The "Sni" field below of an incoming request will be matched aganist a list of server names


### PR DESCRIPTION
Better isolation and interfacing with service certificate
resource naming.

Could be placed in "service" pkg alongside NamespacedService
if we want to avoid a new pkg for this util - they are tightly
related after all.

Fixes #971