### PR TITLE
demo: Do not use GIT_HASH in the identity of the bookstore

### DIFF
--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -9,8 +9,6 @@ SVC="bookstore-$VERSION"
 
 kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  || true
 
-GIT_HASH=$(git rev-parse --short HEAD)
-
 # Create a top level service just for the bookstore.mesh domain
 echo -e "Deploy bookstore Service"
 kubectl apply -f - <<EOF
@@ -89,7 +87,7 @@ spec:
           args: ["--path", "./", "--port", "8080"]
           env:
             - name: IDENTITY
-              value: ${SVC}--${GIT_HASH}
+              value: ${SVC}
             - name: BOOKWAREHOUSE_NAMESPACE
               value: ${BOOKWAREHOUSE_NAMESPACE}
             - name: "OSM_HUMAN_DEBUG_LOG"


### PR DESCRIPTION
This PR removes the git hash from the identity of the bookstore. This identity is passed via HTTP response header back to the bookbuyer and bookthief and are displayed in the web UI. This answers the question "who did I purchase a book from".  For better flowing demo I decided to remove this, which leaves us with `bookstore-v1` and `bookstore-v2` -- this instead of `bookstore-v1-abcdefg`