### PR TITLE
ref(make): add variables for e2e test flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ BUILD_GITCOMMIT_VAR := github.com/openservicemesh/osm/pkg/version.GitCommit
 
 LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CLI_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X main.chartTGZSource=$$(cat -) -s -w"
 
+# These two values are combined and passed to go test
+E2E_FLAGS ?= -kindCluster
+E2E_FLAGS_DEFAULT := -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG)
+
 check-env:
 ifndef CTR_REGISTRY
 	$(error CTR_REGISTRY environment variable is not defined; see the .env.example file for more information; then source .env)
@@ -89,7 +93,7 @@ kind-reset:
 
 .PHONY: test-e2e
 test-e2e: docker-build-osm-controller docker-build-init build-osm
-	go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG) -kindCluster
+	go test ./tests/e2e $(E2E_FLAGS_DEFAULT) $(E2E_FLAGS)
 
 .env:
 	cp .env.example .env


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This change adds two new variables to the Makefile to handle e2e test
flags: `E2E_FLAGS` and `E2E_FLAGS_DEFAULT`. These flags can optionally
be defined on the command line while invoking `make test-e2e` so flags
can be modified while also automatically building the required images.

Two separate flags were created so a sensible set of
defaults can be kept in `E2E_FLAGS_DEFAULT` and flags more likely to be
changed like cleanup or focus can be overridden without redefining all
the default flags. The default flags include verbose output and image
parameters, so the `test-e2e` target will always test with locally built
images from the current source. To use pre-built images, `go test`
should be invoked directly.

The default behavior for `make test-e2e` is unchanged.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No