### PR TITLE
kubecontroller: add GetNamespace interface and impl

### DIFF
--- a/pkg/injector/errors.go
+++ b/pkg/injector/errors.go
@@ -1,0 +1,7 @@
+package injector
+
+import "github.com/pkg/errors"
+
+var (
+	errNamespaceNotFound = errors.New("namespace not found")
+)

--- a/pkg/injector/metrics.go
+++ b/pkg/injector/metrics.go
@@ -1,20 +1,18 @@
 package injector
 
 import (
-	"context"
 	"strings"
 
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 func (wh *webhook) isMetricsEnabled(namespace string) (bool, error) {
-	ns, err := wh.kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		log.Error().Err(err).Msgf("Error retrieving namespace %s", namespace)
-		return false, err
+	ns := wh.kubeController.GetNamespace(namespace)
+	if ns == nil {
+		log.Error().Err(errNamespaceNotFound).Msgf("Error retrieving namespace %s", namespace)
+		return false, errNamespaceNotFound
 	}
 
 	enabled, err := isAnnotatedForMetrics(ns.Annotations)

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -248,9 +248,9 @@ func (wh *webhook) mustInject(pod *corev1.Pod, namespace string) (bool, error) {
 	}
 
 	// Check if the namespace is annotated for injection
-	ns, err := wh.kubeClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		log.Error().Err(err).Msgf("Error retrieving namespace %s", namespace)
+	ns := wh.kubeController.GetNamespace(namespace)
+	if ns == nil {
+		log.Error().Err(errNamespaceNotFound).Msgf("Error retrieving namespace %s", namespace)
 		return false, err
 	}
 	nsInjectAnnotationExists, nsInject, err := isAnnotatedForInjection(ns.Annotations)

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Testing mustInject", func() {
 				Name: namespace,
 			},
 		}
-		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		retNs, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		podWithInjectAnnotationEnabled := &corev1.Pod{
@@ -219,6 +219,7 @@ var _ = Describe("Testing mustInject", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mockKubeController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+		mockKubeController.EXPECT().GetNamespace(namespace).Return(retNs)
 
 		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
 
@@ -232,7 +233,7 @@ var _ = Describe("Testing mustInject", func() {
 				Name: namespace,
 			},
 		}
-		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		retNs, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		podWithInjectAnnotationEnabled := &corev1.Pod{
@@ -250,6 +251,7 @@ var _ = Describe("Testing mustInject", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mockKubeController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+		mockKubeController.EXPECT().GetNamespace(namespace).Return(retNs)
 
 		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
 
@@ -266,7 +268,7 @@ var _ = Describe("Testing mustInject", func() {
 				},
 			},
 		}
-		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		retNs, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		podWithInjectAnnotationEnabled := &corev1.Pod{
@@ -281,6 +283,7 @@ var _ = Describe("Testing mustInject", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mockKubeController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+		mockKubeController.EXPECT().GetNamespace(namespace).Return(retNs)
 
 		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
 
@@ -297,7 +300,7 @@ var _ = Describe("Testing mustInject", func() {
 				},
 			},
 		}
-		_, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		retNs, err := fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		podWithInjectAnnotationEnabled := &corev1.Pod{
@@ -315,6 +318,7 @@ var _ = Describe("Testing mustInject", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		mockKubeController.EXPECT().IsMonitoredNamespace(namespace).Return(true).Times(1)
+		mockKubeController.EXPECT().GetNamespace(namespace).Return(retNs)
 
 		inject, err := wh.mustInject(podWithInjectAnnotationEnabled, namespace)
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -157,3 +157,13 @@ func (c Client) ListServices() []*corev1.Service {
 func (c Client) GetAnnouncementsChannel(informerID InformerKey) <-chan interface{} {
 	return c.announcements[informerID]
 }
+
+// GetNamespace returns namespace.
+func (c Client) GetNamespace(ns string) *corev1.Namespace {
+	nsIf, exists, err := c.informers[Namespaces].GetStore().GetByKey(ns)
+	if exists && err == nil {
+		ns := nsIf.(*corev1.Namespace)
+		return ns
+	}
+	return nil
+}

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -158,7 +158,7 @@ func (c Client) GetAnnouncementsChannel(informerID InformerKey) <-chan interface
 	return c.announcements[informerID]
 }
 
-// GetNamespace returns namespace.
+// GetNamespace returns a Namespace resource if found, nil otherwise.
 func (c Client) GetNamespace(ns string) *corev1.Namespace {
 	nsIf, exists, err := c.informers[Namespaces].GetStore().GetByKey(ns)
 	if exists && err == nil {

--- a/pkg/kubernetes/mock_controller.go
+++ b/pkg/kubernetes/mock_controller.go
@@ -48,6 +48,20 @@ func (mr *MockControllerMockRecorder) GetAnnouncementsChannel(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnouncementsChannel", reflect.TypeOf((*MockController)(nil).GetAnnouncementsChannel), arg0)
 }
 
+// GetNamespace mocks base method
+func (m *MockController) GetNamespace(arg0 string) *v1.Namespace {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespace", arg0)
+	ret0, _ := ret[0].(*v1.Namespace)
+	return ret0
+}
+
+// GetNamespace indicates an expected call of GetNamespace
+func (mr *MockControllerMockRecorder) GetNamespace(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockController)(nil).GetNamespace), arg0)
+}
+
 // GetService mocks base method
 func (m *MockController) GetService(arg0 service.MeshService) *v1.Service {
 	m.ctrl.T.Helper()

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -80,6 +80,9 @@ type Controller interface {
 	// ListMonitoredNamespaces returns the namespaces monitored by the mesh
 	ListMonitoredNamespaces() ([]string, error)
 
+	// GetNamespace returns k8s namespace present in cache
+	GetNamespace(ns string) *corev1.Namespace
+
 	// Returns the announcement channel for a certain Informer ID
 	GetAnnouncementsChannel(informerID InformerKey) <-chan interface{}
 }


### PR DESCRIPTION
Identified a problem/bottleneck with webhook, where with enough pods/calls,
the webhook takes too much time to reply and times out, rendering any further
mesh deployments undone.

This fixes going through local caches instead of API calls to get
namespaces. This improves but doesn't totally solve the problem.

- Added tests, fixed existing tests

- Control Plane          [X]
- Tests / CI System      [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No