### PR TITLE
tests(catalog): fix flaky test

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -80,7 +80,10 @@ var _ = Describe("Catalog tests", func() {
 				},
 			}
 
-			Expect(allTrafficPolicies).To(Equal(expected))
+			Expect(len(allTrafficPolicies)).To(Equal(len(expected)))
+			for _, actual := range allTrafficPolicies {
+				Expect(actual).To(BeElementOf(expected))
+			}
 		})
 	})
 


### PR DESCRIPTION
Don't enforce the order of traffic policies returned by `getTrafficPoliciesForService()`.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No