### PR TITLE
fix(release): update chart release tag match

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,7 +2,7 @@ name: Release Helm Chart
 on:
   push:
     tags:
-      - "chart*"
+      - "chart/*"
 
 jobs:
   release:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: We've seen the GH action we use to publish the OSM chart to gh-pages is not triggered on releases. The `*` character in the tag match does not match the `/` character that we've documented to use for chart release tags, so `chart*` does not match a tag like `chart/0.4.1`. This change updates the filter to match those tags.

ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No