### PR TITLE
catalog,rds: simplify hostname API and remove unnecessary code

### DIFF
--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -89,8 +89,9 @@ type MeshCataloger interface {
 	// GetServiceForServiceAccount returns the service corresponding to a service account
 	GetServiceForServiceAccount(service.K8sServiceAccount) (service.MeshService, error)
 
-	//GetDomainForService returns the domain name of a service
-	GetDomainForService(service service.MeshService, routeHeaders map[string]string) (string, error)
+	// GetHostnamesForService returns the hostnames for a service
+	// TODO(ref: PR #1316): return a list of strings
+	GetHostnamesForService(service service.MeshService) (string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -153,7 +153,7 @@ var _ = Describe("RDS Response", func() {
 
 	meshCatalog := catalog.NewMeshCatalog(kubeClient, smi.NewFakeMeshSpecClient(), certManager, ingress.NewFakeIngressMonitor(), make(<-chan struct{}), cfg, endpointProviders...)
 
-	Context("Test GetDomainForService", func() {
+	Context("Test GetHostnamesForService", func() {
 		contains := func(domains []string, expected string) bool {
 			for _, entry := range domains {
 				if entry == expected {
@@ -164,7 +164,7 @@ var _ = Describe("RDS Response", func() {
 		}
 		It("returns the domain for a service when traffic split is specified for the given service", func() {
 
-			actual, err := meshCatalog.GetDomainForService(tests.BookstoreService, tests.HTTPRouteGroup.Matches[0].Headers)
+			actual, err := meshCatalog.GetHostnamesForService(tests.BookstoreService)
 			Expect(err).ToNot(HaveOccurred())
 
 			domainList := strings.Split(actual, ",")
@@ -174,7 +174,7 @@ var _ = Describe("RDS Response", func() {
 
 		It("returns a list of domains for a service when traffic split is not specified for the given service", func() {
 
-			actual, err := meshCatalog.GetDomainForService(tests.BookbuyerService, nil)
+			actual, err := meshCatalog.GetHostnamesForService(tests.BookbuyerService)
 			Expect(err).ToNot(HaveOccurred())
 
 			domainList := strings.Split(actual, ",")
@@ -194,7 +194,7 @@ var _ = Describe("RDS Response", func() {
 
 		It("No service found when mesh does not have service", func() {
 
-			_, err := meshCatalog.GetDomainForService(tests.BookwarehouseService, tests.HTTPRouteGroup.Matches[0].Headers)
+			_, err := meshCatalog.GetHostnamesForService(tests.BookwarehouseService)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
- Simplifies the catalog API where a custom object needed to be passed,
  which is unnecessary from an interface perspective and confusing.

- Renames Domain to Hostnames

- Removes the dependency on the `Host` header in the route policy.
  `GetHostnamesForService` builds the service hostnames based on
  Kubernetes service hostnames. This applies to permissive mode
  and when SMI traffic split policy isn't applicable for the service.
  The code path for generating service hostnames for in these 2
  scenarios are the same.