### PR TITLE
Rename buildInboundListener to newInboundListener; buildOutboundListener to newOutboundListener

### DIFF
--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -31,8 +31,8 @@ var _ = Describe("Construct inbound and outbound listeners", func() {
 				Egress:         true,
 				MeshCIDRRanges: []string{cidr1, cidr2},
 			})
-			connManager := getHTTPConnectionManager("fake-outbound", cfg)
-			listener, err := buildOutboundListener(connManager, cfg)
+
+			listener, err := newOutboundListener(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(listener.Address).To(Equal(envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyOutboundListenerPort)))
@@ -59,8 +59,8 @@ var _ = Describe("Construct inbound and outbound listeners", func() {
 			cfg := configurator.NewFakeConfiguratorWithOptions(configurator.FakeConfigurator{
 				Egress: false,
 			})
-			connManager := getHTTPConnectionManager("fake-outbound", cfg)
-			listener, err := buildOutboundListener(connManager, cfg)
+
+			listener, err := newOutboundListener(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(listener.Address).To(Equal(envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyOutboundListenerPort)))
@@ -110,7 +110,7 @@ var _ = Describe("Construct inbound and outbound listeners", func() {
 
 	Context("Test creation of inbound listener", func() {
 		It("Tests the inbound listener config", func() {
-			listener := buildInboundListener()
+			listener := newInboundListener()
 			Expect(listener.Address).To(Equal(envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyInboundListenerPort)))
 			Expect(len(listener.ListenerFilters)).To(Equal(1)) // tls-inpsector listener filter
 			Expect(listener.ListenerFilters[0].Name).To(Equal(wellknown.TlsInspector))

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -43,8 +43,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 	}
 
 	// Build the outbound listener config
-	outboundConnManager := getHTTPConnectionManager(route.OutboundRouteConfig, cfg)
-	outboundListener, err := buildOutboundListener(outboundConnManager, cfg)
+	outboundListener, err := newOutboundListener(cfg)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error building outbound listener config for proxy %s", proxyServiceName)
 		return nil, err
@@ -64,7 +63,7 @@ func NewResponse(ctx context.Context, catalog catalog.MeshCataloger, meshSpec sm
 		return nil, err
 	}
 
-	inboundListener := buildInboundListener()
+	inboundListener := newInboundListener()
 	meshFilterChain, err := getInboundInMeshFilterChain(proxyServiceName, catalog, marshalledInboundConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to construct in-mesh filter chain for proxy %s", proxy.GetCommonName())


### PR DESCRIPTION
This PR simplifies the creation of Listener Envoy Structs

 - `buildInboundListener` renamed to `newInboundListener`
 - `buildOutboundListener` renamed to `newOutboundListener`
 - `newOutboundListener` is responsible for creating its own `HttpConnectionManager`


This is part of https://github.com/open-service-mesh/osm/pull/1166
ref https://github.com/open-service-mesh/osm/issues/734
ref https://github.com/open-service-mesh/osm/issues/666