### PR TITLE
tests(e2e): add vault test

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -312,6 +312,10 @@ func (td *OsmTestData) installVault(instOpts InstallOSMOpts) error {
 							Command:         []string{"/bin/sh", "-c"},
 							Args: []string{
 								fmt.Sprintf(`
+# The TTL for the expiration of CA certificate must be beyond that of the longest
+# TTL for a certificate issued by OSM. The longest TTL for a certificate issued
+# within OSM is 87600h.
+
 # Start the Vault Server
 vault server -dev -dev-listen-address=0.0.0.0:8200 -dev-root-token-id=%s & sleep 1;
 
@@ -322,16 +326,16 @@ echo %s>~/.vault-token;
 vault secrets enable pki;
 
 # Set the max allowed lease for a certificate to a decade
-vault secrets tune -max-lease-ttl=87600h pki;
+vault secrets tune -max-lease-ttl=87700h pki;
 
 # Set the URLs (See: https://www.vaultproject.io/docs/secrets/pki#set-url-configuration)
 vault write pki/config/urls issuing_certificates='http://127.0.0.1:8200/v1/pki/ca' crl_distribution_points='http://127.0.0.1:8200/v1/pki/crl';
 
 # Configure a role for OSM (See: https://www.vaultproject.io/docs/secrets/pki#configure-a-role)
-vault write pki/roles/%s allow_any_name=true allow_subdomains=true;
+vault write pki/roles/%s allow_any_name=true allow_subdomains=true max_ttl=87700h;
 
 # Create the root certificate (See: https://www.vaultproject.io/docs/secrets/pki#setup)
-vault write pki/root/generate/internal common_name='osm.root' ttl='8765h';
+vault write pki/root/generate/internal common_name='osm.root' ttl='87700h';
 tail /dev/random;
 `, instOpts.vaultToken, instOpts.vaultToken, instOpts.vaultRole),
 							},

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("1 Client pod -> 1 Server pod test using Vault", func() {
+	Context("HashivaultSimpleClientServer", func() {
+		sourceNs := "client"
+		destNs := "server"
+		var ns []string = []string{sourceNs, destNs}
+
+		It("Tests HTTP traffic for client pod -> server pod", func() {
+			// Install OSM
+			installOpts := td.GetOSMInstallOpts()
+			installOpts.certManager = "vault"
+			Expect(td.InstallOSM(installOpts)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 2)).To(Succeed())
+
+			// Create Test NS
+			for _, n := range ns {
+				Expect(td.CreateNs(n, nil)).To(Succeed())
+				Expect(td.AddNsToMesh(true, n)).To(Succeed())
+			}
+
+			// Get simple pod definitions for the HTTP server
+			svcAccDef, podDef, svcDef := td.SimplePodApp(
+				SimplePodAppDef{
+					name:      "server",
+					namespace: destNs,
+					image:     "kennethreitz/httpbin",
+					ports:     []int{80},
+				})
+
+			_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			dstPod, err := td.CreatePod(destNs, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = td.CreateService(destNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+
+			// Get simple Pod definitions for the client
+			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
+				name:      "client",
+				namespace: sourceNs,
+				command:   []string{"/bin/bash", "-c", "--"},
+				args:      []string{"while true; do sleep 30; done;"},
+				image:     "songrgg/alpine-debug",
+				ports:     []int{80},
+			})
+
+			_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			srcPod, err := td.CreatePod(sourceNs, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = td.CreateService(sourceNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+
+			// Deploy allow rule client->server
+			httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+				SimpleAllowPolicy{
+					RouteGroupName:    "routes",
+					TrafficTargetName: "test-target",
+
+					SourceNamespace:      sourceNs,
+					SourceSVCAccountName: "client",
+
+					DestinationNamespace:      destNs,
+					DestinationSvcAccountName: "server",
+				})
+
+			// Configs have to be put into a monitored NS, and osm-system can't be by cli
+			_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+			Expect(err).NotTo(HaveOccurred())
+
+			// All ready. Expect client to reach server
+			// Need to get the pod though.
+			cond := td.WaitForRepeatedSuccess(func() bool {
+				result :=
+					td.HTTPRequest(HTTPRequestDef{
+						SourceNs:        srcPod.Namespace,
+						SourcePod:       srcPod.Name,
+						SourceContainer: "client", // We can do better
+
+						Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+
+						HTTPUrl: "/",
+						Port:    80,
+					})
+
+				if result.Err != nil || result.StatusCode != 200 {
+					td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+					return false
+				}
+				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+				return true
+			}, 5, 60*time.Second)
+			Expect(cond).To(BeTrue())
+		})
+	})
+})

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -106,7 +106,7 @@ var _ = Describe("1 Client pod -> 1 Server pod test using Vault", func() {
 				}
 				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 				return true
-			}, 5, 60*time.Second)
+			}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
 			Expect(cond).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: This PR adds a new e2e test that uses HashiCorp Vault to issue certificates. It otherwise runs the same test as the original simple client/server test.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No