### PR TITLE
ref(ci): Use default KUBECONFIG handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: Always
 # export IMAGE_PULL_POLICY=Always
 
-# optional: Path to your Kubernetes config file present locally. Required if not using in-cluster config.
+# optional: Path to your Kubernetes config file present locally.
 # export KUBECONFIG=~/.kube/config
 
 # optional: Enable human readable logs on the console

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ on:
       - "docs/**"
       - "**.md"
 env:
-  KUBECONFIG: ".kube/config"
   CI_WAIT_FOR_OK_SECONDS: 120
   CI_MAX_ITERATIONS_THRESHOLD: 120
   CI_CLIENT_CONCURRENT_CONNECTIONS: 1

--- a/ci/cmd/maestro/types.go
+++ b/ci/cmd/maestro/types.go
@@ -20,9 +20,6 @@ const (
 	// TestsTimedOut is used for tests that timed out.
 	TestsTimedOut
 
-	// KubeConfigEnvVar is the environment variable for KUBECONFIG.
-	KubeConfigEnvVar = "KUBECONFIG"
-
 	// OSMNamespaceEnvVar is the environment variable for the OSM namespace.
 	OSMNamespaceEnvVar = "K8S_NAMESPACE"
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -51,7 +51,7 @@ To see the results of deploying the services and the service mesh - run the tail
   - the scripts will connect to the respective Kubernetes Pod and stream its logs
   - the output will be the output of the curl command to the `bookstore` service and the count of books sold, and the output of the curl command to `github.com` to demonstrate access to an external service
   - a properly working service mesh will result in HTTP 200 OK response code for the `bookstore` service with `./demo/tail-bookbuyer.sh` along with a monotonically increasing counter appearing in the response headers, while `./demo/tail-bookthief.sh` will result in HTTP 404 Not Found response code for the `bookstore` service. When egress is enabled, HTTP requests to an out-of-mesh host will result in a HTTP `200 OK` response code for both the `bookbuyer` and `bookthief` services.
-  This can be automatically checked with `KUBECONFIG=$HOME/.kube/config go run ./ci/cmd/maestro.go`
+  This can be automatically checked with `go run ./ci/cmd/maestro.go`
 
 ## View Mesh Topology with Jaeger
 The OSM demo will install a Jaeger pod, and configure all participating Envoys to send spans to it. Jaeger's UI is running on port 16686. To view the web UI, forward port 16686 from the Jaeger pod to the local workstation and navigate to http://localhost:16686/. In the `./scripts` directory we have included a helper script to find the Jaeger pod and forward the port: `./scripts/port-forward-jaeger.sh`

--- a/demo/cmd/common/const.go
+++ b/demo/cmd/common/const.go
@@ -7,9 +7,6 @@ const (
 	// Failure is the string constant emitted at the end of the Bookbuyer/Bookthief logs when the test failed.
 	Failure = "MAESTRO, WE HAVE A PROBLEM! THIS TEST FAILED!"
 
-	// KubeConfigEnvVar is the environment variable holding path to kube config
-	KubeConfigEnvVar = "KUBECONFIG"
-
 	// KubeNamespaceEnvVar is the environment variable with the k8s namespace
 	KubeNamespaceEnvVar = "K8S_NAMESPACE"
 


### PR DESCRIPTION
The clientcmd package in k8s.io/client-go provides helpers for getting a
kube config that automatically check in-cluster first and fallback to
out-of-cluster and handle parsing and merging files listed in the
`$KUBECONFIG` variable to match the behavior of `kubectl`. This change
eliminates the need to explicitly define `$KUBECONFIG` for the maestro
when the file is in the default location.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No