### PR TITLE
envoy: Replace deprecated v3 tracing API for HTTPConnectionManager 

### DIFF
--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -2,9 +2,11 @@ package lds
 
 import (
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xds_tracing "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -17,7 +19,7 @@ const (
 )
 
 func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *xds_hcm.HttpConnectionManager {
-	connManager := xds_hcm.HttpConnectionManager{
+	connManager := &xds_hcm.HttpConnectionManager{
 		StatPrefix: statPrefix,
 		CodecType:  xds_hcm.HttpConnectionManager_AUTO,
 		HttpFilters: []*xds_hcm.HttpFilter{{
@@ -37,12 +39,34 @@ func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *
 		connManager.GenerateRequestId = &wrappers.BoolValue{
 			Value: true,
 		}
-		connManager.Tracing = &xds_hcm.HttpConnectionManager_Tracing{
-			Verbose: true,
+
+		zipkinConf := &xds_tracing.ZipkinConfig{
+			CollectorCluster:         constants.EnvoyZipkinCluster,
+			CollectorEndpoint:        constants.EnvoyZipkinEndpoint,
+			CollectorEndpointVersion: xds_tracing.ZipkinConfig_HTTP_JSON,
 		}
+
+		zipkinConfMarshalled, err := ptypes.MarshalAny(zipkinConf)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error marshalling zipkinConf config %s", err)
+			return connManager
+		}
+
+		tracing := &xds_hcm.HttpConnectionManager_Tracing{
+			Verbose: true,
+			Provider: &xds_tracing.Tracing_Http{
+				// Name must refer to an instantiatable tracing driver
+				Name: "envoy.tracers.zipkin",
+				ConfigType: &xds_tracing.Tracing_Http_TypedConfig{
+					TypedConfig: zipkinConfMarshalled,
+				},
+			},
+		}
+
+		connManager.Tracing = tracing
 	}
 
-	return &connManager
+	return connManager
 }
 
 func getPrometheusConnectionManager(listenerName string, routeName string, clusterName string) *xds_hcm.HttpConnectionManager {

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta) ([]byte, error) {
@@ -106,18 +105,6 @@ func getEnvoyConfigYAML(config envoyBootstrapConfigMeta) ([]byte, error) {
 							},
 						},
 					},
-				},
-			},
-		},
-
-		"tracing": map[string]interface{}{
-			"http": map[string]interface{}{
-				"name": "envoy.zipkin",
-				"typed_config": map[string]interface{}{
-					"@type":                      envoy.TypeZipkinConfig,
-					"collector_cluster":          constants.EnvoyZipkinCluster,
-					"collector_endpoint":         constants.EnvoyZipkinEndpoint,
-					"collector_endpoint_version": "HTTP_JSON",
 				},
 			},
 		},

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -64,14 +64,6 @@ static_resources:
             trusted_ca:
               inline_bytes: RootCert
     type: LOGICAL_DNS
-tracing:
-  http:
-    name: envoy.zipkin
-    typed_config:
-      '@type': type.googleapis.com/envoy.config.trace.v3.ZipkinConfig
-      collector_cluster: envoy-zipkin-cluster
-      collector_endpoint: /api/v2/spans
-      collector_endpoint_version: HTTP_JSON
 `
 
 var _ = Describe("Test Envoy configuration creation", func() {


### PR DESCRIPTION
This field has been deprecated in favor of HttpConnectionManager.Tracing.provider,
which works on per Connection Manager basis.

https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto

- added a test
- fixed prometheus test which was using wrong
connection manager