### PR TITLE
demo: Adding join-namespaces.sh helper script

### DIFF
--- a/demo/join-namespaces.sh
+++ b/demo/join-namespaces.sh
@@ -20,10 +20,11 @@ BOOKSTORE_NAMESPACE="${BOOKSTORE_NAMESPACE:-bookstore}"
 BOOKTHIEF_NAMESPACE="${BOOKTHIEF_NAMESPACE:-bookthief}"
 BOOKWAREHOUSE_NAMESPACE="${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}"
 
+MESH_NAME="${MESH_NAME:-osm}"
 
 
 for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE"; do
-    kubectl label namespaces "$ns" openservicemesh.io/monitored-by=osm --overwrite="true"
+    kubectl label namespaces "$ns" openservicemesh.io/monitored-by="$MESH_NAME" --overwrite="true"
 done
 
 


### PR DESCRIPTION
This PR adds `join-namespaces.sh` helper script, which joins the given list of namespaces to the service mesh.

ref https://github.com/open-service-mesh/osm/issues/1058

---

This is what the demo flow is and where this script fits in:

1. Reset the demo   --  ./demo/reset.sh && ./demo/unjoin-namespaces.sh && ./demo/delete-policies.sh
2. Capture tcpdump from bookstore   --   ./scripts/get-pcap-bookstore.sh
3. Join the existing mesh   --   **./demo/join-namespaces.sh** && ./demo/rolling-restart.sh
4. Show encrypted traffic   --   ./scripts/get-pcap-bookstore.sh
5. Show the topology (surprise)   --   http://localhost:9411/zipkin/dependency
6. Apply SMI TrafficTarget policy to prevent Bookthief   --    ./demo/deploy-policies.sh
7. Traffic Split   --   ./demo/deploy-traffic-split.sh && ./demo/reset-counters.sh
