### PR TITLE
Add Namespace Endpoint

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -185,6 +185,7 @@ func main() {
 	}
 
 	meshCatalog := catalog.NewMeshCatalog(
+		namespaceController,
 		kubeClient,
 		meshSpec,
 		certManager,

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,4 @@ require (
 	rsc.io/letsencrypt v0.0.3 // indirect
 )
 
-replace (
-	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible
-)
+replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -898,6 +898,8 @@ k8s.io/apiextensions-apiserver v0.18.0 h1:HN4/P8vpGZFvB5SOMuPPH2Wt9Y/ryX+KRvIyAk
 k8s.io/apiextensions-apiserver v0.18.0/go.mod h1:18Cwn1Xws4xnWQNC00FLq1E350b9lUF+aOdIWDOZxgo=
 k8s.io/apimachinery v0.18.0 h1:fuPfYpk3cs1Okp/515pAf0dNhL66+8zk8RLbSX+EgAE=
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
+k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
 k8s.io/cli-runtime v0.18.0 h1:jG8XpSqQ5TrV0N+EZ3PFz6+gqlCk71dkggWCCq9Mq34=
 k8s.io/cli-runtime v0.18.0/go.mod h1:1eXfmBsIJosjn9LjEBUd2WVPoPAY9XGTqTFcPMIBsUQ=

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -10,11 +10,13 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/ingress"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/smi"
 )
 
 // NewMeshCatalog creates a new service catalog
-func NewMeshCatalog(kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
+func NewMeshCatalog(namespaceController namespace.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
+	log.Info().Msg("Create a new Service MeshCatalog.")
 	sc := MeshCatalog{
 		endpointsProviders: endpointsProviders,
 		meshSpec:           meshSpec,
@@ -31,6 +33,8 @@ func NewMeshCatalog(kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, cert
 		// In multicluster scenarios this would be a map of cluster ID to Kubernetes client.
 		// The certificate itself would contain the cluster ID making it easy to lookup the client in this map.
 		kubeClient: kubeClient,
+
+		namespaceController: namespaceController,
 	}
 
 	for _, announcementChannel := range sc.getAnnouncementChannels() {
@@ -54,6 +58,7 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		{"CertManager", mc.certManager.GetAnnouncementsChannel()},
 		{"IngressMonitor", mc.ingressMonitor.GetAnnouncementsChannel()},
 		{"Ticker", ticking},
+		{"Namespace", mc.namespaceController.GetAnnouncementsChannel()},
 	}
 	for _, ep := range mc.endpointsProviders {
 		annCh := announcementChannel{ep.GetID(), ep.GetAnnouncementsChannel()}

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -75,3 +75,14 @@ func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.Weigh
 
 	return trafficSplits, splitServices, serviceAccouns, trafficSpecs, trafficTargets, services
 }
+
+// ListMonitoredNamespaces returns all namespaces that the mesh is monitoring.
+func (mc *MeshCatalog) ListMonitoredNamespaces() []string {
+	namespaces, err := mc.namespaceController.ListMonitoredNamespaces()
+
+	if err != nil {
+		return nil
+	}
+
+	return namespaces
+}

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
 	"github.com/openservicemesh/osm/pkg/ingress"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/smi"
 )
 
@@ -29,5 +30,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-	return NewMeshCatalog(kubeClient, meshSpec, certManager, ingressMonitor, stop, cfg, endpointProviders...)
+	namespaceController := namespace.NewFakeNamespaceController([]string{osmNamespace})
+
+	return NewMeshCatalog(namespaceController, kubeClient, meshSpec, certManager, ingressMonitor, stop, cfg, endpointProviders...)
 }

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/ingress"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 )
@@ -48,7 +49,9 @@ func newFakeMeshCatalog() *MeshCatalog {
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-	return NewMeshCatalog(kubeClient, meshSpec, certManager, ingressMonitor, stop, cfg, endpointProviders...)
+	namespaceController := namespace.NewFakeNamespaceController([]string{osmNamespace})
+
+	return NewMeshCatalog(namespaceController, kubeClient, meshSpec, certManager, ingressMonitor, stop, cfg, endpointProviders...)
 }
 
 func getFakeIngresses() []*extensionsV1beta.Ingress {

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
 	"github.com/openservicemesh/osm/pkg/ingress"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -34,7 +35,9 @@ var _ = Describe("Catalog tests", func() {
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-	meshCatalog := NewMeshCatalog(kubeClient, smi.NewFakeMeshSpecClient(), certManager, ingress.NewFakeIngressMonitor(), make(<-chan struct{}), cfg, endpointProviders...)
+	namespaceController := namespace.NewFakeNamespaceController([]string{osmNamespace})
+
+	meshCatalog := NewMeshCatalog(namespaceController, kubeClient, smi.NewFakeMeshSpecClient(), certManager, ingress.NewFakeIngressMonitor(), make(<-chan struct{}), cfg, endpointProviders...)
 
 	Context("Test ListTrafficPolicies", func() {
 		It("lists traffic policies", func() {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -48,6 +49,8 @@ type MeshCatalog struct {
 	// Current assumption is that OSM is working with a single Kubernetes cluster.
 	// This here is the client to that cluster.
 	kubeClient kubernetes.Interface
+
+	namespaceController namespace.Controller
 }
 
 // MeshCataloger is the mechanism by which the Service Mesh controller discovers all Envoy proxies connected to the catalog.
@@ -98,6 +101,9 @@ type MeshCataloger interface {
 
 	// GetIngressRoutesPerHost returns the routes per host associated with an ingress service
 	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.Route, error)
+
+	// ListMonitoredNamespaces lists namespaces monitored by the control plane
+	ListMonitoredNamespaces() []string
 }
 
 type announcementChannel struct {

--- a/pkg/debugger/namespace.go
+++ b/pkg/debugger/namespace.go
@@ -1,0 +1,26 @@
+package debugger
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type namespaces struct {
+	Namespaces []string `json:"namespaces"`
+}
+
+func (ds debugServer) getMonitoredNamespacesHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		var n namespaces
+		n.Namespaces = ds.meshCatalogDebugger.ListMonitoredNamespaces()
+
+		jsonPolicies, err := json.Marshal(n)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error marshalling policy %+v", n)
+		}
+
+		_, _ = fmt.Fprint(w, string(jsonPolicies))
+	})
+}

--- a/pkg/debugger/namespace_test.go
+++ b/pkg/debugger/namespace_test.go
@@ -1,0 +1,27 @@
+package debugger
+
+import (
+	"fmt"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// Tests if namespace handler returns default namespace correctly
+var _ = Describe("Test debugger methods", func() {
+	Context("Testing getMonitoredNamespacesHandler()", func() {
+		It("returns JSON serialized monitored namespaces", func() {
+			mc := NewFakeMeshCatalogDebugger()
+			ds := debugServer{
+				meshCatalogDebugger: mc,
+			}
+			monitoredNamespacesHandler := ds.getMonitoredNamespacesHandler()
+			responseRecorder := httptest.NewRecorder()
+			monitoredNamespacesHandler.ServeHTTP(responseRecorder, nil)
+			actualResponseBody := responseRecorder.Body.String()
+			expectedResponseBody := `{"namespaces":["default"]}`
+			Expect(actualResponseBody).To(Equal(expectedResponseBody), fmt.Sprintf("Actual value did not match expectations:\n%s", actualResponseBody))
+		})
+	})
+})

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -88,6 +88,11 @@ func (f fakeMeshCatalogDebuger) ListSMIPolicies() ([]*split.TrafficSplit, []serv
 		}}
 }
 
+// ListMonitoredNamespaces implements MeshCatalogDebugger
+func (f fakeMeshCatalogDebuger) ListMonitoredNamespaces() []string {
+	return []string{tests.Namespace}
+}
+
 // NewFakeMeshCatalogDebugger implements and creates a new MeshCatalogDebugger
 func NewFakeMeshCatalogDebugger() MeshCatalogDebugger {
 	return fakeMeshCatalogDebuger{}

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -12,11 +12,12 @@ import (
 // GetHandlers implements DebugServer interface and returns the rest of URLs and the handling functions.
 func (ds debugServer) GetHandlers() map[string]http.Handler {
 	handlers := map[string]http.Handler{
-		"/debug/certs":    ds.getCertHandler(),
-		"/debug/xds":      ds.getXDSHandler(),
-		"/debug/proxy":    ds.getProxies(),
-		"/debug/policies": ds.getSMIPoliciesHandler(),
-		"/debug/config":   ds.getOSMConfigHandler(),
+		"/debug/certs":      ds.getCertHandler(),
+		"/debug/xds":        ds.getXDSHandler(),
+		"/debug/proxy":      ds.getProxies(),
+		"/debug/policies":   ds.getSMIPoliciesHandler(),
+		"/debug/config":     ds.getOSMConfigHandler(),
+		"/debug/namespaces": ds.getMonitoredNamespacesHandler(),
 	}
 
 	// provides an index of the available /debug endpoints

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -49,6 +49,9 @@ type MeshCatalogDebugger interface {
 
 	// ListSMIPolicies lists the SMI policies detected by OSM.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget, []*corev1.Service)
+
+	// ListMonitoredNamespaces lists the namespaces that the control plan knows about.
+	ListMonitoredNamespaces() []string
 }
 
 // XDSDebugger is an interface providing debugging server with methods introspecting XDS.

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
 	"github.com/openservicemesh/osm/pkg/ingress"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -150,8 +151,8 @@ var _ = Describe("RDS Response", func() {
 	osmNamespace := "-test-osm-namespace-"
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-
-	meshCatalog := catalog.NewMeshCatalog(kubeClient, smi.NewFakeMeshSpecClient(), certManager, ingress.NewFakeIngressMonitor(), make(<-chan struct{}), cfg, endpointProviders...)
+	namespaceController := namespace.NewFakeNamespaceController([]string{osmNamespace})
+	meshCatalog := catalog.NewMeshCatalog(namespaceController, kubeClient, smi.NewFakeMeshSpecClient(), certManager, ingress.NewFakeIngressMonitor(), make(<-chan struct{}), cfg, endpointProviders...)
 
 	Context("Test GetHostnamesForService", func() {
 		contains := func(domains []string, expected string) bool {

--- a/pkg/namespace/errors.go
+++ b/pkg/namespace/errors.go
@@ -3,6 +3,7 @@ package namespace
 import "github.com/pkg/errors"
 
 var (
-	errSyncingCaches = errors.New("Failed initial cache sync for Namespace informers")
-	errInitInformers = errors.New("Namespace informers are not initialized")
+	errSyncingCaches     = errors.New("Failed initial cache sync for Namespace informers")
+	errInitInformers     = errors.New("Namespace informers are not initialized")
+	errListingNamespaces = errors.New("Failed to list monitored namespaces")
 )

--- a/pkg/namespace/fake.go
+++ b/pkg/namespace/fake.go
@@ -23,3 +23,13 @@ func (f FakeNamespaceController) IsMonitoredNamespace(namespace string) bool {
 	}
 	return false
 }
+
+// ListMonitoredNamespaces returns the namespaces monitored by the mesh
+func (f FakeNamespaceController) ListMonitoredNamespaces() ([]string, error) {
+	return f.monitoredNamespaces, nil
+}
+
+// GetAnnouncementsChannel returns the channel on which namespace makes announcements
+func (f FakeNamespaceController) GetAnnouncementsChannel() <-chan interface{} {
+	return make(chan interface{})
+}

--- a/pkg/namespace/types.go
+++ b/pkg/namespace/types.go
@@ -20,5 +20,13 @@ type Client struct {
 
 // Controller is the controller interface for K8s namespaces
 type Controller interface {
+	// IsMonitoredNamespace returns whether a namespace with the given name is being monitored
+	// by the mesh
 	IsMonitoredNamespace(string) bool
+
+	// ListMonitoredNamespaces returns the namespaces monitored by the mesh
+	ListMonitoredNamespaces() ([]string, error)
+
+	// GetAnnouncementsChannel returns the channel on which namespace makes announcements
+	GetAnnouncementsChannel() <-chan interface{}
 }


### PR DESCRIPTION
feat(osm/pkg and osm/cmd): add an endpoint for retrieving monitored namespaces of a mesh, add necessary tests, refactor related code to integrate changes

Adds an endpoint for getting namespaces of a mesh to be used by the osm dashboard.