### PR TITLE
docs/ingress: update ingress doc in lieu of HTTP being the default

### DIFF
--- a/docs/patterns/ingress.md
+++ b/docs/patterns/ingress.md
@@ -1,7 +1,5 @@
 # Exposing services outside the cluster using Ingress
-This document describes the workflow to expose HTTPS routes outside the cluster to services within the cluster using Kubernetes Ingress.
-
-OSM supports one way TLS authentication to backend services.
+This document describes how to expose HTTP and HTTPS routes outside the cluster to services within the cluster using Kubernetes Ingress.
 
 ## Prerequisites
 - An instance of OSM must be running in the cluster.
@@ -9,29 +7,49 @@ OSM supports one way TLS authentication to backend services.
 - The ingress resource must belong to the same namespace as the backend service.
 - A sidecar must be injected to the pod hosting the service, either using automatic sidecar injection or by manually annotating the pod spec for sidecar injection. Refer to the [Readme][1] for details.
 - An ingress controller must be running in the cluster.
-- The service must be an HTTPS service whose certificates are provisioned by OSM. OSM uses its own root certificate and a custom Certificate Authority (CA) for issuing certificates to services.
 
-## Exposing an HTTPS service using Ingress
-A service can expose HTTPS routes outside the cluster using Kubernetes Ingress along with an ingress controller. Once an ingress resource is configured to expose HTTPS routes outside the cluster to a service within the cluster, OSM will configure the sidecar proxy on pods to allow ingress traffic to the service based on the ingress routing rules defined by the Kubernetes Ingress resource.
+## Exposing an HTTP or HTTPS service using Ingress
+A service can expose HTTP or HTTPS routes outside the cluster using Kubernetes Ingress along with an ingress controller. Once an ingress resource is configured to expose HTTP routes outside the cluster to a service within the cluster, OSM will configure the sidecar proxy on pods to allow ingress traffic to the service based on the ingress routing rules defined by the Kubernetes Ingress resource.
+For HTTPS ingress, OSM supports one way TLS authentication to backend services.
+
+By default, OSM configures HTTP as the backend protocol for services when an ingress resource is applied with a backend service that belongs to the mesh. A mesh wide configuration setting in OSM's `osm-config` ConfigMap enables configuring ingress with the backend protocol to be HTTPS. HTTPS ingress can be enabled by updating the `osm-config` ConfigMap in `osm-controller`'s namespace (`osm-system` by default).
+
+Edit the ConfigMap by setting `use_https_ingress: "true"`.
+
+```shell
+kubectl edit configmap -n osm-system osm-config
+```
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: osm-config
+    namespace: osm-system
+data:
+    use_https_ingress: "true"
+...
+```
 
 ## Ingress controller compatibility
 Ingress in OSM is compatible with the following ingress controllers.
 - [Nginx Ingress Controller][2]
 - [Azure Application Gateway Ingress Controller][3]
 
-Other ingress controllers might also work as long as they allow provisioning a custom root certificate for backend server certificate validation.
+Other ingress controllers might also work as long as they use Kubernetes Ingress resource and allow provisioning a custom root certificate for HTTPS backend server certificate validation.
 
 ## Ingress configurations
-The following section describes sample ingress configurations used to expose services managed by OSM outside the cluster.  Different ingress controllers require different configurations.
+The following section describes sample ingress configurations used to expose services managed by OSM outside the cluster. The configuration might differ based on the ingress controller being used.
 
-The example configurations describe how to expose HTTPS routes for the `bookstore-v1` HTTPS service running on port `80` in the `bookstore-ns` namespace, outside the cluster. The ingress configuration will expose the HTTPS path `/books-bought` on the `bookstore-v1` service.
+The example configurations describe how to expose HTTP and HTTPS routes for the `bookstore-v1` service running on port `80` in the `bookstore-ns` namespace, outside the cluster. The ingress configuration will expose the HTTP path `/books-bought` on the `bookstore-v1` service.
 
-Since OSM uses its own root certificate, the ingress controller must be provisioned with OSM's root certificate to be able to authenticate the certificate presented by backend servers. OSM stores the CA root certificate in a Kubernetes secret called `osm-ca-bundle` with the key `ca.crt` in the namespace OSM is deployed (`osm-system` by default).
+Since OSM uses its own root certificate, the ingress controller must be provisioned with OSM's root certificate to be able to authenticate the certificate presented by backend servers when using HTTPS ingress. OSM stores the CA root certificate in a Kubernetes secret named `osm-ca-bundle` with the key `ca.crt` in the namespace OSM is deployed (`osm-system` by default).
 
 ### Using Nginx Ingress Controller
 An ingress configuration yaml with [Nginx Ingress Controller][2] for the `bookstore-v1` service described above would look as follows.
 
 - Specify the ingress controller as nginx using the annotation `kubernetes.io/ingress.class: nginx`.
+
+For HTTPS ingress, additional annotations are required.
 - Specify the backend protocol as HTTPS using the annotation `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"`.
 - Specify the hostname of the service using the annotation `nginx.ingress.kubernetes.io/configuration-snippet`.
 - Specify the secret corresponding to the root certificate using the annotation `nginx.ingress.kubernetes.io/proxy-ssl-secret`.
@@ -39,7 +57,29 @@ An ingress configuration yaml with [Nginx Ingress Controller][2] for the `bookst
 - Enable SSL verification of backend service using the annotation `nginx.ingress.kubernetes.io/proxy-ssl-verify`.
 
 The host defined by `spec.rules.host` field is optional.
+
+HTTP ingress sample configuration:
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bookstore-v1
+  namespace: bookstore-ns
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: bookstore-v1.bookstore-ns.svc.cluster.local
+    http:
+      paths:
+      - path: /books-bought
+        backend:
+          serviceName: bookstore-v1
+          servicePort: 80
 ```
+
+HTTPS ingress sample configuration:
+```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -68,6 +108,8 @@ spec:
 An ingress configuration yaml with [Azure Application Gateway Ingress Controller][3] for the `bookstore-v1` service described above would look as follows.
 
 - Specify the ingress controller as Azure Application Gateway using the annotation `kubernetes.io/ingress.class: azure/application-gateway`.
+
+For HTTPS ingress, additional annotations are required.
 - Specify the backend protocol as HTTPS using the annotation `appgw.ingress.kubernetes.io/backend-protocol: "https"`.
 - Specify the root certificate name added to Azure Application Gateway corresponding to OSM's root certificate using the annotation `appgw.ingress.kubernetes.io/appgw-trusted-root-certificate`. Refer to the document on [adding trusted root certificates to Azure Application Gateway][4].
     ```bash
@@ -85,7 +127,27 @@ An ingress configuration yaml with [Azure Application Gateway Ingress Controller
 
 The host defined by `spec.rules.host` field is optional and skipped in the example below.
 
+HTTP ingress sample configuration:
+```yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bookstore-v1
+  namespace: bookstore-ns
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /books-bought
+        backend:
+          serviceName: bookstore-v1
+          servicePort: 80
 ```
+
+HTTPS ingress sample configuration:
+```yaml
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -103,7 +165,7 @@ spec:
       - path: /books-bought
         backend:
           serviceName: bookstore-v1
-          servicePort: 80
+          servicePort: 8080 # Note: port 80 cannot be used for HTTPS ingress with Azure Application Gateway ingress
 ```
 
 [1]: https://github.com/openservicemesh/osm/blob/main/README.md


### PR DESCRIPTION
Previously, OSM only supported HTTPS ingress. Since both HTTP and HTTPS
backends are supported with ingress, updates the document to reflect
the current behavior.

Resolves #1251