### PR TITLE
cli: add version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 #!make
 
 TARGETS    := darwin/amd64 linux/amd64
-LDFLAGS    :=
 SHELL      := bash -o pipefail
 BINNAME    ?= osm
 DIST_DIRS  := find * -type d -exec
@@ -9,6 +8,13 @@ DIST_DIRS  := find * -type d -exec
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 GOX    = $(GOPATH)/bin/gox
+
+CLI_VERSION = 0.0.1
+BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
+BUILD_DATE_VAR := main.BuildDate
+BUILD_VERSION_VAR := main.BuildVersion
+
+LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CLI_VERSION) -X main.chartTGZSource=$$(cat -)"
 
 .PHONY: gox
 gox:
@@ -43,7 +49,7 @@ build-osm-controller: clean-osm-controller
 .PHONY: build-osm
 build-osm:
 	@mkdir -p $(shell pwd)/bin
-	go run scripts/generate_chart/generate_chart.go | CGO_ENABLED=0  go build -v -o ./bin/osm -ldflags "-X main.chartTGZSource=$$(cat -)" ./cmd/cli
+	go run scripts/generate_chart/generate_chart.go | CGO_ENABLED=0  go build -v -o ./bin/osm -ldflags ${LDFLAGS} ./cmd/cli
 
 .PHONY: docker-build
 docker-build: docker-build-osm-controller docker-build-bookbuyer docker-build-bookstore docker-build-bookwarehouse

--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -42,6 +42,7 @@ func newRootCmd(config *action.Configuration, out io.Writer, args []string) *cob
 		newCheckCmd(out),
 		newDashboardCmd(config, out),
 		newNamespaceCmd(out),
+		newVersionCmd(out),
 	)
 
 	flags.Parse(args)

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/cmd/helm/require"
+)
+
+const versionHelp = `
+This command prints out all the version information used by OSM
+`
+
+var (
+	// BuildDate is date when binary was built
+	BuildDate string
+	// BuildVersion is the version of binary
+	BuildVersion string
+)
+
+// PrintCliVersion prints the version
+func PrintCliVersion(out io.Writer) {
+	fmt.Fprintf(out, "Version: %s; Date: %s\n", BuildVersion, BuildDate)
+}
+
+func newVersionCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "osm cli version",
+		Long:  versionHelp,
+		Args:  require.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			PrintCliVersion(out)
+		},
+	}
+	return cmd
+}


### PR DESCRIPTION
Fixes #915 

Sample output:

```sh
./bin/osm version                                                          
Version: 0.0.1; Date: 2020-07-17-13:08
```

```sh
./bin/osm help                                                                   
osm enables you to install and manage the
Open Service Mesh in your Kubernetes cluster

To install and configure open service mesh, run:

   $ osm install

Usage:
  osm [command]

Available Commands:
...
  namespace   manage osm namespaces
  version     osm cli version

```
