### PR TITLE
maestro: Test a pod without a k8s svc accessing a service via TrafficTarget

### DIFF
--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -27,3 +27,6 @@ fi
 
 # Deploy bookthief
 ./demo/deploy-bookthief.sh
+
+# Deploy a single pod without a service, which also buys books.
+./demo/deploy-flaneur.sh

--- a/demo/deploy-flaneur.sh
+++ b/demo/deploy-flaneur.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+BOOKSTORE_SVC="${BOOKSTORE_SVC:-bookstore}"
+CI_MAX_ITERATIONS_THRESHOLD="${CI_MAX_ITERATIONS_THRESHOLD:-0}"
+CI_CLIENT_CONCURRENT_CONNECTIONS="${CI_CLIENT_CONCURRENT_CONNECTIONS:-1}"
+ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
+EGRESS_EXPECTED_RESPONSE_CODE="${EGRESS_EXPECTED_RESPONSE_CODE:-404}"
+CI_SLEEP_BETWEEN_REQUESTS_SECONDS="${CI_SLEEP_BETWEEN_REQUESTS_SECONDS:-1}"
+
+kubectl delete deployment flaneur -n "$BOOKBUYER_NAMESPACE"  --ignore-not-found
+
+
+echo -e "Deploy BookBuyer Service Account"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flaneur
+  namespace: $BOOKBUYER_NAMESPACE
+EOF
+
+
+echo -e "Deploy Flaneur Deployment"
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flaneur
+  namespace: $BOOKBUYER_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flaneur
+  template:
+    metadata:
+      labels:
+        app: flaneur
+        version: v1
+    spec:
+      serviceAccountName: flaneur
+
+      containers:
+        # Main container with APP
+        - name: flaneur
+          image: "${CTR_REGISTRY}/bookbuyer:${CTR_TAG}"
+          imagePullPolicy: Always
+          command: ["/bookbuyer"]
+
+          env:
+            - name: "BOOKSTORE_NAMESPACE"
+              value: "$BOOKSTORE_NAMESPACE"
+            - name: "BOOKSTORE_SVC"
+              value: "$BOOKSTORE_SVC"
+            - name: "CI_MAX_ITERATIONS_THRESHOLD"
+              value: "$CI_MAX_ITERATIONS_THRESHOLD"
+            - name: "ENABLE_EGRESS"
+              value: "$ENABLE_EGRESS"
+            - name: "EGRESS_EXPECTED_RESPONSE_CODE"
+              value: "$EGRESS_EXPECTED_RESPONSE_CODE"
+            - name: "CI_CLIENT_CONCURRENT_CONNECTIONS"
+              value: "$CI_CLIENT_CONCURRENT_CONNECTIONS"
+            - name: "CI_SLEEP_BETWEEN_REQUESTS_SECONDS"
+              value: "$CI_SLEEP_BETWEEN_REQUESTS_SECONDS"
+
+      imagePullSecrets:
+        - name: "$CTR_REGISTRY_CREDS_NAME"
+EOF

--- a/demo/deploy-traffic-target-with-same-sa.sh
+++ b/demo/deploy-traffic-target-with-same-sa.sh
@@ -26,6 +26,9 @@ spec:
   - kind: ServiceAccount
     name: bookbuyer
     namespace: "$BOOKBUYER_NAMESPACE"
+  - kind: ServiceAccount
+    name: flaneur
+    namespace: "$BOOKBUYER_NAMESPACE"
 
 
 # TrafficTarget is deny-by-default policy: if traffic from source to destination is not

--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -26,6 +26,9 @@ spec:
   - kind: ServiceAccount
     name: bookbuyer
     namespace: "$BOOKBUYER_NAMESPACE"
+  - kind: ServiceAccount
+    name: flaneur
+    namespace: "$BOOKBUYER_NAMESPACE"
 
 
 # TrafficTarget is deny-by-default policy: if traffic from source to destination is not

--- a/demo/tail-flaneur-envoy.sh
+++ b/demo/tail-flaneur-envoy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+source .env
+
+kubectl describe pod "$(kubectl get pods -n "$BOOKBUYER_NAMESPACE" --show-labels --selector app=client --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)" -n "$BOOKBUYER_NAMESPACE"
+
+POD="$(kubectl get pods -n "$BOOKBUYER_NAMESPACE" --show-labels --selector app=flaneur --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
+
+kubectl logs "${POD}" -n "$BOOKBUYER_NAMESPACE" -c envoy --tail=100 -f

--- a/demo/tail-flaneur.sh
+++ b/demo/tail-flaneur.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+source .env
+
+POD="$(kubectl get pods -n "$BOOKBUYER_NAMESPACE" --show-labels --selector app=flaneur --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
+
+kubectl logs "${POD}" -n "$BOOKBUYER_NAMESPACE" -c flaneur --tail=100 -f


### PR DESCRIPTION
This PR adds a new pod (`flaneur`) to the bookbuyer + bookstore + bookwarehouse CI system. This pod does not have a related Kubernetes service.  The goal is to prove that even without a service, OSM will allow the pod to buy books from the bookstore. (Relies on an SMI policy with a flaneur service account)

This is a continuation of the work done with https://github.com/openservicemesh/osm/pull/1932

Proves that https://github.com/openservicemesh/osm/issues/1180 is fixed