### PR TITLE
tests: HTTPServer test coverage

### DIFF
--- a/pkg/debugger/fake.go
+++ b/pkg/debugger/fake.go
@@ -1,0 +1,15 @@
+package debugger
+
+import (
+	"net/http"
+)
+
+// FakeDebugServer is a fake debug server interface impl
+type FakeDebugServer struct {
+	Mappings map[string]http.Handler
+}
+
+// GetHandlers implements DebugServer interface and returns the inner object mappings
+func (fds FakeDebugServer) GetHandlers() map[string]http.Handler {
+	return fds.Mappings
+}

--- a/pkg/health/fake.go
+++ b/pkg/health/fake.go
@@ -1,0 +1,17 @@
+package health
+
+// FakeProbe is a fake health.Probes impl for Liveness/Readiness testing
+type FakeProbe struct {
+	LivenessRet  Probe
+	ReadinessRet Probe
+}
+
+// Liveness is interface impl from health.Probes
+func (t FakeProbe) Liveness() bool {
+	return t.LivenessRet()
+}
+
+// Readiness is interface impl from health.Probes
+func (t FakeProbe) Readiness() bool {
+	return t.ReadinessRet()
+}

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -56,10 +56,12 @@ func (s *httpServer) Start() {
 	}()
 }
 
-func (s *httpServer) Stop() {
+func (s *httpServer) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeoutDuration)
 	defer cancel()
 	if err := s.server.Shutdown(ctx); err != nil {
 		log.Error().Err(err).Msg("Unable to shutdown API server gracefully")
+		return err
 	}
+	return nil
 }

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -1,0 +1,126 @@
+package httpserver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/debugger"
+	"github.com/openservicemesh/osm/pkg/health"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
+)
+
+const (
+	url              = "http://localhost"
+	validRoutePath   = "/debug/test1"
+	invalidRoutePath = "/debug/test2"
+	testPort         = 9999
+	responseBody     = "OSM rules"
+
+	// These paths are internal to debugServer
+	readyPath   = "/health/ready"
+	alivePath   = "/health/alive"
+	metricsPath = "/metrics"
+)
+
+// Dynamic variables for extended testing
+var readyResult bool = true
+var aliveResult bool = true
+var boolToRESTMapper map[bool]int = map[bool]int{
+	true:  http.StatusOK,
+	false: http.StatusServiceUnavailable,
+}
+
+var _ = Describe("Test httpserver", func() {
+	Context("HTTP OSM debug server", func() {
+		metricsStore := metricsstore.NewMetricStore("TBD_NameSpace", "TBD_PodName")
+
+		// Fake probes
+		testProbe := health.FakeProbe{
+			LivenessRet: func() bool {
+				return aliveResult
+			},
+			ReadinessRet: func() bool {
+				return readyResult
+			},
+		}
+
+		// Fake debug server
+		var fakeDebugServer debugger.FakeDebugServer = debugger.FakeDebugServer{
+			Mappings: map[string]http.Handler{
+				validRoutePath: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, _ = fmt.Fprintf(w, responseBody)
+				}),
+			},
+		}
+
+		httpServ := NewHTTPServer(testProbe, metricsStore, testPort, fakeDebugServer)
+		httpServ.Start()
+
+		It("should return 404 for a non-existant debug url", func() {
+			resp, err := http.Get(fmt.Sprintf("%s:%d%s", url, testPort, invalidRoutePath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("should return 200 for an existing debug url - body should match", func() {
+			resp, err := http.Get(fmt.Sprintf("%s:%d%s", url, testPort, validRoutePath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			defer resp.Body.Close()
+
+			Expect(err).To(BeNil())
+			Expect(string(bodyBytes)).To(Equal(responseBody))
+		})
+
+		It("should hit proper liveness results", func() {
+			resp, err := http.Get(fmt.Sprintf("%s:%d%s", url, testPort, alivePath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(boolToRESTMapper[aliveResult]))
+
+			// Swap result
+			aliveResult = !aliveResult
+
+			resp, err = http.Get(fmt.Sprintf("%s:%d%s", url, testPort, alivePath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(boolToRESTMapper[aliveResult]))
+		})
+
+		It("should hit proper readiness results", func() {
+			resp, err := http.Get(fmt.Sprintf("%s:%d%s", url, testPort, readyPath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(boolToRESTMapper[readyResult]))
+
+			// Swap result
+			readyResult = !readyResult
+
+			resp, err = http.Get(fmt.Sprintf("%s:%d%s", url, testPort, readyPath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(boolToRESTMapper[readyResult]))
+		})
+
+		It("Should hit and read metrics path", func() {
+			resp, err := http.Get(fmt.Sprintf("%s:%d%s", url, testPort, metricsPath))
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("should stop with no errors", func() {
+			err := httpServ.Stop()
+			Expect(err).To(BeNil())
+		})
+
+	})
+})

--- a/pkg/httpserver/types.go
+++ b/pkg/httpserver/types.go
@@ -13,7 +13,7 @@ var (
 // HTTPServer serving probes and metrics
 type HTTPServer interface {
 	Start()
-	Stop()
+	Stop() error
 }
 
 type httpServer struct {


### PR DESCRIPTION
Adds HTTPServer test coverage.

Adds fakes for Probes and DebugServer, which are needed
for HTTPServer class.

`0.0%` -> `89.5%`

- Tests / CI System      [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No