### PR TITLE
Add Helm chart release workflow

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,16 @@
+name: Release Helm Chart
+on:
+  push:
+    tags:
+      - "chart*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "v*"
 
 jobs:
   version:

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -4,19 +4,38 @@ This guide describes the process to create a GitHub Release for this project.
 
 1. [Create and push a Git tag](#create-and-push-a-git-tag)
 1. [Add release notes](#add-release-notes)
+1. [Create a Helm chart release](#create-a-helm-chart-release)
 1. [Announce the new release](#announce-the-new-release)
 
 ## Create and push a Git tag
+
 ```console
 $ export RELEASE_VERSION=<release-version> # ex: export RELEASE_VERSION=v0.1.0
 $ git tag -a "$RELEASE_VERSION" -m "<add description here>"
 $ git push origin "$RELEASE_VERSION"
 ```
 
-A [GitHub Action](/.github/workflows/release.yml) is triggered when the tag is pushed. It will build the CLI binaries, publish a new GitHub release, upload the packaged binaries and checksums as release assets, and build and push Docker images for OSM and the demo to the [`openservicemesh` organization](https://hub.docker.com/u/openservicemesh) on Docker Hub.
+A [GitHub Action](/.github/workflows/release.yml) is triggered when the tag is pushed.
+It will build the CLI binaries, publish a new GitHub release,
+upload the packaged binaries and checksums as release assets,
+and build and push Docker images for OSM and the demo to the
+[`openservicemesh` organization](https://hub.docker.com/u/openservicemesh) on Docker Hub.
 
 ## Add release notes
-In the description section of the new release, add information about feature additions, bug fixes, and any other administrative tasks completed on the repository.
+
+In the description section of the new release, add information about feature additions, bug fixes,
+and any other administrative tasks completed on the repository.
+
+## Create a Helm chart release
+
+* set the container image tag in `charts/osm/values.yaml` and `charts/osm/Chart.yaml`
+* bump the chart version in `charts/osm/Chart.yaml`
+* create a PR with the above changes and merge it to main
+* create a Git tag from main in the format `chart/x.x.x` where `x.x.x` is the chart version
+* push the Git tag to origin
+* GitHub Actions runs [helm-gh-pages](https://github.com/stefanprodan/helm-gh-pages) that packages the charts, updates `index.yaml` and pushes the changes to `gh-pages` branch
+* GitHub Pages publishes the new version, making the chart available at `https://openservicemesh.github.io/osm`
 
 ## Announce the new release
-- Make an announcement on the [mailing list](https://groups.google.com/g/openservicemesh).
+
+Make an announcement on the [mailing list](https://groups.google.com/g/openservicemesh).


### PR DESCRIPTION
Publish './charts' to gh-pages branch on git tags with 'chart' prefix.

Signed-off-by: stefanprodan <stefan.prodan@gmail.com>

Ref: #1424 

### Release procedure

* create OSM release
* wait for the container image to be pushed to Docker Hub
* set the container image tag in `charts/osm/values.yaml` and `charts/osm/Chart.yaml`
* bump the chart version in `charts/osm/Chart.yaml`
* create a PR with the above changes and merge it to main
* create a git tag from main in the format `chart/vx.x.x` where `vx.x.x` is the chart version
* push the git tag to origin
* GH Actions runs [helm-gh-pages](https://github.com/stefanprodan/helm-gh-pages) that packages the charts, updates `index.yaml` and pushes the changes to `gh-pages` branch
* GH Pages publishes the new version, making the chart available at `https://openservicemesh.github.io/osm`

Note that the above procedure works for any number of charts in the `./charts` dir without any changes to the GH Actions workflow. 

Applicable areas:

- [x] Tests / CI System      


Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

Yes, I'm the author of the GH Action.
