### PR TITLE
charts: update chart and image version for v0.4.0 release (#1748)

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.3.0
+appVersion: v0.4.0

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -6,7 +6,7 @@ OpenServiceMesh:
   image:
     registry: openservicemesh
     pullPolicy: IfNotPresent
-    tag: v0.3.0
+    tag: v0.4.0
   imagePullSecrets: []
   sidecarImage: envoyproxy/envoy-alpine:v1.15.0
   prometheus:
@@ -58,6 +58,6 @@ OpenServiceMesh:
     # Destination port for the listener
     port: 9411
 
-    # Destination's API or collector endpoint where the spans will 
+    # Destination's API or collector endpoint where the spans will
     # be sent to
     endpoint: "/api/v2/spans"

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -133,7 +133,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.StringVar(&inst.containerRegistry, "container-registry", "openservicemesh", "container registry that hosts control plane component images")
 	f.StringVar(&inst.chartPath, "osm-chart-path", "", "path to osm chart to override default chart")
 	f.StringVar(&inst.certificateManager, "certificate-manager", defaultCertManager, "certificate manager to use one of (tresor, vault, cert-manager)")
-	f.StringVar(&inst.osmImageTag, "osm-image-tag", "v0.3.0", "osm image tag")
+	f.StringVar(&inst.osmImageTag, "osm-image-tag", "v0.4.0", "osm image tag")
 	f.StringVar(&inst.osmImagePullPolicy, "osm-image-pull-policy", defaultOsmImagePullPolicy, "osm image pull policy")
 	f.StringVar(&inst.containerRegistrySecret, "container-registry-secret", "", "name of Kubernetes secret for container registry credentials to be created if it doesn't already exist")
 	f.StringVar(&inst.vaultHost, "vault-host", "", "Hashicorp Vault host/service - where Vault is installed")


### PR DESCRIPTION
This is a cherry-pick of commit 69d1d54fe4cf5883ad72852e3ceaf5efbbe959f1
from the `release-v0.4` branch.

Updates the chart and container image versions used as a
part of v0.4.0 release.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`