### PR TITLE
catalog/routes: Update service domains when no TrafficSplit is specified

### DIFF
--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -12,4 +12,5 @@ var (
 	errServiceNotFoundForAnyProvider         = errors.New("no service found for service account with any of the mesh supported providers")
 	errDomainNotFoundForService              = errors.New("no host/domain found to configure service")
 	errNoTrafficSpecFoundForTrafficPolicy    = errors.New("no traffic spec found for the traffic policy")
+	errServiceNotFound                       = errors.New("service not found")
 )

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -32,6 +32,10 @@ func NewFakeMeshSpecClient() MeshSpec {
 			tests.BookstoreServiceAccount,
 			tests.BookbuyerServiceAccount,
 		},
+		services: []*corev1.Service{
+			tests.NewServiceFixture(tests.BookstoreService.Service, tests.BookstoreService.Namespace, nil),
+			tests.NewServiceFixture(tests.BookbuyerService.Service, tests.BookbuyerService.Namespace, nil),
+		},
 
 		backpressures: []*backpressure.Backpressure{&tests.Backpressure},
 	}

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -34,6 +34,9 @@ const (
 	// BookbuyerServiceName is the name of the bookbuyer service
 	BookbuyerServiceName = "bookbuyer"
 
+	// BookwarehouseServiceName is the name of the bookwarehouse service
+	BookwarehouseServiceName = "bookwarehouse"
+
 	// BookstoreServiceAccountName is the name of the bookstore service account
 	BookstoreServiceAccountName = "bookstore"
 	// BookbuyerServiceAccountName is the name of the bookbuyer service account
@@ -93,6 +96,12 @@ var (
 	BookbuyerService = service.NamespacedService{
 		Namespace: Namespace,
 		Service:   BookbuyerServiceName,
+	}
+
+	// BookwarehouseService is the bookwarehouse service.
+	BookwarehouseService = service.NamespacedService{
+		Namespace: Namespace,
+		Service:   BookwarehouseServiceName,
 	}
 
 	// RoutePolicy is a route policy.


### PR DESCRIPTION
When no traffic split is specified, use the Kubernetes DNS names associated with a service.

Fixes: #924