### PR TITLE
fix(cmd/cli): Add client-go auth plugin import

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/cli"
 	"github.com/openservicemesh/osm/pkg/constants"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const installDesc = `
@@ -121,7 +122,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 
 			clientset, err := kubernetes.NewForConfig(kubeconfig)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig, %s", err)
 			}
 			inst.clientSet = clientset
 			return inst.run(config)


### PR DESCRIPTION
Adds a silent import for the client-go auth plugins,
which allows for Kube configurations that use auth plugins
for client credentials to work correctly.

Personally, not a fan of the import side effects,
but this is the current way to do it, see kubernetes/client-go#242

Fixes #1415.

Signed-off-by: Nick Young <ynick@vmware.com>

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [x]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No, and no.