### PR TITLE
main: Create the necessary Kubernetes clients at the top

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
@@ -115,13 +114,14 @@ func main() {
 	// Side effects: This will log.Fatal on error resulting in os.Exit(255)
 	validateCLIParams()
 
-	// TODO(draychev): consolidate kubeConfig vs kubeClient
-	var kubeConfig *rest.Config
-	var err error
-	kubeConfig, err = clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+
+	smiKubeConfig := &kubeConfig
+
 	if err != nil {
 		log.Fatal().Err(err).Msgf("[%s] Failed to create kube config (kubeconfig=%s)", serverType, kubeConfigFile)
 	}
+	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 
 	stop := signals.RegisterExitHandlers()
 
@@ -136,39 +136,39 @@ func main() {
 
 	// TODO(draychev): propagate the Configurator objects to all components below.
 
-	namespaceController := namespace.NewNamespaceController(kubeConfig, meshName, stop)
-	meshSpec := smi.NewMeshSpecClient(kubeConfig, osmNamespace, namespaceController, stop)
+	namespaceController := namespace.NewNamespaceController(kubeClient, meshName, stop)
+	meshSpec := smi.NewMeshSpecClient(*smiKubeConfig, kubeClient, osmNamespace, namespaceController, stop)
 
-	certManager, certDebugger := certManagers[certificateManagerKind(*certManagerKind)](kubeConfig, enableDebugServer)
+	// Get the Certificate Manager based on the CLI argument passed to this module.
+	certManager, certDebugger := certManagers[certificateManagerKind(*certManagerKind)](kubeClient, enableDebugServer)
 
 	log.Info().Msgf("Service certificates will be valid for %+v", getServiceCertValidityPeriod())
 
 	if caBundleSecretName == "" {
 		log.Info().Msgf("CA bundle will not be exported to a k8s secret (no --%s provided)", caBundleSecretNameCLIParam)
 	} else {
-		kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 		if err := createCABundleKubernetesSecret(kubeClient, certManager, osmNamespace, caBundleSecretName); err != nil {
 			log.Error().Err(err).Msgf("Error exporting CA bundle into Kubernetes secret with name %s", caBundleSecretName)
 		}
 	}
 
 	endpointsProviders := []endpoint.Provider{
-		kube.NewProvider(kubeConfig, namespaceController, stop, constants.KubeProviderName),
+		kube.NewProvider(kubeClient, namespaceController, stop, constants.KubeProviderName),
 	}
 
 	if azureAuthFile != "" {
-		azureResourceClient := azureResource.NewClient(kubeConfig, namespaceController, stop)
+		azureResourceClient := azureResource.NewClient(kubeClient, kubeConfig, namespaceController, stop)
 		endpointsProviders = append(endpointsProviders, azure.NewProvider(
 			*azureSubscriptionID, azureAuthFile, stop, meshSpec, azureResourceClient, constants.AzureProviderName))
 	}
 
-	ingressClient, err := ingress.NewIngressClient(kubeConfig, namespaceController, stop)
+	ingressClient, err := ingress.NewIngressClient(kubeClient, namespaceController, stop)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize ingress client")
 	}
 
 	meshCatalog := catalog.NewMeshCatalog(
-		kubernetes.NewForConfigOrDie(kubeConfig),
+		kubeClient,
 		meshSpec,
 		certManager,
 		ingressClient,
@@ -176,7 +176,7 @@ func main() {
 		endpointsProviders...)
 
 	// Create the sidecar-injector webhook
-	if err := injector.NewWebhook(injectorConfig, kubeConfig, certManager, meshCatalog, namespaceController, meshName, osmNamespace, webhookName, stop); err != nil {
+	if err := injector.NewWebhook(injectorConfig, kubeClient, certManager, meshCatalog, namespaceController, meshName, osmNamespace, webhookName, stop); err != nil {
 		log.Fatal().Err(err).Msg("Error creating mutating webhook")
 	}
 
@@ -202,7 +202,7 @@ func main() {
 	// Expose /debug endpoints and data only if the enableDebugServer flag is enabled
 	var debugServer debugger.DebugServer
 	if enableDebugServer {
-		debugServer = debugger.NewDebugServer(certDebugger, xdsServer, meshCatalog, kubeConfig)
+		debugServer = debugger.NewDebugServer(certDebugger, xdsServer, meshCatalog, kubeConfig, kubeClient)
 	}
 	httpServer := httpserver.NewHTTPServer(xdsServer, metricsStore, constants.MetricsServerPort, debugServer)
 	httpServer.Start()

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -23,12 +23,14 @@ func (ds debugServer) GetHandlers() map[string]http.Handler {
 }
 
 // NewDebugServer returns an implementation of DebugServer interface.
-func NewDebugServer(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, kubeConfig *rest.Config) DebugServer {
+func NewDebugServer(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, kubeConfig *rest.Config, kubeClient kubernetes.Interface) DebugServer {
 	return debugServer{
 		certDebugger:        certDebugger,
 		xdsDebugger:         xdsDebugger,
 		meshCatalogDebugger: meshCatalogDebugger,
-		kubeConfig:          kubeConfig,
-		kubeClient:          kubernetes.NewForConfigOrDie(kubeConfig),
+		kubeClient:          kubeClient,
+
+		// We need the Kubernetes config to be able to establish port forwarding to the Envoy pod we want to debug.
+		kubeConfig: kubeConfig,
 	}
 }

--- a/pkg/endpoint/providers/azure/kubernetes/client.go
+++ b/pkg/endpoint/providers/azure/kubernetes/client.go
@@ -20,9 +20,8 @@ const (
 )
 
 // NewClient creates the Kubernetes client, which retrieves the AzureResource CRD and Services resources.
-func NewClient(kubeConfig *rest.Config, namespaceController namespace.Controller, stop chan struct{}) *Client {
-	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
-	azureResourceClient := osmClient.NewForConfigOrDie(kubeConfig)
+func NewClient(kubeClient kubernetes.Interface, azureResourceKubeConfig *rest.Config, namespaceController namespace.Controller, stop chan struct{}) *Client {
+	azureResourceClient := osmClient.NewForConfigOrDie(azureResourceKubeConfig)
 
 	k8sClient := newClient(kubeClient, azureResourceClient, namespaceController)
 	if err := k8sClient.Run(stop); err != nil {
@@ -32,7 +31,7 @@ func NewClient(kubeConfig *rest.Config, namespaceController namespace.Controller
 }
 
 // newClient creates a provider based on a Kubernetes client instance.
-func newClient(kubeClient *kubernetes.Clientset, azureResourceClient *osmClient.Clientset, namespaceController namespace.Controller) *Client {
+func newClient(kubeClient kubernetes.Interface, azureResourceClient *osmClient.Clientset, namespaceController namespace.Controller) *Client {
 	azureResourceFactory := osmInformers.NewSharedInformerFactory(azureResourceClient, k8s.DefaultKubeEventResyncInterval)
 	informerCollection := InformerCollection{
 		AzureResource: azureResourceFactory.Osm().V1().AzureResources().Informer(),

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -13,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/open-service-mesh/osm/pkg/endpoint"
@@ -24,8 +23,7 @@ import (
 const namespaceSelectorLabel = "app"
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
-func NewProvider(kubeConfig *rest.Config, namespaceController namespace.Controller, stop chan struct{}, providerIdent string) *Client {
-	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
+func NewProvider(kubeClient kubernetes.Interface, namespaceController namespace.Controller, stop chan struct{}, providerIdent string) *Client {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
 
 	informerCollection := InformerCollection{

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -6,7 +6,6 @@ import (
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	k8s "github.com/open-service-mesh/osm/pkg/kubernetes"
@@ -15,9 +14,7 @@ import (
 )
 
 // NewIngressClient implements ingress.Monitor and creates the Kubernetes client to monitor Ingress resources.
-func NewIngressClient(kubeConfig *rest.Config, namespaceController namespace.Controller, stop chan struct{}) (Monitor, error) {
-	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
-
+func NewIngressClient(kubeClient kubernetes.Interface, namespaceController namespace.Controller, stop chan struct{}) (Monitor, error) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
 	informer := informerFactory.Extensions().V1beta1().Ingresses().Informer()
 

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/certificate"
@@ -41,7 +40,7 @@ const (
 )
 
 // NewWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
-func NewWebhook(config Config, kubeConfig *rest.Config, certManager certificate.Manager, meshCatalog catalog.MeshCataloger, namespaceController namespace.Controller, meshName, osmNamespace, webhookName string, stop <-chan struct{}) error {
+func NewWebhook(config Config, kubeClient kubernetes.Interface, certManager certificate.Manager, meshCatalog catalog.MeshCataloger, namespaceController namespace.Controller, meshName, osmNamespace, webhookName string, stop <-chan struct{}) error {
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.svc", constants.OSMControllerName, osmNamespace))
 	validityPeriod := constants.XDSCertificateValidityPeriod
 	cert, err := certManager.IssueCertificate(cn, &validityPeriod)
@@ -52,7 +51,7 @@ func NewWebhook(config Config, kubeConfig *rest.Config, certManager certificate.
 
 	wh := webhook{
 		config:              config,
-		kubeClient:          kubernetes.NewForConfigOrDie(kubeConfig),
+		kubeClient:          kubeClient,
 		certManager:         certManager,
 		meshCatalog:         meshCatalog,
 		namespaceController: namespaceController,

--- a/pkg/namespace/client.go
+++ b/pkg/namespace/client.go
@@ -7,7 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	k8s "github.com/open-service-mesh/osm/pkg/kubernetes"
@@ -23,9 +22,7 @@ var (
 )
 
 // NewNamespaceController implements namespace.Controller and creates the Kubernetes client to manage namespaces.
-func NewNamespaceController(kubeConfig *rest.Config, meshName string, stop chan struct{}) Controller {
-	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
-
+func NewNamespaceController(kubeClient kubernetes.Interface, meshName string, stop chan struct{}) Controller {
 	// Only monitor namespaces that are labeled with this OSM's mesh name
 	monitorNamespaceLabel := map[string]string{MonitorLabel: meshName}
 	labelSelector := fields.SelectorFromSet(monitorNamespaceLabel).String()

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -28,11 +28,10 @@ import (
 const kubernetesClientName = "MeshSpec"
 
 // NewMeshSpecClient implements mesh.MeshSpec and creates the Kubernetes client, which retrieves SMI specific CRDs.
-func NewMeshSpecClient(kubeConfig *rest.Config, osmNamespace string, namespaceController namespace.Controller, stop chan struct{}) MeshSpec {
-	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
-	smiTrafficSplitClientSet := smiTrafficSplitClient.NewForConfigOrDie(kubeConfig)
-	smiTrafficSpecClientSet := smiTrafficSpecClient.NewForConfigOrDie(kubeConfig)
-	smiTrafficTargetClientSet := smiTrafficTargetClient.NewForConfigOrDie(kubeConfig)
+func NewMeshSpecClient(smiKubeConfig *rest.Config, kubeClient kubernetes.Interface, osmNamespace string, namespaceController namespace.Controller, stop chan struct{}) MeshSpec {
+	smiTrafficSplitClientSet := smiTrafficSplitClient.NewForConfigOrDie(smiKubeConfig)
+	smiTrafficSpecClientSet := smiTrafficSpecClient.NewForConfigOrDie(smiKubeConfig)
+	smiTrafficTargetClientSet := smiTrafficTargetClient.NewForConfigOrDie(smiKubeConfig)
 
 	client := newSMIClient(kubeClient, smiTrafficSplitClientSet, smiTrafficSpecClientSet, smiTrafficTargetClientSet, osmNamespace, namespaceController, kubernetesClientName)
 
@@ -95,7 +94,7 @@ func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
 }
 
 // newClient creates a provider based on a Kubernetes client instance.
-func newSMIClient(kubeClient *kubernetes.Clientset, smiTrafficSplitClient *smiTrafficSplitClient.Clientset, smiTrafficSpecClient *smiTrafficSpecClient.Clientset, smiTrafficTargetClient *smiTrafficTargetClient.Clientset, osmNamespace string, namespaceController namespace.Controller, providerIdent string) *Client {
+func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient *smiTrafficSplitClient.Clientset, smiTrafficSpecClient *smiTrafficSpecClient.Clientset, smiTrafficTargetClient *smiTrafficTargetClient.Clientset, osmNamespace string, namespaceController namespace.Controller, providerIdent string) *Client {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
 	smiTrafficSplitInformerFactory := smiTrafficSplitInformers.NewSharedInformerFactory(smiTrafficSplitClient, k8s.DefaultKubeEventResyncInterval)
 	smiTrafficSpecInformerFactory := smiTrafficSpecInformers.NewSharedInformerFactory(smiTrafficSpecClient, k8s.DefaultKubeEventResyncInterval)


### PR DESCRIPTION
The goal of this PR is to pass down a reference to a Kubernetes client to every OSM component in lieu of a Kubernetes config.