### PR TITLE
CI: Add e2e to CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,9 @@ jobs:
         env:
           CTR_TAG: "testing"
           CTR_REGISTRY: "localhost:5000"   # unused for kind, but required for testing
-        run: make test-e2e
+        run: 
+          make docker-build-osm-controller docker-build-init build-osm
+          go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG) -kindCluster -test.timeout 0
 
   integration-tresor:
     name: Integration Test with Tresor, SMI traffic policies, and egress disabled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,9 +136,9 @@ jobs:
         env:
           CTR_TAG: "testing"
           CTR_REGISTRY: "localhost:5000"   # unused for kind, but required for testing
-        run: 
+        run: |
           make docker-build-osm-controller docker-build-init build-osm
-          go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG) -kindCluster -test.timeout 0
+          go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -kindCluster -test.timeout 0
 
   integration-tresor:
     name: Integration Test with Tresor, SMI traffic policies, and egress disabled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,11 +134,11 @@ jobs:
           go-version: 1.15
       - name: Run E2E tests
         env:
-          CTR_TAG: "testing"
-          CTR_REGISTRY: "localhost:5000"   # unused for kind, but required for testing
+          CTR_TAG: ${{ github.sha }}
+          CTR_REGISTRY: "localhost:5000"   # unused for kind, but currently required in framework
         run: |
           make docker-build-osm-controller docker-build-init build-osm
-          go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -kindCluster -test.timeout 0
+          go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -kindCluster -test.timeout 0 -test.failfast
 
   integration-tresor:
     name: Integration Test with Tresor, SMI traffic policies, and egress disabled

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,35 @@ jobs:
         if: ${{ success() }}
         run: bash <(curl -s https://codecov.io/bash)
 
+  e2etest:
+    name: Go test e2e
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+      - name: Setup Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
+      - name: Run E2E tests
+        env:
+          CTR_TAG: "testing"
+          CTR_REGISTRY: "localhost:5000"   # unused for kind, but required for testing
+        run: make test-e2e
+
   integration-tresor:
     name: Integration Test with Tresor, SMI traffic policies, and egress disabled
     runs-on: ubuntu-latest

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -79,7 +79,7 @@ func registerFlags(td *OsmTestData) {
 	flag.BoolVar(&td.kindCluster, "kindCluster", false, "Creates kind cluster")
 	flag.StringVar(&td.clusterName, "kindClusterName", "osm-e2e", "Name of the Kind cluster to be created")
 	flag.BoolVar(&td.cleanupKindCluster, "cleanupKindCluster", true, "Cleanup kind cluster upon exit")
-	flag.BoolVar(&td.cleanupKindClusterBetweenTests, "cleanupKindClusterBetweenTests", true, "Cleanup kind cluster between tests")
+	flag.BoolVar(&td.cleanupKindClusterBetweenTests, "cleanupKindClusterBetweenTests", false, "Cleanup kind cluster between tests")
 
 	flag.StringVar(&td.ctrRegistryServer, "ctrRegistry", os.Getenv("CTR_REGISTRY"), "Container registry")
 	flag.StringVar(&td.ctrRegistryUser, "ctrRegistryUser", os.Getenv("CTR_REGISTRY_USER"), "Container registry")

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -146,7 +146,7 @@ func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 	// After client creations, do a wait for kind cluster just in case it's not done yet coming up
 	// Ballparking pod number. kind has a large number of containers to run by default
 	if td.kindCluster && td.clusterProvider != nil {
-		if err := td.WaitForPodsRunningReady("kube-system", 60*time.Second, 5); err != nil {
+		if err := td.WaitForPodsRunningReady("kube-system", 120*time.Second, 5); err != nil {
 			return errors.Wrap(err, "failed to wait for kube-system pods")
 		}
 	}

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -85,7 +85,13 @@ func registerFlags(td *OsmTestData) {
 	flag.StringVar(&td.ctrRegistryUser, "ctrRegistryUser", os.Getenv("CTR_REGISTRY_USER"), "Container registry")
 	flag.StringVar(&td.ctrRegistryPassword, "ctrRegistrySecret", os.Getenv("CTR_REGISTRY_PASSWORD"), "Container registry secret")
 
-	flag.StringVar(&td.osmImageTag, "osmImageTag", "latest", "OSM image tag")
+	flag.StringVar(&td.osmImageTag, "osmImageTag", func() string {
+		tmp := os.Getenv("CTR_TAG")
+		if len(tmp) != 0 {
+			return tmp
+		}
+		return "latest"
+	}(), "OSM image tag")
 
 	flag.StringVar(&td.osmNamespace, "meshName", func() string {
 		tmp := os.Getenv("K8S_NAMESPACE")

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Test HTTP traffic from N deployment client -> 1 deployment ser
 
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Server NS
 			Expect(td.CreateNs(destApp, nil)).To(Succeed())

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
 		It("Tests HTTP traffic for client pod -> server pod", func() {
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Create Test NS
 			for _, n := range ns {
@@ -45,7 +45,7 @@ var _ = Describe("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(destName, 60*time.Second, 1)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
 
 			// Get simple Pod definitions for the client
 			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
@@ -65,7 +65,7 @@ var _ = Describe("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(sourceName, 60*time.Second, 1)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
 
 			By("Creating SMI policies")
 			// Deploy allow rule client->server
@@ -112,7 +112,7 @@ var _ = Describe("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
 				}
 				td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
 				return true
-			}, 5, 60*time.Second)
+			}, 5, 90*time.Second)
 			Expect(cond).To(BeTrue())
 
 			By("Deleting SMI policies")

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
 				}
 				td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
 				return true
-			}, 5, 60*time.Second)
+			}, 5, 150*time.Second)
 			Expect(cond).To(BeTrue())
 		})
 	})

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Test HTTP from N Clients deployments to 1 Server deployment ba
 
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Create NSs
 			Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())


### PR DESCRIPTION
Will run all tests under e2e folder. Failfast is enabled as these can potentially be slow.
Also added proper CTR_TAG reading on test framework.

patchset[]:
- Increased all static timeouts for most pod bringup and some test conditions (as seen pod bringup could sometimes take a lot of time).
Future efforts will include parametrization (#1825)

**Affected area**:

- Tests                  [X]
- CI System          [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No