### PR TITLE
cmd/osm-controller: write private key to CA bundle secret

### DIFF
--- a/cmd/osm-controller/certificates.go
+++ b/cmd/osm-controller/certificates.go
@@ -74,7 +74,7 @@ func getTresorOSMCertificateManager(kubeClient kubernetes.Interface, cfg configu
 
 	certManager, err := tresor.NewCertManager(rootCert, rootCertOrganization, cfg)
 	if err != nil {
-		return nil, nil, errors.Errorf("Failed to instantiate Azure Key Vault as a Certificate Manager")
+		return nil, nil, errors.Errorf("Failed to instantiate Tresor as a Certificate Manager")
 	}
 
 	return certManager, certManager, nil

--- a/cmd/osm-controller/certificates_test.go
+++ b/cmd/osm-controller/certificates_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Test CMD tools", func() {
 			cert, err := tresor.NewCertificateFromPEM(expectedCert, expectedKey, expiration)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = saveOrUpdateSecretToKubernetes(kubeClient, cert, ns, secretName, keyPEM)
+			err = saveOrUpdateSecretToKubernetes(kubeClient, cert, ns, secretName)
 			Expect(err).ToNot(HaveOccurred())
 
 			actual, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, v1.GetOptions{})
@@ -232,7 +232,7 @@ var _ = Describe("Test CMD tools", func() {
 			cert, err := tresor.NewCertificateFromPEM(expectedCert, expectedKey, expiration)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = saveOrUpdateSecretToKubernetes(kubeClient, cert, ns, secretName, keyPEM)
+			err = saveOrUpdateSecretToKubernetes(kubeClient, cert, ns, secretName)
 			Expect(err).ToNot(HaveOccurred())
 
 			actual, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, v1.GetOptions{})

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -258,17 +258,14 @@ func createOrUpdateCABundleKubernetesSecret(kubeClient clientset.Interface, cert
 		return nil
 	}
 
-	return saveOrUpdateSecretToKubernetes(kubeClient, ca, namespace, caBundleSecretName, nil)
+	return saveOrUpdateSecretToKubernetes(kubeClient, ca, namespace, caBundleSecretName)
 }
 
-func saveOrUpdateSecretToKubernetes(kubeClient clientset.Interface, ca certificate.Certificater, namespace, caBundleSecretName string, privKey []byte) error {
+func saveOrUpdateSecretToKubernetes(kubeClient clientset.Interface, ca certificate.Certificater, namespace, caBundleSecretName string) error {
 	secretData := map[string][]byte{
-		constants.KubernetesOpaqueSecretCAKey:        ca.GetCertificateChain(),
-		constants.KubernetesOpaqueSecretCAExpiration: []byte(ca.GetExpiration().Format(constants.TimeDateLayout)),
-	}
-
-	if privKey != nil {
-		secretData[constants.KubernetesOpaqueSecretRootPrivateKeyKey] = privKey
+		constants.KubernetesOpaqueSecretCAKey:             ca.GetCertificateChain(),
+		constants.KubernetesOpaqueSecretCAExpiration:      []byte(ca.GetExpiration().Format(constants.TimeDateLayout)),
+		constants.KubernetesOpaqueSecretRootPrivateKeyKey: ca.GetPrivateKey(),
 	}
 
 	existingSecret, getErr := kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), caBundleSecretName, metav1.GetOptions{})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The private key for the CA bundle secret was not being written
to, because of which restarting a pod (not recreating the deployment)
results in the controller not starting up fine when it loads
the root certificate from the CA bundle secret.

Resolves #1742

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`