### PR TITLE
(automated demo) : Update  automated demo to support multiple services per service account

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: 1
 # export CI_SLEEP_BETWEEN_REQUESTS_SECONDS=1
 
-# optional: Whether to deploy multiple services with the same service account
+# optional: Whether to deploy multiple services (currently bookstore) associated the same service account
 # Default: false
 # export DEPLOY_WITH_SAME_SA=false
 

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: 1
 # export CI_SLEEP_BETWEEN_REQUESTS_SECONDS=1
 
+# optional: Whether to deploy multiple services with the same service account
+# Default: false
+# export DEPLOY_WITH_SAME_SA=false
+
 # optional: Whether to deploy traffic split policy or not
 # Default: true
 # export DEPLOY_TRAFFIC_SPLIT=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,6 +140,50 @@ jobs:
           ./demo/run-osm-demo.sh
           go run ./ci/cmd/maestro.go
 
+  integration-tresor-with-same-sa:
+    name: Integration Test with Tresor, SMI traffic policies, egress disabled and 1:N mapping for service account and services
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+
+      - name: Setup Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+        id: go
+
+      - name: Run Simulation w/ Tresor, SMI policies, egress disabled and 1:N mapping for service account and services
+        env:
+          CERT_MANAGER: "tresor"
+          BOOKSTORE_SVC: "bookstore"
+          BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
+          ENABLE_EGRESS: "false"
+          EGRESS_EXPECTED_RESPONSE_CODE: "404" # egress is disabled
+          DEPLOY_TRAFFIC_SPLIT: "true"
+          DEPLOY_WITH_SAME_SA: "true"
+          CTR_TAG: ${{ github.sha }}
+        run: |
+          touch .env
+          make kind-up
+          ./demo/run-osm-demo.sh
+          go run ./ci/cmd/maestro.go
+
   integration-vault:
     name: Integration test with Hashi Vault, permissive traffic policy mode, and egress enabled
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,50 +140,6 @@ jobs:
           ./demo/run-osm-demo.sh
           go run ./ci/cmd/maestro.go
 
-  integration-tresor-with-same-sa:
-    name: Integration Test with Tresor, SMI traffic policies, egress disabled and 1:N mapping for service account and services
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Restore Module Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomod2-
-
-      - name: Restore Build Cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-
-      - name: Setup Go 1.14
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.14
-        id: go
-
-      - name: Run Simulation w/ Tresor, SMI policies, egress disabled and 1:N mapping for service account and services
-        env:
-          CERT_MANAGER: "tresor"
-          BOOKSTORE_SVC: "bookstore"
-          BOOKTHIEF_EXPECTED_RESPONSE_CODE: "404"
-          ENABLE_EGRESS: "false"
-          EGRESS_EXPECTED_RESPONSE_CODE: "404" # egress is disabled
-          DEPLOY_TRAFFIC_SPLIT: "true"
-          DEPLOY_WITH_SAME_SA: "true"
-          CTR_TAG: ${{ github.sha }}
-        run: |
-          touch .env
-          make kind-up
-          ./demo/run-osm-demo.sh
-          go run ./ci/cmd/maestro.go
-
   integration-vault:
     name: Integration test with Hashi Vault, permissive traffic policy mode, and egress enabled
     runs-on: ubuntu-latest
@@ -233,7 +189,7 @@ jobs:
           go run ./ci/cmd/maestro.go
 
   integration-nosplit:
-    name: Integration Test with jetstack/cert-manager, SMI traffic policies (no Traffic Split), and egress disabled
+    name: Integration Test with jetstack/cert-manager, SMI traffic policies (no Traffic Split), egress disabled, 1:N Service-ServiceAccount mapping
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -260,7 +216,7 @@ jobs:
           go-version: 1.14
         id: go
 
-      - name: Run Simulation w/ jetstack/cert-manager, SMI policies (no Traffic Split), and egress disabled
+      - name: Run Simulation w/ jetstack/cert-manager, SMI policies (no Traffic Split), egress disabled, 1:N Service-ServiceAccount mapping
         env:
           CERT_MANAGER: "cert-manager" # enables jetstack/cert-manager integration
           BOOKSTORE_SVC: "bookstore-v1"
@@ -268,6 +224,7 @@ jobs:
           ENABLE_EGRESS: "false"
           EGRESS_EXPECTED_RESPONSE_CODE: "404" # egress is disabled
           DEPLOY_TRAFFIC_SPLIT: "false"
+          DEPLOY_WITH_SAME_SA: "true"
           CTR_TAG: ${{ github.sha }}
         run: |
           touch .env

--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -5,14 +5,22 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
+DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
+
 # Deploy apps in the order of their dependencies to avoid initial timing errors
 # in osm-controller logs. Server apps are deployed before client apps.
 
 # Deploy bookwarehouse
 ./demo/deploy-bookwarehouse.sh
 # Deploy bookstore versions
-./demo/deploy-bookstore.sh "v1"
-./demo/deploy-bookstore.sh "v2"
+if [ "$DEPLOY_WITH_SAME_SA" = "true" ]; then
+    ./demo/deploy-bookstore-with-same-sa.sh "v1"
+    ./demo/deploy-bookstore-with-same-sa.sh "v2"    
+else
+    ./demo/deploy-bookstore.sh "v1"
+    ./demo/deploy-bookstore.sh "v2"
+fi
+
 # Deploy bookbuyer
 ./demo/deploy-bookbuyer.sh
 # Deploy bookthief

--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+VERSION=${1:-v1}
+SVC="bookstore-$VERSION"
+
+kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  --ignore-not-found
+
+# Create a top level service just for the bookstore domain
+echo -e "Deploy bookstore Service"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore
+  namespace: $BOOKSTORE_NAMESPACE
+  labels:
+    app: bookstore
+spec:
+  ports:
+  - port: 80
+    name: bookstore-port
+  selector:
+    app: bookstore
+EOF
+
+echo -e "Deploy $SVC Service Account"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bookstore
+  namespace: $BOOKSTORE_NAMESPACE
+EOF
+
+echo -e "Deploy $SVC Service"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SVC
+  namespace: $BOOKSTORE_NAMESPACE
+  labels:
+    app: $SVC
+spec:
+  ports:
+  - port: 80
+    name: bookstore-port
+
+  selector:
+    app: $SVC
+EOF
+
+echo -e "Deploy $SVC Deployment"
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: $SVC
+  namespace: $BOOKSTORE_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: $SVC
+      version: $VERSION
+  template:
+    metadata:
+      labels:
+        app: $SVC
+        version: $VERSION
+    spec:
+      serviceAccountName: bookstore
+      containers:
+        - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
+          imagePullPolicy: Always
+          name: $SVC
+          ports:
+            - containerPort: 80
+              name: web
+          command: ["/bookstore"]
+          args: ["--path", "./", "--port", "80"]
+          env:
+            - name: IDENTITY
+              value: ${SVC}
+            - name: BOOKWAREHOUSE_NAMESPACE
+              value: ${BOOKWAREHOUSE_NAMESPACE}
+
+      imagePullSecrets:
+        - name: $CTR_REGISTRY_CREDS_NAME
+EOF
+
+kubectl get pods      --no-headers -o wide --selector app="$SVC" -n "$BOOKSTORE_NAMESPACE"
+kubectl get endpoints --no-headers -o wide --selector app="$SVC" -n "$BOOKSTORE_NAMESPACE"
+kubectl get service                -o wide                       -n "$BOOKSTORE_NAMESPACE"
+
+for x in $(kubectl get service -n "$BOOKSTORE_NAMESPACE" --selector app="$SVC" --no-headers | awk '{print $1}'); do
+    kubectl get service "$x" -n "$BOOKSTORE_NAMESPACE" -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
+done

--- a/demo/deploy-traffic-target-with-same-sa.sh
+++ b/demo/deploy-traffic-target-with-same-sa.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+kubectl apply -f - <<EOF
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha2
+metadata:
+  name: bookbuyer-access-bookstore
+  namespace: "$BOOKSTORE_NAMESPACE"
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookstore
+    namespace: "$BOOKSTORE_NAMESPACE"
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookstore-service-routes
+    matches:
+    - buy-a-book
+    - books-bought
+  sources:
+  - kind: ServiceAccount
+    name: bookbuyer
+    namespace: "$BOOKBUYER_NAMESPACE"
+
+
+# TrafficTarget is deny-by-default policy: if traffic from source to destination is not
+# explicitly declared in this policy - it will be blocked.
+# Should we ever want to allow traffic from bookthief to bookstore the block below needs
+# uncommented.
+
+# - kind: ServiceAccount
+#   name: bookthief
+#   namespace: "$BOOKTHIEF_NAMESPACE"
+
+---
+
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha2
+metadata:
+  name: bookstore-access-bookwarehouse
+  namespace: "$BOOKWAREHOUSE_NAMESPACE"
+spec:
+  destination:
+    kind: ServiceAccount
+    name: bookwarehouse
+    namespace: "$BOOKWAREHOUSE_NAMESPACE"
+  rules:
+  - kind: HTTPRouteGroup
+    name: bookwarehouse-service-routes
+    matches:
+    - restock-books
+  sources:
+  - kind: ServiceAccount
+    name: bookstore
+    namespace: "$BOOKSTORE_NAMESPACE"
+
+EOF

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -29,6 +29,7 @@ CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
 MESH_CIDR=$(./scripts/get_mesh_cidr.sh)
+DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*
@@ -141,7 +142,12 @@ if [ "$DEPLOY_TRAFFIC_SPLIT" = "true" ]; then
 fi
 
 ./demo/deploy-traffic-specs.sh
-./demo/deploy-traffic-target.sh
+
+if [ "$DEPLOY_WITH_SAME_SA" = "true" ]; then
+    ./demo/deploy-traffic-target-with-same-sa.sh
+else
+    ./demo/deploy-traffic-target.sh
+fi
 
 if [[ "$CI" != "true" ]]; then
     watch -n5 "printf \"Namespace ${K8S_NAMESPACE}:\n\"; kubectl get pods -n ${K8S_NAMESPACE} -o wide; printf \"\n\n\"; printf \"Namespace ${BOOKBUYER_NAMESPACE}:\n\"; kubectl get pods -n ${BOOKBUYER_NAMESPACE} -o wide; printf \"\n\n\"; printf \"Namespace ${BOOKSTORE_NAMESPACE}:\n\"; kubectl get pods -n ${BOOKSTORE_NAMESPACE} -o wide; printf \"\n\n\"; printf \"Namespace ${BOOKTHIEF_NAMESPACE}:\n\"; kubectl get pods -n ${BOOKTHIEF_NAMESPACE} -o wide; printf \"\n\n\"; printf \"Namespace ${BOOKWAREHOUSE_NAMESPACE}:\n\"; kubectl get pods -n ${BOOKWAREHOUSE_NAMESPACE} -o wide"


### PR DESCRIPTION
This PR has changes in the scripts for the automated demo to depicting the support of multiple services with one service, which can be enabled/disabled anytime with the use of a environment variable `DEPLOY_WITH_SAME_SA` 

The CI has also been updated to test this scenario

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
