### PR TITLE
demo: Correct string values for ConfigMap in demo script

### DIFF
--- a/demo/delete-policies.sh
+++ b/demo/delete-policies.sh
@@ -31,10 +31,10 @@ metadata:
   namespace: $K8S_NAMESPACE
 
 data:
-  permissive_traffic_policy_mode: true
-  egress: false
-  prometheus_scraping: false
-  zipkin_tracing: false
+  permissive_traffic_policy_mode: "true"
+  egress: "false"
+  prometheus_scraping: "false"
+  zipkin_tracing: "false"
 
 EOF
 


### PR DESCRIPTION
This PR fixes the ConfigMap.
The bool values need to be strings.

Error message observed:
```
The request is invalid: patch: Invalid value: "map[data:map[egress:false permissive_traffic_policy_mode:true prometheus_scraping:false zipkin_tracing:false] metadata:map[annotations:map[kubectl.kubernetes.io/last-applied-configuration:{\"apiVersion\":\"v1\",\"data\":{\"egress\":false,\"permissive_traffic_policy_mode\":true,\"prometheus_scraping\":false,\"zipkin_tracing\":false},\"kind\":\"ConfigMap\",\"metadata\":{\"annotations\":{},\"name\":\"osm-config\",\"namespace\":\"osm-system\"}}\n]]]": unrecognized type: string
```