### PR TITLE
kube/informers: assert for correct types to prevent panic

### DIFF
--- a/pkg/endpoint/providers/azure/kubernetes/client.go
+++ b/pkg/endpoint/providers/azure/kubernetes/client.go
@@ -86,7 +86,11 @@ func (c *Client) Run(stop <-chan struct{}) error {
 func (c *Client) ListAzureResources() []*osm.AzureResource {
 	var azureResources []*osm.AzureResource
 	for _, azureResourceInterface := range c.caches.AzureResource.List() {
-		azureResource := azureResourceInterface.(*osm.AzureResource)
+		azureResource, ok := azureResourceInterface.(*osm.AzureResource)
+		if !ok {
+			log.Error().Err(errInvalidObjectType).Msg("Failed type assertion for AzureResource in cache")
+			continue
+		}
 		if !c.namespaceController.IsMonitoredNamespace(azureResource.Namespace) {
 			// Doesn't belong to namespaces we are observing
 			continue

--- a/pkg/endpoint/providers/azure/kubernetes/errors.go
+++ b/pkg/endpoint/providers/azure/kubernetes/errors.go
@@ -2,4 +2,7 @@ package azure
 
 import "errors"
 
-var errSyncingCaches = errors.New("syncing caches")
+var (
+	errSyncingCaches     = errors.New("syncing caches")
+	errInvalidObjectType = errors.New("invalid object type in cache")
+)

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -83,7 +83,12 @@ func (c Client) ListEndpointsForService(svc service.Name) []endpoint.Endpoint {
 		return endpoints
 	}
 
-	if kubernetesEndpoints := endpointsInterface.(*corev1.Endpoints); kubernetesEndpoints != nil {
+	kubernetesEndpoints, ok := endpointsInterface.(*corev1.Endpoints)
+	if !ok {
+		log.Error().Err(errInvalidObjectType).Msg("Failed type assertion for Endpoints in cache")
+		return endpoints
+	}
+	if kubernetesEndpoints != nil {
 		if !c.namespaceController.IsMonitoredNamespace(kubernetesEndpoints.Namespace) {
 			// Doesn't belong to namespaces we are observing
 			return endpoints
@@ -116,7 +121,12 @@ func (c Client) GetServiceForServiceAccount(svcAccount service.NamespacedService
 	deploymentsInterface := c.caches.Deployments.List()
 
 	for _, deployments := range deploymentsInterface {
-		if kubernetesDeployments := deployments.(*appsv1.Deployment); kubernetesDeployments != nil {
+		kubernetesDeployments, ok := deployments.(*appsv1.Deployment)
+		if !ok {
+			log.Error().Err(errInvalidObjectType).Msg("Failed type assertion for Deployment in cache")
+			continue
+		}
+		if kubernetesDeployments != nil {
 			if !c.namespaceController.IsMonitoredNamespace(kubernetesDeployments.Namespace) {
 				// Doesn't belong to namespaces we are observing
 				continue

--- a/pkg/endpoint/providers/kube/errors.go
+++ b/pkg/endpoint/providers/kube/errors.go
@@ -7,4 +7,5 @@ var (
 	errInitInformers                      = errors.New("informers are not initialized")
 	errDidNotFindServiceForServiceAccount = errors.New("no service exists for the service account")
 	errMoreThanServiceForServiceAccount   = errors.New("more than one service found for the service account")
+	errInvalidObjectType                  = errors.New("invalid object type in cache")
 )

--- a/pkg/smi/errors.go
+++ b/pkg/smi/errors.go
@@ -3,7 +3,7 @@ package smi
 import "errors"
 
 var (
-	errSyncingCaches            = errors.New("failed initial sync of resources required for ingress")
-	errInitInformers            = errors.New("informers are not initialized")
-	errInvalidServiceObjectType = errors.New("invalid object type for Service in cache")
+	errSyncingCaches     = errors.New("failed initial sync of resources required for ingress")
+	errInitInformers     = errors.New("informers are not initialized")
+	errInvalidObjectType = errors.New("invalid object type in cache")
 )


### PR DESCRIPTION
If the object type in caches are not as expected, prevent panics
and log an error.

Part of #667