### PR TITLE
fix(maestro): Make bookwarehouse emit success token

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -108,8 +108,7 @@ func main() {
 	maestro.SearchLogsForSuccess(kubeClient, bookthiefNS, bookThiefPodName, bookThiefLabel, maxWaitForOK(), bookThiefCh, common.Success, common.Failure)
 
 	bookWarehouseCh := make(chan maestro.TestResult)
-	successToken := "Restocking bookstore with 1 new books; Total so far: 3 "
-	maestro.SearchLogsForSuccess(kubeClient, bookWarehouseNS, bookWarehousePodName, bookWarehouseLabel, maxWaitForOK(), bookWarehouseCh, successToken, common.Failure)
+	maestro.SearchLogsForSuccess(kubeClient, bookWarehouseNS, bookWarehousePodName, bookWarehouseLabel, maxWaitForOK(), bookWarehouseCh, common.Success, common.Failure)
 
 	bookBuyerTestResult := <-bookBuyerCh
 	bookThiefTestResult := <-bookThiefCh

--- a/demo/cmd/bookwarehouse/bookwarehouse.go
+++ b/demo/cmd/bookwarehouse/bookwarehouse.go
@@ -44,6 +44,9 @@ func restockBooks(w http.ResponseWriter, r *http.Request) {
 	totalBooks = totalBooks + numberOfBooks
 
 	log.Info().Msgf("Restocking bookstore with %d new books; Total so far: %d", numberOfBooks, totalBooks)
+	if totalBooks >= 3 {
+		fmt.Println(common.Success)
+	}
 }
 
 func main() {


### PR DESCRIPTION
This change makes the bookwarehouse emit the same success token as the bookbuyer and bookthief whenever it receives a request past its second and changes the maestro to look for that success token vs. a string that is only logged once. Currently, the maestro only succeeds if it is run immediately after the apps have been deployed. This change allows users to run the maestro at any point after the apps have been deployed.

I described more details here: https://github.com/openservicemesh/osm/issues/1710#issuecomment-693632564

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No