### PR TITLE
ci: use consistent wait times across test scenarios

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ on:
       - "**.md"
 env:
   KUBECONFIG: ".kube/config"
-  CI_WAIT_FOR_OK_SECONDS: 60
+  CI_WAIT_FOR_OK_SECONDS: 90
   CI_MAX_ITERATIONS_THRESHOLD: 90
   CI_CLIENT_CONCURRENT_CONNECTIONS: 1
-  CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 60
+  CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 90
   CI_MIN_SUCCESS_THRESHOLD: 1
   OSM_HUMAN_DEBUG_LOG: true
 
@@ -172,7 +172,6 @@ jobs:
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
           ENABLE_EGRESS: "false"
           EGRESS_EXPECTED_RESPONSE_CODE: "404" # egress is disabled
-          CI_WAIT_FOR_OK_SECONDS: 75
           DEPLOY_TRAFFIC_SPLIT: "true"
         run: |
           touch .env
@@ -262,7 +261,6 @@ jobs:
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
           ENABLE_EGRESS: "false"
           EGRESS_EXPECTED_RESPONSE_CODE: "404" # egress is disabled
-          CI_WAIT_FOR_OK_SECONDS: 75
           DEPLOY_TRAFFIC_SPLIT: "false"
         run: |
           touch .env


### PR DESCRIPTION
A few CI runs are failing due to the CI timing out just
before the test passes. This change makes the CI timeout
consistent for tests and increasing the timeout by a bit
to give slower CI runs a chance to pass.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`