### PR TITLE
test(split): Refactor tests to use two traffic split backends

### DIFF
--- a/pkg/catalog/debugger_test.go
+++ b/pkg/catalog/debugger_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 		It("lists monitored namespaces", func() {
 			actual := mc.ListMonitoredNamespaces()
 			listExpectedNs := tests.GetUnique([]string{
-				tests.BookstoreService.Namespace,
+				tests.BookstoreV1Service.Namespace,
 				tests.BookbuyerService.Namespace,
 				tests.BookwarehouseService.Namespace,
 			})
@@ -96,7 +96,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 
 			Expect(trafficSplits[0].Spec.Service).To(Equal("bookstore-apex"))
 			Expect(weightedServices[0]).To(Equal(service.WeightedService{
-				Service:     tests.BookstoreService,
+				Service:     tests.BookstoreV1Service,
 				Weight:      100,
 				RootService: "bookstore-apex"}))
 			Expect(serviceAccounts[0].String()).To(Equal("default/bookstore"))

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Test catalog functions", func() {
 	mc := newFakeMeshCatalog()
 	Context("Testing ListEndpointsForService()", func() {
 		It("lists endpoints for a given service", func() {
-			actual, err := mc.ListEndpointsForService(tests.BookstoreService)
+			actual, err := mc.ListEndpointsForService(tests.BookstoreV1Service)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := []endpoint.Endpoint{
@@ -24,7 +24,7 @@ var _ = Describe("Test catalog functions", func() {
 
 	Context("Testing GetResolvableServiceEndpoints()", func() {
 		It("returns the endpoint for the service", func() {
-			actual, err := mc.GetResolvableServiceEndpoints(tests.BookstoreService)
+			actual, err := mc.GetResolvableServiceEndpoints(tests.BookstoreV1Service)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := []endpoint.Endpoint{

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -90,7 +90,8 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
-	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreService.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -75,10 +75,16 @@ func newFakeMeshCatalog() *MeshCatalog {
 		GinkgoT().Fatalf("Error creating new fake Mesh Catalog: %s", err.Error())
 	}
 
-	// Create Bookstore Service
+	// Create Bookstore-v1 Service
 	selector := map[string]string{tests.SelectorKey: tests.SelectorValue}
-	svc := tests.NewServiceFixture(tests.BookstoreService.Name, tests.BookstoreService.Namespace, selector)
-	if _, err := kubeClient.CoreV1().Services(tests.BookstoreService.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
+	svc := tests.NewServiceFixture(tests.BookstoreV1Service.Name, tests.BookstoreV1Service.Namespace, selector)
+	if _, err := kubeClient.CoreV1().Services(tests.BookstoreV1Service.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
+		GinkgoT().Fatalf("Error creating new Bookstore service: %s", err.Error())
+	}
+
+	// Create Bookstore-v2 Service
+	svc = tests.NewServiceFixture(tests.BookstoreV2Service.Name, tests.BookstoreV2Service.Namespace, selector)
+	if _, err := kubeClient.CoreV1().Services(tests.BookstoreV2Service.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
 		GinkgoT().Fatalf("Error creating new Bookstore service: %s", err.Error())
 	}
 
@@ -101,7 +107,7 @@ func newFakeMeshCatalog() *MeshCatalog {
 
 	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
 	listExpectedNs := tests.GetUnique([]string{
-		tests.BookstoreService.Namespace,
+		tests.BookstoreV1Service.Namespace,
 		tests.BookbuyerService.Namespace,
 		tests.BookstoreApexService.Namespace,
 	})
@@ -133,7 +139,8 @@ func newFakeMeshCatalog() *MeshCatalog {
 	}).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
-	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreService.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().ListMonitoredNamespaces().Return(listExpectedNs, nil).AnyTimes()

--- a/pkg/debugger/namespace_test.go
+++ b/pkg/debugger/namespace_test.go
@@ -22,8 +22,8 @@ func TestMonitoredNamespaceHandler(t *testing.T) {
 	monitoredNamespacesHandler := ds.getMonitoredNamespacesHandler()
 
 	uniqueNs := tests.GetUnique([]string{
-		tests.BookbuyerService.Namespace, // default
-		tests.BookstoreService.Namespace, // default
+		tests.BookbuyerService.Namespace,   // default
+		tests.BookstoreV1Service.Namespace, // default
 	})
 
 	mock.EXPECT().ListMonitoredNamespaces().Return(uniqueNs)

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -35,7 +35,8 @@ func TestGetSMIPolicies(t *testing.T) {
 				}},
 		},
 		[]service.WeightedService{
-			tests.WeightedService,
+			tests.BookstoreV1WeightedService,
+			tests.BookstoreV2WeightedService,
 		},
 		[]service.K8sServiceAccount{
 			tests.BookbuyerServiceAccount,
@@ -52,6 +53,6 @@ func TestGetSMIPolicies(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 	smiPoliciesHandler.ServeHTTP(responseRecorder, nil)
 	actualResponseBody := responseRecorder.Body.String()
-	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"weighted_services":[{"service_name:omitempty":{"Namespace":"default","Name":"bookstore"},"weight:omitempty":100,"root_service:omitempty":"bookstore-apex"}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha2","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha2","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"Name","name":"bookstore","namespace":"default"},"sources":[{"kind":"Name","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
+	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"weighted_services":[{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v1"},"weight:omitempty":100,"root_service:omitempty":"bookstore-apex"},{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v2"},"weight:omitempty":100,"root_service:omitempty":"bookstore-apex"}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha2","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha2","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"Name","name":"bookstore","namespace":"default"},"sources":[{"kind":"Name","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
 	assert.Equal(actualResponseBody, expectedResponseBody, "Actual value did not match expectations:\n%s", actualResponseBody)
 }

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Test Kube Client Provider", func() {
 
 		It("returns the services for a given service account", func() {
 			c := NewFakeProvider()
-			actual := c.ListEndpointsForService(tests.BookstoreService)
+			actual := c.ListEndpointsForService(tests.BookstoreV1Service)
 			expected := []endpoint.Endpoint{{
 				IP:   net.ParseIP("8.8.8.8"),
 				Port: 8888,
@@ -177,7 +177,7 @@ var _ = Describe("Test Kube Client Provider", func() {
 
 			sMesh, err := c.GetServicesForServiceAccount(tests.BookstoreServiceAccount)
 			Expect(err).To(BeNil())
-			expectedServices := []service.MeshService{tests.BookstoreService, tests.BookstoreApexService}
+			expectedServices := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService}
 			Expect(sMesh).To(Equal(expectedServices))
 
 			sMesh2, err := c.GetServicesForServiceAccount(tests.BookbuyerServiceAccount)

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -12,12 +12,13 @@ import (
 func NewFakeProvider() endpoint.Provider {
 	return &fakeClient{
 		endpoints: map[string][]endpoint.Endpoint{
-			tests.BookstoreService.String():     {tests.Endpoint},
+			tests.BookstoreV1Service.String():   {tests.Endpoint},
+			tests.BookstoreV2Service.String():   {tests.Endpoint},
 			tests.BookbuyerService.String():     {tests.Endpoint},
 			tests.BookstoreApexService.String(): {tests.Endpoint},
 		},
 		services: map[service.K8sServiceAccount][]service.MeshService{
-			tests.BookstoreServiceAccount: {tests.BookstoreService, tests.BookstoreApexService},
+			tests.BookstoreServiceAccount: {tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
 			tests.BookbuyerServiceAccount: {tests.BookbuyerService},
 		},
 	}

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Test ADS response functions", func() {
 	kubeClient := testclient.NewSimpleClientset()
 	namespace := tests.Namespace
 	envoyUID := tests.EnvoyUID
-	serviceName := tests.BookstoreServiceName
+	serviceName := tests.BookstoreV1ServiceName
 	serviceAccountName := tests.BookstoreServiceAccountName
 
 	labels := map[string]string{constants.EnvoyUniqueIDLabelName: tests.EnvoyUID}

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Cluster configurations", func() {
 	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 
 	localService := tests.BookbuyerService
-	remoteService := tests.BookstoreService
+	remoteService := tests.BookstoreV1Service
 	Context("Test getRemoteServiceCluster", func() {
 		It("Returns an EDS based cluster when permissive mode is disabled", func() {
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -86,12 +86,12 @@ var _ = Describe("CDS Response", func() {
 
 			// There are to any.Any resources in the ClusterDiscoveryStruct (Clusters)
 			// There are 5 types of clusters that can exist based on the configuration:
-			// 1. Destination cluster (Bookstore and BookstoreApex)
+			// 1. Destination cluster (Bookstore-v1, Bookstore-v2, and BookstoreApex)
 			// 2. Source cluster (Bookbuyer)
 			// 3. Prometheus cluster
 			// 4. Tracing cluster
 			// 5. Passthrough cluster for egress
-			numExpectedClusters := 6 // source and destination clusters
+			numExpectedClusters := 7 // source and destination clusters
 			Expect(len((*resp).Resources)).To(Equal(numExpectedClusters))
 		})
 	})
@@ -149,7 +149,7 @@ var _ = Describe("CDS Response", func() {
 
 		It("Returns a remote cluster object", func() {
 			localService := tests.BookbuyerService
-			remoteService := tests.BookstoreService
+			remoteService := tests.BookstoreV1Service
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
 
@@ -260,7 +260,7 @@ var _ = Describe("CDS Response", func() {
 				AllowRenegotiation: false,
 			}
 			Expect(upstreamTLSContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))
-			Expect(upstreamTLSContext.Sni).To(Equal("bookstore.default.svc.cluster.local"))
+			Expect(upstreamTLSContext.Sni).To(Equal("bookstore-v1.default.svc.cluster.local"))
 			// TODO(draychev): finish the rest
 			// Expect(upstreamTLSContext).To(Equal(expectedTLSContext)
 		})

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -31,11 +31,11 @@ var _ = Describe("Test LDS response", func() {
 		})
 
 		It("constructs filter chain used for HTTPS ingress", func() {
-			expectedServerNames := []string{tests.BookstoreService.GetCommonName().String()}
+			expectedServerNames := []string{tests.BookstoreV1Service.GetCommonName().String()}
 
 			mockConfigurator.EXPECT().UseHTTPSIngress().Return(true).AnyTimes()
 
-			filterChains := getIngressFilterChains(tests.BookstoreService, mockConfigurator)
+			filterChains := getIngressFilterChains(tests.BookstoreV1Service, mockConfigurator)
 			Expect(len(filterChains)).To(Equal(2))
 			for _, filterChain := range filterChains {
 				Expect(filterChain.FilterChainMatch.TransportProtocol).To(Equal(envoy.TransportProtocolTLS))
@@ -53,7 +53,7 @@ var _ = Describe("Test LDS response", func() {
 		It("constructs filter chain used for HTTP ingress", func() {
 			mockConfigurator.EXPECT().UseHTTPSIngress().Return(false).AnyTimes()
 
-			filterChains := getIngressFilterChains(tests.BookstoreService, mockConfigurator)
+			filterChains := getIngressFilterChains(tests.BookstoreV1Service, mockConfigurator)
 			Expect(len(filterChains)).To(Equal(1))
 			for _, filterChain := range filterChains {
 				Expect(filterChain.FilterChainMatch.TransportProtocol).To(Equal(""))
@@ -64,24 +64,24 @@ var _ = Describe("Test LDS response", func() {
 		})
 
 		It("constructs in-mesh filter chain", func() {
-			filterChain, err := getInboundInMeshFilterChain(tests.BookstoreService, mockConfigurator)
+			filterChain, err := getInboundInMeshFilterChain(tests.BookstoreV1Service, mockConfigurator)
 			Expect(err).ToNot(HaveOccurred())
 
-			expectedServerNames := []string{tests.BookstoreService.GetCommonName().String()}
+			expectedServerNames := []string{tests.BookstoreV1Service.GetCommonName().String()}
 
 			// Show what this looks like (human readable)!  And ensure this is setup correctly!
-			Expect(expectedServerNames[0]).To(Equal("bookstore.default.svc.cluster.local"))
+			Expect(expectedServerNames[0]).To(Equal("bookstore-v1.default.svc.cluster.local"))
 
 			Expect(filterChain.FilterChainMatch.TransportProtocol).To(Equal(envoy.TransportProtocolTLS))
 			Expect(filterChain.FilterChainMatch.ServerNames).To(Equal(expectedServerNames))
 
 			// Ensure the UpstreamTlsContext.Sni field from the client matches one of the strings
 			// in the servers FilterChainMatch.ServerNames
-			tlsContext := envoy.GetUpstreamTLSContext(tests.BookbuyerService, tests.BookstoreService.GetCommonName().String())
+			tlsContext := envoy.GetUpstreamTLSContext(tests.BookbuyerService, tests.BookstoreV1Service.GetCommonName().String())
 			Expect(tlsContext.Sni).To(Equal(filterChain.FilterChainMatch.ServerNames[0]))
 
 			// Show what that actually looks like
-			Expect(tlsContext.Sni).To(Equal("bookstore.default.svc.cluster.local"))
+			Expect(tlsContext.Sni).To(Equal("bookstore-v1.default.svc.cluster.local"))
 		})
 	})
 })

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Test SDS response functions", func() {
 
 			resourceName := sdsc.String()
 			mc := catalog.NewFakeMeshCatalog(testclient.NewSimpleClientset())
-			actual, err := getRootCert(cert, sdsc, tests.BookstoreService, mc)
+			actual, err := getRootCert(cert, sdsc, tests.BookstoreV1Service, mc)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := &xds_auth.Secret{

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetDownstreamTLSContext()", func() {
 		It("should return TLS context", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, true)
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreV1Service, true)
 
 			expectedTLSContext := &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -141,7 +141,7 @@ var _ = Describe("Test Envoy tools", func() {
 					},
 					TlsCertificates: nil,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-						Name: "service-cert:default/bookstore",
+						Name: "service-cert:default/bookstore-v1",
 						SdsConfig: &core.ConfigSource{
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
@@ -154,7 +154,7 @@ var _ = Describe("Test Envoy tools", func() {
 							Name: SDSCert{
 								MeshService: service.MeshService{
 									Namespace: "default",
-									Name:      "bookstore",
+									Name:      "bookstore-v1",
 								},
 								CertType: RootCertTypeForMTLSInbound,
 							}.String(),
@@ -180,22 +180,22 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetDownstreamTLSContext() for mTLS", func() {
 		It("should return TLS context with client certificate validation enabled", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, true)
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreV1Service, true)
 			Expect(tlsContext.RequireClientCertificate).To(Equal(&wrappers.BoolValue{Value: true}))
 		})
 	})
 
 	Context("Test GetDownstreamTLSContext() for TLS", func() {
 		It("should return TLS context with client certificate validation disabled", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreService, false)
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreV1Service, false)
 			Expect(tlsContext.RequireClientCertificate).To(Equal(&wrappers.BoolValue{Value: false}))
 		})
 	})
 
 	Context("Test GetUpstreamTLSContext()", func() {
 		It("should return TLS context", func() {
-			sni := "bookstore.default.svc.cluster.local"
-			tlsContext := GetUpstreamTLSContext(tests.BookstoreService, sni)
+			sni := "bookstore-v1.default.svc.cluster.local"
+			tlsContext := GetUpstreamTLSContext(tests.BookstoreV1Service, sni)
 
 			expectedTLSContext := &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -205,7 +205,7 @@ var _ = Describe("Test Envoy tools", func() {
 					},
 					TlsCertificates: nil,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-						Name: "service-cert:default/bookstore",
+						Name: "service-cert:default/bookstore-v1",
 						SdsConfig: &core.ConfigSource{
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
@@ -218,7 +218,7 @@ var _ = Describe("Test Envoy tools", func() {
 							Name: SDSCert{
 								MeshService: service.MeshService{
 									Namespace: "default",
-									Name:      "bookstore",
+									Name:      "bookstore-v1",
 								},
 								CertType: RootCertTypeForMTLSOutbound,
 							}.String(),
@@ -237,8 +237,8 @@ var _ = Describe("Test Envoy tools", func() {
 			}
 
 			// Ensure the SNI is in the expected format!
-			Expect(tlsContext.Sni).To(Equal(tests.BookstoreService.GetCommonName().String()))
-			Expect(tlsContext.Sni).To(Equal("bookstore.default.svc.cluster.local"))
+			Expect(tlsContext.Sni).To(Equal(tests.BookstoreV1Service.GetCommonName().String()))
+			Expect(tlsContext.Sni).To(Equal("bookstore-v1.default.svc.cluster.local"))
 
 			Expect(tlsContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))
 			Expect(tlsContext.CommonTlsContext.TlsCertificates).To(Equal(expectedTLSContext.CommonTlsContext.TlsCertificates))

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -185,7 +185,8 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			// Define services to test with
 			testSvcs := []service.MeshService{
 				tests.BookbuyerService,
-				tests.BookstoreService,
+				tests.BookstoreV1Service,
+				tests.BookstoreV2Service,
 				tests.BookwarehouseService,
 			}
 

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -108,7 +108,11 @@ var _ = Describe("When listing TrafficSplit", func() {
 				Service: tests.BookstoreApexServiceName,
 				Backends: []smiSplit.TrafficSplitBackend{
 					{
-						Service: tests.BookstoreServiceName,
+						Service: tests.BookstoreV1ServiceName,
+						Weight:  tests.Weight,
+					},
+					{
+						Service: tests.BookstoreV2ServiceName,
 						Weight:  tests.Weight,
 					},
 				},

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -27,7 +27,7 @@ func NewFakeMeshSpecClient() MeshSpec {
 		httpRouteGroups:  []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 		tcpRoutes:        []*spec.TCPRoute{&tests.TCPRoute},
 		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
-		weightedServices: []service.WeightedService{tests.WeightedService},
+		weightedServices: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService},
 		serviceAccounts: []service.K8sServiceAccount{
 			tests.BookstoreServiceAccount,
 			tests.BookbuyerServiceAccount,

--- a/pkg/utils/service_test.go
+++ b/pkg/utils/service_test.go
@@ -12,10 +12,10 @@ import (
 func TestK8sSvcToMeshSvc(t *testing.T) {
 	assert := assert.New(t)
 
-	v1Service := tests.NewServiceFixture(tests.BookstoreServiceName, tests.Namespace, nil)
+	v1Service := tests.NewServiceFixture(tests.BookstoreV1ServiceName, tests.Namespace, nil)
 	meshSvc := K8sSvcToMeshSvc(v1Service)
 	expectedMeshSvc := service.MeshService{
-		Name:      tests.BookstoreServiceName,
+		Name:      tests.BookstoreV1ServiceName,
 		Namespace: tests.Namespace,
 	}
 
@@ -31,12 +31,12 @@ func TestGetTrafficTargetName(t *testing.T) {
 	}
 
 	getTrafficTargetNameTests := []getTrafficTargetNameTest{
-		{"TrafficTarget", "TrafficTarget:default/bookbuyer->default/bookstore"},
-		{"", "default/bookbuyer->default/bookstore"},
+		{"TrafficTarget", "TrafficTarget:default/bookbuyer->default/bookstore-v1"},
+		{"", "default/bookbuyer->default/bookstore-v1"},
 	}
 
 	for _, tn := range getTrafficTargetNameTests {
-		trafficTargetName := GetTrafficTargetName(tn.input, tests.BookbuyerService, tests.BookstoreService)
+		trafficTargetName := GetTrafficTargetName(tn.input, tests.BookbuyerService, tests.BookstoreV1Service)
 
 		assert.Equal(trafficTargetName, tn.expectedTargetName)
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This PR refactors existing tests to use two traffic split backends to more closely model real world scenarios.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No
