### PR TITLE
httpserver: fix test which fails when the server is stopped

### DIFF
--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -50,7 +50,7 @@ func NewHTTPServer(probes health.Probes, metricStore metricsstore.MetricStore, a
 func (s *httpServer) Start() {
 	go func() {
 		log.Info().Msgf("Starting API Server on %s", s.server.Addr)
-		if err := s.server.ListenAndServe(); err != nil {
+		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatal().Err(err).Msg("Failed to start API server")
 		}
 	}()

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -27,12 +27,14 @@ const (
 )
 
 // Dynamic variables for extended testing
-var readyResult bool = true
-var aliveResult bool = true
-var boolToRESTMapper map[bool]int = map[bool]int{
-	true:  http.StatusOK,
-	false: http.StatusServiceUnavailable,
-}
+var (
+	readyResult      bool
+	aliveResult      bool
+	boolToRESTMapper = map[bool]int{
+		true:  http.StatusOK,
+		false: http.StatusServiceUnavailable,
+	}
+)
 
 var _ = Describe("Test httpserver", func() {
 	Context("HTTP OSM debug server", func() {


### PR DESCRIPTION
Check for ErrServerClosed before calling Fatal() since ListenAndServe
will return this error when the server is shutdown.

Also fixes linting issues.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

Resolves #1562

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`