### PR TITLE
Parametrize metrics stack deployment

### DIFF
--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -111,3 +112,4 @@ data:
       updateIntervalSeconds: 10
       options:
         path: /etc/grafana/provisioning/dashboards/controlplane
+{{- end }}

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,3 +67,4 @@ spec:
             name: osm-grafana-dashboard-definition-dataplane
         - name: osm-grafana-storage
           emptyDir: {}
+{{- end }}

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -31,3 +32,4 @@ roleRef:
   kind: ClusterRole
   name: {{.Release.Name}}-grafana
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/osm/templates/grafana-svc.yaml
+++ b/charts/osm/templates/grafana-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,3 +10,4 @@ spec:
     - port: {{.Values.OpenServiceMesh.grafana.port}}
   selector:
     app: osm-grafana
+{{- end }}

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -146,3 +147,4 @@ data:
         - source_labels: [__meta_kubernetes_service_name]
           action: replace
           target_label: kubernetes_name
+{{- end }}

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -45,3 +46,4 @@ spec:
           name: osm-prometheus-server-conf
       - name: prometheus-storage-volume
         emptyDir: {}
+{{- end }}

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -29,3 +30,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: osm-prometheus
+{{- end }}

--- a/charts/osm/templates/prometheus-svc.yaml
+++ b/charts/osm/templates/prometheus-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.OpenServiceMesh.enableMetricsStack }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
     targetPort: {{.Values.OpenServiceMesh.prometheus.port}}
   selector:
     app: osm-prometheus
+{{- end }}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -29,4 +29,5 @@ OpenServiceMesh:
   enablePermissiveTrafficPolicy: false
   enableBackpressureExperimental: false
   enableEgress: true
+  enableMetricsStack: true
   meshName: osm

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -78,6 +78,9 @@ type installCmd struct {
 	// become part of SMI Spec.
 	enableBackpressureExperimental bool
 
+	// Toggle to deploy/not deploy metrics (Promethus+Grafana) stack
+	enableMetricsStack bool
+
 	// checker runs checks before any installation is attempted. Its type is
 	// abstract here to make testing easy.
 	checker interface {
@@ -116,6 +119,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enablePermissiveTrafficPolicy, "enable-permissive-traffic-policy", false, "Enable permissive traffic policy mode")
 	f.BoolVar(&inst.enableEgress, "enable-egress", true, "Enable egress in the mesh")
 	f.BoolVar(&inst.enableBackpressureExperimental, "enable-backpressure-experimental", false, "Enable experimental backpressure feature")
+	f.BoolVar(&inst.enableMetricsStack, "enable-metrics-stack", true, "Enable metrics (Prometheus and Grafana) deployment")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
 
 	return cmd
@@ -210,6 +214,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
 		fmt.Sprintf("OpenServiceMesh.enablePermissiveTrafficPolicy=%t", i.enablePermissiveTrafficPolicy),
 		fmt.Sprintf("OpenServiceMesh.enableBackpressureExperimental=%t", i.enableBackpressureExperimental),
+		fmt.Sprintf("OpenServiceMesh.enableMetricsStack=%t", i.enableMetricsStack),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
 		fmt.Sprintf("OpenServiceMesh.enableEgress=%t", i.enableEgress),
 	}

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Running the install command", func() {
 				checker:                    passingChecker{},
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
+				enableMetricsStack:         true,
 			}
 
 			err = installCmd.run(config)
@@ -133,6 +134,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
+						"enableMetricsStack":             true,
 					}}))
 			})
 
@@ -177,6 +179,7 @@ var _ = Describe("Running the install command", func() {
 				checker:                    passingChecker{},
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
+				enableMetricsStack:         true,
 			}
 
 			err = installCmd.run(config)
@@ -233,6 +236,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
+						"enableMetricsStack":             true,
 					}}))
 			})
 
@@ -281,6 +285,7 @@ var _ = Describe("Running the install command", func() {
 				checker:                    passingChecker{},
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
+				enableMetricsStack:         true,
 			}
 
 			err = installCmd.run(config)
@@ -338,6 +343,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
+						"enableMetricsStack":             true,
 					}}))
 			})
 
@@ -565,6 +571,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
+			enableMetricsStack:         true,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -604,6 +611,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				"enablePermissiveTrafficPolicy":  false,
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
+				"enableMetricsStack":             true,
 			}}))
 	})
 })


### PR DESCRIPTION
Introduces new flag `enableMetricsStack`, which will
work as a toggle to enable/disable deploying Prometheus
and Graphana jointly with OSM control plane.

This addition is added to better support BYO metrics stack
into OSM.

Fixes #1017