### PR TITLE
demo: Adding rolling-restart.sh

### DIFF
--- a/demo/rolling-restart.sh
+++ b/demo/rolling-restart.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
+
+
 # This script performs a rolling restart of the deployments listed below.
 # This is part of the OSM Bookstore demo helper scripts.
 
-kubectl rollout restart deployment -n bookbuyer       bookbuyer
-kubectl rollout restart deployment -n bookstore       bookstore-v1
-kubectl rollout restart deployment -n bookstore       bookstore-v2
-kubectl rollout restart deployment -n bookthief       bookthief
-kubectl rollout restart deployment -n bookwarehouse   bookwarehouse
+
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+BOOKBUYER_NAMESPACE="${BOOKBUYER_NAMESPACE:-bookbuyer}"
+BOOKSTORE_NAMESPACE="${BOOKSTORE_NAMESPACE:-bookstore}"
+BOOKTHIEF_NAMESPACE="${BOOKTHIEF_NAMESPACE:-bookthief}"
+BOOKWAREHOUSE_NAMESPACE="${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}"
+
+
+
+kubectl rollout restart deployment bookbuyer      -n "$BOOKBUYER_NAMESPACE"
+kubectl rollout restart deployment bookstore-v1   -n "$BOOKSTORE_NAMESPACE"
+kubectl rollout restart deployment bookstore-v2   -n "$BOOKSTORE_NAMESPACE"
+kubectl rollout restart deployment bookthief      -n "$BOOKTHIEF_NAMESPACE"
+kubectl rollout restart deployment bookwarehouse  -n "$BOOKWAREHOUSE_NAMESPACE"


### PR DESCRIPTION
This PR adds a helper script to quickly perform a rolling restart to the Bookstore related deploymets.
This is part of the bookstore brownfield deployment.
We need to restart the pods in these deployments when the namespaces have been added to an OSM service mesh, but the **existing** pods do not **yet** have a sidecar. Restarting these injects them with an Envoy sidecar.



ref https://github.com/open-service-mesh/osm/issues/1058

---

This is what the demo flow is and where this script fits in:

1. Reset the demo   --   ./demo/reset.sh && ./demo/unjoin-namespaces.sh && ./demo/delete-policies.sh
2. Capture tcpdump from bookstore   --   ./scripts/get-pcap-bookstore.sh
3. Join the existing mesh   --   ./demo/join-namespaces.sh && **./demo/rolling-restart.sh**
4. Show encrypted traffic   --   ./scripts/get-pcap-bookstore.sh
5. Show the topology (surprise)   --   http://localhost:9411/zipkin/dependency
6. Apply SMI TrafficTarget policy to prevent Bookthief   --    ./demo/deploy-policies.sh
7. Traffic Split   --   ./demo/deploy-traffic-split.sh && ./demo/reset-counters.sh
