### PR TITLE
debugger: Test GetHandlers()

### DIFF
--- a/pkg/debugger/debugger_test.go
+++ b/pkg/debugger/debugger_test.go
@@ -1,0 +1,45 @@
+package debugger
+
+import (
+	"sort"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
+)
+
+var _ = Describe("Test debugger server", func() {
+	kubeClient := testclient.NewSimpleClientset()
+	cache := make(map[certificate.CommonName]certificate.Certificater)
+	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+	meshCatalog := catalog.NewFakeMeshCatalog(kubeClient)
+	cfg := configurator.NewFakeConfigurator()
+
+	debugServer := NewDebugServer(certManager, nil, meshCatalog, nil, kubeClient, cfg)
+
+	Context("Testing debugger.GetHandlers()", func() {
+		It("returns the list of handlers", func() {
+			var actual []string
+			for debugEndpoint := range debugServer.GetHandlers() {
+				actual = append(actual, debugEndpoint)
+			}
+			expected := []string{
+				"/debug",
+				"/debug/certs",
+				"/debug/config",
+				"/debug/policies",
+				"/debug/proxy",
+				"/debug/xds",
+			}
+			sort.Strings(actual)
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})

--- a/pkg/debugger/fake.go
+++ b/pkg/debugger/fake.go
@@ -1,0 +1,66 @@
+package debugger
+
+import (
+	"time"
+
+	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+type fakeMeshCatalogDebuger struct{}
+
+// ListExpectedProxies implements MeshCatalogDebugger
+func (f fakeMeshCatalogDebuger) ListExpectedProxies() map[certificate.CommonName]time.Time {
+	panic("implement me")
+}
+
+// ListConnectedProxies implements MeshCatalogDebugger
+func (f fakeMeshCatalogDebuger) ListConnectedProxies() map[certificate.CommonName]*envoy.Proxy {
+	panic("implement me")
+}
+
+// ListDisconnectedProxies implements MeshCatalogDebugger
+func (f fakeMeshCatalogDebuger) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
+	panic("implement me")
+}
+
+// ListSMIPolicies implements MeshCatalogDebugger
+func (f fakeMeshCatalogDebuger) ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget, []*corev1.Service) {
+	return []*split.TrafficSplit{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			}},
+		},
+		[]service.WeightedService{
+			tests.WeightedService,
+		},
+		[]service.K8sServiceAccount{
+			tests.BookbuyerServiceAccount,
+		},
+		[]*spec.HTTPRouteGroup{
+			&tests.HTTPRouteGroup,
+		},
+		[]*target.TrafficTarget{
+			&tests.TrafficTarget,
+		},
+		[]*corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "bar",
+			},
+		}}
+}
+
+// NewFakeMeshCatalogDebugger implements and creates a new MeshCatalogDebugger
+func NewFakeMeshCatalogDebugger() MeshCatalogDebugger {
+	return fakeMeshCatalogDebuger{}
+}

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -2,29 +2,12 @@ package debugger
 
 import (
 	"fmt"
-	"net/http/httptest"
-	"testing"
-	"time"
-
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha1"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha2"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/tests"
+	"net/http/httptest"
 )
-
-func TestEndpoints(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
-}
 
 var _ = Describe("Test debugger methods", func() {
 	Context("Testing getSMIPoliciesHandler()", func() {
@@ -42,53 +25,3 @@ var _ = Describe("Test debugger methods", func() {
 		})
 	})
 })
-
-type fakeMeshCatalogDebuger struct{}
-
-// ListExpectedProxies implements MeshCatalogDebugger
-func (f fakeMeshCatalogDebuger) ListExpectedProxies() map[certificate.CommonName]time.Time {
-	panic("implement me")
-}
-
-// ListConnectedProxies implements MeshCatalogDebugger
-func (f fakeMeshCatalogDebuger) ListConnectedProxies() map[certificate.CommonName]*envoy.Proxy {
-	panic("implement me")
-}
-
-// ListDisconnectedProxies implements MeshCatalogDebugger
-func (f fakeMeshCatalogDebuger) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
-	panic("implement me")
-}
-
-// ListSMIPolicies implements MeshCatalogDebugger
-func (f fakeMeshCatalogDebuger) ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget, []*corev1.Service) {
-	return []*split.TrafficSplit{{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar",
-			}},
-		},
-		[]service.WeightedService{
-			tests.WeightedService,
-		},
-		[]service.K8sServiceAccount{
-			tests.BookbuyerServiceAccount,
-		},
-		[]*spec.HTTPRouteGroup{
-			&tests.HTTPRouteGroup,
-		},
-		[]*target.TrafficTarget{
-			&tests.TrafficTarget,
-		},
-		[]*corev1.Service{{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "foo",
-				Name:      "bar",
-			},
-		}}
-}
-
-// NewFakeMeshCatalogDebugger implements and creates a new MeshCatalogDebugger
-func NewFakeMeshCatalogDebugger() MeshCatalogDebugger {
-	return fakeMeshCatalogDebuger{}
-}

--- a/pkg/debugger/suite_test.go
+++ b/pkg/debugger/suite_test.go
@@ -1,0 +1,13 @@
+package debugger
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndpoints(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Suite")
+}


### PR DESCRIPTION
This PR refactors the tests of `pkg/debugger`:
  - move fake stuff into fake.go
  - adds a few minimal tests around GetHandlers()