### PR TITLE
Build TrafficRoutes

### DIFF
--- a/pkg/catalog/debugger_test.go
+++ b/pkg/catalog/debugger_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 				RootService: "bookstore-apex"}))
 			Expect(serviceAccounts[0].String()).To(Equal("default/bookstore"))
 			Expect(routeGroups[0].Name).To(Equal("bookstore-service-routes"))
-			Expect(trafficTargets[0].Name).To(Equal(tests.TrafficTargetName))
+			Expect(trafficTargets[0].Name).To(Equal(tests.BookstoreTrafficTargetName))
 
 		})
 	})

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -31,7 +31,7 @@ func TestListTrafficPolicies(t *testing.T) {
 		},
 		{
 			input:  tests.BookbuyerService,
-			output: []trafficpolicy.TrafficTarget{tests.BookstoreV1TrafficPolicy, tests.BookstoreV2TrafficPolicy, tests.BookstoreApexTrafficPolicy},
+			output: []trafficpolicy.TrafficTarget{tests.BookstoreV1TrafficPolicy, tests.BookstoreV2TrafficPolicy, tests.BookstoreV3TrafficPolicy},
 		},
 	}
 
@@ -68,11 +68,11 @@ func TestGetTrafficPoliciesForService(t *testing.T) {
 					Source:      tests.BookbuyerService,
 					HTTPRoutes:  tests.BookstoreV2TrafficPolicy.HTTPRoutes,
 				},
-				hashSrcDstService(tests.BookbuyerService, tests.BookstoreApexService): {
-					Name:        utils.GetTrafficTargetName(tests.BookstoreTrafficTargetName, tests.BookbuyerService, tests.BookstoreApexService),
-					Destination: tests.BookstoreApexService,
+				hashSrcDstService(tests.BookbuyerService, tests.BookstoreV3Service): {
+					Name:        utils.GetTrafficTargetName(tests.BookstoreTrafficTargetName, tests.BookbuyerService, tests.BookstoreV3Service),
+					Destination: tests.BookstoreV3Service,
 					Source:      tests.BookbuyerService,
-					HTTPRoutes:  tests.BookstoreApexTrafficPolicy.HTTPRoutes,
+					HTTPRoutes:  tests.BookstoreV3TrafficPolicy.HTTPRoutes,
 				},
 			},
 		},
@@ -179,7 +179,7 @@ func TestListAllowedOutboundServices(t *testing.T) {
 	actualList, err := mc.ListAllowedOutboundServices(tests.BookbuyerService)
 	assert.Nil(err)
 
-	expectedList := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService}
+	expectedList := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreV3Service}
 	assert.ElementsMatch(actualList, expectedList)
 }
 
@@ -296,7 +296,7 @@ func TestListTrafficTargetPermutations(t *testing.T) {
 
 	mc := newFakeMeshCatalog()
 
-	trafficTargets, err := mc.listTrafficTargetPermutations(tests.TrafficTarget, tests.TrafficTarget.Spec.Sources[0], tests.TrafficTarget.Spec.Destination)
+	trafficTargets, err := mc.listTrafficTargetPermutations(tests.BookstoreTrafficTarget, tests.BookstoreTrafficTarget.Spec.Sources[0], tests.BookstoreTrafficTarget.Spec.Destination)
 	assert.Nil(err)
 
 	var actualTargetNames []string
@@ -305,9 +305,8 @@ func TestListTrafficTargetPermutations(t *testing.T) {
 	}
 
 	expected := []string{
-		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreV1Service),
-		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreV2Service),
-		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreApexService),
+		utils.GetTrafficTargetName(tests.BookstoreTrafficTargetName, tests.BookbuyerService, tests.BookstoreV1Service),
+		utils.GetTrafficTargetName(tests.BookstoreTrafficTargetName, tests.BookbuyerService, tests.BookstoreV3Service),
 	}
 	assert.ElementsMatch(actualTargetNames, expected)
 }
@@ -376,7 +375,7 @@ func TestGetWeightedBackendsForService(t *testing.T) {
 	getWeightedBackendsForServiceTests := []getWeightedBackendsForServiceTest{
 		{
 			input:  tests.BookstoreApexService,
-			output: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService},
+			output: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService, tests.BookstoreV3WeightedService},
 		},
 		{
 			input: tests.BookbuyerService,

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -394,35 +394,31 @@ func TestGetWeightedBackendsForService(t *testing.T) {
 	}
 }
 
-func TestGetRouteKey(t *testing.T) {
+func TestContainsRouteKey(t *testing.T) {
 	assert := assert.New(t)
 
-	type getRouteKeyTest struct {
+	type containsRouteTest struct {
 		inputRoute trafficpolicy.HTTPRoute
-		inputMap   map[*trafficpolicy.HTTPRoute][]service.WeightedService
-		output     *trafficpolicy.HTTPRoute
+		inputList  []trafficpolicy.HTTPRoute
+		output     bool
 	}
 
-	getRouteKeyTests := []getRouteKeyTest{
+	containsRouteTests := []containsRouteTest{
 		{
 			inputRoute: tests.BookstoreV2TrafficPolicy.HTTPRoutes[0],
-			inputMap: map[*trafficpolicy.HTTPRoute][]service.WeightedService{
-				&tests.BookstoreV1TrafficPolicy.HTTPRoutes[0]: {{Service: tests.BookstoreV1Service, Weight: constants.ClusterWeightAcceptAll}},
-			},
-			output: &tests.BookstoreV1TrafficPolicy.HTTPRoutes[0],
+			inputList:  tests.BookstoreV1TrafficPolicy.HTTPRoutes,
+			output:     true,
 		},
 		{
 			inputRoute: tests.BookstoreV1TrafficPolicy.HTTPRoutes[1],
-			inputMap: map[*trafficpolicy.HTTPRoute][]service.WeightedService{
-				&tests.BookstoreV1TrafficPolicy.HTTPRoutes[0]: {{Service: tests.BookstoreV1Service, Weight: constants.ClusterWeightAcceptAll}},
-			},
-			output: nil,
+			inputList:  tests.BookstoreV2TrafficPolicy.HTTPRoutes,
+			output:     false,
 		},
 	}
 
-	for _, test := range getRouteKeyTests {
-		key := getRouteKey(test.inputRoute, test.inputMap)
-		assert.Equal(key, test.output)
+	for _, test := range containsRouteTests {
+		routeExists := containsRoute(test.inputList, test.inputRoute)
+		assert.Equal(routeExists, test.output)
 	}
 }
 

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -45,7 +45,7 @@ func TestGetSMIPolicies(t *testing.T) {
 			&tests.HTTPRouteGroup,
 		},
 		[]*target.TrafficTarget{
-			&tests.TrafficTarget,
+			&tests.BookstoreTrafficTarget,
 		},
 	)
 

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Test Kube Client Provider", func() {
 
 			sMesh, err := c.GetServicesForServiceAccount(tests.BookstoreServiceAccount)
 			Expect(err).To(BeNil())
-			expectedServices := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreApexService}
+			expectedServices := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV3Service}
 			Expect(sMesh).To(Equal(expectedServices))
 
 			sMesh2, err := c.GetServicesForServiceAccount(tests.BookbuyerServiceAccount)

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -177,7 +177,7 @@ var _ = Describe("Test Kube Client Provider", func() {
 
 			sMesh, err := c.GetServicesForServiceAccount(tests.BookstoreServiceAccount)
 			Expect(err).To(BeNil())
-			expectedServices := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService}
+			expectedServices := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreApexService}
 			Expect(sMesh).To(Equal(expectedServices))
 
 			sMesh2, err := c.GetServicesForServiceAccount(tests.BookbuyerServiceAccount)

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -18,8 +18,9 @@ func NewFakeProvider() endpoint.Provider {
 			tests.BookstoreApexService.String(): {tests.Endpoint},
 		},
 		services: map[service.K8sServiceAccount][]service.MeshService{
-			tests.BookstoreServiceAccount: {tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
-			tests.BookbuyerServiceAccount: {tests.BookbuyerService},
+			tests.BookstoreServiceAccount:   {tests.BookstoreV1Service, tests.BookstoreApexService},
+			tests.BookbuyerServiceAccount:   {tests.BookbuyerService},
+			tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
 		},
 	}
 }

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -14,11 +14,12 @@ func NewFakeProvider() endpoint.Provider {
 		endpoints: map[string][]endpoint.Endpoint{
 			tests.BookstoreV1Service.String():   {tests.Endpoint},
 			tests.BookstoreV2Service.String():   {tests.Endpoint},
+			tests.BookstoreV3Service.String():   {tests.Endpoint},
 			tests.BookbuyerService.String():     {tests.Endpoint},
 			tests.BookstoreApexService.String(): {tests.Endpoint},
 		},
 		services: map[service.K8sServiceAccount][]service.MeshService{
-			tests.BookstoreServiceAccount:   {tests.BookstoreV1Service, tests.BookstoreApexService},
+			tests.BookstoreServiceAccount:   {tests.BookstoreV1Service, tests.BookstoreV3Service},
 			tests.BookbuyerServiceAccount:   {tests.BookbuyerService},
 			tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
 		},

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -26,7 +26,7 @@ func NewFakeMeshSpecClient() MeshSpec {
 		trafficSplits:    []*split.TrafficSplit{&tests.TrafficSplit},
 		httpRouteGroups:  []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 		tcpRoutes:        []*spec.TCPRoute{&tests.TCPRoute},
-		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
+		trafficTargets:   []*target.TrafficTarget{&tests.BookstoreTrafficTarget, &tests.BookstoreV2TrafficTarget},
 		weightedServices: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService},
 		serviceAccounts: []service.K8sServiceAccount{
 			tests.BookstoreServiceAccount,

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -42,11 +42,18 @@ const (
 
 	// BookstoreServiceAccountName is the name of the bookstore service account
 	BookstoreServiceAccountName = "bookstore"
+
+	// BookstoreV2ServiceAccountName is the name of the bookstore service account
+	BookstoreV2ServiceAccountName = "bookstore-v2"
+
 	// BookbuyerServiceAccountName is the name of the bookbuyer service account
 	BookbuyerServiceAccountName = "bookbuyer"
 
-	// TrafficTargetName is the name of the traffic target SMI object.
-	TrafficTargetName = "bookbuyer-access-bookstore"
+	// BookstoreTrafficTargetName is the name of the traffic target SMI object.
+	BookstoreTrafficTargetName = "bookbuyer-access-bookstore"
+
+	// BookstoreV2TrafficTargetName is the name of the traffic target SMI object.
+	BookstoreV2TrafficTargetName = "bookbuyer-access-bookstore-v2"
 
 	// BuyBooksMatchName is the name of the match object.
 	BuyBooksMatchName = "buy-books"
@@ -148,7 +155,7 @@ var (
 
 	// BookstoreV1TrafficPolicy is a traffic policy SMI object.
 	BookstoreV1TrafficPolicy = trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v1", TrafficTargetName),
+		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v1", BookstoreTrafficTargetName),
 		Destination: BookstoreV1Service,
 		Source:      BookbuyerService,
 		HTTPRoutes: []trafficpolicy.HTTPRoute{
@@ -171,7 +178,7 @@ var (
 
 	// BookstoreV2TrafficPolicy is a traffic policy SMI object.
 	BookstoreV2TrafficPolicy = trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v2", TrafficTargetName),
+		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v2", BookstoreV2TrafficTargetName),
 		Destination: BookstoreV2Service,
 		Source:      BookbuyerService,
 		HTTPRoutes: []trafficpolicy.HTTPRoute{
@@ -182,19 +189,12 @@ var (
 					"user-agent": HTTPUserAgent,
 				},
 			},
-			{
-				PathRegex: BookstoreSellPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
 		},
 	}
 
 	// BookstoreApexTrafficPolicy is a traffic policy SMI object.
 	BookstoreApexTrafficPolicy = trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-apex", TrafficTargetName),
+		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-apex", BookstoreTrafficTargetName),
 		Destination: BookstoreApexService,
 		Source:      BookbuyerService,
 		HTTPRoutes: []trafficpolicy.HTTPRoute{
@@ -235,14 +235,14 @@ var (
 		},
 	}
 
-	// TrafficTarget is a traffic target SMI object.
-	TrafficTarget = target.TrafficTarget{
+	// BookstoreTrafficTarget is a traffic target SMI object.
+	BookstoreTrafficTarget = target.TrafficTarget{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: "access.smi-spec.io/v1alpha2",
 			Kind:       "TrafficTarget",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name:      TrafficTargetName,
+			Name:      BookstoreTrafficTargetName,
 			Namespace: "default",
 		},
 		Spec: target.TrafficTargetSpec{
@@ -264,6 +264,35 @@ var (
 		},
 	}
 
+	// BookstoreV2TrafficTarget is a traffic target SMI object.
+	BookstoreV2TrafficTarget = target.TrafficTarget{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "access.smi-spec.io/v1alpha2",
+			Kind:       "TrafficTarget",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      BookstoreV2TrafficTargetName,
+			Namespace: "default",
+		},
+		Spec: target.TrafficTargetSpec{
+			Destination: target.IdentityBindingSubject{
+				Kind:      "Name",
+				Name:      BookstoreV2ServiceAccountName,
+				Namespace: "default",
+			},
+			Sources: []target.IdentityBindingSubject{{
+				Kind:      "Name",
+				Name:      BookbuyerServiceAccountName,
+				Namespace: "default",
+			}},
+			Rules: []target.TrafficTargetRule{{
+				Kind:    "HTTPRouteGroup",
+				Name:    RouteGroupName,
+				Matches: []string{BuyBooksMatchName},
+			}},
+		},
+	}
+
 	// RoutePolicyMap is a map of a key to a route policy SMI object.
 	RoutePolicyMap = map[trafficpolicy.TrafficSpecName]map[trafficpolicy.TrafficSpecMatchName]trafficpolicy.HTTPRoute{
 		trafficpolicy.TrafficSpecName(fmt.Sprintf("HTTPRouteGroup/%s/%s", Namespace, RouteGroupName)): {
@@ -276,6 +305,12 @@ var (
 	BookstoreServiceAccount = service.K8sServiceAccount{
 		Namespace: Namespace,
 		Name:      BookstoreServiceAccountName,
+	}
+
+	// BookstoreV2ServiceAccount is a namespaced service account.
+	BookstoreV2ServiceAccount = service.K8sServiceAccount{
+		Namespace: Namespace,
+		Name:      BookstoreV2ServiceAccountName,
 	}
 
 	// BookbuyerServiceAccount is a namespaced bookbuyer account.

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -31,6 +31,9 @@ const (
 	// BookstoreV2ServiceName is the name of the bookstore-v2 service.
 	BookstoreV2ServiceName = "bookstore-v2"
 
+	// BookstoreV3ServiceName is the name of the bookstore-v3 service.
+	BookstoreV3ServiceName = "bookstore-v3"
+
 	// BookstoreApexServiceName that have been is the name of the bookstore service, which is then split into other services.
 	BookstoreApexServiceName = "bookstore-apex"
 
@@ -70,6 +73,9 @@ const (
 	// Weight10 is the value representing a share of the traffic to be sent this way in a traffic split scenario.
 	Weight10 = 10
 
+	// Weight50 is the value representing a share of the traffic to be sent this way in a traffic split scenario.
+	Weight50 = 50
+
 	// RouteGroupName is the name of the route group SMI object.
 	RouteGroupName = "bookstore-service-routes"
 
@@ -105,10 +111,16 @@ var (
 		Name:      BookstoreV1ServiceName,
 	}
 
-	// BookstoreV2Service is the bookstore service.
+	// BookstoreV2Service is the bookstore-v2 service.
 	BookstoreV2Service = service.MeshService{
 		Namespace: Namespace,
 		Name:      BookstoreV2ServiceName,
+	}
+
+	// BookstoreV3Service is the bookstore-v3 service.
+	BookstoreV3Service = service.MeshService{
+		Namespace: Namespace,
+		Name:      BookstoreV3ServiceName,
 	}
 
 	// BookbuyerService is the bookbuyer service.
@@ -192,6 +204,29 @@ var (
 		},
 	}
 
+	// BookstoreV3TrafficPolicy is a traffic policy SMI object.
+	BookstoreV3TrafficPolicy = trafficpolicy.TrafficTarget{
+		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v3", BookstoreTrafficTargetName),
+		Destination: BookstoreV3Service,
+		Source:      BookbuyerService,
+		HTTPRoutes: []trafficpolicy.HTTPRoute{
+			{
+				PathRegex: BookstoreBuyPath,
+				Methods:   []string{"GET"},
+				Headers: map[string]string{
+					"user-agent": HTTPUserAgent,
+				},
+			},
+			{
+				PathRegex: BookstoreSellPath,
+				Methods:   []string{"GET"},
+				Headers: map[string]string{
+					"user-agent": HTTPUserAgent,
+				},
+			},
+		},
+	}
+
 	// BookstoreApexTrafficPolicy is a traffic policy SMI object.
 	BookstoreApexTrafficPolicy = trafficpolicy.TrafficTarget{
 		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-apex", BookstoreTrafficTargetName),
@@ -230,6 +265,10 @@ var (
 				{
 					Service: BookstoreV2ServiceName,
 					Weight:  Weight10,
+				},
+				{
+					Service: BookstoreV3ServiceName,
+					Weight:  Weight50,
 				},
 			},
 		},
@@ -336,6 +375,16 @@ var (
 			Name:      BookstoreV2ServiceName,
 		},
 		Weight:      Weight10,
+		RootService: BookstoreApexServiceName,
+	}
+
+	// BookstoreV3WeightedService is a service with a weight used for traffic split.
+	BookstoreV3WeightedService = service.WeightedService{
+		Service: service.MeshService{
+			Namespace: Namespace,
+			Name:      BookstoreV3ServiceName,
+		},
+		Weight:      Weight50,
 		RootService: BookstoreApexServiceName,
 	}
 

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -19,16 +19,30 @@ type HTTPRoute struct {
 	Headers   map[string]string `json:"headers:omitempty"`
 }
 
-// TrafficTarget is a struct to represent a traffic policy between a source and destination along with its routes
-type TrafficTarget struct {
-	Name        string              `json:"name:omitempty"`
-	Destination service.MeshService `json:"destination:omitempty"`
-	Source      service.MeshService `json:"source:omitempty"`
-	HTTPRoutes  []HTTPRoute         `json:"http_route:omitempty"`
+// TrafficRoutes is a struct to represent a traffic policy between a source and destination along with its routes
+type TrafficRoutes struct {
+	Name                  string                  `json:"name:omitempty"`
+	Destination           service.MeshService     `json:"destination:omitempty"`
+	Source                service.MeshService     `json:"source:omitempty"`
+	RouteWeightedServices []RouteWeightedServices `json:"route_weighted_services:omitempty"`
 }
 
 // RouteWeightedClusters is a struct of an HTTPRoute and associated weighted clusters
 type RouteWeightedClusters struct {
 	HTTPRoute        HTTPRoute `json:"http_route:omitempty"`
 	WeightedClusters set.Set   `json:"weighted_clusters:omitempty"`
+}
+
+// RouteWeightedServices is a struct of an HTTPRoute and associated weighted services
+type RouteWeightedServices struct {
+	HTTPRoute        HTTPRoute                 `json:"http_route:omitempty"`
+	WeightedServices []service.WeightedService `json:"weighted_clusters:omitempty"`
+}
+
+// TrafficTarget contains all of the routes that go from the Source to the Destination
+type TrafficTarget struct {
+	Name        string              `json:"name:omitempty"`
+	Destination service.MeshService `json:"destination:omitempty"`
+	Source      service.MeshService `json:"source:omitempty"`
+	HTTPRoutes  []HTTPRoute         `json:"http_route:omitempty"`
 }

--- a/pkg/trafficpolicy/utils.go
+++ b/pkg/trafficpolicy/utils.go
@@ -1,0 +1,8 @@
+package trafficpolicy
+
+import "reflect"
+
+// Equal returns true if the routes' fields are equal
+func (r HTTPRoute) Equal(route HTTPRoute) bool {
+	return reflect.DeepEqual(r, route)
+}

--- a/pkg/trafficpolicy/utils_test.go
+++ b/pkg/trafficpolicy/utils_test.go
@@ -1,0 +1,52 @@
+package trafficpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPRouteEqual(t *testing.T) {
+	assert := assert.New(t)
+
+	routes := []HTTPRoute{
+		{
+			PathRegex: "path",
+			Methods:   []string{"GET"},
+			Headers: map[string]string{
+				"user-agent": "header1",
+			},
+		},
+		{
+			PathRegex: "path2",
+			Methods:   []string{"GET"},
+			Headers: map[string]string{
+				"user-agent": "header2",
+			},
+		},
+	}
+
+	type httpRouteEqualTest struct {
+		route1 HTTPRoute
+		route2 HTTPRoute
+		output bool
+	}
+
+	httpRouteEqualTests := []httpRouteEqualTest{
+		{
+			route1: routes[0],
+			route2: routes[0],
+			output: true,
+		},
+		{
+			route1: routes[0],
+			route2: routes[1],
+			output: false,
+		},
+	}
+
+	for _, test := range httpRouteEqualTests {
+		equal := test.route1.Equal(test.route2)
+		assert.Equal(equal, test.output)
+	}
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This PR creates new APIs/structs to build traffic routes in an extensible way as a first step to v1alpha3 traffic split. Only the API work has been done here, the routes are not yet consumed in any place in the code. 

This is a draft PR. There are still a few things to be resolved
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
