### PR TITLE
certificate/tresor: use consistent api to retrieve CA

### DIFF
--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -68,7 +68,7 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 		expiration: template.NotAfter,
 	}
 
-	rootCertificate.issuingCA = rootCertificate
+	rootCertificate.issuingCA = rootCertificate.GetCertificateChain()
 
 	return &rootCertificate, nil
 }
@@ -82,7 +82,7 @@ func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expir
 		expiration: expiration,
 	}
 
-	rootCertificate.issuingCA = rootCertificate
+	rootCertificate.issuingCA = rootCertificate.GetCertificateChain()
 
 	return &rootCertificate, nil
 }

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -28,12 +28,7 @@ func (c Certificate) GetPrivateKey() []byte {
 
 // GetIssuingCA implements certificate.Certificater and returns the root certificate for the given cert.
 func (c Certificate) GetIssuingCA() []byte {
-	if c.issuingCA == nil {
-		log.Fatal().Msgf("No issuing CA available for cert %s", c.commonName)
-		return nil
-	}
-
-	return c.issuingCA.GetCertificateChain()
+	return c.issuingCA
 }
 
 // GetExpiration implements certificate.Certificater and returns the time the given certificate expires.

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -84,7 +84,7 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Dur
 		commonName: cn,
 		certChain:  certPEM,
 		privateKey: privKeyPEM,
-		issuingCA:  cm.ca,
+		issuingCA:  cm.ca.GetCertificateChain(),
 		expiration: template.NotAfter,
 	}
 

--- a/pkg/certificate/providers/tresor/debugger_test.go
+++ b/pkg/certificate/providers/tresor/debugger_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Test Tresor Debugger", func() {
 			expiration: time.Now(),
 			commonName: "foo.bar.co.uk",
 		}
-		cert.issuingCA = cert
+		cert.issuingCA = cert.GetCertificateChain()
 		cache := map[certificate.CommonName]certificate.Certificater{
 			"foo": cert,
 		}

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -56,7 +56,6 @@ type Certificate struct {
 	certChain  pem.Certificate
 	privateKey pem.PrivateKey
 
-	// The CA issuing this certificate.
-	// If the certificate itself is a root certificate this would be nil.
-	issuingCA certificate.Certificater
+	// Certificate authority signing this certificate
+	issuingCA pem.RootCertificate
 }


### PR DESCRIPTION
Updates the issuing CA attribute for tresor.Certificate to
make it consistent with the other certificate providers (Vault
and CertManager).

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`