### PR TITLE
Changing wasm filter api proto for untyped proto

### DIFF
--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -1,13 +1,12 @@
 package lds
 
 import (
-	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	envoy_wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
@@ -23,22 +22,58 @@ const (
 )
 
 func getHTTPConnectionManager(routeName string) *envoy_hcm.HttpConnectionManager {
-	wasm := &envoy_wasm.WasmService{
-		Config: &envoy_wasm.PluginConfig{
-			Name: "stats",
-			VmConfig: &envoy_wasm.PluginConfig_InlineVmConfig{
-				InlineVmConfig: &envoy_wasm.VmConfig{
-					Runtime: "envoy.wasm.runtime.v8",
-					Code: &envoy_core.AsyncDataSource{
-						Specifier: &envoy_core.AsyncDataSource_Local{
-							Local: &envoy_core.DataSource{
-								Specifier: &envoy_core.DataSource_Filename{
-									Filename: "/etc/envoy/stats.wasm",
+
+	// Using untyped proto till the changes are propagated to the APIs upstream
+	wasm := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"config": {
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name": {
+								Kind: &structpb.Value_StringValue{
+									StringValue: "stats",
+								},
+							},
+							"vm_config": {
+								Kind: &structpb.Value_StructValue{
+									StructValue: &structpb.Struct{
+										Fields: map[string]*structpb.Value{
+											"runtime": {
+												Kind: &structpb.Value_StringValue{
+													StringValue: "envoy.wasm.runtime.v8",
+												},
+											},
+											"code": {
+												Kind: &structpb.Value_StructValue{
+													StructValue: &structpb.Struct{
+														Fields: map[string]*structpb.Value{
+															"local": {
+																Kind: &structpb.Value_StructValue{
+																	StructValue: &structpb.Struct{
+																		Fields: map[string]*structpb.Value{
+																			"filename": {
+																				Kind: &structpb.Value_StringValue{
+																					StringValue: "/etc/envoy/stats.wasm",
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+											"allow_precompiled": {
+												Kind: &structpb.Value_BoolValue{BoolValue: true},
+											},
+										},
+									},
 								},
 							},
 						},
 					},
-					AllowPrecompiled: true,
 				},
 			},
 		},


### PR DESCRIPTION
For v3, changes for the filter api are still not yet upstreamed
for http/network wasm filters.

https://github.com/envoyproxy/envoy/pull/12257/files