### PR TITLE
Adding links for community meetings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ After installing OSM, [onboard a microservice application](docs/onboard_services
 Connect with the Open Service Mesh community:
 
 - GitHub [issues](https://github.com/openservicemesh/osm/issues) and [pull requests](https://github.com/openservicemesh/osm/pulls) in this repo
-- OSM Slack (coming soon)
-- Public Community Call (coming soon)
+- OSM Slack: <a href="https://slack.cncf.io/">Join</a> the CNCF Slack for related discussions in <a href="https://cloud-native.slack.com/archives/C018794NV1C">#openservicemesh</a>
+- Public Community Call: OSM Community calls take place on the [second Tuesday of each month, 10:30am-11am Pacific](https://calendar.google.com/calendar?cid=Y181dXJwY3F0NWd2OW5ldXE2c2IxM2hvcnN2Z0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) in the [CNCF OSM Zoom room](https://zoom.us/my/cncfosm?pwd=aXdkaGU3OWRjUllyaHZEZkh0ZjFwUT09) - notes available in [Open Service Mesh (OSM) Community Meeting Notes](https://docs.google.com/document/d/1da-XIqthmyG7zQyFAV1Kt-Qvq4NoNNBX7hZ_sM_kM98/edit?usp=sharing)
 - [Mailing list](https://groups.google.com/g/openservicemesh)
 
 ## Development Guide


### PR DESCRIPTION
We're establishing community meetings and need to publish the links for the zoom call, the meeting doc, and the calendar.

**Affected area**:

- Documentation          [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

Not applicable


Signed-off-by: Bridget Kromhout <bridget@kromhout.org>


