### PR TITLE
demo: deploy apps in the order of their dependencies

### DIFF
--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -5,12 +5,15 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-# Deploy bookstore
+# Deploy apps in the order of their dependencies to avoid initial timing errors
+# in osm-controller logs. Server apps are deployed before client apps.
+
+# Deploy bookwarehouse
+./demo/deploy-bookwarehouse.sh
+# Deploy bookstore versions
 ./demo/deploy-bookstore.sh "v1"
 ./demo/deploy-bookstore.sh "v2"
 # Deploy bookbuyer
 ./demo/deploy-bookbuyer.sh
 # Deploy bookthief
 ./demo/deploy-bookthief.sh
-
-./demo/deploy-bookwarehouse.sh


### PR DESCRIPTION
Deploy server apps before dependent clients, so that initial timing
related errors in osm-controller logs are avoided. This change is
purely a cosmetic fix to avoid false alarms in the demo.

Resolves #955