### PR TITLE
github/workflow: skip builds for docs only PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
 env:
   KUBE_CONFIG: ${{ secrets.KUBECONFIG }}
   AZURE_SUBSCRIPTION: ${{ secrets.AZURE_SUBSCRIPTION }}


### PR DESCRIPTION
Per https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-ignoring-paths
 build events will run for PRs that include at least one file outside
of the ignored paths.