### PR TITLE
Allow explicitly ignoring a namespace for injection

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -17,3 +17,14 @@ webhooks:
   namespaceSelector:
     matchLabels:
       openservicemesh.io/monitored-by: {{.Values.OpenServiceMesh.meshName}}
+    matchExpressions:
+      # This label is explicitly set to ignore a namespace
+      - key: "openservicemesh.io/ignore"
+        operator: DoesNotExist
+
+      # This label is set by Helm when it creates a namespace (https://github.com/helm/helm/blob/release-3.2/pkg/action/install.go#L292)
+      # It ensures that pods in the control plane namespace are never injected with a sidecar
+      - key: "name"
+        operator: NotIn
+        values:
+        - {{.Release.Namespace}}

--- a/cmd/cli/namespace.go
+++ b/cmd/cli/namespace.go
@@ -9,7 +9,6 @@ import (
 const namespaceDescription = `
 This command consists of multiple subcommands related to managing namespaces
 associated with osm installations.
-
 `
 
 func newNamespaceCmd(out io.Writer) *cobra.Command {
@@ -22,6 +21,7 @@ func newNamespaceCmd(out io.Writer) *cobra.Command {
 	}
 	cmd.AddCommand(newNamespaceAdd(out))
 	cmd.AddCommand(newNamespaceRemove(out))
+	cmd.AddCommand(newNamespaceIgnore(out))
 	cmd.AddCommand(newNamespaceList(out))
 
 	return cmd

--- a/cmd/cli/namespace_ignore.go
+++ b/cmd/cli/namespace_ignore.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+const namespaceIgnoreDescription = `
+This command will configure a namespace or a set of namespaces from
+participating in the mesh. Automatic sidecar injection on pods
+belonging to the given namespace or set of namespaces will be prevented.
+The command will not remove previously injected sidecars on pods belonging
+to the given namespaces.
+`
+
+const ignoreLabel = "openservicemesh.io/ignore"
+
+type namespaceIgnoreCmd struct {
+	out        io.Writer
+	namespaces []string
+	clientSet  kubernetes.Interface
+}
+
+func newNamespaceIgnore(out io.Writer) *cobra.Command {
+	ignoreCmd := &namespaceIgnoreCmd{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "ignore NAMESPACE ...",
+		Short: "ignore namespace from participating in the mesh",
+		Long:  namespaceIgnoreDescription,
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			ignoreCmd.namespaces = args
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return errors.Errorf("Error fetching kubeconfig")
+			}
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+			}
+			ignoreCmd.clientSet = clientset
+			return ignoreCmd.run()
+		},
+	}
+
+	return cmd
+}
+
+func (cmd *namespaceIgnoreCmd) run() error {
+	for _, ns := range cmd.namespaces {
+		ns = strings.TrimSpace(ns)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if _, err := cmd.clientSet.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
+			return errors.Errorf("Failed to retrieve namespace [%s]: %v", ns, err)
+		}
+
+		// Patch the namespace with ignore label
+		patch := fmt.Sprintf(`
+{
+	"metadata": {
+		"labels": {
+			"%s": "true"
+		}
+	}
+}`, ignoreLabel)
+
+		_, err := cmd.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
+		if err != nil {
+			return errors.Errorf("Failed to configure namespace [%s] to be ignored: %v", ns, err)
+		}
+
+		fmt.Fprintf(cmd.out, "Successfully configured namespace [%s] to be ignored\n", ns)
+	}
+
+	return nil
+}

--- a/cmd/cli/namespace_ignore.go
+++ b/cmd/cli/namespace_ignore.go
@@ -14,7 +14,7 @@ import (
 )
 
 const namespaceIgnoreDescription = `
-This command will configure a namespace or a set of namespaces from
+This command will prevent a namespace or a set of namespaces from
 participating in the mesh. Automatic sidecar injection on pods
 belonging to the given namespace or set of namespaces will be prevented.
 The command will not remove previously injected sidecars on pods belonging

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -83,7 +83,16 @@ bin/osm mesh uninstall -f --mesh-name "$MESH_NAME" --namespace "$K8S_NAMESPACE"
 
 # The demo uses osm's namespace as defined by environment variables, K8S_NAMESPACE
 # to house the control plane components.
+#
+# Note: `osm install` creates the namespace via Helm only if such a namespace already
+# doesn't exist. We explicitly create the namespace below because of the need to
+# create container registry credentials in this namespace for the purpose of testing.
+# The side effect of creating the namespace here instead of letting Helm create it is
+# that Helm no longer manages namespace creation, and as a result labels that it
+# otherwise adds for using as a namespace selector are no longer available.
 kubectl create namespace "$K8S_NAMESPACE"
+# Mimic Helm namespace label behavior: https://github.com/helm/helm/blob/release-3.2/pkg/action/install.go#L292
+kubectl label namespace "$K8S_NAMESPACE" name="$K8S_NAMESPACE"
 
 echo "Certificate Manager in use: $CERT_MANAGER"
 if [ "$CERT_MANAGER" = "vault" ]; then

--- a/docs/patterns/sidecar_injection.md
+++ b/docs/patterns/sidecar_injection.md
@@ -10,6 +10,8 @@ Automatic sidecar injection can be configured per namespace as a part of enrolli
 
 Prerequisites:
 - The namespace to which the pods belong must be a monitored namespace that is added to the mesh using the `osm namespace add` command.
+- The namespace to which the pods belong must not be set to be ignored using the `osm namespace ignore` command.
+- The namespace to which the pods belong must not have a label with key `name` and value corresponding to the OSM control plane namespace. For example, a namespace with a label `name: osm-system` where `osm-system` is the control plane namespace cannot have sidecar injection enabled for pods in this namespace.
 
 Automatic Sidecar injection can be enabled in the following ways:
 


### PR DESCRIPTION
This change provides a mechanism to explicitly ignore
namespaces to prevent sidecar injection from happening.
A new cli command `osm namespace ignore` is added for this
purpose.

Additionally, the mutatingwebhookconfiguration is updated
to only accept admission requests belonging to namespaces
that are not explicitly ignored and not osm control plane
namespace.

Enhancements such as checking if a namespace is ignored before 
enabling monitoring will be considered in a subsequent change.

Part of #1759

Signed-off-by: Shashank Ram <shashank08@gmail.com>

- New Functionality      [X]
- Documentation          [X]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`