### PR TITLE
docs(development/guide): fixes docs for makefile go-test rule

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -78,7 +78,7 @@ Run `go get -d ./...` to download all required Go packages.
 Many of the operations within the repo have GNU Makefile targets.
 More notable:
   - `make build` builds the project
-  - `make go-tests` to run unit tests
+  - `make go-test` to run unit tests
   - `make go-test-coverage` - run unit tests and output unit test coverage
   - `make go-lint` runs golint and golangci-lint
   - `make go-fmt` - same as `go fmt ./...`


### PR DESCRIPTION
Fixes the development_guide.md to have the proper makefile command displayed for make go-test

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

- [ ] New Functionality
- [X] Documentation
- [ ] Install
- [ ] Control Plane
- [ ] CLI Tool
- [ ] Certificate Management
- [ ] Networking
- [ ] Metrics
- [ ] SMI Policy
- [ ] Security
- [ ] Tests / CI System
- [ ] Other

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No