### PR TITLE
demo: remove automountServiceAccountToken from specs

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -16,7 +16,6 @@ kind: ServiceAccount
 metadata:
   name: bookbuyer-serviceaccount
   namespace: $BOOKBUYER_NAMESPACE
-automountServiceAccountToken: false
 EOF
 
 echo -e "Deploy BookBuyer Service"
@@ -57,7 +56,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookbuyer-serviceaccount
-      automountServiceAccountToken: false
 
       containers:
         # Main container with APP

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -36,7 +36,6 @@ kind: ServiceAccount
 metadata:
   name: "$SVC-serviceaccount"
   namespace: $BOOKSTORE_NAMESPACE
-automountServiceAccountToken: false
 EOF
 
 echo -e "Deploy $SVC Service"
@@ -79,7 +78,6 @@ spec:
         "openservicemesh.io/sidecar-injection": "enabled"
     spec:
       serviceAccountName: "$SVC-serviceaccount"
-      automountServiceAccountToken: false
       containers:
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -17,7 +17,6 @@ kind: ServiceAccount
 metadata:
   name: bookthief-serviceaccount
   namespace: $BOOKTHIEF_NAMESPACE
-automountServiceAccountToken: false
 
 ---
 
@@ -56,7 +55,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookthief-serviceaccount
-      automountServiceAccountToken: false
 
       containers:
         # Main container with APP

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -14,7 +14,6 @@ kind: ServiceAccount
 metadata:
   name: bookwarehouse-serviceaccount
   namespace: $BOOKWAREHOUSE_NAMESPACE
-automountServiceAccountToken: false
 EOF
 
 echo -e "Deploy Bookwarehouse Service"
@@ -54,7 +53,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookwarehouse-serviceaccount
-      automountServiceAccountToken: false
 
       containers:
         # Main container with APP


### PR DESCRIPTION
The demo doesn't require this and having this in the spec
is confusing to readers.

Resolves #932