### PR TITLE
ref(e2e): consolidate HTTP request host, port, and path into one field

### DIFF
--- a/tests/e2e/common_traffic.go
+++ b/tests/e2e/common_traffic.go
@@ -23,12 +23,9 @@ type HTTPRequestDef struct {
 	SourcePod       string
 	SourceContainer string
 
-	// Either host or IP, ie. "server", "server1.server", "192.168.0.1"
+	// The entire destination URL processed by curl, including host name and
+	// optionally protocol, port, and path
 	Destination string
-	// HTTP path on url, ie. "/index.html"
-	HTTPUrl string
-	// TCP port on request
-	Port int
 }
 
 // HTTPRequestResult represents results of an HTTPRequest call
@@ -42,7 +39,7 @@ type HTTPRequestResult struct {
 func (td *OsmTestData) HTTPRequest(ht HTTPRequestDef) HTTPRequestResult {
 	// -s silent progress, -o output to devnull, '-D -' dump headers to "-" (stdout), -i Status code
 	// -I skip body download, '-w StatusCode:%{http_code}' prints Status code label-like for easy parsing
-	command := fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} http://%s:%d%s", StatusCodeWord, ht.Destination, ht.Port, ht.HTTPUrl)
+	command := fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} %s", StatusCodeWord, ht.Destination)
 
 	stdout, stderr, err := td.RunRemote(ht.SourceNs, ht.SourcePod, ht.SourceContainer, command)
 	if err != nil {

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -139,9 +139,6 @@ var _ = Describe("Test HTTP traffic from N deployment client -> 1 deployment ser
 						SourceContainer: ns, // container_name == NS for this test
 
 						Destination: fmt.Sprintf("%s.%s", destApp, destApp),
-
-						HTTPUrl: "/",
-						Port:    80,
 					})
 				}
 			}

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -95,9 +95,6 @@ var _ = Describe("1 Client pod -> 1 Server pod test using Vault", func() {
 						SourceContainer: "client", // We can do better
 
 						Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
-
-						HTTPUrl: "/",
-						Port:    80,
 					})
 
 				if result.Err != nil || result.StatusCode != 200 {

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -94,13 +94,11 @@ var _ = Describe("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
 				SourceContainer: sourceName,
 
 				Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
-				HTTPUrl:     "/",
-				Port:        80,
 			}
 
 			srcToDestStr := fmt.Sprintf("%s -> %s",
 				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				fmt.Sprintf("%s:%d%s", clientToServer.Destination, clientToServer.Port, clientToServer.HTTPUrl))
+				clientToServer.Destination)
 
 			cond := td.WaitForRepeatedSuccess(func() bool {
 				result := td.HTTPRequest(clientToServer)

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -205,9 +205,6 @@ var _ = Describe("Test HTTP from N Clients deployments to 1 Server deployment ba
 
 						// Targeting the trafficsplit FQDN
 						Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
-
-						HTTPUrl: "/",
-						Port:    80,
 					})
 				}
 			}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Currently all test HTTP requests in the e2e framework are hardcoded to use `http://` and expect a port defined. This change consolidates all those fields into one so they're easier to customize for each test.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No