### PR TITLE
demo: check if docker daemon is up in a generic way

### DIFF
--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -72,6 +72,9 @@ wait_for_pod_ready() {
     exit_error "Pod ${pod_name} status is ${pod_status} -- still not Ready"
 }
 
+# Check if Docker daemon is running
+docker info > /dev/null || { echo "Docker daemon is not running"; exit 1; }
+
 make build-osm
 
 # cleanup stale resources from previous runs


### PR DESCRIPTION
Commit 81648aa removed the docker daemon check because
it does not work in certain environments where the docker
daemon is exposed over a localhost.

This change adds the check back although by relying on the
`docker info` command instead, which returns an exit code
if the daemon is not running.

Co-authored-by: Edu Serra <eduser25@gmail.com>

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [ ]
- Other                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`