### PR TITLE
Move certresource to service package

### DIFF
--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 )
 
 func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *envoy_service_discovery_v2.AggregatedDiscoveryService_StreamAggregatedResourcesServer, config *configurator.Config) {
@@ -55,21 +56,21 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, catalog catalog.MeshCataloger)
 
 	return &envoy_api_v2.DiscoveryRequest{
 		ResourceNames: []string{
-			envoy.SDSCert{
+			service.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.ServiceCertType,
+				CertType: service.ServiceCertType,
 			}.String(),
-			envoy.SDSCert{
+			service.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.RootCertTypeForMTLSOutbound,
+				CertType: service.RootCertTypeForMTLSOutbound,
 			}.String(),
-			envoy.SDSCert{
+			service.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: service.RootCertTypeForMTLSInbound,
 			}.String(),
-			envoy.SDSCert{
+			service.CertResource{
 				Service:  *serviceForProxy,
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: service.RootCertTypeForHTTPS,
 			}.String(),
 		},
 		TypeUrl: string(envoy.TypeSDS),

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -66,21 +66,21 @@ var _ = Describe("Test ADS response functions", func() {
 			expected := envoy_api_v2.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					envoy.SDSCert{
+					service.CertResource{
 						Service:  nsService,
-						CertType: envoy.ServiceCertType,
+						CertType: service.ServiceCertType,
 					}.String(),
-					envoy.SDSCert{
+					service.CertResource{
 						Service:  nsService,
-						CertType: envoy.RootCertTypeForMTLSOutbound,
+						CertType: service.RootCertTypeForMTLSOutbound,
 					}.String(),
-					envoy.SDSCert{
+					service.CertResource{
 						Service:  nsService,
-						CertType: envoy.RootCertTypeForMTLSInbound,
+						CertType: service.RootCertTypeForMTLSInbound,
 					}.String(),
-					envoy.SDSCert{
+					service.CertResource{
 						Service:  nsService,
-						CertType: envoy.RootCertTypeForHTTPS,
+						CertType: service.RootCertTypeForHTTPS,
 					}.String(),
 				},
 			}
@@ -134,33 +134,33 @@ var _ = Describe("Test ADS response functions", func() {
 			secretOne := envoy_api_v2_auth.Secret{}
 			firstSecret := (*actualResponses)[4].Resources[0]
 			err = ptypes.UnmarshalAny(firstSecret, &secretOne)
-			Expect(secretOne.Name).To(Equal(envoy.SDSCert{
+			Expect(secretOne.Name).To(Equal(service.CertResource{
 				Service:  nsService,
-				CertType: envoy.ServiceCertType,
+				CertType: service.ServiceCertType,
 			}.String()))
 
 			secretTwo := envoy_api_v2_auth.Secret{}
 			secondSecret := (*actualResponses)[4].Resources[1]
 			err = ptypes.UnmarshalAny(secondSecret, &secretTwo)
-			Expect(secretTwo.Name).To(Equal(envoy.SDSCert{
+			Expect(secretTwo.Name).To(Equal(service.CertResource{
 				Service:  nsService,
-				CertType: envoy.RootCertTypeForMTLSOutbound,
+				CertType: service.RootCertTypeForMTLSOutbound,
 			}.String()))
 
 			secretThree := envoy_api_v2_auth.Secret{}
 			thirdSecret := (*actualResponses)[4].Resources[2]
 			err = ptypes.UnmarshalAny(thirdSecret, &secretThree)
-			Expect(secretThree.Name).To(Equal(envoy.SDSCert{
+			Expect(secretThree.Name).To(Equal(service.CertResource{
 				Service:  nsService,
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: service.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			secretFour := envoy_api_v2_auth.Secret{}
 			forthSecret := (*actualResponses)[4].Resources[3]
 			err = ptypes.UnmarshalAny(forthSecret, &secretFour)
-			Expect(secretFour.Name).To(Equal(envoy.SDSCert{
+			Expect(secretFour.Name).To(Equal(service.CertResource{
 				Service:  nsService,
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: service.RootCertTypeForHTTPS,
 			}.String()))
 		})
 	})

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
+	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/smi"
 	"github.com/open-service-mesh/osm/pkg/tests"
 )
@@ -223,7 +224,13 @@ var _ = Describe("CDS Response", func() {
 					}},
 					ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
-							Name: fmt.Sprintf("%s%s%s", envoy.RootCertTypeForMTLSOutbound, envoy.Separator, "default/bookstore"),
+							Name: service.CertResource{
+								Service: service.NamespacedService{
+									Namespace: "default",
+									Service:   "bookstore",
+								},
+								CertType: service.RootCertTypeForMTLSOutbound,
+							}.String(),
 							SdsConfig: &envoy_api_v2_core.ConfigSource{
 								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
 									Ads: &envoy_api_v2_core.AggregatedConfigSource{},

--- a/pkg/envoy/errors.go
+++ b/pkg/envoy/errors.go
@@ -1,9 +1,3 @@
 package envoy
 
-import (
-	"errors"
-)
-
-var (
-	errInvalidCertFormat = errors.New("invalid certificate string resource format")
-)
+var ()

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -71,9 +71,9 @@ var _ = Describe("Test SDS response functions", func() {
 				Service:   "svc",
 			}
 
-			sdsc := envoy.SDSCert{
+			sdsc := service.CertResource{
 				Service:  svc,
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: service.RootCertTypeForMTLSInbound,
 			}
 
 			resourceName := sdsc.String()
@@ -122,9 +122,9 @@ var _ = Describe("Test SDS response functions", func() {
 				Service:   serviceName,
 			}
 
-			sdsc := envoy.SDSCert{
+			sdsc := service.CertResource{
 				Service:  svc,
-				CertType: envoy.RootCertTypeForMTLSOutbound,
+				CertType: service.RootCertTypeForMTLSOutbound,
 			}
 			resourceNames := []string{sdsc.String()}
 			cert, proxy, mc := prep(resourceNames, namespace, serviceName)

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -34,101 +34,6 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 	})
 
-	Context("Test CertName interface", func() {
-		It("Interface marshals and unmarshals preserving the exact same data", func() {
-			InitialObj := SDSCert{
-				CertType: ServiceCertType,
-				Service: service.NamespacedService{
-					Namespace: "test-namespace",
-					Service:   "test-service",
-				},
-			}
-
-			// Marshal/stringify it
-			marshaledStr := InitialObj.String()
-
-			// Unmarshal it back from the string
-			finalObj, _ := UnmarshalSDSCert(marshaledStr)
-
-			// First and final object must be equal
-			Expect(*finalObj).To(Equal(InitialObj))
-		})
-	})
-
-	Context("Test getRequestedCertType()", func() {
-		It("returns service cert", func() {
-			actual, err := UnmarshalSDSCert("service-cert:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(ServiceCertType))
-			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
-			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
-		})
-		It("returns root cert for mTLS", func() {
-			actual, err := UnmarshalSDSCert("root-cert-for-mtls-outbound:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(RootCertTypeForMTLSOutbound))
-			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
-			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
-		})
-
-		It("returns root cert for non-mTLS", func() {
-			actual, err := UnmarshalSDSCert("root-cert-https:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(RootCertTypeForHTTPS))
-			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
-			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
-		})
-
-		It("returns an error (invalid formatting)", func() {
-			_, err := UnmarshalSDSCert("blahBlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid formatting)", func() {
-			_, err := UnmarshalSDSCert("blahBlahBlahCert:moreblabla/amazingservice:bla")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (missing cert type)", func() {
-			_, err := UnmarshalSDSCert("blahBlahBlahCert/service")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (service is not namespaced)", func() {
-			_, err := UnmarshalSDSCert("root-cert-https:blahBlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid namespace formatting)", func() {
-			_, err := UnmarshalSDSCert("root-cert-https:blah/BlahBl/ahCert")
-			Expect(err).To(HaveOccurred())
-		})
-		It("returns an error (empty left-side namespace)", func() {
-			_, err := UnmarshalSDSCert("root-cert-https:/ahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (empty cert type)", func() {
-			_, err := UnmarshalSDSCert(":ns/svc")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (empty slice on right/wrong number of slices)", func() {
-			_, err := UnmarshalSDSCert("root-cert-https:aaa/ahCert:")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid serv type)", func() {
-			_, err := UnmarshalSDSCert("revoked-cert:blah/BlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid mtls cert type)", func() {
-			_, err := UnmarshalSDSCert("oot-cert-for-mtls-diagonalstream:blah/BlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
 	Context("Test GetDownstreamTLSContext()", func() {
 		It("should return TLS context", func() {
 			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, true)
@@ -150,12 +55,12 @@ var _ = Describe("Test Envoy tools", func() {
 					}},
 					ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
-							Name: SDSCert{
+							Name: service.CertResource{
 								Service: service.NamespacedService{
 									Namespace: "default",
 									Service:   "bookstore",
 								},
-								CertType: RootCertTypeForMTLSInbound,
+								CertType: service.RootCertTypeForMTLSInbound,
 							}.String(),
 							SdsConfig: &envoy_api_v2_core.ConfigSource{
 								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
@@ -211,12 +116,12 @@ var _ = Describe("Test Envoy tools", func() {
 					}},
 					ValidationContextType: &envoy_api_v2_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &envoy_api_v2_auth.SdsSecretConfig{
-							Name: SDSCert{
+							Name: service.CertResource{
 								Service: service.NamespacedService{
 									Namespace: "default",
 									Service:   "bookstore",
 								},
-								CertType: RootCertTypeForMTLSOutbound,
+								CertType: service.RootCertTypeForMTLSOutbound,
 							}.String(),
 							SdsConfig: &envoy_api_v2_core.ConfigSource{
 								ConfigSourceSpecifier: &envoy_api_v2_core.ConfigSource_Ads{
@@ -259,15 +164,15 @@ var _ = Describe("Test Envoy tools", func() {
 				Namespace: "-namespace-",
 				Service:   "-service-",
 			}
-			actual := getCommonTLSContext(namespacedService, true /* mTLS */, Inbound)
+			actual := getCommonTLSContext(namespacedService, true /* mTLS */, service.Inbound)
 
-			expectedServiceCertName := SDSCert{
+			expectedServiceCertName := service.CertResource{
 				Service:  namespacedService,
-				CertType: ServiceCertType,
+				CertType: service.ServiceCertType,
 			}.String()
-			expectedRootCertName := SDSCert{
+			expectedRootCertName := service.CertResource{
 				Service:  namespacedService,
-				CertType: RootCertTypeForMTLSInbound,
+				CertType: service.RootCertTypeForMTLSInbound,
 			}.String()
 
 			expected := &envoy_api_v2_auth.CommonTlsContext{
@@ -295,15 +200,15 @@ var _ = Describe("Test Envoy tools", func() {
 				Namespace: "-namespace-",
 				Service:   "-service-",
 			}
-			actual := getCommonTLSContext(namespacedService, false, false /* Ignored in case of non-tls */)
+			actual := getCommonTLSContext(namespacedService, false, service.NoDirection /* Ignored in case of non-tls */)
 
-			expectedServiceCertName := SDSCert{
+			expectedServiceCertName := service.CertResource{
 				Service:  namespacedService,
-				CertType: ServiceCertType,
+				CertType: service.ServiceCertType,
 			}.String()
-			expectedRootCertName := SDSCert{
+			expectedRootCertName := service.CertResource{
 				Service:  namespacedService,
-				CertType: RootCertTypeForHTTPS,
+				CertType: service.RootCertTypeForHTTPS,
 			}.String()
 
 			expected := &envoy_api_v2_auth.CommonTlsContext{

--- a/pkg/service/certresource.go
+++ b/pkg/service/certresource.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/copier"
+)
+
+// CertType is a type of a certificate requested by an Envoy proxy via SDS.
+type CertType string
+
+// Direction is a type to identify TLS certificate connectivity direction.
+type Direction string
+
+// CertResource is only used to interface the naming and related functions to Marshal/Unmarshal a resource name,
+// this avoids having sprintf/parsing logic all over the place
+type CertResource struct {
+	// Service is a namespaced service struct
+	Service NamespacedService
+	// CertType is the certificate type
+	CertType CertType
+}
+
+func (ct CertType) String() string {
+	return string(ct)
+}
+
+const (
+	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:webservice"
+	ServiceCertType CertType = "service-cert"
+
+	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate resource name for upstream connectivity. Example: "root-cert-for-mtls-outbound:webservice"
+	RootCertTypeForMTLSOutbound CertType = "root-cert-for-mtls-outbound"
+
+	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate resource name for downstream connectivity. Example: "root-cert-for-mtls-inbound:webservice"
+	RootCertTypeForMTLSInbound CertType = "root-cert-for-mtls-inbound"
+
+	// RootCertTypeForHTTPS is the prefix for the HTTPS root certificate resource name. Example: "root-cert-https:webservice"
+	RootCertTypeForHTTPS CertType = "root-cert-https"
+
+	// Outbound refers to Envoy upstream connectivity direction for TLS certs
+	Outbound Direction = "outbound"
+
+	// Inbound refers to Envoy downstream connectivity direction for TLS certs
+	Inbound Direction = "inbound"
+
+	// NoDirection for resources that do not specify a direction implied with the cert resource type
+	NoDirection Direction = "no-direction"
+
+	// Separator is the separator between the prefix and the name of the certificate.
+	certResSeparator = ":"
+)
+
+// Defines valid cert types
+var validCertTypes = map[CertType]interface{}{
+	ServiceCertType:             nil,
+	RootCertTypeForMTLSOutbound: nil,
+	RootCertTypeForMTLSInbound:  nil,
+	RootCertTypeForHTTPS:        nil,
+}
+
+// UnmarshalCertResource parses and returns Certificate type and Namespaced Service name given a
+// correctly formatted string, otherwise returns error
+func UnmarshalCertResource(str string) (*CertResource, error) {
+	var svc *NamespacedService
+	var ret CertResource
+
+	// Check separators, ignore empty string fields
+	slices := strings.Split(str, certResSeparator)
+	if len(slices) != 2 {
+		return nil, errInvalidCertFormat
+	}
+
+	// Make sure the slices are not empty. Split might actually leave empty slices.
+	for _, sep := range slices {
+		if len(sep) == 0 {
+			return nil, errInvalidCertFormat
+		}
+	}
+
+	// Check valid certType
+	ret.CertType = CertType(slices[0])
+	if _, ok := validCertTypes[ret.CertType]; !ok {
+		return nil, errInvalidCertFormat
+	}
+
+	// Check valid namespace'd service name
+	svc, err := UnmarshalNamespacedService(slices[1])
+	if err != nil {
+		return nil, err
+	}
+	err = copier.Copy(&ret.Service, &svc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret, nil
+
+}
+
+// String is a common facility/interface to generate a string resource name out of a SDSCert
+// This is to keep the sprintf logic and/or separators used agnostic to other modules
+func (sdsc CertResource) String() string {
+	return fmt.Sprintf("%s%s%s",
+		sdsc.CertType.String(),
+		certResSeparator,
+		sdsc.Service.String())
+}
+
+// Direction returns direction (Direction type) of a certificate, or error
+// if the specific type has not direction implied
+func (sdsc CertResource) Direction() Direction {
+	switch sdsc.CertType {
+	case RootCertTypeForMTLSOutbound:
+		return Outbound
+	case RootCertTypeForMTLSInbound:
+		return Inbound
+	default:
+		return NoDirection
+	}
+}
+
+func (dir Direction) String() string {
+	return string(dir)
+}

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -6,4 +6,5 @@ import (
 
 var (
 	errInvalidNamespacedServiceFormat = errors.New("invalid namespaced service string format")
+	errInvalidCertFormat              = errors.New("invalid certificate string resource format")
 )

--- a/pkg/service/namespacedservice.go
+++ b/pkg/service/namespacedservice.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	// separator used upon marshalling/unmarshalling Namespaced Service to a string
+	// nsSeparator used upon marshalling/unmarshalling Namespaced Service to a string
 	// or viceversa
-	separator = "/"
+	nsSeparator = "/"
 )
 
 // Name is a type for a service name
@@ -28,7 +28,7 @@ type NamespacedService struct {
 }
 
 func (ns NamespacedService) String() string {
-	return fmt.Sprintf("%s/%s", ns.Namespace, ns.Service)
+	return fmt.Sprintf("%s%s%s", ns.Namespace, nsSeparator, ns.Service)
 }
 
 //Equals checks if two namespaced services are equal
@@ -45,7 +45,7 @@ func (s Account) String() string {
 
 // UnmarshalNamespacedService unmarshals a NamespaceService type from a string
 func UnmarshalNamespacedService(str string) (*NamespacedService, error) {
-	slices := strings.Split(str, separator)
+	slices := strings.Split(str, nsSeparator)
 	if len(slices) != 2 {
 		return nil, errInvalidNamespacedServiceFormat
 	}

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -55,4 +55,99 @@ var _ = Describe("Test types helpers", func() {
 
 	})
 
+	Context("Test CertName interface", func() {
+		It("Interface marshals and unmarshals preserving the exact same data", func() {
+			InitialObj := CertResource{
+				CertType: ServiceCertType,
+				Service: NamespacedService{
+					Namespace: "test-namespace",
+					Service:   "test-service",
+				},
+			}
+
+			// Marshal/stringify it
+			marshaledStr := InitialObj.String()
+
+			// Unmarshal it back from the string
+			finalObj, _ := UnmarshalCertResource(marshaledStr)
+
+			// First and final object must be equal
+			Expect(*finalObj).To(Equal(InitialObj))
+		})
+	})
+
+	Context("Test getRequestedCertType()", func() {
+		It("returns service cert", func() {
+			actual, err := UnmarshalCertResource("service-cert:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(ServiceCertType))
+			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
+			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
+		})
+		It("returns root cert for mTLS", func() {
+			actual, err := UnmarshalCertResource("root-cert-for-mtls-outbound:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(RootCertTypeForMTLSOutbound))
+			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
+			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
+		})
+
+		It("returns root cert for non-mTLS", func() {
+			actual, err := UnmarshalCertResource("root-cert-https:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(RootCertTypeForHTTPS))
+			Expect(actual.Service.Namespace).To(Equal("namespace-test"))
+			Expect(actual.Service.Service).To(Equal("blahBlahBlahCert"))
+		})
+
+		It("returns an error (invalid formatting)", func() {
+			_, err := UnmarshalCertResource("blahBlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid formatting)", func() {
+			_, err := UnmarshalCertResource("blahBlahBlahCert:moreblabla/amazingservice:bla")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (missing cert type)", func() {
+			_, err := UnmarshalCertResource("blahBlahBlahCert/service")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (service is not namespaced)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:blahBlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid namespace formatting)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:blah/BlahBl/ahCert")
+			Expect(err).To(HaveOccurred())
+		})
+		It("returns an error (empty left-side namespace)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:/ahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (empty cert type)", func() {
+			_, err := UnmarshalCertResource(":ns/svc")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (empty slice on right/wrong number of slices)", func() {
+			_, err := UnmarshalCertResource("root-cert-https:aaa/ahCert:")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid serv type)", func() {
+			_, err := UnmarshalCertResource("revoked-cert:blah/BlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid mtls cert type)", func() {
+			_, err := UnmarshalCertResource("oot-cert-for-mtls-diagonalstream:blah/BlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 })


### PR DESCRIPTION
xdsutils might not be a good place to define
types that we use across all modules, hence
moving it to a more isolated package for
better dependency management and interfacing.

Since the structure itself is directly dependent
on NamespacedService, leaving it under
"service" might be good enough.

Fixes #971