### PR TITLE
ref(*): run golangci-lint run --fix

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -172,7 +172,6 @@ func main() {
 				}
 			}
 		}
-
 	}
 
 	// Targeting osm-controller specifically might be ok for now

--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -133,11 +133,9 @@ func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, pod
 		defer logStream.Close()
 		r := bufio.NewReader(logStream)
 		for {
-
 			line, err := r.ReadString('\n')
 
 			switch {
-
 			// Make sure we don't wait too long for success/failure
 			case time.Since(startedWaiting) >= totalWait:
 				result <- TestsTimedOut

--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -48,7 +48,6 @@ type dashboardCmd struct {
 }
 
 func newDashboardCmd(config *action.Configuration, out io.Writer) *cobra.Command {
-
 	dash := &dashboardCmd{
 		out:        out,
 		config:     config,

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -13,13 +13,13 @@ import (
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/strvals"
-
-	"github.com/openservicemesh/osm/pkg/cli"
-	"github.com/openservicemesh/osm/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/cli"
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const installDesc = `

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -7,11 +7,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openservicemesh/osm/pkg/constants"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	fake "k8s.io/client-go/kubernetes/fake"
-
 	helm "helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
@@ -19,6 +14,11 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	fake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 var (

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const namespaceAddDescription = `

--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const namespaceListDescription = `

--- a/cmd/cli/namespace_remove.go
+++ b/cmd/cli/namespace_remove.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const namespaceRemoveDescription = `

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -9,11 +9,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/openservicemesh/osm/pkg/constants"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	fake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 var (

--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -102,7 +102,6 @@ func getBooksWrapper(wg *sync.WaitGroup) {
 }
 
 func main() {
-
 	go debugServer()
 
 	numConnections, err := strconv.Atoi(numConnectionsStr)

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -58,7 +58,6 @@ type handler struct {
 func getIndex(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(w)
 	fmt.Printf("%s;  URL: %q;  Count: %d\n", getIdentity(), html.EscapeString(r.URL.Path), booksStolen)
-
 }
 
 func getHandlers() []handler {
@@ -88,7 +87,6 @@ func debugServer() {
 }
 
 func main() {
-
 	go debugServer()
 
 	// The bookthief is not allowed to purchase books from the bookstore.

--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -137,7 +137,6 @@ func GetBooks(participantName string, meshExpectedResponseCode int, egressExpect
 		startTime := time.Now()
 
 		for url := range urlSuccessMap {
-
 			// We only care about the response code of the HTTP call for the given URL
 			responseCode, identity := fetch(url)
 
@@ -172,7 +171,6 @@ func GetBooks(participantName string, meshExpectedResponseCode int, egressExpect
 					// Maestro will stop tailing logs.
 					fmt.Println(Success)
 				}
-
 			}
 
 			if previouslySucceeded && !succeeded {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -39,7 +39,6 @@ func NewMeshCatalog(namespaceController namespace.Controller, kubeClient kuberne
 
 	for _, announcementChannel := range sc.getAnnouncementChannels() {
 		sc.announcementChannels.Add(announcementChannel)
-
 	}
 
 	go sc.repeater()

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -94,7 +94,6 @@ func (mc *MeshCatalog) getAllowedDirectionalServices(svc service.MeshService, di
 // ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
 func (mc *MeshCatalog) ListAllowedInboundServices(destinationService service.MeshService) ([]service.MeshService, error) {
 	return mc.getAllowedDirectionalServices(destinationService, inbound)
-
 }
 
 // ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
@@ -275,7 +274,6 @@ func getTrafficPolicyPerRoute(mc *MeshCatalog, routePolicies map[trafficpolicy.T
 				if !matchFound {
 					log.Error().Msgf("TrafficTarget %s/%s could not find a TrafficSpec %s", trafficTargets.Namespace, trafficTargets.Name, specKey)
 					return nil, errNoTrafficSpecFoundForTrafficPolicy
-
 				}
 				if len(trafficTargetSpecs.Matches) == 0 {
 					// no match name provided, so routes are build for all matches in traffic spec

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -11,7 +11,6 @@ import (
 func (mc *MeshCatalog) GetServicesForServiceAccount(sa service.K8sServiceAccount) ([]service.MeshService, error) {
 	var services []service.MeshService
 	for _, provider := range mc.endpointsProviders {
-
 		// TODO (#88) : remove this provider check once we have figured out the service account story for azure vms
 		if provider.GetID() == constants.AzureProviderName {
 			continue

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -48,7 +48,6 @@ func (mc *MeshCatalog) GetServicesFromEnvoyCertificate(cn certificate.CommonName
 			Name:      svc.Name,
 		}
 		serviceList = append(serviceList, meshService)
-
 	}
 	return serviceList, nil
 }

--- a/pkg/certificate/encode_test.go
+++ b/pkg/certificate/encode_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
 

--- a/pkg/certificate/file_test.go
+++ b/pkg/certificate/file_test.go
@@ -45,7 +45,6 @@ func getPrivateKeyFixture() *rsa.PrivateKey {
 			CRTValues: []rsa.CRTValue{},
 		},
 	}
-
 }
 
 func getX509CertFixture() *x509.Certificate {

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -218,7 +218,7 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Dur
 	return cert, nil
 }
 
-// NewCertManager will contruct a new certificate.Certificater implemented
+// NewCertManager will construct a new certificate.Certificater implemented
 // using Jetstack's cert-manager,
 func NewCertManager(
 	ca certificate.Certificater,

--- a/pkg/certificate/providers/certmanager/debugger_test.go
+++ b/pkg/certificate/providers/certmanager/debugger_test.go
@@ -27,8 +27,8 @@ var _ = Describe("Test cert-manager Debugger", func() {
 		}
 		It("lists all issued certificets", func() {
 			actual := cm.ListIssuedCertificates()
-			expeced := []certificate.Certificater{cert}
-			Expect(actual).To(Equal(expeced))
+			expected := []certificate.Certificater{cert}
+			Expect(actual).To(Equal(expected))
 		})
 	})
 })

--- a/pkg/certificate/providers/keyvault/types.go
+++ b/pkg/certificate/providers/keyvault/types.go
@@ -2,6 +2,7 @@ package keyvault
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
+
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/vault/api"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 

--- a/pkg/debugger/namespace.go
+++ b/pkg/debugger/namespace.go
@@ -12,7 +12,6 @@ type namespaces struct {
 
 func (ds debugServer) getMonitoredNamespacesHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		var n namespaces
 		n.Namespaces = ds.meshCatalogDebugger.ListMonitoredNamespaces()
 

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -35,7 +35,6 @@ func (ds debugServer) getOSMConfigHandler() http.Handler {
 
 func (ds debugServer) getSMIPoliciesHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		var p policies
 		p.TrafficSplits, p.WeightedServices, p.ServiceAccounts, p.RouteGroups, p.TrafficTargets, p.Services = ds.meshCatalogDebugger.ListSMIPolicies()
 

--- a/pkg/debugger/port_forward.go
+++ b/pkg/debugger/port_forward.go
@@ -58,5 +58,4 @@ func (ds debugServer) forwardPort(req portForward) {
 	if err = fw.ForwardPorts(); err != nil {
 		log.Error().Err(err)
 	}
-
 }

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -7,9 +7,6 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-	"github.com/openservicemesh/osm/pkg/service"
-
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +18,9 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/namespace"
+	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
@@ -103,7 +102,6 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 					}
 					endpoints = append(endpoints, ept)
 				}
-
 			}
 		}
 	}

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -10,7 +10,6 @@ import (
 
 // NewFakeProvider implements mesh.EndpointsProvider, which creates a test Kubernetes cluster/compute provider.
 func NewFakeProvider() endpoint.Provider {
-
 	return &fakeClient{
 		endpoints: map[string][]endpoint.Endpoint{
 			tests.BookstoreService.String(): {tests.Endpoint},

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -50,7 +50,6 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	go receive(requests, &server, proxy, quit)
 
 	for {
-
 		select {
 		case <-ctx.Done():
 			return nil
@@ -148,7 +147,6 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 		case <-proxy.GetAnnouncementsChannel():
 			log.Info().Msgf("Change detected - update all Envoys.")
 			s.sendAllResponses(proxy, &server, s.cfg)
-
 		}
 	}
 }

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -66,7 +66,6 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 			// This proxy is fronting a service that is a backend for an ingress, add a FilterChain for it
 			ingressFilterChains := getIngressFilterChains(proxyServiceName, cfg)
 			inboundListener.FilterChains = append(inboundListener.FilterChains, ingressFilterChains...)
-
 		} else {
 			log.Trace().Msgf("There is no k8s Ingress for service %s", proxyServiceName)
 		}

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/tests"

--- a/pkg/envoy/lds/tracing.go
+++ b/pkg/envoy/lds/tracing.go
@@ -3,15 +3,14 @@ package lds
 import (
 	xds_tracing "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-
 	"github.com/golang/protobuf/ptypes"
+
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 // GetZipkinTracingConfig returns a configuration tracing struct for a connection manager to use
 func GetZipkinTracingConfig(cfg configurator.Configurator) (*xds_hcm.HttpConnectionManager_Tracing, error) {
-
 	zipkinConf := &xds_tracing.ZipkinConfig{
 		CollectorCluster:         constants.EnvoyZipkinCluster,
 		CollectorEndpoint:        cfg.GetZipkinEndpoint(),

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -1,12 +1,11 @@
 package rds
 
 import (
+	set "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-
-	set "github.com/deckarep/golang-set"
-
 	"github.com/golang/protobuf/ptypes"
+
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/envoy/route/config.go
+++ b/pkg/envoy/route/config.go
@@ -5,10 +5,9 @@ import (
 	"sort"
 	"strings"
 
+	set "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-
-	set "github.com/deckarep/golang-set"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -171,7 +170,6 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 			},
 		}
 		headers = append(headers, &header)
-
 	}
 	return headers
 }

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -117,7 +117,6 @@ func UnmarshalSDSCert(str string) (*SDSCert, error) {
 	}
 
 	return &ret, nil
-
 }
 
 // String is a common facility/interface to generate a string resource name out of a SDSCert

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -3,9 +3,11 @@ package health
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openservicemesh/osm/pkg/version"
-	"github.com/rs/zerolog/log"
 	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/openservicemesh/osm/pkg/version"
 )
 
 // Probe is a type alias for a function.

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Test httpserver", func() {
 			Config: httpServ.server,
 		}
 
-		It("should return 404 for a non-existant debug url", func() {
+		It("should return 404 for a non-existent debug url", func() {
 			req := httptest.NewRequest("GET", fmt.Sprintf("%s%s", url, invalidRoutePath), nil)
 
 			w := httptest.NewRecorder()

--- a/pkg/ingress/fake.go
+++ b/pkg/ingress/fake.go
@@ -1,8 +1,9 @@
 package ingress
 
 import (
-	"github.com/openservicemesh/osm/pkg/service"
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+
+	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // FakeIngressMonitor returns a fake ingress monitor object

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -6,10 +6,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const expectedEnvoyConfig = `

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -1,11 +1,11 @@
 package injector
 
 import (
-	"github.com/openservicemesh/osm/pkg/configurator"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
 )

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -244,7 +244,6 @@ func (wh *webhook) mustInject(pod *corev1.Pod, namespace string) (bool, error) {
 	inject := strings.ToLower(pod.ObjectMeta.Annotations[annotationInject])
 	log.Debug().Msgf("Sidecar injection annotation: '%s:%s'", annotationInject, inject)
 	if inject != "" {
-
 		switch inject {
 		case "enabled", "yes", "true":
 			return true, nil

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -5,8 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	osmPolicy "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
-	osmPolicyClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned/fake"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -17,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	osmPolicy "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	osmPolicyClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/featureflags"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -1,12 +1,12 @@
 package smi
 
 import (
-	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 
+	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -1,7 +1,6 @@
 package smi
 
 import (
-	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -9,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
+	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/namespace"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -6,6 +6,7 @@ import (
 
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
+	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -15,7 +16,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
-	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 )
 
 const (

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -2,6 +2,7 @@ package trafficpolicy
 
 import (
 	set "github.com/deckarep/golang-set"
+
 	"github.com/openservicemesh/osm/pkg/service"
 )
 


### PR DESCRIPTION
`golangci-lint run` has a `--fix` flag that will automatically fix
issues if possible. These changes are a result of those automatic fixes,
including import ordering, whitespace, and fixing typos.

This partially addresses #1578.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No