### PR TITLE
certificates: Unit tests for Hashicorp Vault integration

### DIFF
--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"net/url"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -13,6 +14,49 @@ import (
 )
 
 var _ = Describe("Test client helpers", func() {
+	issuingCA := pem.RootCertificate("zz")
+
+	expiredCertCN := certificate.CommonName("this.has.expired")
+	expiredCert := &Certificate{
+		issuingCA:  pem.RootCertificate("zz"),
+		privateKey: pem.PrivateKey("yy"),
+		certChain:  pem.Certificate("xx"),
+		expiration: time.Now(), // This certificate has ALREADY expired
+		commonName: expiredCertCN,
+	}
+
+	validCertCN := certificate.CommonName("valid.certificate")
+	validCert := &Certificate{
+		issuingCA:  issuingCA,
+		privateKey: pem.PrivateKey("yy"),
+		certChain:  pem.Certificate("xx"),
+		expiration: time.Now().Add(24 * time.Hour),
+		commonName: validCertCN,
+	}
+
+	rootCertCN := certificate.CommonName("root.cert")
+	rootCert := &Certificate{
+		issuingCA:  pem.RootCertificate("zz"),
+		privateKey: pem.PrivateKey("yy"),
+		certChain:  pem.Certificate("xx"),
+		expiration: time.Now().Add(24 * time.Hour),
+		commonName: rootCertCN,
+	}
+
+	Context("Test NewCertManager()", func() {
+		It("creates new certificate manager", func() {
+			vaultAddr := "foo://bar/baz"
+			vaultToken := "bar"
+			validityPeriod := 1 * time.Second
+			vaultRole := "baz"
+			_, err := NewCertManager(vaultAddr, vaultToken, validityPeriod, vaultRole)
+			Expect(err).To(HaveOccurred())
+			vaultError := err.(*url.Error)
+			expected := `unsupported protocol scheme "foo"`
+			Expect(vaultError.Err.Error()).To(Equal(expected))
+		})
+	})
+
 	Context("Test creating a Certificate from Hashi Vault Secret", func() {
 		It("creates a Certificate struct from Hashi Vault Secret struct", func() {
 
@@ -39,6 +83,48 @@ var _ = Describe("Test client helpers", func() {
 			}
 
 			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test Hashi Vault functions", func() {
+		cm := CertManager{
+			cache: &map[certificate.CommonName]certificate.Certificater{
+				expiredCertCN: expiredCert,
+				validCertCN:   validCert,
+			},
+			ca: rootCert,
+		}
+
+		It("gets certs from cache", func() {
+			// This cert does not exist - returns nil
+			Expect(cm.getFromCache("nothing")).To(BeNil())
+
+			// This cert has expired -- returns nil
+			Expect(cm.getFromCache(expiredCertCN)).To(BeNil())
+
+			actual := cm.getFromCache(validCertCN)
+			Expect(actual).To(Equal(validCert))
+		})
+
+		It("creates certificates", func() {
+			actual, err := cm.GetCertificate(validCertCN)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(validCert))
+		})
+
+		It("can fetch root cert", func() {
+			actual, err := cm.GetRootCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal(rootCert))
+		})
+
+		It("implements Certificater correctly", func() {
+			actual, err := cm.GetCertificate(validCertCN)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.GetCommonName()).To(Equal(validCertCN))
+			Expect(actual.GetCertificateChain()).To(Equal([]byte(validCert.certChain)))
+			Expect(actual.GetExpiration()).To(Equal(validCert.expiration))
+			Expect(actual.GetIssuingCA()).To(Equal([]byte(issuingCA)))
 		})
 	})
 })


### PR DESCRIPTION
Adding unit tests to `pkg/certificate/providers/vault`

### Before
```
$ go test -cover ./pkg/certificate/providers/vault/...
ok      github.com/openservicemesh/osm/pkg/certificate/providers/vault  0.005s  coverage: 13.6% of statements
```

### After
```
$ go test -cover ./pkg/certificate/providers/vault/...
ok      github.com/openservicemesh/osm/pkg/certificate/providers/vault  3.051s  coverage: 51.9% of statements
```

This PR partially addresses https://github.com/openservicemesh/osm/issues/1489

---


Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ X ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? no
