### PR TITLE
ads: Move ADS health probes to pkg/envoy/ads/health.go

### DIFF
--- a/pkg/envoy/ads/health.go
+++ b/pkg/envoy/ads/health.go
@@ -1,0 +1,11 @@
+package ads
+
+// Liveness is the Kubernetes liveness probe handler.
+func (s *Server) Liveness() bool {
+	return true
+}
+
+// Readiness is the Kubernetes readiness probe handler.
+func (s *Server) Readiness() bool {
+	return true
+}

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Test ADS response functions", func() {
 				ctx:         context.TODO(),
 				catalog:     mc,
 				meshSpec:    smi.NewFakeMeshSpecClient(),
-				xdsHandlers: getHandlers(cfg),
+				xdsHandlers: getHandlers(),
 			}
 
 			s.sendAllResponses(proxy, &server, cfg)

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -24,7 +24,7 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 		catalog:      meshCatalog,
 		ctx:          ctx,
 		meshSpec:     meshSpec,
-		xdsHandlers:  getHandlers(cfg),
+		xdsHandlers:  getHandlers(),
 		enableDebug:  enableDebug,
 		osmNamespace: osmNamespace,
 		cfg:          cfg,
@@ -37,7 +37,7 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, meshSp
 	return &server
 }
 
-func getHandlers(cfg configurator.Configurator) map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error) {
+func getHandlers() map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error) {
 	return map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, smi.MeshSpec, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error){
 		envoy.TypeEDS: eds.NewResponse,
 		envoy.TypeCDS: cds.NewResponse,
@@ -48,18 +48,6 @@ func getHandlers(cfg configurator.Configurator) map[envoy.TypeURI]func(context.C
 }
 
 // DeltaAggregatedResources implements discovery.AggregatedDiscoveryServiceServer
-func (s *Server) DeltaAggregatedResources(server xds_discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+func (s *Server) DeltaAggregatedResources(xds_discovery.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
 	panic("NotImplemented")
-}
-
-// Liveness is the Kubernetes liveness probe handler.
-func (s *Server) Liveness() bool {
-	// TODO(draychev): implement
-	return true
-}
-
-// Readiness is the Kubernetes readiness probe handler.
-func (s *Server) Readiness() bool {
-	// TODO(draychev): implement
-	return true
 }

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -26,10 +26,10 @@ func NewHealthMux(handlers map[string]http.Handler) *http.ServeMux {
 }
 
 // NewHTTPServer creates a new API server
-func NewHTTPServer(somethingWithProbes health.Probes, metricStore metricsstore.MetricStore, apiPort int32, debugServer debugger.DebugServer) HTTPServer {
+func NewHTTPServer(probes health.Probes, metricStore metricsstore.MetricStore, apiPort int32, debugServer debugger.DebugServer) HTTPServer {
 	handlers := map[string]http.Handler{
-		"/health/ready": health.ReadinessHandler(somethingWithProbes),
-		"/health/alive": health.LivenessHandler(somethingWithProbes),
+		"/health/ready": health.ReadinessHandler(probes),
+		"/health/alive": health.LivenessHandler(probes),
 		"/metrics":      metricStore.Handler(),
 	}
 


### PR DESCRIPTION
Tiny refactor - removing TODO comment and moving Liveness and Readines response handlers to a separate file.