### PR TITLE
ref(cmd/osm-controller): simplify validation, certificate manager setup

### DIFF
--- a/cmd/osm-controller/certificates.go
+++ b/cmd/osm-controller/certificates.go
@@ -25,7 +25,7 @@ type certificateManagerKind string
 // These are the supported certificate issuers.
 const (
 	// Tresor is an internal package, which leverages Kubernetes secrets and signs certs on the OSM pod
-	tresorKind certificateManagerKind = "tresor"
+	tresorKind string = "tresor"
 
 	// Azure Key Vault integration; uses AKV for certificate storage only; certs are signed on the OSM pod
 	keyVaultKind = "keyvault"
@@ -43,24 +43,9 @@ const (
 	rootCertOrganization = "Open Service Mesh"
 )
 
-// Functions we can call to create a Certificate Manager for each kind of supported certificate issuer
-var certManagers = map[certificateManagerKind]func(kubeClient kubernetes.Interface, kubeConfig *rest.Config, enableDebugServer bool) (certificate.Manager, debugger.CertificateManagerDebugger, error){
-	tresorKind:      getTresorOSMCertificateManager,
-	keyVaultKind:    getAzureKeyVaultOSMCertificateManager,
-	vaultKind:       getHashiVaultOSMCertificateManager,
-	certmanagerKind: getCertManagerOSMCertificateManager,
-}
+var validCertificateManagerOptions = []string{tresorKind, vaultKind, certmanagerKind}
 
-// Get a list of the supported certificate issuers
-func getPossibleCertManagers() []string {
-	var possible []string
-	for kind := range certManagers {
-		possible = append(possible, string(kind))
-	}
-	return possible
-}
-
-func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, _ *rest.Config, enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	var err error
 	var rootCert certificate.Certificater
 
@@ -154,7 +139,7 @@ func getAzureKeyVaultOSMCertificateManager(_ kubernetes.Interface, _ *rest.Confi
 	return nil, nil, nil
 }
 
-func getHashiVaultOSMCertificateManager(_ kubernetes.Interface, _ *rest.Config, enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getHashiVaultOSMCertificateManager(enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	if _, ok := map[string]interface{}{"http": nil, "https": nil}[*vaultProtocol]; !ok {
 		return nil, nil, errors.Errorf("Value %s is not a valid Hashi Vault protocol", *vaultProtocol)
 	}

--- a/cmd/osm-controller/validate.go
+++ b/cmd/osm-controller/validate.go
@@ -8,35 +8,20 @@ import (
 
 // validateCLIParams contains all checks necessary that various permutations of the CLI flags are consistent
 func validateCLIParams() error {
-	if _, ok := certManagers[certificateManagerKind(*osmCertificateManagerKind)]; !ok {
-		return errors.Errorf("Certificate manager %s is not one of possible options: %s", *osmCertificateManagerKind, strings.Join(getPossibleCertManagers(), ", "))
-	}
-
-	if *osmCertificateManagerKind == vaultKind {
-		if *vaultToken == "" {
-			return errors.Errorf("Empty Hashi Vault token")
-		}
-	}
-
-	if *osmCertificateManagerKind == certmanagerKind {
-		if len(caBundleSecretName) == 0 {
-			return errors.Errorf("Please specify --%s as the Secret name containing the cert-manager CA at 'ca.crt'", caBundleSecretNameCLIParam)
-		}
-		if len(*certmanagerIssuerName) == 0 {
-			return errors.Errorf("Please specify --cert-manager-issuer-name when using cert-manager certificate manager")
-		}
+	if err := validateCertificateManagerOptions(); err != nil {
+		return errors.Errorf("Error validating certificate manager options: %s", err)
 	}
 
 	if meshName == "" {
-		return errors.Errorf("Please specify the mesh name using --mesh-name")
+		return errors.New("Please specify the mesh name using --mesh-name")
 	}
 
 	if osmNamespace == "" {
-		return errors.Errorf("Please specify the OSM namespace using --osm-namespace")
+		return errors.New("Please specify the OSM namespace using --osm-namespace")
 	}
 
 	if injectorConfig.InitContainerImage == "" {
-		return errors.Errorf("Please specify the init container image using --init-container-image")
+		return errors.New("Please specify the init container image using --init-container-image")
 	}
 
 	if injectorConfig.SidecarImage == "" {
@@ -46,5 +31,45 @@ func validateCLIParams() error {
 	if webhookName == "" {
 		return errors.Errorf("Invalid --webhook-name value: '%s'", webhookName)
 	}
+
+	return nil
+}
+
+func validateCertificateManagerOptions() error {
+	switch *osmCertificateManagerKind {
+	case tresorKind:
+		break
+	case vaultKind:
+		if err := validateVaultParams(); err != nil {
+			return err
+		}
+	case certmanagerKind:
+		if err := validateCertManagerParams(); err != nil {
+			return err
+		}
+	default:
+		return errors.Errorf("Invalid certificate manager kind %s. Please specify a valid certificate manager[%v] \n",
+			*osmCertificateManagerKind, strings.Join(validCertificateManagerOptions, "|"))
+	}
+
+	return nil
+}
+
+func validateCertManagerParams() error {
+	if len(caBundleSecretName) == 0 {
+		return errors.Errorf("Please specify --%s as the Secret name containing the cert-manager CA at 'ca.crt'", caBundleSecretNameCLIParam)
+	}
+	if len(*certmanagerIssuerName) == 0 {
+		return errors.New("Please specify --cert-manager-issuer-name when using cert-manager certificate manager")
+	}
+
+	return nil
+}
+
+func validateVaultParams() error {
+	if *vaultToken == "" {
+		return errors.New("Empty Hashi Vault token")
+	}
+
 	return nil
 }

--- a/cmd/osm-controller/validate_test.go
+++ b/cmd/osm-controller/validate_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/injector"
+)
+
+var _ = Describe("Test validateCertificateManagerOptions", func() {
+	var (
+		testCaBundleSecretName = "test-secret"
+	)
+
+	Context("tresor osmCertificateManagerKind is passed in", func() {
+		*osmCertificateManagerKind = tresorKind
+
+		err := validateCertificateManagerOptions()
+
+		It("should not error", func() {
+			Expect(err).To(BeNil())
+		})
+	})
+	Context("vault osmCertificateManagerKind is passed in and vaultToken is not empty", func() {
+		*osmCertificateManagerKind = vaultKind
+		*vaultToken = "anythinghere"
+
+		err := validateCertificateManagerOptions()
+
+		It("should not error", func() {
+			Expect(err).To(BeNil())
+		})
+	})
+	Context("vault osmCertificateManagerKind is passed in but vaultToken is empty", func() {
+		*osmCertificateManagerKind = vaultKind
+		*vaultToken = ""
+
+		err := validateCertificateManagerOptions()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+
+		})
+	})
+	Context("cert-manager osmCertificateManagerKind is passed in with valid caBundleSecretName and certmanagerIssureName", func() {
+		*osmCertificateManagerKind = certmanagerKind
+		caBundleSecretName = testCaBundleSecretName
+		*certmanagerIssuerName = "test-issuer"
+
+		err := validateCertificateManagerOptions()
+
+		It("should not error", func() {
+			Expect(err).To(BeNil())
+		})
+	})
+	Context("cert-manager osmCertificateManagerKind is passed in with caBundleSecretName but no certmanagerIssureName", func() {
+		*osmCertificateManagerKind = certmanagerKind
+		caBundleSecretName = testCaBundleSecretName
+		*certmanagerIssuerName = ""
+
+		err := validateCertificateManagerOptions()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("cert-manager osmCertificateManagerKind is passed in without caBundleSecretName but no certmanagerIssureName", func() {
+		*osmCertificateManagerKind = certmanagerKind
+		caBundleSecretName = ""
+		*certmanagerIssuerName = ""
+
+		err := validateCertificateManagerOptions()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("cert-manager osmCertificateManagerKind is passed in with certmanagerIssureName but without caBundleSecretName ", func() {
+		*osmCertificateManagerKind = certmanagerKind
+		caBundleSecretName = ""
+		*certmanagerIssuerName = "test-issuer"
+
+		err := validateCertificateManagerOptions()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("azure key vault is not implemented", func() {
+		*osmCertificateManagerKind = keyVaultKind
+
+		err := validateCertificateManagerOptions()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("invalid kind is passed in", func() {
+		*osmCertificateManagerKind = "invalidkind"
+
+		err := validateCertificateManagerOptions()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("Test validateCLIParams", func() {
+	var (
+		testMeshName           = "test-mesh-name"
+		testOsmNamespace       = "test-namespace"
+		testInitContainerImage = "test-init-image"
+		testSidecarImage       = "test-sidecar-image"
+		testWebhookName        = "test-webhook-name"
+	)
+
+	Context("none of the necessary CLI params are empty", func() {
+		*osmCertificateManagerKind = tresorKind
+		meshName = testMeshName
+		osmNamespace = testOsmNamespace
+		injectorConfig = injector.Config{
+			InitContainerImage: testInitContainerImage,
+			SidecarImage:       testSidecarImage,
+		}
+		webhookName = testWebhookName
+
+		err := validateCLIParams()
+
+		It("should not error", func() {
+			Expect(err).To(BeNil())
+		})
+	})
+	Context("mesh name is empty", func() {
+		*osmCertificateManagerKind = tresorKind
+		meshName = ""
+		osmNamespace = testOsmNamespace
+		injectorConfig = injector.Config{
+			InitContainerImage: testInitContainerImage,
+			SidecarImage:       testSidecarImage,
+		}
+		webhookName = testWebhookName
+
+		err := validateCLIParams()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("osmNamespace is empty", func() {
+		*osmCertificateManagerKind = tresorKind
+		meshName = testMeshName
+		osmNamespace = ""
+		injectorConfig = injector.Config{
+			InitContainerImage: testInitContainerImage,
+			SidecarImage:       testSidecarImage,
+		}
+		webhookName = testWebhookName
+
+		err := validateCLIParams()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("InitContainerImage on injectorConfig is empty", func() {
+		*osmCertificateManagerKind = tresorKind
+		meshName = testMeshName
+		osmNamespace = testOsmNamespace
+		injectorConfig = injector.Config{
+			InitContainerImage: "",
+			SidecarImage:       testSidecarImage,
+		}
+		webhookName = testWebhookName
+
+		err := validateCLIParams()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("SidecarImage on injectorConfig is empty", func() {
+		*osmCertificateManagerKind = tresorKind
+		meshName = testMeshName
+		osmNamespace = testOsmNamespace
+		injectorConfig = injector.Config{
+			InitContainerImage: testInitContainerImage,
+			SidecarImage:       "",
+		}
+		webhookName = testWebhookName
+
+		err := validateCLIParams()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("webhookName is empty", func() {
+		*osmCertificateManagerKind = tresorKind
+		meshName = testMeshName
+		osmNamespace = testOsmNamespace
+		injectorConfig = injector.Config{
+			InitContainerImage: testInitContainerImage,
+			SidecarImage:       testSidecarImage,
+		}
+		webhookName = ""
+
+		err := validateCLIParams()
+
+		It("should error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This PR restructures how we do CLI parameter validation and adds tests for validation. It also re-organizes how we set up the certificate manager and debugger (certificate.Manager, debugger.CertificateManagerDebugger). With this PR, code coverage for `cmd/osm-controller/` goes from 27.20% to 38.1%. These changes are part of a larger re-factor and effort to make the `cmd/osm-controller/` more readable and testable and more changes are to come after this.


Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
