### PR TITLE
pkg/*: remove type assertions that can be safely asserted (dead code)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -435,7 +435,7 @@ type MeshSpec interface {
 	ListServiceAccounts() []service.K8sServiceAccount
 
 	// GetService fetches a specific service declared in SMI.
-	GetService(service.MeshService) (service *corev1.Service, err error)
+	GetService(service.MeshService) *corev1.Service
 
 	// ListHTTPTrafficSpecs lists TrafficSpec SMI resources.
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup
@@ -443,11 +443,19 @@ type MeshSpec interface {
 	// ListTrafficTargets lists TrafficTarget SMI resources.
 	ListTrafficTargets() []*target.TrafficTarget
 
+	// ListBackpressures lists Backpressure resources.
+	// This is an experimental feature, which will eventually
+	// in some shape or form make its way into SMI Spec.
+	ListBackpressures() []*backpressure.Backpressure
+
+	// GetBackpressurePolicy gets the Backpressure policy corresponding to the MeshService
+	GetBackpressurePolicy(service.MeshService) *backpressure.Backpressure
+
 	// GetAnnouncementsChannel returns the channel on which SMI makes announcements
 	GetAnnouncementsChannel() <-chan interface{}
 
 	// ListServices returns a list of services that are part of monitored namespaces
-	ListServices() ([]*corev1.Service, error)
+	ListServices() []*corev1.Service
 }
 ```
 

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -68,10 +68,7 @@ func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.Weigh
 	serviceAccouns := mc.meshSpec.ListServiceAccounts()
 	trafficSpecs := mc.meshSpec.ListHTTPTrafficSpecs()
 	trafficTargets := mc.meshSpec.ListTrafficTargets()
-	services, err := mc.meshSpec.ListServices()
-	if err != nil {
-		services = nil
-	}
+	services := mc.meshSpec.ListServices()
 
 	return trafficSplits, splitServices, serviceAccouns, trafficSpecs, trafficTargets, services
 }

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -209,8 +209,7 @@ var _ = Describe("Catalog tests", func() {
 
 	Context("Test buildAllowAllTrafficPolicies", func() {
 		It("lists traffic targets for the given service", func() {
-			actual, err := mc.buildAllowAllTrafficPolicies(tests.BookstoreService)
-			Expect(err).ToNot(HaveOccurred())
+			actual := mc.buildAllowAllTrafficPolicies(tests.BookstoreService)
 			var actualTargetNames []string
 			for _, target := range actual {
 				actualTargetNames = append(actualTargetNames, target.Name)

--- a/pkg/endpoint/providers/azure/kubernetes/client.go
+++ b/pkg/endpoint/providers/azure/kubernetes/client.go
@@ -87,11 +87,8 @@ func (c *Client) Run(stop <-chan struct{}) error {
 func (c *Client) ListAzureResources() []*osm.AzureResource {
 	var azureResources []*osm.AzureResource
 	for _, azureResourceInterface := range c.caches.AzureResource.List() {
-		azureResource, ok := azureResourceInterface.(*osm.AzureResource)
-		if !ok {
-			log.Error().Err(errInvalidObjectType).Msg("Failed type assertion for AzureResource in cache")
-			continue
-		}
+		azureResource := azureResourceInterface.(*osm.AzureResource)
+
 		if !c.namespaceController.IsMonitoredNamespace(azureResource.Namespace) {
 			// Doesn't belong to namespaces we are observing
 			continue

--- a/pkg/endpoint/providers/azure/kubernetes/errors.go
+++ b/pkg/endpoint/providers/azure/kubernetes/errors.go
@@ -3,6 +3,5 @@ package azure
 import "github.com/pkg/errors"
 
 var (
-	errSyncingCaches     = errors.New("syncing caches")
-	errInvalidObjectType = errors.New("invalid object type in cache")
+	errSyncingCaches = errors.New("syncing caches")
 )

--- a/pkg/endpoint/providers/azure/provider.go
+++ b/pkg/endpoint/providers/azure/provider.go
@@ -91,9 +91,9 @@ func parseAzureID(id azureID) (resourceGroup, computeKind, computeName, error) {
 func (az *Client) resolveService(svc service.MeshService) []azureID {
 	log.Trace().Msgf("Resolving service %s to an Azure URI", svc)
 	var azureIDs []azureID
-	k8sService, err := az.meshSpec.GetService(svc)
-	if err != nil {
-		log.Error().Err(err).Msg("Error fetching Kubernetes Endpoints from cache")
+	k8sService := az.meshSpec.GetService(svc)
+	if k8sService == nil {
+		log.Error().Msgf("Error fetching Kubernetes Service for MeshService %s", svc)
 		return azureIDs
 	}
 	log.Trace().Msgf("Got the service: %+v", k8sService)

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -82,11 +82,7 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 		return endpoints
 	}
 
-	kubernetesEndpoints, ok := endpointsInterface.(*corev1.Endpoints)
-	if !ok {
-		log.Error().Err(errInvalidObjectType).Msg("Failed type assertion for Endpoints in cache")
-		return endpoints
-	}
+	kubernetesEndpoints := endpointsInterface.(*corev1.Endpoints)
 	if kubernetesEndpoints != nil {
 		if !c.namespaceController.IsMonitoredNamespace(kubernetesEndpoints.Namespace) {
 			// Doesn't belong to namespaces we are observing
@@ -120,11 +116,7 @@ func (c Client) GetServiceForServiceAccount(svcAccount service.K8sServiceAccount
 	deploymentsInterface := c.caches.Deployments.List()
 
 	for _, deployments := range deploymentsInterface {
-		kubernetesDeployments, ok := deployments.(*appsv1.Deployment)
-		if !ok {
-			log.Error().Err(errInvalidObjectType).Msg("Failed type assertion for Deployment in cache")
-			continue
-		}
+		kubernetesDeployments := deployments.(*appsv1.Deployment)
 		if kubernetesDeployments != nil {
 			if !c.namespaceController.IsMonitoredNamespace(kubernetesDeployments.Namespace) {
 				// Doesn't belong to namespaces we are observing

--- a/pkg/endpoint/providers/kube/errors.go
+++ b/pkg/endpoint/providers/kube/errors.go
@@ -7,5 +7,4 @@ var (
 	errInitInformers                      = errors.New("informers are not initialized")
 	errDidNotFindServiceForServiceAccount = errors.New("no service exists for the service account")
 	errMoreThanServiceForServiceAccount   = errors.New("more than one service found for the service account")
-	errInvalidObjectType                  = errors.New("invalid object type in cache")
 )

--- a/pkg/smi/errors.go
+++ b/pkg/smi/errors.go
@@ -3,7 +3,6 @@ package smi
 import "github.com/pkg/errors"
 
 var (
-	errSyncingCaches     = errors.New("failed initial sync of resources required for ingress")
-	errInitInformers     = errors.New("informers are not initialized")
-	errInvalidObjectType = errors.New("invalid object type in cache")
+	errSyncingCaches = errors.New("failed initial sync of resources required for ingress")
+	errInitInformers = errors.New("informers are not initialized")
 )

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
-	"github.com/pkg/errors"
 )
 
 type fakeMeshSpec struct {
@@ -59,13 +58,13 @@ func (f fakeMeshSpec) ListServiceAccounts() []service.K8sServiceAccount {
 }
 
 // GetService fetches a specific service declared in SMI for the fake Mesh Spec.
-func (f fakeMeshSpec) GetService(svc service.MeshService) (service *corev1.Service, err error) {
+func (f fakeMeshSpec) GetService(svc service.MeshService) *corev1.Service {
 	for _, service := range f.services {
 		if service.Name == svc.Name && service.Namespace == svc.Namespace {
-			return service, nil
+			return service
 		}
 	}
-	return nil, errors.Errorf("Service %s not found", svc)
+	return nil
 }
 
 // ListHTTPTrafficSpecs lists TrafficSpec SMI resources for the fake Mesh Spec.
@@ -102,6 +101,6 @@ func (f fakeMeshSpec) GetAnnouncementsChannel() <-chan interface{} {
 }
 
 // ListServices returns a list of services that are part of monitored namespaces
-func (f fakeMeshSpec) ListServices() ([]*corev1.Service, error) {
-	return f.services, nil
+func (f fakeMeshSpec) ListServices() []*corev1.Service {
+	return f.services
 }

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -62,7 +62,7 @@ type MeshSpec interface {
 	ListServiceAccounts() []service.K8sServiceAccount
 
 	// GetService fetches a specific service declared in SMI.
-	GetService(service.MeshService) (service *corev1.Service, err error)
+	GetService(service.MeshService) *corev1.Service
 
 	// ListHTTPTrafficSpecs lists TrafficSpec SMI resources.
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup
@@ -82,5 +82,5 @@ type MeshSpec interface {
 	GetAnnouncementsChannel() <-chan interface{}
 
 	// ListServices returns a list of services that are part of monitored namespaces
-	ListServices() ([]*corev1.Service, error)
+	ListServices() []*corev1.Service
 }


### PR DESCRIPTION
Previously we added type assertions for kubernetes resources in their
caches. These type assertions can only result from bugs in the code
if there is a mismatch between the resource type in the informer
and the code that asserts for the resource type in the informer cache.

Such a scenario is not possible to test if the code is correct (as is
the case now), and the code must be buggy for a potential unit test
to even be able to test such mismatches. Its also not possible for
such a bug to creep in because the tests would panic and fail.

This change removes such checks in the informer caches since its not
possible to even unit test the need for such code. It also simplifies
the return values of some functions that were only returning an error
for these scenarios.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`
