### PR TITLE
test(kube endpoints): fix flaky test

### DIFF
--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -441,7 +441,8 @@ var _ = Describe("When getting a Service associated with a ServiceAccount", func
 			{Name: "test-1", Namespace: testNamespace},
 			{Name: "test-2", Namespace: testNamespace},
 		}
-		Expect(meshServices).To(Equal(expectedServices))
+		Expect(meshServices[0]).To(BeElementOf(expectedServices))
+		Expect(meshServices[1]).To(BeElementOf(expectedServices))
 
 		err = fakeClientSet.AppsV1().Deployments(testNamespace).Delete(context.Background(), deployment.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This changes modifies a flaky test not to rely on the order of services
returned from `GetServicesForServiceAccount()`.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No