### PR TITLE
feat(ci): push images on each push to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,3 +269,36 @@ jobs:
           make kind-up
           ./demo/run-osm-demo.sh
           go run ./ci/cmd/maestro.go
+
+  images:
+    name: Docker Images
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    env:
+      DOCKER_USER: ${{ secrets.RELEASE_DOCKER_USER }}
+      DOCKER_PASS: ${{ secrets.RELEASE_DOCKER_PASS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+      - name: Setup Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Docker Login
+        run: docker login --username "$DOCKER_USER" --password-stdin <<< "$DOCKER_PASS"
+      - name: Push images with git sha tag
+        env:
+          CTR_TAG: ${{ github.sha }}
+        run: make docker-push


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.

This change will push Docker images tagged with the git sha of the commit on each push to the main branch. Since this is added to the main CI workflow, new images will not be pushed when only docs change.

Fixes #1492 

Please mark with X for applicable areas.

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No