### PR TITLE
ref(*): Integrate golangci-lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,31 +31,17 @@ jobs:
       - name: ShellCheck
         run: shellcheck -x $(find . -name '*.sh')
 
-  gofmt:
-    name: Go fmt
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup Go 1.14
-        uses: actions/setup-go@v1
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
         with:
-          go-version: 1.14
-      - name: Go Fmt
-        run: "! gofmt -l . | read"
-
-  golint:
-    name: Go lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Setup Go 1.14
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.14
-      - name: Go Lint
-        run: go run golang.org/x/lint/golint -set_exit_status ./...
+          version: v1.30
+          args: --timeout 5m
 
   build:
     name: Go build
@@ -81,32 +67,6 @@ jobs:
           go-version: 1.14
       - name: Go Build
         run: go build -v ./...
-
-  govet:
-    name: Go vet
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-      - name: Restore Module Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod2-
-      - name: Restore Build Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.14
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.14
-      - name: Go Vet
-        run: go vet -v ./...
 
   unittest:
     name: Go test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+run:
+  tests: true
+
+issues:
+  new: true
+
+linters:
+  enable-all: true
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/openservicemesh/osm

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ clean-osm:
 docker-build: docker-build-osm-controller docker-build-bookbuyer docker-build-bookstore docker-build-bookwarehouse
 
 .PHONY: go-checks
-go-checks: go-vet go-lint go-fmt
+go-checks: go-lint go-fmt
 
 .PHONY: go-vet
 go-vet:
@@ -66,8 +66,7 @@ go-vet:
 
 .PHONY: go-lint
 go-lint:
-	go run golang.org/x/lint/golint ./cmd/... ./pkg/...
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint run --tests --enable-all # --disable gochecknoglobals --disable gochecknoinit
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint run
 
 .PHONY: go-fmt
 go-fmt:

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -80,7 +80,7 @@ More notable:
   - `make build` builds the project
   - `make go-test` to run unit tests
   - `make go-test-coverage` - run unit tests and output unit test coverage
-  - `make go-lint` runs golint and golangci-lint
+  - `make go-lint` runs golangci-lint
   - `make go-fmt` - same as `go fmt ./...`
   - `make go-vet` - same as `go vet ./...`
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/servicemeshinterface/smi-sdk-go v0.4.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	google.golang.org/grpc v1.27.0
 	gopkg.in/yaml.v2 v2.3.0
 	helm.sh/helm/v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -996,8 +996,6 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190909230951-414d861bb4ac/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -1148,7 +1146,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200117220505-0cba7a3a9ee9/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200321224714-0d839f3cf2ed/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200324003944-a576cf524670/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/tools v0.0.0-20200414032229-332987a829c3/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
@@ -1276,8 +1273,6 @@ k8s.io/apimachinery v0.18.0 h1:fuPfYpk3cs1Okp/515pAf0dNhL66+8zk8RLbSX+EgAE=
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.5 h1:Lh6tgsM9FMkC12K5T5QjRm7rDs6aQN5JHkA0JomULDM=
 k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
-k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
-k8s.io/apimachinery v0.18.8 h1:jimPrycCqgx2QPearX3to1JePz7wSbVLq+7PdBTTwQ0=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
 k8s.io/apiserver v0.18.5/go.mod h1:+1XgOMq7YJ3OyqPNSJ54EveHwCoBWcJT9CaPycYI5ps=
 k8s.io/cli-runtime v0.18.0 h1:jG8XpSqQ5TrV0N+EZ3PFz6+gqlCk71dkggWCCq9Mq34=

--- a/scripts/pre-push-hook
+++ b/scripts/pre-push-hook
@@ -12,36 +12,13 @@ fi
 # try to create commit_logs folder
 mkdir -p commit_logs
 
-# run go fmt
-go fmt ./... >/dev/null 2>&1
+# run golangci-lint
+make go-lint >commit_logs/linter.log 2>&1
 if [ $? -ne 0 ]
 then
-    echo "'go fmt': Failed to run. This shouldn't happen. Please"
-    echo "check the output of the command to see what's wrong"
-    echo "or run commit with --no-verify if you know what you"
-    echo "are doing."
-    exit 1
-fi
-
-# run golint
-go run golang.org/x/lint/golint -set_exit_status ./... >commit_logs/linter.log 2>&1
-if [ $? -ne 0 ]
-then
-    echo "'golint': has detected potential issues in the project."
-    echo "Please check the output of 'golint' in: 'commit_logs/linter.log'"
+    echo "'golangci-lint': has detected potential issues in the project."
     echo "Details:"
     cat commit_logs/linter.log
-    exit 1
-fi
-
-# run go vet
-go vet ./... >commit_logs/vet.log 2>&1
-if [ $? -ne 0 ]
-then
-    echo "'go vet': has detected potential issues in the project."
-    echo "Please check the output of 'go vet' in: 'commit_logs/vet.log'"
-    echo "Details:"
-    cat commit_logs/vet.log
     exit 1
 fi
 

--- a/tools.go
+++ b/tools.go
@@ -9,5 +9,4 @@ import (
 	_ "github.com/jstemmer/go-junit-report"
 	_ "github.com/matm/gocov-html"
 	_ "github.com/mitchellh/gox"
-	_ "golang.org/x/lint/golint"
 )


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.

This PR standardizes on `golangci-lint` as the primary static analysis tool for source code across the Makefile, other scripts, and CI. The initial settings only point out new issues (based on git history) and enable all linters (per @draychev). I expect we'll tweak settings as we go, but if we find it's too restrictive we can override the return code to 0 to prevent CI from failing while still showing issues it found.

Some standalone `go vet`, `go lint`, and `go fmt` checks have been removed since `golangci-lint` uses them under the hood.

One notable difference is that by default, `golangci-lint` ignores the ever-popular `exported method should have a comment or be unexported` and similar messages. Those messages are part of a set that are ignored by default (see `--exclude-use-default` in `golangci-lint run --help`), but we can disable those if we want to fail on those messages anyway.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
  No
