### PR TITLE
demo: Adding unjoin-namespaces.sh

### DIFF
--- a/demo/unjoin-namespaces.sh
+++ b/demo/unjoin-namespaces.sh
@@ -11,7 +11,15 @@ source .env
 
 
 K8S_NAMESPACE="${K8S_NAMESPACE:-osm-system}"
+BOOKBUYER_NAMESPACE="${BOOKBUYER_NAMESPACE:-bookbuyer}"
 BOOKSTORE_NAMESPACE="${BOOKSTORE_NAMESPACE:-bookstore}"
+BOOKTHIEF_NAMESPACE="${BOOKTHIEF_NAMESPACE:-bookthief}"
+BOOKWAREHOUSE_NAMESPACE="${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}"
+
+
+for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE"; do
+    kubectl label namespaces "$ns" openservicemesh.io/monitored-by=osm- || true
+done
 
 
 kubectl apply -f - <<EOF
@@ -29,7 +37,7 @@ data:
 EOF
 
 
-# Create a top level service just for the bookstore.mesh domain
+# Create a top level service
 echo -e "Deploy bookstore Service"
 kubectl apply -f - <<EOF
 apiVersion: v1


### PR DESCRIPTION
This PR adds `unjoin-namespaces.sh`, which is a helper script -- very helpful in removing a list of namespaces from an existing service mesh.
This is going to be used for the [OSM Brownfield Deployment demo](https://github.com/open-service-mesh/osm/issues/1058).


ref https://github.com/open-service-mesh/osm/issues/1058

---

This is what the demo flow is and where this script fits in:

1. Reset the demo   --   ./demo/reset.sh && **./demo/unjoin-namespaces.sh** && ./demo/delete-policies.sh
2. Capture tcpdump from bookstore   --   ./scripts/get-pcap-bookstore.sh
3. Join the existing mesh   --   ./demo/join-namespaces.sh && ./demo/rolling-restart.sh
4. Show encrypted traffic   --   ./scripts/get-pcap-bookstore.sh
5. Show the topology (surprise)   --   http://localhost:9411/zipkin/dependency
6. Apply SMI TrafficTarget policy to prevent Bookthief   --    ./demo/deploy-policies.sh
7. Traffic Split   --   ./demo/deploy-traffic-split.sh && ./demo/reset-counters.sh
