### PR TITLE
tests/catalog: remove assumption regarding ordering in list

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -33,8 +33,9 @@ var _ = Describe("Catalog tests", func() {
 			actual, err := mc.ListTrafficPolicies(tests.BookbuyerService)
 			Expect(err).ToNot(HaveOccurred())
 
-			expected := []trafficpolicy.TrafficTarget{tests.BookstoreTrafficPolicy, tests.BookstoreApexTrafficPolicy}
-			Expect(actual).To(Equal(expected))
+			Expect(len(actual)).To(Equal(2)) // bookstore and bookstore-apex traffic policies
+			Expect(tests.BookstoreTrafficPolicy).To(BeElementOf(actual))
+			Expect(tests.BookstoreApexTrafficPolicy).To(BeElementOf(actual))
 		})
 	})
 


### PR DESCRIPTION
**Description**:
The order of traffic policy objects cannot be assumed, compare
presence of element in list instead along with checking the
length of the list.

Resolves #1791

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`