### PR TITLE
ads: Correct printout of OSM ConfigMap

### DIFF
--- a/cmd/ads/ads.go
+++ b/cmd/ads/ads.go
@@ -132,7 +132,7 @@ func main() {
 	if err != nil {
 		log.Error().Err(err).Msgf("Error parsing ConfigMap %s", osmConfigMapName)
 	}
-	log.Info().Msgf("Initial ConfigMap %s: %+v", osmConfigMapName, configMap)
+	log.Info().Msgf("Initial ConfigMap %s: %s", osmConfigMapName, string(configMap))
 
 	namespaceController := namespace.NewNamespaceController(kubeClient, meshName, stop)
 	meshSpec := smi.NewMeshSpecClient(*smiKubeConfig, kubeClient, osmNamespace, namespaceController, stop)


### PR DESCRIPTION
Fixing a log message, which contained a byte slice - needs to be converted to a string.

before:
![image](https://user-images.githubusercontent.com/49918230/87730626-35763480-c77d-11ea-9634-0e96e8f93d0d.png)
