### PR TITLE
catalog/routes: fix naming for TrafficTarget policy

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -343,10 +343,12 @@ func (mc *MeshCatalog) buildAllowPolicyForSourceToDest(source *corev1.Service, d
 		PathRegex: constants.RegexMatchAll,
 		Methods:   []string{constants.WildcardHTTPMethod},
 	}
+	srcMeshSvc := k8sSvcToMeshSvc(source)
+	dstMeshSvc := k8sSvcToMeshSvc(destination)
 	return trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s->%s", source, destination),
-		Destination: k8sSvcToMeshSvc(destination),
-		Source:      k8sSvcToMeshSvc(source),
+		Name:        fmt.Sprintf("%s->%s", srcMeshSvc, dstMeshSvc),
+		Destination: dstMeshSvc,
+		Source:      srcMeshSvc,
 		Route:       allowAllRoute,
 	}
 }


### PR DESCRIPTION
Instead of using `namespace/svc`, the policy was incorrectly
stringifying the k8s service object.

Resolves #1503

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`