### PR TITLE
kubernetes/Controller: Fix return type during initialization

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -149,7 +149,11 @@ func main() {
 	}
 	log.Info().Msgf("Initial ConfigMap %s: %s", osmConfigMapName, string(configMap))
 
-	kubernetesClient := k8s.NewKubernetesClient(kubeClient, meshName, stop)
+	kubernetesClient, err := k8s.NewKubernetesClient(kubeClient, meshName, stop)
+	if err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Kubernetes Controller")
+	}
+
 	meshSpec, err := smi.NewMeshSpecClient(kubeConfig, kubeClient, osmNamespace, kubernetesClient, stop)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating MeshSpec")

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -14,8 +14,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-// NewKubernetesClient returns a new Client which means to provide access to locally-cached k8s resources
-func NewKubernetesClient(kubeClient kubernetes.Interface, meshName string, stop chan struct{}) Client {
+// NewKubernetesClient returns a new kubernetes.Controller which means to provide access to locally-cached k8s resources
+func NewKubernetesClient(kubeClient kubernetes.Interface, meshName string, stop chan struct{}) (Controller, error) {
 	// Initialize client object
 	client := Client{
 		kubeClient:    kubeClient,
@@ -30,10 +30,11 @@ func NewKubernetesClient(kubeClient kubernetes.Interface, meshName string, stop 
 	client.initServicesMonitor()
 
 	if err := client.run(stop); err != nil {
-		log.Fatal().Err(err).Msg("Could not start Kubernetes Namespaces client")
+		log.Error().Err(err).Msg("Could not start Kubernetes Namespaces client")
+		return nil, err
 	}
 
-	return client
+	return client, nil
 }
 
 // Initializes Namespace monitoring

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -24,7 +24,8 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 		It("should return a new namespace controller", func() {
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
-			kubeController := NewKubernetesClient(kubeClient, testMeshName, stop)
+			kubeController, err := NewKubernetesClient(kubeClient, testMeshName, stop)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(kubeController).ToNot(BeNil())
 		})
 	})
@@ -34,7 +35,9 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			// Create namespace controller
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
-			kubeController := NewKubernetesClient(kubeClient, testMeshName, stop)
+			kubeController, err := NewKubernetesClient(kubeClient, testMeshName, stop)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kubeController).ToNot(BeNil())
 
 			// Create a test namespace that is monitored
 			testNamespaceName := fmt.Sprintf("%s-1", tests.Namespace)
@@ -61,7 +64,9 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			// Create namespace controller
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
-			kubeController := NewKubernetesClient(kubeClient, testMeshName, stop)
+			kubeController, err := NewKubernetesClient(kubeClient, testMeshName, stop)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kubeController).ToNot(BeNil())
 
 			// Create a test namespace that is monitored
 			testNamespaceName := fmt.Sprintf("%s-1", tests.Namespace)
@@ -88,10 +93,13 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 	Context("service controller", func() {
 		var kubeClient *testclient.Clientset
 		var kubeController Controller
+		var err error
 
 		BeforeEach(func() {
 			kubeClient = testclient.NewSimpleClientset()
-			kubeController = NewKubernetesClient(kubeClient, testMeshName, make(chan struct{}))
+			kubeController, err = NewKubernetesClient(kubeClient, testMeshName, make(chan struct{}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(kubeController).ToNot(BeNil())
 		})
 
 		It("should create and delete services, and be detected if NS is monitored", func() {

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -45,7 +45,10 @@ func bootstrapClient() (MeshSpec, *fakeKubeClientSet, error) {
 	smiTrafficSpecClientSet := testTrafficSpecClient.NewSimpleClientset()
 	smiTrafficTargetClientSet := testTrafficTargetClient.NewSimpleClientset()
 	osmPolicyClientSet := osmPolicyClient.NewSimpleClientset()
-	kubernetesClient := k8s.NewKubernetesClient(kubeClient, meshName, stop)
+	kubernetesClient, err := k8s.NewKubernetesClient(kubeClient, meshName, stop)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error initializing kubernetes controller")
+	}
 
 	fakeClientSet := &fakeKubeClientSet{
 		kubeClient:                kubeClient,


### PR DESCRIPTION
Fixes the return value and signature when a new Kubernetes
Controller is being initialized by returning the interface
and an error.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`