### PR TITLE
osm-controller/test: compare cert for equality instead of its length

### DIFF
--- a/cmd/osm-controller/osm-controller_test.go
+++ b/cmd/osm-controller/osm-controller_test.go
@@ -32,7 +32,10 @@ var _ = Describe("Test creation of CA bundle k8s secret", func() {
 			expected := "-----BEGIN CERTIFICATE-----\nMIIF"
 			stringPEM := string(actual.Data[constants.KubernetesOpaqueSecretCAKey])[:len(expected)]
 			Expect(stringPEM).To(Equal(expected))
-			Expect(len(actual.Data[constants.KubernetesOpaqueSecretCAKey])).To(Equal(1915))
+
+			expectedRootCert, err := certManager.GetRootCertificate()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.Data[constants.KubernetesOpaqueSecretCAKey]).To(Equal(expectedRootCert.GetCertificateChain()))
 		})
 	})
 })


### PR DESCRIPTION
The test hardcodes the expected length for a certificate, compare
the certificate content instead. An issue was seen when the Go
version was updated, possibly resulting from a change in a lib
used for generating the certs. This change removes the length
check and directly compares the certificate.

Resolves #1635

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`