### PR TITLE
demo: wait a bit longer for pod to be up

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -49,7 +49,7 @@ wait_for_osm_pods() {
 }
 
 wait_for_pod_ready() {
-    max=15
+    max=20
     pod_name=$1
 
     for x in $(seq 1 $max); do


### PR DESCRIPTION
Increases pod wait time giving the CI a better chance to
succeed under heavy load. If the extra time helps, it saves
a lot more time compared to cleaning up and rerunning the suite
again.