### PR TITLE
install: Set 1 day as the default certificate validity period

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -54,6 +54,8 @@ const (
 	defaultCertManager   = "tresor"
 	defaultVaultProtocol = "http"
 	defaultMeshName      = "osm"
+
+	defaultCertValidityMinutes = int(1440) // 24 hours
 )
 
 // chartTGZSource is a base64-encoded, gzipped tarball of the default Helm chart.
@@ -109,7 +111,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.vaultProtocol, "vault-protocol", defaultVaultProtocol, "protocol to use to connect to Vault")
 	f.StringVar(&inst.vaultToken, "vault-token", "", "token that should be used to connect to Vault")
 	f.StringVar(&inst.vaultRole, "vault-role", "open-service-mesh", "Vault role to be used by Open Service Mesh")
-	f.IntVar(&inst.serviceCertValidityMinutes, "service-cert-validity-minutes", int(1), "Certificate TTL in minutes")
+	f.IntVar(&inst.serviceCertValidityMinutes, "service-cert-validity-minutes", defaultCertValidityMinutes, "Certificate TTL in minutes")
 	f.StringVar(&inst.prometheusRetentionTime, "prometheus-retention-time", constants.PrometheusDefaultRetentionTime, "Duration for which data will be retained in prometheus")
 	f.BoolVar(&inst.enableDebugServer, "enable-debug-server", false, "Enable the debug HTTP server")
 	f.BoolVar(&inst.enablePermissiveTrafficPolicy, "enable-permissive-traffic-policy", false, "Enable permissive traffic policy mode")


### PR DESCRIPTION
Defaulting cert validity to 1 day (from 1 minute).


1 Minute is great for testing and CI.
1 Day is more reasonable as the default for general use of this product.

For more context on short-lived certificates:  https://blog.envoyproxy.io/using-spire-to-automatically-deliver-tls-certificates-to-envoy-for-stronger-authentication-be5606ac9c75

ref https://github.com/open-service-mesh/osm/issues/1058