### PR TITLE
demo: revert bookstore port to 8080

### DIFF
--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -18,7 +18,7 @@ import (
 
 var identity = flag.String("ident", "unidentified", "the identity of the container where this demo app is running (VM, K8s, etc)")
 
-var port = flag.Int("port", 80, "port on which this app is listening for incoming HTTP")
+var port = flag.Int("port", 8080, "port on which this app is listening for incoming HTTP")
 var path = flag.String("path", ".", "path to the HTML template")
 var booksBought int
 

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -23,7 +23,7 @@ metadata:
     app: bookstore
 spec:
   ports:
-  - port: 80
+  - port: 8080
     name: bookstore-port
   selector:
     app: bookstore
@@ -49,7 +49,7 @@ metadata:
     app: $SVC
 spec:
   ports:
-  - port: 80
+  - port: 8080
     name: bookstore-port
 
   selector:
@@ -83,10 +83,10 @@ spec:
           imagePullPolicy: Always
           name: $SVC
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: web
           command: ["/bookstore"]
-          args: ["--path", "./", "--port", "80"]
+          args: ["--path", "./", "--port", "8080"]
           env:
             - name: IDENTITY
               value: ${SVC}--${GIT_HASH}

--- a/docs/INGRESS.md
+++ b/docs/INGRESS.md
@@ -24,7 +24,7 @@ Other ingress controllers might also work as long as they allow provisioning a c
 ## Ingress configurations
 The following section describes sample ingress configurations used to expose services managed by OSM outside the cluster.  Different ingress controllers require different configurations.
 
-The example configurations describe how to expose HTTPS routes for the `bookstore-v1` HTTPS service running on port `80` in the `bookstore-ns` namespace, outside the cluster. The ingress configuration will expose the HTTPS path `/books-bought` on the `bookstore-v1` service.
+The example configurations describe how to expose HTTPS routes for the `bookstore-v1` HTTPS service running on port `8080` in the `bookstore-ns` namespace, outside the cluster. The ingress configuration will expose the HTTPS path `/books-bought` on the `bookstore-v1` service.
 
 Since OSM uses its own root certificate, the ingress controller must be provisioned with OSM's root certificate to be able to authenticate the certificate presented by backend servers. OSM stores the CA root certificate in a Kubernetes secret called `osm-ca-bundle` with the key `ca.crt` in the namespace OSM is deployed (`osm-system` by default).
 
@@ -59,7 +59,7 @@ spec:
       - path: /books-bought
         backend:
           serviceName: bookstore-v1
-          servicePort: 80
+          servicePort: 8080
 ```
 
 ### Using Azure Application Gateway Ingress Controller
@@ -90,7 +90,7 @@ spec:
       - path: /books-bought
         backend:
           serviceName: bookstore-v1
-          servicePort: 80
+          servicePort: 8080
 ```
 
 [1]: https://github.com/open-service-mesh/osm/blob/main/README.md


### PR DESCRIPTION
The bookstore service is used to demo HTTPS ingress. Azure
Application Gateway does not support using port 80 for HTTPS:
`https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/annotations.md#backend-protocol`

PR #1009 changed the port to be able to demo brownfield scenarios.
Since the brownfield demo is a work in progress, revert this
change to avoid breaking ingress. A subsequent change will
enable brownfield scenarios to be demoed.

Resolves #1099