### PR TITLE
test: Fix ListAllowedOutboundServices test flake

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -137,7 +137,9 @@ var _ = Describe("Catalog tests", func() {
 			actualList, err := mc.ListAllowedOutboundServices(tests.BookbuyerService)
 			Expect(err).ToNot(HaveOccurred())
 			expectedList := []service.MeshService{tests.BookstoreService, tests.BookstoreApexService}
-			Expect(actualList).To(Equal(expectedList))
+			Expect(len(actualList)).To(Equal(len(expectedList)))
+			Expect(actualList[0]).To(BeElementOf(expectedList))
+			Expect(actualList[1]).To(BeElementOf(expectedList))
 		})
 	})
 

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -441,6 +441,7 @@ var _ = Describe("When getting a Service associated with a ServiceAccount", func
 			{Name: "test-1", Namespace: testNamespace},
 			{Name: "test-2", Namespace: testNamespace},
 		}
+		Expect(len(meshServices)).To(Equal(len(expectedServices)))
 		Expect(meshServices[0]).To(BeElementOf(expectedServices))
 		Expect(meshServices[1]).To(BeElementOf(expectedServices))
 

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -389,6 +389,7 @@ var _ = Describe("When listing Services", func() {
 		Expect(len(services)).To(Equal(2))
 
 		expectedServices := []string{"test-1", "test-2"}
+		Expect(len(services)).To(Equal(len(expectedServices)))
 		Expect(services[0].Name).To(BeElementOf(expectedServices))
 		Expect(services[1].Name).To(BeElementOf(expectedServices))
 


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.

This test previously flaked if the elements were returned in a different order. Using `BeElementOf` to avoid dependency on ordering
Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No