### PR TITLE
ads, test: use 'new' instead of manual object creation

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -21,11 +21,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/envoy/cds"
-	"github.com/openservicemesh/osm/pkg/envoy/eds"
-	"github.com/openservicemesh/osm/pkg/envoy/lds"
-	"github.com/openservicemesh/osm/pkg/envoy/rds"
-	"github.com/openservicemesh/osm/pkg/envoy/sds"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -104,16 +99,9 @@ var _ = Describe("Test ADS response functions", func() {
 		cfg := configurator.NewFakeConfigurator()
 
 		It("returns Aggregated Discovery Service response", func() {
-			s := Server{
-				catalog: mc,
-				xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator) (*xds_discovery.DiscoveryResponse, error){
-					envoy.TypeEDS: eds.NewResponse,
-					envoy.TypeCDS: cds.NewResponse,
-					envoy.TypeRDS: rds.NewResponse,
-					envoy.TypeLDS: lds.NewResponse,
-					envoy.TypeSDS: sds.NewResponse,
-				},
-			}
+			s := NewADSServer(mc, true, tests.Namespace, cfg)
+
+			Expect(s).ToNot(BeNil())
 
 			s.sendAllResponses(proxy, &server, cfg)
 


### PR DESCRIPTION
Coverage: `22%` -> `28.5%`

- Tests / CI System      [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No