### PR TITLE
Move pprof endpoints in debugger pkg

### DIFF
--- a/docs/development_guide.md
+++ b/docs/development_guide.md
@@ -241,7 +241,10 @@ OSM control plane exposes an HTTP server able to serve a number of resources.
 
 For mesh visibility and debugabbility, one can refer to the endpoints provided under [pkg/debugger](https://github.com/openservicemesh/osm/tree/main/pkg/debugger) which contains a number of endpoints able to inspect and list most of the common structures used by the control plane at runtime.
 
-Additionally, OSM imports and hooks [pprof endpoints](https://golang.org/pkg/net/http/pprof/). Pprof is a golang package able to provide profiling information at runtime through HTTP protocol to a connecting client.
+Additionally, the current implementation of the debugger imports and hooks [pprof endpoints](https://golang.org/pkg/net/http/pprof/).
+Pprof is a golang package able to provide profiling information at runtime through HTTP protocol to a connecting client.
+
+Debugging endpoints can be turned on or off through the runtime argument `enable-debug-server`, normally set on the deployment at install time through the CLI.
 
 Example usage:
 ```

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -2,6 +2,7 @@ package debugger
 
 import (
 	"net/http"
+	"net/http/pprof"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -18,6 +19,12 @@ func (ds debugServer) GetHandlers() map[string]http.Handler {
 		"/debug/policies":   ds.getSMIPoliciesHandler(),
 		"/debug/config":     ds.getOSMConfigHandler(),
 		"/debug/namespaces": ds.getMonitoredNamespacesHandler(),
+		// Pprof handlers
+		"/debug/pprof/":        http.HandlerFunc(pprof.Index),
+		"/debug/pprof/cmdline": http.HandlerFunc(pprof.Cmdline),
+		"/debug/pprof/profile": http.HandlerFunc(pprof.Profile),
+		"/debug/pprof/symbol":  http.HandlerFunc(pprof.Symbol),
+		"/debug/pprof/trace":   http.HandlerFunc(pprof.Trace),
 	}
 
 	// provides an index of the available /debug endpoints

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/http/pprof"
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/debugger"
@@ -45,12 +44,6 @@ func NewHTTPServer(probes []health.Probes, httpProbes []health.HTTPProbe, metric
 		"/health/alive": health.LivenessHandler(probes, httpProbes),
 		"/metrics":      metricStore.Handler(),
 		"/version":      getVersionHandler(),
-		// Pprof handlers
-		"/debug/pprof/":        http.HandlerFunc(pprof.Index),
-		"/debug/pprof/cmdline": http.HandlerFunc(pprof.Cmdline),
-		"/debug/pprof/profile": http.HandlerFunc(pprof.Profile),
-		"/debug/pprof/symbol":  http.HandlerFunc(pprof.Symbol),
-		"/debug/pprof/trace":   http.HandlerFunc(pprof.Trace),
 	}
 
 	if debugServer != nil {


### PR DESCRIPTION
The http server was not a proper place.

- Other                  [X]
- Debugging          [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No