### PR TITLE
tracing: Set EnvoyNodeID to the ServiceAccount of the Pod

### DIFF
--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -73,9 +73,15 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 		initContainersBasePath)...,
 	)
 
+	// envoyNodeID and envoyClusterID are required for Envoy proxy to start.
+	envoyNodeID := pod.Spec.ServiceAccountName
+
+	// envoyCluster ID will be used as an identifier to the tracing sink (will be used in Zipkin for example).
+	envoyClusterID := fmt.Sprintf("%s.%s", pod.Spec.ServiceAccountName, namespace)
+
 	patches = append(patches, addContainer(
 		pod.Spec.Containers,
-		getEnvoySidecarContainerSpec(envoyContainerName, wh.config.SidecarImage, proxyUUID, proxyUUID),
+		getEnvoySidecarContainerSpec(envoyContainerName, wh.config.SidecarImage, envoyNodeID, envoyClusterID),
 		"/spec/containers")...,
 	)
 


### PR DESCRIPTION
The goal of this PR is to make Zipkin tracing a bit better in the short term.
Currently we seed UUIDs in Zipkin: 
![image](https://user-images.githubusercontent.com/49918230/88607593-74856f00-d034-11ea-9172-41571b6b9bbd.png)

With this change we'll see aggregations of traffic per Service Account.

After: 
![image](https://user-images.githubusercontent.com/49918230/88616454-0d25ea00-d049-11ea-9cc3-06f4000c71a3.png)
