### PR TITLE
envoy: remove deprecated field in RegexMatcher proto

### DIFF
--- a/pkg/envoy/route/config.go
+++ b/pkg/envoy/route/config.go
@@ -55,14 +55,6 @@ const (
 	httpHostHeader = "host"
 )
 
-var (
-	regexEngine = &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{
-		MaxProgramSize: &wrappers.UInt32Value{
-			Value: uint32(maxRegexProgramSize),
-		},
-	}}
-)
-
 //UpdateRouteConfiguration consrtucts the Envoy construct necessary for TrafficTarget implementation
 func UpdateRouteConfiguration(domainRoutesMap map[string]map[string]trafficpolicy.RouteWeightedClusters, routeConfig *xds_route.RouteConfiguration, direction Direction) {
 	log.Trace().Msgf("[RDS] Updating Route Configuration")
@@ -131,7 +123,7 @@ func getRoute(pathRegex string, method string, headersMap map[string]string, wei
 		Match: &xds_route.RouteMatch{
 			PathSpecifier: &xds_route.RouteMatch_SafeRegex{
 				SafeRegex: &xds_matcher.RegexMatcher{
-					EngineType: regexEngine,
+					EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},
 					Regex:      pathRegex,
 				},
 			},
@@ -156,7 +148,7 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 		Name: MethodHeaderKey,
 		HeaderMatchSpecifier: &xds_route.HeaderMatcher_SafeRegexMatch{
 			SafeRegexMatch: &xds_matcher.RegexMatcher{
-				EngineType: regexEngine,
+				EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},
 				Regex:      getRegexForMethod(method),
 			},
 		},
@@ -173,7 +165,7 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 			Name: headerKey,
 			HeaderMatchSpecifier: &xds_route.HeaderMatcher_SafeRegexMatch{
 				SafeRegexMatch: &xds_matcher.RegexMatcher{
-					EngineType: regexEngine,
+					EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},
 					Regex:      headerValue,
 				},
 			},


### PR DESCRIPTION
The field max_program_size in v3.RegexMatcher.GoogleRE2 is
deprecated, so this change removes it.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`