### PR TITLE
ref(cmd/osm-controller): rm unused keyvault refs

### DIFF
--- a/cmd/osm-controller/certificates.go
+++ b/cmd/osm-controller/certificates.go
@@ -20,15 +20,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/debugger"
 )
 
-type certificateManagerKind string
-
 // These are the supported certificate issuers.
 const (
 	// Tresor is an internal package, which leverages Kubernetes secrets and signs certs on the OSM pod
 	tresorKind string = "tresor"
-
-	// Azure Key Vault integration; uses AKV for certificate storage only; certs are signed on the OSM pod
-	keyVaultKind = "keyvault"
 
 	// Hashi Vault integration; OSM is pointed to an external Vault; signing of certs happens on Vault
 	vaultKind = "vault"
@@ -131,12 +126,6 @@ func getCertFromKubernetes(kubeClient kubernetes.Interface, namespace, secretNam
 		log.Fatal().Err(err).Msgf("Failed to create new Certificate Authority with cert issuer %s", *osmCertificateManagerKind)
 	}
 	return rootCert
-}
-
-func getAzureKeyVaultOSMCertificateManager(_ kubernetes.Interface, _ *rest.Config, enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
-	// TODO(draychev): implement: https://github.com/openservicemesh/osm/issues/577
-	log.Fatal().Msg("Azure Key Vault certificate manager is not implemented")
-	return nil, nil, nil
 }
 
 func getHashiVaultOSMCertificateManager(enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -85,8 +85,6 @@ var (
 func init() {
 	flags.StringVarP(&verbosity, "verbosity", "v", "info", "Set log verbosity level")
 	flags.StringVar(&meshName, "mesh-name", "", "OSM mesh name")
-	// TODO (#88): Azure Auth file disabled, pending on Identity + VM representation in SMI
-	//flags.StringVar(&azureAuthFile, "azure-auth-file", "", "Path to Azure Auth File")
 	flags.StringVar(&kubeConfigFile, "kubeconfig", "", "Path to Kubernetes config file.")
 	flags.StringVar(&osmNamespace, "osm-namespace", "", "Namespace to which OSM belongs to.")
 	flags.StringVar(&webhookName, "webhook-name", "", "Name of the MutatingWebhookConfiguration to be configured by osm-controller")

--- a/cmd/osm-controller/validate_test.go
+++ b/cmd/osm-controller/validate_test.go
@@ -86,15 +86,6 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Context("azure key vault is not implemented", func() {
-		*osmCertificateManagerKind = keyVaultKind
-
-		err := validateCertificateManagerOptions()
-
-		It("should error", func() {
-			Expect(err).To(HaveOccurred())
-		})
-	})
 	Context("invalid kind is passed in", func() {
 		*osmCertificateManagerKind = "invalidkind"
 


### PR DESCRIPTION
+ cleans up azure related and azure key vault related code
since we do not support azure VMs or AKV at this time

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
