### PR TITLE
example/manifests: update bookstore-v2 port to 80

### DIFF
--- a/docs/example/manifests/bookstore-v2/bookstore-v2.yaml
+++ b/docs/example/manifests/bookstore-v2/bookstore-v2.yaml
@@ -9,7 +9,7 @@ metadata:
     app: bookstore-v2
 spec:
   ports:
-  - port: 8080
+  - port: 80
     name: bookstore-port
   selector:
     app: bookstore-v2
@@ -43,10 +43,10 @@ spec:
           image: openservicemesh/bookstore:v0.2.0
           imagePullPolicy: Always
           ports:
-            - containerPort: 8080
+            - containerPort: 80
               name: web
           command: ["/bookstore"]
-          args: ["--path", "./", "--port", "8080"]
+          args: ["--path", "./", "--port", "80"]
           env:
             - name: BOOKWAREHOUSE_NAMESPACE
               value: bookwarehouse


### PR DESCRIPTION
The automated demo and helper scripts use port 80 for the bookstore-v2
service. Use the same port so that the scripts can be reused with
the manual demo workflow.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- [ ] New Functionality
- [ ] Documentation
- [ ] Install
- [ ] Control Plane
- [ ] CLI Tool
- [ ] Certificate Management
- [ ] Networking
- [ ] Metrics
- [ ] SMI Policy
- [ ] Security
- [ ] Tests / CI System
- [X] Other (Demo)

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `No`
