### PR TITLE
Resolve ambiguity between webhook config and webhook name

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -32,7 +32,7 @@ spec:
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--init-container-image", "{{.Values.OpenServiceMesh.image.registry}}/init:{{ .Values.OpenServiceMesh.image.tag }}",
             "--sidecar-image", "{{.Values.OpenServiceMesh.sidecarImage}}",
-            "--webhook-name", "osm-webhook-{{.Values.OpenServiceMesh.meshName}}",
+            "--webhook-config-name", "osm-webhook-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",

--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -119,8 +119,8 @@ func main() {
 	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed {
 		log.Info().Msg("Test succeeded")
 		maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
-		webhookName := fmt.Sprintf("osm-webhook-%s", meshName)
-		maestro.DeleteWebhook(kubeClient, webhookName)
+		webhookConfigName := fmt.Sprintf("osm-webhook-%s", meshName)
+		maestro.DeleteWebhookConfiguration(kubeClient, webhookConfigName)
 		os.Exit(0)
 	}
 

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -49,7 +49,7 @@ var (
 	meshName                   string // An ID that uniquely identifies an OSM instance
 	kubeConfigFile             string
 	osmNamespace               string
-	webhookName                string
+	webhookConfigName          string
 	serviceCertValidityMinutes int
 	caBundleSecretName         string
 	enableDebugServer          bool
@@ -86,7 +86,7 @@ func init() {
 	flags.StringVar(&meshName, "mesh-name", "", "OSM mesh name")
 	flags.StringVar(&kubeConfigFile, "kubeconfig", "", "Path to Kubernetes config file.")
 	flags.StringVar(&osmNamespace, "osm-namespace", "", "Namespace to which OSM belongs to.")
-	flags.StringVar(&webhookName, "webhook-name", "", "Name of the MutatingWebhookConfiguration to be configured by osm-controller")
+	flags.StringVar(&webhookConfigName, "webhook-config-name", "", "Name of the MutatingWebhookConfiguration to be configured by osm-controller")
 	flags.IntVar(&serviceCertValidityMinutes, "service-cert-validity-minutes", defaultServiceCertValidityMinutes, "Certificate validityPeriod duration in minutes")
 	flags.StringVar(&caBundleSecretName, caBundleSecretNameCLIParam, "", "Name of the Kubernetes Secret for the OSM CA bundle")
 	flags.BoolVar(&enableDebugServer, "enable-debug-server", false, "Enable OSM debug HTTP server")
@@ -184,7 +184,7 @@ func main() {
 		endpointsProviders...)
 
 	// Create the sidecar-injector webhook
-	if err := injector.NewWebhook(injectorConfig, kubeClient, certManager, meshCatalog, kubernetesClient, meshName, osmNamespace, webhookName, stop, cfg); err != nil {
+	if err := injector.NewWebhook(injectorConfig, kubeClient, certManager, meshCatalog, kubernetesClient, meshName, osmNamespace, webhookConfigName, stop, cfg); err != nil {
 		log.Fatal().Err(err).Msg("Error creating mutating webhook")
 	}
 

--- a/cmd/osm-controller/validate.go
+++ b/cmd/osm-controller/validate.go
@@ -28,8 +28,8 @@ func validateCLIParams() error {
 		return errors.Errorf("Please specify the sidecar image using --sidecar-image")
 	}
 
-	if webhookName == "" {
-		return errors.Errorf("Invalid --webhook-name value: '%s'", webhookName)
+	if webhookConfigName == "" {
+		return errors.Errorf("Invalid --webhook-config-name value: '%s'", webhookConfigName)
 	}
 
 	return nil

--- a/cmd/osm-controller/validate_test.go
+++ b/cmd/osm-controller/validate_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		testOsmNamespace       = "test-namespace"
 		testInitContainerImage = "test-init-image"
 		testSidecarImage       = "test-sidecar-image"
-		testWebhookName        = "test-webhook-name"
+		testwebhookConfigName  = "test-webhook-name"
 	)
 
 	Context("none of the necessary CLI params are empty", func() {
@@ -114,7 +114,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			InitContainerImage: testInitContainerImage,
 			SidecarImage:       testSidecarImage,
 		}
-		webhookName = testWebhookName
+		webhookConfigName = testwebhookConfigName
 
 		err := validateCLIParams()
 
@@ -130,7 +130,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			InitContainerImage: testInitContainerImage,
 			SidecarImage:       testSidecarImage,
 		}
-		webhookName = testWebhookName
+		webhookConfigName = testwebhookConfigName
 
 		err := validateCLIParams()
 
@@ -146,7 +146,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			InitContainerImage: testInitContainerImage,
 			SidecarImage:       testSidecarImage,
 		}
-		webhookName = testWebhookName
+		webhookConfigName = testwebhookConfigName
 
 		err := validateCLIParams()
 
@@ -162,7 +162,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			InitContainerImage: "",
 			SidecarImage:       testSidecarImage,
 		}
-		webhookName = testWebhookName
+		webhookConfigName = testwebhookConfigName
 
 		err := validateCLIParams()
 
@@ -178,7 +178,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			InitContainerImage: testInitContainerImage,
 			SidecarImage:       "",
 		}
-		webhookName = testWebhookName
+		webhookConfigName = testwebhookConfigName
 
 		err := validateCLIParams()
 
@@ -186,7 +186,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Context("webhookName is empty", func() {
+	Context("webhookConfigName is empty", func() {
 		*osmCertificateManagerKind = tresorKind
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
@@ -194,7 +194,7 @@ var _ = Describe("Test validateCLIParams", func() {
 			InitContainerImage: testInitContainerImage,
 			SidecarImage:       testSidecarImage,
 		}
-		webhookName = ""
+		webhookConfigName = ""
 
 		err := validateCLIParams()
 


### PR DESCRIPTION
Currently the code uses the term 'webhook name' or the variable
'webhookName' when in fact it is referring to the
mutatingwebhookconfiguration name. This is confusing because
the mutatingwebhookconfiguration has a webhook with a name, and
it would be easy to confuse the two.

This change resolves this ambiguity. Commit 03e00587 removed
part of this ambiguity by renaming the the variable used
to represent the name of the webhook.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
