### PR TITLE
Disable zipkin by default

### DIFF
--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -37,7 +37,7 @@ OpenServiceMesh:
   # Set deployZipkin to true to deploy a Zipkin cluster in the
   # namespace where OSM resides. Set this to false if Zipkin
   # has already been installed or is not needed.
-  deployZipkin: true
+  deployZipkin: false
 
   # The following section configures Zipkin tracing for the Envoys
   # connected to the OSM control plane.
@@ -45,7 +45,7 @@ OpenServiceMesh:
 
     ## Toggles Envoy's tracing functionality on/off
     ## for all proxies in the mesh.
-    enable: true
+    enable: false
 
     # Informs Envoys where the Zipkin spans should be sent
     address: "zipkin.osm-system.svc.cluster.local"

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -138,7 +138,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableBackpressureExperimental, "enable-backpressure-experimental", false, "Enable experimental backpressure feature")
 	f.BoolVar(&inst.enableMetricsStack, "enable-metrics-stack", true, "Enable metrics (Prometheus and Grafana) deployment")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
-	f.BoolVar(&inst.deployZipkin, "deploy-zipkin", true, "Deploy Zipkin in the namespace of the OSM controller")
+	f.BoolVar(&inst.deployZipkin, "deploy-zipkin", false, "Deploy Zipkin in the namespace of the OSM controller")
 
 	return cmd
 }

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -105,7 +105,6 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --enable-debug-server \
       --enable-egress="$ENABLE_EGRESS" \
       --mesh-cidr "$MESH_CIDR" \
-      --deploy-zipkin \
       $optionalInstallArgs
 else
   # shellcheck disable=SC2086
@@ -118,7 +117,6 @@ else
       --enable-debug-server \
       --enable-egress="$ENABLE_EGRESS" \
       --mesh-cidr "$MESH_CIDR" \
-      --deploy-zipkin \
       $optionalInstallArgs
 fi
 


### PR DESCRIPTION
Both Zipkin deployment and tracing config
are being marked as disabled by default.

Both of the options are still configurable
at config/install time.

---

Please mark with X for applicable areas.


- Install                [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No