### PR TITLE
chore(*): resolve lint/formatting related issues

### DIFF
--- a/ci/cmd/cleanup/cleanup-namespaces.go
+++ b/ci/cmd/cleanup/cleanup-namespaces.go
@@ -7,12 +7,11 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/openservicemesh/osm/pkg/logger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/openservicemesh/osm/pkg/logger"
 )
 
 var log = logger.New("ci/maestro")

--- a/ci/cmd/maestro_test.go
+++ b/ci/cmd/maestro_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/demo/cmd/common"
 )
 

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -7,15 +7,14 @@ import (
 	"net"
 	"strings"
 
+	"github.com/openservicemesh/osm/pkg/cli"
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	helm "helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/strvals"
-
-	"github.com/openservicemesh/osm/pkg/cli"
-	"github.com/openservicemesh/osm/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -8,10 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openservicemesh/osm/pkg/constants"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	fake "k8s.io/client-go/kubernetes/fake"
-
 	helm "helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -19,6 +15,9 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	fake "k8s.io/client-go/kubernetes/fake"
 )
 
 var (

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -5,10 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/gomega/gstruct"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	"github.com/openservicemesh/osm/pkg/constants"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -6,10 +6,9 @@ import (
 	"io"
 	"os"
 
+	"github.com/openservicemesh/osm/pkg/cli"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
-
-	"github.com/openservicemesh/osm/pkg/cli"
 )
 
 var globalUsage = `The osm cli enables you to install and manage the

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/cli"
 )
 

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/spf13/cobra"
-
 	"github.com/openservicemesh/osm/pkg/version"
+	"github.com/spf13/cobra"
 )
 
 const versionHelp = `

--- a/cmd/osm-controller/certificates.go
+++ b/cmd/osm-controller/certificates.go
@@ -7,17 +7,16 @@ import (
 
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	cmversionedclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
-	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/certmanager"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/vault"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/debugger"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 type certificateManagerKind string

--- a/cmd/osm-controller/certificates_test.go
+++ b/cmd/osm-controller/certificates_test.go
@@ -5,16 +5,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test CMD tools", func() {

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -6,14 +6,6 @@ import (
 	"os"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -35,6 +27,13 @@ import (
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/utils"
 	"github.com/openservicemesh/osm/pkg/version"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (

--- a/cmd/osm-controller/osm-controller_test.go
+++ b/cmd/osm-controller/osm-controller_test.go
@@ -6,12 +6,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/constants"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test creation of CA bundle k8s secret", func() {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -4,14 +4,13 @@ import (
 	"time"
 
 	set "github.com/deckarep/golang-set"
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/smi"
+	"k8s.io/client-go/kubernetes"
 )
 
 // NewMeshCatalog creates a new service catalog

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -1,10 +1,9 @@
 package catalog
 
 import (
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test catalog functions", func() {

--- a/pkg/catalog/certificates_test.go
+++ b/pkg/catalog/certificates_test.go
@@ -3,13 +3,11 @@ package catalog
 import (
 	"time"
 
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/service"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test certificate tooling", func() {

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -3,14 +3,13 @@ package catalog
 import (
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // ListExpectedProxies lists the Envoy proxies yet to connect and the time their XDS certificate was issued.

--- a/pkg/catalog/debugger_test.go
+++ b/pkg/catalog/debugger_test.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/tests"
 )

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -3,8 +3,6 @@ package catalog
 import (
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -13,6 +11,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/ingress"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/smi"
+	"k8s.io/client-go/kubernetes"
 )
 
 // NewFakeMeshCatalog creates a new struct implementing catalog.MeshCataloger interface used for testing.

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -6,12 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	extensionsV1beta "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -23,6 +17,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
+	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var (

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -6,13 +6,12 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -5,10 +5,8 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -5,12 +5,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -21,6 +15,11 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"strings"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/service"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -4,18 +4,16 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/google/uuid"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test XDS certificate tooling", func() {

--- a/pkg/certificate/encode.go
+++ b/pkg/certificate/encode.go
@@ -6,9 +6,8 @@ import (
 	"crypto/x509"
 	pemEnc "encoding/pem"
 
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/pkg/errors"
 )
 
 // EncodeCertDERtoPEM encodes the certificate provided in DER format into PEM format

--- a/pkg/certificate/file.go
+++ b/pkg/certificate/file.go
@@ -4,9 +4,8 @@ import (
 	"encoding/pem"
 	"io/ioutil"
 
-	"github.com/pkg/errors"
-
 	tresorPem "github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/pkg/errors"
 )
 
 // LoadCertificateFromFile loads a certificate from a PEM file.

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -13,10 +13,9 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	cmversionedclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // IssueCertificate implements certificate.Manager and returns a newly issued certificate.

--- a/pkg/certificate/providers/certmanager/certificate_manager_test.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager_test.go
@@ -11,12 +11,11 @@ import (
 	cmfakeapi "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1beta1/fake"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/logger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/logger"
 )
 
 var _ = Describe("Test cert-manager Certificate Manager", func() {

--- a/pkg/certificate/providers/certmanager/debugger_test.go
+++ b/pkg/certificate/providers/certmanager/debugger_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )

--- a/pkg/certificate/providers/certmanager/helpers.go
+++ b/pkg/certificate/providers/certmanager/helpers.go
@@ -6,11 +6,10 @@ import (
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // NewRootCertificateFromPEM is a helper returning a certificate.Certificater

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -7,7 +7,6 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1beta1"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1beta1"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/logger"

--- a/pkg/certificate/providers/keyvault/client.go
+++ b/pkg/certificate/providers/keyvault/client.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	az "github.com/Azure/go-autorest/autorest/azure"
-
 	"github.com/openservicemesh/osm/pkg/providers/azure"
 )
 

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -7,10 +7,9 @@ import (
 	"crypto/x509/pkix"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/pkg/errors"
 )
 
 // NewCA creates a new Certificate Authority.

--- a/pkg/certificate/providers/tresor/ca_test.go
+++ b/pkg/certificate/providers/tresor/ca_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -7,10 +7,9 @@ import (
 	"crypto/x509/pkix"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
+	"github.com/pkg/errors"
 )
 
 func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Duration) (certificate.Certificater, error) {

--- a/pkg/certificate/providers/tresor/certificate_manager_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_test.go
@@ -3,10 +3,9 @@ package tresor
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
 var _ = Describe("Test Certificate Manager", func() {

--- a/pkg/certificate/providers/tresor/debugger_test.go
+++ b/pkg/certificate/providers/tresor/debugger_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -4,13 +4,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/pkg/errors"
 )
 
 var log = logger.New("vault")

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -4,11 +4,9 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/hashicorp/vault/api"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/hashicorp/vault/api"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )

--- a/pkg/certificate/providers/vault/debugger_test.go
+++ b/pkg/certificate/providers/vault/debugger_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )

--- a/pkg/certificate/providers/vault/tools_test.go
+++ b/pkg/certificate/providers/vault/tools_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 

--- a/pkg/certificate/rotor/rotor_test.go
+++ b/pkg/certificate/rotor/rotor_test.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -5,12 +5,11 @@ import (
 	"reflect"
 	"strconv"
 
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 const (

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -7,12 +7,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
+	"github.com/openservicemesh/osm/pkg/kubernetes"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 var _ = Describe("Test OSM ConfigMap parsing", func() {

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -1,9 +1,8 @@
 package configurator
 
 import (
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/logger"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/debugger/envoy.go
+++ b/pkg/debugger/envoy.go
@@ -6,9 +6,8 @@ import (
 	"math/rand"
 	"net/http"
 
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
+	v1 "k8s.io/api/core/v1"
 )
 
 func (ds debugServer) getEnvoyConfig(pod *v1.Pod, cn certificate.CommonName, url string) string {

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -5,12 +5,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/openservicemesh/osm/pkg/service"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 type policies struct {

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -6,19 +6,17 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 func TestEndpoints(t *testing.T) {

--- a/pkg/debugger/port_forward.go
+++ b/pkg/debugger/port_forward.go
@@ -6,9 +6,8 @@ import (
 	"net/url"
 	"strings"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
 )

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -3,10 +3,9 @@ package debugger
 import (
 	"net/http"
 
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 // GetHandlers implements DebugServer interface and returns the rest of URLs and the handling functions.

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -4,18 +4,17 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/service"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/configurator"
-	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/logger"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 var log = logger.New("debugger")

--- a/pkg/endpoint/providers/azure/client.go
+++ b/pkg/endpoint/providers/azure/client.go
@@ -5,10 +5,9 @@ import (
 	c "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	n "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/providers/azure"
 	"github.com/openservicemesh/osm/pkg/smi"
+	"github.com/pkg/errors"
 )
 
 // NewProvider creates an Azure Client

--- a/pkg/endpoint/providers/azure/kubernetes/client.go
+++ b/pkg/endpoint/providers/azure/kubernetes/client.go
@@ -3,18 +3,16 @@ package azure
 import (
 	"reflect"
 
+	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/namespace"
+	osmClient "github.com/openservicemesh/osm/pkg/osm_client/clientset/versioned"
+	osmInformers "github.com/openservicemesh/osm/pkg/osm_client/informers/externalversions"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-
-	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-
-	"github.com/openservicemesh/osm/pkg/configurator"
-	"github.com/openservicemesh/osm/pkg/namespace"
-	osmClient "github.com/openservicemesh/osm/pkg/osm_client/clientset/versioned"
-	osmInformers "github.com/openservicemesh/osm/pkg/osm_client/informers/externalversions"
 )
 
 const (

--- a/pkg/endpoint/providers/azure/kubernetes/types.go
+++ b/pkg/endpoint/providers/azure/kubernetes/types.go
@@ -1,11 +1,10 @@
 package azure
 
 import (
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/endpoint/providers/azure/provider.go
+++ b/pkg/endpoint/providers/azure/provider.go
@@ -5,12 +5,11 @@ import (
 	"net"
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ListEndpointsForService implements endpoints.Provider interface and returns the IP addresses and Ports for the given mesh service.

--- a/pkg/endpoint/providers/azure/provider_test.go
+++ b/pkg/endpoint/providers/azure/provider_test.go
@@ -3,10 +3,9 @@ package azure
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v12 "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	v12 "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
 )
 
 var _ = Describe("Testing Azure Compute Provider", func() {

--- a/pkg/endpoint/providers/azure/types.go
+++ b/pkg/endpoint/providers/azure/types.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
-
 	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/smi"

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/endpoint"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
-
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,10 +20,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-
-	"github.com/openservicemesh/osm/pkg/configurator"
-	"github.com/openservicemesh/osm/pkg/endpoint"
-	"github.com/openservicemesh/osm/pkg/namespace"
 )
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -7,18 +7,16 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	fake "k8s.io/client-go/kubernetes/fake"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fake "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test Kube Client Provider", func() {

--- a/pkg/endpoint/providers/kube/types.go
+++ b/pkg/endpoint/providers/kube/types.go
@@ -1,11 +1,10 @@
 package kube
 
 import (
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/endpoint/types_test.go
+++ b/pkg/endpoint/types_test.go
@@ -3,7 +3,6 @@ package endpoint
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/service"
 )

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -4,11 +4,9 @@ import (
 	"io"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
+	"github.com/openservicemesh/osm/pkg/envoy"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}) {

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -9,12 +9,8 @@ import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
@@ -28,6 +24,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy/sds"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test ADS response functions", func() {

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -5,10 +5,9 @@ import (
 	"strconv"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/utils"
+	"github.com/pkg/errors"
 )
 
 // StreamAggregatedResources handles streaming of the clusters to the connected Envoy proxies

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"

--- a/pkg/envoy/cds/backpressure.go
+++ b/pkg/envoy/cds/backpressure.go
@@ -2,7 +2,6 @@ package cds
 
 import (
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/service"
 )

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -7,10 +7,8 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -2,10 +2,8 @@ package cds
 
 import (
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/tests"
 )

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -6,7 +6,6 @@ import (
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -10,23 +10,20 @@ import (
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/tests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("CDS Response", func() {

--- a/pkg/envoy/cds/tracing.go
+++ b/pkg/envoy/cds/tracing.go
@@ -4,7 +4,6 @@ import (
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/golang/protobuf/ptypes"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/cds/zipkin_test.go
+++ b/pkg/envoy/cds/zipkin_test.go
@@ -3,7 +3,6 @@ package cds
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 )

--- a/pkg/envoy/cla/cluster_load_assignment.go
+++ b/pkg/envoy/cla/cluster_load_assignment.go
@@ -3,9 +3,7 @@ package cla
 import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/envoy/cla/cluster_load_assignment_test.go
+++ b/pkg/envoy/cla/cluster_load_assignment_test.go
@@ -3,11 +3,10 @@ package cla
 import (
 	"net"
 
-	"github.com/openservicemesh/osm/pkg/endpoint"
-	"github.com/openservicemesh/osm/pkg/service"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/service"
 )
 
 var _ = Describe("Testing Cluster Load Assignment", func() {

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -2,10 +2,8 @@ package eds
 
 import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -7,15 +7,14 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/tests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test EDS response", func() {

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -4,9 +4,7 @@ import (
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -4,10 +4,8 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -4,9 +4,7 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -10,10 +10,8 @@ import (
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -5,10 +5,8 @@ import (
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -2,9 +2,7 @@ package lds
 
 import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
 	"github.com/golang/protobuf/ptypes"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"

--- a/pkg/envoy/lds/tracing.go
+++ b/pkg/envoy/lds/tracing.go
@@ -3,7 +3,6 @@ package lds
 import (
 	xds_tracing "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -1,11 +1,9 @@
 package rds
 
 import (
+	set "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
-	set "github.com/deckarep/golang-set"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -6,11 +6,8 @@ import (
 	"time"
 
 	set "github.com/deckarep/golang-set"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
@@ -24,6 +21,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 const (

--- a/pkg/envoy/route/config.go
+++ b/pkg/envoy/route/config.go
@@ -5,12 +5,10 @@ import (
 	"sort"
 	"strings"
 
+	set "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-
-	set "github.com/deckarep/golang-set"
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/kubernetes"

--- a/pkg/envoy/route/config_test.go
+++ b/pkg/envoy/route/config_test.go
@@ -4,14 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-
 	set "github.com/deckarep/golang-set"
+	envoy_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -5,10 +5,8 @@ import (
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -8,14 +8,9 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-
 	"github.com/google/uuid"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	testclient "k8s.io/client-go/kubernetes/fake"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
@@ -23,6 +18,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("Test SDS response functions", func() {

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -9,14 +9,12 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/jinzhu/copier"
-
 	"github.com/openservicemesh/osm/pkg/service"
 )
 

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -4,10 +4,8 @@ import (
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -3,9 +3,10 @@ package health
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/openservicemesh/osm/pkg/version"
 	"github.com/rs/zerolog/log"
-	"net/http"
 )
 
 // Probe is a type alias for a function.

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/debugger"
 	"github.com/openservicemesh/osm/pkg/health"
 	"github.com/openservicemesh/osm/pkg/metricsstore"

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -3,15 +3,14 @@ package ingress
 import (
 	"reflect"
 
-	extensionsV1beta "k8s.io/api/extensions/v1beta1"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
+	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 // NewIngressClient implements ingress.Monitor and creates the Kubernetes client to monitor Ingress resources.

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -1,12 +1,11 @@
 package ingress
 
 import (
-	extensionsV1beta "k8s.io/api/extensions/v1beta1"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
+	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/injector/config.go
+++ b/pkg/injector/config.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"gopkg.in/yaml.v2"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Configurator) ([]byte, error) {

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -5,11 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 const expectedEnvoyConfig = `

--- a/pkg/injector/init-container.go
+++ b/pkg/injector/init-container.go
@@ -3,9 +3,8 @@ package injector
 import (
 	"fmt"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/openservicemesh/osm/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -3,7 +3,6 @@ package injector
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 

--- a/pkg/injector/sidecar.go
+++ b/pkg/injector/sidecar.go
@@ -3,10 +3,9 @@ package injector
 import (
 	"strings"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -1,13 +1,12 @@
 package injector
 
 import (
-	"github.com/openservicemesh/osm/pkg/configurator"
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
+	"k8s.io/client-go/kubernetes"
 )
 
 const (

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -9,6 +9,11 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/pkg/errors"
 	"k8s.io/api/admission/v1beta1"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -18,12 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openservicemesh/osm/pkg/catalog"
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/configurator"
-	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/namespace"
 )
 
 var (

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -6,11 +6,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openservicemesh/osm/pkg/certificate"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
 var _ = Describe("Test MutatingWebhookConfiguration patch", func() {

--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -4,9 +4,8 @@ import (
 	"os"
 	"reflect"
 
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/constants"
+	"k8s.io/client-go/tools/cache"
 )
 
 const (

--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -4,12 +4,10 @@ import (
 	"reflect"
 
 	"github.com/google/uuid"
-	corev1 "k8s.io/api/core/v1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/tests"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (

--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -2,11 +2,10 @@ package kubernetes
 
 import (
 	"fmt"
-	//"strings"
 
+	//"strings"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -7,11 +7,10 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-
-	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 // CallerHook implements zerolog.Hook interface.

--- a/pkg/metricsstore/metricstore.go
+++ b/pkg/metricsstore/metricstore.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	"github.com/openservicemesh/osm/pkg/version"
 )
 
 // PrometheusNamespace is the Prometheus Namespace

--- a/pkg/namespace/client.go
+++ b/pkg/namespace/client.go
@@ -3,14 +3,13 @@ package namespace
 import (
 	"time"
 
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 const (

--- a/pkg/namespace/types.go
+++ b/pkg/namespace/types.go
@@ -1,9 +1,8 @@
 package namespace
 
 import (
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/logger"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -4,6 +4,13 @@ import (
 	"reflect"
 	"strings"
 
+	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	backpressureClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned"
+	backpressureInformers "github.com/openservicemesh/osm/experimental/pkg/client/informers/externalversions"
+	"github.com/openservicemesh/osm/pkg/featureflags"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/namespace"
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/pkg/errors"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
@@ -19,14 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-
-	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
-	backpressureClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned"
-	backpressureInformers "github.com/openservicemesh/osm/experimental/pkg/client/informers/externalversions"
-	"github.com/openservicemesh/osm/pkg/featureflags"
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-	"github.com/openservicemesh/osm/pkg/namespace"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // We have a few different k8s clients. This identifies these in logs.

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -7,6 +7,10 @@ import (
 	. "github.com/onsi/gomega"
 	osmPolicy "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	osmPolicyClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/featureflags"
+	"github.com/openservicemesh/osm/pkg/namespace"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -16,11 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/openservicemesh/osm/pkg/featureflags"
-	"github.com/openservicemesh/osm/pkg/namespace"
-	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 const (

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -2,13 +2,12 @@ package smi
 
 import (
 	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 type fakeMeshSpec struct {

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -2,16 +2,14 @@ package smi
 
 import (
 	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
+	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
 )
 
 var (

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -4,18 +4,17 @@ import (
 	"fmt"
 	"net"
 
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (

--- a/pkg/utils/mtls.go
+++ b/pkg/utils/mtls.go
@@ -5,14 +5,13 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-
-	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
 func setupMutualTLS(insecure bool, serverName string, certPem []byte, keyPem []byte, ca []byte) (grpc.ServerOption, error) {


### PR DESCRIPTION
recent changes related to go-checks made CI fail on some formatting issues.
This PR makes the fixes to make CI happy. These changes are exposed using the
gci tool https://github.com/daixiang0/gci which is not included in the Makefile.
As a follow up, I'll look into whether we need to either tweak our settings or add
the gci check to the go-checks make target.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
