### PR TITLE
injector: Init container test

### DIFF
--- a/pkg/injector/init-container.go
+++ b/pkg/injector/init-container.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-func getInitContainerSpec(pod *corev1.Pod, data *InitContainerData) (corev1.Container, error) {
+func getInitContainerSpec(data *InitContainer) (corev1.Container, error) {
 	return corev1.Container{
 		Name:  data.Name,
 		Image: data.Image,

--- a/pkg/injector/init-container_test.go
+++ b/pkg/injector/init-container_test.go
@@ -1,0 +1,52 @@
+package injector
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Test volume functions", func() {
+	Context("Test updateLabels", func() {
+		It("creates volume spec", func() {
+			container := &InitContainer{
+				Name:  "-container-name-",
+				Image: "-init-container-image-",
+			}
+			actual, err := getInitContainerSpec(container)
+			Expect(err).ToNot(HaveOccurred())
+			expected := v1.Container{
+				Name:       "-container-name-",
+				Image:      "-init-container-image-",
+				WorkingDir: "",
+				Env: []v1.EnvVar{
+					{
+						Name:  "OSM_PROXY_UID",
+						Value: "1337",
+					},
+					{
+						Name:  "OSM_ENVOY_INBOUND_PORT",
+						Value: "15003",
+					},
+					{
+						Name:  "OSM_ENVOY_OUTBOUND_PORT",
+						Value: "15001",
+					},
+				},
+				Resources: v1.ResourceRequirements{},
+				SecurityContext: &v1.SecurityContext{
+					Capabilities: &v1.Capabilities{
+						Add: []v1.Capability{
+							"NET_ADMIN",
+						},
+					},
+					Privileged: nil,
+				},
+				Stdin:     false,
+				StdinOnce: false,
+				TTY:       false,
+			}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+})

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -55,11 +55,11 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 	)
 
 	// Add the Init Container
-	initContainerData := InitContainerData{
+	initContainerData := InitContainer{
 		Name:  constants.InitContainerName,
 		Image: wh.config.InitContainerImage,
 	}
-	initContainerSpec, err := getInitContainerSpec(pod, &initContainerData)
+	initContainerSpec, err := getInitContainerSpec(&initContainerData)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -48,8 +48,8 @@ type JSONPatchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-// InitContainerData is the type used to represent information about the init container
-type InitContainerData struct {
+// InitContainer is the type used to represent information about the init container
+type InitContainer struct {
 	Name  string
 	Image string
 }


### PR DESCRIPTION
This PR adds unit tests for the functions creating the init container.

Also in this PR:
  - Rename `InitContainerData` to `InitContainer`
  - Change the signature of `getInitContainerSpec(...)` - removed unused `pod *corev1.Pod` param

This PR is a piece of https://github.com/openservicemesh/osm/pull/1772

---

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`