### PR TITLE
osm-config: use configurator for prometheus and zipkin config toggle

### DIFF
--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -6,3 +6,5 @@ metadata:
 data:
   permissive_traffic_policy_mode: {{ .Values.OpenServiceMesh.enablePermissiveTrafficPolicy | quote | default "false" }}
   egress: "true"
+  prometheus_scraping: "true"
+  zipkin_tracing: "true"

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -16,6 +16,8 @@ import (
 const (
 	permissiveTrafficPolicyModeKey = "permissive_traffic_policy_mode"
 	egressKey                      = "egress"
+	prometheusScrapingKey          = "prometheus_scraping"
+	zipkinTracingKey               = "zipkin_tracing"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -56,8 +58,14 @@ type osmConfig struct {
 	// existing traffic patterns.
 	PermissiveTrafficPolicyMode bool `yaml:"permissive_traffic_policy_mode"`
 
-	// Egress is a bool toggle used to enable or disable egress globally within the mesh.
+	// Egress is a bool toggle used to enable or disable egress globally within the mesh
 	Egress bool `yaml:"egress"`
+
+	// PrometheusScraping is a bool toggle used to enable or disable metrics scraping by Prometheus
+	PrometheusScraping bool `yaml:"prometheus_scraping"`
+
+	// ZipkinTracing is a bool toggle used to enable ot disable Zipkin tracing
+	ZipkinTracing bool `yaml:"zipkin_tracing"`
 }
 
 func (c *Client) run(stop <-chan struct{}) {
@@ -107,6 +115,20 @@ func (c *Client) getConfigMap() *osmConfig {
 		log.Error().Err(err).Msgf("Error getting value for key=%s", egressKey)
 	}
 	cfg.Egress = modeBool
+
+	// Parse PrometheusScraping
+	modeBool, err = getBoolValueForKey(configMap, prometheusScrapingKey)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting value for key=%s", prometheusScrapingKey)
+	}
+	cfg.PrometheusScraping = modeBool
+
+	// Parse ZipkinTracing
+	modeBool, err = getBoolValueForKey(configMap, zipkinTracingKey)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting value for key=%s", zipkinTracingKey)
+	}
+	cfg.ZipkinTracing = modeBool
 
 	return cfg
 }

--- a/pkg/configurator/fake.go
+++ b/pkg/configurator/fake.go
@@ -1,0 +1,53 @@
+package configurator
+
+// FakeConfigurator is the fake type for the Configurator client
+type FakeConfigurator struct {
+	OSMNamespace                string
+	PermissiveTrafficPolicyMode bool
+	Egress                      bool
+	PrometheusScraping          bool
+	ZipkinTracing               bool
+}
+
+// NewFakeConfigurator create a new fake Configurator
+func NewFakeConfigurator() Configurator {
+	return FakeConfigurator{
+		PrometheusScraping: true,
+		ZipkinTracing:      true,
+	}
+}
+
+// GetConfigMap returns the data stored in the configMap
+func (f FakeConfigurator) GetConfigMap() ([]byte, error) {
+	return nil, nil
+}
+
+// GetOSMNamespace returns the namespace in which the OSM controller pod resides.
+func (f FakeConfigurator) GetOSMNamespace() string {
+	return f.OSMNamespace
+}
+
+// IsPermissiveTrafficPolicyMode tells us whether the OSM Control Plane is in permissive mode
+func (f FakeConfigurator) IsPermissiveTrafficPolicyMode() bool {
+	return f.PermissiveTrafficPolicyMode
+}
+
+// IsEgressEnabled determines whether egress is globally enabled in the mesh or not.
+func (f FakeConfigurator) IsEgressEnabled() bool {
+	return f.Egress
+}
+
+// IsPrometheusScrapingEnabled determines whether Prometheus is enabled for scraping metrics
+func (f FakeConfigurator) IsPrometheusScrapingEnabled() bool {
+	return f.PrometheusScraping
+}
+
+// IsZipkinTracingEnabled determines whether Zipkin tracing is enabled
+func (f FakeConfigurator) IsZipkinTracingEnabled() bool {
+	return f.ZipkinTracing
+}
+
+// GetAnnouncementsChannel returns a fake announcement channel
+func (f FakeConfigurator) GetAnnouncementsChannel() <-chan interface{} {
+	return make(chan interface{})
+}

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -38,6 +38,16 @@ func (c *Client) IsEgressEnabled() bool {
 	return c.getConfigMap().Egress
 }
 
+// IsPrometheusScrapingEnabled determines whether Prometheus is enabled for scraping metrics
+func (c *Client) IsPrometheusScrapingEnabled() bool {
+	return c.getConfigMap().PrometheusScraping
+}
+
+// IsZipkinTracingEnabled determines whether Zipkin tracing is enabled
+func (c *Client) IsZipkinTracingEnabled() bool {
+	return c.getConfigMap().ZipkinTracing
+}
+
 // GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.
 func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
 	return c.announcements

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -10,18 +10,6 @@ var (
 	log = logger.New("configurator")
 )
 
-// Config is a struct with common global config settings.
-type Config struct {
-	// OSMNamespace is the Kubernetes namespace in which the OSM controller is installed.
-	OSMNamespace string
-
-	// EnablePrometheus enables Prometheus metrics integration when true
-	EnablePrometheus bool
-
-	// EnableTracing enables Zipkin tracing when true.
-	EnableTracing bool
-}
-
 // Client is the k8s client struct for the OSM Config.
 type Client struct {
 	osmNamespace     string
@@ -34,18 +22,24 @@ type Client struct {
 
 // Configurator is the controller interface for K8s namespaces
 type Configurator interface {
-	// GetOSMNamespace returns the namespace in which OSM controller pod resides.
+	// GetOSMNamespace returns the namespace in which OSM controller pod resides
 	GetOSMNamespace() string
 
-	// GetConfigMap returns the ConfigMap in pretty JSON (human readable).
+	// GetConfigMap returns the ConfigMap in pretty JSON (human readable)
 	GetConfigMap() ([]byte, error)
 
-	// IsPermissiveTrafficPolicyMode determines whether we are in "allow-all" mode or SMI policy (block by default) mode.
+	// IsPermissiveTrafficPolicyMode determines whether we are in "allow-all" mode or SMI policy (block by default) mode
 	IsPermissiveTrafficPolicyMode() bool
 
-	// IsEgressEnabled determines whether egress is globally enabled in the mesh or not.
+	// IsEgressEnabled determines whether egress is globally enabled in the mesh or not
 	IsEgressEnabled() bool
 
-	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.
+	// IsPrometheusScrapingEnabled determines whether Prometheus is enabled for scraping metrics
+	IsPrometheusScrapingEnabled() bool
+
+	// IsZipkinTracingEnabled determines whether Zipkin tracing is enabled
+	IsZipkinTracingEnabled() bool
+
+	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap
 	GetAnnouncementsChannel() <-chan interface{}
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -13,7 +13,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
 
-func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *envoy_service_discovery_v2.AggregatedDiscoveryService_StreamAggregatedResourcesServer, config *configurator.Config) {
+func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *envoy_service_discovery_v2.AggregatedDiscoveryService_StreamAggregatedResourcesServer, cfg configurator.Configurator) {
 	log.Trace().Msgf("A change announcement triggered *DS update for proxy with CN=%s", proxy.GetCommonName())
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
@@ -32,7 +32,7 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *envoy_service_disc
 			request = &envoy_api_v2.DiscoveryRequest{TypeUrl: string(typeURI)}
 		}
 
-		discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, request, config)
+		discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, request, cfg)
 		if err != nil {
 			log.Error().Err(err).Msgf("%s Failed to create %s discovery response for proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
 			continue
@@ -76,7 +76,7 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, catalog catalog.MeshCataloger)
 	}
 }
 
-func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *envoy_api_v2.DiscoveryRequest, config *configurator.Config) (*envoy_api_v2.DiscoveryResponse, error) {
+func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *envoy_api_v2.DiscoveryRequest, cfg configurator.Configurator) (*envoy_api_v2.DiscoveryResponse, error) {
 	typeURL := envoy.TypeURI(request.TypeUrl)
 	handler, ok := s.xdsHandlers[typeURL]
 	if !ok {
@@ -92,7 +92,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *env
 	}
 
 	log.Trace().Msgf("Invoking handler for %s with request: %+v", typeURL, request)
-	response, err := handler(s.ctx, s.catalog, s.meshSpec, proxy, request, config)
+	response, err := handler(s.ctx, s.catalog, s.meshSpec, proxy, request, cfg)
 	if err != nil {
 		log.Error().Msgf("Responder for TypeUrl %s is not implemented", request.TypeUrl)
 		return nil, errCreatingResponse

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -97,19 +97,17 @@ var _ = Describe("Test ADS response functions", func() {
 		certPEM, _ := certManager.IssueCertificate(cn, nil)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 		server, actualResponses := tests.NewFakeXDSServer(cert, nil, nil)
-		config := &configurator.Config{
-			OSMNamespace: "-test-namespace-",
-		}
+		cfg := configurator.NewFakeConfigurator()
 
 		It("returns Aggregated Discovery Service response", func() {
 			s := Server{
 				ctx:         context.TODO(),
 				catalog:     mc,
 				meshSpec:    smi.NewFakeMeshSpecClient(),
-				xdsHandlers: getHandlers(),
+				xdsHandlers: getHandlers(cfg),
 			}
 
-			s.sendAllResponses(proxy, &server, config)
+			s.sendAllResponses(proxy, &server, cfg)
 
 			Expect(actualResponses).ToNot(BeNil())
 			Expect(len(*actualResponses)).To(Equal(5))

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -25,9 +25,10 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 		catalog:      meshCatalog,
 		ctx:          ctx,
 		meshSpec:     meshSpec,
-		xdsHandlers:  getHandlers(),
+		xdsHandlers:  getHandlers(cfg),
 		enableDebug:  enableDebug,
 		osmNamespace: osmNamespace,
+		cfg:          cfg,
 	}
 
 	if enableDebug {
@@ -37,8 +38,8 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 	return &server
 }
 
-func getHandlers() map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest, *configurator.Config) (*xds.DiscoveryResponse, error) {
-	return map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest, *configurator.Config) (*xds.DiscoveryResponse, error){
+func getHandlers(cfg configurator.Configurator) map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest, configurator.Configurator) (*xds.DiscoveryResponse, error) {
+	return map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest, configurator.Configurator) (*xds.DiscoveryResponse, error){
 		envoy.TypeEDS: eds.NewResponse,
 		envoy.TypeCDS: cds.NewResponse,
 		envoy.TypeRDS: rds.NewResponse,

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -23,8 +23,9 @@ type Server struct {
 	ctx          context.Context
 	catalog      catalog.MeshCataloger
 	meshSpec     smi.MeshSpec
-	xdsHandlers  map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest, *configurator.Config) (*xds.DiscoveryResponse, error)
+	xdsHandlers  map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds.DiscoveryRequest, configurator.Configurator) (*xds.DiscoveryResponse, error)
 	xdsLog       map[certificate.CommonName]map[envoy.TypeURI][]time.Time
 	enableDebug  bool
 	osmNamespace string
+	cfg          configurator.Configurator
 }

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -30,6 +30,7 @@ import (
 var _ = Describe("CDS Response", func() {
 	kubeClient := testclient.NewSimpleClientset()
 	catalog := catalog.NewFakeMeshCatalog(kubeClient)
+	cfg := configurator.NewFakeConfigurator()
 	proxyServiceName := tests.BookbuyerServiceName
 	proxyServiceAccountName := tests.BookbuyerServiceAccountName
 	proxyService := tests.BookbuyerService
@@ -66,12 +67,7 @@ var _ = Describe("CDS Response", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			config := &configurator.Config{
-				OSMNamespace:     "-test-namespace-",
-				EnablePrometheus: true,
-				EnableTracing:    true,
-			}
-			resp, err := NewResponse(context.Background(), catalog, smiClient, proxy, nil, config)
+			resp, err := NewResponse(context.Background(), catalog, smiClient, proxy, nil, cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			// There are to any.Any resources in the ClusterDiscoveryStruct (Clusters)

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewResponse creates a new Endpoint Discovery Response.
-func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, config *configurator.Config) (*xds.DiscoveryResponse, error) {
+func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, cfg configurator.Configurator) (*xds.DiscoveryResponse, error) {
 	svc, err := catalog.GetServiceFromEnvoyCertificate(proxy.GetCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up Service for Envoy with CN=%q", proxy.GetCommonName())

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewResponse creates a new Route Discovery Response.
-func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, config *configurator.Config) (*xds.DiscoveryResponse, error) {
+func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, cfg configurator.Configurator) (*xds.DiscoveryResponse, error) {
 	svc, err := catalog.GetServiceFromEnvoyCertificate(proxy.GetCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up Service for Envoy with CN=%q", proxy.GetCommonName())

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -25,7 +25,7 @@ var directionMap = map[envoy.SDSCertType]string{
 }
 
 // NewResponse creates a new Secrets Discovery Response.
-func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, config *configurator.Config) (*xds.DiscoveryResponse, error) {
+func NewResponse(_ context.Context, catalog catalog.MeshCataloger, _ smi.MeshSpec, proxy *envoy.Proxy, request *xds.DiscoveryRequest, cfg configurator.Configurator) (*xds.DiscoveryResponse, error) {
 	log.Info().Msgf("Composing SDS Discovery Response for proxy: %s", proxy.GetCommonName())
 
 	serviceForProxy, err := catalog.GetServiceFromEnvoyCertificate(proxy.GetCommonName())


### PR DESCRIPTION
This change deprecates the `Config` struct previously used to configure
zipkin and prometheus in `pkg/envoy`. Instead, the `Configurator`
interface is used to retrieve the configured values for toggling
associated settings.
Also wraps the Prometheus listener with its config flag.

Part of #1017