### PR TITLE
ci: run cert-manager scenario with SMI policies enabled

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
           go run ./ci/cmd/maestro.go
 
   integration-nosplit:
-    name: Integration Test with jetstack/cert-manager, SMI traffic policies (no Traffic Split), and egress disabled
+    name: Integration Test with jetstack/cert-manager, SMI traffic policies, and egress disabled
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -254,14 +254,14 @@ jobs:
           go-version: 1.14
         id: go
 
-      - name: Run Simulation w/ jetstack/cert-manager, SMI policies (no Traffic Split), and egress disabled
+      - name: Run Simulation w/ jetstack/cert-manager, SMI policies, and egress disabled
         env:
           CERT_MANAGER: "cert-manager" # enables jetstack/cert-manager integration
-          BOOKSTORE_SVC: "bookstore-v1"
+          BOOKSTORE_SVC: "bookstore"
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
           ENABLE_EGRESS: "false"
           EGRESS_EXPECTED_RESPONSE_CODE: "404" # egress is disabled
-          DEPLOY_TRAFFIC_SPLIT: "false"
+          DEPLOY_TRAFFIC_SPLIT: "true"
         run: |
           touch .env
           make kind-up


### PR DESCRIPTION
Only the nosplit integration test is meant to run without traffic
split. This change makes the cert-manager scenario testable with
SMI policies similar to the `tresor` scenario.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`