### PR TITLE
Added race detector to go-test and makefile changes to install required go-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,21 @@ clean-osm:
 .PHONY: docker-build
 docker-build: docker-build-osm-controller docker-build-bookbuyer docker-build-bookstore docker-build-bookwarehouse
 
+.PHONY: go-tools
+go-tools:
+	./scripts/go-tools.sh
+
+.PHONY: go-checks
+go-checks: go-vet go-lint go-fmt
+
 .PHONY: go-vet
 go-vet:
 	go vet ./...
 
 .PHONY: go-lint
 go-lint:
-	golint ./cmd ./pkg
+	golint ./cmd/...
+	golint ./pkg/...
 	golangci-lint run --tests --enable-all # --disable gochecknoglobals --disable gochecknoinit
 
 .PHONY: go-fmt

--- a/scripts/go-test.sh
+++ b/scripts/go-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-go test -v ./...; echo $?
+go test -race -v ./...; echo $?

--- a/scripts/go-tools.sh
+++ b/scripts/go-tools.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+go get -u golang.org/x/lint/golint
+go get -u github.com/jstemmer/go-junit-report
+go get -u github.com/axw/gocov/gocov
+go get -u github.com/AlekSi/gocov-xml
+go get -u github.com/matm/gocov-html


### PR DESCRIPTION
Changeset include the following:
- added race flag to "go test" script to catch data races, right now they are not detected.
- added "go-tools" target in Makefile to install all required go-tools.
- fixed go-lint (make target) errors reported below.
    golint ./cmd ./pkg
    read ./cmd: is a directory
    read ./pkg: is a directory
- added makefile target "go-checks" to run vet,lint,fmt all together.