### PR TITLE
Move GetServiceNameFromHost from pkg/kubernetes to pkg/envoy/route

### DIFF
--- a/pkg/envoy/route/routeConfiguration.go
+++ b/pkg/envoy/route/routeConfiguration.go
@@ -14,7 +14,6 @@ import (
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
-	"github.com/open-service-mesh/osm/pkg/kubernetes"
 	"github.com/open-service-mesh/osm/pkg/service"
 	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
 )
@@ -80,7 +79,7 @@ func createVirtualHostStub(namePrefix string, domain string) *v2route.VirtualHos
 		domains[i] = strings.TrimSpace(domains[i])
 	}
 
-	name := fmt.Sprintf("%s|%s", namePrefix, kubernetes.GetServiceNameFromDomain(domains[0]))
+	name := fmt.Sprintf("%s|%s", namePrefix, getServiceFromHost(domains[0]))
 	virtualHost := v2route.VirtualHost{
 		Name:    name,
 		Domains: domains,
@@ -263,4 +262,11 @@ func getRegexForMethod(httpMethod string) string {
 		methodRegex = constants.RegexMatchAll
 	}
 	return methodRegex
+}
+
+// getServiceFromHost returns the service name from its host
+func getServiceFromHost(host string) string {
+	// The service name is the first string in the host name for a service.
+	// Ex. service.namespace, service.namespace.cluster.local
+	return strings.Split(host, ".")[0]
 }

--- a/pkg/envoy/route/routeConfiguration_test.go
+++ b/pkg/envoy/route/routeConfiguration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/service"
+	"github.com/open-service-mesh/osm/pkg/tests"
 	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
 )
 
@@ -347,6 +348,32 @@ var _ = Describe("Routes with headers", func() {
 			Expect(len(headers)).To(Equal(1))
 			Expect(headers[0].Name).To(Equal(MethodHeaderKey))
 			Expect(headers[0].GetSafeRegexMatch().Regex).To(Equal(routePolicy.Methods[0]))
+		})
+	})
+})
+
+var _ = Describe("Service name for a service domain", func() {
+	service := "test-service"
+	Context("Testing getServiceFromHost", func() {
+		It("Returns the service name from its domain", func() {
+			domain := service
+			Expect(getServiceFromHost(domain)).To(Equal(service))
+		})
+		It("Returns the service name from its domain", func() {
+			domain := fmt.Sprintf("%s:%d", service, tests.ServicePort)
+			Expect(getServiceFromHost(domain)).To(Equal(fmt.Sprintf("%s:%d", service, tests.ServicePort)))
+		})
+		It("Returns the service name from its domain", func() {
+			domain := fmt.Sprintf("%s.namespace", service)
+			Expect(getServiceFromHost(domain)).To(Equal(service))
+		})
+		It("Returns the service name from its domain", func() {
+			domain := fmt.Sprintf("%s.namespace.svc", service)
+			Expect(getServiceFromHost(domain)).To(Equal(service))
+		})
+		It("Returns the service name from its domain", func() {
+			domain := fmt.Sprintf("%s.namespace.svc.cluster", service)
+			Expect(getServiceFromHost(domain)).To(Equal(service))
 		})
 	})
 })

--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -2,11 +2,8 @@ package kubernetes
 
 import (
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/open-service-mesh/osm/pkg/constants"
 )
 
 const (
@@ -38,11 +35,4 @@ func GetDomainsForService(service *corev1.Service) []string {
 		domains = append(domains, fmt.Sprintf("%s.%s.svc.%s:%d", serviceName, namespace, clusterDomain, port)) // service.namespace.svc.cluster.local:port
 	}
 	return domains
-}
-
-// GetServiceNameFromDomain returns the service name from its domain
-func GetServiceNameFromDomain(domain string) string {
-	// The service name is the first string in the domain name for a service.
-	// Ex. service.namespace, service.namespace.cluster.local
-	return strings.Split(domain, constants.DomainDelimiter)[0]
 }

--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -40,29 +40,3 @@ var _ = Describe("Domains for a kubernetes service", func() {
 		})
 	})
 })
-
-var _ = Describe("Service name for a service domain", func() {
-	service := "test-service"
-	Context("Testing GetServiceNameFromDomain", func() {
-		It("Returns the service name from its domain", func() {
-			domain := service
-			Expect(GetServiceNameFromDomain(domain)).To(Equal(service))
-		})
-		It("Returns the service name from its domain", func() {
-			domain := fmt.Sprintf("%s:%d", service, tests.ServicePort)
-			Expect(GetServiceNameFromDomain(domain)).To(Equal(fmt.Sprintf("%s:%d", service, tests.ServicePort)))
-		})
-		It("Returns the service name from its domain", func() {
-			domain := fmt.Sprintf("%s.namespace", service)
-			Expect(GetServiceNameFromDomain(domain)).To(Equal(service))
-		})
-		It("Returns the service name from its domain", func() {
-			domain := fmt.Sprintf("%s.namespace.svc", service)
-			Expect(GetServiceNameFromDomain(domain)).To(Equal(service))
-		})
-		It("Returns the service name from its domain", func() {
-			domain := fmt.Sprintf("%s.namespace.svc.cluster", service)
-			Expect(GetServiceNameFromDomain(domain)).To(Equal(service))
-		})
-	})
-})


### PR DESCRIPTION
Moving `GetServiceNameFromHost` from `pkg/kubernetes` to `pkg/envoy/route`, the only place this is used.

Also renaming it to `getServiceFromHost`.

Moved the unit tests as well.