### PR TITLE
smi: Small refactor; Removing TODOs

### DIFF
--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -95,7 +95,7 @@ func (c *Client) run(stop <-chan struct{}) error {
 	return nil
 }
 
-// GetID implements EndpointsProvider interface and returns a string descriptor / identifier of the compute provider.
+// GetID implements endpoints.Provider interface and returns a string descriptor / identifier of the compute provider.
 func (c *Client) GetID() string {
 	return c.providerIdent
 }


### PR DESCRIPTION
This PR is a noop - no functional code changes.
In this PR we:
  - improve (delete) a few comment
  - remove a stale TODO
  - most importantly - fix variable names that collide with imported package names