### PR TITLE
docs(issue triage): add issue triage guide for github issue queue

### DIFF
--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -1,6 +1,6 @@
 # Issue Triage Guide
 
-This guide describes how to triage git issues on the [issue queue](https://github.com/openservicemesh/osm/issues) for Open Service Mesh (OSM).
+This guide describes how to triage GitHub issues on the [issue queue](https://github.com/openservicemesh/osm/issues) for Open Service Mesh (OSM).
 
 ## Steps for Traige
 1. Identify the cause of the issue as explained below
@@ -34,6 +34,5 @@ This guide describes how to triage git issues on the [issue queue](https://githu
  
 ## Size and Milestone Assignment
 [WIP]
-
 
 

--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -1,0 +1,39 @@
+# Issue Triage Guide
+
+This guide describes how to triage git issues on the [issue queue](https://github.com/openservicemesh/osm/issues) for Open Service Mesh (OSM).
+
+## Steps for Traige
+1. Identify the cause of the issue as explained below
+2. Tag the issue with relevant tags
+3. Assign the issue
+4. Prioritize the issue with a P1, P2 or P3 label where:
+    - P1: product cannot ship. Should be addressed as soon as possible. Eg: high priority bug
+    - P2: Product cannot ship, but it does not need to be addressed immediately. Eg: high priority feature, lower priority bug
+    - P3: Resolution of the work item is optional based on resources, time, and risk. Eg: a nice to have feature
+5. Size the issue and assign it to a milestone:
+    [WIP]
+6. If you don't have time to resolve it, put links to the code to where you see the problem arising
+7. Assign the issue to someone
+
+
+## Identifying the cause of the issue
+- If it's a bug: 
+    - Reproduce the issue to make sure it is an actual issue
+    - Tag it with the `bug` label
+    - If possible, fix it or else reference links to the code 
+
+- If it's a question: 
+    - Ask around, go through docs, etc.
+    - Respond to the question
+    - Label appropriately
+
+- Feature request 
+    - Ask/understand the use cases
+    - Tag it with the `Improvement/Feature Request` label and add other appropriate labels
+
+ 
+## Size and Milestone Assignment
+[WIP]
+
+
+

--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -4,32 +4,27 @@ This guide describes how to triage GitHub issues on the [issue queue](https://gi
 
 ## Steps for Triage
 1. Identify the cause of the issue as explained [below](#identifying-the-cause-of-the-issue)
-1. Tag the issue with relevant tags
-1. Prioritize the issue with a P1, P2 or P3 label where:
+1. Tag the issue with relevant labels. Relevant labels would include what area of the codebase the issue is most aligned with (ex. cli) or if it is a bug, label the issue with the bug label
+1. Prioritize the issue with a P1, P2 or P3 label (if possible) where:
     - P1: product cannot ship. Should be addressed as soon as possible. Eg: high priority bug
     - P2: Product cannot ship, but it does not need to be addressed immediately. Eg: high priority feature, lower priority bug
     - P3: Resolution of the work item is optional based on resources, time, and risk. Eg: a nice to have feature
-1. Size the issue and assign it to a milestone:
-    [WIP]
-1. If you don't have time to resolve it, put links to the code to where you see the problem arising
-1. Assign the issue to someone
+1. If you have time and can resolve the issue, resolve it. If not, put links to the code to where you see the problem arising
+1. If the issue looks like it is a bug that needs to be resolved immediately, either fix the issue or reach out to the core maintainers to see if you can assign the issue to someone for follow up
 
 
 ## Identifying the cause of the issue
 - If it's a bug: 
     - Reproduce the issue to make sure it is an actual issue
-    - Tag it with the `bug` label
+    - Label it with the `bug` label
     - If possible, fix it or else reference links to the code 
 
 - If it's a question: 
     - Ask around, go through docs, etc.
-    - Tag it with the `question` label
+    - Label it with the `question` label
     - Respond to the question
 
 - If it's a feature request 
     - Ask/understand the use cases
-    - Tag it with the `Improvement/Feature Request` label and add other appropriate labels
+    - Label it with the `Improvement/Feature Request` label and add other appropriate labels
 
- 
-## Size and Milestone Assignment
-[WIP]

--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -4,16 +4,15 @@ This guide describes how to triage GitHub issues on the [issue queue](https://gi
 
 ## Steps for Triage
 1. Identify the cause of the issue as explained [below](#identifying-the-cause-of-the-issue)
-2. Tag the issue with relevant tags
-3. Assign the issue
-4. Prioritize the issue with a P1, P2 or P3 label where:
+1. Tag the issue with relevant tags
+1. Prioritize the issue with a P1, P2 or P3 label where:
     - P1: product cannot ship. Should be addressed as soon as possible. Eg: high priority bug
     - P2: Product cannot ship, but it does not need to be addressed immediately. Eg: high priority feature, lower priority bug
     - P3: Resolution of the work item is optional based on resources, time, and risk. Eg: a nice to have feature
-5. Size the issue and assign it to a milestone:
+1. Size the issue and assign it to a milestone:
     [WIP]
-6. If you don't have time to resolve it, put links to the code to where you see the problem arising
-7. Assign the issue to someone
+1. If you don't have time to resolve it, put links to the code to where you see the problem arising
+1. Assign the issue to someone
 
 
 ## Identifying the cause of the issue
@@ -24,8 +23,8 @@ This guide describes how to triage GitHub issues on the [issue queue](https://gi
 
 - If it's a question: 
     - Ask around, go through docs, etc.
+    - Tag it with the `question` label
     - Respond to the question
-    - Label appropriately
 
 - Feature request 
     - Ask/understand the use cases

--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -3,7 +3,7 @@
 This guide describes how to triage GitHub issues on the [issue queue](https://github.com/openservicemesh/osm/issues) for Open Service Mesh (OSM).
 
 ## Steps for Triage
-1. Identify the cause of the issue as explained below
+1. Identify the cause of the issue as explained [below](#identifying-the-cause-of-the-issue)
 2. Tag the issue with relevant tags
 3. Assign the issue
 4. Prioritize the issue with a P1, P2 or P3 label where:
@@ -34,4 +34,3 @@ This guide describes how to triage GitHub issues on the [issue queue](https://gi
  
 ## Size and Milestone Assignment
 [WIP]
-

--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -2,7 +2,7 @@
 
 This guide describes how to triage GitHub issues on the [issue queue](https://github.com/openservicemesh/osm/issues) for Open Service Mesh (OSM).
 
-## Steps for Traige
+## Steps for Triage
 1. Identify the cause of the issue as explained below
 2. Tag the issue with relevant tags
 3. Assign the issue
@@ -34,5 +34,4 @@ This guide describes how to triage GitHub issues on the [issue queue](https://gi
  
 ## Size and Milestone Assignment
 [WIP]
-
 

--- a/docs/issue_triage_guide.md
+++ b/docs/issue_triage_guide.md
@@ -26,7 +26,7 @@ This guide describes how to triage GitHub issues on the [issue queue](https://gi
     - Tag it with the `question` label
     - Respond to the question
 
-- Feature request 
+- If it's a feature request 
     - Ask/understand the use cases
     - Tag it with the `Improvement/Feature Request` label and add other appropriate labels
 


### PR DESCRIPTION
Adds a guide with steps for triaging OSM's GitHub issues

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [x]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? no
