### PR TITLE
endpoint/provider: reword comments for types

### DIFF
--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-// Provider is an interface to be implemented by components abstracting Kubernetes, Azure, and other compute/cluster providers
+// Provider is an interface to be implemented by components abstracting Kubernetes, and other compute/cluster providers
 type Provider interface {
 	// Retrieve the IP addresses comprising the given service.
 	ListEndpointsForService(service.MeshService) []Endpoint
@@ -22,7 +22,7 @@ type Provider interface {
 	GetAnnouncementsChannel() <-chan interface{}
 }
 
-// Endpoint is a tuple of IP and Port, representing an Envoy proxy, fronting an instance of a service
+// Endpoint is a tuple of IP and Port representing an instance of a service
 type Endpoint struct {
 	net.IP `json:"ip"`
 	Port   `json:"port"`
@@ -32,5 +32,5 @@ func (ep Endpoint) String() string {
 	return fmt.Sprintf("(ip=%s, port=%d)", ep.IP, ep.Port)
 }
 
-// Port is a numerical port of an Envoy proxy
+// Port is a numerical type representing a port on which a service is exposed
 type Port uint32


### PR DESCRIPTION
Rewords a few comments in the endpoint.Provider interface for clarity.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`