### PR TITLE
demo: Small fixes to the demo scripts and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ DOCKER_PUSH_TARGETS = $(addprefix docker-push-, $(DEMO_TARGETS) init osm-control
 $(DOCKER_PUSH_TARGETS): NAME=$(@:docker-push-%=%)
 $(DOCKER_PUSH_TARGETS):
 	make docker-build-$(NAME)
-	docker push "$(CTR_REGISTRY)/$(NAME):$(CTR_TAG)"
+	docker push "$(CTR_REGISTRY)/$(NAME):$(CTR_TAG)" || { echo "Error pushing images to container registry $(CTR_REGISTRY)/$(NAME):$(CTR_TAG)"; exit 1; }
 
 .PHONY: docker-push
 docker-push: $(DOCKER_PUSH_TARGETS)

--- a/demo/deploy-apps.sh
+++ b/demo/deploy-apps.sh
@@ -12,10 +12,11 @@ DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 
 # Deploy bookwarehouse
 ./demo/deploy-bookwarehouse.sh
+
 # Deploy bookstore versions
 if [ "$DEPLOY_WITH_SAME_SA" = "true" ]; then
     ./demo/deploy-bookstore-with-same-sa.sh "v1"
-    ./demo/deploy-bookstore-with-same-sa.sh "v2"    
+    ./demo/deploy-bookstore-with-same-sa.sh "v2"
 else
     ./demo/deploy-bookstore.sh "v1"
     ./demo/deploy-bookstore.sh "v2"
@@ -23,5 +24,6 @@ fi
 
 # Deploy bookbuyer
 ./demo/deploy-bookbuyer.sh
+
 # Deploy bookthief
 ./demo/deploy-bookthief.sh

--- a/demo/deploy-smi-policies.sh
+++ b/demo/deploy-smi-policies.sh
@@ -5,7 +5,7 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-./demo/deploy-traffic-spec.sh
+./demo/deploy-traffic-specs.sh
 ./demo/deploy-traffic-target.sh
 ./demo/deploy-traffic-split.sh
 

--- a/demo/reset.sh
+++ b/demo/reset.sh
@@ -13,7 +13,7 @@ set -aueo pipefail
 source .env
 
 
-./demo/deploy-policies.sh     # Add SMI policies
+./demo/deploy-smi-policies.sh # Add SMI policies
 ./demo/unjoin-namespaces.sh   # Remove namespaces from OSM.
 ./demo/reset-counters.sh      # Reset counters
 

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -32,6 +32,9 @@ ENABLE_GRAFANA="${ENABLE_GRAFANA:-false}"
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 
+# Check if Docker daemon is running
+pgrep -f docker > /dev/null || { echo "Docker daemon is not running"; exit 1; }
+
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*
 


### PR DESCRIPTION
While running the demo scenario via `demo/run-osm-demo.sh` I ran into a few tiny issues.
This PR:
  - correct the names of the shell scripts invoked
  - add an error message to `demo/run-osm-demo.sh` to exit early if/when Docker daemon is not found
  - augment the docker push error with some context


Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
