### PR TITLE
demo: remove check for docker daemon

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -32,9 +32,6 @@ ENABLE_GRAFANA="${ENABLE_GRAFANA:-false}"
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 
-# Check if Docker daemon is running
-pgrep -f docker > /dev/null || { echo "Docker daemon is not running"; exit 1; }
-
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*
 


### PR DESCRIPTION
Commit 5fc44c5df90dc8078023e553feefda493f1d6c99 added this
check but it breaks the demo for users running the Docker
daemon on Windows and exposing the daemon over localhost.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`