### PR TITLE
debugger: Add links to debug endpoints

### DIFF
--- a/pkg/debugger/envoy.go
+++ b/pkg/debugger/envoy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
-func (ds debugServer) getEnvoyConfig(pod *v1.Pod, cn certificate.CommonName) string {
+func (ds debugServer) getEnvoyConfig(pod *v1.Pod, cn certificate.CommonName, url string) string {
 	log.Info().Msgf("Getting Envoy config for CN=%s, podIP=%s", cn, pod.Status.PodIP)
 
 	minPort := 16000
@@ -28,7 +28,7 @@ func (ds debugServer) getEnvoyConfig(pod *v1.Pod, cn certificate.CommonName) str
 	<-portFwdRequest.Ready
 
 	client := &http.Client{}
-	resp, err := client.Get(fmt.Sprintf("http://%s:%d/certs", "localhost", portFwdRequest.LocalPort))
+	resp, err := client.Get(fmt.Sprintf("http://%s:%d/%s", "localhost", portFwdRequest.LocalPort, url))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting pod with CN=%s and podIP=%s", cn, pod.Status.PodIP)
 		return fmt.Sprintf("Error: %s", err)

--- a/pkg/debugger/index.go
+++ b/pkg/debugger/index.go
@@ -7,8 +7,11 @@ import (
 
 func (ds debugServer) getDebugIndex(handlers map[string]http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = fmt.Fprint(w, `<ul>`)
 		for url := range handlers {
-			_, _ = fmt.Fprintf(w, "%s\n", url)
+			_, _ = fmt.Fprintf(w, `<li><a href="%s">%s</a><br/>`, url, url)
 		}
+		_, _ = fmt.Fprint(w, `</ul>`)
 	})
 }

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -22,6 +22,17 @@ type policies struct {
 	Services         []*corev1.Service           `json:"services"`
 }
 
+func (ds debugServer) getOSMConfigHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		confJSON, err := ds.configurator.GetConfigMap()
+		if err != nil {
+			log.Error().Err(err)
+			return
+		}
+		_, _ = fmt.Fprint(w, string(confJSON))
+	})
+}
+
 func (ds debugServer) getSMIPoliciesHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -10,7 +10,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
-const specificProxyQueryKey = "proxy"
+const (
+	specificProxyQueryKey = "proxy"
+	proxyConfigQueryKey   = "cfg"
+)
 
 func (ds debugServer) getProxies() http.Handler {
 	// This function is needed to convert the list of connected proxies to
@@ -24,12 +27,15 @@ func (ds debugServer) getProxies() http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if specificProxy, ok := r.URL.Query()[specificProxyQueryKey]; !ok {
+		w.Header().Set("Content-Type", "text/html")
+		if proxyConfigDump, ok := r.URL.Query()[proxyConfigQueryKey]; ok {
+			ds.getConfigDump(certificate.CommonName(proxyConfigDump[0]), w)
+		} else if specificProxy, ok := r.URL.Query()[specificProxyQueryKey]; ok {
+			ds.getProxy(certificate.CommonName(specificProxy[0]), w)
+		} else {
 			printProxies(w, listConnected(), "Connected")
 			printProxies(w, ds.meshCatalogDebugger.ListExpectedProxies(), "Expected")
 			printProxies(w, ds.meshCatalogDebugger.ListDisconnectedProxies(), "Disconnected")
-		} else {
-			ds.getProxy(certificate.CommonName(specificProxy[0]), w)
 		}
 	})
 }
@@ -42,12 +48,25 @@ func printProxies(w http.ResponseWriter, proxies map[certificate.CommonName]time
 
 	sort.Strings(commonNames)
 
-	_, _ = fmt.Fprintf(w, "---| %s Proxies (%d):\n", category, len(proxies))
+	_, _ = fmt.Fprintf(w, "<h1>%s Proxies (%d):</h1>", category, len(proxies))
+	_, _ = fmt.Fprint(w, `<table>`)
+	_, _ = fmt.Fprint(w, "<tr><td>#</td><td>Envoy's certificate CN</td><td>Connected At</td><td>How long ago</td><td>tools</td></tr>")
 	for idx, cn := range commonNames {
 		ts := proxies[certificate.CommonName(cn)]
-		_, _ = fmt.Fprintf(w, "\t%d: \t %s \t %+v \t(%+v ago)\n", idx, cn, ts, time.Since(ts))
+		_, _ = fmt.Fprintf(w, `<tr><td>%d:</td><td>%s</td><td>%+v</td><td>(%+v ago)</td><td><a href="/debug/proxy?%s=%s">certs</a></td><td><a href="/debug/proxy?%s=%s">cfg</a></td></tr>`,
+			idx, cn, ts, time.Since(ts), specificProxyQueryKey, cn, proxyConfigQueryKey, cn)
 	}
-	_, _ = fmt.Fprint(w, "\n")
+	_, _ = fmt.Fprint(w, `</table>`)
+}
+
+func (ds debugServer) getConfigDump(cn certificate.CommonName, w http.ResponseWriter) {
+	pod, err := catalog.GetPodFromCertificate(cn, ds.kubeClient)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	envoyConfig := ds.getEnvoyConfig(pod, cn, "config_dump")
+	_, _ = fmt.Fprintf(w, "%s", envoyConfig)
 }
 
 func (ds debugServer) getProxy(cn certificate.CommonName, w http.ResponseWriter) {
@@ -55,6 +74,7 @@ func (ds debugServer) getProxy(cn certificate.CommonName, w http.ResponseWriter)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
 	}
-	envoyConfig := ds.getEnvoyConfig(pod, cn)
-	_, _ = fmt.Fprintf(w, "%s\n", envoyConfig)
+	w.Header().Set("Content-Type", "application/json")
+	envoyConfig := ds.getEnvoyConfig(pod, cn, "certs")
+	_, _ = fmt.Fprintf(w, "%s", envoyConfig)
 }

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -9,13 +9,14 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
-// GetHandlers implements DebugServer interface and returns the rist of URLs and the handling functions.
+// GetHandlers implements DebugServer interface and returns the rest of URLs and the handling functions.
 func (ds debugServer) GetHandlers() map[string]http.Handler {
 	handlers := map[string]http.Handler{
 		"/debug/certs":    ds.getCertHandler(),
 		"/debug/xds":      ds.getXDSHandler(),
 		"/debug/proxy":    ds.getProxies(),
 		"/debug/policies": ds.getSMIPoliciesHandler(),
+		"/debug/config":   ds.getOSMConfigHandler(),
 	}
 
 	// provides an index of the available /debug endpoints
@@ -34,5 +35,7 @@ func NewDebugServer(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebu
 
 		// We need the Kubernetes config to be able to establish port forwarding to the Envoy pod we want to debug.
 		kubeConfig: kubeConfig,
+
+		configurator: cfg,
 	}
 }

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -26,6 +27,7 @@ type debugServer struct {
 	meshCatalogDebugger MeshCatalogDebugger
 	kubeConfig          *rest.Config
 	kubeClient          kubernetes.Interface
+	configurator        configurator.Configurator
 }
 
 // CertificateManagerDebugger is an interface with methods for debugging certificate issuance.


### PR DESCRIPTION
This is a small tweak to the OSM control plane's `/debug` endpoints, making them clickable links.

![image](https://user-images.githubusercontent.com/49918230/88744282-c0e7b200-d0fb-11ea-9b51-716a5197389d.png)
