### PR TITLE
catalog: add an API to retrieve endpoints for service FQDN

### DIFF
--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -37,7 +37,7 @@ func (mc *MeshCatalog) GetResolvableServiceEndpoints(svc service.MeshService) ([
 
 	if len(service.Spec.ClusterIP) == 0 {
 		// If no cluster IP, use final endpoint as resolvable destinations
-		endpoints, err = mc.ListEndpointsForService(svc)
+		return mc.ListEndpointsForService(svc)
 	}
 
 	// Cluster IP is present

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -1,6 +1,8 @@
 package catalog
 
 import (
+	"net"
+
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -17,4 +19,38 @@ func (mc *MeshCatalog) ListEndpointsForService(svc service.MeshService) ([]endpo
 		endpoints = append(endpoints, ep...)
 	}
 	return endpoints, nil
+}
+
+// GetServiceEndpoints returns the highest abstract set of endpoint destinations where the service is made available at.
+// If no LB/virtual IPs are assigned to the service, GetServiceEndpoints will return ListEndpointsForService
+func (mc *MeshCatalog) GetServiceEndpoints(svc service.MeshService) ([]endpoint.Endpoint, error) {
+	var endpoints []endpoint.Endpoint
+	var err error
+
+	// Check if the service has been given Cluster IP
+	// TODO: push this in providers. Providers currently do not have services cache.
+	service := mc.GetSMISpec().GetService(svc)
+	if service == nil {
+		log.Error().Msgf("Could not find service %s", svc.String())
+		return []endpoint.Endpoint{}, errServiceNotFound
+	}
+
+	if len(service.Spec.ClusterIP) > 0 {
+		ip := net.ParseIP(service.Spec.ClusterIP)
+		if ip == nil {
+			log.Error().Msgf("Could not parse IP %s", service.Spec.ClusterIP)
+			return []endpoint.Endpoint{}, errParseClusterIP
+		}
+
+		for _, svcPort := range service.Spec.Ports {
+			endpoints = append(endpoints, endpoint.Endpoint{
+				IP:   ip,
+				Port: endpoint.Port(svcPort.Port),
+			})
+		}
+	} else {
+		endpoints, err = mc.ListEndpointsForService(svc)
+	}
+
+	return endpoints, err
 }

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -21,4 +21,17 @@ var _ = Describe("Test catalog functions", func() {
 			Expect(actual).To(Equal(expected))
 		})
 	})
+
+	Context("Testing GetServiceEndpoints()", func() {
+		It("returns the endpoint for the service", func() {
+			actual, err := mc.GetServiceEndpoints(tests.BookstoreService)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := []endpoint.Endpoint{
+				tests.Endpoint,
+			}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
 })

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -22,9 +22,9 @@ var _ = Describe("Test catalog functions", func() {
 		})
 	})
 
-	Context("Testing GetServiceEndpoints()", func() {
+	Context("Testing GetResolvableServiceEndpoints()", func() {
 		It("returns the endpoint for the service", func() {
-			actual, err := mc.GetServiceEndpoints(tests.BookstoreService)
+			actual, err := mc.GetResolvableServiceEndpoints(tests.BookstoreService)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := []endpoint.Endpoint{

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -11,4 +11,6 @@ var (
 	errNamespaceDoesNotMatchCertificate      = errors.New("namespace does not match certificate")
 	errServiceNotFoundForAnyProvider         = errors.New("no service found for service account with any of the mesh supported providers")
 	errNoTrafficSpecFoundForTrafficPolicy    = errors.New("no traffic spec found for the traffic policy")
+	errServiceNotFound                       = errors.New("service not found")
+	errParseClusterIP                        = errors.New("could not parse cluster IP")
 )

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -70,10 +70,10 @@ type MeshCataloger interface {
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget, []*corev1.Service)
 
-	// ListEndpointsForService returns the list of individual instance endpoint destinations that comprise the backed service
+	// ListEndpointsForService returns the list of individual instance endpoint backing a service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
 
-	// GetResolvableServiceEndpoints returns the resolvable set of endpoint destinations where the service is made available at.
+	// GetResolvableServiceEndpoints returns the resolvable set of endpoint over which a service is accessible using its FQDN.
 	// These are the endpoint destinations we'd expect client applications sends the traffic towards to, when attemtpting to
 	// reach a specific service.
 	// If no LB/virtual IPs are assigned to the service, GetResolvableServiceEndpoints will return ListEndpointsForService

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -73,9 +73,11 @@ type MeshCataloger interface {
 	// ListEndpointsForService returns the list of individual instance endpoint destinations that comprise the backed service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
 
-	// GetServiceEndpoint returns the highest abstract set of endpoint destinations where the service is made available at.
-	// If no LB/virtual IPs are assigned to the service, GetServiceEndpoints will return ListEndpointsForService
-	GetServiceEndpoints(service.MeshService) ([]endpoint.Endpoint, error)
+	// GetResolvableServiceEndpoints returns the resolvable set of endpoint destinations where the service is made available at.
+	// These are the endpoint destinations we'd expect client applications sends the traffic towards to, when attemtpting to
+	// reach a specific service.
+	// If no LB/virtual IPs are assigned to the service, GetResolvableServiceEndpoints will return ListEndpointsForService
+	GetResolvableServiceEndpoints(service.MeshService) ([]endpoint.Endpoint, error)
 
 	// GetCertificateForService returns the SSL Certificate for the given service.
 	// This certificate will be used for service-to-service mTLS.

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -70,8 +70,12 @@ type MeshCataloger interface {
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget, []*corev1.Service)
 
-	// ListEndpointsForService returns the list of provider endpoints corresponding to a service
+	// ListEndpointsForService returns the list of individual instance endpoint destinations that comprise the backed service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
+
+	// GetServiceEndpoint returns the highest abstract set of endpoint destinations where the service is made available at.
+	// If no LB/virtual IPs are assigned to the service, GetServiceEndpoints will return ListEndpointsForService
+	GetServiceEndpoints(service.MeshService) ([]endpoint.Endpoint, error)
 
 	// GetCertificateForService returns the SSL Certificate for the given service.
 	// This certificate will be used for service-to-service mTLS.


### PR DESCRIPTION
One of our ongoing proposals in order to implement per-service filtering
at listener level will require being able to identify the traffic destination
of an ongoing request.

For that to be able to happen, we need to be able to do L3/L4 mapping to
a service.

In cases where the service is behind a cluster IP (in K8s), the FQDN resolvable IP is that
of the Cluster IP, henceforth we will require to get the Cluster IP from a specific
service when programming the outbound listener.

This commit introduces a new API called GetResolvableServiceEndpoints,
which post-conditions to return the expected resolvable endpoint where a service
is made available from a client application perspective.

To properly test, needs some larger changes that I will follow up
with on a commit on top.

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.
- Control Plane          [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No