### PR TITLE
Move to official container repo for osm-controller

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -21,7 +21,7 @@ This command is equivalent to installing the osm control plane using the OSM CLI
 | enableDebugServer | bool | `false` | Enable the debug HTTP server |
 | grafana.port | int | `3000` | Grafana port |
 | image.pullPolicy | string | `"Always"` | osm-controller image pull policy |
-| image.registry | string | `"smctest.azurecr.io"` |  osm-controller image registry |
+| image.registry | string | `"openservicemesh"` |  osm-controller image registry |
 | image.tag | string | `"latest"` | osm-controller image tag |
 | imagePullSecrets[0].name | string | `"acr-creds"` | osm-controller image pull secrets |
 | prometheus.port | int | `7070` | Prometheus port |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -4,7 +4,7 @@
 OpenServiceMesh:
   replicaCount: 1
   image:
-    registry: smctest.azurecr.io
+    registry: openservicemesh
     pullPolicy: Always
     tag: latest
   imagePullSecrets:

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -113,7 +113,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&inst.containerRegistry, "container-registry", "smctest.azurecr.io", "container registry that hosts control plane component images")
+	f.StringVar(&inst.containerRegistry, "container-registry", "openservicemesh", "container registry that hosts control plane component images")
 	f.StringVar(&inst.osmImageTag, "osm-image-tag", "latest", "osm image tag")
 	f.StringVar(&inst.containerRegistrySecret, "container-registry-secret", "acr-creds", "name of Kubernetes secret for container registry credentials to be created if it doesn't already exist")
 	f.StringVar(&inst.chartPath, "osm-chart-path", "", "path to osm chart to override default chart")


### PR DESCRIPTION
Changed default container registry to `openservicemesh`

Container registry will use whatever underlying default
registry is set (index.docker.io) if not explicitely
specified as part of `container-registry` variable.