### PR TITLE
feat(cmd/cli/mesh_delete): add verbose flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ build-osm-controller: clean-osm-controller
 	@mkdir -p $(shell pwd)/bin
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CONTROLLER_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA)" ./cmd/osm-controller
 
+# builds the osm cli
 .PHONY: build-osm
 build-osm:
 	@mkdir -p $(shell pwd)/bin

--- a/cmd/cli/mesh_delete.go
+++ b/cmd/cli/mesh_delete.go
@@ -24,6 +24,7 @@ type meshDeleteCmd struct {
 	meshName string
 	force    bool
 	client   *action.Uninstall
+	verbose  bool
 }
 
 func newMeshDelete(config *action.Configuration, in io.Reader, out io.Writer) *cobra.Command {
@@ -45,6 +46,7 @@ func newMeshDelete(config *action.Configuration, in io.Reader, out io.Writer) *c
 
 	f := cmd.Flags()
 	f.StringVar(&del.meshName, "mesh-name", defaultMeshName, "Name of the service mesh")
+	f.BoolVarP(&del.verbose, "verbose", "v", false, "verbose output")
 	f.BoolVarP(&del.force, "force", "f", false, "Attempt to delete the osm control plane instance without prompting for confirmation.  If the control plane with specified mesh name does not exist, do not display a diagnostic message or modify the exit status to reflect an error.")
 
 	return cmd


### PR DESCRIPTION
Adds the verbose flag for no reason. No one asked.
This is just an example.
resolves #1232nothing


Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
