### PR TITLE
envoy/cds: use downstream connection for HTTP protocol selection

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -41,6 +41,8 @@ func getRemoteServiceCluster(remoteService, localService service.MeshService, cf
 				TypedConfig: marshalledUpstreamTLSContext,
 			},
 		},
+		ProtocolSelection:    xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		Http2ProtocolOptions: &xds_core.Http2ProtocolOptions{},
 	}
 
 	if cfg.IsPermissiveTrafficPolicyMode() {
@@ -65,7 +67,9 @@ func getOutboundPassthroughCluster() *xds_cluster.Cluster {
 		ClusterDiscoveryType: &xds_cluster.Cluster_Type{
 			Type: xds_cluster.Cluster_ORIGINAL_DST,
 		},
-		LbPolicy: xds_cluster.Cluster_CLUSTER_PROVIDED,
+		LbPolicy:             xds_cluster.Cluster_CLUSTER_PROVIDED,
+		ProtocolSelection:    xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		Http2ProtocolOptions: &xds_core.Http2ProtocolOptions{},
 	}
 }
 
@@ -89,6 +93,8 @@ func getLocalServiceCluster(catalog catalog.MeshCataloger, proxyServiceName serv
 				// Filled based on discovered endpoints for the service
 			},
 		},
+		ProtocolSelection:    xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		Http2ProtocolOptions: &xds_core.Http2ProtocolOptions{},
 	}
 
 	endpoints, err := catalog.ListEndpointsForService(proxyServiceName)

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Cluster configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(remoteCluster.GetType()).To(Equal(xds_cluster.Cluster_EDS))
 			Expect(remoteCluster.LbPolicy).To(Equal(xds_cluster.Cluster_ROUND_ROBIN))
+			Expect(remoteCluster.ProtocolSelection).To(Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL))
 		})
 
 		It("Returns an Original Destination based cluster when permissive mode is enabled", func() {
@@ -39,6 +40,7 @@ var _ = Describe("Cluster configurations", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(remoteCluster.GetType()).To(Equal(xds_cluster.Cluster_ORIGINAL_DST))
 			Expect(remoteCluster.LbPolicy).To(Equal(xds_cluster.Cluster_CLUSTER_PROVIDED))
+			Expect(remoteCluster.ProtocolSelection).To(Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL))
 		})
 	})
 })

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -84,7 +84,7 @@ var _ = Describe("CDS Response", func() {
 
 	Context("Test cds clusters", func() {
 		It("Returns a local cluster object", func() {
-			remoteCluster, err := getLocalServiceCluster(catalog, proxyService, getLocalClusterName(proxyService))
+			localCluster, err := getLocalServiceCluster(catalog, proxyService, getLocalClusterName(proxyService))
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedClusterLoadAssignment := &xds_endpoint.ClusterLoadAssignment{
@@ -126,10 +126,11 @@ var _ = Describe("CDS Response", func() {
 				LoadAssignment:         expectedClusterLoadAssignment,
 			}
 
-			Expect(remoteCluster.Name).To(Equal(expectedCluster.Name))
-			Expect(remoteCluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
-			Expect(len(remoteCluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
-			Expect(remoteCluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+			Expect(localCluster.Name).To(Equal(expectedCluster.Name))
+			Expect(localCluster.LoadAssignment.ClusterName).To(Equal(expectedClusterLoadAssignment.ClusterName))
+			Expect(len(localCluster.LoadAssignment.Endpoints)).To(Equal(len(expectedClusterLoadAssignment.Endpoints)))
+			Expect(localCluster.LoadAssignment.Endpoints[0].LbEndpoints).To(Equal(expectedClusterLoadAssignment.Endpoints[0].LbEndpoints))
+			Expect(localCluster.ProtocolSelection).To(Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL))
 		})
 
 		It("Returns a remote cluster object", func() {


### PR DESCRIPTION
Currently OSM does not honor the protocol version of downstream
connections. As a result, HTTP2 clients are unable to route traffic
to HTTP2 servers. By default, Envoy uses HTTP 1.1 if
http2_protocol_options is not configured, as is the case now.

This change configures Envoy to use a HTTP protocol version
based on the downstream connection, allowing both HTTP1.1 and
HTTP2 clients to be able to route traffic. Default values
are used for the http2_protocol_options, but option must be
explicitly set as a part of the cluster config.

This change is primarily useful for HTTP2 connections over
plaintext, ex. with `grpc.WithInsecure()`.

Testing done:
```
 curl -v --http2 -H "client-app: bookbuyer" \
    -H "user-agent: Go-http-client/1.1" \
    http://bookstore.bookstore/books-bought

< HTTP/1.1 200 OK
< booksbought: 99
< identity: bookstore-v2
< date: Wed, 19 Aug 2020 18:40:00 GMT
< content-length: 1397
< content-type: text/html; charset=utf-8
< x-envoy-upstream-service-time: 2
< server: envo
```

Resolves #1589

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`