### PR TITLE
rds: Move updateRoutesForIngress to new pkg/envoy/rds/ingress.go file

### DIFF
--- a/pkg/envoy/rds/ingress.go
+++ b/pkg/envoy/rds/ingress.go
@@ -1,0 +1,35 @@
+package rds
+
+import (
+	"github.com/open-service-mesh/osm/pkg/catalog"
+	"github.com/open-service-mesh/osm/pkg/constants"
+	"github.com/open-service-mesh/osm/pkg/service"
+	"github.com/open-service-mesh/osm/pkg/trafficpolicy"
+)
+
+func updateRoutesForIngress(svc service.NamespacedService, catalog catalog.MeshCataloger, routesPerHost map[string]map[string]trafficpolicy.RouteWeightedClusters) error {
+	ingressRoutesPerHost, err := catalog.GetIngressRoutesPerHost(svc)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to get ingress route configuration for proxy %s", svc)
+		return err
+	}
+
+	if len(ingressRoutesPerHost) == 0 {
+		return nil
+	}
+
+	ingressWeightedCluster := service.WeightedCluster{
+		ClusterName: service.ClusterName(svc.String()),
+		Weight:      constants.ClusterWeightAcceptAll,
+	}
+
+	for host, routes := range ingressRoutesPerHost {
+		for _, rt := range routes {
+			aggregateRoutesByHost(routesPerHost, rt, ingressWeightedCluster, host)
+		}
+	}
+
+	log.Trace().Msgf("Ingress routes for service %s: %+v", svc, routesPerHost)
+
+	return nil
+}

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -8,7 +8,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/open-service-mesh/osm/pkg/catalog"
 	"github.com/open-service-mesh/osm/pkg/configurator"
-	"github.com/open-service-mesh/osm/pkg/constants"
 	"github.com/open-service-mesh/osm/pkg/envoy"
 	"github.com/open-service-mesh/osm/pkg/envoy/route"
 	"github.com/open-service-mesh/osm/pkg/service"
@@ -115,29 +114,4 @@ func createRoutePolicyWeightedClusters(routePolicy trafficpolicy.Route, weighted
 		Route:            routePolicy,
 		WeightedClusters: set.NewSet(weightedCluster),
 	}
-}
-
-func updateRoutesForIngress(proxyServiceName service.NamespacedService, catalog catalog.MeshCataloger, domainRoutesMap map[string]map[string]trafficpolicy.RouteWeightedClusters) error {
-	ingressRoutesPerHost, err := catalog.GetIngressRoutesPerHost(proxyServiceName)
-	if err != nil {
-		log.Error().Err(err).Msgf("Failed to get ingress route configuration for proxy %s", proxyServiceName)
-		return err
-	}
-
-	if len(ingressRoutesPerHost) == 0 {
-		return nil
-	}
-
-	ingressWeightedCluster := service.WeightedCluster{
-		ClusterName: service.ClusterName(proxyServiceName.String()),
-		Weight:      constants.ClusterWeightAcceptAll,
-	}
-
-	for host, routes := range ingressRoutesPerHost {
-		for _, rt := range routes {
-			aggregateRoutesByHost(domainRoutesMap, rt, ingressWeightedCluster, host)
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
This PR moves `updateRoutesForIngress()` to new pkg/envoy/rds/ingress.go file in an attempt to keep all ingress related functions in an ingress.go file (for all modules - refactoring one PR at a time)

This is part of https://github.com/open-service-mesh/osm/pull/1166
ref https://github.com/open-service-mesh/osm/issues/734
ref https://github.com/open-service-mesh/osm/issues/666