### PR TITLE
feat(providers): Update providers to return list of services for a service account

### DIFF
--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -12,12 +12,12 @@ func (mc *MeshCatalog) GetServicesForServiceAccount(sa service.K8sServiceAccount
 		// TODO (#88) : remove this provider check once we have figured out the service account story for azure vms
 		if provider.GetID() != constants.AzureProviderName {
 			log.Trace().Msgf("[%s] Looking for Services for Name=%s", provider.GetID(), sa)
-			service, err := provider.GetServiceForServiceAccount(sa)
+			providerServices, err := provider.GetServicesForServiceAccount(sa)
 			if err != nil {
 				log.Warn().Msgf("Error getting services from provider %s: %s", provider.GetID(), err)
 			} else {
-				log.Trace().Msgf("[%s] Found service %s for Name=%s", provider.GetID(), service.String(), sa)
-				services = append(services, service)
+				log.Trace().Msgf("[%s] Found services %v for Name=%s", provider.GetID(), services, sa)
+				services = append(services, providerServices...)
 			}
 		}
 	}

--- a/pkg/endpoint/providers/azure/provider.go
+++ b/pkg/endpoint/providers/azure/provider.go
@@ -52,8 +52,8 @@ func (az Client) ListEndpointsForService(svc service.MeshService) []endpoint.End
 	return endpoints
 }
 
-// GetServiceForServiceAccount retrieves the service for the given service account
-func (az Client) GetServiceForServiceAccount(svcAccount service.K8sServiceAccount) (service.MeshService, error) {
+// GetServicesForServiceAccount retrieves a list of services for the given service account.
+func (az Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {
 	//TODO (snchh) : need to figure out the service account equivalnent for azure
 	panic("NotImplemented")
 }

--- a/pkg/endpoint/providers/kube/errors.go
+++ b/pkg/endpoint/providers/kube/errors.go
@@ -6,5 +6,4 @@ var (
 	errSyncingCaches                      = errors.New("failed initial sync of resources required for ingress")
 	errInitInformers                      = errors.New("informers are not initialized")
 	errDidNotFindServiceForServiceAccount = errors.New("no service exists for the service account")
-	errMoreThanServiceForServiceAccount   = errors.New("more than one service found for the service account")
 )

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -16,16 +16,16 @@ func NewFakeProvider() endpoint.Provider {
 			tests.BookstoreService.String(): {tests.Endpoint},
 			tests.BookbuyerService.String(): {tests.Endpoint},
 		},
-		services: map[service.K8sServiceAccount]service.MeshService{
-			tests.BookstoreServiceAccount: tests.BookstoreService,
-			tests.BookbuyerServiceAccount: tests.BookbuyerService,
+		services: map[service.K8sServiceAccount][]service.MeshService{
+			tests.BookstoreServiceAccount: {tests.BookstoreService},
+			tests.BookbuyerServiceAccount: {tests.BookbuyerService},
 		},
 	}
 }
 
 type fakeClient struct {
 	endpoints map[string][]endpoint.Endpoint
-	services  map[service.K8sServiceAccount]service.MeshService
+	services  map[service.K8sServiceAccount][]service.MeshService
 }
 
 // Retrieve the IP addresses comprising the given service.
@@ -36,10 +36,10 @@ func (f fakeClient) ListEndpointsForService(svc service.MeshService) []endpoint.
 	panic(fmt.Sprintf("You are asking for MeshService=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", svc.String(), f.endpoints))
 }
 
-func (f fakeClient) GetServiceForServiceAccount(svcAccount service.K8sServiceAccount) (service.MeshService, error) {
+func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {
 	services, ok := f.services[svcAccount]
 	if !ok {
-		panic(fmt.Sprintf("You asked fake k8s provider's GetServiceForServiceAccount for a Name=%s, but that's not in cache: %+v", svcAccount, f.services))
+		panic(fmt.Sprintf("ServiceAccount %s is not in cache: %+v", svcAccount, f.services))
 	}
 	return services, nil
 }

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -12,8 +12,8 @@ type Provider interface {
 	// Retrieve the IP addresses comprising the given service.
 	ListEndpointsForService(service.MeshService) []Endpoint
 
-	// Retrieve the namespaced service for a given service account
-	GetServiceForServiceAccount(service.K8sServiceAccount) (service.MeshService, error)
+	// Retrieve the namespaced services for a given service account
+	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
 	// GetID returns the unique identifier of the EndpointsProvider.
 	GetID() string


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.

Providers should return all associated services for a service account, not just 1.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No