### PR TITLE
fix(endpoints): watch Pods instead of Deployments

### DIFF
--- a/pkg/endpoint/providers/kube/types.go
+++ b/pkg/endpoint/providers/kube/types.go
@@ -14,14 +14,14 @@ var (
 
 // InformerCollection is a struct of the Kubernetes informers used in OSM
 type InformerCollection struct {
-	Endpoints   cache.SharedIndexInformer
-	Deployments cache.SharedIndexInformer
+	Endpoints cache.SharedIndexInformer
+	Pods      cache.SharedIndexInformer
 }
 
 // CacheCollection is a struct of the Kubernetes caches used in OSM
 type CacheCollection struct {
-	Endpoints   cache.Store
-	Deployments cache.Store
+	Endpoints cache.Store
+	Pods      cache.Store
 }
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.


### PR DESCRIPTION
This change modifies the kube endpoints provider to watch Pods instead
of Deployments to map ServiceAccounts to Services. This will allow OSM
to work with workloads deployed as bare Pods or as other workload kinds
that control Pods besides only Deployments.

Fixes #1744

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No