### PR TITLE
refactor makefile and enable kind based demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,14 @@
 # env variables required for running the demo
 
 # mandatory: URL of the container registry to use.
-# Default: osmci.azurecr.io/osm
-export CTR_REGISTRY=your.azurecr.io/osm
+# Default (local Kind registry): localhost:5000
+# Azure Container Registry (ACR) example: osmci.azurecr.io/osm
+export CTR_REGISTRY=localhost:5000
 
 # mandatory: Password to the container registry to use. Leave blank if no authentication is required.
 # For Azure Container Registry (ACR), the following command may be used: az acr credential show -n <your_registry_name> --query "passwords[0].value" | tr -d '"'
-export CTR_REGISTRY_PASSWORD=
+# For Kind, this can be any value
+export CTR_REGISTRY_PASSWORD=your-password
 #---------------------------------------------------------------------------------
 
 

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -47,7 +47,7 @@ wait_for_osm_pods() {
 }
 
 wait_for_pod_ready() {
-    max=12
+    max=15
     pod_name=$1
 
     for x in $(seq 1 $max); do

--- a/scripts/kind-with-registry.sh
+++ b/scripts/kind-with-registry.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# desired cluster name; default is "kind"
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-osm}"
+
+if kind get clusters | grep -q ^osm$ ; then
+  echo "cluster already exists, moving on"
+  exit 0
+fi
+
+# create registry container unless it already exists
+kind_version=$(kind version)
+kind_network='kind'
+reg_name='kind-registry'
+reg_port='5000'
+case "${kind_version}" in
+  "kind v0.7."* | "kind v0.6."* | "kind v0.5."*)
+    kind_network='bridge'
+    ;;
+esac
+
+# create registry container unless it already exists
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+reg_host="${reg_name}"
+if [ "${kind_network}" = "bridge" ]; then
+    reg_host="$(docker inspect -f '{{.NetworkSettings.IPAddress}}' "${reg_name}")"
+fi
+echo "Registry Host: ${reg_host}"
+
+# create a cluster with the local registry enabled in containerd
+cat <<EOF | kind create cluster --name "${KIND_CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_host}:${reg_port}"]
+EOF
+
+for node in $(kind get nodes --name "${KIND_CLUSTER_NAME}"); do
+  kubectl annotate node "${node}" tilt.dev/registry=localhost:${reg_port};
+done
+
+if [ "${kind_network}" != "bridge" ]; then
+  containers=$(docker network inspect ${kind_network} -f "{{range .Containers}}{{.Name}} {{end}}")
+  needs_connect="true"
+  for c in $containers; do
+    if [ "$c" = "${reg_name}" ]; then
+      needs_connect="false"
+    fi
+  done
+  if [ "${needs_connect}" = "true" ]; then               
+    docker network connect "${kind_network}" "${reg_name}" || true
+  fi
+fi


### PR DESCRIPTION
This should enable a user with `kind` that first arrives on the repo to simply run `make kind-demo` and have a fully working demo.