### PR TITLE
test(routes): ListTrafficPolicies should include all services for a service account

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -25,7 +25,15 @@ var _ = Describe("Catalog tests", func() {
 			actual, err := mc.ListTrafficPolicies(tests.BookstoreService)
 			Expect(err).ToNot(HaveOccurred())
 
-			expected := []trafficpolicy.TrafficTarget{tests.TrafficPolicy}
+			expected := []trafficpolicy.TrafficTarget{tests.BookstoreTrafficPolicy}
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("lists traffic policies for all services associated with the service account", func() {
+			actual, err := mc.ListTrafficPolicies(tests.BookbuyerService)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := []trafficpolicy.TrafficTarget{tests.BookstoreTrafficPolicy, tests.BookstoreApexTrafficPolicy}
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -134,10 +134,33 @@ var (
 		Port: endpoint.Port(ServicePort),
 	}
 
-	// TrafficPolicy is a traffic policy SMI object.
-	TrafficPolicy = trafficpolicy.TrafficTarget{
+	// BookstoreTrafficPolicy is a traffic policy SMI object.
+	BookstoreTrafficPolicy = trafficpolicy.TrafficTarget{
 		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore", TrafficTargetName),
 		Destination: BookstoreService,
+		Source:      BookbuyerService,
+		HTTPRoutes: []trafficpolicy.HTTPRoute{
+			{
+				PathRegex: BookstoreBuyPath,
+				Methods:   []string{"GET"},
+				Headers: map[string]string{
+					"user-agent": HTTPUserAgent,
+				},
+			},
+			{
+				PathRegex: BookstoreSellPath,
+				Methods:   []string{"GET"},
+				Headers: map[string]string{
+					"user-agent": HTTPUserAgent,
+				},
+			},
+		},
+	}
+
+	// BookstoreApexTrafficPolicy is a traffic policy SMI object.
+	BookstoreApexTrafficPolicy = trafficpolicy.TrafficTarget{
+		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-apex", TrafficTargetName),
+		Destination: BookstoreApexService,
 		Source:      BookbuyerService,
 		HTTPRoutes: []trafficpolicy.HTTPRoute{
 			{


### PR DESCRIPTION
This change ensures we test that all traffic target permutations are returned by ListTrafficPolicies

Please mark with X for applicable areas.

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests / CI System      [X]
- Other                  [ ]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No
