### PR TITLE
bash: Do not print executed commands

### DIFF
--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -auexo pipefail
+set -aueo pipefail
 
 # shellcheck disable=SC1091
 source .env

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -auexo pipefail
+set -aueo pipefail
 
 # shellcheck disable=SC1091
 source .env

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -auexo pipefail
+set -aueo pipefail
 
 # shellcheck disable=SC1091
 source .env

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -auexo pipefail
+set -aueo pipefail
 
 # shellcheck disable=SC1091
 source .env

--- a/init-iptables.sh
+++ b/init-iptables.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -auexo pipefail
+set -aueo pipefail
 
 PROXY_ADMIN_PORT=${PROXY_ADMIN_PORT:-15000}
 PROXY_STATS_PORT=${PROXY_STATS_PORT:-15010}

--- a/scripts/gen-backpressure-client.sh
+++ b/scripts/gen-backpressure-client.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -auexo pipefail
+set -aueo pipefail
 
 DIR="$GOPATH/src/k8s.io/"
 


### PR DESCRIPTION
I would not miss any of these bash commands if we stopped printing them.

The goal of this PR is to make stdout, while running a demo and CI, a bit tidier.  This affects the iptables script as well.