### PR TITLE
certificates: allow reconfiguring cert validity for short lived certs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -488,7 +488,7 @@ package certificate
 // Manager is the interface declaring the methods for the Certificate Manager.
 type Manager interface {
 	// IssueCertificate issues a new certificate.
-	IssueCertificate(CommonName, *time.Duration) (Certificater, error)
+	IssueCertificate(CommonName, time.Duration) (Certificater, error)
 
 	// GetCertificate returns a certificate given its Common Name (CN)
 	GetCertificate(CommonName) (Certificater, error)

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -30,7 +30,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.prometheus.port | int | `7070` |  |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` |  |
 | OpenServiceMesh.replicaCount | int | `1` |  |
-| OpenServiceMesh.serviceCertValidityMinutes | int | `1` |  |
+| OpenServiceMesh.serviceCertValidityDuration | string | `24h` |  |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.15.0"` |  |
 | OpenServiceMesh.useHTTPSIngress | bool | `false` |  |
 | OpenServiceMesh.vault.host | string | `nil` |  |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -30,7 +30,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.prometheus.port | int | `7070` |  |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` |  |
 | OpenServiceMesh.replicaCount | int | `1` |  |
-| OpenServiceMesh.serviceCertValidityDuration | string | `24h` |  |
+| OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` |  |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.15.0"` |  |
 | OpenServiceMesh.useHTTPSIngress | bool | `false` |  |
 | OpenServiceMesh.vault.host | string | `nil` |  |

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -18,3 +18,4 @@ data:
 {{- end }}
 
   use_https_ingress: {{ .Values.OpenServiceMesh.useHTTPSIngress | default "false" | quote }}
+  service_cert_validity_duration: {{ .Values.OpenServiceMesh.serviceCertValidityDuration | quote }}

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -41,7 +41,6 @@ spec:
             "--cert-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
             "--cert-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
             "--cert-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
-            "--service-cert-validity-minutes", "{{.Values.OpenServiceMesh.serviceCertValidityMinutes}}",
             {{- if .Values.OpenServiceMesh.enableBackpressureExperimental }}
             "--enable-backpressure-experimental",
             {{- end }}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -23,7 +23,7 @@ OpenServiceMesh:
     issuerName: osm-ca
     issuerKind: Issuer
     issuerGroup: cert-manager
-  serviceCertValidityMinutes: 1
+    serviceCertValidityDuration: 24h
   caBundleSecretName: osm-ca-bundle
   grafana:
     port: 3000

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -68,20 +68,20 @@ var _ = Describe("Running the install command", func() {
 			fakeClientSet = fake.NewSimpleClientset()
 
 			installCmd := &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				osmImageTag:                testOsmImageTag,
-				osmImagePullPolicy:         defaultOsmImagePullPolicy,
-				certificateManager:         "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   defaultMeshName,
-				enableEgress:               true,
-				enablePrometheus:           true,
-				enableGrafana:              true,
-				clientSet:                  fakeClientSet,
-				envoyLogLevel:              testEnvoyLogLevel,
+				out:                         out,
+				chartPath:                   "testdata/test-chart",
+				containerRegistry:           testRegistry,
+				osmImageTag:                 testOsmImageTag,
+				osmImagePullPolicy:          defaultOsmImagePullPolicy,
+				certificateManager:          "tresor",
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    defaultMeshName,
+				enableEgress:                true,
+				enablePrometheus:            true,
+				enableGrafana:               true,
+				clientSet:                   fakeClientSet,
+				envoyLogLevel:               testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -124,7 +124,7 @@ var _ = Describe("Running the install command", func() {
 							"tag":        testOsmImageTag,
 							"pullPolicy": defaultOsmImagePullPolicy,
 						},
-						"serviceCertValidityMinutes": int64(1),
+						"serviceCertValidityDuration": "24h",
 						"vault": map[string]interface{}{
 							"host":     "",
 							"protocol": "",
@@ -180,20 +180,20 @@ var _ = Describe("Running the install command", func() {
 			fakeClientSet = fake.NewSimpleClientset()
 
 			installCmd := &installCmd{
-				out:                        out,
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				osmImageTag:                testOsmImageTag,
-				osmImagePullPolicy:         defaultOsmImagePullPolicy,
-				certificateManager:         "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   defaultMeshName,
-				enableEgress:               true,
-				enablePrometheus:           true,
-				enableGrafana:              true,
-				clientSet:                  fakeClientSet,
-				envoyLogLevel:              testEnvoyLogLevel,
+				out:                         out,
+				containerRegistry:           testRegistry,
+				containerRegistrySecret:     testRegistrySecret,
+				osmImageTag:                 testOsmImageTag,
+				osmImagePullPolicy:          defaultOsmImagePullPolicy,
+				certificateManager:          "tresor",
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    defaultMeshName,
+				enableEgress:                true,
+				enablePrometheus:            true,
+				enableGrafana:               true,
+				clientSet:                   fakeClientSet,
+				envoyLogLevel:               testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -241,7 +241,7 @@ var _ = Describe("Running the install command", func() {
 								"name": testRegistrySecret,
 							},
 						},
-						"serviceCertValidityMinutes": int64(1),
+						"serviceCertValidityDuration": "24h",
 						"vault": map[string]interface{}{
 							"host":     "",
 							"protocol": "",
@@ -296,28 +296,28 @@ var _ = Describe("Running the install command", func() {
 			fakeClientSet = fake.NewSimpleClientset()
 
 			installCmd := &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				certificateManager:         "vault",
-				vaultHost:                  testVaultHost,
-				vaultToken:                 testVaultToken,
-				vaultRole:                  testVaultRole,
-				vaultProtocol:              "http",
-				certmanagerIssuerName:      testCertManagerIssuerName,
-				certmanagerIssuerKind:      testCertManagerIssuerKind,
-				certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-				osmImageTag:                testOsmImageTag,
-				osmImagePullPolicy:         defaultOsmImagePullPolicy,
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   defaultMeshName,
-				enableEgress:               true,
-				enablePrometheus:           true,
-				enableGrafana:              true,
-				clientSet:                  fakeClientSet,
-				envoyLogLevel:              testEnvoyLogLevel,
+				out:                         out,
+				chartPath:                   "testdata/test-chart",
+				containerRegistry:           testRegistry,
+				containerRegistrySecret:     testRegistrySecret,
+				certificateManager:          "vault",
+				vaultHost:                   testVaultHost,
+				vaultToken:                  testVaultToken,
+				vaultRole:                   testVaultRole,
+				vaultProtocol:               "http",
+				certmanagerIssuerName:       testCertManagerIssuerName,
+				certmanagerIssuerKind:       testCertManagerIssuerKind,
+				certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+				osmImageTag:                 testOsmImageTag,
+				osmImagePullPolicy:          defaultOsmImagePullPolicy,
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    defaultMeshName,
+				enableEgress:                true,
+				enablePrometheus:            true,
+				enableGrafana:               true,
+				clientSet:                   fakeClientSet,
+				envoyLogLevel:               testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -365,7 +365,7 @@ var _ = Describe("Running the install command", func() {
 								"name": testRegistrySecret,
 							},
 						},
-						"serviceCertValidityMinutes": int64(1),
+						"serviceCertValidityDuration": "24h",
 						"vault": map[string]interface{}{
 							"host":     testVaultHost,
 							"protocol": "http",
@@ -462,28 +462,28 @@ var _ = Describe("Running the install command", func() {
 			fakeClientSet = fake.NewSimpleClientset()
 
 			installCmd := &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				certificateManager:         "cert-manager",
-				vaultHost:                  testVaultHost,
-				vaultToken:                 testVaultToken,
-				vaultRole:                  testVaultRole,
-				vaultProtocol:              "http",
-				certmanagerIssuerName:      testCertManagerIssuerName,
-				certmanagerIssuerKind:      testCertManagerIssuerKind,
-				certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-				osmImageTag:                testOsmImageTag,
-				osmImagePullPolicy:         defaultOsmImagePullPolicy,
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   defaultMeshName,
-				enableEgress:               true,
-				enablePrometheus:           true,
-				enableGrafana:              true,
-				clientSet:                  fakeClientSet,
-				envoyLogLevel:              testEnvoyLogLevel,
+				out:                         out,
+				chartPath:                   "testdata/test-chart",
+				containerRegistry:           testRegistry,
+				containerRegistrySecret:     testRegistrySecret,
+				certificateManager:          "cert-manager",
+				vaultHost:                   testVaultHost,
+				vaultToken:                  testVaultToken,
+				vaultRole:                   testVaultRole,
+				vaultProtocol:               "http",
+				certmanagerIssuerName:       testCertManagerIssuerName,
+				certmanagerIssuerKind:       testCertManagerIssuerKind,
+				certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+				osmImageTag:                 testOsmImageTag,
+				osmImagePullPolicy:          defaultOsmImagePullPolicy,
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    defaultMeshName,
+				enableEgress:                true,
+				enablePrometheus:            true,
+				enableGrafana:               true,
+				clientSet:                   fakeClientSet,
+				envoyLogLevel:               testEnvoyLogLevel,
 			}
 
 			err = installCmd.run(config)
@@ -531,7 +531,7 @@ var _ = Describe("Running the install command", func() {
 								"name": testRegistrySecret,
 							},
 						},
-						"serviceCertValidityMinutes": int64(1),
+						"serviceCertValidityDuration": "24h",
 						"vault": map[string]interface{}{
 							"host":     testVaultHost,
 							"protocol": "http",
@@ -591,17 +591,17 @@ var _ = Describe("Running the install command", func() {
 			fakeClientSet.AppsV1().Deployments(settings.Namespace()).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
 
 			install = &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				osmImageTag:                testOsmImageTag,
-				certificateManager:         "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   defaultMeshName,
-				enableEgress:               true,
-				clientSet:                  fakeClientSet,
+				out:                         out,
+				chartPath:                   "testdata/test-chart",
+				containerRegistry:           testRegistry,
+				containerRegistrySecret:     testRegistrySecret,
+				osmImageTag:                 testOsmImageTag,
+				certificateManager:          "tresor",
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    defaultMeshName,
+				enableEgress:                true,
+				clientSet:                   fakeClientSet,
 			}
 
 			err = config.Releases.Create(&release.Release{
@@ -659,17 +659,17 @@ var _ = Describe("Running the install command", func() {
 			fakeClientSet.AppsV1().Deployments(settings.Namespace()).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
 
 			install = &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				osmImageTag:                testOsmImageTag,
-				certificateManager:         "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   defaultMeshName + "-2",
-				enableEgress:               true,
-				clientSet:                  fakeClientSet,
+				out:                         out,
+				chartPath:                   "testdata/test-chart",
+				containerRegistry:           testRegistry,
+				containerRegistrySecret:     testRegistrySecret,
+				osmImageTag:                 testOsmImageTag,
+				certificateManager:          "tresor",
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    defaultMeshName + "-2",
+				enableEgress:                true,
+				clientSet:                   fakeClientSet,
 			}
 
 			err = config.Releases.Create(&release.Release{
@@ -721,16 +721,16 @@ var _ = Describe("Running the install command", func() {
 			}
 
 			install = &installCmd{
-				out:                        out,
-				chartPath:                  "testdata/test-chart",
-				containerRegistry:          testRegistry,
-				containerRegistrySecret:    testRegistrySecret,
-				osmImageTag:                testOsmImageTag,
-				certificateManager:         "tresor",
-				serviceCertValidityMinutes: 1,
-				prometheusRetentionTime:    testRetentionTime,
-				meshName:                   "osm!!123456789012345678901234567890123456789012345678901234567890", // >65 characters, contains !
-				enableEgress:               true,
+				out:                         out,
+				chartPath:                   "testdata/test-chart",
+				containerRegistry:           testRegistry,
+				containerRegistrySecret:     testRegistrySecret,
+				osmImageTag:                 testOsmImageTag,
+				certificateManager:          "tresor",
+				serviceCertValidityDuration: "24h",
+				prometheusRetentionTime:     testRetentionTime,
+				meshName:                    "osm!!123456789012345678901234567890123456789012345678901234567890", // >65 characters, contains !
+				enableEgress:                true,
 			}
 
 			err = install.run(config)
@@ -751,25 +751,25 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:          testRegistry,
-			containerRegistrySecret:    testRegistrySecret,
-			certificateManager:         "vault",
-			vaultHost:                  testVaultHost,
-			vaultProtocol:              testVaultProtocol,
-			certmanagerIssuerName:      testCertManagerIssuerName,
-			certmanagerIssuerKind:      testCertManagerIssuerKind,
-			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-			vaultToken:                 testVaultToken,
-			vaultRole:                  testVaultRole,
-			osmImageTag:                testOsmImageTag,
-			osmImagePullPolicy:         defaultOsmImagePullPolicy,
-			serviceCertValidityMinutes: 1,
-			prometheusRetentionTime:    testRetentionTime,
-			meshName:                   defaultMeshName,
-			enableEgress:               true,
-			enablePrometheus:           true,
-			enableGrafana:              true,
-			envoyLogLevel:              testEnvoyLogLevel,
+			containerRegistry:           testRegistry,
+			containerRegistrySecret:     testRegistrySecret,
+			certificateManager:          "vault",
+			vaultHost:                   testVaultHost,
+			vaultProtocol:               testVaultProtocol,
+			certmanagerIssuerName:       testCertManagerIssuerName,
+			certmanagerIssuerKind:       testCertManagerIssuerKind,
+			certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+			vaultToken:                  testVaultToken,
+			vaultRole:                   testVaultRole,
+			osmImageTag:                 testOsmImageTag,
+			osmImagePullPolicy:          defaultOsmImagePullPolicy,
+			serviceCertValidityDuration: "24h",
+			prometheusRetentionTime:     testRetentionTime,
+			meshName:                    defaultMeshName,
+			enableEgress:                true,
+			enablePrometheus:            true,
+			enableGrafana:               true,
+			envoyLogLevel:               testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -799,7 +799,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 						"name": testRegistrySecret,
 					},
 				},
-				"serviceCertValidityMinutes": int64(1),
+				"serviceCertValidityDuration": "24h",
 				"vault": map[string]interface{}{
 					"host":     testVaultHost,
 					"protocol": "http",
@@ -831,25 +831,25 @@ var _ = Describe("Ensure that grafana is disabled when flag is set to false", fu
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:          testRegistry,
-			containerRegistrySecret:    testRegistrySecret,
-			certificateManager:         "vault",
-			vaultHost:                  testVaultHost,
-			vaultProtocol:              testVaultProtocol,
-			certmanagerIssuerName:      testCertManagerIssuerName,
-			certmanagerIssuerKind:      testCertManagerIssuerKind,
-			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-			vaultToken:                 testVaultToken,
-			vaultRole:                  testVaultRole,
-			osmImageTag:                testOsmImageTag,
-			osmImagePullPolicy:         defaultOsmImagePullPolicy,
-			serviceCertValidityMinutes: 1,
-			prometheusRetentionTime:    testRetentionTime,
-			meshName:                   defaultMeshName,
-			enableEgress:               true,
-			enablePrometheus:           true,
-			enableGrafana:              false,
-			envoyLogLevel:              testEnvoyLogLevel,
+			containerRegistry:           testRegistry,
+			containerRegistrySecret:     testRegistrySecret,
+			certificateManager:          "vault",
+			vaultHost:                   testVaultHost,
+			vaultProtocol:               testVaultProtocol,
+			certmanagerIssuerName:       testCertManagerIssuerName,
+			certmanagerIssuerKind:       testCertManagerIssuerKind,
+			certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+			vaultToken:                  testVaultToken,
+			vaultRole:                   testVaultRole,
+			osmImageTag:                 testOsmImageTag,
+			osmImagePullPolicy:          defaultOsmImagePullPolicy,
+			serviceCertValidityDuration: "24h",
+			prometheusRetentionTime:     testRetentionTime,
+			meshName:                    defaultMeshName,
+			enableEgress:                true,
+			enablePrometheus:            true,
+			enableGrafana:               false,
+			envoyLogLevel:               testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -879,7 +879,7 @@ var _ = Describe("Ensure that grafana is disabled when flag is set to false", fu
 						"name": testRegistrySecret,
 					},
 				},
-				"serviceCertValidityMinutes": int64(1),
+				"serviceCertValidityDuration": "24h",
 				"vault": map[string]interface{}{
 					"host":     testVaultHost,
 					"protocol": "http",
@@ -912,25 +912,25 @@ var _ = Describe("Ensure that grafana is enabled when flag is set to true", func
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:          testRegistry,
-			containerRegistrySecret:    testRegistrySecret,
-			certificateManager:         "vault",
-			vaultHost:                  testVaultHost,
-			vaultProtocol:              testVaultProtocol,
-			certmanagerIssuerName:      testCertManagerIssuerName,
-			certmanagerIssuerKind:      testCertManagerIssuerKind,
-			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-			vaultToken:                 testVaultToken,
-			vaultRole:                  testVaultRole,
-			osmImageTag:                testOsmImageTag,
-			osmImagePullPolicy:         defaultOsmImagePullPolicy,
-			serviceCertValidityMinutes: 1,
-			prometheusRetentionTime:    testRetentionTime,
-			meshName:                   defaultMeshName,
-			enableEgress:               true,
-			enablePrometheus:           true,
-			enableGrafana:              true,
-			envoyLogLevel:              testEnvoyLogLevel,
+			containerRegistry:           testRegistry,
+			containerRegistrySecret:     testRegistrySecret,
+			certificateManager:          "vault",
+			vaultHost:                   testVaultHost,
+			vaultProtocol:               testVaultProtocol,
+			certmanagerIssuerName:       testCertManagerIssuerName,
+			certmanagerIssuerKind:       testCertManagerIssuerKind,
+			certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+			vaultToken:                  testVaultToken,
+			vaultRole:                   testVaultRole,
+			osmImageTag:                 testOsmImageTag,
+			osmImagePullPolicy:          defaultOsmImagePullPolicy,
+			serviceCertValidityDuration: "24h",
+			prometheusRetentionTime:     testRetentionTime,
+			meshName:                    defaultMeshName,
+			enableEgress:                true,
+			enablePrometheus:            true,
+			enableGrafana:               true,
+			envoyLogLevel:               testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -960,7 +960,7 @@ var _ = Describe("Ensure that grafana is enabled when flag is set to true", func
 						"name": testRegistrySecret,
 					},
 				},
-				"serviceCertValidityMinutes": int64(1),
+				"serviceCertValidityDuration": "24h",
 				"vault": map[string]interface{}{
 					"host":     testVaultHost,
 					"protocol": "http",
@@ -993,25 +993,25 @@ var _ = Describe("Ensure that prometheus is disabled when flag is set to false",
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:          testRegistry,
-			containerRegistrySecret:    testRegistrySecret,
-			certificateManager:         "vault",
-			vaultHost:                  testVaultHost,
-			vaultProtocol:              testVaultProtocol,
-			certmanagerIssuerName:      testCertManagerIssuerName,
-			certmanagerIssuerKind:      testCertManagerIssuerKind,
-			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-			vaultToken:                 testVaultToken,
-			vaultRole:                  testVaultRole,
-			osmImageTag:                testOsmImageTag,
-			osmImagePullPolicy:         defaultOsmImagePullPolicy,
-			serviceCertValidityMinutes: 1,
-			prometheusRetentionTime:    testRetentionTime,
-			meshName:                   defaultMeshName,
-			enableEgress:               true,
-			enablePrometheus:           false,
-			enableGrafana:              true,
-			envoyLogLevel:              testEnvoyLogLevel,
+			containerRegistry:           testRegistry,
+			containerRegistrySecret:     testRegistrySecret,
+			certificateManager:          "vault",
+			vaultHost:                   testVaultHost,
+			vaultProtocol:               testVaultProtocol,
+			certmanagerIssuerName:       testCertManagerIssuerName,
+			certmanagerIssuerKind:       testCertManagerIssuerKind,
+			certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+			vaultToken:                  testVaultToken,
+			vaultRole:                   testVaultRole,
+			osmImageTag:                 testOsmImageTag,
+			osmImagePullPolicy:          defaultOsmImagePullPolicy,
+			serviceCertValidityDuration: "24h",
+			prometheusRetentionTime:     testRetentionTime,
+			meshName:                    defaultMeshName,
+			enableEgress:                true,
+			enablePrometheus:            false,
+			enableGrafana:               true,
+			envoyLogLevel:               testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -1041,7 +1041,7 @@ var _ = Describe("Ensure that prometheus is disabled when flag is set to false",
 						"name": testRegistrySecret,
 					},
 				},
-				"serviceCertValidityMinutes": int64(1),
+				"serviceCertValidityDuration": "24h",
 				"vault": map[string]interface{}{
 					"host":     testVaultHost,
 					"protocol": "http",
@@ -1073,25 +1073,25 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 
 	BeforeEach(func() {
 		installCmd := &installCmd{
-			containerRegistry:          testRegistry,
-			containerRegistrySecret:    testRegistrySecret,
-			certificateManager:         "cert-manager",
-			vaultHost:                  testVaultHost,
-			vaultProtocol:              testVaultProtocol,
-			certmanagerIssuerName:      testCertManagerIssuerName,
-			certmanagerIssuerKind:      testCertManagerIssuerKind,
-			certmanagerIssuerGroup:     testCertManagerIssuerGroup,
-			vaultToken:                 testVaultToken,
-			vaultRole:                  testVaultRole,
-			osmImageTag:                testOsmImageTag,
-			osmImagePullPolicy:         defaultOsmImagePullPolicy,
-			serviceCertValidityMinutes: 1,
-			prometheusRetentionTime:    testRetentionTime,
-			meshName:                   defaultMeshName,
-			enableEgress:               true,
-			enablePrometheus:           true,
-			enableGrafana:              true,
-			envoyLogLevel:              testEnvoyLogLevel,
+			containerRegistry:           testRegistry,
+			containerRegistrySecret:     testRegistrySecret,
+			certificateManager:          "cert-manager",
+			vaultHost:                   testVaultHost,
+			vaultProtocol:               testVaultProtocol,
+			certmanagerIssuerName:       testCertManagerIssuerName,
+			certmanagerIssuerKind:       testCertManagerIssuerKind,
+			certmanagerIssuerGroup:      testCertManagerIssuerGroup,
+			vaultToken:                  testVaultToken,
+			vaultRole:                   testVaultRole,
+			osmImageTag:                 testOsmImageTag,
+			osmImagePullPolicy:          defaultOsmImagePullPolicy,
+			serviceCertValidityDuration: "24h",
+			prometheusRetentionTime:     testRetentionTime,
+			meshName:                    defaultMeshName,
+			enableEgress:                true,
+			enablePrometheus:            true,
+			enableGrafana:               true,
+			envoyLogLevel:               testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()
@@ -1121,7 +1121,7 @@ var _ = Describe("Resolving values for install command with cert-manager paramet
 						"name": testRegistrySecret,
 					},
 				},
-				"serviceCertValidityMinutes": int64(1),
+				"serviceCertValidityDuration": "24h",
 				"vault": map[string]interface{}{
 					"host":     testVaultHost,
 					"protocol": "http",
@@ -1233,6 +1233,32 @@ var _ = Describe("Test osm image pull policy cli option", func() {
 
 		pullPolicy := vals["OpenServiceMesh"].(map[string]interface{})["image"].(map[string]interface{})["pullPolicy"]
 		Expect(pullPolicy).To(Equal("Always"))
+	})
+})
+
+var _ = Describe("Resolving values for service cert validity duration", func() {
+	It("Should correctly resolve the validity duration", func() {
+		installCmd := &installCmd{
+			serviceCertValidityDuration: "24h",
+		}
+
+		vals, err := installCmd.resolveValues()
+		Expect(err).NotTo(HaveOccurred())
+
+		actual := vals["OpenServiceMesh"].(map[string]interface{})["serviceCertValidityDuration"]
+		Expect(actual).To(Equal("24h"))
+	})
+
+	It("Should correctly resolve the validity duration", func() {
+		installCmd := &installCmd{
+			serviceCertValidityDuration: "1h30m",
+		}
+
+		vals, err := installCmd.resolveValues()
+		Expect(err).NotTo(HaveOccurred())
+
+		actual := vals["OpenServiceMesh"].(map[string]interface{})["serviceCertValidityDuration"]
+		Expect(actual).To(Equal("1h30m"))
 	})
 })
 

--- a/cmd/osm-controller/certificates.go
+++ b/cmd/osm-controller/certificates.go
@@ -41,7 +41,7 @@ const (
 
 var validCertificateManagerOptions = []string{tresorKind, vaultKind, certmanagerKind}
 
-func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, enableDebug bool, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	var err error
 	var rootCert certificate.Certificater
 
@@ -123,7 +123,7 @@ func getCertFromKubernetes(kubeClient kubernetes.Interface, namespace, secretNam
 	return rootCert, nil
 }
 
-func getHashiVaultOSMCertificateManager(enableDebug bool, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getHashiVaultOSMCertificateManager(cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	if _, ok := map[string]interface{}{"http": nil, "https": nil}[*vaultProtocol]; !ok {
 		return nil, nil, errors.Errorf("Value %s is not a valid Hashi Vault protocol", *vaultProtocol)
 	}
@@ -138,7 +138,7 @@ func getHashiVaultOSMCertificateManager(enableDebug bool, cfg configurator.Confi
 	return vaultCertManager, vaultCertManager, nil
 }
 
-func getCertManagerOSMCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, enableDebug bool, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getCertManagerOSMCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	rootCertSecret, err := kubeClient.CoreV1().Secrets(osmNamespace).Get(context.TODO(), caBundleSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to get cert-manager CA secret %s/%s: %s", osmNamespace, caBundleSecretName, err)

--- a/cmd/osm-controller/certificates.go
+++ b/cmd/osm-controller/certificates.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/providers/certmanager"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/vault"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/debugger"
 )
@@ -40,7 +41,7 @@ const (
 
 var validCertificateManagerOptions = []string{tresorKind, vaultKind, certmanagerKind}
 
-func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, enableDebug bool, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	var err error
 	var rootCert certificate.Certificater
 
@@ -71,7 +72,7 @@ func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, enableDebug
 		}
 	}
 
-	certManager, err := tresor.NewCertManager(rootCert, getServiceCertValidityPeriod(), rootCertOrganization)
+	certManager, err := tresor.NewCertManager(rootCert, rootCertOrganization, cfg)
 	if err != nil {
 		return nil, nil, errors.Errorf("Failed to instantiate Azure Key Vault as a Certificate Manager")
 	}
@@ -122,14 +123,14 @@ func getCertFromKubernetes(kubeClient kubernetes.Interface, namespace, secretNam
 	return rootCert, nil
 }
 
-func getHashiVaultOSMCertificateManager(enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getHashiVaultOSMCertificateManager(enableDebug bool, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	if _, ok := map[string]interface{}{"http": nil, "https": nil}[*vaultProtocol]; !ok {
 		return nil, nil, errors.Errorf("Value %s is not a valid Hashi Vault protocol", *vaultProtocol)
 	}
 
 	// A Vault address would have the following shape: "http://vault.default.svc.cluster.local:8200"
 	vaultAddr := fmt.Sprintf("%s://%s:%d", *vaultProtocol, *vaultHost, *vaultPort)
-	vaultCertManager, err := vault.NewCertManager(vaultAddr, *vaultToken, getServiceCertValidityPeriod(), *vaultRole)
+	vaultCertManager, err := vault.NewCertManager(vaultAddr, *vaultToken, *vaultRole, cfg)
 	if err != nil {
 		return nil, nil, errors.Errorf("Error instantiating Hashicorp Vault as a Certificate Manager: %+v", err)
 	}
@@ -137,7 +138,7 @@ func getHashiVaultOSMCertificateManager(enableDebug bool) (certificate.Manager, 
 	return vaultCertManager, vaultCertManager, nil
 }
 
-func getCertManagerOSMCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, enableDebug bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getCertManagerOSMCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, enableDebug bool, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
 	rootCertSecret, err := kubeClient.CoreV1().Secrets(osmNamespace).Get(context.TODO(), caBundleSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to get cert-manager CA secret %s/%s: %s", osmNamespace, caBundleSecretName, err)
@@ -158,18 +159,14 @@ func getCertManagerOSMCertificateManager(kubeClient kubernetes.Interface, kubeCo
 		return nil, nil, fmt.Errorf("Failed to build cert-manager client set: %s", err)
 	}
 
-	certmanagerCertManager, err := certmanager.NewCertManager(rootCert, client, osmNamespace, getServiceCertValidityPeriod(), cmmeta.ObjectReference{
+	certmanagerCertManager, err := certmanager.NewCertManager(rootCert, client, osmNamespace, cmmeta.ObjectReference{
 		Name:  *certmanagerIssuerName,
 		Kind:  *certmanagerIssuerKind,
 		Group: *certmanagerIssuerGroup,
-	})
+	}, cfg)
 	if err != nil {
 		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager as a Certificate Manager: %+v", err)
 	}
 
 	return certmanagerCertManager, certmanagerCertManager, nil
-}
-
-func getServiceCertValidityPeriod() time.Duration {
-	return time.Duration(serviceCertValidityMinutes) * time.Minute
 }

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -315,15 +315,13 @@ func saveOrUpdateSecretToKubernetes(kubeClient clientset.Interface, ca certifica
 }
 
 func getCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
-	enableDebugServer := cfg.IsDebugServerEnabled()
-
 	switch *osmCertificateManagerKind {
 	case tresorKind:
-		return getTresorOSMCertificateManager(kubeClient, enableDebugServer, cfg)
+		return getTresorOSMCertificateManager(kubeClient, cfg)
 	case vaultKind:
-		return getHashiVaultOSMCertificateManager(enableDebugServer, cfg)
+		return getHashiVaultOSMCertificateManager(cfg)
 	case certmanagerKind:
-		return getCertManagerOSMCertificateManager(kubeClient, kubeConfig, enableDebugServer, cfg)
+		return getCertManagerOSMCertificateManager(kubeClient, kubeConfig, cfg)
 	default:
 		return nil, nil, fmt.Errorf("Unsupported Certificate Manager %s", *osmCertificateManagerKind)
 	}

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -41,20 +41,18 @@ import (
 )
 
 const (
-	defaultServiceCertValidityMinutes = 60 // 1 hour
-	caBundleSecretNameCLIParam        = "ca-bundle-secret-name"
-	xdsServerCertificateCommonName    = "ads"
+	caBundleSecretNameCLIParam     = "ca-bundle-secret-name"
+	xdsServerCertificateCommonName = "ads"
 )
 
 var (
-	verbosity                  string
-	meshName                   string // An ID that uniquely identifies an OSM instance
-	kubeConfigFile             string
-	osmNamespace               string
-	webhookConfigName          string
-	serviceCertValidityMinutes int
-	caBundleSecretName         string
-	osmConfigMapName           string
+	verbosity          string
+	meshName           string // An ID that uniquely identifies an OSM instance
+	kubeConfigFile     string
+	osmNamespace       string
+	webhookConfigName  string
+	caBundleSecretName string
+	osmConfigMapName   string
 
 	injectorConfig injector.Config
 
@@ -88,7 +86,6 @@ func init() {
 	flags.StringVar(&kubeConfigFile, "kubeconfig", "", "Path to Kubernetes config file.")
 	flags.StringVar(&osmNamespace, "osm-namespace", "", "Namespace to which OSM belongs to.")
 	flags.StringVar(&webhookConfigName, "webhook-config-name", "", "Name of the MutatingWebhookConfiguration to be configured by osm-controller")
-	flags.IntVar(&serviceCertValidityMinutes, "service-cert-validity-minutes", defaultServiceCertValidityMinutes, "Certificate validityPeriod duration in minutes")
 	flags.StringVar(&caBundleSecretName, caBundleSecretNameCLIParam, "", "Name of the Kubernetes Secret for the OSM CA bundle")
 	flags.StringVar(&osmConfigMapName, "osm-configmap-name", "osm-config", "Name of the OSM ConfigMap")
 
@@ -157,13 +154,11 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating MeshSpec")
 	}
 
-	certManager, certDebugger, err := getCertificateManager(kubeClient, kubeConfig, cfg.IsDebugServerEnabled())
+	certManager, certDebugger, err := getCertificateManager(kubeClient, kubeConfig, cfg)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 			"Error fetching certificate manager of kind %s", *osmCertificateManagerKind)
 	}
-
-	log.Info().Msgf("Service certificates will be valid for %+v", getServiceCertValidityPeriod())
 
 	if caBundleSecretName == "" {
 		log.Info().Msgf("CA bundle will not be exported to a k8s secret (no --%s provided)", caBundleSecretNameCLIParam)
@@ -200,9 +195,7 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating sidecar injector webhook")
 	}
 
-	// TODO(draychev): we need to pass this hard-coded string is a CLI argument (https://github.com/openservicemesh/osm/issues/542)
-	validityPeriod := constants.XDSCertificateValidityPeriod
-	adsCert, err := certManager.IssueCertificate(xdsServerCertificateCommonName, &validityPeriod)
+	adsCert, err := certManager.IssueCertificate(xdsServerCertificateCommonName, constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.CertificateIssuanceFailure, "Error issuing XDS certificate to ADS server")
 	}
@@ -321,14 +314,16 @@ func saveOrUpdateSecretToKubernetes(kubeClient clientset.Interface, ca certifica
 	return nil
 }
 
-func getCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, enableDebugServer bool) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func getCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator) (certificate.Manager, debugger.CertificateManagerDebugger, error) {
+	enableDebugServer := cfg.IsDebugServerEnabled()
+
 	switch *osmCertificateManagerKind {
 	case tresorKind:
-		return getTresorOSMCertificateManager(kubeClient, enableDebugServer)
+		return getTresorOSMCertificateManager(kubeClient, enableDebugServer, cfg)
 	case vaultKind:
-		return getHashiVaultOSMCertificateManager(enableDebugServer)
+		return getHashiVaultOSMCertificateManager(enableDebugServer, cfg)
 	case certmanagerKind:
-		return getCertManagerOSMCertificateManager(kubeClient, kubeConfig, enableDebugServer)
+		return getCertManagerOSMCertificateManager(kubeClient, kubeConfig, enableDebugServer, cfg)
 	default:
 		return nil, nil, fmt.Errorf("Unsupported Certificate Manager %s", *osmCertificateManagerKind)
 	}

--- a/cmd/osm-controller/osm-controller_test.go
+++ b/cmd/osm-controller/osm-controller_test.go
@@ -4,22 +4,34 @@ import (
 	"context"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 var _ = Describe("Test creation of CA bundle k8s secret", func() {
+	var (
+		mockCtrl         *gomock.Controller
+		mockConfigurator *configurator.MockConfigurator
+	)
+	mockCtrl = gomock.NewController(GinkgoT())
+
 	Context("Testing createCABundleKubernetesSecret", func() {
+		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
+
 		It("creates a k8s secret", func() {
 
 			cache := make(map[certificate.CommonName]certificate.Certificater)
-			certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+			certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
 			secretName := "--secret--name--"
 			namespace := "--namespace--"
 			k8sClient := testclient.NewSimpleClientset()

--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -35,6 +35,10 @@ spec:
         command: ["/bin/sh","-c"]
         args:
           - |
+            # The TTL for the expiration of CA certificate must be beyond that of the longest
+            # TTL for a certificate issued by OSM. The longest TTL for a certificate issued
+            # within OSM is 87600h.
+
             # Start the Vault Server
             vault server -dev -dev-listen-address=0.0.0.0:8200 -dev-root-token-id=$VAULT_TOKEN & sleep 1;
 
@@ -45,16 +49,16 @@ spec:
             vault secrets enable pki;
 
             # Set the max allowed lease for a certificate to a decade
-            vault secrets tune -max-lease-ttl=87600h pki;
+            vault secrets tune -max-lease-ttl=87700h pki;
 
             # Set the URLs (See: https://www.vaultproject.io/docs/secrets/pki#set-url-configuration)
             vault write pki/config/urls issuing_certificates='http://127.0.0.1:8200/v1/pki/ca' crl_distribution_points='http://127.0.0.1:8200/v1/pki/crl';
 
             # Configure a role for OSM (See: https://www.vaultproject.io/docs/secrets/pki#configure-a-role)
-            vault write pki/roles/${VAULT_ROLE} allow_any_name=true allow_subdomains=true;
+            vault write pki/roles/${VAULT_ROLE} allow_any_name=true allow_subdomains=true max_ttl=87700h;
 
             # Create the root certificate (See: https://www.vaultproject.io/docs/secrets/pki#setup)
-            vault write pki/root/generate/internal common_name='osm.root' ttl='8765h';
+            vault write pki/root/generate/internal common_name='osm.root' ttl='87700h';
             tail /dev/random;
         securityContext:
           capabilities:

--- a/docs/patterns/certificates.md
+++ b/docs/patterns/certificates.md
@@ -40,7 +40,7 @@ CLI flags control how OSM integrates with Vault. The following OSM command line 
   - `--vault-protocol` - protocol for Vault connection (`http` or `https`)
   - `--vault-token` - token to be used by OSM to connect to Vault (this is issued on the Vault server for the particular role)
   - `--vault-role` - role created on Vault server and dedicated to Open Service Mesh (example: `openservicemesh`)
-  - `--service-cert-validity-minutes` - number of minutes - period for which each new certificate issued for service-to-service communication will be valid
+  - `--service-cert-validity-duration` - period for which each new certificate issued for service-to-service communication will be valid. It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix, ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
 
 Additionally:
   - `--ca-bundle-secret-name` - this string is the name of the Kubernetes secret where the service mesh root certificate will be stored. When using Vault (unlike Tresor) the root key will **not** be exported to this secret.
@@ -116,7 +116,7 @@ When running OSM on your local workstation, use the following CLI parameters:
 --vault-protocol="http"
 --vault-token="xyz"
 --vault-role="openservicemesh'
---service-cert-validity-minutes=60
+--service-cert-validity-duration=24h
 ```
 
 ### How OSM Integrates with Vault

--- a/pkg/catalog/certificates.go
+++ b/pkg/catalog/certificates.go
@@ -12,7 +12,7 @@ func (mc *MeshCatalog) GetCertificateForService(meshService service.MeshService)
 	cert, err := mc.certManager.GetCertificate(cn)
 	if err != nil {
 		// Certificate was not found in CertManager's cache, issue one
-		newCert, err := mc.certManager.IssueCertificate(cn, nil)
+		newCert, err := mc.certManager.IssueCertificate(cn, mc.configurator.GetServiceCertValidityPeriod())
 		if err != nil {
 			log.Error().Err(err).Msgf("Error issuing a new certificate for service:%s, CN: %s", meshService, cn)
 			return nil, err

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -2,7 +2,6 @@ package catalog
 
 import (
 	"context"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/onsi/ginkgo"
@@ -36,8 +35,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	mockIngressMonitor = ingress.NewMockMonitor(mockCtrl)
 
 	meshSpec := smi.NewFakeMeshSpecClient()
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+
 	stop := make(<-chan struct{})
 	endpointProviders := []endpoint.Provider{
 		kube.NewFakeProvider(),
@@ -46,6 +44,9 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	osmNamespace := "-test-osm-namespace-"
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+
+	cache := make(map[certificate.CommonName]certificate.Certificater)
+	certManager := tresor.NewFakeCertManager(&cache, cfg)
 
 	testChan := make(chan interface{})
 

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -56,7 +56,6 @@ type CertManager struct {
 	// crLister is used to list CertificateRequests in the given namespace.
 	crLister cmlisters.CertificateRequestNamespaceLister
 
-	// dynamic config retrieval
 	cfg configurator.Configurator
 }
 

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -28,9 +29,6 @@ var (
 
 // CertManager implements certificate.Manager
 type CertManager struct {
-	// How long will newly issued certificates be valid for.
-	validityPeriod time.Duration
-
 	// The Certificate Authority root certificate to be used by this certificate
 	// manager.
 	ca certificate.Certificater
@@ -57,6 +55,9 @@ type CertManager struct {
 
 	// crLister is used to list CertificateRequests in the given namespace.
 	crLister cmlisters.CertificateRequestNamespaceLister
+
+	// dynamic config retrieval
+	cfg configurator.Configurator
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
+	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 const (
@@ -65,7 +66,7 @@ func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
 }
 
 // NewCertManager creates a new CertManager with the passed CA and CA Private Key
-func NewCertManager(ca certificate.Certificater, validityPeriod time.Duration, certificatesOrganization string) (*CertManager, error) {
+func NewCertManager(ca certificate.Certificater, certificatesOrganization string, cfg configurator.Configurator) (*CertManager, error) {
 	if ca == nil {
 		return nil, errNoIssuingCA
 	}
@@ -76,9 +77,6 @@ func NewCertManager(ca certificate.Certificater, validityPeriod time.Duration, c
 		// The root certificate signing all newly issued certificates
 		ca: ca,
 
-		// Newly issued certificates will be valid for this duration
-		validityPeriod: validityPeriod,
-
 		// Channel used to inform other components of cert changes (rotation etc.)
 		announcements: make(chan interface{}),
 
@@ -86,6 +84,8 @@ func NewCertManager(ca certificate.Certificater, validityPeriod time.Duration, c
 		cache: &cache,
 
 		certificatesOrganization: certificatesOrganization,
+
+		cfg: cfg,
 	}
 
 	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -13,11 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 )
 
-func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Duration) (certificate.Certificater, error) {
-	if validityPeriod == nil {
-		validityPeriod = &cm.validityPeriod
-	}
-
+func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
 	if cm.ca == nil {
 		log.Error().Msgf("Invalid CA provided for issuance of certificate with CN=%s", cn)
 		return nil, errNoIssuingCA
@@ -45,7 +41,7 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod *time.Dur
 			Organization: []string{cm.certificatesOrganization},
 		},
 		NotBefore: now,
-		NotAfter:  now.Add(*validityPeriod),
+		NotAfter:  now.Add(validityPeriod),
 
 		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
@@ -108,7 +104,7 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 }
 
 // IssueCertificate implements certificate.Manager and returns a newly issued certificate.
-func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPeriod *time.Duration) (certificate.Certificater, error) {
+func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
 	start := time.Now()
 
 	if cert := cm.getFromCache(cn); cert != nil {
@@ -143,7 +139,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 
 	start := time.Now()
 
-	cert, err := cm.issue(cn, &cm.validityPeriod)
+	cert, err := cm.issue(cn, cm.cfg.GetServiceCertValidityPeriod())
 	if err != nil {
 		return cert, err
 	}

--- a/pkg/certificate/providers/tresor/certificate_manager_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_test.go
@@ -3,14 +3,22 @@ package tresor
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
-
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 var _ = Describe("Test Certificate Manager", func() {
 	defer GinkgoRecover()
+
+	var (
+		mockCtrl         *gomock.Controller
+		mockConfigurator *configurator.MockConfigurator
+	)
+	mockCtrl = gomock.NewController(GinkgoT())
 
 	const (
 		serviceFQDN = "a.b.c"
@@ -22,6 +30,9 @@ var _ = Describe("Test Certificate Manager", func() {
 		rootCertPem := "../../sample_certificate.pem"
 		rootKeyPem := "../../sample_private_key.pem"
 
+		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+
 		It("should be able to load a certificate from disk", func() {
 			var err error
 			rootCert, err := LoadCA(rootCertPem, rootKeyPem)
@@ -30,10 +41,10 @@ var _ = Describe("Test Certificate Manager", func() {
 			expected := "-----BEGIN CERTIFICATE-----\nMIIElzCCA3+gAwIBAgIRAOsakgIV4y"
 			Expect(string(rootCert.GetCertificateChain()[:len(expected)])).To(Equal(expected))
 
-			m, newCertError := NewCertManager(rootCert, validity, "org")
+			m, newCertError := NewCertManager(rootCert, "org", mockConfigurator)
 			Expect(newCertError).ToNot(HaveOccurred())
 
-			cert, err := m.IssueCertificate(serviceFQDN, nil)
+			cert, err := m.IssueCertificate(serviceFQDN, validity)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cert.GetCommonName()).To(Equal(certificate.CommonName(serviceFQDN)))
 
@@ -64,14 +75,18 @@ var _ = Describe("Test Certificate Manager", func() {
 		rootCertCountry := "US"
 		rootCertLocality := "CA"
 		rootCertOrganization := "Open Service Mesh Tresor"
+
+		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+
 		rootCert, err := NewCA(cn, 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
 		if err != nil {
 			GinkgoT().Fatalf("Error loading CA from files %s and %s: %s", rootCertPem, rootKeyPem, err.Error())
 		}
-		m, newCertError := NewCertManager(rootCert, validity, "org")
+		m, newCertError := NewCertManager(rootCert, "org", mockConfigurator)
 		It("should issue a certificate", func() {
 			Expect(newCertError).ToNot(HaveOccurred())
-			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, nil)
+			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)
 			Expect(issueCertificateError).ToNot(HaveOccurred())
 			Expect(cert.GetCommonName()).To(Equal(certificate.CommonName(serviceFQDN)))
 
@@ -102,14 +117,18 @@ var _ = Describe("Test Certificate Manager", func() {
 		rootCertCountry := "US"
 		rootCertLocality := "CA"
 		rootCertOrganization := "Open Service Mesh Tresor"
+
+		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+
 		rootCert, err := NewCA(cn, validity, rootCertCountry, rootCertLocality, rootCertOrganization)
 		if err != nil {
 			GinkgoT().Fatalf("Error loading CA from files %s and %s: %s", rootCertPem, rootKeyPem, err.Error())
 		}
-		m, newCertError := NewCertManager(rootCert, validity, "org")
+		m, newCertError := NewCertManager(rootCert, "org", mockConfigurator)
 		It("should get an issued certificate from the cache", func() {
 			Expect(newCertError).ToNot(HaveOccurred())
-			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, &validity)
+			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)
 			Expect(issueCertificateError).ToNot(HaveOccurred())
 			Expect(cert.GetCommonName()).To(Equal(certificate.CommonName(serviceFQDN)))
 

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 // NewFakeCertManager creates a fake CertManager used for testing.
-func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificater, validityPeriod time.Duration) *CertManager {
+func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificater, cfg configurator.Configurator) *CertManager {
 	rootCertCountry := "US"
 	rootCertLocality := "CA"
 	rootCertOrganization := "Open Service Mesh Tresor"
@@ -18,10 +19,10 @@ func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificat
 	}
 
 	return &CertManager{
-		ca:             ca.(*Certificate),
-		validityPeriod: validityPeriod,
-		announcements:  make(chan interface{}),
-		cache:          cache,
+		ca:            ca.(*Certificate),
+		announcements: make(chan interface{}),
+		cache:         cache,
+		cfg:           cfg,
 	}
 }
 

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -28,9 +29,6 @@ var (
 
 // CertManager implements certificate.Manager
 type CertManager struct {
-	// Period for which the newly issued certificate will be valid.
-	validityPeriod time.Duration
-
 	// The Certificate Authority root certificate to be used by this certificate manager
 	ca certificate.Certificater
 
@@ -42,6 +40,9 @@ type CertManager struct {
 	cacheLock sync.Mutex
 
 	certificatesOrganization string
+
+	// Dynamic config retrieval
+	cfg configurator.Configurator
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -41,7 +41,6 @@ type CertManager struct {
 
 	certificatesOrganization string
 
-	// Dynamic config retrieval
 	cfg configurator.Configurator
 }
 

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -2,18 +2,15 @@ package vault
 
 import (
 	"sync"
-	"time"
 
 	"github.com/hashicorp/vault/api"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 // CertManager implements certificate.Manager and contains a Hashi Vault client instance.
 type CertManager struct {
-	// How long will newly issued certificates be valid for
-	validityPeriod time.Duration
-
 	// The Certificate Authority root certificate to be used by this certificate manager
 	ca certificate.Certificater
 
@@ -29,4 +26,7 @@ type CertManager struct {
 
 	// The Vault role configured for OSM and passed as a CLI.
 	vaultRole string
+
+	// Dynamic config retrieval
+	cfg configurator.Configurator
 }

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -27,6 +27,5 @@ type CertManager struct {
 	// The Vault role configured for OSM and passed as a CLI.
 	vaultRole string
 
-	// Dynamic config retrieval
 	cfg configurator.Configurator
 }

--- a/pkg/certificate/rotor/rotor_test.go
+++ b/pkg/certificate/rotor/rotor_test.go
@@ -4,25 +4,37 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
+	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
 var _ = Describe("Test Rotor", func() {
+
+	var (
+		mockCtrl         *gomock.Controller
+		mockConfigurator *configurator.MockConfigurator
+	)
+
+	mockCtrl = gomock.NewController(GinkgoT())
 
 	cn := certificate.CommonName("foo")
 
 	Context("Testing rotating expiring certificates", func() {
 		cache := make(map[certificate.CommonName]certificate.Certificater)
 		validityPeriod := 1 * time.Hour
-		certManager := tresor.NewFakeCertManager(&cache, validityPeriod)
+		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Times(0)
+
+		certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
 
 		It("determines whether a certificate has expired", func() {
-			cert, err := certManager.IssueCertificate(cn, nil)
+			cert, err := certManager.IssueCertificate(cn, validityPeriod)
 			Expect(err).ToNot(HaveOccurred())
 			actual := rotor.ShouldRotate(cert)
 			Expect(actual).To(BeFalse())
@@ -32,9 +44,13 @@ var _ = Describe("Test Rotor", func() {
 	Context("Testing rotating expiring certificates", func() {
 		cache := make(map[certificate.CommonName]certificate.Certificater)
 		validityPeriod := -1 * time.Hour // negative time means this cert has already expired -- will be rotated asap
-		certManager := tresor.NewFakeCertManager(&cache, validityPeriod)
 
-		certA, err := certManager.IssueCertificate(cn, nil)
+		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
+
+		certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
+
+		certA, err := certManager.IssueCertificate(cn, validityPeriod)
 
 		It("issued a new certificate", func() {
 			Expect(err).ToNot(HaveOccurred())
@@ -58,7 +74,7 @@ var _ = Describe("Test Rotor", func() {
 
 			fmt.Printf("It took %+v to rotate certificate %s\n", time.Since(start), cn)
 
-			newCert, err := certManager.IssueCertificate(cn, nil)
+			newCert, err := certManager.IssueCertificate(cn, validityPeriod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newCert.GetExpiration()).ToNot(Equal(certA.GetExpiration()))
 			Expect(newCert).ToNot(Equal(certA))

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -47,7 +47,7 @@ type Certificater interface {
 // Manager is the interface declaring the methods for the Certificate Manager.
 type Manager interface {
 	// IssueCertificate issues a new certificate.
-	IssueCertificate(CommonName, *time.Duration) (Certificater, error)
+	IssueCertificate(CommonName, time.Duration) (Certificater, error)
 
 	// GetCertificate returns a certificate given its Common Name (CN)
 	GetCertificate(CommonName) (Certificater, error)

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -109,9 +109,9 @@ var _ = Describe("Test ADS response functions", func() {
 	Context("Test sendAllResponses()", func() {
 
 		cache := make(map[certificate.CommonName]certificate.Certificater)
-		certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+		certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
 		cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), serviceAccountName, tests.Namespace))
-		certPEM, _ := certManager.IssueCertificate(cn, nil)
+		certPEM, _ := certManager.IssueCertificate(cn, 1*time.Hour)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 		server, actualResponses := tests.NewFakeXDSServer(cert, nil, nil)
 

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	set "github.com/deckarep/golang-set"
 	corev1 "k8s.io/api/core/v1"
@@ -160,13 +159,14 @@ var _ = Describe("RDS Response", func() {
 
 	endpointProviders := []endpoint.Provider{kube.NewFakeProvider()}
 	kubeClient := testclient.NewSimpleClientset()
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
 
 	stop := make(<-chan struct{})
 	osmNamespace := "-test-osm-namespace-"
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+
+	cache := make(map[certificate.CommonName]certificate.Certificater)
+	certManager := tresor.NewFakeCertManager(&cache, cfg)
 
 	testChan := make(chan interface{})
 

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -13,12 +13,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -26,6 +28,14 @@ import (
 )
 
 var _ = Describe("Test SDS response functions", func() {
+
+	var (
+		mockCtrl         *gomock.Controller
+		mockConfigurator *configurator.MockConfigurator
+	)
+
+	mockCtrl = gomock.NewController(GinkgoT())
+	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 
 	prep := func(resourceNames []string, namespace, svcName string) (certificate.Certificater, *envoy.Proxy, catalog.MeshCataloger) {
 		serviceAccount := tests.BookstoreServiceAccountName
@@ -50,9 +60,9 @@ var _ = Describe("Test SDS response functions", func() {
 		proxy := envoy.NewProxy(cn, nil)
 		cache := make(map[certificate.CommonName]certificate.Certificater)
 		validityPeriod := 1 * time.Hour
-		certManager := tresor.NewFakeCertManager(&cache, validityPeriod)
+		certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
 
-		cert, err := certManager.IssueCertificate(cn, nil)
+		cert, err := certManager.IssueCertificate(cn, validityPeriod)
 		Expect(err).ToNot(HaveOccurred())
 
 		mc := catalog.NewFakeMeshCatalog(kubeClient)
@@ -63,9 +73,9 @@ var _ = Describe("Test SDS response functions", func() {
 	Context("Test getRootCert()", func() {
 		It("returns a properly formatted struct", func() {
 			cache := make(map[certificate.CommonName]certificate.Certificater)
-			certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+			certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
 
-			cert, err := certManager.IssueCertificate("blah", nil)
+			cert, err := certManager.IssueCertificate("blah", 1*time.Hour)
 			Expect(err).ToNot(HaveOccurred())
 
 			svc := service.MeshService{

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -30,8 +30,7 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string) ([]byte, error
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
 	cn := catalog.NewCertCommonNameWithProxyID(proxyUUID, pod.Spec.ServiceAccountName, namespace)
 	log.Info().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN=%s", pod.Spec.ServiceAccountName, namespace, cn)
-	validityPeriod := constants.XDSCertificateValidityPeriod
-	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn, &validityPeriod)
+	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn, constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing bootstrap certificate for Envoy with CN=%s", cn)
 		return nil, err

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -50,8 +50,7 @@ const (
 // NewWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
 func NewWebhook(config Config, kubeClient kubernetes.Interface, certManager certificate.Manager, meshCatalog catalog.MeshCataloger, kubeController k8s.Controller, meshName, osmNamespace, webhookConfigName string, stop <-chan struct{}, cfg configurator.Configurator) error {
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.svc", constants.OSMControllerName, osmNamespace))
-	validityPeriod := constants.XDSCertificateValidityPeriod
-	cert, err := certManager.IssueCertificate(cn, &validityPeriod)
+	cert, err := certManager.IssueCertificate(cn, constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing certificate for the mutating webhook: %+v", err)
 	}

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -14,7 +14,7 @@ import (
 func TestNewGrpc(t *testing.T) {
 	assert := assert.New(t)
 	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+	certManager := tresor.NewFakeCertManager(&cache, nil)
 	adsCert, err := certManager.GetRootCertificate()
 	assert.Nil(err)
 
@@ -54,7 +54,7 @@ func TestGrpcServe(t *testing.T) {
 	assert := assert.New(t)
 
 	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+	certManager := tresor.NewFakeCertManager(&cache, nil)
 	adsCert, err := certManager.GetRootCertificate()
 	assert.Nil(err)
 

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -30,7 +30,7 @@ func TestSetupMutualTLS(t *testing.T) {
 	}
 
 	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+	certManager := tresor.NewFakeCertManager(&cache, nil)
 	adsCert, err := certManager.GetRootCertificate()
 	assert.Nil(err)
 
@@ -68,9 +68,9 @@ func TestValidateClient(t *testing.T) {
 	}
 
 	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, 1*time.Hour)
+	certManager := tresor.NewFakeCertManager(&cache, nil)
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), tests.BookstoreServiceAccountName, tests.Namespace))
-	certPEM, _ := certManager.IssueCertificate(cn, nil)
+	certPEM, _ := certManager.IssueCertificate(cn, 1*time.Hour)
 	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 
 	goodCommonNameMapping := map[string]interface{}{string(cn): cn}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change allows reconfiguring the validity period for short lived
certs. The validity period of such certs are no longer static, but
dynamically retrieved from the osm-config ConfigMap.
Additionally, the validity period at the time of certificate issuance
must be explicitly be specified to prevent issuing certs with wrong
validity.

It also makes the default validity period for service certificates 
consistent across the code.

Part of #1757

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`