### PR TITLE
smi/test: remove comment left behind during development

### DIFF
--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -347,7 +347,7 @@ var _ = Describe("When listing Services", func() {
 
 	It("should return an empty list when no services are found", func() {
 		services := meshSpec.ListServices()
-		Expect(len(services)).To(Equal(0)) // fixme cache sync not done yet
+		Expect(len(services)).To(Equal(0))
 	})
 
 	It("should return a list of Services", func() {


### PR DESCRIPTION
This comment was added during debugging an issue while developing
the test with fake caches. It no longer holds true.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`
