### PR TITLE
fix(docs): align k8s version pre-req to v1.15

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -2,7 +2,7 @@
 
 ## System Requirements
 - Go version 1.14 or higher
-- Kubectl version 1.16 or higher
+- Kubectl version 1.15 or higher
 - Docker CLI
    - on a Debian based GNU/Linux system: `sudo apt-get install docker`
    - on a macOS use `brew install docker` or alternatively visit [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)


### PR DESCRIPTION
This PR ensures the minimum Kubernetes version requirement is
consistently documented to be v1.15.0 since our CI cluster is v1.15.11
and our documentation should align with the `osm check --pre-install`
command.

Fixes #1290