### PR TITLE
Fix a commit conflict for Envoy's tracing boostrap struct

### DIFF
--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Configurator) ([]byte, error) {
@@ -110,20 +109,6 @@ func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Config
 				},
 			},
 		},
-	}
-
-	if cfg.IsZipkinTracingEnabled() {
-		m["tracing"] = map[string]interface{}{
-			"http": map[string]interface{}{
-				"name": "envoy.zipkin",
-				"typed_config": map[string]interface{}{
-					"@type":                      envoy.TypeZipkinConfig,
-					"collector_cluster":          constants.EnvoyZipkinCluster,
-					"collector_endpoint":         cfg.GetZipkinEndpoint(),
-					"collector_endpoint_version": "HTTP_JSON",
-				},
-			},
-		}
 	}
 
 	configYAML, err := yaml.Marshal(&m)


### PR DESCRIPTION
rebasing https://github.com/openservicemesh/osm/pull/1273 brought back
the tracing struct in config.go, which is no longer needed
as v3 uses connection_manager to set specific tracing config.