### PR TITLE
feat(metrics): Disable Prometheus by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,17 +90,17 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: false
 # export ENABLE_EGRESS=true
 
-# optional: ENABLE_GRAFANA (true/false)
+# optional: DEPLOY_GRAFANA (true/false)
 # Default: true
-# export ENABLE_GRAFANA=true
+# export DEPLOY_GRAFANA=true
 
 # optional: ENABLE_FLUENTBIT (true/false)
 # Default: false
 # export ENABLE_FLUENTBIT=true
 
-# optional: ENABLE_PROMETHEUS_DEPLOYMENT (true/false)
+# optional: DEPLOY_PROMETHEUS (true/false)
 # Default: true
-# export ENABLE_PROMETHEUS_DEPLOYMENT=true
+# export DEPLOY_PROMETHEUS=true
 
 # optional: ENABLE_PROMETHEUS_SCRAPING (true/false)
 # Default: true

--- a/.env.example
+++ b/.env.example
@@ -98,13 +98,13 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: false
 # export ENABLE_FLUENTBIT=true
 
-# optional: ENABLE_PROMETHEUS (true/false)
+# optional: ENABLE_PROMETHEUS_DEPLOYMENT (true/false)
 # Default: true
-# export ENABLE_PROMETHEUS=true
+# export ENABLE_PROMETHEUS_DEPLOYMENT=true
 
 # optional: ENABLE_PROMETHEUS_SCRAPING (true/false)
-# Default: false
-# export ENABLE_PROMETHEUS_SCRAPING=false
+# Default: true
+# export ENABLE_PROMETHEUS_SCRAPING=true
 
 # optional: Maximum of iterations to test for expected return codes. 0 means unlimited.
 # export CI_MAX_ITERATIONS_THRESHOLD=0

--- a/.env.example
+++ b/.env.example
@@ -91,12 +91,20 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # export ENABLE_EGRESS=true
 
 # optional: ENABLE_GRAFANA (true/false)
-# Default: false
+# Default: true
 # export ENABLE_GRAFANA=true
 
 # optional: ENABLE_FLUENTBIT (true/false)
 # Default: false
 # export ENABLE_FLUENTBIT=true
+
+# optional: ENABLE_PROMETHEUS (true/false)
+# Default: true
+# export ENABLE_PROMETHEUS=true
+
+# optional: ENABLE_PROMETHEUS_SCRAPING (true/false)
+# Default: false
+# export ENABLE_PROMETHEUS_SCRAPING=false
 
 # optional: Maximum of iterations to test for expected return codes. 0 means unlimited.
 # export CI_MAX_ITERATIONS_THRESHOLD=0

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -21,7 +21,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.enableFluentbit | bool | `false` |  |
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` |  |
 | OpenServiceMesh.enablePrometheusDeployment | bool | `false` |  |
-| OpenServiceMesh.enablePrometheusScraping | bool | `true` | Automatically set to true if `enablePrometheusDeployment` is true |
+| OpenServiceMesh.enablePrometheusScraping | bool | `true` | Cannot be false if `enablePrometheusDeployment` is true |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` |  |
 | OpenServiceMesh.grafana.port | int | `3000` |  |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -17,11 +17,11 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.enableBackpressureExperimental | bool | `false` |  |
 | OpenServiceMesh.enableDebugServer | bool | `false` |  |
 | OpenServiceMesh.enableEgress | bool | `false` |  |
-| OpenServiceMesh.enableGrafana | bool | `false` |  |
+| OpenServiceMesh.deployGrafana | bool | `false` |  |
 | OpenServiceMesh.enableFluentbit | bool | `false` |  |
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` |  |
-| OpenServiceMesh.enablePrometheusDeployment | bool | `false` |  |
-| OpenServiceMesh.enablePrometheusScraping | bool | `true` | Cannot be false if `enablePrometheusDeployment` is true |
+| OpenServiceMesh.deployPrometheus | bool | `false` |  |
+| OpenServiceMesh.enablePrometheusScraping | bool | `true` | Cannot be false if `deployPrometheus` is true |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` |  |
 | OpenServiceMesh.grafana.port | int | `3000` |  |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -20,7 +20,8 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.enableGrafana | bool | `false` |  |
 | OpenServiceMesh.enableFluentbit | bool | `false` |  |
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` |  |
-| OpenServiceMesh.enablePrometheus | bool | `true` |  |
+| OpenServiceMesh.enablePrometheus | bool | `false` |  |
+| OpenServiceMesh.enablePrometheusScraping | bool | `false` | Automatically set to true if `enablePrometheus` is true |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` |  |
 | OpenServiceMesh.grafana.port | int | `3000` |  |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -20,8 +20,8 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.enableGrafana | bool | `false` |  |
 | OpenServiceMesh.enableFluentbit | bool | `false` |  |
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` |  |
-| OpenServiceMesh.enablePrometheus | bool | `false` |  |
-| OpenServiceMesh.enablePrometheusScraping | bool | `false` | Automatically set to true if `enablePrometheus` is true |
+| OpenServiceMesh.enablePrometheusDeployment | bool | `false` |  |
+| OpenServiceMesh.enablePrometheusScraping | bool | `true` | Automatically set to true if `enablePrometheusDeployment` is true |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` |  |
 | OpenServiceMesh.grafana.port | int | `3000` |  |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.deployGrafana}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.deployGrafana}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.deployGrafana}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/osm/templates/grafana-svc.yaml
+++ b/charts/osm/templates/grafana-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enableGrafana}}
+{{- if .Values.OpenServiceMesh.deployGrafana}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -8,7 +8,7 @@ data:
   egress: {{ .Values.OpenServiceMesh.enableEgress | quote }}
   envoy_log_level: {{ .Values.OpenServiceMesh.envoyLogLevel | quote }}
   enable_debug_server: {{ .Values.OpenServiceMesh.enableDebugServer | quote }}
-  prometheus_scraping: "true"
+  prometheus_scraping: {{ .Values.OpenServiceMesh.enablePrometheusScraping | quote }}
 
 {{- if .Values.OpenServiceMesh.tracing.enable }}
   tracing_enable: {{ .Values.OpenServiceMesh.tracing.enable | quote }}

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheus }}
+{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
+{{- if .Values.OpenServiceMesh.deployPrometheus }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
+{{- if .Values.OpenServiceMesh.deployPrometheus }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheus }}
+{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
+{{- if .Values.OpenServiceMesh.deployPrometheus }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheus }}
+{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/osm/templates/prometheus-svc.yaml
+++ b/charts/osm/templates/prometheus-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheus }}
+{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/osm/templates/prometheus-svc.yaml
+++ b/charts/osm/templates/prometheus-svc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.OpenServiceMesh.enablePrometheusDeployment }}
+{{- if .Values.OpenServiceMesh.deployPrometheus }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -22,7 +22,8 @@
                 "enablePermissiveTrafficPolicy",
                 "enableBackpressureExperimental",
                 "enableEgress",
-                "enablePrometheus",
+                "enablePrometheusDeployment",
+                "enablePrometheusScraping",
                 "enableGrafana",
                 "meshName",
                 "useHTTPSIngress",
@@ -163,11 +164,20 @@
                         false
                     ]
                 },
-                "enablePrometheus": {
-                    "$id": "#/properties/OpenServiceMesh/properties/enablePrometheus",
+                "enablePrometheusDeployment": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enablePrometheusDeployment",
                     "type": "boolean",
-                    "title": "The enablePrometheus schema",
+                    "title": "The enablePrometheusDeployment schema",
                     "description": "Indicates whether Prometheus should be installed and configured as part of the osm control plane.",
+                    "examples": [
+                        false
+                    ]
+                },
+                "enablePrometheusScraping": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enablePrometheusScraping",
+                    "type": "boolean",
+                    "title": "The enablePrometheusScraping schema",
+                    "description": "Indicates whether Prometheus scraping should be enabled.",
                     "examples": [
                         true
                     ]

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -22,9 +22,9 @@
                 "enablePermissiveTrafficPolicy",
                 "enableBackpressureExperimental",
                 "enableEgress",
-                "enablePrometheusDeployment",
+                "deployPrometheus",
                 "enablePrometheusScraping",
-                "enableGrafana",
+                "deployGrafana",
                 "meshName",
                 "useHTTPSIngress",
                 "envoyLogLevel",
@@ -164,10 +164,10 @@
                         false
                     ]
                 },
-                "enablePrometheusDeployment": {
-                    "$id": "#/properties/OpenServiceMesh/properties/enablePrometheusDeployment",
+                "deployPrometheus": {
+                    "$id": "#/properties/OpenServiceMesh/properties/deployPrometheus",
                     "type": "boolean",
-                    "title": "The enablePrometheusDeployment schema",
+                    "title": "The deployPrometheus schema",
                     "description": "Indicates whether Prometheus should be installed and configured as part of the osm control plane.",
                     "examples": [
                         false
@@ -182,10 +182,10 @@
                         true
                     ]
                 },
-                "enableGrafana": {
-                    "$id": "#/properties/OpenServiceMesh/properties/enableGrafana",
+                "deployGrafana": {
+                    "$id": "#/properties/OpenServiceMesh/properties/deployGrafana",
                     "type": "boolean",
-                    "title": "The enableGrafana schema",
+                    "title": "The deployGrafana schema",
                     "description": "Indicates whether Grafana should be installed and configured as part of the osm control plane.",
                     "examples": [
                         false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -32,7 +32,8 @@ OpenServiceMesh:
   enablePermissiveTrafficPolicy: false
   enableBackpressureExperimental: false
   enableEgress: false
-  enablePrometheus: true
+  enablePrometheus: false
+  enablePrometheusScraping: false
   enableGrafana: false
   enableFluentbit: false
   fluentBitImage:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -32,9 +32,9 @@ OpenServiceMesh:
   enablePermissiveTrafficPolicy: false
   enableBackpressureExperimental: false
   enableEgress: false
-  enablePrometheusDeployment: false
+  deployPrometheus: false
   enablePrometheusScraping: true
-  enableGrafana: false
+  deployGrafana: false
   enableFluentbit: false
   fluentBitImage:
     name: fluentbit-logger

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -32,8 +32,8 @@ OpenServiceMesh:
   enablePermissiveTrafficPolicy: false
   enableBackpressureExperimental: false
   enableEgress: false
-  enablePrometheus: false
-  enablePrometheusScraping: false
+  enablePrometheusDeployment: false
+  enablePrometheusScraping: true
   enableGrafana: false
   enableFluentbit: false
   fluentBitImage:

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -352,13 +352,13 @@ func (i *installCmd) validateOptions() error {
 	// Enforce single mesh cluster if needed
 	if i.enforceSingleMesh {
 		if len(list.Items) != 0 {
-			return errors.Errorf("Meshes already exist in cluster. Cannot enforce single mesh cluster. ")
+			return errors.Errorf("Meshes already exist in cluster. Cannot enforce single mesh cluster.")
 		}
 	}
 
 	if i.deployPrometheus {
 		if !i.enablePrometheusScraping {
-			return errors.Errorf("Prometheus scraping cannot be disabled when deploying Prometheus.")
+			fmt.Fprintf(i.out, "Prometheus scraping is disabled. To enable it, set prometheus_scraping in %s/%s to true.\n", settings.Namespace(), constants.OSMConfigMap)
 		}
 	}
 

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -75,9 +75,9 @@ const (
 	defaultEnableEgress                   = false
 	defaultEnablePermissiveTrafficPolicy  = false
 	defaultEnableBackpressureExperimental = false
-	defaultEnablePrometheusDeployment     = false
+	defaultDeployPrometheus               = false
 	defaultEnablePrometheusScraping       = true
-	defaultEnableGrafana                  = false
+	defaultDeployGrafana                  = false
 	defaultEnableFluentbit                = false
 	defaultDeployJaeger                   = true
 	defaultEnforceSingleMesh              = false
@@ -118,13 +118,13 @@ type installCmd struct {
 	enableBackpressureExperimental bool
 
 	// Toggle to enable/disable Prometheus installation
-	enablePrometheusDeployment bool
+	deployPrometheus bool
 
 	// Toggle to enable/disable Prometheus scraping
 	enablePrometheusScraping bool
 
 	// Toggle to enable/disable Grafana installation
-	enableGrafana bool
+	deployGrafana bool
 
 	// Toggle to enable/disable FluentBit sidecar
 	enableFluentbit bool
@@ -180,9 +180,9 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enablePermissiveTrafficPolicy, "enable-permissive-traffic-policy", defaultEnablePermissiveTrafficPolicy, "Enable permissive traffic policy mode")
 	f.BoolVar(&inst.enableEgress, "enable-egress", defaultEnableEgress, "Enable egress in the mesh")
 	f.BoolVar(&inst.enableBackpressureExperimental, "enable-backpressure-experimental", defaultEnableBackpressureExperimental, "Enable experimental backpressure feature")
-	f.BoolVar(&inst.enablePrometheusDeployment, "enable-prometheus-deployment", defaultEnablePrometheusDeployment, "Enable Prometheus installation and deployment")
+	f.BoolVar(&inst.deployPrometheus, "deploy-prometheus", defaultDeployPrometheus, "Install and deploy Prometheus")
 	f.BoolVar(&inst.enablePrometheusScraping, "enable-prometheus-scraping", defaultEnablePrometheusScraping, "Enable Prometheus metrics scraping on sidecar proxies")
-	f.BoolVar(&inst.enableGrafana, "enable-grafana", defaultEnableGrafana, "Enable Grafana installation and deployment")
+	f.BoolVar(&inst.deployGrafana, "deploy-grafana", defaultDeployGrafana, "Install and deploy Grafana")
 	f.BoolVar(&inst.enableFluentbit, "enable-fluentbit", defaultEnableFluentbit, "Enable Fluentbit sidecar deployment")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
 	f.BoolVar(&inst.deployJaeger, "deploy-jaeger", defaultDeployJaeger, "Deploy Jaeger in the namespace of the OSM controller")
@@ -251,9 +251,9 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%t", i.enableDebugServer),
 		fmt.Sprintf("OpenServiceMesh.enablePermissiveTrafficPolicy=%t", i.enablePermissiveTrafficPolicy),
 		fmt.Sprintf("OpenServiceMesh.enableBackpressureExperimental=%t", i.enableBackpressureExperimental),
-		fmt.Sprintf("OpenServiceMesh.enablePrometheusDeployment=%t", i.enablePrometheusDeployment),
+		fmt.Sprintf("OpenServiceMesh.deployPrometheus=%t", i.deployPrometheus),
 		fmt.Sprintf("OpenServiceMesh.enablePrometheusScraping=%t", i.enablePrometheusScraping),
-		fmt.Sprintf("OpenServiceMesh.enableGrafana=%t", i.enableGrafana),
+		fmt.Sprintf("OpenServiceMesh.deployGrafana=%t", i.deployGrafana),
 		fmt.Sprintf("OpenServiceMesh.enableFluentbit=%t", i.enableFluentbit),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
 		fmt.Sprintf("OpenServiceMesh.enableEgress=%t", i.enableEgress),
@@ -356,9 +356,9 @@ func (i *installCmd) validateOptions() error {
 		}
 	}
 
-	if i.enablePrometheusDeployment {
+	if i.deployPrometheus {
 		if !i.enablePrometheusScraping {
-			return errors.Errorf("Prometheus cannot be disabled when deploying Prometheus.")
+			return errors.Errorf("Prometheus scraping cannot be disabled when deploying Prometheus.")
 		}
 	}
 

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -75,7 +75,8 @@ const (
 	defaultEnableEgress                   = false
 	defaultEnablePermissiveTrafficPolicy  = false
 	defaultEnableBackpressureExperimental = false
-	defaultEnablePrometheus               = true
+	defaultEnablePrometheus               = false
+	defaultEnablePrometheusScraping       = false
 	defaultEnableGrafana                  = false
 	defaultEnableFluentbit                = false
 	defaultDeployJaeger                   = true
@@ -118,6 +119,9 @@ type installCmd struct {
 
 	// Toggle to enable/disable Prometheus installation
 	enablePrometheus bool
+
+	// Toggle to enable/disable Prometheus scraping
+	enablePrometheusScraping bool
 
 	// Toggle to enable/disable Grafana installation
 	enableGrafana bool
@@ -177,6 +181,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 	f.BoolVar(&inst.enableEgress, "enable-egress", defaultEnableEgress, "Enable egress in the mesh")
 	f.BoolVar(&inst.enableBackpressureExperimental, "enable-backpressure-experimental", defaultEnableBackpressureExperimental, "Enable experimental backpressure feature")
 	f.BoolVar(&inst.enablePrometheus, "enable-prometheus", defaultEnablePrometheus, "Enable Prometheus installation and deployment")
+	f.BoolVar(&inst.enablePrometheus, "enable-prometheus-scraping", defaultEnablePrometheusScraping, "Enable Prometheus metrics scraping on sidecar proxies")
 	f.BoolVar(&inst.enableGrafana, "enable-grafana", defaultEnableGrafana, "Enable Grafana installation and deployment")
 	f.BoolVar(&inst.enableFluentbit, "enable-fluentbit", defaultEnableFluentbit, "Enable Fluentbit sidecar deployment")
 	f.StringVar(&inst.meshName, "mesh-name", defaultMeshName, "name for the new control plane instance")
@@ -247,6 +252,7 @@ func (i *installCmd) resolveValues() (map[string]interface{}, error) {
 		fmt.Sprintf("OpenServiceMesh.enablePermissiveTrafficPolicy=%t", i.enablePermissiveTrafficPolicy),
 		fmt.Sprintf("OpenServiceMesh.enableBackpressureExperimental=%t", i.enableBackpressureExperimental),
 		fmt.Sprintf("OpenServiceMesh.enablePrometheus=%t", i.enablePrometheus),
+		fmt.Sprintf("OpenServiceMesh.enablePrometheusScraping=%t", i.enablePrometheusScraping),
 		fmt.Sprintf("OpenServiceMesh.enableGrafana=%t", i.enableGrafana),
 		fmt.Sprintf("OpenServiceMesh.enableFluentbit=%t", i.enableFluentbit),
 		fmt.Sprintf("OpenServiceMesh.meshName=%s", i.meshName),
@@ -348,6 +354,10 @@ func (i *installCmd) validateOptions() error {
 		if len(list.Items) != 0 {
 			return errors.Errorf("Meshes already exist in cluster. Cannot enforce single mesh cluster. ")
 		}
+	}
+
+	if i.enablePrometheus {
+		i.enablePrometheusScraping = true
 	}
 
 	return nil

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -555,9 +555,9 @@ var _ = Describe("deployPrometheus is true", func() {
 		err = installCmd.run(config)
 	})
 
-	It("should error", func() {
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("Prometheus scraping cannot be disabled when deploying Prometheus."))
+	It("should not error", func() {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out.String()).To(Equal("Prometheus scraping is disabled. To enable it, set prometheus_scraping in osm-system/osm-config to true.\nOSM installed successfully in namespace [osm-system] with mesh name [osm]\n"))
 	})
 })
 

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -525,7 +525,7 @@ var _ = Describe("Test envoy log level types", func() {
 	})
 })
 
-var _ = Describe("enablePrometheusDeployment is true", func() {
+var _ = Describe("deployPrometheus is true", func() {
 	var (
 		out    *bytes.Buffer
 		store  *storage.Storage
@@ -549,7 +549,7 @@ var _ = Describe("enablePrometheusDeployment is true", func() {
 		}
 
 		installCmd := getDefaultInstallCmd(out)
-		installCmd.enablePrometheusDeployment = true
+		installCmd.deployPrometheus = true
 		installCmd.enablePrometheusScraping = false
 
 		err = installCmd.run(config)
@@ -557,7 +557,7 @@ var _ = Describe("enablePrometheusDeployment is true", func() {
 
 	It("should error", func() {
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("Prometheus cannot be disabled when deploying Prometheus."))
+		Expect(err.Error()).To(Equal("Prometheus scraping cannot be disabled when deploying Prometheus."))
 	})
 })
 
@@ -623,7 +623,7 @@ func TestEnforceSingleMesh(t *testing.T) {
 		prometheusRetentionTime:     testRetentionTime,
 		meshName:                    defaultMeshName,
 		enableEgress:                true,
-		enableGrafana:               false,
+		deployGrafana:               false,
 		clientSet:                   fakeClientSet,
 		envoyLogLevel:               testEnvoyLogLevel,
 		enforceSingleMesh:           true,
@@ -680,8 +680,8 @@ func TestEnforceSingleMeshRejectsNewMesh(t *testing.T) {
 		prometheusRetentionTime:     testRetentionTime,
 		meshName:                    defaultMeshName + "-2",
 		enableEgress:                true,
-		enablePrometheusDeployment:  true,
-		enableGrafana:               false,
+		deployPrometheus:            true,
+		deployGrafana:               false,
 		clientSet:                   fakeClientSet,
 		envoyLogLevel:               testEnvoyLogLevel,
 	}
@@ -726,8 +726,8 @@ func TestEnforceSingleMeshWithExistingMesh(t *testing.T) {
 		prometheusRetentionTime:     testRetentionTime,
 		meshName:                    defaultMeshName + "-2",
 		enableEgress:                true,
-		enablePrometheusDeployment:  true,
-		enableGrafana:               false,
+		deployPrometheus:            true,
+		deployGrafana:               false,
 		clientSet:                   fakeClientSet,
 		envoyLogLevel:               testEnvoyLogLevel,
 		enforceSingleMesh:           true,
@@ -778,9 +778,9 @@ func getDefaultInstallCmd(writer *bytes.Buffer) installCmd {
 		enablePermissiveTrafficPolicy:  defaultEnablePermissiveTrafficPolicy,
 		clientSet:                      fake.NewSimpleClientset(),
 		enableBackpressureExperimental: defaultEnableBackpressureExperimental,
-		enablePrometheusDeployment:     defaultEnablePrometheusDeployment,
+		deployPrometheus:               defaultDeployPrometheus,
 		enablePrometheusScraping:       defaultEnablePrometheusScraping,
-		enableGrafana:                  defaultEnableGrafana,
+		deployGrafana:                  defaultDeployGrafana,
 		enableFluentbit:                defaultEnableFluentbit,
 		deployJaeger:                   defaultDeployJaeger,
 		enforceSingleMesh:              defaultEnforceSingleMesh,
@@ -819,9 +819,9 @@ func getDefaultValues() map[string]interface{} {
 			"enablePermissiveTrafficPolicy":  defaultEnablePermissiveTrafficPolicy,
 			"enableBackpressureExperimental": defaultEnableBackpressureExperimental,
 			"enableEgress":                   defaultEnableEgress,
-			"enablePrometheusDeployment":     defaultEnablePrometheusDeployment,
+			"deployPrometheus":               defaultDeployPrometheus,
 			"enablePrometheusScraping":       defaultEnablePrometheusScraping,
-			"enableGrafana":                  defaultEnableGrafana,
+			"deployGrafana":                  defaultDeployGrafana,
 			"enableFluentbit":                defaultEnableFluentbit,
 			"deployJaeger":                   defaultDeployJaeger,
 			"envoyLogLevel":                  testEnvoyLogLevel,

--- a/demo/README.md
+++ b/demo/README.md
@@ -33,8 +33,8 @@ From the root of this repository execute:
 ```
 
 ### Observability
-By default, Prometheus is deployed by the demo script. To turn this off. Set the variable `ENABLE_PROMETHEUS` in your `.env` file to false. 
-By default, Grafana is deployed by the demo script. To turn this off. Set the variable `ENABLE_PROMETHEUS` in your `.env` file to false. 
+By default, Prometheus is deployed by the demo script. To turn this off. Set the variable `DEPLOY_PROMETHEUS` in your `.env` file to false. 
+By default, Grafana is deployed by the demo script. To turn this off. Set the variable `DEPLOY_GRAFANA` in your `.env` file to false. 
 
 ### This script will:
   - compile OSM's control plane (`cmd/osm-controller`), create a separate container image and push it to the workstation's default container registry (See `~/.docker/config.json`)

--- a/demo/README.md
+++ b/demo/README.md
@@ -32,6 +32,10 @@ From the root of this repository execute:
 ./demo/run-osm-demo.sh
 ```
 
+### Observability
+By default, Prometheus is deployed by the demo script. To turn this off. Set the variable `ENABLE_PROMETHEUS` in your `.env` file to false. 
+By default, Grafana is deployed by the demo script. To turn this off. Set the variable `ENABLE_PROMETHEUS` in your `.env` file to false. 
+
 ### This script will:
   - compile OSM's control plane (`cmd/osm-controller`), create a separate container image and push it to the workstation's default container registry (See `~/.docker/config.json`)
   - build and push demo application images described below

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -31,8 +31,8 @@ ENABLE_DEBUG_SERVER="${ENABLE_DEBUG_SERVER:-true}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
 ENABLE_GRAFANA="${ENABLE_GRAFANA:-true}"
 ENABLE_FLUENTBIT="${ENABLE_FLUENTBIT:-false}"
-ENABLE_PROMETHEUS="${ENABLE_PROMETHEUS:-true}"
-ENABLE_PROMETHEUS_SCRAPING="${ENABLE_PROMETHEUS_SCRAPING:-false}"
+ENABLE_PROMETHEUS_DEPLOYMENT="${ENABLE_PROMETHEUS_DEPLOYMENT:-true}"
+ENABLE_PROMETHEUS_SCRAPING="${ENABLE_PROMETHEUS_SCRAPING:-true}"
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 
@@ -99,7 +99,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
       --enable-fluentbit="$ENABLE_FLUENTBIT" \
-      --enable-prometheus="$ENABLE_PROMETHEUS" \
+      --enable-prometheus-deployment="$ENABLE_PROMETHEUS_DEPLOYMENT" \
       --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       --timeout=90s \
@@ -118,7 +118,7 @@ else
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
       --enable-fluentbit="$ENABLE_FLUENTBIT" \
-      --enable-prometheus="$ENABLE_PROMETHEUS" \
+      --enable-prometheus-deployment="$ENABLE_PROMETHEUS_DEPLOYMENT" \
       --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       --timeout=90s \

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -29,8 +29,10 @@ CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_DEBUG_SERVER="${ENABLE_DEBUG_SERVER:-true}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
-ENABLE_GRAFANA="${ENABLE_GRAFANA:-false}"
+ENABLE_GRAFANA="${ENABLE_GRAFANA:-true}"
 ENABLE_FLUENTBIT="${ENABLE_FLUENTBIT:-false}"
+ENABLE_PROMETHEUS="${ENABLE_PROMETHEUS:-true}"
+ENABLE_PROMETHEUS_SCRAPING="${ENABLE_PROMETHEUS_SCRAPING:-false}"
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 
@@ -97,6 +99,8 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
       --enable-fluentbit="$ENABLE_FLUENTBIT" \
+      --enable-prometheus="$ENABLE_PROMETHEUS" \
+      --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       --timeout=90s \
       $optionalInstallArgs
@@ -114,6 +118,8 @@ else
       --enable-egress="$ENABLE_EGRESS" \
       --enable-grafana="$ENABLE_GRAFANA" \
       --enable-fluentbit="$ENABLE_FLUENTBIT" \
+      --enable-prometheus="$ENABLE_PROMETHEUS" \
+      --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       --timeout=90s \
       $optionalInstallArgs

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -29,9 +29,9 @@ CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_DEBUG_SERVER="${ENABLE_DEBUG_SERVER:-true}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
-ENABLE_GRAFANA="${ENABLE_GRAFANA:-true}"
+DEPLOY_GRAFANA="${DEPLOY_GRAFANA:-true}"
 ENABLE_FLUENTBIT="${ENABLE_FLUENTBIT:-false}"
-ENABLE_PROMETHEUS_DEPLOYMENT="${ENABLE_PROMETHEUS_DEPLOYMENT:-true}"
+DEPLOY_PROMETHEUS="${DEPLOY_PROMETHEUS:-true}"
 ENABLE_PROMETHEUS_SCRAPING="${ENABLE_PROMETHEUS_SCRAPING:-true}"
 DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
@@ -97,9 +97,9 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --osm-image-pull-policy "$IMAGE_PULL_POLICY" \
       --enable-debug-server="$ENABLE_DEBUG_SERVER" \
       --enable-egress="$ENABLE_EGRESS" \
-      --enable-grafana="$ENABLE_GRAFANA" \
+      --deploy-grafana="$DEPLOY_GRAFANA" \
       --enable-fluentbit="$ENABLE_FLUENTBIT" \
-      --enable-prometheus-deployment="$ENABLE_PROMETHEUS_DEPLOYMENT" \
+      --deploy-prometheus="$DEPLOY_PROMETHEUS" \
       --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       --timeout=90s \
@@ -116,9 +116,9 @@ else
       --osm-image-pull-policy "$IMAGE_PULL_POLICY" \
       --enable-debug-server="$ENABLE_DEBUG_SERVER"\
       --enable-egress="$ENABLE_EGRESS" \
-      --enable-grafana="$ENABLE_GRAFANA" \
+      --deploy-grafana="$DEPLOY_GRAFANA" \
       --enable-fluentbit="$ENABLE_FLUENTBIT" \
-      --enable-prometheus-deployment="$ENABLE_PROMETHEUS_DEPLOYMENT" \
+      --deploy-prometheus="$DEPLOY_PROMETHEUS" \
       --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
       --envoy-log-level "$ENVOY_LOG_LEVEL" \
       --timeout=90s \

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -37,9 +37,16 @@ The OSM Manual Install Demo Guide is designed to quickly allow you to demo and e
 Use the [installation guide](/docs/installation_guide.md) to install the `osm` cli.
 
 ## Install OSM Control Plane
-```bash
-osm install
-```
+
+1.  By default, OSM does not enable Prometheus or Grafana.
+    ```bash
+    osm install
+    ```
+1. To enable Prometheus and Grafana, use their respective flags
+    ```bash
+    osm install --enable-prometheus true --enable-grafana true
+    ```
+    See the [metrics documentation](/docs/patterns/observability/metrics.md#automatic-bring-up) for more details.
 
 ## Deploying the Bookstore Demo Applications
 The `Bookstore`, `Bookbuyer`, `Bookthief`, `Bookwarehouse` demo applications will be installed in their respective Kubernetes Namespaces. In order for these applications to be injected with a Envoy sidecar automatically, we must add the Namespaces to be monitored by the mesh.
@@ -208,7 +215,7 @@ Wait for the changes to propagate and observe the counters increment for booksto
 - http://localhost:8082 - **bookstore-v2**
 
 ## Inspect Dashboards
-OSM ships with a set of pre-configured Grafana dashboards. **NOTE** If you still have the additional terminal still running the `./scripts/port-forward-all.sh` script, go ahead and `CTRL+C` to terminate the port forwarding. The `osm dashboard` port redirection will not work simultaneously with the port forwarding script still running. The `osm dashboard` can be viewed with the following command:
+OSM can be configured to deploy Grafana dashboards using the `--enable-grafana` flag in `osm install`. **NOTE** If you still have the additional terminal still running the `./scripts/port-forward-all.sh` script, go ahead and `CTRL+C` to terminate the port forwarding. The `osm dashboard` port redirection will not work simultaneously with the port forwarding script still running. The `osm dashboard` can be viewed with the following command:
 ```bash
 $ osm dashboard
 ```

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -44,7 +44,7 @@ Use the [installation guide](/docs/installation_guide.md) to install the `osm` c
     ```
 1. To enable Prometheus and Grafana, use their respective flags
     ```bash
-    osm install --enable-prometheus-deployment true --enable-grafana true
+    osm install --deploy-prometheus true --deploy-grafana true
     ```
     See the [metrics documentation](/docs/patterns/observability/metrics.md#automatic-bring-up) for more details.
 
@@ -215,7 +215,7 @@ Wait for the changes to propagate and observe the counters increment for booksto
 - http://localhost:8082 - **bookstore-v2**
 
 ## Inspect Dashboards
-OSM can be configured to deploy Grafana dashboards using the `--enable-grafana` flag in `osm install`. **NOTE** If you still have the additional terminal still running the `./scripts/port-forward-all.sh` script, go ahead and `CTRL+C` to terminate the port forwarding. The `osm dashboard` port redirection will not work simultaneously with the port forwarding script still running. The `osm dashboard` can be viewed with the following command:
+OSM can be configured to deploy Grafana dashboards using the `--deploy-grafana` flag in `osm install`. **NOTE** If you still have the additional terminal still running the `./scripts/port-forward-all.sh` script, go ahead and `CTRL+C` to terminate the port forwarding. The `osm dashboard` port redirection will not work simultaneously with the port forwarding script still running. The `osm dashboard` can be viewed with the following command:
 ```bash
 $ osm dashboard
 ```

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -44,7 +44,7 @@ Use the [installation guide](/docs/installation_guide.md) to install the `osm` c
     ```
 1. To enable Prometheus and Grafana, use their respective flags
     ```bash
-    osm install --enable-prometheus true --enable-grafana true
+    osm install --enable-prometheus-deployment true --enable-grafana true
     ```
     See the [metrics documentation](/docs/patterns/observability/metrics.md#automatic-bring-up) for more details.
 

--- a/docs/osm_config_map.md
+++ b/docs/osm_config_map.md
@@ -10,7 +10,7 @@ OSM deploys a configMap `osm-config` as a part of its control plane (in the same
 | egress | bool | true, false| `"false"` | Enables egress in the mesh. |
 | enable_debug_server | bool | true, false| `"true"` | Enables a debug endpoint on the osm-controller pod to list information regarding the mesh such as proxy connections, certificates, and SMI policies. |
 | envoy_log_level | string | trace, debug, info, warning, warn, error, critical, off | `"error"` | Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh. |
-| prometheus_scraping | bool | true, false | `"true"` | Enables Prometheus metrics scraping on sidecar proxies. |
+| prometheus_scraping | bool | true, false | `"false"` | Enables Prometheus metrics scraping on sidecar proxies. |
 | service_cert_validity_duration | string | 24h, 1h30m (any time duration) | `"24h"` | Sets the service certificatevalidity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix. |
 | tracing_enable | bool | true, false | `"true"` | Enables Jaeger tracing for the mesh. |
 | tracing_address | string | jaeger.mesh-namespace.svc.cluster.local | `jaeger.osm-system.svc.cluster.local` | Addess of the Jaeger deployment, if tracing is enabled. |

--- a/docs/osm_config_map.md
+++ b/docs/osm_config_map.md
@@ -10,7 +10,7 @@ OSM deploys a configMap `osm-config` as a part of its control plane (in the same
 | egress | bool | true, false| `"false"` | Enables egress in the mesh. |
 | enable_debug_server | bool | true, false| `"true"` | Enables a debug endpoint on the osm-controller pod to list information regarding the mesh such as proxy connections, certificates, and SMI policies. |
 | envoy_log_level | string | trace, debug, info, warning, warn, error, critical, off | `"error"` | Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh. |
-| prometheus_scraping | bool | true, false | `"false"` | Enables Prometheus metrics scraping on sidecar proxies. |
+| prometheus_scraping | bool | true, false | `"true"` | Enables Prometheus metrics scraping on sidecar proxies. |
 | service_cert_validity_duration | string | 24h, 1h30m (any time duration) | `"24h"` | Sets the service certificatevalidity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix. |
 | tracing_enable | bool | true, false | `"true"` | Enables Jaeger tracing for the mesh. |
 | tracing_address | string | jaeger.mesh-namespace.svc.cluster.local | `jaeger.osm-system.svc.cluster.local` | Addess of the Jaeger deployment, if tracing is enabled. |

--- a/docs/patterns/observability/README.md
+++ b/docs/patterns/observability/README.md
@@ -1,6 +1,6 @@
 # Observability
 
-OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--enable-prometheus-deployment`, `--enable-grafana` and `--enable-fluentbit`.
+OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--deploy-grafana`, `--deploy-grafana` and `--enable-fluentbit`.
 
 ## Table of Contents
 - [Metrics - Prometheus and Grafana](/docs/patterns/observability/metrics.md)

--- a/docs/patterns/observability/README.md
+++ b/docs/patterns/observability/README.md
@@ -1,6 +1,6 @@
 # Observability
 
-OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--enable-prometheus`, `--enable-grafana` and `--enable-fluentbit`.
+OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--enable-prometheus-deployment`, `--enable-grafana` and `--enable-fluentbit`.
 
 ## Table of Contents
 - [Metrics - Prometheus and Grafana](/docs/patterns/observability/metrics.md)

--- a/docs/patterns/observability/metrics.md
+++ b/docs/patterns/observability/metrics.md
@@ -15,7 +15,7 @@ OSM is able to automatically provision Prometheus and Grafana instances to monit
 ### Automatic bring up
 By default, both Prometheus and Grafana are disabled.
 
-However, when configured with the `--enable-prometheus` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `enable-grafana` flag to true when installing OSM using the `osm install` command.
+However, when configured with the `--enable-prometheus-deployment` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `enable-grafana` flag to true when installing OSM using the `osm install` command.
 
 The automatic bring up can be overridden with the `osm install` option during install time:
 ```
@@ -23,7 +23,7 @@ osm install --help
 
 This command installs an osm control plane on the Kubernetes...
 ...
---enable-prometheus               Enable Prometheus deployment (default false)
+--enable-prometheus-deployment    Enable Prometheus deployment (default false)
 --enable-grafana                  Enable Grafana deployment (default false)
 ...
 ```

--- a/docs/patterns/observability/metrics.md
+++ b/docs/patterns/observability/metrics.md
@@ -36,7 +36,7 @@ The following section will document the additional steps needed to allow an alre
 
 - Already running an accessible Prometheus instance *outside* of the mesh.
 - A running OSM control plane instance, deployed without metrics stack.
-   - OSM controls the Envoy's Prometheus listener aperture through `prometheus_scraping: "true"`, under OSM configmap. By default this is set to false (unless OSM was installed with Prometheus enabled.)
+   - OSM controls the Envoy's Prometheus listener aperture through `prometheus_scraping: "true"`, under OSM configmap. By default this is set to true, but do double check it has been enabled on the OSM configmap, or else Prometheus might not be able to reach the pods.
 - We will assume having Grafana reach Prometheus, exposing or forwarding Prometheus or Grafana web ports and configuring Prometheus to reach Kubernetes API services is taken care of or otherwise out of the scope of these steps.
 
 #### Configuration
@@ -116,7 +116,7 @@ Metrics scraping can be configured using the `osm metrics` command. By default, 
 For metrics to be scraped, the following prerequisites must be met:
 - The namespace must be a part of the mesh, ie. it must be labeled with the `openservicemesh.io/monitored-by` label with an appropriate mesh name. This can be done using the `osm namespace add` command.
 - A running service able to scrap Prometheus endpoints. OSM provides configuration for an [automatic bringup of Prometheus](#automatic-bring-up); alternatively users can [bring their own Prometheus](#byo-bring-your-own).
-- The `prometheus_scraping` config key in osm-controller's `osm-config` ConfigMap must be set to `"true"`. It is `"false"` by default.
+- The `prometheus_scraping` config key in osm-controller's `osm-config` ConfigMap must be set to `"true"`, which is the default configuration.
 
 
 To enable one or more namespaces for metrics scraping:

--- a/docs/patterns/observability/metrics.md
+++ b/docs/patterns/observability/metrics.md
@@ -15,7 +15,7 @@ OSM is able to automatically provision Prometheus and Grafana instances to monit
 ### Automatic bring up
 By default, both Prometheus and Grafana are disabled.
 
-However, when configured with the `--enable-prometheus-deployment` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `enable-grafana` flag to true when installing OSM using the `osm install` command.
+However, when configured with the `--deploy-grafana` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `deploy-grafana` flag to true when installing OSM using the `osm install` command.
 
 The automatic bring up can be overridden with the `osm install` option during install time:
 ```
@@ -23,8 +23,8 @@ osm install --help
 
 This command installs an osm control plane on the Kubernetes...
 ...
---enable-prometheus-deployment    Enable Prometheus deployment (default false)
---enable-grafana                  Enable Grafana deployment (default false)
+--deploy-prometheus               Enable Prometheus deployment (default false)
+--deploy-grafana                  Enable Grafana deployment (default false)
 ...
 ```
 

--- a/docs/patterns/observability/metrics.md
+++ b/docs/patterns/observability/metrics.md
@@ -13,8 +13,9 @@ Each service that is part of the mesh has an Envoy sidecar and is capable of exp
 OSM is able to automatically provision Prometheus and Grafana instances to monitor the mesh, however the user can choose not to, in favour of an already existing deployment or service (we will refer to the latter as Bring-Your-Own, or BYO)
 
 ### Automatic bring up
+By default, both Prometheus and Grafana are disabled.
 
-By default, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `enable-grafana` flag to true when installing OSM using the `osm install` command.
+However, when configured with the `--enable-prometheus` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `enable-grafana` flag to true when installing OSM using the `osm install` command.
 
 The automatic bring up can be overridden with the `osm install` option during install time:
 ```
@@ -22,7 +23,7 @@ osm install --help
 
 This command installs an osm control plane on the Kubernetes...
 ...
---enable-prometheus               Enable Prometheus deployment (default true)
+--enable-prometheus               Enable Prometheus deployment (default false)
 --enable-grafana                  Enable Grafana deployment (default false)
 ...
 ```
@@ -35,7 +36,7 @@ The following section will document the additional steps needed to allow an alre
 
 - Already running an accessible Prometheus instance *outside* of the mesh.
 - A running OSM control plane instance, deployed without metrics stack.
-   - OSM controls the Envoy's Prometheus listener aperture through `prometheus_scraping: "true"`, under OSM configmap. By default this is set to true, but do double check it has been enabled on the OSM configmap, or else Prometheus might not be able to reach the pods.
+   - OSM controls the Envoy's Prometheus listener aperture through `prometheus_scraping: "true"`, under OSM configmap. By default this is set to false (unless OSM was installed with Prometheus enabled.)
 - We will assume having Grafana reach Prometheus, exposing or forwarding Prometheus or Grafana web ports and configuring Prometheus to reach Kubernetes API services is taken care of or otherwise out of the scope of these steps.
 
 #### Configuration
@@ -115,7 +116,7 @@ Metrics scraping can be configured using the `osm metrics` command. By default, 
 For metrics to be scraped, the following prerequisites must be met:
 - The namespace must be a part of the mesh, ie. it must be labeled with the `openservicemesh.io/monitored-by` label with an appropriate mesh name. This can be done using the `osm namespace add` command.
 - A running service able to scrap Prometheus endpoints. OSM provides configuration for an [automatic bringup of Prometheus](#automatic-bring-up); alternatively users can [bring their own Prometheus](#byo-bring-your-own).
-- The `prometheus_scraping` config key in osm-controller's `osm-config` ConfigMap must be set to `"true"`, which is the default configuration.
+- The `prometheus_scraping` config key in osm-controller's `osm-config` ConfigMap must be set to `"true"`. It is `"false"` by default.
 
 
 To enable one or more namespaces for metrics scraping:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -140,6 +140,9 @@ const (
 	// EnvoyServiceNodeSeparator is the character separating the strings used to create an Envoy service node parameter.
 	// Example use: envoy --service-node 52883c80-6e0d-4c64-b901-cbcb75134949/bookstore/10.144.2.91/bookstore-v1/bookstore-v1
 	EnvoyServiceNodeSeparator = "/"
+
+	// OSMConfigMap is the name of the OSM ConfigMap
+	OSMConfigMap = "osm-config"
 )
 
 // Annotations used by the controller

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -419,8 +419,8 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		args = append(args, "--container-registry-secret="+registrySecretName)
 	}
 
-	args = append(args, fmt.Sprintf("--enable-prometheus-deployment=%v", instOpts.deployPrometheus))
-	args = append(args, fmt.Sprintf("--enable-grafana=%v", instOpts.deployGrafana))
+	args = append(args, fmt.Sprintf("--deploy-prometheus=%v", instOpts.deployPrometheus))
+	args = append(args, fmt.Sprintf("--deploy-grafana=%v", instOpts.deployGrafana))
 	args = append(args, fmt.Sprintf("--deploy-jaeger=%v", instOpts.deployJaeger))
 	args = append(args, fmt.Sprintf("--enable-fluentbit=%v", instOpts.deployFluentbit))
 	args = append(args, fmt.Sprintf("--timeout=%v", 90*time.Second))

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -419,7 +419,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		args = append(args, "--container-registry-secret="+registrySecretName)
 	}
 
-	args = append(args, fmt.Sprintf("--enable-prometheus=%v", instOpts.deployPrometheus))
+	args = append(args, fmt.Sprintf("--enable-prometheus-deployment=%v", instOpts.deployPrometheus))
 	args = append(args, fmt.Sprintf("--enable-grafana=%v", instOpts.deployGrafana))
 	args = append(args, fmt.Sprintf("--deploy-jaeger=%v", instOpts.deployJaeger))
 	args = append(args, fmt.Sprintf("--enable-fluentbit=%v", instOpts.deployFluentbit))


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This PR disables Prometheus by default in `osm install` but deploys prometheus by default for the demo only.

Fixes #1753 #1893 #1897 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No
