### PR TITLE
demo: cleanup stale namespace before recreating

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -70,7 +70,9 @@ wait_for_pod_ready() {
 
 make build-osm
 
+# cleanup stale resources from previous runs
 bin/osm mesh delete -f --mesh-name "$MESH_NAME" --namespace "$K8S_NAMESPACE"
+./demo/clean-kubernetes.sh
 
 # The demo uses osm's namespace as defined by environment variables, K8S_NAMESPACE
 # to house the control plane components.


### PR DESCRIPTION
Rerunning the demo in specific environments results in an error because the existing
namespace is not deleted prior to recreation:
Error from server (AlreadyExists): namespaces "osm-system" already exists