### PR TITLE
ref(demo): use --ignore-not-found for kubectl delete commands

### DIFF
--- a/demo/clean-kubernetes.sh
+++ b/demo/clean-kubernetes.sh
@@ -6,9 +6,9 @@ set -aueo pipefail
 source .env
 
 for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" "$K8S_NAMESPACE"; do
-    kubectl delete namespace "$ns" || true
+    kubectl delete namespace "$ns" --ignore-not-found
 done
 
 # Clean up Hashicorp Vault deployment
-kubectl delete deployment vault -n "$K8S_NAMESPACE" || true
-kubectl delete service vault -n "$K8S_NAMESPACE" || true
+kubectl delete deployment vault -n "$K8S_NAMESPACE" --ignore-not-found
+kubectl delete service vault -n "$K8S_NAMESPACE" --ignore-not-found

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -7,7 +7,7 @@ source .env
 BOOKSTORE_SVC="${BOOKSTORE_SVC:-bookstore}"
 CI_MAX_ITERATIONS_THRESHOLD="${CI_MAX_ITERATIONS_THRESHOLD:-0}"
 
-kubectl delete deployment bookbuyer -n "$BOOKBUYER_NAMESPACE"  || true
+kubectl delete deployment bookbuyer -n "$BOOKBUYER_NAMESPACE"  --ignore-not-found
 
 echo -e "Deploy BookBuyer Service Account"
 kubectl apply -f - <<EOF

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -7,7 +7,7 @@ source .env
 VERSION=${1:-v1}
 SVC="bookstore-$VERSION"
 
-kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  || true
+kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  --ignore-not-found
 
 # Create a top level service just for the bookstore domain
 echo -e "Deploy bookstore Service"

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -9,7 +9,7 @@ BOOKSTORE_SVC="${BOOKSTORE_SVC:-bookstore}"
 BOOKTHIEF_EXPECTED_RESPONSE_CODE="${BOOKTHIEF_EXPECTED_RESPONSE_CODE:-404}"
 CI_MAX_ITERATIONS_THRESHOLD="${CI_MAX_ITERATIONS_THRESHOLD:-0}"
 
-kubectl delete deployment bookthief -n "$BOOKTHIEF_NAMESPACE"  || true
+kubectl delete deployment bookthief -n "$BOOKTHIEF_NAMESPACE"  --ignore-not-found
 
 echo -e "Deploy BookThief demo service"
 kubectl apply -f - <<EOF

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -5,7 +5,7 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-kubectl delete deployment bookwarehouse -n "$BOOKWAREHOUSE_NAMESPACE"  || true
+kubectl delete deployment bookwarehouse -n "$BOOKWAREHOUSE_NAMESPACE"  --ignore-not-found
 
 echo -e "Deploy Bookwarehouse Service Account"
 kubectl apply -f - <<EOF

--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -5,9 +5,9 @@
 # shellcheck disable=SC1091
 source .env
 
-kubectl delete deployment vault -n "$K8S_NAMESPACE" || true
-kubectl delete pod vault -n "$K8S_NAMESPACE" || true
-kubectl delete service vault -n "$K8S_NAMESPACE" || true
+kubectl delete deployment vault -n "$K8S_NAMESPACE" --ignore-not-found
+kubectl delete pod vault -n "$K8S_NAMESPACE" --ignore-not-found
+kubectl delete service vault -n "$K8S_NAMESPACE" --ignore-not-found
 
 kubectl apply -f - <<EOF
 apiVersion: apps/v1

--- a/scripts/create-container-registry-creds.sh
+++ b/scripts/create-container-registry-creds.sh
@@ -20,7 +20,7 @@ REGISTRY_URL=$(echo "$CTR_REGISTRY" | awk -F'.' '{print $1 "." $2 "." $3}')
 
 echo "Creating container registry credentials ($CTR_REGISTRY_CREDS_NAME) for Kubernetes in namespace ($namespace) for the given Azure Container Registry ($REGISTRY_URL)"
 
-kubectl delete secrets "$CTR_REGISTRY_CREDS_NAME" -n "$namespace" || true
+kubectl delete secrets "$CTR_REGISTRY_CREDS_NAME" -n "$namespace" --ignore-not-found
 kubectl create secret docker-registry "$CTR_REGISTRY_CREDS_NAME" \
     -n "$namespace" \
     --docker-server="$REGISTRY_URL" \


### PR DESCRIPTION
Many `kubectl delete` commands in the demo have a `|| true` guard on the
end to prevent failure when the resource doesn't exist. This change
replaces that guard with the `--ignore-not-found` flag of `kubectl
delete`. 
This flag better communicates intent, allows the commands to
fail for other errors we are not able to handle, and prevents error
messages from being displayed when the resources do not exist.

(This is of course under the assumption we don't expect any errors 
other than 404 for those commands. If there are other failure scenarios 
we expect and can't easily handle, I'm happy to keep things the way they are.)