### PR TITLE
egress: remove mesh cidr dependency

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -26,7 +26,6 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` |  |
 | OpenServiceMesh.image.tag | string | `"v0.3.0"` |  |
 | OpenServiceMesh.imagePullSecrets | object | `{}` |  |
-| OpenServiceMesh.meshCIDRRanges | string | `"0.0.0.0/0"` |  |
 | OpenServiceMesh.meshName | string | `"osm"` |  |
 | OpenServiceMesh.prometheus.port | int | `7070` |  |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` |  |

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -16,7 +16,4 @@ data:
   tracing_endpoint: {{ .Values.OpenServiceMesh.tracing.endpoint | quote }}
 {{- end }}
 
-{{- if .Values.OpenServiceMesh.enableEgress }}
-  mesh_cidr_ranges: {{ .Values.OpenServiceMesh.meshCIDRRanges | quote }}
-{{- end }}
   use_https_ingress: {{ .Values.OpenServiceMesh.useHTTPSIngress | default "false" | quote }}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -35,7 +35,6 @@ OpenServiceMesh:
   enablePrometheus: true
   enableGrafana: false
   meshName: osm
-  meshCIDRRanges: 0.0.0.0/0
   useHTTPSIngress: false
   envoyLogLevel: error
 

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -35,7 +35,6 @@ var (
 	testCABundleSecretName     = "osm-ca-bundle"
 	testRetentionTime          = "5d"
 	testMeshCIDR               = "10.20.0.0/16"
-	testMeshCIDRRanges         = []string{testMeshCIDR}
 	testEnvoyLogLevel          = "error"
 )
 
@@ -81,7 +80,6 @@ var _ = Describe("Running the install command", func() {
 				enableEgress:               true,
 				enablePrometheus:           true,
 				enableGrafana:              true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
 				envoyLogLevel:              testEnvoyLogLevel,
 			}
@@ -141,7 +139,6 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
-						"meshCIDRRanges":                 testMeshCIDR,
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
@@ -193,7 +190,6 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
@@ -260,7 +256,6 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
-						"meshCIDRRanges":                 testMeshCIDR,
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
@@ -319,7 +314,6 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
@@ -387,7 +381,6 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
-						"meshCIDRRanges":                 testMeshCIDR,
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
@@ -432,7 +425,6 @@ var _ = Describe("Running the install command", func() {
 				certificateManager:      "vault",
 				meshName:                defaultMeshName,
 				enableEgress:            true,
-				meshCIDRRanges:          testMeshCIDRRanges,
 			}
 
 			err = installCmd.run(config)
@@ -488,7 +480,6 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 				enablePrometheus:           true,
 				enableGrafana:              true,
 				clientSet:                  fakeClientSet,
@@ -556,7 +547,6 @@ var _ = Describe("Running the install command", func() {
 						"enablePermissiveTrafficPolicy":  false,
 						"enableBackpressureExperimental": false,
 						"enableEgress":                   true,
-						"meshCIDRRanges":                 testMeshCIDR,
 						"enablePrometheus":               true,
 						"enableGrafana":                  true,
 						"deployJaeger":                   false,
@@ -611,7 +601,6 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName,
 				enableEgress:               true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -680,7 +669,6 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   defaultMeshName + "-2",
 				enableEgress:               true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 				clientSet:                  fakeClientSet,
 			}
 
@@ -743,7 +731,6 @@ var _ = Describe("Running the install command", func() {
 				prometheusRetentionTime:    testRetentionTime,
 				meshName:                   "osm!!123456789012345678901234567890123456789012345678901234567890", // >65 characters, contains !
 				enableEgress:               true,
-				meshCIDRRanges:             testMeshCIDRRanges,
 			}
 
 			err = install.run(config)
@@ -780,7 +767,6 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
-			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              true,
 			envoyLogLevel:              testEnvoyLogLevel,
@@ -829,7 +815,6 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 				"enablePermissiveTrafficPolicy":  false,
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
-				"meshCIDRRanges":                 testMeshCIDR,
 				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
@@ -862,7 +847,6 @@ var _ = Describe("Ensure that grafana is disabled when flag is set to false", fu
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
-			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              false,
 			envoyLogLevel:              testEnvoyLogLevel,
@@ -911,7 +895,6 @@ var _ = Describe("Ensure that grafana is disabled when flag is set to false", fu
 				"enablePermissiveTrafficPolicy":  false,
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
-				"meshCIDRRanges":                 testMeshCIDR,
 				"enablePrometheus":               true,
 				"enableGrafana":                  false,
 				"deployJaeger":                   false,
@@ -945,7 +928,6 @@ var _ = Describe("Ensure that grafana is enabled when flag is set to true", func
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
-			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              true,
 			envoyLogLevel:              testEnvoyLogLevel,
@@ -994,7 +976,6 @@ var _ = Describe("Ensure that grafana is enabled when flag is set to true", func
 				"enablePermissiveTrafficPolicy":  false,
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
-				"meshCIDRRanges":                 testMeshCIDR,
 				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
@@ -1028,7 +1009,6 @@ var _ = Describe("Ensure that prometheus is disabled when flag is set to false",
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
-			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           false,
 			enableGrafana:              true,
 			envoyLogLevel:              testEnvoyLogLevel,
@@ -1077,7 +1057,6 @@ var _ = Describe("Ensure that prometheus is disabled when flag is set to false",
 				"enablePermissiveTrafficPolicy":  false,
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
-				"meshCIDRRanges":                 testMeshCIDR,
 				"enablePrometheus":               false,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
@@ -1110,7 +1089,6 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 			prometheusRetentionTime:    testRetentionTime,
 			meshName:                   defaultMeshName,
 			enableEgress:               true,
-			meshCIDRRanges:             testMeshCIDRRanges,
 			enablePrometheus:           true,
 			enableGrafana:              true,
 			envoyLogLevel:              testEnvoyLogLevel,
@@ -1159,7 +1137,6 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 				"enablePermissiveTrafficPolicy":  false,
 				"enableBackpressureExperimental": false,
 				"enableEgress":                   true,
-				"meshCIDRRanges":                 testMeshCIDR,
 				"enablePrometheus":               true,
 				"enableGrafana":                  true,
 				"deployJaeger":                   false,
@@ -1184,8 +1161,7 @@ var _ = Describe("Resolving values for egress option", func() {
 
 		It("Should enable egress in the Helm chart", func() {
 			installCmd := &installCmd{
-				enableEgress:   true,
-				meshCIDRRanges: testMeshCIDRRanges,
+				enableEgress: true,
 			}
 
 			vals, err := installCmd.resolveValues()
@@ -1193,44 +1169,6 @@ var _ = Describe("Resolving values for egress option", func() {
 
 			enableEgressVal := vals["OpenServiceMesh"].(map[string]interface{})["enableEgress"]
 			Expect(enableEgressVal).To(BeTrue())
-		})
-	})
-})
-
-var _ = Describe("Test mesh CIDR ranges", func() {
-	Context("Test meshCIDRRanges chart value with install cli option", func() {
-		It("Should correctly resolve meshCIDRRanges when egress is enabled", func() {
-			installCmd := &installCmd{
-				enableEgress:   true,
-				meshCIDRRanges: testMeshCIDRRanges,
-			}
-
-			vals, err := installCmd.resolveValues()
-			Expect(err).NotTo(HaveOccurred())
-
-			cidrRanges := vals["OpenServiceMesh"].(map[string]interface{})["meshCIDRRanges"]
-			Expect(cidrRanges).To(Equal(testMeshCIDR))
-		})
-	})
-
-	Context("Test validateCIDRs", func() {
-		It("Should correctly validate valid CIDR ranges", func() {
-			err := validateCIDRs([]string{"10.2.0.0/16"})
-			Expect(err).NotTo(HaveOccurred())
-
-			err = validateCIDRs([]string{"10.0.0.0/16", "10.20.0.0/16"})
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Should correctly error invalid CIDR ranges", func() {
-			err := validateCIDRs([]string{"10.0.0.0/16", "10.20.0.0/99"})
-			Expect(err).To(HaveOccurred())
-
-			err = validateCIDRs([]string{"300.0.0.0/16"})
-			Expect(err).To(HaveOccurred())
-
-			err = validateCIDRs([]string{"10.2.0.0"})
-			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -29,7 +29,6 @@ CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
 ENABLE_GRAFANA="${ENABLE_GRAFANA:-false}"
-MESH_CIDR=$(./scripts/get_mesh_cidr.sh)
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 
@@ -115,7 +114,6 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --enable-debug-server \
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
-      --mesh-cidr "$MESH_CIDR" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       $optionalInstallArgs
 else
@@ -131,7 +129,6 @@ else
       --enable-debug-server \
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
-      --mesh-cidr "$MESH_CIDR" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       $optionalInstallArgs
 fi

--- a/docs/patterns/egress.md
+++ b/docs/patterns/egress.md
@@ -15,39 +15,24 @@ While in-mesh traffic is routed based on L7 traffic policies, egress traffic is 
 Enabling egress is done via a global setting. The setting is toggled on or off and affects all services in the mesh. Egress is enabled by default when OSM is installed.
 
 ### Enabling egress
-Egress can be enabled during OSM install or post install. When egress is enabled, OSM requires the mesh [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges to be specified. The mesh CIDR ranges are the list of CIDR ranges corresponding to the pod and service CIDRs configured in the cluster. The mesh CIDR ranges are required with egress to prevent any traffic destined within the cluster from escaping out as egress traffic, to be able to enforce mesh traffic policies.
-
-A [convenience script](https://github.com/openservicemesh/osm/blob/main/scripts/get_mesh_cidr.sh) to retrieve the mesh CIDR ranges can be used if the user is not aware of the pod and service CIDR ranges for their cluster.
-```console
-$ ./scripts/get_mesh_cidr.sh
-10.0.0.0/16,10.2.0.0/16
-```
+Egress can be enabled during OSM install or post install. When egress is enabled, outbound traffic from pods are allowed to egress the pod as long as the traffic does not match in-mesh traffic policies that otherwise deny the traffic.
 
 Egress can be configured using either of the following ways.
 1. During OSM install (default `--enable-egress=false`)
 	```bash
-	osm install --enable-egress --mesh-cidr "10.0.0.0/16,10.2.0.0/16"
-	```
-	or
-	```bash
-	osm install --enable-egress --mesh-cidr 10.0.0.0/16 --mesh-cidr 10.2.0.0/16
+	osm install --enable-egress
 	```
 
 2. Post OSM install
 
-	`osm-controller` retrieves the egress configuration from the `osm-config` ConfigMap in its namespace (`osm-system` by default). Patch the ConfigMap by setting `egress: "true"` and `mesh_cidr_ranges` with the CIDR ranges obtained above.
+	`osm-controller` retrieves the egress configuration from the `osm-config` ConfigMap in its namespace (`osm-system` by default). Patch the ConfigMap by setting `egress: "true"`.
 	```bash
-	kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"egress":"true", "mesh_cidr_ranges":"10.0.0.0/16,10.2.0.0/16"}}' --type=merge
+	kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"egress":"true"}}' --type=merge
 	```
-	*Note: The value for `mesh_cidr_ranges` can either be space or comma separated.*
-
-
-With egress enabled, traffic from pods within the mesh will be allowed to access external services outside the mesh CIDR ranges.
 
 ### Disabling Egress
 
-Similar to enabling egress, egress can be disabled during OSM install or post install. The mesh CIDR ranges are not required when egress is being disabled.
-
+Similar to enabling egress, egress can be disabled during OSM install or post install.
 1. During OSM install
 	```bash
 	bin osm install --enable-egress=false
@@ -59,4 +44,4 @@ Similar to enabling egress, egress can be disabled during OSM install or post in
 	kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"egress":"false"}}' --type=merge
     ```
 
-With egress disabled, traffic from pods within the mesh will not be able to access external services outside the mesh CIDR ranges.
+With egress disabled, traffic from pods within the mesh will not be able to access external services outside the cluster.

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSR
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
+cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
@@ -467,6 +468,7 @@ github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gookit/color v1.2.5/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -17,7 +17,6 @@ const (
 	permissiveTrafficPolicyModeKey = "permissive_traffic_policy_mode"
 	egressKey                      = "egress"
 	prometheusScrapingKey          = "prometheus_scraping"
-	meshCIDRRangesKey              = "mesh_cidr_ranges"
 	useHTTPSIngressKey             = "use_https_ingress"
 	tracingEnableKey               = "tracing_enable"
 	tracingAddressKey              = "tracing_address"
@@ -90,9 +89,6 @@ type osmConfig struct {
 	// TracingEndpoint is the collector endpoint on the listener
 	TracingEndpoint string `yaml:"tracing_endpoint"`
 
-	// MeshCIDRRanges is the list of CIDR ranges for in-mesh traffic
-	MeshCIDRRanges string `yaml:"mesh_cidr_ranges"`
-
 	// EnvoyLogLevel is a string that defines the log level for envoy proxies
 	EnvoyLogLevel string `yaml:"envoy_log_level"`
 }
@@ -134,7 +130,6 @@ func (c *Client) getConfigMap() *osmConfig {
 		PermissiveTrafficPolicyMode: getBoolValueForKey(configMap, permissiveTrafficPolicyModeKey),
 		Egress:                      getBoolValueForKey(configMap, egressKey),
 		PrometheusScraping:          getBoolValueForKey(configMap, prometheusScrapingKey),
-		MeshCIDRRanges:              getEgressCIDR(configMap),
 		UseHTTPSIngress:             getBoolValueForKey(configMap, useHTTPSIngressKey),
 
 		TracingEnable: getBoolValueForKey(configMap, tracingEnableKey),
@@ -148,18 +143,6 @@ func (c *Client) getConfigMap() *osmConfig {
 	}
 
 	return &osmConfigMap
-}
-
-func getEgressCIDR(configMap *v1.ConfigMap) string {
-	cidr, ok := configMap.Data[meshCIDRRangesKey]
-	if !ok {
-		if getBoolValueForKey(configMap, egressKey) {
-			log.Error().Err(errMissingKeyInConfigMap).Msgf("Missing ConfigMap %s/%s key %s, required when egress is enabled; Defaulting to %+v", configMap.Namespace, configMap.Name, meshCIDRRangesKey, defaultInMeshCIDR)
-		}
-		return defaultInMeshCIDR
-	}
-
-	return cidr
 }
 
 func getBoolValueForKey(configMap *v1.ConfigMap, key string) bool {

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -11,8 +11,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 var _ = Describe("Test OSM ConfigMap parsing", func() {
@@ -36,66 +34,6 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 
 	Context("Ensure we are able to get reasonable defaults from ConfigMap", func() {
 
-		It("Parsed blank in-mesh CIDR", func() {
-			Expect(cfg.getConfigMap().Egress).To(BeFalse())
-			actual := cfg.getConfigMap().MeshCIDRRanges
-			expected := ""
-			Expect(actual).To(Equal(expected))
-		})
-
-		It("Parsed default in-mesh CIDR", func() {
-			cm := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: map[string]string{
-					egressKey: "true",
-				},
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &cm, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			<-cfg.GetAnnouncementsChannel()
-
-			Expect(cfg.getConfigMap().Egress).To(BeTrue())
-
-			actual := cfg.getConfigMap().MeshCIDRRanges
-			Expect(actual).To(Equal(defaultInMeshCIDR))
-
-			// TODO(draychev): once we have reasonable defaults this will change to something like:
-			// expectedCIDR := []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
-			var expectedCIDR []string
-			Expect(cfg.GetMeshCIDRRanges()).To(Equal(expectedCIDR))
-		})
-
-		It("Parsed specific in-mesh CIDR", func() {
-			cm := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: map[string]string{
-					egressKey:         "true",
-					meshCIDRRangesKey: ",  8.8.8.8/24   ,  ,  1.1.0.0/8,   8.8.8.8/24   , someIncorrectlyFormattedCIDR ",
-				},
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &cm, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			event := <-cfg.GetAnnouncementsChannel()
-			log.Info().Msgf("ConfigMap Update Event:  %+v", event.(kubernetes.Event).Value.(*v1.ConfigMap).Data)
-
-			Expect(cfg.getConfigMap().Egress).To(BeTrue())
-
-			actual := cfg.getConfigMap().MeshCIDRRanges
-			Expect(actual).To(Equal(cm.Data[meshCIDRRangesKey]))
-
-			Expect(cfg.IsEgressEnabled()).To(BeTrue())
-
-			expectedCIDR := []string{"1.1.0.0/8", "8.8.8.8/24"}
-			Expect(cfg.GetMeshCIDRRanges()).To(Equal(expectedCIDR))
-		})
-
 		It("Tag matches const key for all fields of OSM ConfigMap struct", func() {
 			fieldNameTag := map[string]string{
 				"PermissiveTrafficPolicyMode": permissiveTrafficPolicyModeKey,
@@ -105,14 +43,13 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"TracingAddress":              tracingAddressKey,
 				"TracingPort":                 tracingPortKey,
 				"TracingEndpoint":             tracingEndpointKey,
-				"MeshCIDRRanges":              meshCIDRRangesKey,
 				"UseHTTPSIngress":             useHTTPSIngressKey,
 				"EnvoyLogLevel":               envoyLogLevel,
 			}
 			t := reflect.TypeOf(osmConfig{})
 
 			actualNumberOfFields := t.NumField()
-			expectedNumberOfFields := 10
+			expectedNumberOfFields := len(fieldNameTag)
 			Expect(actualNumberOfFields).To(
 				Equal(expectedNumberOfFields),
 				fmt.Sprintf("Fields have been added or removed from the osmConfig struct -- expected %d, actual %d; please correct this unit test", expectedNumberOfFields, actualNumberOfFields))

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -3,9 +3,6 @@ package configurator
 import (
 	"encoding/json"
 	"fmt"
-	"net"
-	"sort"
-	"strings"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 )
@@ -79,37 +76,6 @@ func (c *Client) GetTracingEndpoint() string {
 		return tracingEndpoint
 	}
 	return constants.DefaultTracingEndpoint
-}
-
-// GetMeshCIDRRanges returns a list of mesh CIDR ranges
-func (c *Client) GetMeshCIDRRanges() []string {
-	noSpaces := strings.ReplaceAll(c.getConfigMap().MeshCIDRRanges, " ", ",")
-	commaSeparatedCIDRs := strings.Split(noSpaces, ",")
-
-	cidrSet := make(map[string]interface{})
-	for _, cidr := range commaSeparatedCIDRs {
-		trimmedCIDR := strings.Trim(cidr, " ")
-		if len(trimmedCIDR) == 0 {
-			continue
-		}
-
-		_, _, err := net.ParseCIDR(trimmedCIDR)
-		if err != nil {
-			log.Error().Err(err).Msgf("Found incorrectly formatted in-mesh CIDR %s from ConfigMap %s/%s; Skipping CIDR", trimmedCIDR, c.osmNamespace, c.osmConfigMapName)
-			continue
-		}
-
-		cidrSet[trimmedCIDR] = nil
-	}
-
-	var cidrs []string
-	for cidr := range cidrSet {
-		cidrs = append(cidrs, cidr)
-	}
-
-	sort.Strings(cidrs)
-
-	return cidrs
 }
 
 // UseHTTPSIngress determines whether traffic between ingress and backend pods should use HTTPS protocol

--- a/pkg/configurator/mock_client.go
+++ b/pkg/configurator/mock_client.go
@@ -76,20 +76,6 @@ func (mr *MockConfiguratorMockRecorder) GetEnvoyLogLevel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvoyLogLevel", reflect.TypeOf((*MockConfigurator)(nil).GetEnvoyLogLevel))
 }
 
-// GetMeshCIDRRanges mocks base method
-func (m *MockConfigurator) GetMeshCIDRRanges() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMeshCIDRRanges")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetMeshCIDRRanges indicates an expected call of GetMeshCIDRRanges
-func (mr *MockConfiguratorMockRecorder) GetMeshCIDRRanges() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshCIDRRanges", reflect.TypeOf((*MockConfigurator)(nil).GetMeshCIDRRanges))
-}
-
 // GetOSMNamespace mocks base method
 func (m *MockConfigurator) GetOSMNamespace() string {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -49,9 +49,6 @@ type Configurator interface {
 	// GetTracingEndpoint returns the collector endpoint
 	GetTracingEndpoint() string
 
-	// GetMeshCIDRRanges returns a list of mesh CIDR ranges
-	GetMeshCIDRRanges() []string
-
 	// UseHTTPSIngress determines whether protocol used for traffic from ingress to backend pods should be HTTPS.
 	UseHTTPSIngress() bool
 


### PR DESCRIPTION
After the introduction of per service outbound filter chains
in dac3552f72ea38f0d283af842d80e4ce0400ec81, there is no
longer a need for the mesh cidr ranges to be explicitly
configured for egress to work.

This change removes code related to mesh cidr ranges in
osm-controller and osm cli that are no longer used.

Resolves #1340

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [ ]
- Documentation          [X]
- Install                [X]
- Control Plane          [X]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`