### PR TITLE
ref(meshspec): Return error when client fails to run

### DIFF
--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -162,7 +162,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 
 	err := client.run(stop)
 	if err != nil {
-		return &client, errors.Errorf("Could not start %s client", kubernetesClientName)
+		return &client, errors.Errorf("Could not start %s client: %s", kubernetesClientName, err)
 	}
 
 	return &client, err


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough
information so that others can review it.

Return error when client.run() fails
Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No