### PR TITLE
ci: Convert log.Info() to log.Error()

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -57,7 +57,7 @@ func RestockBooks(amount int) {
 	requestBody := strings.NewReader(strconv.Itoa(1))
 	req, err := http.NewRequest("POST", chargeAccountURL, requestBody)
 	if err != nil {
-		log.Info().Msgf("RestockBooks: error posting to %s: %s ", chargeAccountURL, err)
+		log.Error().Err(err).Msgf("RestockBooks: error posting to %s", chargeAccountURL)
 		return
 	}
 
@@ -65,7 +65,7 @@ func RestockBooks(amount int) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Info().Msgf("RestockBooks: Error posting to %s: %s ", chargeAccountURL, err)
+		log.Error().Err(err).Msgf("RestockBooks: Error posting to %s", chargeAccountURL)
 		return
 	}
 


### PR DESCRIPTION
This PR switches from `log.Info()` to `log.Error()` for demo/cmd/common/books.go