### PR TITLE
certificate: Adding NewFakeCertificate() - creates certs for testing

### DIFF
--- a/pkg/certificate/providers/tresor/debugger_test.go
+++ b/pkg/certificate/providers/tresor/debugger_test.go
@@ -1,23 +1,19 @@
 package tresor
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
 
 var _ = Describe("Test Tresor Debugger", func() {
 	Context("test ListIssuedCertificates()", func() {
-		cert := &Certificate{
-			privateKey: pem.PrivateKey("yy"),
-			certChain:  pem.Certificate("xx"),
-			expiration: time.Now(),
-			commonName: "foo.bar.co.uk",
-		}
+		// Setup:
+		//   1. Create a new (fake) certificate
+		//   2. Reuse the same certificate as the Issuing CA
+		//   3. Populate the CertManager's cache w/ cert
+		cert := NewFakeCertificate()
 		cert.issuingCA = cert.GetCertificateChain()
 		cache := map[certificate.CommonName]certificate.Certificater{
 			"foo": cert,
@@ -25,6 +21,7 @@ var _ = Describe("Test Tresor Debugger", func() {
 		cm := CertManager{
 			cache: &cache,
 		}
+
 		It("lists all issued certificets", func() {
 			actual := cm.ListIssuedCertificates()
 			expected := []certificate.Certificater{cert}

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
 
 // NewFakeCertManager creates a fake CertManager used for testing.
@@ -22,4 +23,20 @@ func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificat
 		announcements:  make(chan interface{}),
 		cache:          cache,
 	}
+}
+
+// NewFakeCertificate is a helper creating Certificates for unit tests.
+func NewFakeCertificate() *Certificate {
+	cert := Certificate{
+		privateKey: pem.PrivateKey("yy"),
+		certChain:  pem.Certificate("xx"),
+		expiration: time.Now(),
+		commonName: "foo.bar.co.uk",
+	}
+
+	// It is acceptable in the context of a unit test (so far) for
+	// the Issuing CA to be the same as the certificate itself.
+	cert.issuingCA = pem.RootCertificate(cert.certChain)
+
+	return &cert
 }


### PR DESCRIPTION
This PR adds `NewFakeCertificate()` funcion to `pkg/certificate/providers/tresor`, which is a helper function to create certificates for testing.

Other use cases for this are in the PR, which this was carved out from: https://github.com/openservicemesh/osm/pull/1772

---

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
