### PR TITLE
osm: Get XDS Certificate Validity Period from ConfigMap

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -201,8 +201,7 @@ func main() {
 	// TODO(draychev): there should be no need to pass meshSpec to the ADS - it is already in meshCatalog
 	xdsServer := ads.NewADSServer(ctx, meshCatalog, meshSpec, enableDebugServer, osmNamespace, cfg)
 
-	// TODO(draychev): we need to pass this hard-coded string is a CLI argument (https://github.com/openservicemesh/osm/issues/542)
-	validityPeriod := constants.XDSCertificateValidityPeriod
+	validityPeriod := cfg.GetGetControlPlaneCertValidityPeriod()
 	adsCert, err := certManager.IssueCertificate(xdsServerCertificateCommonName, &validityPeriod)
 	if err != nil {
 		log.Fatal().Err(err)

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -109,11 +109,13 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"ZipkinEndpoint":              zipkinEndpointKey,
 				"MeshCIDRRanges":              meshCIDRRangesKey,
 				"UseHTTPSIngress":             useHTTPSIngressKey,
+
+				"GetGetControlPlaneCertValidityPeriod": controlPlaneCertValidityPeriodMinutesKey,
 			}
 			t := reflect.TypeOf(osmConfig{})
 
 			actualNumberOfFields := t.NumField()
-			expectedNumberOfFields := 9
+			expectedNumberOfFields := 10
 			Expect(actualNumberOfFields).To(
 				Equal(expectedNumberOfFields),
 				fmt.Sprintf("Fields have been added or removed from the osmConfig struct -- expected %d, actual %d; please correct this unit test", expectedNumberOfFields, actualNumberOfFields))

--- a/pkg/configurator/fake.go
+++ b/pkg/configurator/fake.go
@@ -1,6 +1,8 @@
 package configurator
 
 import (
+	"time"
+
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -96,4 +98,9 @@ func (f FakeConfigurator) GetZipkinPort() uint32 {
 // GetZipkinEndpoint returns the Zipkin endpoint
 func (f FakeConfigurator) GetZipkinEndpoint() string {
 	return constants.DefaultZipkinEndpoint
+}
+
+// GetGetControlPlaneCertValidityPeriod determines the validity period of the certificate used for Envoy to XDS mTLS.
+func (f FakeConfigurator) GetGetControlPlaneCertValidityPeriod() time.Duration {
+	return constants.ControlPlaneCertificateValidityPeriod
 }

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"time"
 )
 
 // The functions in this file implement the configurator.Configurator interface
@@ -114,6 +115,15 @@ func (c *Client) GetMeshCIDRRanges() []string {
 // UseHTTPSIngress determines whether traffic between ingress and backend pods should use HTTPS protocol
 func (c *Client) UseHTTPSIngress() bool {
 	return c.getConfigMap().UseHTTPSIngress
+}
+
+// GetGetControlPlaneCertValidityPeriod determines the validity period of the certificate used for Envoy to XDS mTLS.
+func (c *Client) GetGetControlPlaneCertValidityPeriod() time.Duration {
+	validityPeriod := c.getConfigMap().GetControlPlaneCertValidityPeriod
+	if validityPeriod != 0 {
+		return validityPeriod
+	}
+	return constants.ControlPlaneCertificateValidityPeriod
 }
 
 // GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -2,6 +2,7 @@ package configurator
 
 import (
 	"k8s.io/client-go/tools/cache"
+	"time"
 
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -54,6 +55,9 @@ type Configurator interface {
 
 	// UseHTTPSIngress determines whether protocol used for traffic from ingress to backend pods should be HTTPS.
 	UseHTTPSIngress() bool
+
+	// GetGetControlPlaneCertValidityPeriod returns the duration of validity for the Envoy to XDS certificate
+	GetGetControlPlaneCertValidityPeriod() time.Duration
 
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap
 	GetAnnouncementsChannel() <-chan interface{}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,8 +81,8 @@ const (
 	// CertificationAuthorityRootValidityPeriod is when the root certificate expires
 	CertificationAuthorityRootValidityPeriod = 87600 * time.Hour // a decade
 
-	// XDSCertificateValidityPeriod is the TTL of the certificates used for Envoy to xDS communication.
-	XDSCertificateValidityPeriod = 87600 * time.Hour // a decade
+	// ControlPlaneCertificateValidityPeriod is the TTL of the certificates used for Envoy to xDS communication.
+	ControlPlaneCertificateValidityPeriod = 87600 * time.Hour // a decade
 
 	// RegexMatchAll is a regex pattern match for all
 	RegexMatchAll = ".*"

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -34,7 +34,7 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
 	cn := catalog.NewCertCommonNameWithProxyID(proxyUUID, pod.Spec.ServiceAccountName, namespace)
 	log.Info().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN=%s", pod.Spec.ServiceAccountName, namespace, cn)
-	validityPeriod := constants.XDSCertificateValidityPeriod
+	validityPeriod := wh.configurator.GetGetControlPlaneCertValidityPeriod()
 	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn, &validityPeriod)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing bootstrap certificate for Envoy with CN=%s", cn)


### PR DESCRIPTION
This PR makes the validity of the certificate issued to Envoy proxies for connectivity to the XDS Control Plane controlable via ConfigMap.

The configurator gets `GetGetControlPlaneCertValidityPeriod`, which convert the ConfigMap's `control_plane_cert_validity_period_minutes` into `time.Duration`