### PR TITLE
Update guidance traffic split bookstore v2

### DIFF
--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -187,7 +187,7 @@ kubectl apply -f docs/example/manifests/bookstore-v2/
 
 Browse to http://localhost:8082. You should see the `bookstore-v2` heading in your browser window. **NOTE** Please exit and restart the `./scripts/port-forward-all.sh` script in order to access v2 of Bookstore.
 
-After restarting the port forwarding script, you should now be able to access the `bookstore-v2` application at http://localhost:8082. The count for the books sold should remain at 0, this is because the current traffic split policy is currently weighted 100% for `bookstore-v2`. You can verify the traffic split policy by running the following and viewing the **Backends** properties:
+After restarting the port forwarding script, you should now be able to access the `bookstore-v2` application at http://localhost:8082. The count for the books sold should remain at 0, this is because the current traffic split policy is currently weighted 100% for `bookstore-v1`. You can verify the traffic split policy by running the following and viewing the **Backends** properties:
 ```
 kubectl describe trafficsplit bookstore-split -n bookstore
 ```


### PR DESCRIPTION
I believe it's just a minor writing mistake, but I have to submit a PR ( avoiding to mislead people ) cuz up to this point ( before deploying traffic split policy for bookstore v2 ), using kubectl describe trafficsplit bookstore-split -n bookstore command will see bookstore v1 still have 100% weight of the traffic sending through. And after that point, it works pretty well to lift 100% traffic to bookstore v2 and it can be adjusted using traffic split policy.  Like this demo ! Simple and well-explained !

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
