### PR TITLE
configurator: remove error field from debug log

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -165,7 +165,8 @@ func getEgressCIDR(configMap *v1.ConfigMap) string {
 func getBoolValueForKey(configMap *v1.ConfigMap, key string) bool {
 	configMapStringValue, ok := configMap.Data[key]
 	if !ok {
-		log.Debug().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
+		log.Debug().Msgf("Key %s does not exist in ConfigMap %s/%s (%s)",
+			key, configMap.Namespace, configMap.Name, configMap.Data)
 		return false
 	}
 
@@ -181,7 +182,8 @@ func getBoolValueForKey(configMap *v1.ConfigMap, key string) bool {
 func getIntValueForKey(configMap *v1.ConfigMap, key string) int {
 	configMapStringValue, ok := configMap.Data[key]
 	if !ok {
-		log.Debug().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
+		log.Debug().Msgf("Key %s does not exist in ConfigMap %s/%s (%s)",
+			key, configMap.Namespace, configMap.Name, configMap.Data)
 		return 0
 	}
 
@@ -197,7 +199,8 @@ func getIntValueForKey(configMap *v1.ConfigMap, key string) int {
 func getStringValueForKey(configMap *v1.ConfigMap, key string) string {
 	configMapStringValue, ok := configMap.Data[key]
 	if !ok {
-		log.Debug().Err(errInvalidKeyInConfigMap).Msgf("Key %s does not exist in ConfigMap %s/%s (%s)", key, configMap.Namespace, configMap.Name, configMap.Data)
+		log.Debug().Msgf("Key %s does not exist in ConfigMap %s/%s (%s)",
+			key, configMap.Namespace, configMap.Name, configMap.Data)
 		return ""
 	}
 	return configMapStringValue

--- a/pkg/configurator/errors.go
+++ b/pkg/configurator/errors.go
@@ -3,6 +3,5 @@ package configurator
 import "github.com/pkg/errors"
 
 var (
-	errInvalidKeyInConfigMap = errors.New("invalid key in ConfigMap")
 	errMissingKeyInConfigMap = errors.New("missing key in ConfigMap")
 )


### PR DESCRIPTION
Debug logs shouldn't log errors, remove error tag to prevent the
logger from logging unnecessary error fields in the logs. This
log statement is intended to be Debug level, as changed by PR #1547.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`