### PR TITLE
(WIP) Enabling tls/https between prometheus and envoy

### DIFF
--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -46,6 +46,11 @@ data:
       - job_name: 'kubernetes-pods'
         kubernetes_sd_configs:
         - role: pod
+        scheme: https
+        tls_config:
+          # TODO(WIP)
+          # ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: true
         relabel_configs:
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep

--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/endpoint/providers/azure"
 	azureResource "github.com/open-service-mesh/osm/pkg/endpoint/providers/azure/kubernetes"
 	"github.com/open-service-mesh/osm/pkg/endpoint/providers/kube"
+	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/ads"
 	"github.com/open-service-mesh/osm/pkg/featureflags"
 	"github.com/open-service-mesh/osm/pkg/httpserver"
@@ -209,6 +210,10 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err)
 	}
+
+	// Force generation of prometheus certificate.
+	// If scrapping is off, it will just not get used.
+	envoy.GetPrometheusCertificate(certManager, cfg)
 
 	grpcServer, lis := utils.NewGrpc(serverType, *port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetIssuingCA())
 	xds.RegisterAggregatedDiscoveryServiceServer(grpcServer, xdsServer)

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -64,6 +64,14 @@ type osmConfig struct {
 	// PrometheusScraping is a bool toggle used to enable or disable metrics scraping by Prometheus
 	PrometheusScraping bool `yaml:"prometheus_scraping"`
 
+	// PrometheusNamespace is the namespace where Prometheus will be living in
+	// If not defined, system will pick from default values
+	PrometheusNamespace string `yaml:"prometheus_namespace"`
+
+	// PrometheusServiceName is the prometheus service name. If not defined, system will pick
+	// from default values
+	PrometheusServiceName string `yaml:"prometheus_service_name"`
+
 	// ZipkinTracing is a bool toggle used to enable ot disable Zipkin tracing
 	ZipkinTracing bool `yaml:"zipkin_tracing"`
 }

--- a/pkg/configurator/fake.go
+++ b/pkg/configurator/fake.go
@@ -6,15 +6,19 @@ type FakeConfigurator struct {
 	PermissiveTrafficPolicyMode bool
 	Egress                      bool
 	PrometheusScraping          bool
+	PrometheusNamespace         string
+	PrometheusServiceName       string
 	ZipkinTracing               bool
 }
 
 // NewFakeConfigurator create a new fake Configurator
 func NewFakeConfigurator() Configurator {
 	return FakeConfigurator{
-		Egress:             true,
-		PrometheusScraping: true,
-		ZipkinTracing:      true,
+		Egress:                true,
+		PrometheusScraping:    true,
+		ZipkinTracing:         true,
+		PrometheusNamespace:   "osm-system",
+		PrometheusServiceName: "osm-prometheus",
 	}
 }
 
@@ -51,4 +55,14 @@ func (f FakeConfigurator) IsZipkinTracingEnabled() bool {
 // GetAnnouncementsChannel returns a fake announcement channel
 func (f FakeConfigurator) GetAnnouncementsChannel() <-chan interface{} {
 	return make(chan interface{})
+}
+
+// GetPrometheusNamespace returns prometheus namespace
+func (f FakeConfigurator) GetPrometheusNamespace() string {
+	return f.PrometheusNamespace
+}
+
+// GetPrometheusServiceName returns prometheus service name
+func (f FakeConfigurator) GetPrometheusServiceName() string {
+	return f.PrometheusServiceName
 }

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -52,3 +52,13 @@ func (c *Client) IsZipkinTracingEnabled() bool {
 func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
 	return c.announcements
 }
+
+// GetPrometheusNamespace returns prometheus namespace
+func (c *Client) GetPrometheusNamespace() string {
+	return c.getConfigMap().PrometheusNamespace
+}
+
+// GetPrometheusServiceName returns prometheus service name
+func (c *Client) GetPrometheusServiceName() string {
+	return c.getConfigMap().PrometheusServiceName
+}

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -37,6 +37,12 @@ type Configurator interface {
 	// IsPrometheusScrapingEnabled determines whether Prometheus is enabled for scraping metrics
 	IsPrometheusScrapingEnabled() bool
 
+	// GetPrometheusNamespace returns the namespace for the Prometheus instance
+	GetPrometheusNamespace() string
+
+	// GetPrometheusServiceName returns the name for the Prometheus service
+	GetPrometheusServiceName() string
+
 	// IsZipkinTracingEnabled determines whether Zipkin tracing is enabled
 	IsZipkinTracingEnabled() bool
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -76,6 +76,12 @@ const (
 	// PrometheusScrapePath is the path for prometheus to scrap envoy metrics from
 	PrometheusScrapePath = "/stats/prometheus"
 
+	// PrometheusVirtualHostName is used to setup a remote endpoint for comms
+	PrometheusVirtualHostName = "prometheus_envoy_admin"
+
+	// PrometheusDefaultName when not given, is a default prometheus name given by the platform itself
+	PrometheusDefaultName = "osm-prometheus"
+
 	// CertificationAuthorityCommonName is the CN used for the root certificate for OSM.
 	CertificationAuthorityCommonName = "Open Service Mesh Certification Authority"
 

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -48,9 +48,9 @@ func getHTTPConnectionManager(routeName string) *envoy_hcm.HttpConnectionManager
 	return &connManager
 }
 
-func getPrometheusConnectionManager(listenerName string, routeName string, clusterName string) *envoy_hcm.HttpConnectionManager {
+func getPrometheusConnectionManager() *envoy_hcm.HttpConnectionManager {
 	return &envoy_hcm.HttpConnectionManager{
-		StatPrefix: listenerName,
+		StatPrefix: prometheusListenerName,
 		CodecType:  envoy_hcm.HttpConnectionManager_AUTO,
 		HttpFilters: []*envoy_hcm.HttpFilter{{
 			Name: wellknown.Router,
@@ -58,18 +58,18 @@ func getPrometheusConnectionManager(listenerName string, routeName string, clust
 		RouteSpecifier: &envoy_hcm.HttpConnectionManager_RouteConfig{
 			RouteConfig: &v2.RouteConfiguration{
 				VirtualHosts: []*envoy_route.VirtualHost{{
-					Name:    "prometheus_envoy_admin",
+					Name:    constants.PrometheusVirtualHostName,
 					Domains: []string{"*"},
 					Routes: []*envoy_route.Route{{
 						Match: &envoy_route.RouteMatch{
 							PathSpecifier: &envoy_route.RouteMatch_Prefix{
-								Prefix: routeName,
+								Prefix: constants.PrometheusScrapePath,
 							},
 						},
 						Action: &envoy_route.Route_Route{
 							Route: &envoy_route.RouteAction{
 								ClusterSpecifier: &envoy_route.RouteAction_Cluster{
-									Cluster: clusterName,
+									Cluster: constants.EnvoyMetricsCluster,
 								},
 								PrefixRewrite: constants.PrometheusScrapePath,
 							},

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -2,13 +2,16 @@ package lds
 
 import (
 	xds "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	listener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 
+	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
@@ -69,14 +72,17 @@ func buildInboundListener() *xds.Listener {
 	}
 }
 
-func buildPrometheusListener(connManager *envoy_hcm.HttpConnectionManager) (*xds.Listener, error) {
-	marshalledConnManager, err := ptypes.MarshalAny(connManager)
+func buildPrometheusListener(cfg configurator.Configurator) (*xds.Listener, error) {
+
+	promConnMngr := getPrometheusConnectionManager()
+	marshalledConnManager, err := ptypes.MarshalAny(promConnMngr)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling HttpConnectionManager object")
 		return nil, err
 	}
 
-	listener := &xds.Listener{
+	// Create the Listener
+	prometheusListener := &xds.Listener{
 		Name:             prometheusListenerName,
 		TrafficDirection: envoy_api_v2_core.TrafficDirection_INBOUND,
 		Address:          envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyPrometheusInboundListenerPort),
@@ -92,8 +98,59 @@ func buildPrometheusListener(connManager *envoy_hcm.HttpConnectionManager) (*xds
 				},
 			},
 		},
+		ListenerFilters: []*listener.ListenerFilter{
+			{
+				Name: wellknown.TlsInspector,
+			},
+		},
 	}
-	return listener, nil
+
+	// Create the TLS context
+	downstreamTLSContext := &auth.DownstreamTlsContext{
+		CommonTlsContext: &auth.CommonTlsContext{
+			TlsParams: envoy.GetTLSParams(),
+			TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
+				Name: envoy.SDSCert{
+					Service:  envoy.GetPrometheusNamespacedService(cfg),
+					CertType: envoy.ServiceCertType,
+				}.String(),
+				SdsConfig: envoy.GetADSConfigSource(),
+			}},
+		},
+
+		// We do not authenticate client at this time
+		RequireClientCertificate: &wrappers.BoolValue{Value: false},
+	}
+	marshalledDownstreamTLSContext, err := envoy.MessageToAny(downstreamTLSContext)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext object for proxy %s", constants.EnvoyMetricsCluster)
+		return nil, err
+	}
+
+	// Create the filter chain, attach TLS context
+	prometheusFilterChain := &listener.FilterChain{
+		FilterChainMatch: &listener.FilterChainMatch{
+			// TODO: `ServerNames ?`
+			TransportProtocol: envoy.TransportProtocolTLS,
+		},
+		TransportSocket: &envoy_api_v2_core.TransportSocket{
+			Name: envoy.TransportSocketTLS,
+			ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
+				TypedConfig: marshalledDownstreamTLSContext,
+			},
+		},
+		Filters: []*listener.Filter{
+			{
+				Name: wellknown.HTTPConnectionManager,
+				ConfigType: &listener.Filter_TypedConfig{
+					TypedConfig: marshalledConnManager,
+				},
+			},
+		},
+	}
+
+	prometheusListener.FilterChains = append(prometheusListener.FilterChains, prometheusFilterChain)
+	return prometheusListener, nil
 }
 
 func buildEgressHTTPSFilterChain() (*listener.FilterChain, error) {

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 )
@@ -64,12 +65,13 @@ var _ = Describe("Construct inbound and outbound listeners", func() {
 		})
 	})
 
-	Context("Test creation of Prometheus listener", func() {
-		It("Tests the Prometheus listener config", func() {
-			connManager := getHTTPConnectionManager("fake-prometheus")
-			listener, _ := buildPrometheusListener(connManager)
+	Context("Testing the creating of Prometheus listener", func() {
+		cfg := configurator.NewFakeConfigurator()
+
+		It("Returns Prometheus listener config", func() {
+			listener, _ := buildPrometheusListener(cfg)
 			Expect(listener.Address).To(Equal(envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyPrometheusInboundListenerPort)))
-			Expect(len(listener.ListenerFilters)).To(Equal(0)) //  no listener filters
+			Expect(len(listener.ListenerFilters)).To(Equal(1)) //  no listener filters
 			Expect(listener.TrafficDirection).To(Equal(envoy_api_v2_core.TrafficDirection_INBOUND))
 		})
 	})

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/configurator"
-	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/route"
 	"github.com/open-service-mesh/osm/pkg/service"
@@ -100,14 +99,15 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		resp.Resources = append(resp.Resources, marshalledInbound)
 	}
 
+	// Build Prometheus config
 	if cfg.IsPrometheusScrapingEnabled() {
-		// Build Prometheus listener config
-		prometheusConnManager := getPrometheusConnectionManager(prometheusListenerName, constants.PrometheusScrapePath, constants.EnvoyMetricsCluster)
-		prometheusListener, err := buildPrometheusListener(prometheusConnManager)
+		log.Info().Msgf("Enabling prometheus ingress for proxy: %s", proxyServiceName)
+		prometheusListener, err := buildPrometheusListener(cfg)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error building Prometheus listener config for proxy %s", proxyServiceName)
 			return nil, err
 		}
+
 		marshalledPrometheus, err := ptypes.MarshalAny(prometheusListener)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error marshalling Prometheus listener config for proxy %s", proxyServiceName)

--- a/pkg/envoy/prometheus_helpers.go
+++ b/pkg/envoy/prometheus_helpers.go
@@ -1,0 +1,48 @@
+package envoy
+
+import (
+	"time"
+
+	"github.com/open-service-mesh/osm/pkg/certificate"
+	"github.com/open-service-mesh/osm/pkg/configurator"
+	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/service"
+)
+
+// GetPrometheusCertificate will try to grab the Prometheus service certificate and return it,
+// creating it if it doesn't exist in the process
+func GetPrometheusCertificate(certManager certificate.Manager, cfg configurator.Configurator) (certificate.Certificater, error) {
+
+	ns := GetPrometheusNamespacedService(cfg)
+
+	cert, err := certManager.GetCertificate(ns.GetCommonName())
+	if err == nil {
+		return cert, nil
+	}
+
+	duration := 87600 * time.Hour // FIXME, long-lived, use potential defines
+
+	return certManager.IssueCertificate(ns.GetCommonName(), &duration)
+}
+
+// GetPrometheusNamespacedService returns a namespaced service object which identifies a
+// prometheus instance
+func GetPrometheusNamespacedService(cfg configurator.Configurator) service.NamespacedService {
+	var promNs string
+	var promSvc string
+
+	// Prometheus namespace will default to OSM NS if none is defined
+	if promNs = cfg.GetPrometheusNamespace(); promNs == "" {
+		promNs = cfg.GetOSMNamespace()
+	}
+
+	// Prometheus service name will assume a default if none is provided
+	if promSvc = cfg.GetPrometheusServiceName(); promSvc == "" {
+		promSvc = constants.PrometheusDefaultName
+	}
+
+	return service.NamespacedService{
+		Namespace: promNs,
+		Service:   promSvc,
+	}
+}

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/open-service-mesh/osm/pkg/configurator"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/service"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,6 +117,7 @@ var _ = Describe("Test SDS response functions", func() {
 		It("returns a list of root certificate issuance tasks for a mTLS root cert", func() {
 			namespace := uuid.New().String()
 			serviceName := uuid.New().String()
+			cfg := configurator.NewFakeConfigurator()
 
 			svc := service.NamespacedService{
 				Namespace: namespace,
@@ -129,7 +131,7 @@ var _ = Describe("Test SDS response functions", func() {
 			resourceNames := []string{sdsc.String()}
 			cert, proxy, mc := prep(resourceNames, namespace, serviceName)
 
-			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc)
+			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc, cfg)
 
 			Expect(len(actual)).To(Equal(1))
 			Expect(actual[0].Name).To(Equal(sdsc.String()))
@@ -143,8 +145,9 @@ var _ = Describe("Test SDS response functions", func() {
 			serviceName := uuid.New().String()
 			resourceNames := []string{fmt.Sprintf("root-cert-https:%s/%s", namespace, serviceName)}
 			cert, proxy, mc := prep(resourceNames, namespace, serviceName)
+			cfg := configurator.NewFakeConfigurator()
 
-			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc)
+			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc, cfg)
 
 			Expect(len(actual)).To(Equal(1))
 			Expect(actual[0].Name).To(Equal(fmt.Sprintf("root-cert-https:%s/%s", namespace, serviceName)))
@@ -158,8 +161,9 @@ var _ = Describe("Test SDS response functions", func() {
 			serviceName := uuid.New().String()
 			resourceNames := []string{fmt.Sprintf("service-cert:%s/%s", namespace, serviceName)}
 			cert, proxy, mc := prep(resourceNames, namespace, serviceName)
+			cfg := configurator.NewFakeConfigurator()
 
-			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc)
+			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc, cfg)
 
 			Expect(len(actual)).To(Equal(1))
 			Expect(actual[0].Name).To(Equal(fmt.Sprintf("service-cert:%s/%s", namespace, serviceName)))
@@ -173,8 +177,9 @@ var _ = Describe("Test SDS response functions", func() {
 			serviceName := uuid.New().String()
 			resourceNames := []string{"service-cert:SomeOtherNamespace/SomeOtherService"}
 			cert, proxy, mc := prep(resourceNames, namespace, serviceName)
+			cfg := configurator.NewFakeConfigurator()
 
-			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc)
+			actual := getEnvoySDSSecrets(cert, proxy, resourceNames, mc, cfg)
 
 			Expect(len(actual)).To(Equal(0))
 		})


### PR DESCRIPTION
Things that have changed:
- New configmap values to define specific instance and namespace
names for prometheus, in case customers want to put their own
prometheus instance in play. By default, it takes our default values
and prometheus instance.
- Enabled server side TLS, with no client validation on envoy.
- Enabled insecure TLS on client-side (Prometheus). Following patch will
add the OSM public root cert on Prometheus programatically to have
client-side validation.

Things that haven't changed, and are up for discussion:
- Separate listener has been kept: we can move it to a single listener
if we think it reduces surface of attack.