### PR TITLE
tests/e2e: force always pull in non kind-based deployment

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -265,6 +265,11 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		)
 	}
 
+	if !td.kindCluster {
+		// Making sure the image is always pulled in registry-based testing
+		args = append(args, "--osm-image-pull-policy=Always")
+	}
+
 	if len(instOpts.containerRegistrySecret) != 0 {
 		args = append(args, "--container-registry-secret="+registrySecretName)
 	}


### PR DESCRIPTION
Seen a condition where OSM is not necessarily always pulled if present in
container cache in nodes (even with `latest` tag) and registry is enabled.

Verified this was the case comparing SHAs. ~Not sure the reason though.~
Reason is install cli sets`imagePullPolicy` to `IfNotPresent` by default (and never omitted)
https://kubernetes.io/docs/concepts/containers/images/#updating-images

**Affected area**:

- Tests                  [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No