### PR TITLE
Adding a default for DEPLOY_TRAFFIC_SPLIT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,10 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 
 # optional: Maximum of iterations to test for expected return codes. 0 means unlimited.
 # export CI_MAX_ITERATIONS_THRESHOLD=0
+
+# optional: Whether to deploy traffic split policy or not
+# Default: true
+# export DEPLOY_TRAFFIC_SPLIT=true
 #--------------------------------------
 
 ### The section below configures certificates management

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -25,6 +25,7 @@ CERT_MANAGER="${CERT_MANAGER:-tresor}"
 CTR_REGISTRY="${CTR_REGISTRY:-osmci.azurecr.io/osm}"
 CTR_REGISTRY_CREDS_NAME="${CTR_REGISTRY_CREDS_NAME:-acr-creds}"
 CTR_TAG="${CTR_TAG:-latest}"
+DEPLOY_TRAFFIC_SPLIT="${DEPLOY_TRAFFIC_SPLIT:-true}"
 MESH_CIDR=$(./scripts/get_mesh_cidr.sh)
 
 optionalInstallArgs=$*
@@ -133,7 +134,7 @@ bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOK
 ./demo/deploy-apps.sh
 
 # Apply SMI policies
-if [ "${DEPLOY_TRAFFIC_SPLIT:-true}" = "true" ]; then
+if [ "$DEPLOY_TRAFFIC_SPLIT" = "true" ]; then
     ./demo/deploy-traffic-split.sh
 fi
 


### PR DESCRIPTION
It would be nice to have a default for `DEPLOY_TRAFFIC_SPLIT` to avoid having to know to put it in `.env` before running the demo.