### PR TITLE
smi/client: add API to fetch TCP routes

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -36,7 +36,7 @@ rules:
     resources: ["traffictargets"]
     verbs: ["list", "get", "watch"]
   - apiGroups: ["specs.smi-spec.io"]
-    resources: ["httproutegroups"]
+    resources: ["httproutegroups", "tcproutes"]
     verbs: ["list", "get", "watch"]
 
   # Backpressure is an experimental extension of SMI.

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -70,6 +70,7 @@ func (c *Client) run(stop <-chan struct{}) error {
 		"TrafficSplit":   c.informers.TrafficSplit,
 		"Services":       c.informers.Services,
 		"HTTPRouteGroup": c.informers.HTTPRouteGroup,
+		"TCPRoute":       c.informers.TCPRoute,
 		"TrafficTarget":  c.informers.TrafficTarget,
 	}
 
@@ -117,6 +118,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		Services:       informerFactory.Core().V1().Services().Informer(),
 		TrafficSplit:   smiTrafficSplitInformerFactory.Split().V1alpha2().TrafficSplits().Informer(),
 		HTTPRouteGroup: smiTrafficSpecInformerFactory.Specs().V1alpha3().HTTPRouteGroups().Informer(),
+		TCPRoute:       smiTrafficSpecInformerFactory.Specs().V1alpha3().TCPRoutes().Informer(),
 		TrafficTarget:  smiTrafficTargetInformerFactory.Access().V1alpha2().TrafficTargets().Informer(),
 	}
 
@@ -124,6 +126,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		Services:       informerCollection.Services.GetStore(),
 		TrafficSplit:   informerCollection.TrafficSplit.GetStore(),
 		HTTPRouteGroup: informerCollection.HTTPRouteGroup.GetStore(),
+		TCPRoute:       informerCollection.TCPRoute.GetStore(),
 		TrafficTarget:  informerCollection.TrafficTarget.GetStore(),
 	}
 
@@ -150,6 +153,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 	informerCollection.Services.AddEventHandler(k8s.GetKubernetesEventHandlers("Services", "SMI", client.announcements, shouldObserve))
 	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", client.announcements, shouldObserve))
 	informerCollection.HTTPRouteGroup.AddEventHandler(k8s.GetKubernetesEventHandlers("HTTPRouteGroup", "SMI", client.announcements, shouldObserve))
+	informerCollection.TCPRoute.AddEventHandler(k8s.GetKubernetesEventHandlers("TCPRoute", "SMI", client.announcements, shouldObserve))
 	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", client.announcements, shouldObserve))
 
 	if featureflags.IsBackpressureEnabled() {
@@ -190,6 +194,20 @@ func (c *Client) ListHTTPTrafficSpecs() []*smiSpecs.HTTPRouteGroup {
 		httpTrafficSpec = append(httpTrafficSpec, routeGroup)
 	}
 	return httpTrafficSpec
+}
+
+// ListTCPTrafficSpecs lists SMI TCPRoute resources
+func (c *Client) ListTCPTrafficSpecs() []*smiSpecs.TCPRoute {
+	var tcpRouteSpec []*smiSpecs.TCPRoute
+	for _, specIface := range c.caches.TCPRoute.List() {
+		tcpRoute := specIface.(*smiSpecs.TCPRoute)
+
+		if !c.namespaceController.IsMonitoredNamespace(tcpRoute.Namespace) {
+			continue
+		}
+		tcpRouteSpec = append(tcpRouteSpec, tcpRoute)
+	}
+	return tcpRouteSpec
 }
 
 // ListTrafficTargets implements mesh.Topology by returning the list of traffic targets.

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -13,7 +13,8 @@ import (
 
 type fakeMeshSpec struct {
 	trafficSplits    []*split.TrafficSplit
-	routeGroups      []*spec.HTTPRouteGroup
+	httpRouteGroups  []*spec.HTTPRouteGroup
+	tcpRoutes        []*spec.TCPRoute
 	trafficTargets   []*target.TrafficTarget
 	backpressures    []*backpressure.Backpressure
 	weightedServices []service.WeightedService
@@ -25,7 +26,8 @@ type fakeMeshSpec struct {
 func NewFakeMeshSpecClient() MeshSpec {
 	return fakeMeshSpec{
 		trafficSplits:    []*split.TrafficSplit{&tests.TrafficSplit},
-		routeGroups:      []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
+		httpRouteGroups:  []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
+		tcpRoutes:        []*spec.TCPRoute{&tests.TCPRoute},
 		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
 		weightedServices: []service.WeightedService{tests.WeightedService},
 		serviceAccounts: []service.K8sServiceAccount{
@@ -69,7 +71,12 @@ func (f fakeMeshSpec) GetService(svc service.MeshService) *corev1.Service {
 
 // ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 func (f fakeMeshSpec) ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup {
-	return f.routeGroups
+	return f.httpRouteGroups
+}
+
+// ListTCPTrafficSpecs lists SMI TCPRoute resources
+func (f fakeMeshSpec) ListTCPTrafficSpecs() []*spec.TCPRoute {
+	return f.tcpRoutes
 }
 
 // ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -23,6 +23,7 @@ type InformerCollection struct {
 	Services       cache.SharedIndexInformer
 	TrafficSplit   cache.SharedIndexInformer
 	HTTPRouteGroup cache.SharedIndexInformer
+	TCPRoute       cache.SharedIndexInformer
 	TrafficTarget  cache.SharedIndexInformer
 	Backpressure   cache.SharedIndexInformer
 }
@@ -32,6 +33,7 @@ type CacheCollection struct {
 	Services       cache.Store
 	TrafficSplit   cache.Store
 	HTTPRouteGroup cache.Store
+	TCPRoute       cache.Store
 	TrafficTarget  cache.Store
 	Backpressure   cache.Store
 }
@@ -66,6 +68,9 @@ type MeshSpec interface {
 
 	// ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup
+
+	// ListTCPTrafficSpecs lists SMI TCPRoute resources
+	ListTCPTrafficSpecs() []*spec.TCPRoute
 
 	// ListTrafficTargets lists SMI TrafficTarget resources
 	ListTrafficTargets() []*target.TrafficTarget

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -271,6 +271,19 @@ var (
 		},
 	}
 
+	// TCPRoute is a TCPRoute SMI resource
+	TCPRoute = spec.TCPRoute{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "specs.smi-spec.io/v1alpha2",
+			Kind:       "TCPRoute",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "default",
+			Name:      "tcp-route",
+		},
+		Spec: spec.TCPRouteSpec{},
+	}
+
 	// Backpressure is an experimental Backpressure policy.
 	// This will be replaced by an SMI Spec when it is ready.
 	Backpressure = backpressure.Backpressure{


### PR DESCRIPTION
Adds the informer, cache, and an API to retrieve the
TCP routes.

Part of #1521

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`