### PR TITLE
Updating assignment of optional values in osm-config ConfigMap

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -165,7 +165,7 @@ func getEgressCIDR(configMap *v1.ConfigMap) string {
 func getBoolValueForKey(configMap *v1.ConfigMap, key string) bool {
 	configMapStringValue, ok := configMap.Data[key]
 	if !ok {
-		log.Error().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
+		log.Debug().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
 		return false
 	}
 
@@ -181,7 +181,7 @@ func getBoolValueForKey(configMap *v1.ConfigMap, key string) bool {
 func getIntValueForKey(configMap *v1.ConfigMap, key string) int {
 	configMapStringValue, ok := configMap.Data[key]
 	if !ok {
-		log.Error().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
+		log.Debug().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
 		return 0
 	}
 
@@ -197,7 +197,7 @@ func getIntValueForKey(configMap *v1.ConfigMap, key string) int {
 func getStringValueForKey(configMap *v1.ConfigMap, key string) string {
 	configMapStringValue, ok := configMap.Data[key]
 	if !ok {
-		log.Error().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
+		log.Debug().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
 		return ""
 	}
 	return configMapStringValue

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -130,19 +130,24 @@ func (c *Client) getConfigMap() *osmConfig {
 
 	configMap := item.(*v1.ConfigMap)
 
-	return &osmConfig{
+	osmConfigMap := osmConfig{
 		PermissiveTrafficPolicyMode: getBoolValueForKey(configMap, permissiveTrafficPolicyModeKey),
 		Egress:                      getBoolValueForKey(configMap, egressKey),
 		PrometheusScraping:          getBoolValueForKey(configMap, prometheusScrapingKey),
 		MeshCIDRRanges:              getEgressCIDR(configMap),
 		UseHTTPSIngress:             getBoolValueForKey(configMap, useHTTPSIngressKey),
 
-		ZipkinTracing:  getBoolValueForKey(configMap, zipkinTracingKey),
-		ZipkinAddress:  getStringValueForKey(configMap, zipkinAddressKey),
-		ZipkinPort:     getIntValueForKey(configMap, zipkinPortKey),
-		ZipkinEndpoint: getStringValueForKey(configMap, zipkinEndpointKey),
-		EnvoyLogLevel:  getStringValueForKey(configMap, envoyLogLevel),
+		ZipkinTracing: getBoolValueForKey(configMap, zipkinTracingKey),
+		EnvoyLogLevel: getStringValueForKey(configMap, envoyLogLevel),
 	}
+
+	if osmConfigMap.ZipkinTracing {
+		osmConfigMap.ZipkinAddress = getStringValueForKey(configMap, zipkinAddressKey)
+		osmConfigMap.ZipkinPort = getIntValueForKey(configMap, zipkinPortKey)
+		osmConfigMap.ZipkinEndpoint = getStringValueForKey(configMap, zipkinEndpointKey)
+	}
+
+	return &osmConfigMap
 }
 
 func getEgressCIDR(configMap *v1.ConfigMap) string {


### PR DESCRIPTION
This PR updates the way the optional values in the osm-config configmap are assigned. It fixes #1543 

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `No`
