### PR TITLE
zipkin : Updating configmap for zipkin

### DIFF
--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -9,10 +9,12 @@ data:
   envoy_log_level: {{ .Values.OpenServiceMesh.envoyLogLevel | quote }}
   prometheus_scraping: "true"
 
+{{- if .Values.OpenServiceMesh.zipkin.enable }}
   zipkin_tracing: {{ .Values.OpenServiceMesh.zipkin.enable | quote }}
   zipkin_address: {{ .Values.OpenServiceMesh.zipkin.address | quote }}
   zipkin_port: {{ .Values.OpenServiceMesh.zipkin.port | quote }}
   zipkin_endpoint: {{ .Values.OpenServiceMesh.zipkin.endpoint | quote }}
+{{- end }}
 
 {{- if .Values.OpenServiceMesh.enableEgress }}
   mesh_cidr_ranges: {{ .Values.OpenServiceMesh.meshCIDRRanges | quote }}


### PR DESCRIPTION
This PR adds updates the configmap to show zipkin related values only when zipkin tracking is enabled in OSM

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
