### PR TITLE
configurator: Implement ConfigMap informer

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -1,0 +1,99 @@
+package configurator
+
+import (
+	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	k8s "github.com/open-service-mesh/osm/pkg/kubernetes"
+)
+
+// NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
+func NewConfigurator(kubeClient kubernetes.Interface, stop chan struct{}, osmNamespace, osmConfigMapName string) Configurator {
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
+	informer := informerFactory.Core().V1().ConfigMaps().Informer()
+	client := Client{
+		informer:         informer,
+		cache:            informer.GetStore(),
+		cacheSynced:      make(chan interface{}),
+		announcements:    make(chan interface{}),
+		osmNamespace:     osmNamespace,
+		osmConfigMapName: osmConfigMapName,
+	}
+
+	// Ensure this only watches the Namespace where OSM in installed
+	shouldObserve := func(obj interface{}) bool {
+		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
+		return ns == osmNamespace
+	}
+
+	informerName := "ConfigMap"
+	providerName := "OSMConfigMap"
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers(informerName, providerName, client.announcements, shouldObserve))
+
+	go client.run(stop)
+
+	return &client
+}
+
+// This struct must match the shape of the "osm-config" ConfigMap
+// which was created in the OSM namespace.
+type osmConfig struct {
+	ConfigVersion int  `yaml:"config_version"`
+	AllowAll      bool `yaml:"allow_all"`
+}
+
+func (c *Client) run(stop <-chan struct{}) {
+	go c.informer.Run(stop)
+	log.Info().Msgf("Started OSM ConfigMap informer - watching for %s", c.getConfigMapCacheKey())
+	log.Info().Msg("[ConfigMap Client] Waiting for ConfigMap informer's cache to sync")
+	if !cache.WaitForCacheSync(stop, c.informer.HasSynced) {
+		log.Error().Msg("Failed initial cache sync for ConfigMap informer")
+		return
+	}
+
+	// Closing the cacheSynced channel signals to the rest of the system that caches have been synced.
+	close(c.cacheSynced)
+	log.Info().Msg("[ConfigMap Client] Cache sync for ConfigMap informer finished")
+}
+
+func (c *Client) getConfigMapCacheKey() string {
+	return fmt.Sprintf("%s/%s", c.osmNamespace, c.osmConfigMapName)
+}
+
+func (c *Client) getConfigMap() *osmConfig {
+	configMapCacheKey := c.getConfigMapCacheKey()
+	item, exists, err := c.cache.GetByKey(configMapCacheKey)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting ConfigMap by key=%s from cache", configMapCacheKey)
+	}
+
+	if !exists {
+		return &osmConfig{}
+	}
+
+	configMap := item.(*v1.ConfigMap)
+
+	if len(configMap.Data) == 0 {
+		log.Error().Msgf("The ConfigMap %s does not contain any Data", configMapCacheKey)
+		return &osmConfig{}
+	}
+
+	var config []byte
+	for _, cfg := range configMap.Data {
+		config = []byte(cfg)
+	}
+
+	conf := osmConfig{}
+	err = yaml.Unmarshal(config, &conf)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshaling ConfigMap %s with content %s", c.osmConfigMapName, string(config))
+	}
+
+	return &conf
+}

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -1,0 +1,35 @@
+package configurator
+
+import (
+	"encoding/json"
+)
+
+// The functions in this file implement the configurator.Configurator interface
+
+// GetOSMNamespace returns the namespace in which the OSM controller pod resides.
+func (c *Client) GetOSMNamespace() string {
+	return c.osmNamespace
+}
+
+// GetConfigMap returns the ConfigMap in pretty JSON.
+func (c *Client) GetConfigMap() ([]byte, error) {
+	cm, err := json.MarshalIndent(c.getConfigMap(), "", "    ")
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshaling ConfigMap %s: %+v", c.getConfigMapCacheKey(), c.getConfigMap())
+		return nil, err
+	}
+	return cm, nil
+}
+
+// IsAllowAll tells us whether the OSM Control Plane is in permissive mode,
+// where all existing traffic is allowed to flow as it is,
+// or it is in SMI Spec mode, in which only traffic between source/destinations
+// referenced in SMI policies is allowed.
+func (c *Client) IsAllowAll() bool {
+	return c.getConfigMap().AllowAll
+}
+
+// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.
+func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
+	return c.announcements
+}

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -1,0 +1,65 @@
+package configurator
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("Test Envoy configuration creation", func() {
+	Context("create envoy config", func() {
+		kubeClient := testclient.NewSimpleClientset()
+		stop := make(chan struct{})
+		osmNamespace := "-test-osm-namespace-"
+		osmConfigMapName := "-test-osm-config-map-"
+		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+
+		It("correctly creates a cache key", func() {
+			c := Client{
+				osmConfigMapName: "mapName",
+				osmNamespace:     "namespaceName",
+			}
+			expected := "namespaceName/mapName"
+			actual := c.getConfigMapCacheKey()
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("correctly identifies whether the service mesh is in allow_all mode", func() {
+			Expect(cfg.IsAllowAll()).To(BeFalse())
+			configMap := v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: osmNamespace,
+					Name:      osmConfigMapName,
+				},
+				Data: map[string]string{
+					"osm.conf": `
+config_version: 111
+allow_all: true
+`,
+				},
+			}
+			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for the config map change to propagate to the cache.
+			<-cfg.GetAnnouncementsChannel()
+
+			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
+			configMapData, err := cfg.GetConfigMap()
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedConfigMap := `{
+    "ConfigVersion": 111,
+    "AllowAll": true
+}`
+
+			Expect(string(configMapData)).To(Equal(expectedConfigMap))
+			Expect(cfg.IsAllowAll()).To(BeTrue())
+		})
+	})
+})

--- a/pkg/configurator/suite_test.go
+++ b/pkg/configurator/suite_test.go
@@ -1,0 +1,13 @@
+package configurator
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -1,5 +1,15 @@
 package configurator
 
+import (
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-service-mesh/osm/pkg/logger"
+)
+
+var (
+	log = logger.New("configurator")
+)
+
 // Config is a struct with common global config settings.
 type Config struct {
 	// OSMNamespace is the Kubernetes namespace in which the OSM controller is installed.
@@ -10,4 +20,29 @@ type Config struct {
 
 	// EnableTracing enables Zipkin tracing when true.
 	EnableTracing bool
+}
+
+// Client is the k8s client struct for the OSM Config.
+type Client struct {
+	osmNamespace     string
+	osmConfigMapName string
+	announcements    chan interface{}
+	informer         cache.SharedIndexInformer
+	cache            cache.Store
+	cacheSynced      chan interface{}
+}
+
+// Configurator is the controller interface for K8s namespaces
+type Configurator interface {
+	// GetOSMNamespace returns the namespace in which OSM controller pod resides.
+	GetOSMNamespace() string
+
+	// GetConfigMap returns the ConfigMap in pretty JSON (human readable).
+	GetConfigMap() ([]byte, error)
+
+	// IsAllowAll determines whether we are in "allow-all" mode or SMI policy (block by default) mode.
+	IsAllowAll() bool
+
+	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.
+	GetAnnouncementsChannel() <-chan interface{}
 }


### PR DESCRIPTION
This PR implements a `ConfigMap` informer.  This will start as soon as the controller starts. It has a very limited scope - will watch `osm-config` in the OSM namespace.

The ConfigMap will be exposed to the rest of the OSM components in a follow up PR.  So far the ConfigMap only implements `allow_all` key.

I am deliberately keeping this PR bare-bones - I know @shashankram and @Jont828 will be adding more components to this.

OSM Controller is already allowed to list ConfigMaps via https://github.com/open-service-mesh/osm/pull/1026

ref https://github.com/open-service-mesh/osm/issues/1006