### PR TITLE
Rename function that creates kubernetes controller

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -149,7 +149,7 @@ func main() {
 	}
 	log.Info().Msgf("Initial ConfigMap %s: %s", osmConfigMapName, string(configMap))
 
-	kubernetesClient, err := k8s.NewKubernetesClient(kubeClient, meshName, stop)
+	kubernetesClient, err := k8s.NewKubernetesController(kubeClient, meshName, stop)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Kubernetes Controller")
 	}
@@ -175,12 +175,12 @@ func main() {
 		}
 	}
 
-	provider, err := kube.NewProvider(kubeClient, kubernetesClient, stop, constants.KubeProviderName, cfg)
+	kubeProvider, err := kube.NewProvider(kubeClient, kubernetesClient, stop, constants.KubeProviderName, cfg)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Kubernetes endpoints provider")
 	}
 
-	endpointsProviders := []endpoint.Provider{provider}
+	endpointsProviders := []endpoint.Provider{kubeProvider}
 
 	ingressClient, err := ingress.NewIngressClient(kubeClient, kubernetesClient, stop, cfg)
 	if err != nil {

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -14,8 +14,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-// NewKubernetesClient returns a new kubernetes.Controller which means to provide access to locally-cached k8s resources
-func NewKubernetesClient(kubeClient kubernetes.Interface, meshName string, stop chan struct{}) (Controller, error) {
+// NewKubernetesController returns a new kubernetes.Controller which means to provide access to locally-cached k8s resources
+func NewKubernetesController(kubeClient kubernetes.Interface, meshName string, stop chan struct{}) (Controller, error) {
 	// Initialize client object
 	client := Client{
 		kubeClient:    kubeClient,

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 		It("should return a new namespace controller", func() {
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
-			kubeController, err := NewKubernetesClient(kubeClient, testMeshName, stop)
+			kubeController, err := NewKubernetesController(kubeClient, testMeshName, stop)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubeController).ToNot(BeNil())
 		})
@@ -35,7 +35,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			// Create namespace controller
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
-			kubeController, err := NewKubernetesClient(kubeClient, testMeshName, stop)
+			kubeController, err := NewKubernetesController(kubeClient, testMeshName, stop)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubeController).ToNot(BeNil())
 
@@ -64,7 +64,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			// Create namespace controller
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
-			kubeController, err := NewKubernetesClient(kubeClient, testMeshName, stop)
+			kubeController, err := NewKubernetesController(kubeClient, testMeshName, stop)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubeController).ToNot(BeNil())
 
@@ -97,7 +97,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		BeforeEach(func() {
 			kubeClient = testclient.NewSimpleClientset()
-			kubeController, err = NewKubernetesClient(kubeClient, testMeshName, make(chan struct{}))
+			kubeController, err = NewKubernetesController(kubeClient, testMeshName, make(chan struct{}))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(kubeController).ToNot(BeNil())
 		})

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -45,7 +45,7 @@ func bootstrapClient() (MeshSpec, *fakeKubeClientSet, error) {
 	smiTrafficSpecClientSet := testTrafficSpecClient.NewSimpleClientset()
 	smiTrafficTargetClientSet := testTrafficTargetClient.NewSimpleClientset()
 	osmPolicyClientSet := osmPolicyClient.NewSimpleClientset()
-	kubernetesClient, err := k8s.NewKubernetesClient(kubeClient, meshName, stop)
+	kubernetesClient, err := k8s.NewKubernetesController(kubeClient, meshName, stop)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error initializing kubernetes controller")
 	}


### PR DESCRIPTION
Renames `NewKubernetesClient` to `NewKubernetesController`
based on the suggestion https://github.com/openservicemesh/osm/pull/1705#discussion_r489566700.
Also renames the kubernetes endpoints provider variable.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`