### PR TITLE
ref(tests): remove duplicate test output when tests fail

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -5,7 +5,7 @@ set -aueo pipefail
 go test -timeout 80s \
    -v \
    -coverprofile=coverage.txt \
-   -covermode count ./... | tee testoutput.txt || { echo "go test returned non-zero"; cat testoutput.txt; exit 1; }
+   -covermode count ./... | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }
 
 # shellcheck disable=SC2002
 cat testoutput.txt | go run github.com/jstemmer/go-junit-report > report.xml


### PR DESCRIPTION
The test output will be shown because of the `tee` command, so printing it again if the tests fail is redundant.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No