### PR TITLE
Makefile: Add environment variable checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ SHELL      := bash -o pipefail
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 
+check-env:
+ifndef CTR_REGISTRY
+	$(error CTR_REGISTRY environment variable is not defined; see the .env.example file for more information; then source .env)
+endif
+ifndef CTR_TAG
+	$(error CTR_TAG environment variable is not defined; see the .env.example file for more information; then source .env)
+endif
+
 .PHONY: clean-cert
 clean-cert:
 	@rm -rf bin/cert
@@ -53,7 +61,7 @@ go-test-coverage:
 	./scripts/test-w-coverage.sh
 
 .PHONY: docker-build-osm-controller
-docker-build-osm-controller: build-osm-controller
+docker-build-osm-controller: check-env build-osm-controller
 	docker build --build-arg $(HOME)/go/ -t $(CTR_REGISTRY)/osm-controller:$(CTR_TAG) -f dockerfiles/Dockerfile.osm-controller .
 
 .PHONY: build-bookstore
@@ -81,47 +89,47 @@ build-bookthief:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./demo/bin/bookthief ./demo/cmd/bookthief/bookthief.go
 
 .PHONY: docker-build-bookbuyer
-docker-build-bookbuyer: build-bookbuyer
+docker-build-bookbuyer: check-env build-bookbuyer
 	docker build -t $(CTR_REGISTRY)/bookbuyer:$(CTR_TAG) -f dockerfiles/Dockerfile.bookbuyer .
 
 .PHONY: docker-build-bookthief
-docker-build-bookthief: build-bookthief
+docker-build-bookthief: check-env build-bookthief
 	docker build -t $(CTR_REGISTRY)/bookthief:$(CTR_TAG) -f dockerfiles/Dockerfile.bookthief .
 
 .PHONY: docker-build-bookstore
-docker-build-bookstore: build-bookstore
+docker-build-bookstore: check-env build-bookstore
 	docker build -t $(CTR_REGISTRY)/bookstore:$(CTR_TAG) -f dockerfiles/Dockerfile.bookstore .
 
 .PHONY: docker-build-bookwarehouse
-docker-build-bookwarehouse: build-bookwarehouse
+docker-build-bookwarehouse: check-env build-bookwarehouse
 	docker build -t $(CTR_REGISTRY)/bookwarehouse:$(CTR_TAG) -f dockerfiles/Dockerfile.bookwarehouse .
 
 .PHONY: docker-build-init
-docker-build-init:
+docker-build-init: check-env
 	docker build -t $(CTR_REGISTRY)/init:$(CTR_TAG) -f dockerfiles/Dockerfile.init .
 
 .PHONY: docker-push-osm-controller
-docker-push-osm-controller: docker-build-osm-controller
+docker-push-osm-controller: check-env docker-build-osm-controller
 	docker push "$(CTR_REGISTRY)/osm-controller:$(CTR_TAG)"
 
 .PHONY: docker-push-bookbuyer
-docker-push-bookbuyer: docker-build-bookbuyer
+docker-push-bookbuyer: check-env docker-build-bookbuyer
 	docker push "$(CTR_REGISTRY)/bookbuyer:$(CTR_TAG)"
 
 .PHONY: docker-push-bookthief
-docker-push-bookthief: docker-build-bookthief
+docker-push-bookthief: check-env docker-build-bookthief
 	docker push "$(CTR_REGISTRY)/bookthief:$(CTR_TAG)"
 
 .PHONY: docker-push-bookstore
-docker-push-bookstore: docker-build-bookstore
+docker-push-bookstore: check-env docker-build-bookstore
 	docker push "$(CTR_REGISTRY)/bookstore:$(CTR_TAG)"
 
 .PHONY: docker-push-bookwarehouse
-docker-push-bookwarehouse: docker-build-bookwarehouse
+docker-push-bookwarehouse: check-env docker-build-bookwarehouse
 	docker push "$(CTR_REGISTRY)/bookwarehouse:$(CTR_TAG)"
 
 .PHONY: docker-push-init
-docker-push-init: docker-build-init
+docker-push-init: check-env docker-build-init
 	docker push "$(CTR_REGISTRY)/init:$(CTR_TAG)"
 
 .PHONY: docker-push


### PR DESCRIPTION
This PR is a chunk from https://github.com/open-service-mesh/osm/pull/884

Goal is to ensure that env variables needed by the Makefile have been set.