### PR TITLE
Fix spacing issues on values.yaml file

### DIFF
--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -23,7 +23,7 @@ OpenServiceMesh:
     issuerName: osm-ca
     issuerKind: Issuer
     issuerGroup: cert-manager
-    serviceCertValidityDuration: 24h
+  serviceCertValidityDuration: 24h
   caBundleSecretName: osm-ca-bundle
   grafana:
     port: 3000


### PR DESCRIPTION
Helm Chart ConfigMap is using `OpenServiceMesh.serviceCertValidityDuration`
Current default values are using `OpenServiceMesh.certmanager.serviceCertValidityDuration`
Looking at the other places this is referenced I believe this should be updated to be outside of certmanager. It looks like it doesn't happen in the [osm cli](https://github.com/openservicemesh/osm/blob/11e7e5eae48790bef3c7e3a51f7d1e6206d45a0d/cmd/cli/install.go#L210) because it is passing the value itself.
[Configmap Template](https://github.com/openservicemesh/osm/blob/11e7e5eae48790bef3c7e3a51f7d1e6206d45a0d/charts/osm/templates/osm-configmap.yaml#L21):
```
service_cert_validity_duration: {{ .Values.OpenServiceMesh.serviceCertValidityDuration | quote }}
```

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updating default values file on the helm charts to match installer values.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No
