### PR TITLE
chore(*): specify linters to run

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,8 +6,15 @@ issues:
 
 linters:
   enable:
+    - goconst
+    - gocyclo
     - gofmt
+    - goimports
     - golint
+    - govet
+    - misspell
+    - unused
+    - whitespace
 
 linters-settings:
   goimports:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,9 @@ issues:
   new: true
 
 linters:
-  enable-all: true
+  enable:
+    - gofmt
+    - golint
 
 linters-settings:
   goimports:


### PR DESCRIPTION
+ we had go-vet, gofmt and go-lint enabled before
using golangci-lint, so I've re-enabled that setting
using golangci-lint. Let's iteratively add linters.

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
