### PR TITLE
Fixing empty filterchain/endpoint conditions on Outbound listener

### DIFF
--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -76,6 +76,16 @@ func TestGetFilterChainMatchForService(t *testing.T) {
 	assert.Equal(filterChainMatch.PrefixRanges[0].GetPrefixLen().GetValue(), uint32(32))
 	assert.Equal(filterChainMatch.PrefixRanges[1].GetAddressPrefix(), net.IPv4(192, 168, 0, 1).String())
 	assert.Equal(filterChainMatch.PrefixRanges[1].GetPrefixLen().GetValue(), uint32(32))
+
+	// Test negative getOutboundFilterChainMatchForService when no endpoints are present
+	mockCatalog.EXPECT().GetResolvableServiceEndpoints(tests.BookbuyerService).Return(
+		[]endpoint.Endpoint{},
+		nil,
+	)
+
+	filterChainMatch, err = getOutboundFilterChainMatchForService(tests.BookbuyerService, mockCatalog, mockConfigurator)
+	assert.NoError(err)
+	assert.Nil(filterChainMatch)
 }
 
 var _ = Describe("Construct inbound listeners", func() {

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -36,13 +36,18 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 	}
 
 	// --- OUTBOUND -------------------
-	if outboundListener, err := newOutboundListener(catalog, cfg, svcList); err != nil {
+	outboundListener, err := newOutboundListener(catalog, cfg, svcList)
+	if err != nil {
 		log.Error().Err(err).Msgf("Error making outbound listener config for proxy %s", proxyServiceName)
 	} else {
-		if marshalledOutbound, err := ptypes.MarshalAny(outboundListener); err != nil {
-			log.Error().Err(err).Msgf("Failed to marshal outbound listener config for proxy %s", proxyServiceName)
+		if outboundListener == nil {
+			log.Debug().Msgf("Not programming Outbound listener for proxy %s", proxyServiceName)
 		} else {
-			resp.Resources = append(resp.Resources, marshalledOutbound)
+			if marshalledOutbound, err := ptypes.MarshalAny(outboundListener); err != nil {
+				log.Error().Err(err).Msgf("Failed to marshal outbound listener config for proxy %s", proxyServiceName)
+			} else {
+				resp.Resources = append(resp.Resources, marshalledOutbound)
+			}
 		}
 	}
 


### PR DESCRIPTION
In conditions where the the outbound listener filter logic cannot find any endpoints,
or there are no destination services (nor egress) programmed via SMI for a local
service, we should not attempt to program the listener altogether.

fixes #1793

- Control Plane          [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No