### PR TITLE
cmd/certificate: handle error scenarios when fetching secret

### DIFF
--- a/cmd/osm-controller/certificates_test.go
+++ b/cmd/osm-controller/certificates_test.go
@@ -44,7 +44,8 @@ var _ = Describe("Test CMD tools", func() {
 			_, err := kubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, v1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			actual := getCertFromKubernetes(kubeClient, ns, secretName)
+			actual, err := getCertFromKubernetes(kubeClient, ns, secretName)
+			Expect(err).ToNot(HaveOccurred())
 
 			expectedCert := pem.Certificate(certPEM)
 			expectedKey := pem.PrivateKey(keyPEM)
@@ -55,6 +56,99 @@ var _ = Describe("Test CMD tools", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(actual).To(Equal(expected))
+		})
+
+		It("should not error when the root certificate secret is not found", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			rootCert, err := getCertFromKubernetes(kubeClient, ns, secretName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rootCert).To(BeNil())
+		})
+
+		It("should return an error when the root cert CA is missing in the secret", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			keyPEM := []byte(uuid.New().String())
+
+			secret := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					constants.KubernetesOpaqueSecretCAExpiration:      []byte("2020-05-07T14:25:18.677Z"),
+					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
+				},
+			}
+
+			_, err := kubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, v1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			rootCert, err := getCertFromKubernetes(kubeClient, ns, secretName)
+			Expect(err).To(HaveOccurred())
+			Expect(rootCert).To(BeNil())
+		})
+
+		It("should return an error when the root cert private key is missing in the secret", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			certPEM := []byte(uuid.New().String())
+
+			secret := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					constants.KubernetesOpaqueSecretCAKey:        certPEM,
+					constants.KubernetesOpaqueSecretCAExpiration: []byte("2020-05-07T14:25:18.677Z"),
+				},
+			}
+
+			_, err := kubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, v1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			rootCert, err := getCertFromKubernetes(kubeClient, ns, secretName)
+			Expect(err).To(HaveOccurred())
+			Expect(rootCert).To(BeNil())
+		})
+
+		It("should return an error when the root cert expiration time is missing in the secret", func() {
+			kubeClient := testclient.NewSimpleClientset()
+
+			ns := uuid.New().String()
+			secretName := uuid.New().String()
+
+			certPEM := []byte(uuid.New().String())
+			keyPEM := []byte(uuid.New().String())
+
+			secret := &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      secretName,
+					Namespace: ns,
+				},
+				Data: map[string][]byte{
+					constants.KubernetesOpaqueSecretCAKey:             certPEM,
+					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
+				},
+			}
+
+			_, err := kubeClient.CoreV1().Secrets(ns).Create(context.Background(), secret, v1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			rootCert, err := getCertFromKubernetes(kubeClient, ns, secretName)
+			Expect(err).To(HaveOccurred())
+			Expect(rootCert).To(BeNil())
 		})
 	})
 

--- a/cmd/osm-controller/errors.go
+++ b/cmd/osm-controller/errors.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/pkg/errors"
+
+var (
+	errInvalidCertSecret = errors.New("Invalid secret for certificate")
+)


### PR DESCRIPTION
This change refactors the `getCertFromKubernetes` function to
handle error scenarios. The function is only expected to error
if it finds a secret with an invalid root certificate. It also
helps remove the call to `log.Fatal` while parsing the root
certificate.

Also updates the existing test context (Ginkgo based) to test error scenarios.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`