### PR TITLE
Switch from cert-manager to certificate-manager

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             "--sidecar-image", "{{.Values.OpenServiceMesh.sidecarImage}}",
             "--webhook-name", "osm-webhook-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "osm-ca-bundle",
-            "--cert-manager", "{{.Values.OpenServiceMesh.certManager}}",
+            "--certificate-manager", "{{.Values.OpenServiceMesh.certManager}}",
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
             "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -124,7 +124,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.osmImageTag, "osm-image-tag", "v0.2.0", "osm image tag")
 	f.StringVar(&inst.containerRegistrySecret, "container-registry-secret", "acr-creds", "name of Kubernetes secret for container registry credentials to be created if it doesn't already exist")
 	f.StringVar(&inst.chartPath, "osm-chart-path", "", "path to osm chart to override default chart")
-	f.StringVar(&inst.certManager, "cert-manager", defaultCertManager, "certificate manager to use (tresor or vault)")
+	f.StringVar(&inst.certManager, "certificate-manager", defaultCertManager, "certificate manager to use (tresor or vault)")
 	f.StringVar(&inst.vaultHost, "vault-host", "", "Hashicorp Vault host/service - where Vault is installed")
 	f.StringVar(&inst.vaultProtocol, "vault-protocol", defaultVaultProtocol, "protocol to use to connect to Vault")
 	f.StringVar(&inst.vaultToken, "vault-token", "", "token that should be used to connect to Vault")
@@ -170,7 +170,7 @@ func (i *installCmd) run(config *helm.Configuration) error {
 			missingFields = append(missingFields, "vault-token")
 		}
 		if len(missingFields) != 0 {
-			return errors.Errorf("Missing arguments for cert-manager vault: %v", missingFields)
+			return errors.Errorf("Missing arguments for certificate-manager vault: %v", missingFields)
 		}
 	}
 

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -403,7 +403,7 @@ var _ = Describe("Running the install command", func() {
 		})
 
 		It("should error", func() {
-			Expect(err).To(MatchError("Missing arguments for cert-manager vault: [vault-host vault-token]"))
+			Expect(err).To(MatchError("Missing arguments for certificate-manager vault: [vault-host vault-token]"))
 		})
 	})
 

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -67,7 +67,7 @@ var (
 	log                 = logger.New("ads/main")
 
 	// What is the Certification Authority to be used
-	certManagerKind = flags.String("cert-manager", "tresor", "Certificate manager")
+	certManagerKind = flags.String("certificate-manager", "tresor", "Certificate manager")
 
 	// TODO(draychev): convert all these flags to spf13/cobra: https://github.com/openservicemesh/osm/issues/576
 	// When certmanager == "vault"

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -94,7 +94,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
   bin/osm install \
       --namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
-      --cert-manager="$CERT_MANAGER" \
+      --certificate-manager="$CERT_MANAGER" \
       --vault-host="$VAULT_HOST" \
       --vault-token="$VAULT_TOKEN" \
       --vault-protocol="$VAULT_PROTOCOL" \

--- a/docs/patterns/certificates.md
+++ b/docs/patterns/certificates.md
@@ -34,7 +34,7 @@ The following configuration parameters will be required for OSM to integrate wit
   - Validity period for certificates
 
 CLI flags control how OSM integrates with Vault. The following OSM command line parameters must be configured to issue certificates with Vault:
-  - `--cert-manager` - set this to `vault`
+  - `--certificate-manager` - set this to `vault`
   - `--vault-host` - host name of the Vault server (example: `vault.contoso.com`)
   - `--vault-protocol` - protocol for Vault connection (`http` or `https`)
   - `--vault-token` - token to be used by OSM to connect to Vault (this is issued on the Vault server for the particular role)
@@ -110,7 +110,7 @@ VAULT_ROLE=openservicemesh
 
 When running OSM on your local workstation, use the following CLI parameters:
 ```
---cert-manager="vault"
+--certificate-manager="vault"
 --vault-host="localhost"  # or the host where Vault is installed
 --vault-protocol="http"
 --vault-token="xyz"
@@ -121,7 +121,7 @@ When running OSM on your local workstation, use the following CLI parameters:
 ### How OSM Integrates with Vault
 
 When the OSM control plane starts, a new certificate issuer is instantiated.
-The kind of cert issuer is determined by the `--cert-manager` CLI parameter.
+The kind of cert issuer is determined by the `--certificate-manager` CLI parameter.
 When this is set to `vault` OSM uses a Vault cert issuer.
 This is a Hashicorp Vault client, which satisfies the `certificate.Manager`
 interface. It provides the following methods:


### PR DESCRIPTION
Cert-manager as a CLI argument is misleading, wherein it confuses the
user with the open source project by Jetstack called cert-manager.

Switching to a more descriptive argument name to capture the meaning and
not cause in confusion.

Signed-off-by: Nitish Malhotra <nitish.malhotra@gmail.com>

Resolves #1440

Please mark with X for applicable areas.

- [ ] New Functionality
- [ ] Documentation
- [ ] Install
- [ ] Control Plane
- [X] CLI Tool
- [ ] Certificate Management
- [ ] Networking
- [ ] Metrics
- [ ] SMI Policy
- [ ] Security
- [ ] Tests / CI System
- [ ] Other

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? no
