### PR TITLE
cli: Add enforce single mesh functionality to osm install

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -41,4 +41,4 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.vault.protocol | string | `"http"` |  |
 | OpenServiceMesh.vault.role | string | `"openservicemesh"` |  |
 | OpenServiceMesh.vault.token | string | `nil` |  |
-
+| OpenServiceMesh.enforceSingleMesh | bool | `"false"` |  |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: osm-controller
     meshName: {{ .Values.OpenServiceMesh.meshName }}
+    {{ if .Values.OpenServiceMesh.enforceSingleMesh }}enforceSingleMesh: "true"{{ end }}
 spec:
   replicas: {{ .Values.OpenServiceMesh.replicaCount }}
   selector:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -37,6 +37,7 @@ OpenServiceMesh:
   meshName: osm
   useHTTPSIngress: false
   envoyLogLevel: error
+  enforceSingleMesh: false
 
   # Set deployJaeger to true to deploy a Jaeger cluster in the
   # namespace where OSM resides.

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -304,9 +304,9 @@ func (i *installCmd) validateOptions() error {
 	}
 
 	// Check if single mesh cluster is already specified
-	for _, mesh := range list.Items {
-		singleMeshEnforced := mesh.ObjectMeta.Labels["enforceSingleMesh"] == "true"
-		name := mesh.ObjectMeta.Labels["meshName"]
+	for _, deployment := range list.Items {
+		singleMeshEnforced := deployment.ObjectMeta.Labels["enforceSingleMesh"] == "true"
+		name := deployment.ObjectMeta.Labels["meshName"]
 		if singleMeshEnforced {
 			return errors.Errorf("Cannot install mesh [%s]. Existing mesh [%s] enforces single mesh cluster.", i.meshName, name)
 		}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
--enable-single-mesh enforces that only one mesh is installed in the cluster
Fixes #1754
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No