### PR TITLE
helm chart fixes

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -10,6 +10,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 |-----|------|---------|-------------|
 | OpenServiceMesh.caBundleSecretName | string | `"osm-ca-bundle"` |  |
 | OpenServiceMesh.certficateManager | string | `"tresor"` |  |
+| OpenServiceMesh.enableCertManager | string | `false` |  |
 | OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager"` |  |
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` |  |
 | OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` |  |
@@ -33,6 +34,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.serviceCertValidityMinutes | int | `1` |  |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.15.0"` |  |
 | OpenServiceMesh.useHTTPSIngress | bool | `false` |  |
+| OpenServiceMesh.enableVault | string | `false` |  |
 | OpenServiceMesh.vault.host | string | `nil` |  |
 | OpenServiceMesh.vault.protocol | string | `"http"` |  |
 | OpenServiceMesh.vault.role | string | `"openservicemesh"` |  |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -35,6 +35,7 @@ spec:
             "--webhook-name", "osm-webhook-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.OpenServiceMesh.certficateManager}}",
+            "--service-cert-validity-minutes", "{{.Values.OpenServiceMesh.serviceCertValidityMinutes}}",
             {{- if .Values.OpenServiceMesh.enableVault}}
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
@@ -44,7 +45,6 @@ spec:
             "--certificate-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
             "--certificate-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
             "--certificate-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
-            "--service-cert-validity-minutes", "{{.Values.OpenServiceMesh.serviceCertValidityMinutes}}",
             {{- end }}
             {{- if .Values.OpenServiceMesh.enableDebugServer }}
             "--enable-debug-server",

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -34,14 +34,18 @@ spec:
             "--sidecar-image", "{{.Values.OpenServiceMesh.sidecarImage}}",
             "--webhook-name", "osm-webhook-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
-            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
+            "--certificate-manager", "{{.Values.OpenServiceMesh.certficateManager}}",
+            {{- if .Values.OpenServiceMesh.enableVault}}
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
             "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",
-            "--cert-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
-            "--cert-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
-            "--cert-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
+            {{- end }}
+            {{- if .Values.OpenServiceMesh.enableCertManager }}
+            "--certificate-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
+            "--certificate-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
+            "--certificate-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
             "--service-cert-validity-minutes", "{{.Values.OpenServiceMesh.serviceCertValidityMinutes}}",
+            {{- end }}
             {{- if .Values.OpenServiceMesh.enableDebugServer }}
             "--enable-debug-server",
             {{- end }}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -14,11 +14,13 @@ OpenServiceMesh:
     retention:
       time: 15d
   certficateManager: tresor
+  enableVault: false
   vault:
     host:
     protocol: http
     token:
     role: openservicemesh
+  enableCertManager: false
   certmanager:
     issuerName: osm-ca
     issuerKind: Issuer

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -50,7 +50,7 @@ for i in bookstore bookbuyer bookthief bookwarehouse; do kubectl create ns $i; d
 ```
 ### Onboard the Namespaces to the OSM Mesh and enable sidecar injection on the namespaces
 ```bash
-osm namespace add bookstore bookbuyer bookthief bookwarehouse --enable-sidecar-injection
+osm namespace add bookstore bookbuyer bookthief bookwarehouse
 ```
 ### Deploy the Bookstore Application
 Install `Bookstore`, `Bookbuyer`, `Bookthief`, `Bookwarehouse`.

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -50,7 +50,7 @@ for i in bookstore bookbuyer bookthief bookwarehouse; do kubectl create ns $i; d
 ```
 ### Onboard the Namespaces to the OSM Mesh and enable sidecar injection on the namespaces
 ```bash
-osm namespace add bookstore bookbuyer bookthief bookwarehouse
+osm namespace add bookstore bookbuyer bookthief bookwarehouse --enable-sidecar-injection
 ```
 ### Deploy the Bookstore Application
 Install `Bookstore`, `Bookbuyer`, `Bookthief`, `Bookwarehouse`.


### PR DESCRIPTION
Added two variables in the helm chart to make the Cert-manager and Vault section optional, so now a simple

```
helm install -n osm osm charts/osm 
```

works again (fixes #1600 ). While validating, I noticed the demo instructions had the old `--enable-sidecar-injection` flag for `osm namespace add` command and removed it.
 

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

no


