### PR TITLE
tests: Adding -failfast to go test

### DIFF
--- a/scripts/go-test.sh
+++ b/scripts/go-test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-go test -race -v ./...; echo $?
+go test -failfast -race -v ./...; echo $?

--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -3,6 +3,7 @@
 set -aueo pipefail
 
 go test -timeout 80s \
+   -failfast \
    -v \
    -coverprofile=coverage.txt \
    -covermode count ./... | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }


### PR DESCRIPTION
Adding `-failfast` to the 2 scripts that run unit tests (both locally and in the CI system). Per [documentation](https://golang.org/pkg/cmd/go/internal/test/) this option will: `not start new tests after the first test failure`

This should lead to quicker discovery of broken tests.

---

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
