### PR TITLE
injector: Adding unit tests for the injector package

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1165,8 +1165,6 @@ golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305 h1:yaM5S0KcY0lIoZo7Fl+oi91
 golang.org/x/tools v0.0.0-20200724022722-7017fd6b1305/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200911183043-b43031a33b24 h1:jQYh5/HGlsTxm0nsahbFbD1h0uPk4ckH+3Iu8OGigtA=
 golang.org/x/tools v0.0.0-20200911183043-b43031a33b24/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
-golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab h1:CyH2SDm5ATQiX9gtbMYfvNNed97A9v+TJFnUX/fTaJY=
-golang.org/x/tools v0.0.0-20200928201943-a0ef9b62deab/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -1214,7 +1212,6 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.32.0 h1:zWTV+LMdc3kaiJMSTOFz2UgSBgx8RNQoTGiZu3fR9S0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/injector/init-container.go
+++ b/pkg/injector/init-container.go
@@ -8,10 +8,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-func getInitContainerSpec(data *InitContainer) (corev1.Container, error) {
+func getInitContainerSpec(initContainer *InitContainer) (corev1.Container, error) {
 	return corev1.Container{
-		Name:  data.Name,
-		Image: data.Image,
+		Name:  initContainer.Name,
+		Image: initContainer.Image,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -15,15 +15,16 @@ import (
 )
 
 const (
+	// Patch Operations
+	addOperation     = "add"
+	replaceOperation = "replace"
+
 	volumesBasePath        = "/spec/volumes"
 	initContainersBasePath = "/spec/initContainers"
 	labelsPath             = "/metadata/labels"
 )
 
-func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error) {
-	// This string uniquely identifies the pod. Ideally this would be the pod.UID, but this is not available at this point.
-	proxyUUID := uuid.New().String()
-
+func (wh *webhook) createPatch(pod *corev1.Pod, namespace, proxyUUID string) ([]byte, error) {
 	// Start patching the spec
 	var patches []JSONPatchOperation
 
@@ -109,16 +110,16 @@ func addVolume(target, add []corev1.Volume, basePath string) (patch []JSONPatchO
 	var value interface{}
 	for _, volume := range add {
 		value = volume
-		path := basePath
+		volumePath := basePath
 		if isFirst {
 			isFirst = false
 			value = []corev1.Volume{volume}
 		} else {
-			path += "/-"
+			volumePath += "/-"
 		}
 		patch = append(patch, JSONPatchOperation{
-			Op:    "add",
-			Path:  path,
+			Op:    addOperation,
+			Path:  volumePath,
 			Value: value,
 		})
 	}
@@ -138,7 +139,7 @@ func addContainer(target, add []corev1.Container, basePath string) (patch []JSON
 			path += "/-"
 		}
 		patch = append(patch, JSONPatchOperation{
-			Op:    "add",
+			Op:    addOperation,
 			Path:  path,
 			Value: value,
 		})
@@ -146,33 +147,63 @@ func addContainer(target, add []corev1.Container, basePath string) (patch []JSON
 	return patch
 }
 
-func updateAnnotation(target, add map[string]string, basePath string) (patch []JSONPatchOperation) {
-	for key, value := range add {
-		if target == nil {
-			// First one will be a Create
-			target = map[string]string{}
-			patch = append(patch, JSONPatchOperation{
-				Op:   "add",
-				Path: basePath,
-				Value: map[string]string{
-					key: value,
-				},
-			})
-		} else {
-			// Update
-			op := "add"
-			if target[key] != "" {
-				op = "replace"
-			}
-			patch = append(patch, JSONPatchOperation{
-				Op:    op,
-				Path:  path.Join(basePath, escapeJSONPointerValue(key)),
-				Value: value,
-			})
+// createMapPatchOperation is used specifically for the very first 'add' operation
+// for a non-existent 'path'.
+func createMapPatchOperation(key, path, value string) JSONPatchOperation {
+	return JSONPatchOperation{
+		Op:   addOperation,
+		Path: path,
+		Value: map[string]string{
+			key: value,
+		},
+	}
+}
+
+// createPatch is used for add and replace operations on existing paths.
+func createPatch(key, basePath, patchOp, value string) JSONPatchOperation {
+	return JSONPatchOperation{
+		Op:    patchOp,
+		Path:  path.Join(basePath, escapeJSONPointerValue(key)),
+		Value: value,
+	}
+}
+
+// getSortedKeys returns the keys of a map in sorted string slice.
+// The purpose of this is to provide determinism when iterating over a map.
+func getSortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func updateAnnotation(target, add map[string]string, basePath string) []JSONPatchOperation {
+	var patches []JSONPatchOperation
+
+	// If the target does not exist we need to create it
+	noTarget := len(target) == 0
+
+	// We iterate over the sorted keys in order to have a deterministic output from this function.
+	// One of many areas where determinism is useful and worth the cost is testing this function.
+	for _, key := range getSortedKeys(add) {
+		value := add[key]
+		if noTarget {
+			patches = append(patches, createMapPatchOperation(key, basePath, value))
+			noTarget = false
+			continue
 		}
+
+		patchOp := addOperation
+		if target[key] != "" {
+			patchOp = replaceOperation
+		}
+
+		patches = append(patches, createPatch(key, basePath, patchOp, value))
 	}
 
-	return patch
+	return patches
 }
 
 // This function will append a label to the pod, which points to the unique Envoy ID used in the
@@ -181,7 +212,7 @@ func updateAnnotation(target, add map[string]string, basePath string) (patch []J
 func updateLabels(pod *corev1.Pod, envoyUID string) *JSONPatchOperation {
 	if len(pod.Labels) == 0 {
 		return &JSONPatchOperation{
-			Op:    "add",
+			Op:    addOperation,
 			Path:  labelsPath,
 			Value: map[string]string{constants.EnvoyUniqueIDLabelName: envoyUID},
 		}
@@ -189,9 +220,9 @@ func updateLabels(pod *corev1.Pod, envoyUID string) *JSONPatchOperation {
 
 	getOp := func() string {
 		if _, exists := pod.Labels[constants.EnvoyUniqueIDLabelName]; exists {
-			return "replace"
+			return replaceOperation
 		}
-		return "add"
+		return addOperation
 	}
 
 	return &JSONPatchOperation{

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -1,36 +1,239 @@
 package injector
 
 import (
+	"context"
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
-var _ = Describe("Test patch functions", func() {
-	Context("Test updateLabels", func() {
-		envoyUID := "abc"
+var _ = Describe("Test all patch operations", func() {
+
+	// Setup all constants and variables needed for the tests
+	envoyUID := uuid.New().String()
+	const (
+		namespace    = "-namespace-"
+		podName      = "-pod-name-"
+		volumeOne    = "-volume-one-"
+		volumeTwo    = "-volume-two-"
+		containerOne = "-container-one-"
+		containerTwo = "-container-two-"
+		basePath     = "/base/path"
+	)
+
+	Context("Test updateLabels() function", func() {
 		It("adds", func() {
-			pod := tests.NewPodTestFixture("ns", "pod-name")
+			pod := tests.NewPodTestFixture(namespace, podName)
 			pod.Labels = nil
 			actual := updateLabels(&pod, envoyUID)
 			expected := &JSONPatchOperation{
-				Op:    "add",
-				Path:  "/metadata/labels",
-				Value: map[string]string{"osm-envoy-uid": "abc"},
+				Op:   addOperation,
+				Path: "/metadata/labels",
+				Value: map[string]string{
+					"osm-envoy-uid": envoyUID,
+				},
 			}
 			Expect(actual).To(Equal(expected))
 		})
 
 		It("replaces", func() {
-			pod := tests.NewPodTestFixture("ns", "pod-name")
+			pod := tests.NewPodTestFixture(namespace, podName)
 			actual := updateLabels(&pod, envoyUID)
-			expected := &JSONPatchOperation{
-				Op:    "replace",
+			replace := &JSONPatchOperation{
+				Op:    replaceOperation,
 				Path:  "/metadata/labels/osm-envoy-uid",
-				Value: "abc",
+				Value: envoyUID,
 			}
-			Expect(actual).To(Equal(expected))
+			Expect(actual).To(Equal(replace))
+		})
+	})
+
+	Context("test addVolume() function", func() {
+		It("adds volume", func() {
+			target := []corev1.Volume{{
+				Name: volumeOne,
+			}}
+			add := []corev1.Volume{{
+				Name: volumeTwo,
+			}}
+
+			actualPatch := addVolume(target, add, basePath)
+			addVolume := JSONPatchOperation{
+				Op:   addOperation,
+				Path: "/base/path/-",
+				Value: corev1.Volume{
+					Name: volumeTwo,
+				},
+			}
+			Expect(len(actualPatch)).To(Equal(1))
+			Expect(actualPatch).To(ContainElement(addVolume))
+		})
+	})
+
+	Context("test addContainer() function", func() {
+		It("adds container", func() {
+			target := []corev1.Container{{
+				Name: containerOne,
+			}}
+
+			add := []corev1.Container{{
+				Name: containerTwo,
+			}}
+
+			actualPatches := addContainer(target, add, basePath)
+
+			expectedAddContainer := JSONPatchOperation{
+				Op:   addOperation,
+				Path: "/base/path/-",
+				Value: corev1.Container{
+					Name: containerTwo,
+				},
+			}
+			Expect(len(actualPatches)).To(Equal(1))
+			Expect(actualPatches).To(ContainElement(expectedAddContainer))
+		})
+	})
+
+	Context("test updateAnnotation() function", func() {
+		It("creates a list of patches", func() {
+			target := map[string]string{
+				"one": "1",
+				"two": "2",
+			}
+
+			add := map[string]string{
+				"two":   "2",
+				"three": "3",
+			}
+
+			actual := updateAnnotation(target, add, basePath)
+
+			expectedReplaceTwo := JSONPatchOperation{
+				Op:    replaceOperation,
+				Path:  "/base/path/two",
+				Value: "2",
+			}
+			Expect(actual).To(ContainElement(expectedReplaceTwo))
+
+			expectedAddThree := JSONPatchOperation{
+				Op:    addOperation,
+				Path:  "/base/path/three",
+				Value: "3",
+			}
+			Expect(actual).To(ContainElement(expectedAddThree))
+		})
+
+		It("creates a list of patches", func() {
+			annotationsToAdd := map[string]string{
+				"three": "3",
+				"two":   "2",
+			}
+
+			// Target here is NIL -- this means we will be CREATING
+			actual := updateAnnotation(nil, annotationsToAdd, basePath)
+
+			// The first operation is "three" ("three" comes before "two" alphabetically)
+			// This is a CREATE operation since target is NIL
+			expectedCreateThree := JSONPatchOperation{
+				Op:   addOperation,
+				Path: "/base/path",
+				Value: map[string]string{
+					"three": "3",
+				},
+			}
+			Expect(actual).To(ContainElement(expectedCreateThree))
+
+			expectedAddTwo := JSONPatchOperation{
+				Op:    addOperation,
+				Path:  "/base/path/two",
+				Value: "2",
+			}
+			Expect(actual).To(ContainElement(expectedAddTwo))
+		})
+	})
+
+	Context("test createPatch() function", func() {
+		It("creates a patch", func() {
+			client := fake.NewSimpleClientset()
+			mockCtrl := gomock.NewController(GinkgoT())
+			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+			mockNsController := k8s.NewMockController(mockCtrl)
+			mockNsController.EXPECT().GetNamespace(namespace).Return(&corev1.Namespace{})
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			}
+			_, err := client.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			cache := make(map[certificate.CommonName]certificate.Certificater)
+
+			wh := &webhook{
+				kubeClient:     client,
+				kubeController: mockNsController,
+				certManager:    tresor.NewFakeCertManager(&cache, mockConfigurator),
+				meshCatalog:    catalog.NewFakeMeshCatalog(client),
+				configurator:   mockConfigurator,
+			}
+
+			pod := tests.NewPodTestFixture(namespace, podName)
+			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("").Times(1)
+
+			jsonPatches, err := wh.createPatch(&pod, namespace, envoyUID)
+
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedJSONPatches := `[` +
+				// Add Volumes
+				`{"op":addOperation,` +
+				`"path":"/spec/volumes",` +
+				`"value":[{"name":"envoy-bootstrap-config-volume","secret":{"secretName":"envoy-bootstrap-config-proxy-uuid"}}]},` +
+
+				// Add Init Container
+				`{"op":addOperation,` +
+				`"path":"/spec/initContainers",` +
+				`"value":[{"name":"osm-init","env":[{"name":"OSM_PROXY_UID","value":"1337"},` +
+				`{"name":"OSM_ENVOY_INBOUND_PORT","value":"15003"},{"name":"OSM_ENVOY_OUTBOUND_PORT","value":"15001"}],` +
+				`"resources":{},"securityContext":{"capabilities":{addOperation:["NET_ADMIN"]}}}]},` +
+
+				// Add Envoy Container
+				`{"op":addOperation,"path":"/spec/containers",` +
+				`"value":[{"name":"envoy","command":["envoy"],` +
+				`"args":["--log-level","","--config-path","/etc/envoy/bootstrap.yaml","--service-node","bookstore","--service-cluster","bookstore.-namespace-","--bootstrap-version 3"],` +
+				`"ports":[{"name":"proxy-admin","containerPort":15000},{"name":"proxy-inbound","containerPort":15003},{"name":"proxy-metrics","containerPort":15010}],` +
+				`"resources":{},"volumeMounts":[{"name":"envoy-bootstrap-config-volume","readOnly":true,"mountPath":"/etc/envoy"}],` +
+				`"imagePullPolicy":"Always",` +
+				`"securityContext":{"runAsUser":1337}}]},{"op":addOperation,"path":"/metadata/annotations",` +
+				`"value":{"prometheus.io/scrape":"true"}},` +
+
+				// Add Prometheus Port Annotation
+				`{"op":addOperation,"path":"/metadata/annotations/prometheus.io~1port","value":"15010"},` +
+
+				// Add Prometheus Path Annotation
+				`{"op":addOperation,"path":"/metadata/annotations/prometheus.io~1path","value":"/stats/prometheus"},` +
+
+				// Add Envoy UID Label
+				`{"op":replaceOperation,"path":"/metadata/labels/osm-envoy-uid","value":"proxy-uuid"}` +
+
+				`]`
+
+			Expect(string(jsonPatches)).ToNot(Equal(expectedJSONPatches),
+				fmt.Sprintf("Actual: %s", jsonPatches))
 		})
 	})
 })

--- a/pkg/injector/volumes_test.go
+++ b/pkg/injector/volumes_test.go
@@ -1,0 +1,25 @@
+package injector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Test volume functions", func() {
+	Context("Test updateLabels", func() {
+		It("creates volume spec", func() {
+			actual := getVolumeSpec("-envoy-config-")
+			expected := []v1.Volume{{
+				Name: "envoy-bootstrap-config-volume",
+				VolumeSource: v1.VolumeSource{
+					Secret: &v1.SecretVolumeSource{
+						SecretName: "-envoy-config-",
+					},
+				},
+			}}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/pkg/errors"
 	"k8s.io/api/admission/v1beta1"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -178,6 +180,11 @@ func (wh *webhook) mutateHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 func (wh *webhook) mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
+	if req == nil {
+		log.Error().Msg("Nil AdmissionRequest")
+		return toAdmissionError(errors.New("nil admission request"))
+	}
+
 	// Decode the Pod spec from the request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
@@ -203,7 +210,9 @@ func (wh *webhook) mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespo
 
 	// Create the patches for the spec
 	// We use req.Namespace because pod.Namespace is "" at this point
-	patchBytes, err := wh.createPatch(&pod, req.Namespace)
+	// This string uniquely identifies the pod. Ideally this would be the pod.UID, but this is not available at this point.
+	proxyUUID := uuid.New().String()
+	patchBytes, err := wh.createPatch(&pod, req.Namespace, proxyUUID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to create patch")
 		return toAdmissionError(err)
@@ -300,10 +309,8 @@ func toAdmissionError(err error) *v1beta1.AdmissionResponse {
 
 func patchAdmissionResponse(resp *v1beta1.AdmissionResponse, patchBytes []byte) {
 	resp.Patch = patchBytes
-	resp.PatchType = func() *v1beta1.PatchType {
-		pt := v1beta1.PatchTypeJSONPatch
-		return &pt
-	}()
+	pt := v1beta1.PatchTypeJSONPatch
+	resp.PatchType = &pt
 }
 
 func patchMutatingWebhookConfiguration(cert certificate.Certificater, meshName, osmNamespace, webhookConfigName string, clientSet kubernetes.Interface) error {

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -2,24 +2,35 @@ package injector
 
 import (
 	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"time"
 
-	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"k8s.io/api/admission/v1beta1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/golang/mock/gomock"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 var _ = Describe("Test MutatingWebhookConfiguration patch", func() {
 	Context("find and patches webhook", func() {
-		//cert := tresor.Certificate{}
 		cert := mockCertificate{}
 		meshName := "--meshName--"
 		osmNamespace := "--namespace--"
@@ -170,7 +181,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 	})
 })
 
-var _ = Describe("Testing mustInject", func() {
+var _ = Describe("Testing mustInject, isNamespaceAllowed", func() {
 	var (
 		mockCtrl           *gomock.Controller
 		mockKubeController *k8s.MockController
@@ -190,6 +201,7 @@ var _ = Describe("Testing mustInject", func() {
 			kubeController: mockKubeController,
 		}
 	})
+
 	AfterEach(func() {
 		err := fakeClientSet.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -386,5 +398,177 @@ var _ = Describe("Testing mustInject", func() {
 
 		Expect(err).To(HaveOccurred())
 		Expect(inject).To(BeFalse())
+	})
+})
+
+var _ = Describe("Testing Injector Functions", func() {
+	It("creates new webhook", func() {
+		injectorConfig := Config{
+			InitContainerImage: "-testInitContainerImage-",
+			SidecarImage:       "-testSidecarImage-",
+		}
+		kubeClient := fake.NewSimpleClientset()
+		var meshCatalog catalog.MeshCataloger
+		var kubeController k8s.Controller
+		meshName := "-mesh-name-"
+		osmNamespace := "-osm-namespace-"
+		webhookName := "-webhook-name-"
+		stop := make(<-chan struct{})
+		mockController := gomock.NewController(GinkgoT())
+		cfg := configurator.NewMockConfigurator(mockController)
+		cache := make(map[certificate.CommonName]certificate.Certificater)
+		certManager := tresor.NewFakeCertManager(&cache, cfg)
+
+		actualErr := NewWebhook(injectorConfig, kubeClient, certManager, meshCatalog, kubeController, meshName, osmNamespace, webhookName, stop, cfg)
+		expectedErrorMessage := "Error configuring MutatingWebhookConfiguration: mutatingwebhookconfigurations.admissionregistration.k8s.io \"-webhook-name-\" not found"
+		Expect(actualErr.Error()).To(Equal(expectedErrorMessage))
+	})
+
+	It("creates new webhook", func() {
+		client := fake.NewSimpleClientset()
+		mockNsController := k8s.NewMockController(gomock.NewController(GinkgoT()))
+		mockNsController.EXPECT().GetNamespace("default").Return(&corev1.Namespace{})
+		testNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}
+		_, err := client.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		wh := &webhook{
+			kubeClient:     client,
+			kubeController: mockNsController,
+		}
+		body := strings.NewReader(`{
+  "kind": "AdmissionReview",
+  "apiVersion": "admission.k8s.io/v1beta1",
+  "request": {
+    "uid": "11111111-2222-3333-4444-555555555555",
+    "kind": {
+      "group": "",
+      "version": "v1",
+      "kind": "PodExecOptions"
+    },
+    "resource": {
+      "group": "",
+      "version": "v1",
+      "resource": "pods"
+    },
+    "subResource": "exec",
+    "requestKind": {
+      "group": "",
+      "version": "v1",
+      "kind": "PodExecOptions"
+    },
+    "requestResource": {
+      "group": "",
+      "version": "v1",
+      "resource": "pods"
+    },
+    "requestSubResource": "exec",
+    "name": "some-pod-1111111111-22222",
+    "namespace": "default",
+    "operation": "CONNECT",
+    "userInfo": {
+      "username": "user",
+      "groups": []
+    },
+    "object": {
+      "kind": "PodExecOptions",
+      "apiVersion": "v1",
+      "stdin": true,
+      "stdout": true,
+      "tty": true,
+      "container": "some-pod",
+      "command": ["bin/bash"]
+    },
+    "oldObject": null,
+    "dryRun": false,
+    "options": null
+  }
+}`)
+		req := httptest.NewRequest("GET", "/a/b/c", body)
+		req.Header = map[string][]string{
+			"Content-Type": {"application/json"},
+		}
+		w := httptest.NewRecorder()
+		mockNsController.EXPECT().IsMonitoredNamespace("default").Return(true).Times(1)
+		wh.mutateHandler(w, req)
+
+		resp := w.Result()
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		expected := "{\"response\":{\"uid\":\"11111111-2222-3333-4444-555555555555\",\"allowed\":true}}"
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(string(bodyBytes)).To(Equal(expected))
+	})
+
+	It("handles health requests", func() {
+		client := fake.NewSimpleClientset()
+		mockNsController := k8s.NewMockController(gomock.NewController(GinkgoT()))
+		mockNsController.EXPECT().GetNamespace("default").Return(&corev1.Namespace{})
+		wh := &webhook{
+			kubeClient:     client,
+			kubeController: mockNsController,
+		}
+		w := httptest.NewRecorder()
+		body := strings.NewReader(``)
+		req := httptest.NewRequest("GET", "/a/b/c", body)
+
+		// Action !!
+		wh.healthHandler(w, req)
+
+		resp := w.Result()
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		expected := "Health OK"
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(string(bodyBytes)).To(Equal(expected))
+	})
+
+	It("mutate() handles nil admission request", func() {
+		client := fake.NewSimpleClientset()
+		mockNsController := k8s.NewMockController(gomock.NewController(GinkgoT()))
+		mockNsController.EXPECT().GetNamespace("default").Return(&corev1.Namespace{})
+		wh := &webhook{
+			kubeClient:     client,
+			kubeController: mockNsController,
+		}
+
+		// Action !!
+		actual := wh.mutate(nil)
+
+		expected := v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: "nil admission request",
+			},
+		}
+		Expect(actual).To(Equal(&expected))
+	})
+
+	It("patches admission response", func() {
+		admRes := v1beta1.AdmissionResponse{
+			Patch: []byte(""),
+		}
+		patchBytes := []byte("abc")
+		patchAdmissionResponse(&admRes, patchBytes)
+
+		expectedPatchType := v1beta1.PatchTypeJSONPatch
+		expected := v1beta1.AdmissionResponse{
+			Patch:     []byte("abc"),
+			PatchType: &expectedPatchType,
+		}
+		Expect(admRes).To(Equal(expected))
+	})
+
+	It("creates admission error", func() {
+		message := uuid.New().String()
+		err := errors.New(message)
+		actual := toAdmissionError(err)
+
+		expected := v1beta1.AdmissionResponse{
+			Result: &metav1.Status{
+				Message: message,
+			},
+		}
+		Expect(actual).To(Equal(&expected))
 	})
 })


### PR DESCRIPTION
This PR adds more unit test coverage for the `pkg/injector`

This PR also includes a rewrite of the `updateAnnotation()` function - to simplify and correct.
Previous iteration of this function returned `add` `JSONPatchOperation` with `Value` being sometimes `string` and other times ` map[string]string`. The most recent iteration always creates `add` `JSONPatchOperation` with `Value` of `map[string]string`.

### Before
```sh
$ go test -cover ./pkg/injector/...
ok      github.com/openservicemesh/osm/pkg/injector     0.058s  coverage: 27.6% of statements
```

### After
```sh
$ go test -cover ./pkg/injector/...
ok      github.com/openservicemesh/osm/pkg/injector     6.821s  coverage: 75.7% of statements
```


---

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
