### PR TITLE
fix(ci): increase tresor test timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -270,6 +270,7 @@ jobs:
           CERT_MANAGER: "tresor"
           BOOKSTORE_SVC: "bookstore"
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
+          CI_WAIT_FOR_OK_SECONDS: 75
         run: |
           touch .env  # it is OK for this file to be empty - needed by Makefile
           mkdir -p ".kube"


### PR DESCRIPTION
CI has been failing in the tresor integration test recently since the new bookwarehouse check was added to the maestro. Since the bookwarehouse test will never pass before the bookbuyer test, test now need more time.

Fixes #1199