### PR TITLE
errors: use errors pkg for error types across the repo

### DIFF
--- a/cmd/ads/validate.go
+++ b/cmd/ads/validate.go
@@ -1,40 +1,41 @@
 package main
 
 import (
-	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // validateCLIParams contains all checks necessary that various permutations of the CLI flags are consistent
 func validateCLIParams() error {
 	if _, ok := certManagers[certificateManagerKind(*certManagerKind)]; !ok {
-		return fmt.Errorf("Certificate manager %s is not one of possible options: %s", *certManagerKind, strings.Join(getPossibleCertManagers(), ", "))
+		return errors.Errorf("Certificate manager %s is not one of possible options: %s", *certManagerKind, strings.Join(getPossibleCertManagers(), ", "))
 	}
 
 	if *certManagerKind == vaultKind {
 		if *vaultToken == "" {
-			return fmt.Errorf("Empty Hashi Vault token")
+			return errors.Errorf("Empty Hashi Vault token")
 		}
 	}
 
 	if meshName == "" {
-		return fmt.Errorf("Please specify the mesh name using --mesh-name")
+		return errors.Errorf("Please specify the mesh name using --mesh-name")
 	}
 
 	if osmNamespace == "" {
-		return fmt.Errorf("Please specify the OSM namespace using --osm-namespace")
+		return errors.Errorf("Please specify the OSM namespace using --osm-namespace")
 	}
 
 	if injectorConfig.InitContainerImage == "" {
-		return fmt.Errorf("Please specify the init container image using --init-container-image")
+		return errors.Errorf("Please specify the init container image using --init-container-image")
 	}
 
 	if injectorConfig.SidecarImage == "" {
-		return fmt.Errorf("Please specify the sidecar image using --sidecar-image")
+		return errors.Errorf("Please specify the sidecar image using --sidecar-image")
 	}
 
 	if webhookName == "" {
-		return fmt.Errorf("Invalid --webhook-name value: '%s'", webhookName)
+		return errors.Errorf("Invalid --webhook-name value: '%s'", webhookName)
 	}
 	return nil
 }

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -152,7 +152,7 @@ func (i *installCmd) run(config *helm.Configuration) error {
 	meshNameErrs := validation.IsDNS1123Label(i.meshName)
 
 	if len(meshNameErrs) != 0 {
-		return fmt.Errorf("Invalid mesh-name: %v", meshNameErrs)
+		return errors.Errorf("Invalid mesh-name: %v", meshNameErrs)
 	}
 
 	if strings.EqualFold(i.certManager, "vault") {
@@ -164,14 +164,14 @@ func (i *installCmd) run(config *helm.Configuration) error {
 			missingFields = append(missingFields, "vault-token")
 		}
 		if len(missingFields) != 0 {
-			return fmt.Errorf("Missing arguments for cert-manager vault: %v", missingFields)
+			return errors.Errorf("Missing arguments for cert-manager vault: %v", missingFields)
 		}
 	}
 
 	// Validate CIDR ranges if egress is enabled
 	if i.enableEgress {
 		if err := validateCIDRs(i.meshCIDRRanges); err != nil {
-			return fmt.Errorf("Invalid mesh-cidr-ranges: %q, error: %v", i.meshCIDRRanges, err)
+			return errors.Errorf("Invalid mesh-cidr-ranges: %q, error: %v", i.meshCIDRRanges, err)
 		}
 	}
 
@@ -239,18 +239,18 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 }
 
 func errMeshAlreadyExists(name string) error {
-	return fmt.Errorf("Mesh %s already exists in cluster. Please specify a new mesh name using --mesh-name", name)
+	return errors.Errorf("Mesh %s already exists in cluster. Please specify a new mesh name using --mesh-name", name)
 }
 
 func validateCIDRs(cidrRanges []string) error {
 	if len(cidrRanges) == 0 {
-		return fmt.Errorf("CIDR ranges cannot be empty")
+		return errors.Errorf("CIDR ranges cannot be empty")
 	}
 	for _, cidr := range cidrRanges {
 		cidrNoSpaces := strings.Replace(cidr, " ", "", -1)
 		_, _, err := net.ParseCIDR(cidrNoSpaces)
 		if err != nil {
-			return fmt.Errorf("Error parsing CIDR %s", cidr)
+			return errors.Errorf("Error parsing CIDR %s", cidr)
 		}
 	}
 	return nil

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -464,7 +464,7 @@ var _ = Describe("Running the install command", func() {
 		})
 
 		It("should error", func() {
-			Expect(err).To(MatchError(errMeshAlreadyExists(install.meshName)))
+			Expect(err.Error()).To(Equal(errMeshAlreadyExists(install.meshName).Error()))
 		})
 	})
 

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/cmd/helm/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,12 +41,12 @@ func newNamespaceAdd(out io.Writer) *cobra.Command {
 			namespaceAdd.namespaces = args
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return fmt.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig")
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return fmt.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
 			}
 			namespaceAdd.clientSet = clientset
 			return namespaceAdd.run()
@@ -67,7 +68,7 @@ func (a *namespaceAddCmd) run() error {
 		patch := `{"metadata":{"labels":{"` + constants.OSMKubeResourceMonitorAnnotation + `":"` + a.meshName + `"}}}`
 		_, err := a.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 		if err != nil {
-			return fmt.Errorf("Could not label namespace [%s]: %v", ns, err)
+			return errors.Errorf("Could not label namespace [%s]: %v", ns, err)
 		}
 
 		fmt.Fprintf(a.out, "Namespace [%s] succesfully added to mesh [%s]\n", ns, a.meshName)

--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/cmd/helm/require"
 	v1 "k8s.io/api/core/v1"
@@ -40,12 +41,12 @@ func newNamespaceList(out io.Writer) *cobra.Command {
 
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return fmt.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig")
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return fmt.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
 			}
 			namespaceList.clientSet = clientset
 			return namespaceList.run()
@@ -62,7 +63,7 @@ func newNamespaceList(out io.Writer) *cobra.Command {
 func (l *namespaceListCmd) run() error {
 	namespaces, err := l.selectNamespaces()
 	if err != nil {
-		return fmt.Errorf("Could not list namespaces related to osm [%s]: %v", l.meshName, err)
+		return errors.Errorf("Could not list namespaces related to osm [%s]: %v", l.meshName, err)
 	}
 
 	if len(namespaces.Items) == 0 {

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -1,6 +1,6 @@
 package catalog
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errInvalidCertificateCN                  = errors.New("invalid cn")

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -1,10 +1,10 @@
 package vault
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
@@ -37,7 +37,7 @@ func NewCertManager(vaultAddr, token string, validityPeriod time.Duration, vault
 
 	var err error
 	if c.client, err = api.NewClient(config); err != nil {
-		return nil, fmt.Errorf("Error creating Vault CertManager without TLS at %s", vaultAddr)
+		return nil, errors.Errorf("Error creating Vault CertManager without TLS at %s", vaultAddr)
 	}
 
 	log.Info().Msgf("Created Vault CertManager, with vaultRole=%q at %v", vaultRole, vaultAddr)

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/openservicemesh/osm/pkg/cli"
+	"github.com/pkg/errors"
 	authv1 "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -89,7 +90,7 @@ func (c *Checker) checkAuthz(verb, group, version, resource, name string) error 
 	}
 
 	if !result.Status.Allowed {
-		return fmt.Errorf("cannot %s %s", verb, resource)
+		return errors.Errorf("cannot %s %s", verb, resource)
 	}
 	return nil
 }
@@ -132,7 +133,7 @@ var (
 			v, _ := semver.NewVersion(c.k8sVersion.String())
 			minVer, _ := semver.NewConstraint("^1.15-0")
 			if !minVer.Check(v) {
-				err = fmt.Errorf("Kubernetes version %s does not match supported versions %s", c.k8sVersion, minVer)
+				err = errors.Errorf("Kubernetes version %s does not match supported versions %s", c.k8sVersion, minVer)
 			}
 			return
 		},
@@ -175,7 +176,7 @@ var (
 					}
 				}
 			}
-			return fmt.Errorf("No PodSecurityPolicies found providing the capabilities %q, sidecar injection will fail if the PSP admission controller is running", requiredCaps)
+			return errors.Errorf("No PodSecurityPolicies found providing the capabilities %q, sidecar injection will fail if the PSP admission controller is running", requiredCaps)
 		},
 	}
 )

--- a/pkg/configurator/errors.go
+++ b/pkg/configurator/errors.go
@@ -1,6 +1,6 @@
 package configurator
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errInvalidKeyInConfigMap = errors.New("invalid key in ConfigMap")

--- a/pkg/endpoint/providers/azure/client.go
+++ b/pkg/endpoint/providers/azure/client.go
@@ -1,12 +1,11 @@
 package azure
 
 import (
-	"fmt"
-
 	r "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
 	c "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/providers/azure"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -19,7 +18,7 @@ func NewProvider(subscriptionID string, azureAuthFile string, stop chan struct{}
 	var az Client
 
 	if authorizer, err = azure.GetAuthorizerWithRetry(azureAuthFile, n.DefaultBaseURI); err != nil {
-		return az, fmt.Errorf("Failed to obtain authentication token for Azure Resource Manager: %+v", err)
+		return az, errors.Errorf("Failed to obtain authentication token for Azure Resource Manager: %+v", err)
 	}
 
 	// TODO(draychev): The subscriptionID should be observed from the AzureResource (SMI)
@@ -63,7 +62,7 @@ func NewProvider(subscriptionID string, azureAuthFile string, stop chan struct{}
 	*/
 
 	if err := az.run(stop); err != nil {
-		return az, fmt.Errorf("Failed to start Azure EndpointsProvider client: %+v", err)
+		return az, errors.Errorf("Failed to start Azure EndpointsProvider client: %+v", err)
 	}
 
 	return az, nil

--- a/pkg/endpoint/providers/azure/errors.go
+++ b/pkg/endpoint/providers/azure/errors.go
@@ -1,5 +1,5 @@
 package azure
 
-import "errors"
+import "github.com/pkg/errors"
 
 var errIncorrectAzureURI = errors.New("incorrect Azure URI")

--- a/pkg/endpoint/providers/azure/kubernetes/client.go
+++ b/pkg/endpoint/providers/azure/kubernetes/client.go
@@ -1,9 +1,9 @@
 package azure
 
 import (
-	"fmt"
 	"reflect"
 
+	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -27,7 +27,7 @@ func NewClient(kubeClient kubernetes.Interface, azureResourceKubeConfig *rest.Co
 
 	k8sClient := newClient(kubeClient, azureResourceClient, namespaceController)
 	if err := k8sClient.Run(stop); err != nil {
-		return nil, fmt.Errorf("Failed to start %s client: %+v", kubernetesClientName, err)
+		return nil, errors.Errorf("Failed to start %s client: %+v", kubernetesClientName, err)
 	}
 	return k8sClient, nil
 }

--- a/pkg/endpoint/providers/azure/kubernetes/errors.go
+++ b/pkg/endpoint/providers/azure/kubernetes/errors.go
@@ -1,6 +1,6 @@
 package azure
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errSyncingCaches     = errors.New("syncing caches")

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"fmt"
 	"net"
 	"reflect"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -55,7 +55,7 @@ func NewProvider(kubeClient kubernetes.Interface, namespaceController namespace.
 	informerCollection.Deployments.AddEventHandler(k8s.GetKubernetesEventHandlers("Deployments", "Kubernetes", client.announcements, shouldObserve))
 
 	if err := client.run(stop); err != nil {
-		return nil, fmt.Errorf("Failed to start Kubernetes EndpointProvider client: %+v", err)
+		return nil, errors.Errorf("Failed to start Kubernetes EndpointProvider client: %+v", err)
 	}
 
 	return &client, nil

--- a/pkg/endpoint/providers/kube/errors.go
+++ b/pkg/endpoint/providers/kube/errors.go
@@ -1,6 +1,6 @@
 package kube
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errSyncingCaches                      = errors.New("failed initial sync of resources required for ingress")

--- a/pkg/envoy/lds/errors.go
+++ b/pkg/envoy/lds/errors.go
@@ -1,6 +1,6 @@
 package lds
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errInvalidCIDRRange = errors.New("invalid CIDR range")

--- a/pkg/ingress/errors.go
+++ b/pkg/ingress/errors.go
@@ -1,6 +1,6 @@
 package ingress
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errSyncingCaches = errors.New("Failed initial cache sync for Ingress informer")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
@@ -68,7 +69,7 @@ func SetLogLevel(verbosity string) error {
 
 	default:
 		allowedLevels := []string{"debug", "info", "warn", "error", "fatal", "panic", "disabled", "trace"}
-		return fmt.Errorf("Invalid log level '%s' specified. Please specify one of %v", verbosity, allowedLevels)
+		return errors.Errorf("Invalid log level '%s' specified. Please specify one of %v", verbosity, allowedLevels)
 	}
 	return nil
 }

--- a/pkg/namespace/errors.go
+++ b/pkg/namespace/errors.go
@@ -1,6 +1,6 @@
 package namespace
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errSyncingCaches = errors.New("Failed initial cache sync for Namespace informers")

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -1,10 +1,10 @@
 package smi
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -47,7 +47,7 @@ func NewMeshSpecClient(smiKubeConfig *rest.Config, kubeClient kubernetes.Interfa
 
 	err := client.run(stop)
 	if err != nil {
-		return client, fmt.Errorf("Could not start %s client", kubernetesClientName)
+		return client, errors.Errorf("Could not start %s client", kubernetesClientName)
 	}
 	return client, nil
 }

--- a/pkg/smi/errors.go
+++ b/pkg/smi/errors.go
@@ -1,6 +1,6 @@
 package smi
 
-import "errors"
+import "github.com/pkg/errors"
 
 var (
 	errSyncingCaches     = errors.New("failed initial sync of resources required for ingress")

--- a/pkg/utils/mtls.go
+++ b/pkg/utils/mtls.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -18,14 +18,14 @@ import (
 func setupMutualTLS(insecure bool, serverName string, certPem []byte, keyPem []byte, ca []byte) (grpc.ServerOption, error) {
 	certif, err := tls.X509KeyPair(certPem, keyPem)
 	if err != nil {
-		return nil, fmt.Errorf("[grpc][mTLS][%s] Failed loading Certificate (%+v) and Key (%+v) PEM files", serverName, certPem, keyPem)
+		return nil, errors.Errorf("[grpc][mTLS][%s] Failed loading Certificate (%+v) and Key (%+v) PEM files", serverName, certPem, keyPem)
 	}
 
 	certPool := x509.NewCertPool()
 
 	// Load the set of Root CAs
 	if ok := certPool.AppendCertsFromPEM(ca); !ok {
-		return nil, fmt.Errorf("[grpc][mTLS][%s] Filed to append client certs", serverName)
+		return nil, errors.Errorf("[grpc][mTLS][%s] Filed to append client certs", serverName)
 	}
 
 	tlsConfig := tls.Config{


### PR DESCRIPTION
Makes the code consistent in terms of defining values for
the error type. The errors pkg provides a few useful error
handling primitives such as error wrapping, cause retrieval etc.

Resolves #1146