### PR TITLE
injector: ignore osm-controller namespace

### DIFF
--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -225,6 +225,11 @@ func (wh *webhook) mutate(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionRespo
 }
 
 func (wh *webhook) isNamespaceAllowed(namespace string) bool {
+	// Skip osm-controller namespace
+	if namespace == wh.osmNamespace {
+		return false
+	}
+
 	// Skip Kubernetes system namespaces
 	for _, ns := range kubeSystemNamespaces {
 		if ns == namespace {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an extra safety check to ignore osm-controller namespace
from injection. This will only come into use if the controller
namespace does not have a label used to prevent the webhook
from being invoked (namespaceSelector in the
mutatingwebhookconfiguration).

Resolves #1859

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`