### PR TITLE
Minor doc update: services are namespaced

### DIFF
--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -67,7 +67,7 @@ The following are the key components of the demo application:
 
 To view these resources on your cluster, run the following commands:
 ```
-kubectl get svc
+kubectl get svc --all-namespaces
 kubectl get deploy --all-namespaces
 kubectl get trafficsplit -n bookstore
 ```


### PR DESCRIPTION
This PR just adds the `--all-namespaces` flag to the `kubectl get svc` command. All of the demo app services are namespaced, so without the flag, it doesn't return any services.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [x]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No.
