### PR TITLE
docs: use patch command to edit ConfigMap

### DIFF
--- a/docs/patterns/egress.md
+++ b/docs/patterns/egress.md
@@ -18,50 +18,29 @@ Enabling egress is done via a global setting. The setting is toggled on or off a
 Egress can be enabled during OSM install or post install. When egress is enabled, OSM requires the mesh [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges to be specified. The mesh CIDR ranges are the list of CIDR ranges corresponding to the pod and service CIDRs configured in the cluster. The mesh CIDR ranges are required with egress to prevent any traffic destined within the cluster from escaping out as egress traffic, to be able to enforce mesh traffic policies.
 
 A [convenience script](https://github.com/openservicemesh/osm/blob/main/scripts/get_mesh_cidr.sh) to retrieve the mesh CIDR ranges can be used if the user is not aware of the pod and service CIDR ranges for their cluster.
-```shell
+```console
 $ ./scripts/get_mesh_cidr.sh
 10.0.0.0/16,10.2.0.0/16
 ```
 
 Egress can be configured using either of the following ways.
 1. During OSM install (default `--enable-egress=false`)
-	```shell
-	$ osm install --enable-egress --mesh-cidr "10.0.0.0/16,10.2.0.0/16"
+	```bash
+	osm install --enable-egress --mesh-cidr "10.0.0.0/16,10.2.0.0/16"
 	```
 	or
-	```shell
-	$ osm install --enable-egress --mesh-cidr 10.0.0.0/16 --mesh-cidr 10.2.0.0/16
+	```bash
+	osm install --enable-egress --mesh-cidr 10.0.0.0/16 --mesh-cidr 10.2.0.0/16
 	```
 
 2. Post OSM install
 
-	`osm-controller` retrieves the egress configuration from the `osm-config` ConfigMap in its namespace (`osm-system` by default). Edit the ConfigMap by setting `egress: "true"` and `mesh_cidr_ranges` with the CIDR ranges obtained above.
-	```shell
-	$ kubectl edit configmap -n osm-system osm-config
+	`osm-controller` retrieves the egress configuration from the `osm-config` ConfigMap in its namespace (`osm-system` by default). Patch the ConfigMap by setting `egress: "true"` and `mesh_cidr_ranges` with the CIDR ranges obtained above.
+	```bash
+	kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"egress":"true", "mesh_cidr_ranges":"10.0.0.0/16,10.2.0.0/16"}}' --type=merge
 	```
-	The value for `mesh_cidr_ranges` can either be space or comma separated.
-    ```yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-        name: osm-config
-        namespace: osm-system
-    data:
-        egress: "true"
-        mesh_cidr_ranges: 10.0.0.0/16 10.2.0.0/16
-    ...
-    ```
-    ```yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-        name: osm-config
-        namespace: osm-system
-    data:
-        egress: "true"
-        mesh_cidr_ranges: 10.0.0.0/16,10.2.0.0/16
-    ...
-	```
+	*Note: The value for `mesh_cidr_ranges` can either be space or comma separated.*
+
 
 With egress enabled, traffic from pods within the mesh will be allowed to access external services outside the mesh CIDR ranges.
 
@@ -70,24 +49,14 @@ With egress enabled, traffic from pods within the mesh will be allowed to access
 Similar to enabling egress, egress can be disabled during OSM install or post install. The mesh CIDR ranges are not required when egress is being disabled.
 
 1. During OSM install
-	```shell
-	$ bin osm install --enable-egress=false
+	```bash
+	bin osm install --enable-egress=false
 	```
 
 2. Post OSM install
-	Edit the `osm-config` ConfigMap and set `egress: "false"`.
-	```shell
-	$ kubectl edit configmap -n osm-system osm-config
-    ```
-    ```yaml
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-        name: osm-config
-        namespace: osm-system
-    data:
-        egress: "false"
-    ...
+	Patch the `osm-config` ConfigMap and set `egress: "false"`.
+	```bash
+	kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"egress":"false"}}' --type=merge
     ```
 
 With egress disabled, traffic from pods within the mesh will not be able to access external services outside the mesh CIDR ranges.


### PR DESCRIPTION
Inspired by Christian Posta's demo https://www.youtube.com/watch?v=eFawBTtoJmE,
to use a one liner to update the ConfigMap. This makes it easier to
run and automate as opposed to the `kubectl edit` command.

Also removes `$` from command blocks and uses the `bash` markdown
syntax for consistency, which is an alias for `shell, sh, zsh`.

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`