### PR TITLE
tests(catalog): fix flake in TestListTrafficPolicies

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -40,7 +40,7 @@ func TestListTrafficPolicies(t *testing.T) {
 	for _, test := range listTrafficPoliciesTests {
 		trafficTargets, err := mc.ListTrafficPolicies(test.input)
 		assert.Nil(err)
-		assert.Equal(trafficTargets, test.output)
+		assert.ElementsMatch(trafficTargets, test.output)
 	}
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Change TestListTrafficPolicies to not test order of returned elements.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No