### PR TITLE
feat(cli) : Show whether the namespace is enabled with Sidecar Injection

### DIFF
--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -77,10 +77,15 @@ func (l *namespaceListCmd) run() error {
 	}
 
 	w := newTabWriter(l.out)
-	fmt.Fprintln(w, "NAMESPACE\tMESH\t")
+	fmt.Fprintln(w, "NAMESPACE\tMESH\tSIDECAR-INJECTION\t")
 	for _, ns := range namespaces.Items {
 		osmName, _ := ns.ObjectMeta.Labels[constants.OSMKubeResourceMonitorAnnotation]
-		fmt.Fprintf(w, "%s\t%s\t\n", ns.Name, osmName)
+		sidecarInjectionEnabled, ok := ns.ObjectMeta.Annotations[constants.SidecarInjectionAnnotation]
+		if !ok {
+			sidecarInjectionEnabled = "-" // not set
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t\n", ns.Name, osmName, sidecarInjectionEnabled)
 	}
 	w.Flush()
 


### PR DESCRIPTION
Please describe the motivation for this PR and provide enough information so that others can review it.
You can clearly let users know which namespace enabled Sidecar is automatically injected.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [x]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
NO

```
osm namespace list
NAMESPACE       MESH   INJECTION   
bookbuyer       osm    enabled     
bookstore       osm    enabled     
bookthief       osm    enabled     
bookwarehouse   osm 
```