### PR TITLE
envoy: fix go-vet warnings regarding mutex copy

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Test ADS response functions", func() {
 		It("returns service cert", func() {
 
 			actual := makeRequestForAllSecrets(proxy, mc)
-			expected := envoy_api_v2.DiscoveryRequest{
+			expected := &envoy_api_v2.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
 					envoy.SDSCert{
@@ -85,7 +85,7 @@ var _ = Describe("Test ADS response functions", func() {
 				},
 			}
 			Expect(actual).ToNot(BeNil())
-			Expect(*actual).To(Equal(expected))
+			Expect(actual).To(Equal(expected))
 		})
 	})
 

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -33,7 +33,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 		TypeUrl: string(envoy.TypeCDS),
 	}
 
-	clusterFactories := make(map[string]xds.Cluster)
+	var clusterFactories []*xds.Cluster
 	for _, trafficPolicies := range allTrafficPolicies {
 		isSourceService := trafficPolicies.Source.Service.Equals(proxyServiceName)
 		//iterate through only destination services here since envoy is programmed by destination
@@ -44,7 +44,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 				log.Error().Err(err).Msgf("Failed to construct service cluster for proxy %s", proxyServiceName)
 				return nil, err
 			}
-			clusterFactories[remoteCluster.Name] = *remoteCluster
+			clusterFactories = append(clusterFactories, remoteCluster)
 		}
 	}
 
@@ -56,11 +56,11 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpe
 		log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
 		return nil, err
 	}
-	clusterFactories[localClusterName] = *localCluster
+	clusterFactories = append(clusterFactories, localCluster)
 
 	for _, cluster := range clusterFactories {
 		log.Debug().Msgf("Proxy service %s constructed ClusterConfiguration: %+v ", proxyServiceName, cluster)
-		marshalledClusters, err := ptypes.MarshalAny(&cluster)
+		marshalledClusters, err := ptypes.MarshalAny(cluster)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed to marshal cluster for proxy %s", proxy.GetCommonName())
 			return nil, err

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -279,7 +279,7 @@ var _ = Describe("CDS Response", func() {
 					},
 				},
 			}
-			expectedCluster := xds.Cluster{
+			expectedCluster := &xds.Cluster{
 				TransportSocketMatches: nil,
 				Name:                   constants.EnvoyMetricsCluster,
 				AltStatName:            constants.EnvoyMetricsCluster,
@@ -293,7 +293,7 @@ var _ = Describe("CDS Response", func() {
 			Expect(len(cluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
 			Expect(cluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
 			Expect(cluster.LoadAssignment).To(Equal(expectedClusterLoadAssignment))
-			Expect(cluster).To(Equal(expectedCluster))
+			Expect(&cluster).To(Equal(expectedCluster))
 		})
 	})
 })

--- a/pkg/envoy/cla/cluster_load_assignment.go
+++ b/pkg/envoy/cla/cluster_load_assignment.go
@@ -16,8 +16,8 @@ const (
 )
 
 // NewClusterLoadAssignment constructs the Envoy struct necessary for TrafficSplit implementation.
-func NewClusterLoadAssignment(serviceName service.NamespacedService, serviceEndpoints []osmEndpoint.Endpoint) v2.ClusterLoadAssignment {
-	cla := v2.ClusterLoadAssignment{
+func NewClusterLoadAssignment(serviceName service.NamespacedService, serviceEndpoints []osmEndpoint.Endpoint) *v2.ClusterLoadAssignment {
+	cla := &v2.ClusterLoadAssignment{
 		ClusterName: serviceName.String(),
 		Endpoints: []*endpoint.LocalityLbEndpoints{
 			{

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -50,7 +50,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 	for serviceName, serviceEndpoints := range allServicesEndpoints {
 		loadAssignment := cla.NewClusterLoadAssignment(serviceName, serviceEndpoints)
 
-		proto, err := ptypes.MarshalAny(&loadAssignment)
+		proto, err := ptypes.MarshalAny(loadAssignment)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error marshalling EDS payload %+v", loadAssignment)
 			continue

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -36,7 +36,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		TypeUrl: string(envoy.TypeRDS),
 	}
 
-	routeConfiguration := []xds.RouteConfiguration{}
+	routeConfiguration := []*xds.RouteConfiguration{}
 	sourceRouteConfig := route.NewRouteConfigurationStub(route.OutboundRouteConfig)
 	destinationRouteConfig := route.NewRouteConfigurationStub(route.InboundRouteConfig)
 	sourceAggregatedRoutesByDomain := make(map[string]map[string]trafficpolicy.RouteWeightedClusters)
@@ -69,13 +69,13 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		return nil, err
 	}
 
-	sourceRouteConfig = route.UpdateRouteConfiguration(sourceAggregatedRoutesByDomain, sourceRouteConfig, true, false)
-	destinationRouteConfig = route.UpdateRouteConfiguration(destinationAggregatedRoutesByDomain, destinationRouteConfig, false, true)
+	route.UpdateRouteConfiguration(sourceAggregatedRoutesByDomain, sourceRouteConfig, true, false)
+	route.UpdateRouteConfiguration(destinationAggregatedRoutesByDomain, destinationRouteConfig, false, true)
 	routeConfiguration = append(routeConfiguration, sourceRouteConfig)
 	routeConfiguration = append(routeConfiguration, destinationRouteConfig)
 
 	for _, config := range routeConfiguration {
-		marshalledRouteConfig, err := ptypes.MarshalAny(&config)
+		marshalledRouteConfig, err := ptypes.MarshalAny(config)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed to marshal route config for proxy")
 			return nil, err

--- a/pkg/envoy/route/routeConfiguration_test.go
+++ b/pkg/envoy/route/routeConfiguration_test.go
@@ -23,7 +23,7 @@ const (
 
 var _ = Describe("VirtualHost cration", func() {
 	Context("Testing createVirtualHostStub", func() {
-		containsDomain := func(vhost v2route.VirtualHost, domain string) bool {
+		containsDomain := func(vhost *v2route.VirtualHost, domain string) bool {
 			for _, entry := range vhost.Domains {
 				if entry == domain {
 					return true
@@ -234,7 +234,7 @@ var _ = Describe("Route Configuration", func() {
 
 			//Validating the outbound clusters and routes
 			sourceRouteConfig := NewRouteConfigurationStub(OutboundRouteConfig)
-			sourceRouteConfig = UpdateRouteConfiguration(sourceDomainAggregatedData, sourceRouteConfig, true, false)
+			UpdateRouteConfiguration(sourceDomainAggregatedData, sourceRouteConfig, true, false)
 			Expect(sourceRouteConfig).NotTo(Equal(nil))
 			Expect(sourceRouteConfig.Name).To(Equal(OutboundRouteConfig))
 			Expect(len(sourceRouteConfig.VirtualHosts)).To(Equal(len(sourceDomainAggregatedData)))
@@ -275,7 +275,7 @@ var _ = Describe("Route Configuration", func() {
 
 			//Validating the inbound clusters and routes
 			destRouteConfig := NewRouteConfigurationStub(InboundRouteConfig)
-			destRouteConfig = UpdateRouteConfiguration(destDomainAggregatedData, destRouteConfig, false, true)
+			UpdateRouteConfiguration(destDomainAggregatedData, destRouteConfig, false, true)
 			Expect(destRouteConfig).NotTo(Equal(nil))
 			Expect(destRouteConfig.Name).To(Equal(InboundRouteConfig))
 			Expect(len(destRouteConfig.VirtualHosts)).To(Equal(len(destDomainAggregatedData)))

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Test Envoy tools", func() {
 		It("should return TLS context", func() {
 			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, true)
 
-			expectedTLSContext := envoy_api_v2_auth.DownstreamTlsContext{
+			expectedTLSContext := &envoy_api_v2_auth.DownstreamTlsContext{
 				CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
 					TlsParams: &envoy_api_v2_auth.TlsParameters{
 						TlsMinimumProtocolVersion: 3,
@@ -172,7 +172,7 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(tlsContext.CommonTlsContext.TlsCertificates).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificates))
 			Expect(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificateSdsSecretConfigs))
 			Expect(tlsContext.CommonTlsContext.ValidationContextType).To(Equal(expectedTLSContext.CommonTlsContext.ValidationContextType))
-			Expect(*tlsContext).To(Equal(expectedTLSContext))
+			Expect(tlsContext).To(Equal(expectedTLSContext))
 		})
 	})
 
@@ -195,7 +195,7 @@ var _ = Describe("Test Envoy tools", func() {
 			sni := "bookstore.default.svc.cluster.local"
 			tlsContext := GetUpstreamTLSContext(tests.BookstoreService, sni)
 
-			expectedTLSContext := envoy_api_v2_auth.UpstreamTlsContext{
+			expectedTLSContext := &envoy_api_v2_auth.UpstreamTlsContext{
 				CommonTlsContext: &envoy_api_v2_auth.CommonTlsContext{
 					TlsParams: &envoy_api_v2_auth.TlsParameters{
 						TlsMinimumProtocolVersion: 3,
@@ -240,7 +240,7 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(tlsContext.CommonTlsContext.TlsCertificates).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificates))
 			Expect(tlsContext.CommonTlsContext.TlsCertificateSdsSecretConfigs).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificateSdsSecretConfigs))
 			Expect(tlsContext.CommonTlsContext.ValidationContextType).To(Equal(expectedTLSContext.CommonTlsContext.ValidationContextType))
-			Expect(*tlsContext).To(Equal(expectedTLSContext))
+			Expect(tlsContext).To(Equal(expectedTLSContext))
 		})
 	})
 


### PR DESCRIPTION
Use a pointer for objects with `sync.mutex` where applicable, especially when
callers want pointers, to prevent go-vet warnings
around mutex copy when the object containing the mutex is copied.

```
call of Expect copies lock value: github.com/envoyproxy/go-control-plane/envoy/api/v2.RouteConfiguration contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex
```