### PR TITLE
ref(routes): ListTrafficTargetPermutation using TrafficTarget fields …

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -294,9 +294,10 @@ func TestBuildAllowAllTrafficPolicies(t *testing.T) {
 func TestListTrafficTargetPermutations(t *testing.T) {
 	assert := assert.New(t)
 
-	destList := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreApexService}
-	srcList := []service.MeshService{tests.BookbuyerService, tests.BookwarehouseService}
-	trafficTargets := listTrafficTargetPermutations(tests.TrafficTargetName, srcList, destList)
+	mc := newFakeMeshCatalog()
+
+	trafficTargets, err := mc.listTrafficTargetPermutations(tests.TrafficTarget, tests.TrafficTarget.Spec.Sources[0], tests.TrafficTarget.Spec.Destination)
+	assert.Nil(err)
 
 	var actualTargetNames []string
 	for _, target := range trafficTargets {
@@ -304,10 +305,9 @@ func TestListTrafficTargetPermutations(t *testing.T) {
 	}
 
 	expected := []string{
-		utils.GetTrafficTargetName(tests.TrafficTargetName, srcList[0], destList[0]),
-		utils.GetTrafficTargetName(tests.TrafficTargetName, srcList[0], destList[1]),
-		utils.GetTrafficTargetName(tests.TrafficTargetName, srcList[1], destList[0]),
-		utils.GetTrafficTargetName(tests.TrafficTargetName, srcList[1], destList[1]),
+		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreV1Service),
+		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreV2Service),
+		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreApexService),
 	}
 	assert.ElementsMatch(actualTargetNames, expected)
 }


### PR DESCRIPTION
…directly

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Refactors ListTrafficTargetPermutation to include all of the logic for getting services from service accounts listed in TrafficTarget. This makes the code a bit more modular and easier to read.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No