### PR TITLE
ref(*): update valid mesh name constraints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,9 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 
 # optional: The mesh name for the osm installation
 # Default: osm
+# Must conform to same guidlines as a valid Kubernetes label value. Must be 63 characters
+# or less and must be empty or begin and end with an alphanumeric character ([a-z0-9A-Z])
+# with dashes (-), underscores (_), dots (.), and alphanumerics between.
 # export MESH_NAME=osm
 
 ### When CERT_MANAGER is set to "vault" the following also have to be set:

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -36,7 +36,11 @@ Example:
 Multiple control plane installations can exist within a cluster. Each
 control plane is given a cluster-wide unqiue identifier called mesh name.
 A mesh name can be passed in via the --mesh-name flag. By default, the
-mesh-name name will be set to "osm."
+mesh-name name will be set to "osm." The mesh name must conform to same
+guidlines as a valid Kubernetes label value. Must be 63 characters or
+less and must be empty or begin and end with an alphanumeric character
+([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and
+alphanumerics between.
 
 Example:
   $ osm install --mesh-name "hello-osm"
@@ -149,10 +153,10 @@ func (i *installCmd) run(config *helm.Configuration) error {
 		return err
 	}
 
-	meshNameErrs := validation.IsDNS1123Label(i.meshName)
+	meshNameErrs := validation.IsValidLabelValue(i.meshName)
 
 	if len(meshNameErrs) != 0 {
-		return errors.Errorf("Invalid mesh-name: %v", meshNameErrs)
+		return errors.Errorf("Invalid mesh-name.\nValid mesh-name:\n- must be no longer than 63 characters\n- must consist of alphanumeric characters, '-', '_' or '.'\n- must start and end with an alphanumeric character\nregex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'")
 	}
 
 	if strings.EqualFold(i.certManager, "vault") {

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -511,7 +511,7 @@ var _ = Describe("Running the install command", func() {
 		})
 
 		It("should error", func() {
-			Expect(err).To(MatchError("Invalid mesh-name: [must be no more than 63 characters a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]"))
+			Expect(err).To(MatchError("Invalid mesh-name.\nValid mesh-name:\n- must be no longer than 63 characters\n- must consist of alphanumeric characters, '-', '_' or '.'\n- must start and end with an alphanumeric character\nregex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'"))
 		})
 	})
 


### PR DESCRIPTION
* mesh name is used as a the value for the "openservicemesh.io/monitoried-by"
label key and should have the same constraints as Kubernetes label
values

resolves #1148

Output:
```console
$ bin/osm install --mesh-name "somessuperrrrinvalidname==bbdfkdjf"
Error: Invalid mesh-name.
Valid mesh-name:
- must be no longer than 63 characters
- must consist of alphanumeric characters, '-', '_' or '.'
- must start and end with an alphanumeric character
regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'
```