### PR TITLE
ingress: add a filter chain with SNI

### DIFF
--- a/docs/INGRESS.md
+++ b/docs/INGRESS.md
@@ -35,6 +35,7 @@ An ingress configuration yaml with [Nginx Ingress Controller][2] for the `bookst
 - Specify the backend protocol as HTTPS using the annotation `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"`.
 - Specify the hostname of the service using the annotation `nginx.ingress.kubernetes.io/configuration-snippet`.
 - Specify the secret corresponding to the root certificate using the annotation `nginx.ingress.kubernetes.io/proxy-ssl-secret`.
+- Specify the passing of TLS Server Name Indication (SNI) to proxied HTTPS backends using the annotation `nginx.ingress.kubernetes.io/proxy-ssl-server-name`. This is optional.
 - Enable SSL verification of backend service using the annotation `nginx.ingress.kubernetes.io/proxy-ssl-verify`.
 
 The host defined by `spec.rules.host` field is optional.
@@ -50,6 +51,7 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       proxy_ssl_name "bookstore-v1.bookstore-ns.svc.cluster.local";
     nginx.ingress.kubernetes.io/proxy-ssl-secret: "osm-system/osm-ca-bundle"
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on" # optional
     nginx.ingress.kubernetes.io/proxy-ssl-verify: "on"
 spec:
   rules:


### PR DESCRIPTION
Before this change, ingress filter does not match incoming
TLS connections for SNI. Commit 790c61ec9d2460f759ce5d86c1df5d7fc4f52d28
changed the SNI matching behavior, which means clients
setting the SNI for ingress traffic would not match the
existing non-SNI based ingress filter chain. This is as a result
of how Envoy implements filter chain matching based on decision
trees. If the connection matches a filter chain property (SNI
in this case), all other filter chains without a matching SNI
are discarded. In order for ingress clients setting an SNI with
TLS, the ingress filter chain needs to have a filter chain with
SNI matching as well.

While the above works for ingress clients setting SNI, other ingress
providers might not set the SNI. Nginx-ingress is an example where
SNI is not set by default. Only recently (pull #5712) an annotation
was added to enable setting the SNI for TLS backends.

This change modifies the ingress filter by allowing ingress clients
the option to both specify and not specify an SNI.