### PR TITLE
ci: Increase timeout when testing with coverage

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -2,7 +2,7 @@
 
 set -aueo pipefail
 
-go test -timeout 80s \
+go test -timeout 120s \
    -failfast \
    -v \
    -coverprofile=coverage.txt \


### PR DESCRIPTION
This PR increases the timeout on testing with coverage to 120s.  This is needed for https://github.com/openservicemesh/osm/pull/1772, which adds many more tests and needs more time.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? no
