### PR TITLE
pkg/injector: Add webhook time tracking facility

### DIFF
--- a/pkg/injector/errors.go
+++ b/pkg/injector/errors.go
@@ -4,5 +4,5 @@ import "github.com/pkg/errors"
 
 var (
 	errNamespaceNotFound   = errors.New("namespace not found")
-	errParseWebhookTimeout = errors.New("Could not read webhook timeout")
+	errParseWebhookTimeout = errors.New("could not read webhook timeout")
 )

--- a/pkg/injector/errors.go
+++ b/pkg/injector/errors.go
@@ -3,5 +3,6 @@ package injector
 import "github.com/pkg/errors"
 
 var (
-	errNamespaceNotFound = errors.New("namespace not found")
+	errNamespaceNotFound   = errors.New("namespace not found")
+	errParseWebhookTimeout = errors.New("Could not read webhook timeout")
 )

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -3,8 +3,6 @@ package injector
 import (
 	"net/http"
 	"time"
-
-	"github.com/rs/zerolog"
 )
 
 // Helper to parse timeout variable from webhook URL
@@ -24,19 +22,11 @@ func readTimeout(req *http.Request) (*time.Duration, error) {
 }
 
 // Time tracking function for webhook processing.
+// Gompares duration and prints timeout values
 func webhookTimeTrack(start time.Time, timeout time.Duration) {
 	elapsed := time.Since(start)
-	var logEv *zerolog.Event
 	percentOfTimeout := float64(elapsed.Microseconds()) / float64(timeout.Microseconds())
 
-	if percentOfTimeout < 0.75 {
-		logEv = log.Debug()
-	} else if percentOfTimeout < 1 {
-		logEv = log.Warn()
-	} else {
-		// Error logging when going beyond timeout value to process a webhook
-		logEv = log.Error()
-	}
-	logEv.Msgf("Mutate Webhook took %v to execute (%.2f of it's timeout, %v)",
+	log.Debug().Msgf("Mutate Webhook took %v to execute (%.2f of it's timeout, %v)",
 		elapsed, percentOfTimeout, timeout)
 }

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -1,0 +1,42 @@
+package injector
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// Helper to parse timeout variable from webhook URL
+func readTimeout(req *http.Request) (*time.Duration, error) {
+	durationValue, found := req.URL.Query()[webhookTimeoutStr]
+	if !found || len(durationValue) != 1 {
+		log.Error().Msgf("Webhook timeout value not found in request")
+		return nil, errParseWebhookTimeout
+	}
+
+	val, err := time.ParseDuration(durationValue[0])
+	if err != nil {
+		log.Error().Msgf("Error parsing timeout value as duration: %v", err)
+		return nil, errParseWebhookTimeout
+	}
+	return &val, nil
+}
+
+// Time tracking function for webhook processing.
+func webhookTimeTrack(start time.Time, timeout time.Duration) {
+	elapsed := time.Since(start)
+	var logEv *zerolog.Event
+	percentOfTimeout := float64(elapsed.Microseconds()) / float64(timeout.Microseconds())
+
+	if percentOfTimeout < 0.75 {
+		logEv = log.Debug()
+	} else if percentOfTimeout < 1 {
+		logEv = log.Warn()
+	} else {
+		// Error logging when going beyond timeout value to process a webhook
+		logEv = log.Error()
+	}
+	logEv.Msgf("Mutate Webhook took %v to execute (%.2f of it's timeout, %v)",
+		elapsed, percentOfTimeout, timeout)
+}

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -22,7 +22,7 @@ func readTimeout(req *http.Request) (*time.Duration, error) {
 }
 
 // Time tracking function for webhook processing.
-// Gompares duration and prints timeout values
+// Will calculate elapsed time since start and log debug how much time spent executing
 func webhookTimeTrack(start time.Time, timeout time.Duration) {
 	elapsed := time.Since(start)
 	percentOfTimeout := float64(elapsed.Microseconds()) / float64(timeout.Microseconds())

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -7,7 +7,7 @@ import (
 
 // Helper to parse timeout variable from webhook URL
 func readTimeout(req *http.Request) (*time.Duration, error) {
-	durationValue, found := req.URL.Query()[webhookTimeoutStr]
+	durationValue, found := req.URL.Query()[webhookMutateTimeoutKey]
 	if !found || len(durationValue) != 1 {
 		log.Error().Msgf("Webhook timeout value not found in request")
 		return nil, errParseWebhookTimeout

--- a/pkg/injector/profiling_test.go
+++ b/pkg/injector/profiling_test.go
@@ -1,0 +1,61 @@
+package injector
+
+import (
+	"bytes"
+	"net/http"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedResults := map[string]bool{
+		"/mutate?timeout=30s":            true,
+		"/mutate?timeout=20h":            true,
+		"/mutate?timeout=s":              false,
+		"/mutate?":                       false,
+		"/mutate?timeout=20&timeout=30m": false,
+		"randomString":                   false,
+	}
+
+	for url, expectedRes := range expectedResults {
+		req, err := http.NewRequest(http.MethodPost, url, http.NoBody)
+		assert.NoError(err)
+
+		_, err = readTimeout(req)
+		if expectedRes {
+			assert.NoError(err)
+		} else {
+			assert.Error(err)
+		}
+	}
+}
+
+func TestDeferredWebhookLogging(t *testing.T) {
+	assert := assert.New(t)
+
+	// Redirect zerolog output temporarily to trap the log message
+	logsave := log
+	var b bytes.Buffer
+	log = log.Output(&b)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		timeout, _ := time.ParseDuration("30s")
+		defer webhookTimeTrack(time.Now(), timeout)
+
+		time.Sleep(100 * time.Millisecond)
+	}()
+	wg.Wait()
+
+	log = logsave
+	match, _ := regexp.MatchString("Mutate Webhook took .* to execute (.* of it's timeout, 30s)", b.String())
+	assert.Equal(true, match)
+}

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -51,7 +51,7 @@ const (
 	WebhookHealthPath = "/healthz"
 
 	// webhookTimeoutStr is the url variable name for timeout
-	webhookTimeoutStr = "timeout"
+	webhookMutateTimeoutKey = "timeout"
 )
 
 // NewWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -139,11 +139,11 @@ func (wh *webhook) mutateHandler(w http.ResponseWriter, req *http.Request) {
 	// For debug/profiling purposes
 	if log.GetLevel() == zerolog.DebugLevel {
 		// Read timeout from request
-		timeoutValue, err := readTimeout(req)
+		reqTimeout, err := readTimeout(req)
 		if err != nil {
 			log.Error().Msgf("Could not read timeout from request url: %v", err)
 		} else {
-			defer webhookTimeTrack(time.Now(), *timeoutValue)
+			defer webhookTimeTrack(time.Now(), *reqTimeout)
 		}
 	}
 

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/pkg/errors"
 	"k8s.io/api/admission/v1beta1"
@@ -135,12 +136,15 @@ func (wh *webhook) healthHandler(w http.ResponseWriter, req *http.Request) {
 func (wh *webhook) mutateHandler(w http.ResponseWriter, req *http.Request) {
 	log.Info().Msgf("Request received: Method=%v, URL=%v", req.Method, req.URL)
 
-	// Read timeout from request
-	timeoutValue, err := readTimeout(req)
-	if err != nil {
-		log.Error().Msgf("Could not read timeout from request url: %v", err)
-	} else {
-		defer webhookTimeTrack(time.Now(), *timeoutValue)
+	// For debug/profiling purposes
+	if log.GetLevel() == zerolog.DebugLevel {
+		// Read timeout from request
+		timeoutValue, err := readTimeout(req)
+		if err != nil {
+			log.Error().Msgf("Could not read timeout from request url: %v", err)
+		} else {
+			defer webhookTimeTrack(time.Now(), *timeoutValue)
+		}
 	}
 
 	if contentType := req.Header.Get("Content-Type"); contentType != "application/json" {

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -574,7 +574,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		}
 
 		// Action !!
-		actual, _ := wh.mutate(nil)
+		actual := wh.mutate(nil)
 
 		expected := v1beta1.AdmissionResponse{
 			Result: &metav1.Status{

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -574,7 +574,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		}
 
 		// Action !!
-		actual := wh.mutate(nil)
+		actual, _ := wh.mutate(nil)
 
 		expected := v1beta1.AdmissionResponse{
 			Result: &metav1.Status{


### PR DESCRIPTION
Adding a small piece to help track time spent by individual routines
handling webhooks.

It parses the timeout value from the webhook call, and based on some
static thresholds will log differently depending on how much time is
taking vs. the timeout value given by the url.

**Affected area**:

- Control Plane          [X]
- Performance            [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No