### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ bin/osm namespace remove --mesh-name <mesh-name> <namespace-name>
 ```
 
 [1]: https://en.wikipedia.org/wiki/Service_mesh
-[2]: https://github.com/servicemeshinterface/smi-spec/blob/master/SPEC.md
+[2]: https://github.com/servicemeshinterface/smi-spec/blob/master/SPEC_LATEST_STABLE.md
 
 ## Code of Conduct
 


### PR DESCRIPTION
Fixed broken link to SMI spec. Was https://github.com/servicemeshinterface/smi-spec/blob/master/SPEC.md, which doesn't appear to exist anymore. Updated with https://github.com/servicemeshinterface/smi-spec/blob/master/SPEC_LATEST_STABLE.md