### PR TITLE
metrics: support configuring select namespaces

### DIFF
--- a/cmd/cli/metrics.go
+++ b/cmd/cli/metrics.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const metricsDescription = `
+This command consists of multiple subcommands related to managing metrics
+associated with osm.
+`
+
+func newMetricsCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "metrics",
+		Short: "manage metrics",
+		Long:  metricsDescription,
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newMetricsEnable(out))
+	cmd.AddCommand(newMetricsDisable(out))
+
+	return cmd
+}

--- a/cmd/cli/metrics_disable.go
+++ b/cmd/cli/metrics_disable.go
@@ -51,7 +51,6 @@ func newMetricsDisable(out io.Writer) *cobra.Command {
 		},
 	}
 
-	//add mesh name flag
 	f := cmd.Flags()
 	f.StringSliceVar(&disableCmd.namespaces, "namespace", []string{}, "One or more namespaces to disable metrics on")
 

--- a/cmd/cli/metrics_disable.go
+++ b/cmd/cli/metrics_disable.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const metricsDisableDescription = `
+This command will disable metrics on all pods belonging to the given
+namespace or set of namespaces.
+`
+
+type metricsDisableCmd struct {
+	out        io.Writer
+	namespaces []string
+	clientSet  kubernetes.Interface
+}
+
+func newMetricsDisable(out io.Writer) *cobra.Command {
+	disableCmd := &metricsDisableCmd{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "disable ...",
+		Short: "disable metrics",
+		Long:  metricsDisableDescription,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return errors.Errorf("Error fetching kubeconfig")
+			}
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+			}
+			disableCmd.clientSet = clientset
+			return disableCmd.run()
+		},
+	}
+
+	//add mesh name flag
+	f := cmd.Flags()
+	f.StringSliceVar(&disableCmd.namespaces, "namespace", []string{}, "One or more namespaces to disable metrics on")
+
+	return cmd
+}
+
+func (cmd *metricsDisableCmd) run() error {
+	// Add metrics annotation on namepaces
+	for _, ns := range cmd.namespaces {
+		ns = strings.TrimSpace(ns)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if _, err := cmd.clientSet.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+			return errors.Errorf("Failed to retrieve namespace [%s]: %v", ns, err)
+		}
+
+		// Patch the namespace to remove the metrics annotation.
+		patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"annotations": {
+			"%s": null
+		}
+	}
+}`, constants.MetricsAnnotation)
+
+		_, err := cmd.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+		if err != nil {
+			return errors.Errorf("Failed to disable metrics in namespace [%s]: %v", ns, err)
+		}
+
+		// Disable metrics on pods belonging to this namespace
+		if err := cmd.disableMetricsForPods(ns); err != nil {
+			return errors.Errorf("Failed to disable metrics for existing pod in namespace [%s]: %v", ns, err)
+		}
+
+		fmt.Fprintf(cmd.out, "Metrics successfully disabled in namespace [%s]\n", ns)
+	}
+
+	return nil
+}
+
+// disableMetricsForPods disables metrics for existing pods in the given namespace
+func (cmd *metricsDisableCmd) disableMetricsForPods(namespace string) error {
+	listOptions := metav1.ListOptions{
+		// Matches on pods which are already a part of the mesh, which contain the Envoy ID label
+		LabelSelector: constants.EnvoyUniqueIDLabelName,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	podList, err := cmd.clientSet.CoreV1().Pods(namespace).List(ctx, listOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range podList.Items {
+		// Patch existing pods in this namespace to remove metrics annotation
+		patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"annotations": {
+			"%s": null,
+			"%s": null,
+			"%s": null
+		}
+	}
+}`, constants.PrometheusScrapeAnnotation, constants.PrometheusPortAnnotation, constants.PrometheusPathAnnotation)
+
+		_, err = cmd.clientSet.CoreV1().Pods(namespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/cli/metrics_disable.go
+++ b/cmd/cli/metrics_disable.go
@@ -16,7 +16,7 @@ import (
 )
 
 const metricsDisableDescription = `
-This command will disable metrics on all pods belonging to the given
+This command will disable metrics scraping on all pods belonging to the given
 namespace or set of namespaces.
 `
 

--- a/cmd/cli/metrics_enable.go
+++ b/cmd/cli/metrics_enable.go
@@ -19,6 +19,8 @@ const metricsEnableDescription = `
 This command will enable metrics on all pods belonging to the given namespace
 or set of namespaces. Newly created pods belonging to namespaces that
 are enabled for metrics will be automatically enabled with metrics.
+
+The command does not deploy a metrics collection service such as Prometheus.
 `
 
 type metricsEnableCmd struct {

--- a/cmd/cli/metrics_enable.go
+++ b/cmd/cli/metrics_enable.go
@@ -16,8 +16,8 @@ import (
 )
 
 const metricsEnableDescription = `
-This command will enable metrics on all pods belonging to the given namespace
-or set of namespaces. Newly created pods belonging to namespaces that
+This command will enable metrics scraping on all pods belonging to the given
+namespace or set of namespaces. Newly created pods belonging to namespaces that
 are enabled for metrics will be automatically enabled with metrics.
 
 The command does not deploy a metrics collection service such as Prometheus.

--- a/cmd/cli/metrics_enable.go
+++ b/cmd/cli/metrics_enable.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const metricsEnableDescription = `
+This command will enable metrics on all pods belonging to the given namespace
+or set of namespaces. Newly created pods belonging to namespaces that
+are enabled for metrics will be automatically enabled with metrics.
+`
+
+type metricsEnableCmd struct {
+	out        io.Writer
+	namespaces []string
+	clientSet  kubernetes.Interface
+}
+
+func newMetricsEnable(out io.Writer) *cobra.Command {
+	enableCmd := &metricsEnableCmd{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "enable ...",
+		Short: "enable metrics",
+		Long:  metricsEnableDescription,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, args []string) error {
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return errors.Errorf("Error fetching kubeconfig")
+			}
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+			}
+			enableCmd.clientSet = clientset
+			return enableCmd.run()
+		},
+	}
+
+	//add mesh name flag
+	f := cmd.Flags()
+	f.StringSliceVar(&enableCmd.namespaces, "namespace", []string{}, "One or more namespaces to enable metrics on")
+
+	return cmd
+}
+
+func (cmd *metricsEnableCmd) run() error {
+	// Add metrics annotation on namepaces
+	for _, ns := range cmd.namespaces {
+		ns = strings.TrimSpace(ns)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if _, err := cmd.clientSet.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+			return errors.Errorf("Failed to retrieve namespace [%s]: %v", ns, err)
+		}
+
+		// Patch the namespace with metrics annotation.
+		// osm-controller uses this annotation to automatically enable new pods for metrics scraping.
+		patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"annotations": {
+			"%s": "enabled"
+		}
+	}
+}`, constants.MetricsAnnotation)
+
+		_, err := cmd.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+		if err != nil {
+			return errors.Errorf("Failed to enable metrics in namespace [%s]: %v", ns, err)
+		}
+
+		// For existing pods in this namespace that are already part of the mesh, add the prometheus
+		// scraping annotations.
+		if err := cmd.enableMetricsForPods(ns); err != nil {
+			return errors.Errorf("Failed to enable metrics for existing pod in namespace [%s]: %v", ns, err)
+		}
+
+		fmt.Fprintf(cmd.out, "Metrics successfully enabled in namespace [%s]\n", ns)
+	}
+
+	return nil
+}
+
+// enableMetricsForPods enables metrics for existing pods in the given namespace
+func (cmd *metricsEnableCmd) enableMetricsForPods(namespace string) error {
+	listOptions := metav1.ListOptions{
+		// Matches on pods which are already a part of the mesh, which contain the Envoy ID label
+		LabelSelector: constants.EnvoyUniqueIDLabelName,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	podList, err := cmd.clientSet.CoreV1().Pods(namespace).List(ctx, listOptions)
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range podList.Items {
+		// Patch existing pods in this namespace with annotations used for metrics scraping
+		patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"annotations": {
+			"%s": "true",
+			"%s": "%d",
+			"%s": "%s"
+		}
+	}
+}`, constants.PrometheusScrapeAnnotation, constants.PrometheusPortAnnotation, constants.EnvoyPrometheusInboundListenerPort,
+			constants.PrometheusPathAnnotation, constants.PrometheusScrapePath)
+
+		_, err = cmd.clientSet.CoreV1().Pods(namespace).Patch(ctx, pod.Name, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func newNamespace(name string, annotations map[string]string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if annotations != nil {
+		ns.Annotations = annotations
+	}
+
+	return ns
+}
+
+func TestRun_MetricsEnable(t *testing.T) {
+	assert := assert.New(t)
+	fakeClient := fake.NewSimpleClientset()
+
+	type test struct {
+		cmd           *metricsEnableCmd
+		nsAnnotations map[string]string
+	}
+
+	testScenarios := []test{
+		{
+			cmd: &metricsEnableCmd{
+				out:        new(bytes.Buffer),
+				namespaces: []string{"ns-1"},
+				clientSet:  fakeClient,
+			},
+			nsAnnotations: nil,
+		},
+		{
+			cmd: &metricsEnableCmd{
+				out:        new(bytes.Buffer),
+				namespaces: []string{"ns-2", "ns-3"},
+				clientSet:  fakeClient,
+			},
+			nsAnnotations: map[string]string{constants.MetricsAnnotation: "enabled"},
+		},
+	}
+
+	for _, scenario := range testScenarios {
+		// Create test fixrures for test scenario
+		for _, ns := range scenario.cmd.namespaces {
+			newNs := newNamespace(ns, scenario.nsAnnotations)
+			ns, _ := fakeClient.CoreV1().Namespaces().Create(context.TODO(), newNs, metav1.CreateOptions{})
+			assert.NotNil(ns)
+		}
+
+		err := scenario.cmd.run()
+		assert.Nil(err)
+
+		// Test expectation for scenario
+		for _, ns := range scenario.cmd.namespaces {
+			nsWithMetrics, _ := fakeClient.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{})
+			assert.NotNil(nsWithMetrics)
+			assert.Equal(nsWithMetrics.Annotations[constants.MetricsAnnotation], "enabled")
+		}
+	}
+}
+
+func TestRun_MetricsDisable(t *testing.T) {
+	assert := assert.New(t)
+	fakeClient := fake.NewSimpleClientset()
+
+	type test struct {
+		cmd           *metricsDisableCmd
+		nsAnnotations map[string]string
+	}
+
+	testScenarios := []test{
+		{
+			cmd: &metricsDisableCmd{
+				out:        new(bytes.Buffer),
+				namespaces: []string{"ns-1"},
+				clientSet:  fakeClient,
+			},
+			nsAnnotations: map[string]string{constants.MetricsAnnotation: "enabled"},
+		},
+		{
+			cmd: &metricsDisableCmd{
+				out:        new(bytes.Buffer),
+				namespaces: []string{"ns-2", "ns-3"},
+				clientSet:  fakeClient,
+			},
+			nsAnnotations: map[string]string{constants.MetricsAnnotation: "enabled"},
+		},
+	}
+
+	for _, scenario := range testScenarios {
+		// Create test fixrures for test scenario
+		for _, ns := range scenario.cmd.namespaces {
+			newNs := newNamespace(ns, scenario.nsAnnotations)
+			ns, _ := fakeClient.CoreV1().Namespaces().Create(context.TODO(), newNs, metav1.CreateOptions{})
+			assert.NotNil(ns)
+		}
+
+		err := scenario.cmd.run()
+		assert.Nil(err)
+
+		// Test expectation for scenario
+		for _, ns := range scenario.cmd.namespaces {
+			nsWithMetrics, _ := fakeClient.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{})
+			assert.NotNil(nsWithMetrics)
+			assert.NotContains(nsWithMetrics.Annotations, constants.MetricsAnnotation)
+		}
+	}
+}

--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -41,6 +41,7 @@ func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args 
 		newInstallCmd(config, out),
 		newDashboardCmd(config, out),
 		newNamespaceCmd(out),
+		newMetricsCmd(out),
 		newVersionCmd(out),
 	)
 

--- a/demo/configure-app-namespaces.sh
+++ b/demo/configure-app-namespaces.sh
@@ -9,3 +9,9 @@ for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPAC
     kubectl create namespace "$ns" --save-config
     ./scripts/create-container-registry-creds.sh "$ns"
 done
+
+# Add namespaces to the mesh
+bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" --enable-sidecar-injection
+
+# Enable metrics for pods belonging to app namespaces
+bin/osm metrics enable --namespace "$BOOKWAREHOUSE_NAMESPACE, $BOOKBUYER_NAMESPACE, $BOOKSTORE_NAMESPACE, $BOOKTHIEF_NAMESPACE"

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -139,7 +139,7 @@ fi
 wait_for_osm_pods
 
 ./demo/configure-app-namespaces.sh
-bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" --enable-sidecar-injection
+
 ./demo/deploy-apps.sh
 
 # Apply SMI policies

--- a/go.sum
+++ b/go.sum
@@ -1290,6 +1290,7 @@ k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftc
 k8s.io/apimachinery v0.18.5 h1:Lh6tgsM9FMkC12K5T5QjRm7rDs6aQN5JHkA0JomULDM=
 k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
+k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
 k8s.io/apiserver v0.18.5/go.mod h1:+1XgOMq7YJ3OyqPNSJ54EveHwCoBWcJT9CaPycYI5ps=
 k8s.io/cli-runtime v0.18.0 h1:jG8XpSqQ5TrV0N+EZ3PFz6+gqlCk71dkggWCCq9Mq34=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -133,7 +133,25 @@ const (
 
 	// InitContainerName is the name of the init container
 	InitContainerName = "osm-init"
+)
 
+// Annotations used by the controller
+const (
 	// SidecarInjectionAnnotation is the annotation used for sidecar injection
 	SidecarInjectionAnnotation = "openservicemesh.io/sidecar-injection"
+
+	// MetricsAnnotation is the annotation used for enabling/disabling metrics
+	MetricsAnnotation = "openservicemesh.io/metrics"
+)
+
+// Annotations used for Metrics
+const (
+	// PrometheusScrapeAnnotation is the annotation used to configure prometheus scraping
+	PrometheusScrapeAnnotation = "prometheus.io/scrape"
+
+	// PrometheusPortAnnotation is the anontation used to configure the port to scrape on
+	PrometheusPortAnnotation = "prometheus.io/port"
+
+	// PrometheusPathAnnotation is the annotation used to configure the path to scrape on
+	PrometheusPathAnnotation = "prometheus.io/path"
 )

--- a/pkg/injector/metrics.go
+++ b/pkg/injector/metrics.go
@@ -1,0 +1,47 @@
+package injector
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func (wh *webhook) isMetricsEnabled(namespace string) (bool, error) {
+	ns, err := wh.kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
+	if err != nil {
+		log.Error().Err(err).Msgf("Error retrieving namespace %s", namespace)
+		return false, err
+	}
+
+	enabled, err := isAnnotatedForMetrics(ns.Annotations)
+	if err != nil {
+		return false, err
+	}
+
+	return enabled, nil
+}
+
+func isAnnotatedForMetrics(annotations map[string]string) (enabled bool, err error) {
+	metrics, ok := annotations[constants.MetricsAnnotation]
+	if !ok {
+		return false, nil
+	}
+
+	log.Trace().Msgf("Metrics annotation: '%s:%s'", constants.MetricsAnnotation, metrics)
+	metrics = strings.ToLower(metrics)
+	if metrics != "" {
+		switch metrics {
+		case "enabled", "yes", "true":
+			enabled = true
+		case "disabled", "no", "false":
+			enabled = false
+		default:
+			err = errors.Errorf("Invalid annotion value specified for annotation %q: %s", constants.MetricsAnnotation, metrics)
+		}
+	}
+	return
+}

--- a/pkg/injector/metrics_test.go
+++ b/pkg/injector/metrics_test.go
@@ -1,0 +1,100 @@
+package injector
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func newNamespace(name string, annotations map[string]string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	if annotations != nil {
+		ns.Annotations = annotations
+	}
+
+	return ns
+}
+
+func TestIsMetricsEnabled(t *testing.T) {
+	assert := assert.New(t)
+	fakeClient := fake.NewSimpleClientset()
+
+	// create namespace with metrics enabled
+	nsWithMetrics := newNamespace("ns-1", map[string]string{constants.MetricsAnnotation: "enabled"})
+	ns, _ := fakeClient.CoreV1().Namespaces().Create(context.TODO(), nsWithMetrics, metav1.CreateOptions{})
+	assert.NotNil(ns)
+
+	// create namespace with metrics disabled
+	nsWithMetricsDisabled := newNamespace("ns-2", map[string]string{constants.MetricsAnnotation: "disabled"})
+	ns, _ = fakeClient.CoreV1().Namespaces().Create(context.TODO(), nsWithMetricsDisabled, metav1.CreateOptions{})
+	assert.NotNil(ns)
+
+	// create namespace without metrics annotation
+	nsWithoutMetricsAnnotation := newNamespace("ns-3", nil)
+	ns, _ = fakeClient.CoreV1().Namespaces().Create(context.TODO(), nsWithoutMetricsAnnotation, metav1.CreateOptions{})
+	assert.NotNil(ns)
+
+	// create namespace with invalid annotation value
+	nsWithInvalidAnnotation := newNamespace("ns-4", map[string]string{constants.MetricsAnnotation: "invalid"})
+	ns, _ = fakeClient.CoreV1().Namespaces().Create(context.TODO(), nsWithInvalidAnnotation, metav1.CreateOptions{})
+	assert.NotNil(ns)
+
+	// Test different scenarios using table driven testing
+	testCases := []struct {
+		namespace                string
+		expectMetricsToBeEnabled bool // set to true if metrics is expected to be enabled
+		expectedErr              bool // set to true if error is expected
+	}{
+		{nsWithMetrics.Name, true, false},
+		{nsWithMetricsDisabled.Name, false, false},
+		{nsWithoutMetricsAnnotation.Name, false, false},
+		{nsWithInvalidAnnotation.Name, false, true},
+	}
+
+	wh := &webhook{
+		kubeClient: fakeClient,
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Namespace %s", tc.namespace), func(t *testing.T) {
+			enabled, err := wh.isMetricsEnabled(tc.namespace)
+			assert.Equal(enabled, tc.expectMetricsToBeEnabled)
+			assert.Equal(err != nil, tc.expectedErr)
+		})
+	}
+}
+
+func TestIsAnnotatedForMetrics(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		annotations              map[string]string
+		expectMetricsToBeEnabled bool // set to true if metrics is expected to be enabled
+		expectedErr              bool // set to true if error is expected
+	}{
+		{map[string]string{constants.MetricsAnnotation: "enabled"}, true, false},
+		{map[string]string{constants.MetricsAnnotation: "disabled"}, false, false},
+		{nil, false, false},
+		{map[string]string{constants.MetricsAnnotation: "invalid"}, false, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Annotation %v", tc.annotations), func(t *testing.T) {
+			enabled, err := isAnnotatedForMetrics(tc.annotations)
+			assert.Equal(enabled, tc.expectMetricsToBeEnabled)
+			assert.Equal(err != nil, tc.expectedErr)
+		})
+	}
+}


### PR DESCRIPTION
Adds support to configure namespaces for metrics
collection.

- osm cli command to enable/disable metrics on
  select namespaces. Existing mesh participating
  pods will be enabled for metrics.

- injector changes to auto enable metrics on
  pods belonging to namespaces for which metrics
  are enabled.

`osm metrics` command is limited to namespace scope
configurations at this time. It should be possible
in the future to enable metrics for select pods.

Part of #1016

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`