### PR TITLE
configurator: add config option for service cert validity duration

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -22,8 +22,8 @@ const (
 	tracingAddressKey              = "tracing_address"
 	tracingPortKey                 = "tracing_port"
 	tracingEndpointKey             = "tracing_endpoint"
-	defaultInMeshCIDR              = ""
 	envoyLogLevel                  = "envoy_log_level"
+	serviceCertValidityDurationKey = "service_cert_validity_duration"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -91,6 +91,11 @@ type osmConfig struct {
 
 	// EnvoyLogLevel is a string that defines the log level for envoy proxies
 	EnvoyLogLevel string `yaml:"envoy_log_level"`
+
+	// ServiceCertValidityDuration is a string that defines the validity duration of service certificates
+	// It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix.
+	// Ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
+	ServiceCertValidityDuration string `yaml:"service_cert_validity_duration"`
 }
 
 func (c *Client) run(stop <-chan struct{}) {
@@ -132,8 +137,9 @@ func (c *Client) getConfigMap() *osmConfig {
 		PrometheusScraping:          getBoolValueForKey(configMap, prometheusScrapingKey),
 		UseHTTPSIngress:             getBoolValueForKey(configMap, useHTTPSIngressKey),
 
-		TracingEnable: getBoolValueForKey(configMap, tracingEnableKey),
-		EnvoyLogLevel: getStringValueForKey(configMap, envoyLogLevel),
+		TracingEnable:               getBoolValueForKey(configMap, tracingEnableKey),
+		EnvoyLogLevel:               getStringValueForKey(configMap, envoyLogLevel),
+		ServiceCertValidityDuration: getStringValueForKey(configMap, serviceCertValidityDurationKey),
 	}
 
 	if osmConfigMap.TracingEnable {

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"TracingEndpoint":             tracingEndpointKey,
 				"UseHTTPSIngress":             useHTTPSIngressKey,
 				"EnvoyLogLevel":               envoyLogLevel,
+				"ServiceCertValidityDuration": serviceCertValidityDurationKey,
 			}
 			t := reflect.TypeOf(osmConfig{})
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -3,8 +3,14 @@ package configurator
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const (
+	// defaultServiceCertValidityDuration is the default validity duration for service certificates
+	defaultServiceCertValidityDuration = 24 * time.Hour
 )
 
 // The functions in this file implement the configurator.Configurator interface
@@ -95,4 +101,16 @@ func (c *Client) GetEnvoyLogLevel() string {
 // GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.
 func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
 	return c.announcements
+}
+
+// GetServiceCertValidityPeriod returns the validity duration for service certificates, and a default in case of invalid duration
+func (c *Client) GetServiceCertValidityPeriod() time.Duration {
+	durationStr := c.getConfigMap().ServiceCertValidityDuration
+	validityDuration, err := time.ParseDuration(durationStr)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error parsing service certificate validity duration %s=%s", serviceCertValidityDurationKey, durationStr)
+		return defaultServiceCertValidityDuration
+	}
+
+	return validityDuration
 }

--- a/pkg/configurator/mock_client.go
+++ b/pkg/configurator/mock_client.go
@@ -6,6 +6,7 @@ package configurator
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -88,6 +89,20 @@ func (m *MockConfigurator) GetOSMNamespace() string {
 func (mr *MockConfiguratorMockRecorder) GetOSMNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOSMNamespace", reflect.TypeOf((*MockConfigurator)(nil).GetOSMNamespace))
+}
+
+// GetServiceCertValidityPeriod mocks base method
+func (m *MockConfigurator) GetServiceCertValidityPeriod() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceCertValidityPeriod")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetServiceCertValidityPeriod indicates an expected call of GetServiceCertValidityPeriod
+func (mr *MockConfiguratorMockRecorder) GetServiceCertValidityPeriod() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceCertValidityPeriod", reflect.TypeOf((*MockConfigurator)(nil).GetServiceCertValidityPeriod))
 }
 
 // GetTracingEndpoint mocks base method

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -1,6 +1,8 @@
 package configurator
 
 import (
+	"time"
+
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -57,4 +59,7 @@ type Configurator interface {
 
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap
 	GetAnnouncementsChannel() <-chan interface{}
+
+	// GetServiceCertValidityPeriod returns the validity duration for service certificates
+	GetServiceCertValidityPeriod() time.Duration
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a new config option to retrieve the service certificate validity
duration. This is a prerequisite to make the service cert validity
duration dynamically configurable via the osm-config ConfigMap.

Part of #1757

Signed-off-by: Shashank Ram <shashank08@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`