### PR TITLE
Retrive logs for all containers in CI

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -116,7 +116,7 @@ func main() {
 	bookWarehouseTestResult := <-bookWarehouseCh
 
 	// When both pods return success - easy - we are good to go! CI passed!
-	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed {
+	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed && false {
 		log.Info().Msg("Test succeeded")
 		maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
 		webhookName := fmt.Sprintf("osm-webhook-%s", meshName)

--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/demo/cmd/common"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/logger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var log = logger.NewPretty("ci/maestro")
@@ -43,12 +45,12 @@ var (
 	maxOKWaitString  = common.GetEnv(maestro.WaitForOKSecondsEnvVar, "30")
 	meshName         = osmNamespace
 
+	// Mesh namespaces
 	namespaces = []string{
 		bookbuyerNS,
 		bookthiefNS,
 		bookstoreNS,
 		bookWarehouseNS,
-		osmNamespace,
 	}
 )
 
@@ -115,7 +117,7 @@ func main() {
 	// When both pods return success - easy - we are good to go! CI passed!
 	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed {
 		log.Info().Msg("Test succeeded")
-		maestro.DeleteNamespaces(kubeClient, namespaces...)
+		maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
 		webhookName := fmt.Sprintf("osm-webhook-%s", meshName)
 		maestro.DeleteWebhook(kubeClient, webhookName)
 		os.Exit(0)
@@ -140,24 +142,47 @@ func main() {
 		log.Error().Msgf("BookWarehouse test %s", humanize[bookWarehouseTestResult])
 	}
 
-	fmt.Println("The integration test failed")
+	fmt.Println("The integration test failed -- Getting Logs")
 
-	bookBuyerLogs := maestro.GetPodLogs(kubeClient, bookbuyerNS, bookBuyerPodName, bookBuyerLabel, maestro.FailureLogsFromTimeSince)
-	fmt.Println("-------- Bookbuyer LOGS --------\n", cutIt(bookBuyerLogs))
+	// Walk mesh-participant namespaces
+	for _, ns := range namespaces {
+		pods, err := kubeClient.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			log.Error().Msgf("Could not get Pods for Namespace %s", ns)
+			continue
+		}
 
-	bookThiefLogs := maestro.GetPodLogs(kubeClient, bookthiefNS, bookThiefPodName, bookThiefLabel, maestro.FailureLogsFromTimeSince)
-	fmt.Println("-------- Bookthief LOGS --------\n", cutIt(bookThiefLogs))
+		for _, podObj := range pods.Items {
 
-	bookWarehouseLogs := maestro.GetPodLogs(kubeClient, bookWarehouseNS, bookWarehousePodName, bookWarehouseLabel, maestro.FailureLogsFromTimeSince)
-	fmt.Println("-------- BookWarehouse LOGS --------\n", cutIt(bookWarehouseLogs))
+			for _, initContainer := range podObj.Spec.InitContainers {
+				initLogs := maestro.GetPodLogs(kubeClient, ns, podObj.Name, initContainer.Name, maestro.FailureLogsFromTimeSince)
+				fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  InitContainer: %s --------\n",
+					ns, podObj.Name, initContainer.Name), cutIt(initLogs))
+			}
+
+			for _, containerObj := range podObj.Spec.Containers {
+				initLogs := maestro.GetPodLogs(kubeClient, ns, podObj.Name, containerObj.Name, maestro.FailureLogsFromTimeSince)
+				switch containerObj.Name {
+				case constants.EnvoyContainerName:
+					fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Envoy Logs: --------\n",
+						ns, podObj.Name), initLogs)
+				default:
+					fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Container: %s --------\n",
+						ns, podObj.Name, containerObj.Name), cutIt(initLogs))
+				}
+
+			}
+		}
+
+	}
 
 	osmPodName, err := maestro.GetPodName(kubeClient, osmNamespace, osmControllerPodSelector)
 
 	if err != nil {
-		log.Fatal().Err(err).Msgf("Error getting ADS pods with selector %s in namespace %s", osmPodName, osmNamespace)
+		log.Fatal().Err(err).Msgf("Error getting OSM-Controller pods with selector %s in namespace %s", osmPodName, osmNamespace)
 	}
 
-	fmt.Println("-------- ADS LOGS --------\n", maestro.GetPodLogs(kubeClient, osmNamespace, osmPodName, "", maestro.FailureLogsFromTimeSince))
+	fmt.Println("-------- OSM-Controller LOGS --------\n", maestro.GetPodLogs(kubeClient, osmNamespace, osmPodName, "", maestro.FailureLogsFromTimeSince))
 
 	os.Exit(1)
 }

--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -153,7 +153,6 @@ func main() {
 		}
 
 		for _, podObj := range pods.Items {
-
 			for _, initContainer := range podObj.Spec.InitContainers {
 				initLogs := maestro.GetPodLogs(kubeClient, ns, podObj.Name, initContainer.Name, maestro.FailureLogsFromTimeSince)
 				fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  InitContainer: %s --------\n",
@@ -170,12 +169,12 @@ func main() {
 					fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Container: %s --------\n",
 						ns, podObj.Name, containerObj.Name), cutIt(initLogs))
 				}
-
 			}
 		}
 
 	}
 
+	// Targetting osm-controller specifically might be ok for now
 	osmPodName, err := maestro.GetPodName(kubeClient, osmNamespace, osmControllerPodSelector)
 
 	if err != nil {

--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -9,11 +9,12 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openservicemesh/osm/ci/cmd/maestro"
 	"github.com/openservicemesh/osm/demo/cmd/common"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/logger"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var log = logger.NewPretty("ci/maestro")
@@ -174,7 +175,7 @@ func main() {
 
 	}
 
-	// Targetting osm-controller specifically might be ok for now
+	// Targeting osm-controller specifically might be ok for now
 	osmPodName, err := maestro.GetPodName(kubeClient, osmNamespace, osmControllerPodSelector)
 
 	if err != nil {

--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -116,7 +116,7 @@ func main() {
 	bookWarehouseTestResult := <-bookWarehouseCh
 
 	// When both pods return success - easy - we are good to go! CI passed!
-	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed && false {
+	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed {
 		log.Info().Msg("Test succeeded")
 		maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
 		webhookName := fmt.Sprintf("osm-webhook-%s", meshName)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -127,4 +127,10 @@ const (
 
 	// DomainDelimiter is a delimiter used in representing domains
 	DomainDelimiter = "."
+
+	// EnvoyContainerName is the name used to identify the envoy sidecard container added on mesh-enabled deployments
+	EnvoyContainerName = "envoy"
+
+	// InitContainerName is the name of the init container
+	InitContainerName = "osm-init"
 )

--- a/pkg/injector/init-container.go
+++ b/pkg/injector/init-container.go
@@ -8,10 +8,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-const (
-	// InitContainerName is the name of the init container
-	InitContainerName = "osm-init"
-)
+const ()
 
 func getInitContainerSpec(pod *corev1.Pod, data *InitContainerData) (corev1.Container, error) {
 	return corev1.Container{

--- a/pkg/injector/init-container.go
+++ b/pkg/injector/init-container.go
@@ -8,8 +8,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-const ()
-
 func getInitContainerSpec(pod *corev1.Pod, data *InitContainerData) (corev1.Container, error) {
 	return corev1.Container{
 		Name:  data.Name,

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -60,7 +60,7 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 
 	// Add the Init Container
 	initContainerData := InitContainerData{
-		Name:  InitContainerName,
+		Name:  constants.InitContainerName,
 		Image: wh.config.InitContainerImage,
 	}
 	initContainerSpec, err := getInitContainerSpec(pod, &initContainerData)
@@ -81,7 +81,7 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 
 	patches = append(patches, addContainer(
 		pod.Spec.Containers,
-		getEnvoySidecarContainerSpec(envoyContainerName, wh.config.SidecarImage, envoyNodeID, envoyClusterID, wh.configurator),
+		getEnvoySidecarContainerSpec(constants.EnvoyContainerName, wh.config.SidecarImage, envoyNodeID, envoyClusterID, wh.configurator),
 		"/spec/containers")...,
 	)
 

--- a/pkg/injector/sidecar.go
+++ b/pkg/injector/sidecar.go
@@ -12,7 +12,6 @@ import (
 const (
 	envoyBootstrapConfigFile = "bootstrap.yaml"
 	envoyProxyConfigPath     = "/etc/envoy"
-	envoyContainerName       = "envoy"
 )
 
 func getEnvoySidecarContainerSpec(containerName, envoyImage, nodeID, clusterID string, cfg configurator.Configurator) []corev1.Container {


### PR DESCRIPTION
This commit adds the output for both Envoy containers
and Init containers in-mesh directly on stdout,
for CI maestro logging.

To follow up with folks to see if this is something
we want through this output form.

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

- Tests / CI System      [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No