### PR TITLE
envoy/eds: add test for EDS response

### DIFF
--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -1,0 +1,78 @@
+package eds
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+var _ = Describe("Test EDS response", func() {
+	kubeClient := testclient.NewSimpleClientset()
+	catalog := catalog.NewFakeMeshCatalog(kubeClient)
+	cfg := configurator.NewFakeConfigurator()
+
+	Context("Test eds.NewResponse", func() {
+		It("Correctly returns an response for endpoints when the certificate and service are valid", func() {
+			// Initialize the proxy service
+			proxyServiceName := tests.BookbuyerServiceName
+			proxyServiceAccountName := tests.BookbuyerServiceAccountName
+			proxyUUID := fmt.Sprintf("proxy-0-%s", uuid.New())
+
+			// The format of the CN matters
+			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
+			proxy := envoy.NewProxy(xdsCertificate, nil)
+
+			{
+				// Create a pod to match the CN
+				podName := fmt.Sprintf("pod-0-%s", uuid.New())
+				pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, podName, proxyServiceAccountName)
+				pod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID // This is what links the Pod and the Certificate
+				_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			{
+				// Create a service for the pod created above
+				selectors := map[string]string{
+					// These need to match the POD created above
+					tests.SelectorKey: tests.SelectorValue,
+				}
+				// The serviceName must match the SMI
+				service := tests.NewServiceFixture(proxyServiceName, tests.Namespace, selectors)
+				_, err := kubeClient.CoreV1().Services(tests.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			_, err := NewResponse(context.Background(), catalog, proxy, nil, cfg)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Correctly returns an error response for endpoints when the proxy isn't associated with a MeshService", func() {
+			// Initialize the proxy service
+			proxyServiceAccountName := "non-existent-service-account"
+			proxyUUID := fmt.Sprintf("non-existent-pod-%s", uuid.New())
+
+			// The format of the CN matters
+			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
+			proxy := envoy.NewProxy(xdsCertificate, nil)
+
+			// Don't create a pod/service for this proxy, this should result in an error when the
+			// service is being looked up based on the proxy's certificate
+
+			_, err := NewResponse(context.Background(), catalog, proxy, nil, cfg)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This change adds adds tests for EDS. It improves the
test coverage from 0% to 80%. A subsequent change
will refactor the code further to make the existing
code more unit testable.

Part of #1489 

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`