### PR TITLE
Setting default NS on get_mesh_cidr.sh

### DIFF
--- a/scripts/get_mesh_cidr.sh
+++ b/scripts/get_mesh_cidr.sh
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: fake
+  namespace: default
 spec:
   clusterIP: 1.1.1.1
   ports:


### PR DESCRIPTION
Users might be using a different ns default other than
kubectl usual "default", ie. through `kubectl config set-context` for example. 
So it is possible that the custom namespace set as default does not exist,
in which case the script fails. To avoid this, force the namespace.