### PR TITLE
demo: move mesh delete command into the cleanup script

### DIFF
--- a/demo/clean-kubernetes.sh
+++ b/demo/clean-kubernetes.sh
@@ -5,6 +5,8 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
+bin/osm mesh uninstall -f --mesh-name "$MESH_NAME" --namespace "$K8S_NAMESPACE"
+
 for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" "$K8S_NAMESPACE"; do
     kubectl delete namespace "$ns" --ignore-not-found --wait &
 done

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -78,7 +78,6 @@ docker info > /dev/null || { echo "Docker daemon is not running"; exit 1; }
 make build-osm
 
 # cleanup stale resources from previous runs
-bin/osm mesh uninstall -f --mesh-name "$MESH_NAME" --namespace "$K8S_NAMESPACE"
 ./demo/clean-kubernetes.sh
 
 # The demo uses osm's namespace as defined by environment variables, K8S_NAMESPACE


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
It is useful to run the cleanup script by itself. The mesh
delete command must also be run to cleanup mesh resources
created by install. This change moves the mesh delete command
into the cleanup script so that this single cleanup script
can be used to clean up all resources deployed by the demo.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`