### PR TITLE
demo: Use port 80 everywhere

### DIFF
--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -21,7 +21,7 @@ var (
 	booksSold = 0
 	log       = logger.NewPretty("bookstore")
 	identity  = flag.String("ident", "unidentified", "the identity of the container where this demo app is running (VM, K8s, etc)")
-	port      = flag.Int("port", 8080, "port on which this app is listening for incoming HTTP")
+	port      = flag.Int("port", 80, "port on which this app is listening for incoming HTTP")
 	path      = flag.String("path", ".", "path to the HTML template")
 )
 

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -21,7 +21,7 @@ metadata:
     app: bookstore
 spec:
   ports:
-  - port: 8080
+  - port: 80
     name: bookstore-port
   selector:
     app: bookstore
@@ -47,7 +47,7 @@ metadata:
     app: $SVC
 spec:
   ports:
-  - port: 8080
+  - port: 80
     name: bookstore-port
 
   selector:
@@ -79,10 +79,10 @@ spec:
           imagePullPolicy: Always
           name: $SVC
           ports:
-            - containerPort: 8080
+            - containerPort: 80
               name: web
           command: ["/bookstore"]
-          args: ["--path", "./", "--port", "8080"]
+          args: ["--path", "./", "--port", "80"]
           env:
             - name: IDENTITY
               value: ${SVC}

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -24,7 +24,7 @@ Other ingress controllers might also work as long as they allow provisioning a c
 ## Ingress configurations
 The following section describes sample ingress configurations used to expose services managed by OSM outside the cluster.  Different ingress controllers require different configurations.
 
-The example configurations describe how to expose HTTPS routes for the `bookstore-v1` HTTPS service running on port `8080` in the `bookstore-ns` namespace, outside the cluster. The ingress configuration will expose the HTTPS path `/books-bought` on the `bookstore-v1` service.
+The example configurations describe how to expose HTTPS routes for the `bookstore-v1` HTTPS service running on port `80` in the `bookstore-ns` namespace, outside the cluster. The ingress configuration will expose the HTTPS path `/books-bought` on the `bookstore-v1` service.
 
 Since OSM uses its own root certificate, the ingress controller must be provisioned with OSM's root certificate to be able to authenticate the certificate presented by backend servers. OSM stores the CA root certificate in a Kubernetes secret called `osm-ca-bundle` with the key `ca.crt` in the namespace OSM is deployed (`osm-system` by default).
 
@@ -61,7 +61,7 @@ spec:
       - path: /books-bought
         backend:
           serviceName: bookstore-v1
-          servicePort: 8080
+          servicePort: 80
 ```
 
 ### Using Azure Application Gateway Ingress Controller
@@ -103,7 +103,7 @@ spec:
       - path: /books-bought
         backend:
           serviceName: bookstore-v1
-          servicePort: 8080
+          servicePort: 80
 ```
 
 [1]: https://github.com/open-service-mesh/osm/blob/main/README.md

--- a/scripts/port-forward-bookstore-ui-v1.sh
+++ b/scripts/port-forward-bookstore-ui-v1.sh
@@ -19,4 +19,4 @@ POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no
 
 kubectl describe pod "$POD" -n "$BOOKSTORE_NAMESPACE"
 
-kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 8081:8080
+kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 8081:80

--- a/scripts/port-forward-bookstore-ui-v2.sh
+++ b/scripts/port-forward-bookstore-ui-v2.sh
@@ -19,4 +19,4 @@ POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no
 
 kubectl describe pod "$POD" -n "$BOOKSTORE_NAMESPACE"
 
-kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 8082:8080
+kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 8082:80


### PR DESCRIPTION
We kept switching this from port 80 to port 8080 to make HTTPS Ingress work (https://github.com/open-service-mesh/osm/pull/1102 https://github.com/open-service-mesh/osm/pull/1009 https://github.com/open-service-mesh/osm/pull/676). With https://github.com/open-service-mesh/osm/pull/1166 we will be using **HTTP** ingress, which will allow us again to have services run on port 80 and be exposed to the Internet via App Gateway.

This PR moves us back to using port 80 everywhere.

This is part of https://github.com/open-service-mesh/osm/pull/1166
ref https://github.com/open-service-mesh/osm/issues/734
ref https://github.com/open-service-mesh/osm/issues/666