### PR TITLE
Rename CLI arg disableSMIAccessControlPolicy to permissiveTrafficPolicyMode

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -17,7 +17,7 @@ This command is equivalent to installing the osm control plane using the OSM CLI
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | certManager | string | `"tresor"` | Certificate manager to use (tresor or vault) |
-| disableSMIAccessControlPolicy | bool | `false` | Disable SMI access control policy |
+| permissiveTrafficPolicyMode | bool | `false` | Disable SMI access control policy |
 | enableDebugServer | bool | `false` | Enable the debug HTTP server |
 | grafana.port | int | `3000` | Grafana port |
 | image.pullPolicy | string | `"Always"` | osm-controller image pull policy |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             {{- if .Values.OpenServiceMesh.enableDebugServer }}
             "--enableDebugServer",
             {{- end }}
-            {{- if .Values.OpenServiceMesh.disableSMIAccessControlPolicy }}
+            {{- if .Values.OpenServiceMesh.permissiveTrafficPolicyMode }}
             "--disable-smi-access-control-policy",
             {{- end }}
           ]

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -26,5 +26,5 @@ OpenServiceMesh:
   zipkin:
     port: 9411
   enableDebugServer: false
-  disableSMIAccessControlPolicy: false
+  permissiveTrafficPolicyMode: false
   meshName: osm

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -61,21 +61,21 @@ const (
 var chartTGZSource string
 
 type installCmd struct {
-	out                           io.Writer
-	containerRegistry             string
-	containerRegistrySecret       string
-	chartPath                     string
-	osmImageTag                   string
-	certManager                   string
-	vaultHost                     string
-	vaultProtocol                 string
-	vaultToken                    string
-	vaultRole                     string
-	serviceCertValidityMinutes    int
-	prometheusRetentionTime       string
-	enableDebugServer             bool
-	disableSMIAccessControlPolicy bool
-	meshName                      string
+	out                         io.Writer
+	containerRegistry           string
+	containerRegistrySecret     string
+	chartPath                   string
+	osmImageTag                 string
+	certManager                 string
+	vaultHost                   string
+	vaultProtocol               string
+	vaultToken                  string
+	vaultRole                   string
+	serviceCertValidityMinutes  int
+	prometheusRetentionTime     string
+	enableDebugServer           bool
+	permissiveTrafficPolicyMode bool
+	meshName                    string
 
 	// checker runs checks before any installation is attempted. Its type is
 	// abstract here to make testing easy.
@@ -112,7 +112,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.IntVar(&inst.serviceCertValidityMinutes, "service-cert-validity-minutes", int(1), "Certificate TTL in minutes")
 	f.StringVar(&inst.prometheusRetentionTime, "prometheus-retention-time", constants.PrometheusDefaultRetentionTime, "Duration for which data will be retained in prometheus")
 	f.BoolVar(&inst.enableDebugServer, "enable-debug-server", false, "Enable the debug HTTP server")
-	f.BoolVar(&inst.disableSMIAccessControlPolicy, "disable-smi-access-control-policy", false, "Disable SMI access control policy")
+	f.BoolVar(&inst.permissiveTrafficPolicyMode, "disable-smi-access-control-policy", false, "Disable SMI access control policy")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "Name of the service mesh")
 
 	return cmd
@@ -205,7 +205,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.serviceCertValidityMinutes=%d", i.serviceCertValidityMinutes),
 		fmt.Sprintf("OpenServiceMesh.prometheus.retention.time=%s", i.prometheusRetentionTime),
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
-		fmt.Sprintf("OpenServiceMesh.disableSMIAccessControlPolicy=%t", i.disableSMIAccessControlPolicy),
+		fmt.Sprintf("OpenServiceMesh.permissiveTrafficPolicyMode=%t", i.permissiveTrafficPolicyMode),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
 	}
 

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -128,8 +128,8 @@ var _ = Describe("Running the install command", func() {
 							"retention": map[string]interface{}{
 								"time": "5d",
 							}},
-						"enableDebugServer":             false,
-						"disableSMIAccessControlPolicy": false,
+						"enableDebugServer":           false,
+						"permissiveTrafficPolicyMode": false,
 					}}))
 			})
 
@@ -225,8 +225,8 @@ var _ = Describe("Running the install command", func() {
 							"retention": map[string]interface{}{
 								"time": "5d",
 							}},
-						"enableDebugServer":             false,
-						"disableSMIAccessControlPolicy": false,
+						"enableDebugServer":           false,
+						"permissiveTrafficPolicyMode": false,
 					}}))
 			})
 
@@ -327,8 +327,8 @@ var _ = Describe("Running the install command", func() {
 								"time": "5d",
 							},
 						},
-						"enableDebugServer":             false,
-						"disableSMIAccessControlPolicy": false,
+						"enableDebugServer":           false,
+						"permissiveTrafficPolicyMode": false,
 					}}))
 			})
 
@@ -586,8 +586,8 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 						"time": "5d",
 					},
 				},
-				"enableDebugServer":             false,
-				"disableSMIAccessControlPolicy": false,
+				"enableDebugServer":           false,
+				"permissiveTrafficPolicyMode": false,
 			}}))
 	})
 })


### PR DESCRIPTION
Rename `disableSMIAccessControlPolicy` to `permissiveTrafficPolicyMode`

The goal of this PR is to prevent double negative and ambiguity with `disableSMIAccessControlPolicy=false` -- it is tough to decipher what that exactly does.