### PR TITLE
Record fatal events and return error where possible

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -211,7 +211,9 @@ func main() {
 
 	// Create and start the ADS gRPC service
 	xdsServer := ads.NewADSServer(meshCatalog, enableDebugServer, osmNamespace, cfg)
-	xdsServer.Start(ctx, cancel, *port, adsCert)
+	if err := xdsServer.Start(ctx, cancel, *port, adsCert); err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error initializing ADS server")
+	}
 
 	// initialize the http server and start it
 	// TODO(draychev): figure out the NS and POD

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -45,13 +45,18 @@ func NewADSServer(meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamesp
 }
 
 // Start starts the ADS server
-func (s *Server) Start(ctx context.Context, cancel context.CancelFunc, port int, adsCert certificate.Certificater) {
-	grpcServer, lis := utils.NewGrpc(ServerType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetIssuingCA())
+func (s *Server) Start(ctx context.Context, cancel context.CancelFunc, port int, adsCert certificate.Certificater) error {
+	grpcServer, lis, err := utils.NewGrpc(ServerType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetIssuingCA())
+	if err != nil {
+		log.Error().Err(err).Msg("Error starting ADS server")
+		return err
+	}
+
 	xds_discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, s)
-
 	go utils.GrpcServe(ctx, grpcServer, lis, cancel, ServerType)
-
 	s.ready = true
+
+	return nil
 }
 
 // DeltaAggregatedResources implements discovery.AggregatedDiscoveryServiceServer

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/debugger"
 	"github.com/openservicemesh/osm/pkg/health"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 	"github.com/openservicemesh/osm/pkg/version"
@@ -65,7 +66,8 @@ func (s *HTTPServer) Start() {
 	go func() {
 		log.Info().Msgf("Starting API Server on %s", s.server.Addr)
 		if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatal().Err(err).Msg("Failed to start API server")
+			events.GenericEventRecorder().FatalEvent(err, events.InitializationError,
+				"Error starting HTTP server")
 		}
 	}()
 }

--- a/pkg/kubernetes/events/types.go
+++ b/pkg/kubernetes/events/types.go
@@ -16,7 +16,7 @@ const (
 	InvalidCLIParameters = "FatalInvalidCLIParameters"
 
 	// InitializationError signifies an error during initialization
-	InitializationError = "FatalInnitializationError"
+	InitializationError = "FatalInitializationError"
 
 	// InvalidCertificateManager signifies that the certificate manager is invalid
 	InvalidCertificateManager = "FatalInvalidCertificateManager"


### PR DESCRIPTION
Updates the code to record fatal events in the httpserver
goroutine and when the ADS server initialization fails.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`