### PR TITLE
CI cleanup timeout increase

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -677,7 +677,7 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 
 		if len(nsList) > 0 && td.waitForCleanup {
 			// on kind this can take a while apparently
-			err := td.WaitForNamespacesDeleted(nsList, 120*time.Second)
+			err := td.WaitForNamespacesDeleted(nsList, 240*time.Second)
 			if err != nil {
 				td.T.Logf("Could not confirm all namespace deletion in time: %v", err)
 			}


### PR DESCRIPTION
With enough test applications/namespaces in combination with a slow
instance of gh actions, we've seen some delays to clean up all test
namespaces, and consequently test failures.

Relaxing further the wait-for-namespaces cleanup time, as re-running
the test suite for a non-osm-related/infra timeout can be a lot more expensive
than grating additional infra cleanup time.

**Affected area**:
- Tests                  [X]
- CI System              [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No