### PR TITLE
Rename Route type to HTTPRoute where applicable

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -298,7 +298,7 @@ type MeshCataloger interface {
 	// ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
 	ExpectProxy(certificate.CommonName)
 
-    // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided, 
+    // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided,
     // which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
 	GetServicesFromEnvoyCertificate(certificate.CommonName) ([]service.MeshService, error)
 
@@ -317,8 +317,8 @@ type MeshCataloger interface {
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)
 
-	// GetIngressRoutesPerHost returns the routes per host associated with an ingress service
-	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.Route, error)
+	// GetIngressRoutesPerHost returns the HTTP routes per host associated with an ingress service
+	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRoute, error)
 }
 ```
 

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -7,8 +7,8 @@ import (
 )
 
 // GetIngressRoutesPerHost returns routes per host as defined in observed ingress k8s resources.
-func (mc *MeshCatalog) GetIngressRoutesPerHost(service service.MeshService) (map[string][]trafficpolicy.Route, error) {
-	domainRoutesMap := make(map[string][]trafficpolicy.Route)
+func (mc *MeshCatalog) GetIngressRoutesPerHost(service service.MeshService) (map[string][]trafficpolicy.HTTPRoute, error) {
+	domainRoutesMap := make(map[string][]trafficpolicy.HTTPRoute)
 	ingresses, err := mc.ingressMonitor.GetIngressResources(service)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get ingress resources with backend %s", service)
@@ -18,14 +18,14 @@ func (mc *MeshCatalog) GetIngressRoutesPerHost(service service.MeshService) (map
 		return domainRoutesMap, err
 	}
 
-	defaultRoute := trafficpolicy.Route{
+	defaultRoute := trafficpolicy.HTTPRoute{
 		PathRegex: constants.RegexMatchAll,
 		Methods:   []string{constants.RegexMatchAll},
 	}
 
 	for _, ingress := range ingresses {
 		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == service.Name {
-			domainRoutesMap[constants.WildcardHTTPMethod] = []trafficpolicy.Route{defaultRoute}
+			domainRoutesMap[constants.WildcardHTTPMethod] = []trafficpolicy.HTTPRoute{defaultRoute}
 		}
 
 		for _, rule := range ingress.Spec.Rules {

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Catalog tests", func() {
 					Name:        utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreService),
 					Destination: tests.BookstoreService,
 					Source:      tests.BookbuyerService,
-					Route: trafficpolicy.Route{PathRegex: tests.BookstoreBuyPath, Methods: []string{"GET"}, Headers: map[string]string{
+					HTTPRoute: trafficpolicy.HTTPRoute{PathRegex: tests.BookstoreBuyPath, Methods: []string{"GET"}, Headers: map[string]string{
 						"user-agent": tests.HTTPUserAgent,
 					}},
 				},
@@ -48,7 +48,7 @@ var _ = Describe("Catalog tests", func() {
 					Name:        utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreApexService),
 					Destination: tests.BookstoreApexService,
 					Source:      tests.BookbuyerService,
-					Route: trafficpolicy.Route{PathRegex: tests.BookstoreBuyPath, Methods: []string{"GET"}, Headers: map[string]string{
+					HTTPRoute: trafficpolicy.HTTPRoute{PathRegex: tests.BookstoreBuyPath, Methods: []string{"GET"}, Headers: map[string]string{
 						"user-agent": tests.HTTPUserAgent,
 					}},
 				},
@@ -65,7 +65,7 @@ var _ = Describe("Catalog tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			specKey := mc.getTrafficSpecName("HTTPRouteGroup", tests.Namespace, tests.RouteGroupName)
-			expected := map[trafficpolicy.TrafficSpecName]map[trafficpolicy.TrafficSpecMatchName]trafficpolicy.Route{
+			expected := map[trafficpolicy.TrafficSpecName]map[trafficpolicy.TrafficSpecMatchName]trafficpolicy.HTTPRoute{
 				specKey: {
 					trafficpolicy.TrafficSpecMatchName(tests.BuyBooksMatchName): {
 						PathRegex: tests.BookstoreBuyPath,
@@ -117,7 +117,7 @@ var _ = Describe("Catalog tests", func() {
 			expectedDestinationTrafficResource := utils.K8sSvcToMeshSvc(destination)
 
 			expectedHostHeaders := map[string]string{"user-agent": tests.HTTPUserAgent}
-			expectedRoute := trafficpolicy.Route{
+			expectedRoute := trafficpolicy.HTTPRoute{
 				PathRegex: constants.RegexMatchAll,
 				Methods:   []string{constants.WildcardHTTPMethod},
 				Headers:   expectedHostHeaders,
@@ -126,8 +126,8 @@ var _ = Describe("Catalog tests", func() {
 			trafficTarget := mc.buildAllowPolicyForSourceToDest(source, destination)
 			Expect(cmp.Equal(trafficTarget.Source, expectedSourceTrafficResource)).To(BeTrue())
 			Expect(cmp.Equal(trafficTarget.Destination, expectedDestinationTrafficResource)).To(BeTrue())
-			Expect(cmp.Equal(trafficTarget.Route.PathRegex, expectedRoute.PathRegex)).To(BeTrue())
-			Expect(cmp.Equal(trafficTarget.Route.Methods, expectedRoute.Methods)).To(BeTrue())
+			Expect(cmp.Equal(trafficTarget.HTTPRoute.PathRegex, expectedRoute.PathRegex)).To(BeTrue())
+			Expect(cmp.Equal(trafficTarget.HTTPRoute.Methods, expectedRoute.Methods)).To(BeTrue())
 		})
 	})
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -99,8 +99,8 @@ type MeshCataloger interface {
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)
 
-	// GetIngressRoutesPerHost returns the routes per host associated with an ingress service
-	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.Route, error)
+	// GetIngressRoutesPerHost returns the HTTP routes per host associated with an ingress service
+	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRoute, error)
 
 	// ListMonitoredNamespaces lists namespaces monitored by the control plane
 	ListMonitoredNamespaces() []string

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -57,11 +57,11 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 		}
 
 		if isSourceService {
-			aggregateRoutesByHost(outboundAggregatedRoutesByHostnames, trafficPolicies.Route, weightedCluster, hostnames)
+			aggregateRoutesByHost(outboundAggregatedRoutesByHostnames, trafficPolicies.HTTPRoute, weightedCluster, hostnames)
 		}
 
 		if isDestinationService {
-			aggregateRoutesByHost(inboundAggregatedRoutesByHostnames, trafficPolicies.Route, weightedCluster, hostnames)
+			aggregateRoutesByHost(inboundAggregatedRoutesByHostnames, trafficPolicies.HTTPRoute, weightedCluster, hostnames)
 		}
 	}
 
@@ -85,7 +85,7 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 	return resp, nil
 }
 
-func aggregateRoutesByHost(routesPerHost map[string]map[string]trafficpolicy.RouteWeightedClusters, routePolicy trafficpolicy.Route, weightedCluster service.WeightedCluster, host string) {
+func aggregateRoutesByHost(routesPerHost map[string]map[string]trafficpolicy.RouteWeightedClusters, routePolicy trafficpolicy.HTTPRoute, weightedCluster service.WeightedCluster, host string) {
 	_, exists := routesPerHost[host]
 	if !exists {
 		// no host found, create a new route map
@@ -95,12 +95,12 @@ func aggregateRoutesByHost(routesPerHost map[string]map[string]trafficpolicy.Rou
 	if routeFound {
 		// add the cluster to the existing route
 		routePolicyWeightedCluster.WeightedClusters.Add(weightedCluster)
-		routePolicyWeightedCluster.Route.Methods = append(routePolicyWeightedCluster.Route.Methods, routePolicy.Methods...)
-		if routePolicyWeightedCluster.Route.Headers == nil {
-			routePolicyWeightedCluster.Route.Headers = make(map[string]string)
+		routePolicyWeightedCluster.HTTPRoute.Methods = append(routePolicyWeightedCluster.HTTPRoute.Methods, routePolicy.Methods...)
+		if routePolicyWeightedCluster.HTTPRoute.Headers == nil {
+			routePolicyWeightedCluster.HTTPRoute.Headers = make(map[string]string)
 		}
 		for headerKey, headerValue := range routePolicy.Headers {
-			routePolicyWeightedCluster.Route.Headers[headerKey] = headerValue
+			routePolicyWeightedCluster.HTTPRoute.Headers[headerKey] = headerValue
 		}
 		routesPerHost[host][routePolicy.PathRegex] = routePolicyWeightedCluster
 	} else {
@@ -109,9 +109,9 @@ func aggregateRoutesByHost(routesPerHost map[string]map[string]trafficpolicy.Rou
 	}
 }
 
-func createRoutePolicyWeightedClusters(routePolicy trafficpolicy.Route, weightedCluster service.WeightedCluster) trafficpolicy.RouteWeightedClusters {
+func createRoutePolicyWeightedClusters(routePolicy trafficpolicy.HTTPRoute, weightedCluster service.WeightedCluster) trafficpolicy.RouteWeightedClusters {
 	return trafficpolicy.RouteWeightedClusters{
-		Route:            routePolicy,
+		HTTPRoute:        routePolicy,
 		WeightedClusters: set.NewSet(weightedCluster),
 	}
 }

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -40,15 +40,15 @@ var _ = Describe("Construct RoutePolicyWeightedClusters object", func() {
 				ClusterName: service.ClusterName("osm/bookstore-1"),
 				Weight:      constants.ClusterWeightAcceptAll,
 			}
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 			}
 
 			routePolicyWeightedClusters := createRoutePolicyWeightedClusters(routePolicy, weightedCluster)
 			Expect(routePolicyWeightedClusters).NotTo(Equal(nil))
-			Expect(routePolicyWeightedClusters.Route.PathRegex).To(Equal("/books-bought"))
-			Expect(routePolicyWeightedClusters.Route.Methods).To(Equal([]string{"GET"}))
+			Expect(routePolicyWeightedClusters.HTTPRoute.PathRegex).To(Equal("/books-bought"))
+			Expect(routePolicyWeightedClusters.HTTPRoute.Methods).To(Equal([]string{"GET"}))
 			Expect(routePolicyWeightedClusters.WeightedClusters.Cardinality()).To(Equal(1))
 			routePolicyWeightedClustersSlice := routePolicyWeightedClusters.WeightedClusters.ToSlice()
 			Expect(string(routePolicyWeightedClustersSlice[0].(service.WeightedCluster).ClusterName)).To(Equal("osm/bookstore-1"))
@@ -64,7 +64,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 		It("Returns a new aggregated map of domain and routes", func() {
 
 			weightedCluster := service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100}
-			routePolicies := []trafficpolicy.Route{
+			routePolicies := []trafficpolicy.HTTPRoute{
 				{PathRegex: "/books-bought", Methods: []string{"GET"}},
 				{PathRegex: "/buy-a-book", Methods: []string{"GET"}},
 			}
@@ -95,7 +95,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 				ClusterName: service.ClusterName("osm/bookstore-1"),
 				Weight:      constants.ClusterWeightAcceptAll,
 			}
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/update-books-bought",
 				Methods:   []string{"GET"},
 				Headers: map[string]string{
@@ -108,9 +108,9 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 			Expect(domainRoutesMap).NotTo(Equal(nil))
 			Expect(len(domainRoutesMap)).To(Equal(1))
 			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(3))
-			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].Route).To(Equal(routePolicy))
+			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].HTTPRoute).To(Equal(routePolicy))
 			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].WeightedClusters.Cardinality()).To(Equal(1))
-			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].Route).To(Equal(trafficpolicy.Route{PathRegex: "/update-books-bought", Methods: []string{"GET"}, Headers: map[string]string{testHeaderKey1: "This is a test header 1"}}))
+			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].HTTPRoute).To(Equal(trafficpolicy.HTTPRoute{PathRegex: "/update-books-bought", Methods: []string{"GET"}, Headers: map[string]string{testHeaderKey1: "This is a test header 1"}}))
 			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].WeightedClusters.Equal(weightedClustersMap)).To(Equal(true))
 		})
 	})
@@ -122,7 +122,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 				ClusterName: service.ClusterName("osm/bookstore-2"),
 				Weight:      constants.ClusterWeightAcceptAll,
 			}
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/update-books-bought",
 				Methods:   []string{"GET"},
 				Headers: map[string]string{
@@ -136,7 +136,7 @@ var _ = Describe("AggregateRoutesByDomain", func() {
 			Expect(len(domainRoutesMap)).To(Equal(1))
 			Expect(len(domainRoutesMap["bookstore.mesh"])).To(Equal(3))
 			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].WeightedClusters.Cardinality()).To(Equal(2))
-			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].Route).To(Equal(trafficpolicy.Route{PathRegex: "/update-books-bought", Methods: []string{"GET", "GET"}, Headers: map[string]string{testHeaderKey1: "This is a test header 1", testHeaderKey2: "This is a test header 2"}}))
+			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].HTTPRoute).To(Equal(trafficpolicy.HTTPRoute{PathRegex: "/update-books-bought", Methods: []string{"GET", "GET"}, Headers: map[string]string{testHeaderKey1: "This is a test header 1", testHeaderKey2: "This is a test header 2"}}))
 			Expect(domainRoutesMap["bookstore.mesh"][routePolicy.PathRegex].WeightedClusters.Equal(weightedClustersMap)).To(Equal(true))
 		})
 	})

--- a/pkg/envoy/route/config.go
+++ b/pkg/envoy/route/config.go
@@ -108,9 +108,9 @@ func createRoutes(routePolicyWeightedClustersMap map[string]trafficpolicy.RouteW
 	for _, routePolicyWeightedClusters := range routePolicyWeightedClustersMap {
 		// For a given route path, sanitize the methods in case there
 		// is wildcard or if there are duplicates
-		allowedMethods := sanitizeHTTPMethods(routePolicyWeightedClusters.Route.Methods)
+		allowedMethods := sanitizeHTTPMethods(routePolicyWeightedClusters.HTTPRoute.Methods)
 		for _, method := range allowedMethods {
-			route := getRoute(routePolicyWeightedClusters.Route.PathRegex, method, routePolicyWeightedClusters.Route.Headers, routePolicyWeightedClusters.WeightedClusters, 100, direction)
+			route := getRoute(routePolicyWeightedClusters.HTTPRoute.PathRegex, method, routePolicyWeightedClusters.HTTPRoute.Headers, routePolicyWeightedClusters.WeightedClusters, 100, direction)
 			routes = append(routes, route)
 		}
 	}

--- a/pkg/envoy/route/config_test.go
+++ b/pkg/envoy/route/config_test.go
@@ -149,12 +149,12 @@ var _ = Describe("Routes with weighted clusters", func() {
 
 		It("Adds a new route", func() {
 
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET", "POST"},
 			}
 
-			routeWeightedClustersMap[routePolicy.PathRegex] = trafficpolicy.RouteWeightedClusters{Route: routePolicy, WeightedClusters: weightedClusters}
+			routeWeightedClustersMap[routePolicy.PathRegex] = trafficpolicy.RouteWeightedClusters{HTTPRoute: routePolicy, WeightedClusters: weightedClusters}
 			rt := createRoutes(routeWeightedClustersMap, InboundRoute)
 			Expect(len(rt)).To(Equal(len(routePolicy.Methods)))
 
@@ -174,11 +174,11 @@ var _ = Describe("Routes with weighted clusters", func() {
 
 		It("Appends another route", func() {
 
-			routePolicy2 := trafficpolicy.Route{
+			routePolicy2 := trafficpolicy.HTTPRoute{
 				PathRegex: "/buy-a-book",
 				Methods:   []string{"GET"},
 			}
-			routeWeightedClustersMap[routePolicy2.PathRegex] = trafficpolicy.RouteWeightedClusters{Route: routePolicy2, WeightedClusters: weightedClusters}
+			routeWeightedClustersMap[routePolicy2.PathRegex] = trafficpolicy.RouteWeightedClusters{HTTPRoute: routePolicy2, WeightedClusters: weightedClusters}
 
 			httpMethodCount := 3 // 2 from previously added routes + 1 append
 
@@ -217,7 +217,7 @@ var _ = Describe("Route Configuration", func() {
 				cluster := clusterInterface.(service.WeightedCluster)
 				totalClusterWeight += cluster.Weight
 			}
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 				Headers: map[string]string{
@@ -226,7 +226,7 @@ var _ = Describe("Route Configuration", func() {
 			}
 
 			sourceDomainRouteData := map[string]trafficpolicy.RouteWeightedClusters{
-				routePolicy.PathRegex: {Route: routePolicy, WeightedClusters: weightedClusters},
+				routePolicy.PathRegex: {HTTPRoute: routePolicy, WeightedClusters: weightedClusters},
 			}
 
 			sourceDomainAggregatedData := map[string]map[string]trafficpolicy.RouteWeightedClusters{
@@ -257,7 +257,7 @@ var _ = Describe("Route Configuration", func() {
 				cluster := clusterInterface.(service.WeightedCluster)
 				totalClusterWeight += cluster.Weight
 			}
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET"},
 				Headers: map[string]string{
@@ -266,7 +266,7 @@ var _ = Describe("Route Configuration", func() {
 			}
 
 			destDomainRouteData := map[string]trafficpolicy.RouteWeightedClusters{
-				routePolicy.PathRegex: {Route: routePolicy, WeightedClusters: weightedClusters},
+				routePolicy.PathRegex: {HTTPRoute: routePolicy, WeightedClusters: weightedClusters},
 			}
 
 			destDomainAggregatedData := map[string]map[string]trafficpolicy.RouteWeightedClusters{
@@ -307,7 +307,7 @@ var _ = Describe("Route Configuration", func() {
 var _ = Describe("Routes with headers", func() {
 	Context("Testing getHeadersForRoute", func() {
 		It("Returns a list of HeaderMatcher for a route", func() {
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET", "POST"},
 				Headers: map[string]string{
@@ -324,7 +324,7 @@ var _ = Describe("Routes with headers", func() {
 		})
 
 		It("Returns only one HeaderMatcher for a route", func() {
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET", "POST"},
 			}
@@ -336,7 +336,7 @@ var _ = Describe("Routes with headers", func() {
 		})
 
 		It("Returns only one HeaderMatcher for a route ignoring the host", func() {
-			routePolicy := trafficpolicy.Route{
+			routePolicy := trafficpolicy.HTTPRoute{
 				PathRegex: "/books-bought",
 				Methods:   []string{"GET", "POST"},
 				Headers: map[string]string{

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -111,7 +111,7 @@ var (
 	}
 
 	// RoutePolicy is a route policy.
-	RoutePolicy = trafficpolicy.Route{
+	RoutePolicy = trafficpolicy.HTTPRoute{
 		PathRegex: BookstoreBuyPath,
 		Methods:   []string{"GET"},
 		Headers: map[string]string{
@@ -130,7 +130,7 @@ var (
 		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore", TrafficTargetName),
 		Destination: BookstoreService,
 		Source:      BookbuyerService,
-		Route: trafficpolicy.Route{
+		HTTPRoute: trafficpolicy.HTTPRoute{
 			PathRegex: BookstoreBuyPath,
 			Methods:   []string{"GET"},
 			Headers: map[string]string{
@@ -185,7 +185,7 @@ var (
 	}
 
 	// RoutePolicyMap is a map of a key to a route policy SMI object.
-	RoutePolicyMap = map[trafficpolicy.TrafficSpecName]map[trafficpolicy.TrafficSpecMatchName]trafficpolicy.Route{
+	RoutePolicyMap = map[trafficpolicy.TrafficSpecName]map[trafficpolicy.TrafficSpecMatchName]trafficpolicy.HTTPRoute{
 		trafficpolicy.TrafficSpecName(fmt.Sprintf("HTTPRouteGroup/%s/%s", Namespace, RouteGroupName)): {
 			trafficpolicy.TrafficSpecMatchName(BuyBooksMatchName): RoutePolicy}}
 

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -12,23 +12,23 @@ type TrafficSpecName string
 // TrafficSpecMatchName is the  name of a match in SMI TrafficSpec
 type TrafficSpecMatchName string
 
-// Route is a struct of a path regex and the methods on a given route
-type Route struct {
+// HTTPRoute is a struct to represent an HTTP route comprised of a path regex, methods, and headers
+type HTTPRoute struct {
 	PathRegex string            `json:"path_regex:omitempty"`
 	Methods   []string          `json:"methods:omitempty"`
 	Headers   map[string]string `json:"headers:omitempty"`
 }
 
-// TrafficTarget is a struct of the allowed RoutePaths from sources to a destination
+// TrafficTarget is a struct to represent a traffic policy between a source and destination along with its routes
 type TrafficTarget struct {
 	Name        string              `json:"name:omitempty"`
 	Destination service.MeshService `json:"destination:omitempty"`
 	Source      service.MeshService `json:"source:omitempty"`
-	Route       Route               `json:"route:omitempty"`
+	HTTPRoute   HTTPRoute           `json:"http_route:omitempty"`
 }
 
-//RouteWeightedClusters is a struct of a route and the weighted clusters on that route
+// RouteWeightedClusters is a struct of an HTTPRoute and associated weighted clusters
 type RouteWeightedClusters struct {
-	Route            Route   `json:"route:omitempty"`
-	WeightedClusters set.Set `json:"weighted_clusters:omitempty"`
+	HTTPRoute        HTTPRoute `json:"http_route:omitempty"`
+	WeightedClusters set.Set   `json:"weighted_clusters:omitempty"`
 }


### PR DESCRIPTION
Currently the code refers to an HTTPRoute as a Route in a traffic target
policy. Rename this to HTTPRoute to be explicit. In the future, a route
for different traffic types will be supported, ex. TCPRoute.

This also helps disambiguate the HTTP route type in the traffic target from
the XDS Route type in Envoy.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`