### PR TITLE
ci: use MESH_CIDR env var for egress

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -325,6 +325,7 @@ jobs:
           VAULT_ROLE: "open-service-mesh"
           BOOKSTORE_SVC: "bookstore-v1"
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "200"
+          MESH_CIDR: "10.244.0.0/16,10.0.0.0/16"
         run: |
           touch .env  # it is OK for this file to be empty - needed by Makefile
           mkdir -p ".kube"
@@ -333,5 +334,5 @@ jobs:
           ./demo/clean-kubernetes.sh
           echo "Creating Kubernetes namespace: $K8S_NAMESPACE"
           echo "$DOCKER_PASS" | docker login "$ACR" -u "$DOCKER_USER" --password-stdin
-          ./demo/run-osm-demo.sh --enable-permissive-traffic-policy --mesh-cidr "10.244.0.0/16,10.0.0.0/16"
+          ./demo/run-osm-demo.sh --enable-permissive-traffic-policy
           go run ./ci/cmd/maestro.go


### PR DESCRIPTION
Since the demo script uses the MESH_CIDR env
variable, make use of this instead of passing the
same command twice to the CLI.