### PR TITLE
ads: Simplify and delete getHandlers()

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/cds"
+	"github.com/openservicemesh/osm/pkg/envoy/eds"
+	"github.com/openservicemesh/osm/pkg/envoy/lds"
+	"github.com/openservicemesh/osm/pkg/envoy/rds"
+	"github.com/openservicemesh/osm/pkg/envoy/sds"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -100,9 +105,15 @@ var _ = Describe("Test ADS response functions", func() {
 
 		It("returns Aggregated Discovery Service response", func() {
 			s := Server{
-				ctx:         context.TODO(),
-				catalog:     mc,
-				xdsHandlers: getHandlers(),
+				ctx:     context.TODO(),
+				catalog: mc,
+				xdsHandlers: map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error){
+					envoy.TypeEDS: eds.NewResponse,
+					envoy.TypeCDS: cds.NewResponse,
+					envoy.TypeRDS: rds.NewResponse,
+					envoy.TypeLDS: lds.NewResponse,
+					envoy.TypeSDS: sds.NewResponse,
+				},
 			}
 
 			s.sendAllResponses(proxy, &server, cfg)

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -20,9 +20,15 @@ import (
 // NewADSServer creates a new Aggregated Discovery Service server
 func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamespace string, cfg configurator.Configurator) *Server {
 	server := Server{
-		catalog:      meshCatalog,
-		ctx:          ctx,
-		xdsHandlers:  getHandlers(),
+		catalog: meshCatalog,
+		ctx:     ctx,
+		xdsHandlers: map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error){
+			envoy.TypeEDS: eds.NewResponse,
+			envoy.TypeCDS: cds.NewResponse,
+			envoy.TypeRDS: rds.NewResponse,
+			envoy.TypeLDS: lds.NewResponse,
+			envoy.TypeSDS: sds.NewResponse,
+		},
 		enableDebug:  enableDebug,
 		osmNamespace: osmNamespace,
 		cfg:          cfg,
@@ -33,16 +39,6 @@ func NewADSServer(ctx context.Context, meshCatalog catalog.MeshCataloger, enable
 	}
 
 	return &server
-}
-
-func getHandlers() map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error) {
-	return map[envoy.TypeURI]func(context.Context, catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error){
-		envoy.TypeEDS: eds.NewResponse,
-		envoy.TypeCDS: cds.NewResponse,
-		envoy.TypeRDS: rds.NewResponse,
-		envoy.TypeLDS: lds.NewResponse,
-		envoy.TypeSDS: sds.NewResponse,
-	}
 }
 
 // DeltaAggregatedResources implements discovery.AggregatedDiscoveryServiceServer

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -31,6 +31,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	}
 	log.Info().Msgf("Client %s connected: Subject CN=%s; Service=%s", ip, cn, namespacedService)
 
+	// This is the Envoy proxy that just connected to the control plane.
 	proxy := envoy.NewProxy(cn, ip)
 	s.catalog.RegisterProxy(proxy)
 	defer s.catalog.UnregisterProxy(proxy)


### PR DESCRIPTION
I find going through the `getHandlers()` to take more cycles while reading or reasoning about this code than if the list of XDS handlers was directly in the struct.

To make this slightly more readable - removing `getHandlers()` 

---

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ x ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`