### PR TITLE
kubernetes/events: remove unnecessary logging

### DIFF
--- a/pkg/kubernetes/events/events.go
+++ b/pkg/kubernetes/events/events.go
@@ -69,7 +69,6 @@ func GenericEventRecorder() *EventRecorder {
 // eventRecorder returns an EventRecorder that can be used to post Kubernetes events
 func eventRecorder(kubeClient kubernetes.Interface, namespace string) record.EventRecorder {
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(log.Trace().Msgf)
 	eventBroadcaster.StartRecordingToSink(
 		&typedcorev1.EventSinkImpl{
 			Interface: kubeClient.CoreV1().Events(namespace)})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Each of the xxxEvent() apis exposed by the EventRecorder already
log at the corresponding log levels. This change removes the
additional trace logging which results in duplicate log messages
for each event.

The additional logging as a part of the event recorder also
results in data races in unit tests, which is similar to the issue
seen in https://github.com/kubernetes/kubernetes/issues/92500.

Part of #1791

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`