### PR TITLE
injector: Simplify tests and use YAML values closer to reality

### DIFF
--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
 
 // NewFakeCertManager creates a fake CertManager used for testing.
@@ -22,4 +23,20 @@ func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificat
 		announcements:  make(chan interface{}),
 		cache:          cache,
 	}
+}
+
+// NewFakeCertificate is a helper creating Certificates for unit tests.
+func NewFakeCertificate() *Certificate {
+	cert := Certificate{
+		privateKey: pem.PrivateKey("yy"),
+		certChain:  pem.Certificate("xx"),
+		expiration: time.Now(),
+		commonName: "foo.bar.co.uk",
+	}
+
+	// It is acceptable in the context of a unit test (so far) for
+	// the Issuing CA to be the same as the certificate itself.
+	cert.issuingCA = pem.RootCertificate(cert.certChain)
+
+	return &cert
 }


### PR DESCRIPTION
This PR is a step in preparation towards https://github.com/openservicemesh/osm/pull/1772, which adds new unit tests for the injector package.  These are small tweaks in string literals, no functional code changes.

This PR is stacked on top of https://github.com/openservicemesh/osm/pull/1773
This PR is a small piece of https://github.com/openservicemesh/osm/pull/1772

---

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`