### PR TITLE
sidecar-injection: provide granular control for injection

### DIFF
--- a/cmd/cli/namespace_remove.go
+++ b/cmd/cli/namespace_remove.go
@@ -17,7 +17,6 @@ import (
 const namespaceRemoveDescription = `
 This command will remove a namespace from the mesh. All
 services in this namespace will be removed from the mesh.
-
 `
 
 type namespaceRemoveCmd struct {
@@ -73,12 +72,25 @@ func (r *namespaceRemoveCmd) run() error {
 	val, exists := namespace.ObjectMeta.Labels[constants.OSMKubeResourceMonitorAnnotation]
 	if exists {
 		if val == r.meshName {
-			patch := `{"metadata":{"labels":{"$patch":"delete", "` + constants.OSMKubeResourceMonitorAnnotation + `":"` + r.meshName + `"}}}`
+			// Setting null for a key in a map removes only that specific key, which is the desired behavior.
+			// Even if the key does not exist, there will be no side effects with setting the key to null, which
+			// will result in the same behavior as if the key were present - the key being removed.
+			patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"labels": {
+			"%s": null
+		},
+		"annotations": {
+			"%s": null
+		}
+	}
+}`, constants.OSMKubeResourceMonitorAnnotation, constants.SidecarInjectionAnnotation)
 
 			_, err = r.clientSet.CoreV1().Namespaces().Patch(ctx, r.namespace, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 
 			if err != nil {
-				return errors.Errorf("Could not remove label from namespace %s: %v", r.namespace, err)
+				return errors.Errorf("Could not remove namespace [%s] from mesh [%s]: %v", r.namespace, r.meshName, err)
 			}
 
 			fmt.Fprintf(r.out, "Namespace [%s] successfully removed from mesh [%s]\n", r.namespace, r.meshName)

--- a/demo/join-namespaces.sh
+++ b/demo/join-namespaces.sh
@@ -13,10 +13,10 @@ set -aueo pipefail
 source .env
 
 
-./bin/osm namespace add "${BOOKBUYER_NAMESPACE:-bookbuyer}"         --mesh-name "${MESH_NAME:-osm}"
-./bin/osm namespace add "${BOOKSTORE_NAMESPACE:-bookstore}"         --mesh-name "${MESH_NAME:-osm}"
-./bin/osm namespace add "${BOOKTHIEF_NAMESPACE:-bookthief}"         --mesh-name "${MESH_NAME:-osm}"
-./bin/osm namespace add "${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}" --mesh-name "${MESH_NAME:-osm}"
+./bin/osm namespace add "${BOOKBUYER_NAMESPACE:-bookbuyer}"         --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
+./bin/osm namespace add "${BOOKSTORE_NAMESPACE:-bookstore}"         --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
+./bin/osm namespace add "${BOOKTHIEF_NAMESPACE:-bookthief}"         --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
+./bin/osm namespace add "${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}" --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
 
 
 kubectl apply -f - <<EOF

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -132,7 +132,7 @@ fi
 wait_for_osm_pods
 
 ./demo/configure-app-namespaces.sh
-bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE"
+bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" --enable-sidecar-injection
 ./demo/deploy-apps.sh
 
 # Apply SMI policies

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -20,7 +20,7 @@
 - [Inspect Dashbaords](#inspect-dashboards)
 
 ## Overview
-The OSM Manual Install Demo Guide is designed to quickly allow you to demo and experience the OSM mesh. 
+The OSM Manual Install Demo Guide is designed to quickly allow you to demo and experience the OSM mesh.
 
 ## Configure Prerequisites
 - Kubernetes cluster running Kubernetes v1.15.0 or greater
@@ -48,9 +48,9 @@ The `Bookstore`, `Bookbuyer`, `Bookthief`, `Bookwarehouse` demo applications wil
 ```bash
 for i in bookstore bookbuyer bookthief bookwarehouse; do kubectl create ns $i; done
 ```
-### Onboard the Namespaces to the OSM Mesh
+### Onboard the Namespaces to the OSM Mesh and enable sidecar injection on the namespaces
 ```bash
-for i in bookstore bookbuyer bookthief bookwarehouse; do osm namespace add $i; done
+osm namespace add bookstore bookbuyer bookthief bookwarehouse --enable-sidecar-injection
 ```
 ### Deploy the Bookstore Application
 Install `Bookstore`, `Bookbuyer`, `Bookthief`, `Bookwarehouse`.
@@ -78,7 +78,7 @@ A simple topology view of the Bookstore application looks like the following:
 *Note: At the moment, you must configure a TrafficSplit object to get your applications set up correctly for inbound traffic because it helps us properly configure the dataplane. We're working on removing the need for this entirely.* [#1370](https://github.com/openservicemesh/osm/issues/1370)
 
 ### View the Application UIs
-We will now setup client port forwarding, so we can access the services in the Kubernetes cluster. It is best to start a new terminal session for running the port forwarding script to maintain the port forwarding session, while using the original terminal to continue to issue commands. The port-forward-all.sh script will look for a ```".env"``` file for variables. The ```".env"``` creates the necessary variables that target the previously created namespaces. We will use the reference .env.examples file and then run the port forwarding script. 
+We will now setup client port forwarding, so we can access the services in the Kubernetes cluster. It is best to start a new terminal session for running the port forwarding script to maintain the port forwarding session, while using the original terminal to continue to issue commands. The port-forward-all.sh script will look for a ```".env"``` file for variables. The ```".env"``` creates the necessary variables that target the previously created namespaces. We will use the reference .env.examples file and then run the port forwarding script.
 
 In a new terminal session, run the following commands to enable port forwarding into the Kubernetes cluster.
 ```bash
@@ -93,11 +93,11 @@ BOOKBUYER_LOCAL_PORT=7070 BOOKSTOREv1_LOCAL_PORT=7071 BOOKSTOREv2_LOCAL_PORT=707
 In a browser, open up the following urls:
 - http://localhost:8080 - **Bookbuyer**
 - http://localhost:8081 - **bookstore-v1**
-- http://localhost:8082 - **bookstore-v2** 
+- http://localhost:8082 - **bookstore-v2**
   - *Note: This page will not be available at this time in the demo. This will become available during the Traffic Split Configuration*
 - http://localhost:8083 - **bookthief**
 
-Position the windows so that you can see all four at the same time. The header at the top of the webpage indicates the application and version. 
+Position the windows so that you can see all four at the same time. The header at the top of the webpage indicates the application and version.
 
 ## Deploy SMI Access Control Policies
 At this point, no applications have access to each other because no access control policies have been applied. Confirm this by confirming that none of the counters in the UI are incrementing. Apply the [SMI Traffic Target][1] and [SMI Traffic Specs][2] resources to define access control policies below:
@@ -137,7 +137,7 @@ spec:
     #name: bookthief
     #namespace: bookthief
  ```
- 
+
  Updated TrafficTarget spec with uncommented `Bookthief` kind:
  ```
  kind: TrafficTarget

--- a/docs/onboard_services.md
+++ b/docs/onboard_services.md
@@ -2,7 +2,7 @@
 The following guide describes how to onboard a Kubernetes microservice to an OSM instance.
 
 
-1. Configure and Install [Service Mesh Interface (SMI) policies](https://github.com/servicemeshinterface/smi-spec) 
+1. Configure and Install [Service Mesh Interface (SMI) policies](https://github.com/servicemeshinterface/smi-spec)
 
     OSM conforms to the SMI specification. By default, OSM denies all traffic communications between Kubernetes services unless explicitly allowed by SMI policies. This behavior can be overridden with the `--enable-permissive-traffic-policy` flag on the `osm install` command, allowing SMI policies not to be enforced while allowing traffic and services to still take advantage of features such as mTLS-encrypted traffic, metrics, and tracing.
 
@@ -19,7 +19,14 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
     $ kubectl label namespace <namespace> openservicemesh.io/monitored-by=<mesh-name>
     ```
 
-    All newly created pods in the added namespace(s) will automatically have a proxy sidecar container injected. To prevent specific pods from participating in the mesh, they can easily be labeled to prevent the sidecar injection. See the [Sidecar Injection](patterns/sidecar_injection.md) document for more details.
+    By default, the `osm namespace add` command does not enable the namespace for automatic sidecar injection. To enable automatic sidecar injection as a part of enrolling a namespace into the mesh, use `osm namespace add <namespace> --enable-sidecar-injection`. This does the equivalent of the following:
+
+    ```console
+    $ kubectl label namespace <namespace> openservicemesh.io/monitored-by=<mesh-name>
+    $ kubectl annotate namespace <namespace> openservicemesh.io/sidecar-injection=enabled
+    ```
+
+    Once a namespace has been onboarded, pods can be enrolled in the mesh by configuring automatic sidecar injection. See the [Sidecar Injection](patterns/sidecar_injection.md) document for more details.
 
     For an example on how to onboard and join namespaces to the OSM mesh, please see the following example:
     - [demo/join-namespaces.sh](/demo/join-namespaces.sh)

--- a/docs/patterns/sidecar_injection.md
+++ b/docs/patterns/sidecar_injection.md
@@ -8,6 +8,9 @@ Automatic sidecar injection can be configured per namespace as a part of enrolli
 
 ### Enabling Automatic Sidecar Injection
 
+Prerequisites:
+- The namespace to which the pods belong must be a monitored namespace that is added to the mesh using the `osm namespace add` command.
+
 Automatic Sidecar injection can be enabled in the following ways:
 
 - While enrolling a namespace into the mesh using `osm` cli: `osm namespace add <namespace> --enable-sidecar-injection`

--- a/docs/patterns/sidecar_injection.md
+++ b/docs/patterns/sidecar_injection.md
@@ -4,6 +4,54 @@ Services participating in the service mesh communicate via sidecar proxies insta
 ## Automatic Sidecar Injection
 Automatic sidecar injection is currently the only way to inject sidecars into the service mesh. Sidecars can be automatically injected into applicable Kubernetes pods using a mutating webhook admission controller provided by OSM.
 
-Each OSM instance is given a unique ID on installation. This ID is used while labeling namespaces as a way to configure OSM to monitor the namespaces. When a namespace is labeled with `openservicemesh.io/monitored-by=<mesh-name>`, pods deployed in the monitored namespaces are automatically injected with sidecars by the corresponding OSM instance.
+Automatic sidecar injection can be configured per namespace as a part of enrolling a namespace into the mesh, or later using the Kubernetes API. Automatic sidecar injection can be enabled either on a per namespace or per pod basis by annotating the namespace or pod resource with the sidecar injection annotation. Individual pods and namespaces can be explicitly configured to either enable or disable automatic sidecar injection, giving users the flexibility to control sidecar injection on pods and namespaces.
 
-Since sidecars are automatically injected to pods deployed in OSM monitored namespaces, pods that should not be a part of the service mesh but belong to monitored namespaces need to be explicitly annotated to disable automatic sidecar injection. Using the annotation `"openservicemesh.io/sidecar-injection": "disabled"` on the POD will inform OSM to not inject the sidecar on the POD.
+### Enabling Automatic Sidecar Injection
+
+Automatic Sidecar injection can be enabled in the following ways:
+
+- While enrolling a namespace into the mesh using `osm` cli: `osm namespace add <namespace> --enable-sidecar-injection`
+
+- Using `kubectl` to annotate individual namespaces and pods to enable sidecar injection:
+
+  ```console
+  # Enable sidecar injection on a namespace
+  $ kubectl annotate namespace <namespace> openservicemesh.io/sidecar-injection=enabled
+  ```
+
+  ```console
+  # Enable sidecar injection on a pod
+  $ kubectl annotate pod <pod> openservicemesh.io/sidecar-injection=enabled
+  ```
+
+- Setting the sidecar injection annotation to `enabled` in the Kubernetes resource spec for a namespace or pod:
+  ```yaml
+  metadata:
+    name: test
+    annotations:
+      'openservicemesh.io/sidecar-injection': 'enabled'
+  ```
+
+  Pods will be injected with a sidecar only if the following conditions are met:
+  1. The namespace to which the pod belongs is a monitored namespace.
+  2. The pod is explicitly enabled for the sidecar injection, OR the namespace to which the pod belongs is enabled for the sidecar injection and the pod is not explicitly disabled for sidecar injection.
+
+### Explicitly Disabling Automatic Sidecar Injection on Pods
+
+Individual pods can be explicitly disabled for sidecar injection. This is useful when a namespace is enabled for sidecar injection but specific pods should not be injected with sidecars.
+
+- Using `kubectl` to annotate individual pods to disable sidecar injection:
+  ```console
+  # Disable sidecar injection on a pod
+  $ kubectl annotate pod <pod> openservicemesh.io/sidecar-injection=disabled
+  ```
+
+- Setting the sidecar injection annotation to `disabled` in the Kubernetes resource spec for the pod:
+  ```yaml
+  metadata:
+    name: test
+    annotations:
+      'openservicemesh.io/sidecar-injection': 'disabled'
+  ```
+
+Automatic sidecar injection is implicitly disabled for a namespace when it is removed from the mesh using the `osm namespace remove` command.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -133,4 +133,7 @@ const (
 
 	// InitContainerName is the name of the init container
 	InitContainerName = "osm-init"
+
+	// SidecarInjectionAnnotation is the annotation used for sidecar injection
+	SidecarInjectionAnnotation = "openservicemesh.io/sidecar-injection"
 )

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -11,9 +11,6 @@ import (
 )
 
 const (
-	// OSM Annotations
-	annotationInject = "openservicemesh.io/sidecar-injection"
-
 	envoyBootstrapConfigVolume = "envoy-bootstrap-config-volume"
 )
 

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -154,8 +154,10 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when the inject annotation does not exist", func() {
 		It("should return false to indicate the annotation does not exist", func() {
 			annotation := map[string]string{}
-			exists, _, _ := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation)
 			Expect(exists).To(BeFalse())
+			Expect(enabled).To(BeFalse())
+			Expect(err).To(BeNil())
 		})
 	})
 

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/namespace"
 )
 
 var _ = Describe("Test MutatingWebhookConfiguration patch", func() {
@@ -93,3 +97,288 @@ func (mc mockCertificate) GetCertificateChain() []byte           { return []byte
 func (mc mockCertificate) GetPrivateKey() []byte                 { return []byte("key") }
 func (mc mockCertificate) GetIssuingCA() []byte                  { return []byte("ca") }
 func (mc mockCertificate) GetExpiration() time.Time              { return time.Now() }
+
+var _ = Describe("Testing isAnnotatedForInjection", func() {
+	Context("when the inject annotation is one of enabled/yes/true", func() {
+		It("should return true to enable sidecar injection", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "enabled"}
+			exists, enabled, err := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeTrue())
+			Expect(enabled).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should return true to enable sidecar injection", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "yes"}
+			exists, enabled, err := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeTrue())
+			Expect(enabled).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+
+		It("should return true to enable sidecar injection", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "true"}
+			exists, enabled, err := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeTrue())
+			Expect(enabled).To(BeTrue())
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when the inject annotation is one of disabled/no/false", func() {
+		It("should return false to disable sidecar injection", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "disabled"}
+			exists, enabled, err := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeTrue())
+			Expect(enabled).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+
+		It("should return false to disable sidecar injection", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "no"}
+			exists, enabled, err := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeTrue())
+			Expect(enabled).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+
+		It("should return false to disable sidecar injection", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "false"}
+			exists, enabled, err := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeTrue())
+			Expect(enabled).To(BeFalse())
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("when the inject annotation does not exist", func() {
+		It("should return false to indicate the annotation does not exist", func() {
+			annotation := map[string]string{}
+			exists, _, _ := isAnnotatedForInjection(annotation)
+			Expect(exists).To(BeFalse())
+		})
+	})
+
+	Context("when an invalid inject annotation is specified", func() {
+		It("should return an error", func() {
+			annotation := map[string]string{constants.SidecarInjectionAnnotation: "invalid-value"}
+			_, _, err := isAnnotatedForInjection(annotation)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("Testing mustInject", func() {
+	var (
+		mockCtrl         *gomock.Controller
+		mockNsController *namespace.MockController
+		fakeClientSet    *fake.Clientset
+		wh               *webhook
+	)
+
+	mockCtrl = gomock.NewController(GinkgoT())
+	mockNsController = namespace.NewMockController(mockCtrl)
+	fakeClientSet = fake.NewSimpleClientset()
+	namespace := "test"
+
+	BeforeEach(func() {
+		fakeClientSet = fake.NewSimpleClientset()
+		wh = &webhook{
+			kubeClient:          fakeClientSet,
+			namespaceController: mockNsController,
+		}
+	})
+	AfterEach(func() {
+		err := fakeClientSet.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("should return true when the pod is enabled for sidecar injection", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		podWithInjectAnnotationEnabled := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-with-injection-enabled",
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "enabled",
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-SA",
+			},
+		}
+		_, err = fakeClientSet.CoreV1().Pods(namespace).Create(context.TODO(), podWithInjectAnnotationEnabled, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		mockNsController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+
+		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeTrue())
+	})
+
+	It("should return false when the pod is disabled for sidecar injection", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		podWithInjectAnnotationEnabled := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-with-injection-disabled",
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "disabled",
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-SA",
+			},
+		}
+		_, err = fakeClientSet.CoreV1().Pods(namespace).Create(context.TODO(), podWithInjectAnnotationEnabled, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		mockNsController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+
+		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeFalse())
+	})
+
+	It("should return true when the namespace is enabled for injection and the pod is not explicitly disabled for injection", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "enabled",
+				},
+			},
+		}
+		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		podWithInjectAnnotationEnabled := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-with-no-injection-annotation",
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-SA",
+			},
+		}
+		_, err = fakeClientSet.CoreV1().Pods(namespace).Create(context.TODO(), podWithInjectAnnotationEnabled, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		mockNsController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+
+		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeTrue())
+	})
+
+	It("should return false when the namespace is enabled for injection and the pod is explicitly disabled for injection", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "enabled",
+				},
+			},
+		}
+		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		podWithInjectAnnotationEnabled := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-with-injection-disabled",
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "disabled",
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-SA",
+			},
+		}
+		_, err = fakeClientSet.CoreV1().Pods(namespace).Create(context.TODO(), podWithInjectAnnotationEnabled, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		mockNsController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+
+		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeFalse())
+	})
+
+	It("should return false when the pod's namespace is not being monitored", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		podWithInjectAnnotationEnabled := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-with-injection-enabled",
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "enabled",
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-SA",
+			},
+		}
+		_, err = fakeClientSet.CoreV1().Pods(namespace).Create(context.TODO(), podWithInjectAnnotationEnabled, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		mockNsController.EXPECT().IsMonitoredNamespace(namespace).Return(false).Times(1)
+
+		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeFalse())
+	})
+
+	It("should return an error when an invalid annotation is specified", func() {
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		podWithInjectAnnotationEnabled := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-with-injection-enabled",
+				Annotations: map[string]string{
+					constants.SidecarInjectionAnnotation: "invalid-value",
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "test-SA",
+			},
+		}
+		_, err = fakeClientSet.CoreV1().Pods(namespace).Create(context.TODO(), podWithInjectAnnotationEnabled, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		mockNsController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+
+		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
+
+		Expect(err).To(HaveOccurred())
+		Expect(inject).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Currently it is not possible to enroll specific pods within
the mesh for sidecar injection without enrolling the entire
namespace. This behavior is not desirable when several
application pods run in the same namespace and only certain
pods need to be enrolled in the mesh with a sidecar.

This change decouples the sidecar injection for pods from
the namespace monitoring workflow.

A pod will be injected with the sidecar if its namespace
is monitored, and either of the following are true:

1. The pod is explicitly enabled for injection
2. The namespace is enabled for injection and the pod
   is not explicitly disabled for injection

This change also extends the `osm namespace add` command
with an `--enable-sidecar-injection` flag which automatically
adds the sidecar injection annotation on the namespace.
Similarly, the `osm namespace remove` command is updated
to remove the annotation if present.

It also fixes an existing bug in the `osm namespace remove` command
where all the labels are removed instead of just the monitor label.

Resolves #1617

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [X]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`