### PR TITLE
fix(cli): osm namespace add should fail when adding osm-system NS

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -202,7 +202,7 @@ func (i *installCmd) run(config *helm.Configuration) error {
 	}
 
 	deploymentsClient = i.clientSet.AppsV1().Deployments(settings.Namespace()) // Get deployments for specified namespace
-	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{"app": OSMControllerName}}
+	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{"app": constants.OSMControllerName}}
 
 	listOptions = metav1.ListOptions{
 		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -56,7 +56,6 @@ const (
 	defaultCertManager         = "tresor"
 	defaultVaultProtocol       = "http"
 	defaultMeshName            = "osm"
-	osmControllerLabel         = "osm-controller"
 	defaultCertValidityMinutes = int(1440) // 24 hours
 )
 
@@ -203,7 +202,7 @@ func (i *installCmd) run(config *helm.Configuration) error {
 	}
 
 	deploymentsClient = i.clientSet.AppsV1().Deployments(settings.Namespace()) // Get deployments for specified namespace
-	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{"app": osmControllerLabel}}
+	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{"app": OSMControllerName}}
 
 	listOptions = metav1.ListOptions{
 		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -53,10 +53,10 @@ well as for adding a Kubernetes Namespace to the list of Namespaces a control
 plane should watch for sidecar injection of Envoy proxies.
 `
 const (
-	defaultCertManager   = "tresor"
-	defaultVaultProtocol = "http"
-	defaultMeshName      = "osm"
-
+	defaultCertManager         = "tresor"
+	defaultVaultProtocol       = "http"
+	defaultMeshName            = "osm"
+	osmControllerLabel         = "osm-controller"
 	defaultCertValidityMinutes = int(1440) // 24 hours
 )
 
@@ -203,7 +203,7 @@ func (i *installCmd) run(config *helm.Configuration) error {
 	}
 
 	deploymentsClient = i.clientSet.AppsV1().Deployments(settings.Namespace()) // Get deployments for specified namespace
-	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{"app": "osm-controller"}}
+	labelSelector = metav1.LabelSelector{MatchLabels: map[string]string{"app": osmControllerLabel}}
 
 	listOptions = metav1.ListOptions{
 		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openservicemesh/osm/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	fake "k8s.io/client-go/kubernetes/fake"
@@ -732,11 +733,11 @@ func createDeploymentSpec(namespace, meshName string) *v1.Deployment {
 	labelMap := make(map[string]string)
 	if meshName != "" {
 		labelMap["meshName"] = meshName
-		labelMap["app"] = OSMControllerName
+		labelMap["app"] = constants.OSMControllerName
 	}
 	return &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      OSMControllerName,
+			Name:      constants.OSMControllerName,
 			Namespace: namespace,
 			Labels:    labelMap,
 		},

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -732,11 +732,11 @@ func createDeploymentSpec(namespace, meshName string) *v1.Deployment {
 	labelMap := make(map[string]string)
 	if meshName != "" {
 		labelMap["meshName"] = meshName
-		labelMap["app"] = "osm-controller"
+		labelMap["app"] = osmControllerLabel
 	}
 	return &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "osm-controller",
+			Name:      osmControllerLabel,
 			Namespace: namespace,
 			Labels:    labelMap,
 		},

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -732,11 +732,11 @@ func createDeploymentSpec(namespace, meshName string) *v1.Deployment {
 	labelMap := make(map[string]string)
 	if meshName != "" {
 		labelMap["meshName"] = meshName
-		labelMap["app"] = osmControllerLabel
+		labelMap["app"] = OSMControllerName
 	}
 	return &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      osmControllerLabel,
+			Name:      OSMControllerName,
 			Namespace: namespace,
 			Labels:    labelMap,
 		},

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -66,16 +66,16 @@ func (a *namespaceAddCmd) run() error {
 		defer cancel()
 
 		deploymentsClient := a.clientSet.AppsV1().Deployments(ns)
-		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "osm-controller"}}
+		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": osmControllerLabel}}
 
 		listOptions := metav1.ListOptions{
 			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 		}
 		list, _ := deploymentsClient.List(context.TODO(), listOptions)
 
-		// if osm-controller is installed in that namespace then don't add that to mesh
+		// if osm-controller is installed in this namespace then don't add that to mesh
 		if len(list.Items) != 0 {
-			fmt.Fprintf(a.out, "Namespace [%s] already has osm-controller installed and cannot be added to mesh [%s]\n", ns, a.meshName)
+			fmt.Fprintf(a.out, "Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", ns, osmControllerLabel, a.meshName)
 		} else {
 			patch := `{"metadata":{"labels":{"` + constants.OSMKubeResourceMonitorAnnotation + `":"` + a.meshName + `"}}}`
 			_, err := a.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -66,7 +66,7 @@ func (a *namespaceAddCmd) run() error {
 		defer cancel()
 
 		deploymentsClient := a.clientSet.AppsV1().Deployments(ns)
-		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": OSMControllerName}}
+		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": constants.OSMControllerName}}
 
 		listOptions := metav1.ListOptions{
 			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
@@ -75,7 +75,7 @@ func (a *namespaceAddCmd) run() error {
 
 		// if osm-controller is installed in this namespace then don't add that to mesh
 		if len(list.Items) != 0 {
-			fmt.Fprintf(a.out, "Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", ns, OSMControllerName, a.meshName)
+			fmt.Fprintf(a.out, "Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", ns, constants.OSMControllerName, a.meshName)
 		} else {
 			patch := `{"metadata":{"labels":{"` + constants.OSMKubeResourceMonitorAnnotation + `":"` + a.meshName + `"}}}`
 			_, err := a.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -66,7 +66,7 @@ func (a *namespaceAddCmd) run() error {
 		defer cancel()
 
 		deploymentsClient := a.clientSet.AppsV1().Deployments(ns)
-		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": osmControllerLabel}}
+		labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": OSMControllerName}}
 
 		listOptions := metav1.ListOptions{
 			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
@@ -75,7 +75,7 @@ func (a *namespaceAddCmd) run() error {
 
 		// if osm-controller is installed in this namespace then don't add that to mesh
 		if len(list.Items) != 0 {
-			fmt.Fprintf(a.out, "Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", ns, osmControllerLabel, a.meshName)
+			fmt.Fprintf(a.out, "Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", ns, OSMControllerName, a.meshName)
 		} else {
 			patch := `{"metadata":{"labels":{"` + constants.OSMKubeResourceMonitorAnnotation + `":"` + a.meshName + `"}}}`
 			_, err := a.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Running the namespace add command", func() {
 			})
 
 			It("should give a warning message", func() {
-				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", testNamespace, OSMControllerName, testMeshName)))
+				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", testNamespace, constants.OSMControllerName, testMeshName)))
 			})
 		})
 	})

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -93,6 +93,34 @@ var _ = Describe("Running the namespace add command", func() {
 				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] successfully added to mesh [%s]\nNamespace [%s] successfully added to mesh [%s]\n", testNamespace, testMeshName, testNamespace2, testMeshName)))
 			})
 		})
+		Context("given one namespace with osm-controller installed in it as an arg", func() {
+			BeforeEach(func() {
+				out = new(bytes.Buffer)
+				fakeClientSet = fake.NewSimpleClientset()
+				// mimic osm controller deployment in testNamespace
+				deploymentSpec := createDeploymentSpec(testNamespace, defaultMeshName)
+				fakeClientSet.AppsV1().Deployments(testNamespace).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
+
+				nsSpec := createNamespaceSpec(testNamespace, "")
+				fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
+
+				namespaceAddCmd := &namespaceAddCmd{
+					out:        out,
+					meshName:   testMeshName,
+					namespaces: []string{testNamespace},
+					clientSet:  fakeClientSet,
+				}
+
+				err = namespaceAddCmd.run()
+			})
+			It("should not error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should give a warning message", func() {
+				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has osm-controller installed and cannot be added to mesh [%s]\n", testNamespace, testMeshName)))
+			})
+		})
 	})
 
 	Describe("with non-existent namespace", func() {

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Running the namespace add command", func() {
 			})
 
 			It("should give a warning message", func() {
-				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has osm-controller installed and cannot be added to mesh [%s]\n", testNamespace, testMeshName)))
+				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", testNamespace, osmControllerLabel, testMeshName)))
 			})
 		})
 	})

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Running the namespace add command", func() {
 			})
 
 			It("should give a warning message", func() {
-				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", testNamespace, osmControllerLabel, testMeshName)))
+				Expect(out.String()).To(Equal(fmt.Sprintf("Namespace [%s] already has [%s] installed and cannot be added to mesh [%s]\n", testNamespace, OSMControllerName, testMeshName)))
 			})
 		})
 	})


### PR DESCRIPTION
fixes: https://github.com/openservicemesh/osm/issues/1196
This has changes to return an error when a user tries to add a namespace which has osm control plane running in it.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [x]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No

todo:
- [x] update tests