### PR TITLE
demo: Use OSM CLI

### DIFF
--- a/demo/join-namespaces.sh
+++ b/demo/join-namespaces.sh
@@ -13,7 +13,6 @@ set -aueo pipefail
 source .env
 
 
-./bin/osm namespace add "${K8S_NAMESPACE:-osm-system}"              --mesh-name "${MESH_NAME:-osm}"
 ./bin/osm namespace add "${BOOKBUYER_NAMESPACE:-bookbuyer}"         --mesh-name "${MESH_NAME:-osm}"
 ./bin/osm namespace add "${BOOKSTORE_NAMESPACE:-bookstore}"         --mesh-name "${MESH_NAME:-osm}"
 ./bin/osm namespace add "${BOOKTHIEF_NAMESPACE:-bookthief}"         --mesh-name "${MESH_NAME:-osm}"


### PR DESCRIPTION
Use the OSM CLI instead of kubectl in the join namespaces script of the demo.