### PR TITLE
ref: Use K8sSvcToMeshSvc util

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 const (
@@ -325,20 +326,13 @@ func (mc *MeshCatalog) buildAllowAllTrafficPolicies(service service.MeshService)
 	return trafficTargets
 }
 
-func k8sSvcToMeshSvc(svc *corev1.Service) service.MeshService {
-	return service.MeshService{
-		Namespace: svc.Namespace,
-		Name:      svc.Name,
-	}
-}
-
 func (mc *MeshCatalog) buildAllowPolicyForSourceToDest(source *corev1.Service, destination *corev1.Service) trafficpolicy.TrafficTarget {
 	allowAllRoute := trafficpolicy.Route{
 		PathRegex: constants.RegexMatchAll,
 		Methods:   []string{constants.WildcardHTTPMethod},
 	}
-	srcMeshSvc := k8sSvcToMeshSvc(source)
-	dstMeshSvc := k8sSvcToMeshSvc(destination)
+	srcMeshSvc := utils.K8sSvcToMeshSvc(source)
+	dstMeshSvc := utils.K8sSvcToMeshSvc(destination)
 	return trafficpolicy.TrafficTarget{
 		Name:        fmt.Sprintf("%s->%s", srcMeshSvc, dstMeshSvc),
 		Destination: dstMeshSvc,

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 var _ = Describe("Catalog tests", func() {
@@ -101,15 +102,9 @@ var _ = Describe("Catalog tests", func() {
 				tests.SelectorKey: tests.SelectorValue,
 			}
 			source := tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, selectors)
-			expectedSourceTrafficResource := service.MeshService{
-				Namespace: source.Namespace,
-				Name:      source.Name,
-			}
+			expectedSourceTrafficResource := utils.K8sSvcToMeshSvc(source)
 			destination := tests.NewServiceFixture(tests.BookstoreServiceName, tests.Namespace, selectors)
-			expectedDestinationTrafficResource := service.MeshService{
-				Namespace: destination.Namespace,
-				Name:      destination.Name,
-			}
+			expectedDestinationTrafficResource := utils.K8sSvcToMeshSvc(destination)
 
 			expectedHostHeaders := map[string]string{"user-agent": tests.HTTPUserAgent}
 			expectedRoute := trafficpolicy.Route{

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
@@ -70,10 +71,7 @@ func (mc *MeshCatalog) filterTrafficSplitServices(services []v1.Service) []v1.Se
 	var filteredServices []v1.Service
 
 	for _, svc := range services {
-		nsSvc := service.MeshService{
-			Namespace: svc.Namespace,
-			Name:      svc.Name,
-		}
+		nsSvc := utils.K8sSvcToMeshSvc(&svc)
 		if _, shouldSkip := excludeTheseServices[nsSvc]; shouldSkip {
 			continue
 		}

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 var _ = Describe("Test Kube Client Provider", func() {
@@ -261,10 +262,7 @@ var _ = Describe("When getting a Service associated with a ServiceAccount", func
 		}
 
 		// Expect a MeshService that corresponds to a Service that matches the Deployment spec labels
-		expectedMeshSvc := service.MeshService{
-			Namespace: svc.Namespace,
-			Name:      svc.Name,
-		}
+		expectedMeshSvc := utils.K8sSvcToMeshSvc(svc)
 
 		meshSvcs, err := provider.GetServicesForServiceAccount(givenSvcAccount)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/utils/service.go
+++ b/pkg/utils/service.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+// K8sSvcToMeshSvc converts a Kubernetes service to a MeshService.
+func K8sSvcToMeshSvc(svc *corev1.Service) service.MeshService {
+	return service.MeshService{
+		Namespace: svc.Namespace,
+		Name:      svc.Name,
+	}
+}

--- a/pkg/utils/service_test.go
+++ b/pkg/utils/service_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+var _ = Describe("Testing utils helpers", func() {
+	Context("Test K8sSvcToMeshSvc", func() {
+		It("works as expected", func() {
+			v1Service := tests.NewServiceFixture(tests.BookstoreServiceName, tests.Namespace, nil)
+			meshSvc := K8sSvcToMeshSvc(v1Service)
+			expectedMeshSvc := service.MeshService{
+				Name:      tests.BookstoreServiceName,
+				Namespace: tests.Namespace,
+			}
+			Expect(meshSvc).To(Equal(expectedMeshSvc))
+		})
+	})
+})


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.
Use K8sSvcToMeshSvc helper function to convert between corev1.Service and service.MeshService
Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No