### PR TITLE
Rev go to 1.15 & alpine to 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Go Build
         run: go build -v ./...
 
@@ -87,10 +87,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Test
         run: make go-test-coverage
       - name: Upload Coverage
@@ -119,10 +119,10 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
 
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
 
       - name: Run Simulation w/ Tresor, SMI policies, and egress disabled
@@ -162,10 +162,10 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
 
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
 
       - name: Run Simulation w/ Hashi Vault, permissive traffic policy mode, and egress enabled
@@ -210,10 +210,10 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
 
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
         id: go
 
       - name: Run Simulation w/ jetstack/cert-manager, SMI policies (no Traffic Split), and egress disabled
@@ -253,10 +253,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Docker Login
         run: docker login --username "$DOCKER_USER" --password-stdin <<< "$DOCKER_PASS"
       - name: Push images with git sha tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Build Binaries
         run: |
           make release-artifacts
@@ -121,10 +121,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.14
+      - name: Setup Go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.15
       - name: Docker Login
         run: docker login --username "$DOCKER_USER" --password-stdin <<< "$DOCKER_PASS"
       - name: Push images with version tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 
 #build stage
-FROM golang:1.14.3-alpine3.11 AS builder
+FROM golang:1.15-alpine AS builder
 
 RUN apk update
 RUN apk add --no-cache make

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate
 BUILD_VERSION_VAR := github.com/openservicemesh/osm/pkg/version.Version
 BUILD_GITCOMMIT_VAR := github.com/openservicemesh/osm/pkg/version.GitCommit
 
-LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CLI_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X main.chartTGZSource=$$(cat -)"
+LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CLI_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X main.chartTGZSource=$$(cat -) -s -w"
 
 check-env:
 ifndef CTR_REGISTRY
@@ -42,7 +42,7 @@ build: build-osm-controller
 
 .PHONY: build-osm-controller
 build-osm-controller: clean-osm-controller
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CONTROLLER_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA)" ./cmd/osm-controller
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CONTROLLER_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w" ./cmd/osm-controller
 
 .PHONY: build-osm
 build-osm:

--- a/demo/README.md
+++ b/demo/README.md
@@ -3,7 +3,7 @@
 ## System Requirements
 - MacOS, Linux or WSL2 on Windows
 - GCC
-- Go version 1.14 or higher
+- Go version 1.15 or higher
 - Kubectl version 1.15 or higher
 - Docker CLI
    - on a Debian based GNU/Linux system: `sudo apt-get install docker`

--- a/dockerfiles/Dockerfile.bookbuyer
+++ b/dockerfiles/Dockerfile.bookbuyer
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.12
 ADD bookbuyer /
 ADD bookbuyer.html.template /
 RUN apk add --no-cache curl openssl ca-certificates

--- a/dockerfiles/Dockerfile.bookstore
+++ b/dockerfiles/Dockerfile.bookstore
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.12
 ADD bookstore /
 ADD bookstore.html.template /
 RUN chmod +x /bookstore

--- a/dockerfiles/Dockerfile.bookthief
+++ b/dockerfiles/Dockerfile.bookthief
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.12
 ADD bookthief /
 ADD bookthief.html.template /
 RUN apk add --no-cache curl openssl ca-certificates

--- a/dockerfiles/Dockerfile.bookwarehouse
+++ b/dockerfiles/Dockerfile.bookwarehouse
@@ -1,3 +1,3 @@
-FROM alpine:3.10.1
+FROM alpine:3.12
 ADD bookwarehouse /
 RUN chmod +x /bookwarehouse

--- a/dockerfiles/Dockerfile.init
+++ b/dockerfiles/Dockerfile.init
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.12
 RUN apk add --no-cache iptables
 ADD init-iptables.sh /
 WORKDIR /

--- a/dockerfiles/Dockerfile.osm-controller
+++ b/dockerfiles/Dockerfile.osm-controller
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.12
 
 ADD osm-controller /
 RUN chmod +x /osm-controller

--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -63,7 +63,7 @@ OSM leverages [Envoy proxy](https://github.com/envoyproxy/envoy) as a data plane
 
 ## Get Go-ing
 
-This repository uses [Go v1.14](https://golang.org/). If you are not familiar with Go, spend some time with the excellent [Tour of Go](https://tour.golang.org/).
+This repository uses [Go v1.15](https://golang.org/). If you are not familiar with Go, spend some time with the excellent [Tour of Go](https://tour.golang.org/).
 
 ## Get the dependencies
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openservicemesh/osm
 
-go 1.14
+go 1.15
 
 require (
 	github.com/AlekSi/gocov-xml v0.0.0-20190121064608-3a14fb1c4737


### PR DESCRIPTION
This PR updates go to 1.15 and alpine to 3.12.
It also removes the patch version from these dependencies to allow for implicit patch upgrades which are considered non-breaking but often include important security fixes.
In addition I added `-s -w` to the ldflags for `osm` and `osm-controller` to remove debug symbols.

Size Before:
`55M	bin/osm-controller/osm-controller`
After:
`39M	bin/osm-controller/osm-controller`

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No.
