### PR TITLE
README/env: update example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,69 +1,85 @@
 #!/bin/bash
 
-# optional: Kubernetes namespace where OSM will be installed.
-# This cannot be the default namespace because it has to be a namespace that can be deleted.
-# Default: osm-system
-export K8S_NAMESPACE=osm-system
+#---------------------------------------------------------------------------------
+# env variables required for running the demo
 
-# optional: Kubernetes namespace where bookwarehouse app will be installed.
-# This cannot be the default namespace because it has to be a namespace that can be deleted.
-# Default: bookwarehouse
-export BOOKWAREHOUSE_NAMESPACE=bookwarehouse-ns-1
-
-# optional: Kubernetes namespace where bookbuyer app will be installed.
-# This cannot be the default namespace because it has to be a namespace that can be deleted.
-# Default: bookbuyer
-export BOOKBUYER_NAMESPACE=bookbuyer-ns
-
-# optional: Kubernetes namespace where bookstore app will be installed.
-# This cannot be the default namespace because it has to be a namespace that can be deleted.
-# Default: bookstore
-export BOOKSTORE_NAMESPACE=bookstore-ns
-
-# optional: Kubernetes namespace where bookthief app will be installed.
-# This cannot be the default namespace because it has to be a namespace that can be deleted.
-# Default: bookthief
-export BOOKTHIEF_NAMESPACE=bookthief-ns
-
-# optional: URL of the container registry to use.
+# mandatory: URL of the container registry to use.
 # Default: osmci.azurecr.io/osm
 export CTR_REGISTRY=your.azurecr.io/osm
 
 # mandatory: Password to the container registry to use. Leave blank if no authentication is required.
 # For Azure Container Registry (ACR), the following command may be used: az acr credential show -n <your_registry_name> --query "passwords[0].value" | tr -d '"'
 export CTR_REGISTRY_PASSWORD=
+#---------------------------------------------------------------------------------
+
+
+
+#---------------------------------------------------------------------------------
+# env variables required to use helper scripts (logs, port forwarding etc.)
+
+# optional: Kubernetes namespace where OSM will be installed.
+# This cannot be the default namespace because it has to be a namespace that can be deleted.
+# Default: osm-system
+export K8S_NAMESPACE=osm-system
+
+# optional: Kubernetes namespace where bookbuyer app will be installed.
+# This cannot be the default namespace because it has to be a namespace that can be deleted.
+# Default: bookbuyer
+export BOOKBUYER_NAMESPACE=bookbuyer
+
+# optional: Kubernetes namespace where bookthief app will be installed.
+# This cannot be the default namespace because it has to be a namespace that can be deleted.
+# Default: bookthief
+export BOOKTHIEF_NAMESPACE=bookthief
+
+# optional: Kubernetes namespace where bookstore app will be installed.
+# This cannot be the default namespace because it has to be a namespace that can be deleted.
+# Default: bookstore
+export BOOKSTORE_NAMESPACE=bookstore
+
+# optional: Kubernetes namespace where bookwarehouse app will be installed.
+# This cannot be the default namespace because it has to be a namespace that can be deleted.
+# Default: bookwarehouse
+export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
+#--------------------------------------------------------------------------------
+
+
+
+#--------------------------------------------------------------------------------
+# optional environment variables used to change defaults
 
 # optional: Name to be used for the Kubernetes secrets resource to be created from the Docker container registry.
 # Default: acr-creds
-export CTR_REGISTRY_CREDS_NAME=acr-creds
+# export CTR_REGISTRY_CREDS_NAME=acr-creds
 
 # optional: A tag for the containers used to version the container images in the registry
 # Default: latest
-export CTR_TAG=latest
+# export CTR_TAG=latest
 
-# optional: Path to your Kubernetes config file present locally.
-export KUBECONFIG=~/.kube/config
+# optional: Path to your Kubernetes config file present locally. Required if not using in-cluster config.
+# export KUBECONFIG=~/.kube/config
 
 # optional: Enable human readable logs on the console
-export OSM_HUMAN_DEBUG_LOG=true
+# export OSM_HUMAN_DEBUG_LOG=true
 
 # optional: Enable logging of observed Kubernetes events (must have trace logging level enabled as well)
-export OSM_LOG_KUBERNETES_EVENTS=true
-
+# export OSM_LOG_KUBERNETES_EVENTS=true
 
 # optional: Retention time for the data scraped by Prometheus service. Default is 15d
-export PROMETHEUS_RETENTION_TIME=5d
+# export PROMETHEUS_RETENTION_TIME=5d
 
 # optional: Name of the bookstore service bookbuyer and bookthief make requests to.
 # Default: bookstore
-export BOOKSTORE_SVC=bookstore
+# export BOOKSTORE_SVC=bookstore
 
 # optional: Expected response code when bookthief makes reqeusts to bookstore
-# Default: 404
-export BOOKTHIEF_EXPECTED_RESPONSE_CODE=404
+# Default: 503 (with egress enabled)
+# export BOOKTHIEF_EXPECTED_RESPONSE_CODE=503
 
 # optional: Maximum of iterations to test for expected return codes. 0 means unlimited.
-export CI_MAX_ITERATIONS_THRESHOLD=0
+# export CI_MAX_ITERATIONS_THRESHOLD=0
+
+#--------------------------------------
 
 ### The section below configures certificates management
 ### OSM has 2 ways to manage certificates
@@ -72,11 +88,11 @@ export CI_MAX_ITERATIONS_THRESHOLD=0
 
 # optional: What certificate manager to use. One of: tresor, vault
 # Default: tresor
-export CERT_MANAGER=tresor
+# export CERT_MANAGER=tresor
 
 # optional: The mesh name for the osm installation
 # Default: osm
-export MESH_NAME=osm
+# export MESH_NAME=osm
 
 ### When CERT_MANAGER is set to "vault" the following also have to be set:
 
@@ -97,3 +113,4 @@ export MESH_NAME=osm
 
 # See ./demo/deploy-vault.sh script on an example of how to deploy Hashicorp Vault
 # to your Kubernetes cluster.
+#--------------------------------------------------------------------------------

--- a/demo/README.md
+++ b/demo/README.md
@@ -38,7 +38,7 @@ From the root of the repository:
 cp .env.example .env
 ```
 
-In the newly created `.env` file, update the two values `CTR_REGISTRY` and `CTR_REGISTRY_PASSWORD` with appropriate values.
+In the newly created `.env` file, update the two values `CTR_REGISTRY` and `CTR_REGISTRY_PASSWORD` with appropriate values. The optional environment variables only need to be set if the default values used in the demo need to be overridden.
 
 
 ## Run the Demo


### PR DESCRIPTION
New developers are using the example file as their base env file
to run the demo. This however doesn't work because the values
in .env.example are samples and left to the user to configure.
Since this introduces confusion as to what values should be put
in the env file, comment out optional exports of env variables
by default.

The example env file will only have the defaults required to run
and observe the state of the demo. All other optional env variables
are for documentation purpose only, and need to be uncommented
by the user based on their demo configuration.

Resolves #1117