### PR TITLE
feat(ci): add release GH Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: Release
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  version:
+    name: Set Version from git ref
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - id: version
+        run: echo "::set-output name=version::$(sed 's#^refs/tags/\(.*\)#\1#' <<< '${{ github.ref }}')"
+
+  binaries:
+    name: Binaries
+    runs-on: ubuntu-latest
+    needs: version
+    env:
+      CLI_VERSION: ${{ needs.version.outputs.version }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+      - name: Setup Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Build Binaries
+        run: |
+          make release-artifacts
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+      - name: Upload macOS .zip
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-darwin-amd64.zip"
+          asset_name: "osm-${{ env.CLI_VERSION }}-darwin-amd64.zip"
+          asset_content_type: application/zip
+      - name: Upload macOS .tar.gz
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-darwin-amd64.tar.gz"
+          asset_name: "osm-${{ env.CLI_VERSION }}-darwin-amd64.tar.gz"
+          asset_content_type: application/gzip
+      - name: Upload Linux .zip
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-linux-amd64.zip"
+          asset_name: "osm-${{ env.CLI_VERSION }}-linux-amd64.zip"
+          asset_content_type: application/zip
+      - name: Upload Linux .tar.gz
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-linux-amd64.tar.gz"
+          asset_name: "osm-${{ env.CLI_VERSION }}-linux-amd64.tar.gz"
+          asset_content_type: application/gzip
+      - name: Upload Checksums
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: _dist/sha256sums.txt
+          asset_name: sha256sums.txt
+          asset_content_type: text/plain
+
+  images:
+    name: Docker Images
+    runs-on: ubuntu-latest
+    needs: version
+    env:
+      DOCKER_USER: ${{ secrets.RELEASE_DOCKER_USER }}
+      DOCKER_PASS: ${{ secrets.RELEASE_DOCKER_PASS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+      - name: Setup Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Docker Login
+        run: docker login --username "$DOCKER_USER" --password-stdin <<< "$DOCKER_PASS"
+      - name: Push images with version tag
+        env:
+          CTR_TAG: ${{ needs.version.outputs.version }}
+        run: make docker-push
+      - name: Push images with latest tag
+        env:
+          CTR_TAG: latest
+        run: make docker-push


### PR DESCRIPTION
This PR adds a new Github Actions workflow whenever any tag is pushed. It will create a new GitHub release, upload CLI binaries and checksums to the release, and push docker images to the openservicemesh Docker Hub org with `latest` and version tags equal to the git tag name. Creating release notes and adding them to the release is not handled by these steps. (I did experiment with using a git tag annotation for the release notes, but GitHub doesn't render it as Markdown. I didn't see an easy way to extract just the annotation of a tag either to feed it into the API.)

I also added two new secrets to the repo for GH Actions: `RELEASE_DOCKER_USER` and `RELEASE_DOCKER_PASS` to keep Docker Hub credentials distinct from the credentials we use for the registry used for tests.

Things to consider:
- What should the manual step to cut a release be? We could either trigger based on a new release being published in GitHub or a tag being pushed, then have the action create the release (which is what it does now). Having the action create the release minimizes the time between the release being published and the assets being uploaded. Creating the release manually lets us add release notes before the release is published (so they would be included in email notifications).
- Should we make every release before v1.0 a pre-release? i.e. not reachable via https://github.com/open-service-mesh/osm/releases/latest? Or reserve that for explicit alpha/beta/rc/etc. tags?
- Should docker image tags with the version have a leading `v`? Looks like most of the [official Docker images](https://hub.docker.com/search?q=&type=image&image_filter=official) do not.
- Should we push other floating tags for images to Docker Hub (Like a `MAJOR` and `MAJOR.MINOR` in addition to `MAJOR.MINOR.PATCH`)?

Sample build from my fork: https://github.com/nojnhuh/osm/actions/runs/186035251
The release it generated: https://github.com/nojnhuh/osm/releases/tag/v0.1.0-test

Fixes #1183
