### PR TITLE
Set envoy log level as error to default in OSM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,10 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # optional: Whether to deploy traffic split policy or not
 # Default: true
 # export DEPLOY_TRAFFIC_SPLIT=true
+
+# optional: specify the log level for the enovy's
+# Default: debug
+# export ENVOY_LOG_LEVEL=debug
 #--------------------------------------
 
 ### The section below configures certificates management

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -19,7 +19,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.enableEgress | bool | `false` |  |
 | OpenServiceMesh.enableMetricsStack | bool | `true` |  |
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` |  |
-| OpenServiceMesh.envoyLogLevel | string | `"debug"` |  |
+| OpenServiceMesh.envoyLogLevel | string | `"error"` |  |
 | OpenServiceMesh.grafana.port | int | `3000` |  |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` |  |
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` |  |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -37,7 +37,7 @@ OpenServiceMesh:
   meshName: osm
   meshCIDRRanges: 0.0.0.0/0
   useHTTPSIngress: false
-  envoyLogLevel: debug
+  envoyLogLevel: error
 
   # Set deployJaeger to true to deploy a Jaeger cluster in the
   # namespace where OSM resides.

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -81,6 +81,7 @@ type installCmd struct {
 	vaultProtocol                 string
 	vaultToken                    string
 	vaultRole                     string
+	envoyLogLevel                 string
 	serviceCertValidityMinutes    int
 	enableDebugServer             bool
 	enableEgress                  bool
@@ -152,6 +153,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableGrafana, "enable-grafana", false, "Enable Grafana installation and deployment")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
 	f.BoolVar(&inst.deployJaeger, "deploy-jaeger", true, "Deploy Jaeger in the namespace of the OSM controller")
+	f.StringVar(&inst.envoyLogLevel, "envoy-log-level", "error", "Envoy log level is used to specify the level of logs collected from envoy")
 
 	return cmd
 }
@@ -218,6 +220,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableEgress=%t", i.enableEgress),
 		fmt.Sprintf("OpenServiceMesh.meshCIDRRanges=%s", strings.Join(i.meshCIDRRanges, " ")),
 		fmt.Sprintf("OpenServiceMesh.deployJaeger=%t", i.deployJaeger),
+		fmt.Sprintf("OpenServiceMesh.envoyLogLevel=%s", i.envoyLogLevel),
 	}
 
 	if i.containerRegistrySecret != "" {

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -308,7 +308,7 @@ func isValidEnvoyLogLevel(envoyLogLevel string) error {
 			return nil
 		}
 	}
-	return errors.Errorf("Invalid envoy log level.\n A valid envoy log level must be one from the following : trace, debug, info, warning, warn, error, critical, off")
+	return errors.Errorf("Invalid envoy log level.\n A valid envoy log level must be one from the following : %v", allowedLogLevels)
 }
 
 func isValidMeshName(meshName string) error {

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -302,6 +302,7 @@ func (i *installCmd) validateOptions() error {
 }
 
 func isValidEnvoyLogLevel(envoyLogLevel string) error {
+	// allowedLogLevels referenced from : https://github.com/envoyproxy/envoy/blob/release/v1.15/test/server/options_impl_test.cc#L373
 	allowedLogLevels := []string{"trace", "debug", "info", "warning", "warn", "error", "critical", "off"}
 	for _, logLevel := range allowedLogLevels {
 		if strings.EqualFold(envoyLogLevel, logLevel) {

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -36,6 +36,7 @@ var (
 	testRetentionTime          = "5d"
 	testMeshCIDR               = "10.20.0.0/16"
 	testMeshCIDRRanges         = []string{testMeshCIDR}
+	testEnvoyLogLevel          = "error"
 )
 
 var _ = Describe("Running the install command", func() {
@@ -82,6 +83,7 @@ var _ = Describe("Running the install command", func() {
 				enableGrafana:              true,
 				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
+				envoyLogLevel:              testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -143,6 +145,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
+						"envoyLogLevel":                  testEnvoyLogLevel,
 					}}))
 			})
 
@@ -194,6 +197,7 @@ var _ = Describe("Running the install command", func() {
 				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
+				envoyLogLevel:              testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -260,6 +264,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
+						"envoyLogLevel":                  testEnvoyLogLevel,
 					}}))
 			})
 
@@ -318,6 +323,7 @@ var _ = Describe("Running the install command", func() {
 				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
+				envoyLogLevel:              testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -385,6 +391,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
+						"envoyLogLevel":                  testEnvoyLogLevel,
 					}}))
 			})
 
@@ -485,6 +492,7 @@ var _ = Describe("Running the install command", func() {
 				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
+				envoyLogLevel:              testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -552,6 +560,7 @@ var _ = Describe("Running the install command", func() {
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
+						"envoyLogLevel":                  testEnvoyLogLevel,
 					}}))
 			})
 
@@ -774,6 +783,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              true,
+			envoyLogLevel:              testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -823,6 +833,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
+				"envoyLogLevel":                  testEnvoyLogLevel,
 			}}))
 	})
 })
@@ -854,6 +865,7 @@ var _ = Describe("Ensure that grafana is disabled when flag is set to false", fu
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              false,
+			envoyLogLevel:              testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -903,6 +915,7 @@ var _ = Describe("Ensure that grafana is disabled when flag is set to false", fu
 				"enablePrometheus":               true,
 				"enableGrafana":                  false,
 				"deployJaeger":                   false,
+				"envoyLogLevel":                  testEnvoyLogLevel,
 			}}))
 	})
 
@@ -1016,6 +1029,7 @@ var _ = Describe("Ensure that prometheus is disabled when flag is set to false",
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           false,
 			enableGrafana:              true,
+			envoyLogLevel:              testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -1065,6 +1079,7 @@ var _ = Describe("Ensure that prometheus is disabled when flag is set to false",
 				"enablePrometheus":               false,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
+				"envoyLogLevel":                  testEnvoyLogLevel,
 			}}))
 	})
 })
@@ -1096,6 +1111,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              true,
+			envoyLogLevel:              testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -1145,6 +1161,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
+				"envoyLogLevel":                  testEnvoyLogLevel,
 			}}))
 	})
 })

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -948,6 +948,7 @@ var _ = Describe("Ensure that grafana is enabled when flag is set to true", func
 			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              true,
+			envoyLogLevel:              testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -997,6 +998,7 @@ var _ = Describe("Ensure that grafana is enabled when flag is set to true", func
 				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
+				"envoyLogLevel":                  testEnvoyLogLevel,
 			}}))
 	})
 

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -1233,6 +1233,43 @@ var _ = Describe("Test mesh CIDR ranges", func() {
 	})
 })
 
+var _ = Describe("Test envoy log level types", func() {
+	Context("Test envoyLogLevel chart value with install cli option", func() {
+		It("Should correctly resolve envoyLogLevel when specified", func() {
+			installCmd := &installCmd{
+				envoyLogLevel: testEnvoyLogLevel,
+			}
+
+			vals, err := installCmd.resolveValues()
+			Expect(err).NotTo(HaveOccurred())
+
+			logLevel := vals["OpenServiceMesh"].(map[string]interface{})["envoyLogLevel"]
+			Expect(logLevel).To(Equal(testEnvoyLogLevel))
+		})
+	})
+
+	Context("Test isValidEnvoyLogLevel", func() {
+		It("Should validate if the specified envoy log level is supported", func() {
+			err := isValidEnvoyLogLevel("error")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = isValidEnvoyLogLevel("off")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = isValidEnvoyLogLevel("warn")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should correctly error for invalid envoy log level", func() {
+			err := isValidEnvoyLogLevel("tracing")
+			Expect(err).To(HaveOccurred())
+
+			err = isValidEnvoyLogLevel("warns")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
 var _ = Describe("Test osm image pull policy cli option", func() {
 	It("Should correctly resolve the pull policy option to chart values", func() {
 		installCmd := &installCmd{

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -31,6 +31,7 @@ ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
 ENABLE_GRAFANA="${ENABLE_GRAFANA:-false}"
 MESH_CIDR=$(./scripts/get_mesh_cidr.sh)
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
+ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*
@@ -115,6 +116,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
       --mesh-cidr "$MESH_CIDR" \
+      --envoy-log-level "$ENVOY_LOG_LEVEL" \
       $optionalInstallArgs
 else
   # shellcheck disable=SC2086
@@ -130,6 +132,7 @@ else
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
       --mesh-cidr "$MESH_CIDR" \
+      --envoy-log-level "$ENVOY_LOG_LEVEL" \
       $optionalInstallArgs
 fi
 

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -13,14 +13,14 @@ import (
 
 var _ = Describe("Test Envoy configuration creation", func() {
 	testCIDRRanges := "10.2.0.0/16 10.0.0.0/16"
-	testDebugEnvoyLogLevel := "debug"
+	testErrorEnvoyLogLevel := "error"
 	defaultConfigMap := map[string]string{
 		permissiveTrafficPolicyModeKey: "false",
 		egressKey:                      "true",
 		meshCIDRRangesKey:              testCIDRRanges,
 		prometheusScrapingKey:          "true",
 		tracingEnableKey:               "true",
-		envoyLogLevel:                  testDebugEnvoyLogLevel,
+		envoyLogLevel:                  testErrorEnvoyLogLevel,
 	}
 
 	Context("create OSM configurator client", func() {
@@ -61,7 +61,7 @@ var _ = Describe("Test Envoy configuration creation", func() {
 				PrometheusScraping:          true,
 				TracingEnable:               true,
 				MeshCIDRRanges:              testCIDRRanges,
-				EnvoyLogLevel:               testDebugEnvoyLogLevel,
+				EnvoyLogLevel:               testErrorEnvoyLogLevel,
 			}
 			expectedConfigBytes, err := marshalConfigToJSON(expectedConfig)
 			Expect(err).ToNot(HaveOccurred())
@@ -315,11 +315,11 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		osmNamespace := "-test-osm-namespace-"
 		osmConfigMapName := "-test-osm-config-map-"
 		testInfoEnvoyLogLevel := "info"
-		testErrorEnvoyLogLevel := "error"
+		testDebugEnvoyLogLevel := "debug"
 		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-		It("correctly identifies that the Envoy log level is debug", func() {
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testDebugEnvoyLogLevel))
+		It("correctly identifies that the Envoy log level is error", func() {
+			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testErrorEnvoyLogLevel))
 			configMap := v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,
@@ -337,7 +337,7 @@ var _ = Describe("Test Envoy configuration creation", func() {
 			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testDebugEnvoyLogLevel))
+			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testErrorEnvoyLogLevel))
 		})
 
 		It("correctly identifies that Envoy log level is info", func() {
@@ -362,8 +362,8 @@ var _ = Describe("Test Envoy configuration creation", func() {
 			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testInfoEnvoyLogLevel))
 		})
 
-		It("correctly identifies that Envoy log level is error", func() {
-			defaultConfigMap[envoyLogLevel] = testErrorEnvoyLogLevel
+		It("correctly identifies that Envoy log level is debug", func() {
+			defaultConfigMap[envoyLogLevel] = testDebugEnvoyLogLevel
 			configMap := v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,
@@ -381,7 +381,7 @@ var _ = Describe("Test Envoy configuration creation", func() {
 			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testErrorEnvoyLogLevel))
+			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testDebugEnvoyLogLevel))
 		})
 	})
 })

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -58,7 +58,7 @@ const (
 	DefaultTracingPort = uint32(9411)
 
 	// DefaultEnvoyLogLevel is the default envoy log level if not defined in the osm configmap
-	DefaultEnvoyLogLevel = "debug"
+	DefaultEnvoyLogLevel = "error"
 
 	// EnvoyPrometheusInboundListenerPort is Envoy's inbound listener port number for prometheus
 	EnvoyPrometheusInboundListenerPort = 15010


### PR DESCRIPTION
This PR : 
- sets the default value of the log level for the envoy to `error` when OSM is installed
- exposes `envoy-log-level` as an install feature flag so that the demo and cli can run in the debug mode for envoy
- updates the demo and .env file to have the log level as debug 

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no. 

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
