### PR TITLE
Updated Bookstore Demo Apps requesting custom port number

### DIFF
--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -85,7 +85,11 @@ In a new terminal session, run the following commands to enable port forwarding 
 cp .env.example .env
 ./scripts/port-forward-all.sh
 ```
+*Note: To override the default ports, prefix the `BOOKBUYER_LOCAL_PORT`, `BOOKSTOREv1_LOCAL_PORT`, `BOOKSTOREv2_LOCAL_PORT`, and/or `BOOKTHIEF_LOCAL_PORT` variable assignments to the `port-forward` scripts. For example:*
 
+```bash
+BOOKBUYER_LOCAL_PORT=7070 BOOKSTOREv1_LOCAL_PORT=7071 BOOKSTOREv2_LOCAL_PORT=7072 BOOKTHIEF_LOCAL_PORT=7073 ./scripts/port-forward-all.sh
+```
 In a browser, open up the following urls:
 - http://localhost:8080 - **Bookbuyer**
 - http://localhost:8081 - **bookstore-v1**

--- a/scripts/port-forward-all.sh
+++ b/scripts/port-forward-all.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
+read -p "Enter BOOKBUYER pod local port:" -i "8080" -e BOOKBUYER_PORT
+read -p "Enter BOOKSTOREv1 pod local port:" -i "8081" -e BOOKSTOREv1_PORT
+read -p "Enter BOOKSTOREv2 pod local port:" -i "8082" -e BOOKSTOREv2_PORT
+read -p "Enter BOOKTHIEF pod local port:" -i "8083" -e BOOKTHIEF_PORT
+
 ./scripts/port-forward-zipkin.sh &
-./scripts/port-forward-bookbuyer-ui.sh &
-./scripts/port-forward-bookstore-ui-v2.sh &
-./scripts/port-forward-bookstore-ui-v1.sh &
-./scripts/port-forward-bookthief-ui.sh &
+./scripts/port-forward-bookbuyer-ui.sh $BOOKBUYER_PORT &
+./scripts/port-forward-bookstore-ui-v2.sh bookstore-v2 $BOOKSTOREv2_PORT &
+./scripts/port-forward-bookstore-ui-v1.sh bookstore-v1 $BOOKSTOREv1_PORT &
+./scripts/port-forward-bookthief-ui.sh $BOOKTHIEF_PORT &
 ./scripts/port-forward-osm-debug.sh &
 ./scripts/port-forward-grafana.sh &
 

--- a/scripts/port-forward-all.sh
+++ b/scripts/port-forward-all.sh
@@ -1,15 +1,10 @@
 #!/bin/bash
 
-read -p "Enter BOOKBUYER pod local port:" -i "8080" -e BOOKBUYER_PORT
-read -p "Enter BOOKSTOREv1 pod local port:" -i "8081" -e BOOKSTOREv1_PORT
-read -p "Enter BOOKSTOREv2 pod local port:" -i "8082" -e BOOKSTOREv2_PORT
-read -p "Enter BOOKTHIEF pod local port:" -i "8083" -e BOOKTHIEF_PORT
-
 ./scripts/port-forward-zipkin.sh &
-./scripts/port-forward-bookbuyer-ui.sh $BOOKBUYER_PORT &
-./scripts/port-forward-bookstore-ui-v2.sh bookstore-v2 $BOOKSTOREv2_PORT &
-./scripts/port-forward-bookstore-ui-v1.sh bookstore-v1 $BOOKSTOREv1_PORT &
-./scripts/port-forward-bookthief-ui.sh $BOOKTHIEF_PORT &
+./scripts/port-forward-bookbuyer-ui.sh &
+./scripts/port-forward-bookstore-ui-v2.sh &
+./scripts/port-forward-bookstore-ui-v1.sh &
+./scripts/port-forward-bookthief-ui.sh &
 ./scripts/port-forward-osm-debug.sh &
 ./scripts/port-forward-grafana.sh &
 

--- a/scripts/port-forward-bookbuyer-ui.sh
+++ b/scripts/port-forward-bookbuyer-ui.sh
@@ -7,17 +7,9 @@
 # shellcheck disable=SC1091
 source .env
 
+BOOKBUYER_LOCAL_PORT="${BOOKBUYER_LOCAL_PORT:-8080}"
 POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
 
 kubectl describe pod "$POD" -n "$BOOKBUYER_NAMESPACE"
 
-# Check if run as standalone or from scripts/port-forward-all.sh
-if [ $# -eq 0 ]; then
-  # Prompt for a port number
-  read -p "Enter BOOKBUYER pod local port:" -i "8080" -e PORT
-else
-  # Port number read from scripts/port-forward-all.sh
-  PORT=$1
-fi
-
-kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" $PORT:80
+kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" "$BOOKBUYER_LOCAL_PORT":80

--- a/scripts/port-forward-bookbuyer-ui.sh
+++ b/scripts/port-forward-bookbuyer-ui.sh
@@ -11,4 +11,13 @@ POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-
 
 kubectl describe pod "$POD" -n "$BOOKBUYER_NAMESPACE"
 
-kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" 8080:80
+# Check if run as standalone or from scripts/port-forward-all.sh
+if [ $# -eq 0 ]; then
+  # Prompt for a port number
+  read -p "Enter BOOKBUYER pod local port:" -i "8080" -e PORT
+else
+  # Port number read from scripts/port-forward-all.sh
+  PORT=$1
+fi
+
+kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" $PORT:80

--- a/scripts/port-forward-bookstore-ui-v1.sh
+++ b/scripts/port-forward-bookstore-ui-v1.sh
@@ -15,17 +15,9 @@ if [ -z "$backend" ]; then
     exit 1
 fi
 
+BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8081}"
 POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
 
 kubectl describe pod "$POD" -n "$BOOKSTORE_NAMESPACE"
 
-# Check if run as standalone or from scripts/port-forward-all.sh
-if [ $# -eq 0 ]; then
-  # Prompt for a port number
-  read -p "Enter BOOKSTORE pod local port:" -i "8081" -e PORT
-else
-  # Port number read from scripts/port-forward-all.sh
-  PORT=$2
-fi
-
-kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" $PORT:80
+kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv1_LOCAL_PORT":80

--- a/scripts/port-forward-bookstore-ui-v1.sh
+++ b/scripts/port-forward-bookstore-ui-v1.sh
@@ -19,4 +19,13 @@ POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no
 
 kubectl describe pod "$POD" -n "$BOOKSTORE_NAMESPACE"
 
-kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 8081:80
+# Check if run as standalone or from scripts/port-forward-all.sh
+if [ $# -eq 0 ]; then
+  # Prompt for a port number
+  read -p "Enter BOOKSTORE pod local port:" -i "8081" -e PORT
+else
+  # Port number read from scripts/port-forward-all.sh
+  PORT=$2
+fi
+
+kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" $PORT:80

--- a/scripts/port-forward-bookstore-ui-v2.sh
+++ b/scripts/port-forward-bookstore-ui-v2.sh
@@ -19,4 +19,13 @@ POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no
 
 kubectl describe pod "$POD" -n "$BOOKSTORE_NAMESPACE"
 
-kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 8082:80
+# Check if run as standalone or from scripts/port-forward-all.sh
+if [ $# -eq 0 ]; then
+  # Prompt for a port number
+  read -p "Enter BOOKSTORE pod local port:" -i "8082" -e PORT
+else
+  # Port number read from scripts/port-forward-all.sh
+  PORT=$2
+fi
+
+kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" $PORT:80

--- a/scripts/port-forward-bookstore-ui-v2.sh
+++ b/scripts/port-forward-bookstore-ui-v2.sh
@@ -15,17 +15,9 @@ if [ -z "$backend" ]; then
     exit 1
 fi
 
+BOOKSTOREv2_LOCAL_PORT="${BOOKSTOREv2_LOCAL_PORT:-8082}"
 POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
 
 kubectl describe pod "$POD" -n "$BOOKSTORE_NAMESPACE"
 
-# Check if run as standalone or from scripts/port-forward-all.sh
-if [ $# -eq 0 ]; then
-  # Prompt for a port number
-  read -p "Enter BOOKSTORE pod local port:" -i "8082" -e PORT
-else
-  # Port number read from scripts/port-forward-all.sh
-  PORT=$2
-fi
-
-kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" $PORT:80
+kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv2_LOCAL_PORT":80

--- a/scripts/port-forward-bookthief-ui.sh
+++ b/scripts/port-forward-bookthief-ui.sh
@@ -11,4 +11,13 @@ POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-
 
 kubectl describe pod "$POD" -n "$BOOKTHIEF_NAMESPACE"
 
-kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" 8083:80
+# Check if run as standalone or from scripts/port-forward-all.sh
+if [ $# -eq 0 ]; then
+  # Prompt for a port number
+  read -p "Enter BOOKTHIEF pod local port:" -i "8083" -e PORT
+else
+  # Port number read from scripts/port-forward-all.sh
+  PORT=$1
+fi
+
+kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" $PORT:80

--- a/scripts/port-forward-bookthief-ui.sh
+++ b/scripts/port-forward-bookthief-ui.sh
@@ -7,17 +7,9 @@
 # shellcheck disable=SC1091
 source .env
 
+BOOKTHIEF_LOCAL_PORT="${BOOKTHIEF_LOCAL_PORT:-8083}"
 POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
 
 kubectl describe pod "$POD" -n "$BOOKTHIEF_NAMESPACE"
 
-# Check if run as standalone or from scripts/port-forward-all.sh
-if [ $# -eq 0 ]; then
-  # Prompt for a port number
-  read -p "Enter BOOKTHIEF pod local port:" -i "8083" -e PORT
-else
-  # Port number read from scripts/port-forward-all.sh
-  PORT=$1
-fi
-
-kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" $PORT:80
+kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" "$BOOKTHIEF_LOCAL_PORT":80


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.

fixes #1483
This allows users to specify port numbers for the Bookstore Demo Applications.  It will prompt with the default port numbers but these can be changed.  The port-forward-ui scripts can be run individually or from port-forward-all.sh

Please mark with X for applicable areas.

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No. 