### PR TITLE
dockerfile: add curl, openssl, ca-certificates to client apps

### DIFF
--- a/dockerfiles/Dockerfile.bookbuyer
+++ b/dockerfiles/Dockerfile.bookbuyer
@@ -1,6 +1,5 @@
 FROM alpine:3.10.1
 ADD ./demo/bin/bookbuyer /
 ADD ./demo/bookbuyer.html.template /
-ENV PACKAGES "curl openssl ca-certificates"
-RUN apk add --no-cache $PACKAGES
+RUN apk add --no-cache curl openssl ca-certificates
 RUN chmod +x /bookbuyer

--- a/dockerfiles/Dockerfile.bookthief
+++ b/dockerfiles/Dockerfile.bookthief
@@ -1,6 +1,5 @@
 FROM alpine:3.10.1
 ADD ./demo/bin/bookthief /
 ADD ./demo/bookthief.html.template /
-ENV PACKAGES "curl openssl ca-certificates"
-RUN apk add --no-cache $PACKAGES
+RUN apk add --no-cache curl openssl ca-certificates
 RUN chmod +x /bookthief


### PR DESCRIPTION
These packages allow to demo HTTP and/or HTTPS egress. The next
step is to integrate egress scenarios with the demo which will
make use of these packages.

Part of #1185