### PR TITLE
envoy: consolidate cluster creation and use SDK value for TLS socket

### DIFF
--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -41,7 +41,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, meshSpec smi.
 		//iterate through only destination services here since envoy is programmed by destination
 		dstService := trafficPolicies.Destination.Service
 		if isSourceService {
-			remoteCluster, err := envoy.GetServiceCluster(dstService, proxyServiceName)
+			remoteCluster, err := getRemoteServiceCluster(dstService, proxyServiceName)
 			if err != nil {
 				log.Error().Err(err).Msgf("Failed to construct service cluster for proxy %s", proxyServiceName)
 				return nil, err
@@ -59,7 +59,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, meshSpec smi.
 	// Create a local cluster for the service.
 	// The local cluster will be used for incoming traffic.
 	localClusterName := getLocalClusterName(proxyServiceName)
-	localCluster, err := getServiceClusterLocal(catalog, proxyServiceName, localClusterName)
+	localCluster, err := getLocalServiceCluster(catalog, proxyServiceName, localClusterName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
 		return nil, err
@@ -68,7 +68,7 @@ func NewResponse(_ context.Context, catalog catalog.MeshCataloger, meshSpec smi.
 
 	if cfg.IsEgressEnabled() {
 		// Add a passthrough cluster for egress
-		passthroughCluster := envoy.GetOutboundPassthroughCluster()
+		passthroughCluster := getOutboundPassthroughCluster()
 		clusterFactories = append(clusterFactories, passthroughCluster)
 	}
 

--- a/pkg/envoy/cds/tracing.go
+++ b/pkg/envoy/cds/tracing.go
@@ -13,7 +13,7 @@ func getZipkinCluster(zipkinHostname string) xds.Cluster {
 	return xds.Cluster{
 		Name:           constants.EnvoyZipkinCluster,
 		AltStatName:    constants.EnvoyZipkinCluster,
-		ConnectTimeout: ptypes.DurationProto(connectionTimeout),
+		ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
 		ClusterDiscoveryType: &xds.Cluster_Type{
 			Type: xds.Cluster_LOGICAL_DNS,
 		},

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -147,7 +147,7 @@ func getInboundInMeshFilterChain(proxyServiceName service.NamespacedService, mc 
 		},
 
 		TransportSocket: &envoy_api_v2_core.TransportSocket{
-			Name: envoy.TransportSocketTLS,
+			Name: wellknown.TransportSocketTls,
 			ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 				TypedConfig: marshalledDownstreamTLSContext,
 			},
@@ -171,7 +171,7 @@ func getInboundIngressFilterChains(proxyServiceName service.NamespacedService, f
 				ServerNames:       []string{proxyServiceName.GetCommonName().String()},
 			},
 			TransportSocket: &envoy_api_v2_core.TransportSocket{
-				Name: envoy.TransportSocketTLS,
+				Name: wellknown.TransportSocketTls,
 				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 					TypedConfig: marshalledDownstreamTLSContext,
 				},
@@ -191,7 +191,7 @@ func getInboundIngressFilterChains(proxyServiceName service.NamespacedService, f
 				TransportProtocol: envoy.TransportProtocolTLS,
 			},
 			TransportSocket: &envoy_api_v2_core.TransportSocket{
-				Name: envoy.TransportSocketTLS,
+				Name: wellknown.TransportSocketTls,
 				ConfigType: &envoy_api_v2_core.TransportSocket_TypedConfig{
 					TypedConfig: marshalledDownstreamTLSContext,
 				},

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -41,9 +41,6 @@ const (
 	// TypeZipkinConfig is an Envoy type URI.
 	TypeZipkinConfig TypeURI = "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig"
 
-	// TransportSocketTLS is an Envoy string constant.
-	TransportSocketTLS = "envoy.transport_sockets.tls"
-
 	accessLogPath = "/dev/stdout"
 
 	//LocalClusterSuffix is the tag to append to local clusters


### PR DESCRIPTION
This change refactors `envoy/cds` by consolidating
cluster creation code in `cluster.go`. The functions
being moved should not be in xdsutil but rather a
part of cds.  It renames some functions to better convey
their purpose. The connect timeout for clusters is
also adjusted for consistency.

The change also used the name of the TLS transport
socket as defined in the SDK.