### PR TITLE
demo: Error out when .env does not exist

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -2,6 +2,14 @@
 
 set -aueo pipefail
 
+if [ ! -f .env ]; then
+    echo -e "\nThere is no .env file in the root of this repository."
+    echo -e "Copy the values from .env.example into .env."
+    echo -e "Modify the values in .env to match your setup.\n"
+    echo -e "    cat .env.example > .env\n\n"
+    exit 1
+fi
+
 # shellcheck disable=SC1091
 source .env
 


### PR DESCRIPTION
Show an error and exit if .env does not exist when running the demo with `./demo/run-osm-demo.sh`

![image](https://user-images.githubusercontent.com/49918230/87737616-47ad9e00-c790-11ea-8127-f6d6ca6496ed.png)
