### PR TITLE
Move remaining XDS vertical API calls to use kubecontroller caches

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -222,7 +222,7 @@ func main() {
 	// Expose /debug endpoints and data only if the enableDebugServer flag is enabled
 	var debugServer debugger.DebugServer
 	if enableDebugServer {
-		debugServer = debugger.NewDebugServer(certDebugger, xdsServer, meshCatalog, kubeConfig, kubeClient, cfg)
+		debugServer = debugger.NewDebugServer(certDebugger, xdsServer, meshCatalog, kubeConfig, kubeClient, cfg, kubernetesClient)
 	}
 
 	funcProbes := []health.Probes{xdsServer}

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -57,9 +57,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 		// play pretend this call queries a controller cache
 		var services []*corev1.Service
 
-		// Things worked before because internally, the APIs were calling kubeClient APIs with "namespace"
-		// parametre. Some tests have been using catalog APIs bypassing the namespace monitoring altogether.
-		// For now, this assumes that catalog tests use monitored namespaces at all times
+		// This assumes that catalog tests use monitored namespaces at all times
 		svcList, _ := kubeClient.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
 		for idx := range svcList.Items {
 			services = append(services, &svcList.Items[idx])
@@ -76,7 +74,6 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 		return vv
 	}).AnyTimes()
-
 	mockKubeController.EXPECT().ListPods().DoAndReturn(func() []*v1.Pod {
 		vv, err := kubeClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -52,23 +52,17 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(testChan).AnyTimes()
 
-	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
-	listExpectedNs := tests.GetUnique([]string{
-		tests.BookstoreService.Namespace,
-		tests.BookbuyerService.Namespace,
-		tests.BookstoreApexService.Namespace,
-	})
-
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {
 		// play pretend this call queries a controller cache
 		var services []*corev1.Service
 
-		for _, ns := range listExpectedNs {
-			svcList, _ := kubeClient.CoreV1().Services(ns).List(context.Background(), metav1.ListOptions{})
-			for _, svcItem := range svcList.Items {
-				services = append(services, &svcItem)
-			}
+		// Things worked before because internally, the APIs were calling kubeClient APIs with "namespace"
+		// parametre. Some tests have been using catalog APIs bypassing the namespace monitoring altogether.
+		// For now, this assumes that catalog tests use monitored namespaces at all times
+		svcList, _ := kubeClient.CoreV1().Services("").List(context.Background(), metav1.ListOptions{})
+		for idx := range svcList.Items {
+			services = append(services, &svcList.Items[idx])
 		}
 
 		return services
@@ -82,6 +76,20 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 		return vv
 	}).AnyTimes()
+
+	mockKubeController.EXPECT().ListPods().DoAndReturn(func() []*v1.Pod {
+		vv, err := kubeClient.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return nil
+		}
+
+		var podRet []*v1.Pod = []*v1.Pod{}
+		for idx := range vv.Items {
+			podRet = append(podRet, &vv.Items[idx])
+		}
+		return podRet
+	}).AnyTimes()
+
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreService.Namespace).Return(true).AnyTimes()

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -1,16 +1,14 @@
 package catalog
 
 import (
-	"context"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
@@ -18,12 +16,12 @@ import (
 // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
 func (mc *MeshCatalog) GetServicesFromEnvoyCertificate(cn certificate.CommonName) ([]service.MeshService, error) {
 	var serviceList []service.MeshService
-	pod, err := GetPodFromCertificate(cn, mc.kubeClient)
+	pod, err := GetPodFromCertificate(cn, mc.kubeController)
 	if err != nil {
 		return nil, err
 	}
 
-	services, err := listServicesForPod(pod, mc.kubeClient)
+	services, err := listServicesForPod(pod, mc.kubeController)
 	if err != nil {
 		return nil, err
 	}
@@ -81,25 +79,22 @@ func (mc *MeshCatalog) filterTrafficSplitServices(services []v1.Service) []v1.Se
 }
 
 // GetPodFromCertificate returns the Kubernetes Pod object for a given certificate.
-func GetPodFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Interface) (*v1.Pod, error) {
+func GetPodFromCertificate(cn certificate.CommonName, kubecontroller k8s.Controller) (*v1.Pod, error) {
 	cnMeta, err := getCertificateCommonNameMeta(cn)
 	if err != nil {
 		return nil, err
 	}
 
 	log.Trace().Msgf("Looking for pod with label %q=%q", constants.EnvoyUniqueIDLabelName, cnMeta.ProxyID)
-
-	podList, err := kubeClient.CoreV1().Pods(cnMeta.Namespace).List(context.Background(), v12.ListOptions{})
-	if err != nil {
-		log.Error().Err(err).Msgf("Error listing pods in namespace %s", cnMeta.Namespace)
-		return nil, err
-	}
-
+	podList := kubecontroller.ListPods()
 	var pods []v1.Pod
-	for _, pod := range podList.Items {
+	for _, pod := range podList {
+		if pod.Namespace != cnMeta.Namespace {
+			continue
+		}
 		for labelKey, labelValue := range pod.Labels {
 			if labelKey == constants.EnvoyUniqueIDLabelName && labelValue == cnMeta.ProxyID {
-				pods = append(pods, pod)
+				pods = append(pods, *pod)
 			}
 		}
 	}
@@ -138,19 +133,18 @@ func GetPodFromCertificate(cn certificate.CommonName, kubeClient kubernetes.Inte
 }
 
 // listServicesForPod lists Kubernetes services whose selectors match pod labels
-func listServicesForPod(pod *v1.Pod, kubeClient kubernetes.Interface) ([]v1.Service, error) {
+func listServicesForPod(pod *v1.Pod, kubeController k8s.Controller) ([]v1.Service, error) {
 	var serviceList []v1.Service
-	svcList, err := kubeClient.CoreV1().Services(pod.Namespace).List(context.Background(), v12.ListOptions{})
-	if err != nil {
-		log.Error().Err(err).Msgf("Error listing pods in namespace %s", pod.Namespace)
-		return nil, err
-	}
+	svcList := kubeController.ListServices()
 
-	for _, svc := range svcList.Items {
+	for _, svc := range svcList {
+		if svc.Namespace != pod.Namespace {
+			continue
+		}
 		svcRawSelector := svc.Spec.Selector
 		selector := labels.Set(svcRawSelector).AsSelector()
 		if selector.Matches(labels.Set(pod.Labels)) {
-			serviceList = append(serviceList, svc)
+			serviceList = append(serviceList, *svc)
 		}
 	}
 

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 var _ = Describe("Test XDS certificate tooling", func() {
-
-	var (
-		mockCtrl *gomock.Controller
-	)
-	mockCtrl = gomock.NewController(ginkgo.GinkgoT())
+	mockCtrl := gomock.NewController(ginkgo.GinkgoT())
 	kubeClient := testclient.NewSimpleClientset()
 
 	mc := NewFakeMeshCatalog(kubeClient)

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -60,7 +60,7 @@ func printProxies(w http.ResponseWriter, proxies map[certificate.CommonName]time
 }
 
 func (ds debugServer) getConfigDump(cn certificate.CommonName, w http.ResponseWriter) {
-	pod, err := catalog.GetPodFromCertificate(cn, ds.kubeClient)
+	pod, err := catalog.GetPodFromCertificate(cn, ds.kubeController)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
 	}
@@ -70,7 +70,7 @@ func (ds debugServer) getConfigDump(cn certificate.CommonName, w http.ResponseWr
 }
 
 func (ds debugServer) getProxy(cn certificate.CommonName, w http.ResponseWriter) {
-	pod, err := catalog.GetPodFromCertificate(cn, ds.kubeClient)
+	pod, err := catalog.GetPodFromCertificate(cn, ds.kubeController)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
 	}

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 // GetHandlers implements DebugServer interface and returns the rest of URLs and the handling functions.
@@ -34,12 +35,13 @@ func (ds debugServer) GetHandlers() map[string]http.Handler {
 }
 
 // NewDebugServer returns an implementation of DebugServer interface.
-func NewDebugServer(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, kubeConfig *rest.Config, kubeClient kubernetes.Interface, cfg configurator.Configurator) DebugServer {
+func NewDebugServer(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, kubeConfig *rest.Config, kubeClient kubernetes.Interface, cfg configurator.Configurator, kubeController k8s.Controller) DebugServer {
 	return debugServer{
 		certDebugger:        certDebugger,
 		xdsDebugger:         xdsDebugger,
 		meshCatalogDebugger: meshCatalogDebugger,
 		kubeClient:          kubeClient,
+		kubeController:      kubeController,
 
 		// We need the Kubernetes config to be able to establish port forwarding to the Envoy pod we want to debug.
 		kubeConfig: kubeConfig,

--- a/pkg/debugger/server_test.go
+++ b/pkg/debugger/server_test.go
@@ -8,6 +8,7 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 // Tests GetHandlers returns the expected debug endpoints and non-nil handlers
@@ -20,13 +21,15 @@ func TestGetHandlers(t *testing.T) {
 	mockCatalogDebugger := NewMockMeshCatalogDebugger(mockCtrl)
 	mockConfig := configurator.NewMockConfigurator(mockCtrl)
 	client := testclient.NewSimpleClientset()
+	mockKubeController := k8s.NewMockController(mockCtrl)
 
 	ds := NewDebugServer(mockCertDebugger,
 		mockXdsDebugger,
 		mockCatalogDebugger,
 		nil,
 		client,
-		mockConfig)
+		mockConfig,
+		mockKubeController)
 
 	handlers := ds.GetHandlers()
 

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -26,6 +27,7 @@ type debugServer struct {
 	meshCatalogDebugger MeshCatalogDebugger
 	kubeConfig          *rest.Config
 	kubeClient          kubernetes.Interface
+	kubeController      k8s.Controller
 	configurator        configurator.Configurator
 }
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -28,6 +28,7 @@ func NewKubernetesController(kubeClient kubernetes.Interface, meshName string, s
 	// Initialize resources here
 	client.initNamespaceMonitor()
 	client.initServicesMonitor()
+	client.initPodMonitor()
 
 	if err := client.run(stop); err != nil {
 		log.Error().Err(err).Msg("Could not start Kubernetes Namespaces client")
@@ -73,6 +74,22 @@ func (c *Client) initServicesMonitor() {
 	c.announcements[Services] = make(chan interface{})
 
 	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.announcements[Services], shouldObserve))
+}
+
+func (c *Client) initPodMonitor() {
+	informerFactory := informers.NewSharedInformerFactory(c.kubeClient, DefaultKubeEventResyncInterval)
+	c.informers[Pods] = informerFactory.Core().V1().Pods().Informer()
+
+	// Function to filter Pods by Namespace
+	shouldObserve := func(obj interface{}) bool {
+		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
+		return c.IsMonitoredNamespace(ns)
+	}
+
+	// Announcement channel for Pods
+	c.announcements[Pods] = make(chan interface{})
+
+	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Services], shouldObserve))
 }
 
 func (c *Client) run(stop <-chan struct{}) error {
@@ -166,4 +183,20 @@ func (c Client) GetNamespace(ns string) *corev1.Namespace {
 		return ns
 	}
 	return nil
+}
+
+// ListPods returns a list of pods part of the mesh
+// Kubecontroller does not currently segment pod notifications, hence it receives notifications
+// for all k8s Pods.
+func (c Client) ListPods() []*corev1.Pod {
+	var pods []*corev1.Pod
+
+	for _, podInterface := range c.informers[Pods].GetStore().List() {
+		pod := podInterface.(*corev1.Pod)
+		if !c.IsMonitoredNamespace(pod.Namespace) {
+			continue
+		}
+		pods = append(pods, pod)
+	}
+	return pods
 }

--- a/pkg/kubernetes/mock_controller.go
+++ b/pkg/kubernetes/mock_controller.go
@@ -105,6 +105,20 @@ func (mr *MockControllerMockRecorder) ListMonitoredNamespaces() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMonitoredNamespaces", reflect.TypeOf((*MockController)(nil).ListMonitoredNamespaces))
 }
 
+// ListPods mocks base method
+func (m *MockController) ListPods() []*v1.Pod {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPods")
+	ret0, _ := ret[0].([]*v1.Pod)
+	return ret0
+}
+
+// ListPods indicates an expected call of ListPods
+func (mr *MockControllerMockRecorder) ListPods() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPods", reflect.TypeOf((*MockController)(nil).ListPods))
+}
+
 // ListServices mocks base method
 func (m *MockController) ListServices() []*v1.Service {
 	m.ctrl.T.Helper()

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -51,6 +51,8 @@ const (
 	Namespaces InformerKey = "Namespaces"
 	// Services lookup identifier
 	Services InformerKey = "Services"
+	// Pods lookup identifier
+	Pods InformerKey = "Pods"
 )
 
 // InformerCollection is the type holding the collection of informers we keep
@@ -85,4 +87,7 @@ type Controller interface {
 
 	// Returns the announcement channel for a certain Informer ID
 	GetAnnouncementsChannel(informerID InformerKey) <-chan interface{}
+
+	// ListPods returns a list of pods part of the mesh
+	ListPods() []*corev1.Pod
 }


### PR DESCRIPTION
GetPodFromCertificate and ListPods were two remaining APIs used by
pretty much all verticals which were still going through kubeclient API
REST calls.

In E2E tests, with a higher count of pods we've seen slowness issues,
which ranged k8s API throttling, go-routine contention (as envoy updates pile up)
and webhooks timeout.

These additions remove any network/API dependency from the XDS paths, making
verticals' execution range between 50-100ms in demo conditions and debug logging.
(Down from 7-10seconds per vertical)

Please describe the motivation for this PR and provide enough
information so that others can review it.

- Control Plane          [X]
- Tests / CI System      [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No