### PR TITLE
version: Set Version variables; Show in liveness/readiness probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,12 @@ GOBIN  = $(GOPATH)/bin
 GOX    = go run github.com/mitchellh/gox
 
 CLI_VERSION ?= dev
+CONTROLLER_VERSION = $$(git describe --abbrev=0 --tags)
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
 GIT_SHA=$$(git rev-parse --short HEAD)
-BUILD_DATE_VAR := main.BuildDate
-BUILD_VERSION_VAR := main.BuildVersion
-BUILD_GITCOMMIT_VAR := main.GitCommit
+BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate
+BUILD_VERSION_VAR := github.com/openservicemesh/osm/pkg/version.Version
+BUILD_GITCOMMIT_VAR := github.com/openservicemesh/osm/pkg/version.GitCommit
 
 LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CLI_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X main.chartTGZSource=$$(cat -)"
 
@@ -42,7 +43,7 @@ build: build-osm-controller
 .PHONY: build-osm-controller
 build-osm-controller: clean-osm-controller
 	@mkdir -p $(shell pwd)/bin
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller ./cmd/osm-controller
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CONTROLLER_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA)" ./cmd/osm-controller
 
 .PHONY: build-osm
 build-osm:

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -5,24 +5,17 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+
+	"github.com/openservicemesh/osm/pkg/version"
 )
 
 const versionHelp = `
 This command prints out all the version information used by OSM
 `
 
-var (
-	// BuildDate is date when binary was built
-	BuildDate string
-	// BuildVersion is the version of binary
-	BuildVersion string
-	// GitCommit is the commit hash when the binary was built
-	GitCommit string
-)
-
 // PrintCliVersion prints the version
 func PrintCliVersion(out io.Writer) {
-	fmt.Fprintf(out, "Version: %s; Commit: %s; Date: %s\n", BuildVersion, GitCommit, BuildDate)
+	_, _ = fmt.Fprintf(out, "Version: %s; Commit: %s; Date: %s\n", version.Version, version.GitCommit, version.BuildDate)
 }
 
 func newVersionCmd(out io.Writer) *cobra.Command {

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/signals"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/utils"
+	"github.com/openservicemesh/osm/pkg/version"
 )
 
 const (
@@ -106,7 +107,7 @@ func init() {
 }
 
 func main() {
-	log.Trace().Msg("Starting osm-controller")
+	log.Info().Msgf("Starting osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 	if err := parseFlags(); err != nil {
 		log.Fatal().Err(err).Msg("Error parsing cmd line arguments")
 	}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,6 +1,12 @@
 package health
 
-import "net/http"
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/openservicemesh/osm/pkg/version"
+	"github.com/rs/zerolog/log"
+	"net/http"
+)
 
 // Probe is a type alias for a function.
 type Probe func() bool
@@ -17,6 +23,18 @@ func makeHandler(probe Probe) http.Handler {
 			true:  http.StatusOK,
 			false: http.StatusServiceUnavailable,
 		}[probe()])
+
+		versionInfo := version.VersionInfo{
+			Version:   version.Version,
+			BuildDate: version.BuildDate,
+			GitCommit: version.GitCommit,
+		}
+
+		if jsonVersionInfo, err := json.Marshal(versionInfo); err != nil {
+			log.Error().Err(err).Msgf("Error marshaling VersionInfo struct: %+v", versionInfo)
+		} else {
+			_, _ = fmt.Fprint(w, string(jsonVersionInfo))
+		}
 	})
 }
 

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -24,14 +24,14 @@ func makeHandler(probe Probe) http.Handler {
 			false: http.StatusServiceUnavailable,
 		}[probe()])
 
-		versionInfo := version.VersionInfo{
+		versionInfo := version.Info{
 			Version:   version.Version,
 			BuildDate: version.BuildDate,
 			GitCommit: version.GitCommit,
 		}
 
 		if jsonVersionInfo, err := json.Marshal(versionInfo); err != nil {
-			log.Error().Err(err).Msgf("Error marshaling VersionInfo struct: %+v", versionInfo)
+			log.Error().Err(err).Msgf("Error marshaling version info struct: %+v", versionInfo)
 		} else {
 			_, _ = fmt.Fprint(w, string(jsonVersionInfo))
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,8 +9,8 @@ var GitCommit string
 // Version is the version of the compiled software
 var Version string
 
-// VersionInfo is a struct helpful for JSON serialization of the OSM Controller version information.
-type VersionInfo struct {
+// Info is a struct helpful for JSON serialization of the OSM Controller version information.
+type Info struct {
 	// Version is the version of the OSM Controller.
 	Version string `json:"version,omitempty"`
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,10 +1,5 @@
 package version
 
-import (
-	"fmt"
-	"os"
-)
-
 // BuildDate is the date when the binary was built
 var BuildDate string
 
@@ -14,8 +9,14 @@ var GitCommit string
 // Version is the version of the compiled software
 var Version string
 
-// PrintVersionAndExit prints the version and exits
-func PrintVersionAndExit() {
-	fmt.Printf("Version: %s; Commit: %s; Date: %s\n", Version, GitCommit, BuildDate)
-	os.Exit(0)
+// VersionInfo is a struct helpful for JSON serialization of the OSM Controller version information.
+type VersionInfo struct {
+	// Version is the version of the OSM Controller.
+	Version string `json:"version,omitempty"`
+
+	// GitCommit is the git commit hash of the OSM Controller.
+	GitCommit string `json:"git_commit,omitempty"`
+
+	// BuildDate is the build date of the OSM Controller.
+	BuildDate string `json:"build_date,omitempty"`
 }


### PR DESCRIPTION
This PR adds version info to the liveness and readiness probes, also prints version info as the very first line of the OSM Controller stdout.

In this PR:
 - OSM CLI and Controller will reuse the same `pkg/version` for storing these values
 - added `VersionInfo` struct to help create a JSON string for liveness/readiness probes
 - removed unused `PrintVersionAndExit()`

Result:

### Readiness probe
![image](https://user-images.githubusercontent.com/49918230/90441535-f5f97b80-e08d-11ea-97a5-0c29133d5d0e.png)

### OSM Controller Logs
```
$ ./demo/tail-osm-controller-logs.sh | head
{"level":"info","component":"osm-controller/main","time":"2020-08-17T20:28:20Z","file":"osm-controller.go:110","message":"Starting osm-controller v0.1.0-rc.1; 247062da; 2020-08-17-13:27"}
```

### OSM CLI
```
$ ./bin/osm version
Version: dev; Commit: 247062da; Date: 2020-08-17-13:27
```

---


Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [x]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
