### PR TITLE
install: make OSM ImagePullPolicy configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,10 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: latest
 # export CTR_TAG=latest
 
+# optional: The image pull policy for OSM images
+# Default: Always
+# export IMAGE_PULL_POLICY=Always
+
 # optional: Path to your Kubernetes config file present locally. Required if not using in-cluster config.
 # export KUBECONFIG=~/.kube/config
 
@@ -89,7 +93,7 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # optional: Maximum of iterations to test for expected return codes. 0 means unlimited.
 # export CI_MAX_ITERATIONS_THRESHOLD=0
 
-# optional: Time in seconds that a bookbuyer sleeps between requests. 
+# optional: Time in seconds that a bookbuyer sleeps between requests.
 # Default: 1
 # export CI_SLEEP_BETWEEN_REQUESTS_SECONDS=1
 

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -57,6 +57,7 @@ const (
 	defaultVaultProtocol       = "http"
 	defaultMeshName            = "osm"
 	defaultCertValidityMinutes = int(1440) // 24 hours
+	defaultOsmImagePullPolicy  = "IfNotPresent"
 )
 
 // chartTGZSource is a base64-encoded, gzipped tarball of the default Helm chart.
@@ -69,6 +70,7 @@ type installCmd struct {
 	containerRegistrySecret       string
 	chartPath                     string
 	osmImageTag                   string
+	osmImagePullPolicy            string
 	certificateManager            string
 	vaultHost                     string
 	vaultProtocol                 string
@@ -124,6 +126,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&inst.containerRegistry, "container-registry", "openservicemesh", "container registry that hosts control plane component images")
 	f.StringVar(&inst.osmImageTag, "osm-image-tag", "v0.3.0", "osm image tag")
+	f.StringVar(&inst.osmImagePullPolicy, "osm-image-pull-policy", defaultOsmImagePullPolicy, "osm image pull policy")
 	f.StringVar(&inst.containerRegistrySecret, "container-registry-secret", "", "name of Kubernetes secret for container registry credentials to be created if it doesn't already exist")
 	f.StringVar(&inst.chartPath, "osm-chart-path", "", "path to osm chart to override default chart")
 	f.StringVar(&inst.certificateManager, "certificate-manager", defaultCertManager, "certificate manager to use one of (tresor, vault, cert-manager)")
@@ -235,6 +238,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 	valuesConfig := []string{
 		fmt.Sprintf("OpenServiceMesh.image.registry=%s", i.containerRegistry),
 		fmt.Sprintf("OpenServiceMesh.image.tag=%s", i.osmImageTag),
+		fmt.Sprintf("OpenServiceMesh.image.pullPolicy=%s", i.osmImagePullPolicy),
 		fmt.Sprintf("OpenServiceMesh.certificateManager=%s", i.certificateManager),
 		fmt.Sprintf("OpenServiceMesh.vault.host=%s", i.vaultHost),
 		fmt.Sprintf("OpenServiceMesh.vault.protocol=%s", i.vaultProtocol),

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Running the install command", func() {
 				chartPath:                  "testdata/test-chart",
 				containerRegistry:          testRegistry,
 				osmImageTag:                testOsmImageTag,
+				osmImagePullPolicy:         defaultOsmImagePullPolicy,
 				certificateManager:         "tresor",
 				serviceCertValidityMinutes: 1,
 				prometheusRetentionTime:    testRetentionTime,
@@ -118,8 +119,9 @@ var _ = Describe("Running the install command", func() {
 						},
 						"meshName": defaultMeshName,
 						"image": map[string]interface{}{
-							"registry": testRegistry,
-							"tag":      testOsmImageTag,
+							"registry":   testRegistry,
+							"tag":        testOsmImageTag,
+							"pullPolicy": defaultOsmImagePullPolicy,
 						},
 						"serviceCertValidityMinutes": int64(1),
 						"vault": map[string]interface{}{
@@ -180,6 +182,7 @@ var _ = Describe("Running the install command", func() {
 				containerRegistry:          testRegistry,
 				containerRegistrySecret:    testRegistrySecret,
 				osmImageTag:                testOsmImageTag,
+				osmImagePullPolicy:         defaultOsmImagePullPolicy,
 				certificateManager:         "tresor",
 				serviceCertValidityMinutes: 1,
 				prometheusRetentionTime:    testRetentionTime,
@@ -226,8 +229,9 @@ var _ = Describe("Running the install command", func() {
 						},
 						"meshName": defaultMeshName,
 						"image": map[string]interface{}{
-							"registry": testRegistry,
-							"tag":      testOsmImageTag,
+							"registry":   testRegistry,
+							"tag":        testOsmImageTag,
+							"pullPolicy": defaultOsmImagePullPolicy,
 						},
 						"imagePullSecrets": []interface{}{
 							map[string]interface{}{
@@ -301,6 +305,7 @@ var _ = Describe("Running the install command", func() {
 				certmanagerIssuerKind:      testCertManagerIssuerKind,
 				certmanagerIssuerGroup:     testCertManagerIssuerGroup,
 				osmImageTag:                testOsmImageTag,
+				osmImagePullPolicy:         defaultOsmImagePullPolicy,
 				serviceCertValidityMinutes: 1,
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
@@ -346,8 +351,9 @@ var _ = Describe("Running the install command", func() {
 						},
 						"meshName": defaultMeshName,
 						"image": map[string]interface{}{
-							"registry": testRegistry,
-							"tag":      testOsmImageTag,
+							"registry":   testRegistry,
+							"tag":        testOsmImageTag,
+							"pullPolicy": defaultOsmImagePullPolicy,
 						},
 						"imagePullSecrets": []interface{}{
 							map[string]interface{}{
@@ -464,6 +470,7 @@ var _ = Describe("Running the install command", func() {
 				certmanagerIssuerKind:      testCertManagerIssuerKind,
 				certmanagerIssuerGroup:     testCertManagerIssuerGroup,
 				osmImageTag:                testOsmImageTag,
+				osmImagePullPolicy:         defaultOsmImagePullPolicy,
 				serviceCertValidityMinutes: 1,
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
@@ -509,8 +516,9 @@ var _ = Describe("Running the install command", func() {
 						},
 						"meshName": defaultMeshName,
 						"image": map[string]interface{}{
-							"registry": testRegistry,
-							"tag":      testOsmImageTag,
+							"registry":   testRegistry,
+							"tag":        testOsmImageTag,
+							"pullPolicy": defaultOsmImagePullPolicy,
 						},
 						"imagePullSecrets": []interface{}{
 							map[string]interface{}{
@@ -750,6 +758,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			vaultToken:                 testVaultToken,
 			vaultRole:                  testVaultRole,
 			osmImageTag:                testOsmImageTag,
+			osmImagePullPolicy:         defaultOsmImagePullPolicy,
 			serviceCertValidityMinutes: 1,
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
@@ -776,8 +785,9 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				},
 				"meshName": defaultMeshName,
 				"image": map[string]interface{}{
-					"registry": testRegistry,
-					"tag":      testOsmImageTag,
+					"registry":   testRegistry,
+					"tag":        testOsmImageTag,
+					"pullPolicy": defaultOsmImagePullPolicy,
 				},
 				"imagePullSecrets": []interface{}{
 					map[string]interface{}{
@@ -826,6 +836,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			vaultToken:                 testVaultToken,
 			vaultRole:                  testVaultRole,
 			osmImageTag:                testOsmImageTag,
+			osmImagePullPolicy:         defaultOsmImagePullPolicy,
 			serviceCertValidityMinutes: 1,
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
@@ -852,8 +863,9 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 				},
 				"meshName": defaultMeshName,
 				"image": map[string]interface{}{
-					"registry": testRegistry,
-					"tag":      testOsmImageTag,
+					"registry":   testRegistry,
+					"tag":        testOsmImageTag,
+					"pullPolicy": defaultOsmImagePullPolicy,
 				},
 				"imagePullSecrets": []interface{}{
 					map[string]interface{}{
@@ -947,6 +959,32 @@ var _ = Describe("Test mesh CIDR ranges", func() {
 			err = validateCIDRs([]string{"10.2.0.0"})
 			Expect(err).To(HaveOccurred())
 		})
+	})
+})
+
+var _ = Describe("Test osm image pull policy cli option", func() {
+	It("Should correctly resolve the pull policy option to chart values", func() {
+		installCmd := &installCmd{
+			osmImagePullPolicy: "IfNotPresent",
+		}
+
+		vals, err := installCmd.resolveValues()
+		Expect(err).NotTo(HaveOccurred())
+
+		pullPolicy := vals["OpenServiceMesh"].(map[string]interface{})["image"].(map[string]interface{})["pullPolicy"]
+		Expect(pullPolicy).To(Equal("IfNotPresent"))
+	})
+
+	It("Should correctly resolve the pull policy option to chart values", func() {
+		installCmd := &installCmd{
+			osmImagePullPolicy: "Always",
+		}
+
+		vals, err := installCmd.resolveValues()
+		Expect(err).NotTo(HaveOccurred())
+
+		pullPolicy := vals["OpenServiceMesh"].(map[string]interface{})["image"].(map[string]interface{})["pullPolicy"]
+		Expect(pullPolicy).To(Equal("Always"))
 	})
 })
 

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -26,6 +26,7 @@ CTR_REGISTRY="${CTR_REGISTRY:-localhost:5000}"
 CTR_REGISTRY_CREDS_NAME="${CTR_REGISTRY_CREDS_NAME:-acr-creds}"
 DEPLOY_TRAFFIC_SPLIT="${DEPLOY_TRAFFIC_SPLIT:-true}"
 CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
+IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
 MESH_CIDR=$(./scripts/get_mesh_cidr.sh)
 
@@ -107,6 +108,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --container-registry "$CTR_REGISTRY" \
       --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
       --osm-image-tag "$CTR_TAG" \
+      --osm-image-pull-policy "$IMAGE_PULL_POLICY" \
       --enable-debug-server \
       --enable-egress="$ENABLE_EGRESS" \
       --mesh-cidr "$MESH_CIDR" \
@@ -120,6 +122,7 @@ else
       --container-registry "$CTR_REGISTRY" \
       --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
       --osm-image-tag "$CTR_TAG" \
+      --osm-image-pull-policy "$IMAGE_PULL_POLICY" \
       --enable-debug-server \
       --enable-egress="$ENABLE_EGRESS" \
       --mesh-cidr "$MESH_CIDR" \


### PR DESCRIPTION
Commit a42c772 changed the default pull policy for
OSM images to `IfNotPresent`, which breaks local
testing where the same CTR_TAG is used across
reruns of the demo. As a result, when a new change
is made locally and the demo is rerun, they don't
get picked by the demo. Even using the git SHA as the
default tag will not solve this problem because an
amended commit will have the same image tag.

This change makes the image pull policy configurable
in the install cli, with the default being set
to `IfNotPresent` as before. The demo is updated
to set the pull policy to `Always` so that rerunning
the demo always picks up the latest built image,
irrespective of the tag.

Resolves #1605

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`