### PR TITLE
smi/client: rename import and objects to reflect pkg group

### DIFF
--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -20,20 +20,20 @@ var (
 
 // InformerCollection is a struct of the Kubernetes informers used in OSM
 type InformerCollection struct {
-	Services      cache.SharedIndexInformer
-	TrafficSplit  cache.SharedIndexInformer
-	TrafficSpec   cache.SharedIndexInformer
-	TrafficTarget cache.SharedIndexInformer
-	Backpressure  cache.SharedIndexInformer
+	Services       cache.SharedIndexInformer
+	TrafficSplit   cache.SharedIndexInformer
+	HTTPRouteGroup cache.SharedIndexInformer
+	TrafficTarget  cache.SharedIndexInformer
+	Backpressure   cache.SharedIndexInformer
 }
 
 // CacheCollection is a struct of the Kubernetes caches used in OSM
 type CacheCollection struct {
-	Services      cache.Store
-	TrafficSplit  cache.Store
-	TrafficSpec   cache.Store
-	TrafficTarget cache.Store
-	Backpressure  cache.Store
+	Services       cache.Store
+	TrafficSplit   cache.Store
+	HTTPRouteGroup cache.Store
+	TrafficTarget  cache.Store
+	Backpressure   cache.Store
 }
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.


### PR DESCRIPTION
Renames the import aliases and types to reflect the core
package. Also renames the informer for the HTTPRouteGroup
resource since the informer is specific to that kind.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`