### PR TITLE
feat(metrics): Decouple Grafana and Prometheus installation for OSM install command

### DIFF
--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/osm/templates/grafana-svc.yaml
+++ b/charts/osm/templates/grafana-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/osm/templates/grafana-svc.yaml
+++ b/charts/osm/templates/grafana-svc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.OpenServiceMesh.enableMetricsStack .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.enableGrafana}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if .Values.OpenServiceMesh.enablePrometheus }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if .Values.OpenServiceMesh.enablePrometheus }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if .Values.OpenServiceMesh.enablePrometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/osm/templates/prometheus-svc.yaml
+++ b/charts/osm/templates/prometheus-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableMetricsStack }}
+{{- if .Values.OpenServiceMesh.enablePrometheus }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -33,6 +33,7 @@ OpenServiceMesh:
   enableBackpressureExperimental: false
   enableEgress: false
   enableMetricsStack: true
+  enableGrafana: true
   meshName: osm
   meshCIDRRanges: 0.0.0.0/0
   useHTTPSIngress: false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -32,7 +32,7 @@ OpenServiceMesh:
   enablePermissiveTrafficPolicy: false
   enableBackpressureExperimental: false
   enableEgress: false
-  enableMetricsStack: true
+  enablePrometheus: true
   enableGrafana: true
   meshName: osm
   meshCIDRRanges: 0.0.0.0/0

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -93,10 +93,10 @@ type installCmd struct {
 	// become part of SMI Spec.
 	enableBackpressureExperimental bool
 
-	// Toggle to deploy/not deploy metrics (Promethus+Grafana) stack
+	// Toggle to enable/disable Prometheus installation
 	enablePrometheus bool
 
-	// Toggle to enable/disable grafana installation
+	// Toggle to enable/disable Grafana installation
 	enableGrafana bool
 
 	// Toggle this to enable/disable the automatic deployment of Jaeger

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -96,6 +96,9 @@ type installCmd struct {
 	// Toggle to deploy/not deploy metrics (Promethus+Grafana) stack
 	enableMetricsStack bool
 
+	// Toggle to enable/disable grafana installation
+	enableGrafana bool
+
 	// Toggle this to enable/disable the automatic deployment of Jaeger
 	deployJaeger bool
 }
@@ -146,6 +149,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.StringSliceVar(&inst.meshCIDRRanges, "mesh-cidr", []string{}, "mesh CIDR range, accepts multiple CIDRs, required if enable-egress option is true")
 	f.BoolVar(&inst.enableBackpressureExperimental, "enable-backpressure-experimental", false, "Enable experimental backpressure feature")
 	f.BoolVar(&inst.enableMetricsStack, "enable-metrics-stack", true, "Enable metrics (Prometheus and Grafana) deployment")
+	f.BoolVar(&inst.enableGrafana, "enable-grafana", true, "Enable Grafana installation")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
 	f.BoolVar(&inst.deployJaeger, "deploy-jaeger", true, "Deploy Jaeger in the namespace of the OSM controller")
 
@@ -209,6 +213,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enablePermissiveTrafficPolicy=%t", i.enablePermissiveTrafficPolicy),
 		fmt.Sprintf("OpenServiceMesh.enableBackpressureExperimental=%t", i.enableBackpressureExperimental),
 		fmt.Sprintf("OpenServiceMesh.enableMetricsStack=%t", i.enableMetricsStack),
+		fmt.Sprintf("OpenServiceMesh.enableGrafana=%t", i.enableGrafana),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
 		fmt.Sprintf("OpenServiceMesh.enableEgress=%t", i.enableEgress),
 		fmt.Sprintf("OpenServiceMesh.meshCIDRRanges=%s", strings.Join(i.meshCIDRRanges, " ")),

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -94,7 +94,7 @@ type installCmd struct {
 	enableBackpressureExperimental bool
 
 	// Toggle to deploy/not deploy metrics (Promethus+Grafana) stack
-	enableMetricsStack bool
+	enablePrometheus bool
 
 	// Toggle to enable/disable grafana installation
 	enableGrafana bool
@@ -148,8 +148,8 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableEgress, "enable-egress", false, "Enable egress in the mesh")
 	f.StringSliceVar(&inst.meshCIDRRanges, "mesh-cidr", []string{}, "mesh CIDR range, accepts multiple CIDRs, required if enable-egress option is true")
 	f.BoolVar(&inst.enableBackpressureExperimental, "enable-backpressure-experimental", false, "Enable experimental backpressure feature")
-	f.BoolVar(&inst.enableMetricsStack, "enable-metrics-stack", true, "Enable metrics (Prometheus and Grafana) deployment")
-	f.BoolVar(&inst.enableGrafana, "enable-grafana", true, "Enable Grafana installation")
+	f.BoolVar(&inst.enablePrometheus, "enable-prometheus", true, "Enable Prometheus installation and deployment")
+	f.BoolVar(&inst.enableGrafana, "enable-grafana", true, "Enable Grafana installation and deployment")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
 	f.BoolVar(&inst.deployJaeger, "deploy-jaeger", true, "Deploy Jaeger in the namespace of the OSM controller")
 
@@ -212,7 +212,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
 		fmt.Sprintf("OpenServiceMesh.enablePermissiveTrafficPolicy=%t", i.enablePermissiveTrafficPolicy),
 		fmt.Sprintf("OpenServiceMesh.enableBackpressureExperimental=%t", i.enableBackpressureExperimental),
-		fmt.Sprintf("OpenServiceMesh.enableMetricsStack=%t", i.enableMetricsStack),
+		fmt.Sprintf("OpenServiceMesh.enablePrometheus=%t", i.enablePrometheus),
 		fmt.Sprintf("OpenServiceMesh.enableGrafana=%t", i.enableGrafana),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
 		fmt.Sprintf("OpenServiceMesh.enableEgress=%t", i.enableEgress),

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Running the install command", func() {
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
 				enableMetricsStack:         true,
-				enableGrafana: 				true,
+				enableGrafana:              true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
 			}
@@ -141,7 +141,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
-						"enableGrafana": 				  true,
+						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -192,7 +192,7 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				enableMetricsStack:         true,
-				enableGrafana: 				true,
+				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -258,7 +258,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
-						"enableGrafana": 				  true,
+						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -316,7 +316,7 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				enableMetricsStack:         true,
-				enableGrafana: 			    true,
+				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -383,7 +383,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
-						"enableGrafana": 				  true,
+						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -483,7 +483,7 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				enableMetricsStack:         true,
-				enableGrafana: 				true,
+				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -550,7 +550,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
-						"enableGrafana": 				  true,
+						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -773,7 +773,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enableMetricsStack:         true,
-			enableGrafana: 				true,
+			enableGrafana:              true,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -821,7 +821,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				"enableEgress":                   true,
 				"meshCIDRRanges":                 testMeshCIDR,
 				"enableMetricsStack":             true,
-				"enableGrafana": 				  true,
+				"enableGrafana":                  true,
 				"deployJaeger":                   false,
 			}}))
 	})
@@ -853,7 +853,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enableMetricsStack:         true,
-			enableGrafana: 				true,
+			enableGrafana:              true,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -901,7 +901,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 				"enableEgress":                   true,
 				"meshCIDRRanges":                 testMeshCIDR,
 				"enableMetricsStack":             true,
-				"enableGrafana": 				  true,
+				"enableGrafana":                  true,
 				"deployJaeger":                   false,
 			}}))
 	})

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Running the install command", func() {
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
 				enableMetricsStack:         true,
+				enableGrafana: 				true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
 			}
@@ -140,6 +141,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
+						"enableGrafana": 				  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -190,6 +192,7 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				enableMetricsStack:         true,
+				enableGrafana: 				true,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -255,6 +258,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
+						"enableGrafana": 				  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -312,6 +316,7 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				enableMetricsStack:         true,
+				enableGrafana: 			    true,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -378,6 +383,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
+						"enableGrafana": 				  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -477,6 +483,7 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				enableMetricsStack:         true,
+				enableGrafana: 				true,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -543,6 +550,7 @@ var _ = Describe("Running the install command", func() {
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
 						"enableMetricsStack":             true,
+						"enableGrafana": 				  true,
 						"deployJaeger":                   false,
 					}}))
 			})
@@ -765,6 +773,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enableMetricsStack:         true,
+			enableGrafana: 				true,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -812,6 +821,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				"enableEgress":                   true,
 				"meshCIDRRanges":                 testMeshCIDR,
 				"enableMetricsStack":             true,
+				"enableGrafana": 				  true,
 				"deployJaeger":                   false,
 			}}))
 	})
@@ -843,6 +853,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enableMetricsStack:         true,
+			enableGrafana: 				true
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -890,6 +901,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 				"enableEgress":                   true,
 				"meshCIDRRanges":                 testMeshCIDR,
 				"enableMetricsStack":             true,
+				"enableGrafana": 				  true,
 				"deployJaeger":                   false,
 			}}))
 	})

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -827,6 +827,157 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 	})
 })
 
+var _ = Describe("Making sure that grafana is disabled when flag is set to false", func() {
+	BeforeEach(func() {
+		installCmd := &installCmd{
+			containerRegistry:          testRegistry,
+			containerRegistrySecret:    testRegistrySecret,
+			certificateManager:         "vault",
+			vaultHost:                  testVaultHost,
+			vaultProtocol:              testVaultProtocol,
+			certmanagerIssuerName:      testCertManagerIssuerName,
+			certmanagerIssuerKind:      testCertManagerIssuerKind,
+			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
+			vaultToken:                 testVaultToken,
+			vaultRole:                  testVaultRole,
+			osmImageTag:                testOsmImageTag,
+			osmImagePullPolicy:         defaultOsmImagePullPolicy,
+			serviceCertValidityMinutes: 1,
+			prometheusRetentionTime:    testRetentionTime,
+			meshName:                   defaultMeshName,
+			enableEgress:               true,
+			meshCIDRRanges:             testMeshCIDRRanges,
+			enablePrometheus:           true,
+			enableGrafana:              false,
+		}
+
+		vals, err = installCmd.resolveValues()
+	})
+
+	It("should not error", func() {
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should resolve correctly", func() {
+		Expect(vals).To(BeEquivalentTo(map[string]interface{}{
+			"OpenServiceMesh": map[string]interface{}{
+				"certificateManager": "vault",
+				"certmanager": map[string]interface{}{
+					"issuerKind":  "ClusterIssuer",
+					"issuerGroup": "example.co.uk",
+					"issuerName":  "my-osm-ca",
+				},
+				"meshName": defaultMeshName,
+				"image": map[string]interface{}{
+					"registry":   testRegistry,
+					"tag":        testOsmImageTag,
+					"pullPolicy": defaultOsmImagePullPolicy,
+				},
+				"imagePullSecrets": []interface{}{
+					map[string]interface{}{
+						"name": testRegistrySecret,
+					},
+				},
+				"serviceCertValidityMinutes": int64(1),
+				"vault": map[string]interface{}{
+					"host":     testVaultHost,
+					"protocol": "http",
+					"token":    testVaultToken,
+					"role":     testVaultRole,
+				},
+				"prometheus": map[string]interface{}{
+					"retention": map[string]interface{}{
+						"time": "5d",
+					},
+				},
+				"enableDebugServer":              false,
+				"enablePermissiveTrafficPolicy":  false,
+				"enableBackpressureExperimental": false,
+				"enableEgress":                   true,
+				"meshCIDRRanges":                 testMeshCIDR,
+				"enablePrometheus":               true,
+				"enableGrafana":                  false,
+				"deployJaeger":                   false,
+			}}))
+	})
+
+})
+
+var _ = Describe("Making sure that prometheus is disabled when flag is set to false", func() {
+	BeforeEach(func() {
+		installCmd := &installCmd{
+			containerRegistry:          testRegistry,
+			containerRegistrySecret:    testRegistrySecret,
+			certificateManager:         "vault",
+			vaultHost:                  testVaultHost,
+			vaultProtocol:              testVaultProtocol,
+			certmanagerIssuerName:      testCertManagerIssuerName,
+			certmanagerIssuerKind:      testCertManagerIssuerKind,
+			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
+			vaultToken:                 testVaultToken,
+			vaultRole:                  testVaultRole,
+			osmImageTag:                testOsmImageTag,
+			osmImagePullPolicy:         defaultOsmImagePullPolicy,
+			serviceCertValidityMinutes: 1,
+			prometheusRetentionTime:    testRetentionTime,
+			meshName:                   defaultMeshName,
+			enableEgress:               true,
+			meshCIDRRanges:             testMeshCIDRRanges,
+			enablePrometheus:           false,
+			enableGrafana:              true,
+		}
+
+		vals, err = installCmd.resolveValues()
+	})
+
+	It("should not error", func() {
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should resolve correctly", func() {
+		Expect(vals).To(BeEquivalentTo(map[string]interface{}{
+			"OpenServiceMesh": map[string]interface{}{
+				"certificateManager": "vault",
+				"certmanager": map[string]interface{}{
+					"issuerKind":  "ClusterIssuer",
+					"issuerGroup": "example.co.uk",
+					"issuerName":  "my-osm-ca",
+				},
+				"meshName": defaultMeshName,
+				"image": map[string]interface{}{
+					"registry":   testRegistry,
+					"tag":        testOsmImageTag,
+					"pullPolicy": defaultOsmImagePullPolicy,
+				},
+				"imagePullSecrets": []interface{}{
+					map[string]interface{}{
+						"name": testRegistrySecret,
+					},
+				},
+				"serviceCertValidityMinutes": int64(1),
+				"vault": map[string]interface{}{
+					"host":     testVaultHost,
+					"protocol": "http",
+					"token":    testVaultToken,
+					"role":     testVaultRole,
+				},
+				"prometheus": map[string]interface{}{
+					"retention": map[string]interface{}{
+						"time": "5d",
+					},
+				},
+				"enableDebugServer":              false,
+				"enablePermissiveTrafficPolicy":  false,
+				"enableBackpressureExperimental": false,
+				"enableEgress":                   true,
+				"meshCIDRRanges":                 testMeshCIDR,
+				"enablePrometheus":               false,
+				"enableGrafana":                  true,
+				"deployJaeger":                   false,
+			}}))
+	})
+})
+
 var _ = Describe("Resolving values for install command with cert-manager parameters", func() {
 	var (
 		vals map[string]interface{}

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -827,7 +827,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 	})
 })
 
-var _ = Describe("Making sure that grafana is disabled when flag is set to false", func() {
+var _ = Describe("Ensure that grafana is disabled when flag is set to false", func() {
 	var (
 		vals map[string]interface{}
 		err  error
@@ -908,7 +908,7 @@ var _ = Describe("Making sure that grafana is disabled when flag is set to false
 
 })
 
-var _ = Describe("Making sure that prometheus is disabled when flag is set to false", func() {
+var _ = Describe("Ensure that prometheus is disabled when flag is set to false", func() {
 	var (
 		vals map[string]interface{}
 		err  error

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -828,6 +828,11 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 })
 
 var _ = Describe("Making sure that grafana is disabled when flag is set to false", func() {
+	var (
+		vals map[string]interface{}
+		err  error
+	)
+
 	BeforeEach(func() {
 		installCmd := &installCmd{
 			containerRegistry:          testRegistry,
@@ -904,6 +909,11 @@ var _ = Describe("Making sure that grafana is disabled when flag is set to false
 })
 
 var _ = Describe("Making sure that prometheus is disabled when flag is set to false", func() {
+	var (
+		vals map[string]interface{}
+		err  error
+	)
+
 	BeforeEach(func() {
 		installCmd := &installCmd{
 			containerRegistry:          testRegistry,

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -853,7 +853,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enableMetricsStack:         true,
-			enableGrafana: 				true
+			enableGrafana: 				true,
 		}
 
 		vals, err = installCmd.resolveValues()

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
-				enableMetricsStack:         true,
+				enablePrometheus:           true,
 				enableGrafana:              true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
@@ -140,7 +140,7 @@ var _ = Describe("Running the install command", func() {
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
-						"enableMetricsStack":             true,
+						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
@@ -191,7 +191,7 @@ var _ = Describe("Running the install command", func() {
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
-				enableMetricsStack:         true,
+				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
 			}
@@ -257,7 +257,7 @@ var _ = Describe("Running the install command", func() {
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
-						"enableMetricsStack":             true,
+						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
@@ -315,7 +315,7 @@ var _ = Describe("Running the install command", func() {
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
-				enableMetricsStack:         true,
+				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
 			}
@@ -382,7 +382,7 @@ var _ = Describe("Running the install command", func() {
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
-						"enableMetricsStack":             true,
+						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
@@ -482,7 +482,7 @@ var _ = Describe("Running the install command", func() {
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
 				meshCIDRRanges:             testMeshCIDRRanges,
-				enableMetricsStack:         true,
+				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
 			}
@@ -549,7 +549,7 @@ var _ = Describe("Running the install command", func() {
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
 						"meshCIDRRanges":                 testMeshCIDR,
-						"enableMetricsStack":             true,
+						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
 					}}))
@@ -772,7 +772,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
-			enableMetricsStack:         true,
+			enablePrometheus:           true,
 			enableGrafana:              true,
 		}
 
@@ -820,7 +820,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
 				"meshCIDRRanges":                 testMeshCIDR,
-				"enableMetricsStack":             true,
+				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
 			}}))
@@ -852,7 +852,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
 			meshCIDRRanges:             testMeshCIDRRanges,
-			enableMetricsStack:         true,
+			enablePrometheus:           true,
 			enableGrafana:              true,
 		}
 
@@ -900,7 +900,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
 				"meshCIDRRanges":                 testMeshCIDR,
-				"enableMetricsStack":             true,
+				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
 			}}))


### PR DESCRIPTION
Remove the "enableMetricStack" flag for the OSM install command. Replace with two separate flags, enable-grafana and enable-prometheus to decouple installation of Grafana and Prometheus

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
