### PR TITLE
tests/e2e: rework NS cleanup

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -48,6 +49,8 @@ const (
 	defaultMeshName = "osm-system"
 	// default image tag
 	defaultImageTag = "latest"
+	// test tag prefix, for NS labeling
+	osmTest = "osmTest"
 )
 
 // OsmTestData stores common state, variables and flags for the test at hand
@@ -78,9 +81,6 @@ type OsmTestData struct {
 	client          *kubernetes.Clientset
 	smiClients      *smiClients
 	clusterProvider *cluster.Provider // provider, used when kindCluster is used
-
-	// Tracks namespaces to cleanup when test finishes (if cleanup is enabled)
-	cleanupNamespaces map[string]bool
 }
 
 // Function to run at init before Ginkgo has called parseFlags
@@ -102,6 +102,14 @@ func registerFlags(td *OsmTestData) {
 	flag.StringVar(&td.osmNamespace, "osmNamespace", utils.GetEnv("K8S_NAMESPACE", defaultMeshName), "OSM mesh name")
 }
 
+// GetTestSelectorMap returns a string-based selector used to refer/select all namespace
+// resources for this test
+func (td *OsmTestData) GetTestSelectorMap() map[string]string {
+	return map[string]string{
+		osmTest: fmt.Sprintf("%d", GinkgoRandomSeed()),
+	}
+}
+
 // AreRegistryCredsPresent checks if Registry Credentials are present
 // It's usually used to factor if a docker registry secret and ImagePullSecret
 // should be installed when creating namespaces and application templates
@@ -113,7 +121,6 @@ func (td *OsmTestData) AreRegistryCredsPresent() bool {
 // Called by Gingkgo BeforeEach
 func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 	td.T = t
-	td.cleanupNamespaces = make(map[string]bool)
 
 	if len(td.ctrRegistryServer) == 0 {
 		td.T.Errorf("Did not read any container registry (is CTR_REGISTRY set?)")
@@ -247,9 +254,6 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	}
 
 	var args []string
-
-	// Add OSM namespace to cleanup namespaces, in case the test can't init
-	td.cleanupNamespaces[instOpts.controlPlaneNS] = true
 
 	args = append(args, "install",
 		"--container-registry="+instOpts.containerRegistryLoc,
@@ -598,13 +602,12 @@ func (td *OsmTestData) CreateMultipleNs(nsName ...string) error {
 // CreateNs creates a Namespace. Will automatically add Docker registry creds if provided
 func (td *OsmTestData) CreateNs(nsName string, labels map[string]string) error {
 	if labels == nil {
-		labels = map[string]string{}
+		labels = td.GetTestSelectorMap()
+	} else {
+		for k, v := range td.GetTestSelectorMap() {
+			labels[k] = v
+		}
 	}
-
-	// For cleanup purposes, we mark this as present at this time.
-	// If the test can't run because there's the same namespace running, it's most
-	// likely that the user will want it gone anyway
-	td.cleanupNamespaces[nsName] = true
 
 	namespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -635,7 +638,6 @@ func (td *OsmTestData) DeleteNs(nsName string) error {
 
 	td.T.Logf("Deleting namespace %v", nsName)
 	err := td.client.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{PropagationPolicy: &backgroundDelete})
-	delete(td.cleanupNamespaces, nsName)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete namespace "+nsName)
 	}
@@ -645,7 +647,7 @@ func (td *OsmTestData) DeleteNs(nsName string) error {
 // WaitForNamespacesDeleted waits for the namespaces to be deleted.
 // Reference impl taken from https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/util.go#L258
 func (td *OsmTestData) WaitForNamespacesDeleted(namespaces []string, timeout time.Duration) error {
-	By(fmt.Sprintf("Waiting for namespaces %+v to vanish", namespaces))
+	By(fmt.Sprintf("Waiting for namespaces %v to vanish", namespaces))
 	nsMap := map[string]bool{}
 	for _, ns := range namespaces {
 		nsMap[ns] = true
@@ -795,25 +797,43 @@ const (
 
 // Cleanup is Used to cleanup resorces once the test is done
 func (td *OsmTestData) Cleanup(ct CleanupType) {
-	// In-cluster Test resources cleanup(namespace, crds, specs and whatnot) here
-	if td.cleanupTest {
-		var nsList []string
-		for ns := range td.cleanupNamespaces {
-			err := td.DeleteNs(ns)
-			if err != nil {
-				td.T.Logf("(warn) delete ns %s err: %v", ns, err)
-			}
-			nsList = append(nsList, ns)
+	// Small speedup: avoid graceful/wait delete of k8s resources on kind if the cluster is destined to be
+	// trashed anyway
+	if td.cleanupTest &&
+		(!td.kindCluster ||
+			(td.kindCluster &&
+				(ct == Test && !td.cleanupKindClusterBetweenTests) ||
+				(ct == Suite && !td.cleanupKindCluster))) {
+		// Use selector to refer to all namespaces used in this test
+		nsSelector := metav1.ListOptions{
+			LabelSelector: labels.SelectorFromSet(td.GetTestSelectorMap()).String(),
 		}
 
-		if len(nsList) > 0 && td.waitForCleanup {
-			// on kind this can take a while apparently
-			err := td.WaitForNamespacesDeleted(nsList, 240*time.Second)
+		testNs, err := td.client.CoreV1().Namespaces().List(context.Background(), nsSelector)
+		if err != nil {
+			td.T.Fatalf("Failed to get list of test NS: %v", err)
+		}
+
+		for _, ns := range testNs.Items {
+			err := td.DeleteNs(ns.Name)
 			if err != nil {
-				td.T.Logf("Could not confirm all namespace deletion in time: %v", err)
+				td.T.Logf("Err deleting ns %s: %v", ns.Name, err)
+				continue
 			}
 		}
-		td.cleanupNamespaces = map[string]bool{}
+		By(fmt.Sprintf("[Cleanup] waiting for %s:%d test NS cleanup", osmTest, GinkgoRandomSeed()))
+		if td.waitForCleanup {
+			wait.Poll(2*time.Second, 240*time.Second,
+				func() (bool, error) {
+					nsList, err := td.client.CoreV1().Namespaces().List(context.TODO(), nsSelector)
+					if err != nil {
+						td.T.Logf("Err waiting for ns list to disappear: %v", err)
+						return false, err
+					}
+					return len(nsList.Items) == 0, nil
+				},
+			)
+		}
 	}
 
 	// Kind cluster deletion, if needed

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -823,7 +823,7 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 		}
 		By(fmt.Sprintf("[Cleanup] waiting for %s:%d test NS cleanup", osmTest, GinkgoRandomSeed()))
 		if td.waitForCleanup {
-			wait.Poll(2*time.Second, 240*time.Second,
+			err := wait.Poll(2*time.Second, 240*time.Second,
 				func() (bool, error) {
 					nsList, err := td.client.CoreV1().Namespaces().List(context.TODO(), nsSelector)
 					if err != nil {
@@ -833,6 +833,9 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 					return len(nsList.Items) == 0, nil
 				},
 			)
+			if err != nil {
+				td.T.Logf("Poll err: %v", err)
+			}
 		}
 	}
 

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -31,13 +31,6 @@ var _ = Describe("Test HTTP traffic from N deployment client -> 1 deployment ser
 		}
 
 		It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
-			// We populate test namespaces in advance, to not have to clean one by one each test run
-			// This is just for convenience
-			td.cleanupNamespaces["server"] = true
-			for _, srcClient := range sourceNamespaces {
-				td.cleanupNamespaces[srcClient] = true
-			}
-
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
 			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -51,11 +51,6 @@ var _ = Describe("Test TrafficSplit where each backend shares the same ServiceAc
 		var wg sync.WaitGroup
 
 		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
-			// For Cleanup only
-			for _, ns := range allNamespaces {
-				td.cleanupNamespaces[ns] = true
-			}
-
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
 			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -50,11 +50,6 @@ var _ = Describe("Test HTTP from N Clients deployments to 1 Server deployment ba
 		var wg sync.WaitGroup
 
 		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
-			// For Cleanup only
-			for _, ns := range allNamespaces {
-				td.cleanupNamespaces[ns] = true
-			}
-
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
 			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())


### PR DESCRIPTION
Removed some of the cumbersomeness from the namespace cleaning
code.

All created testing NS, for a given test, will now be tagged with `osmTest`
as label, and the random seed used by Ginkgo as value.

On test cleanup, only tests matching that specific label (and label value)
will be cleaned up.

When a test error occurs and cleanup can't be done (because of some major
error condition that prevents cleanup from executing altogether),
stale test applications and config can be left behind.

From now on, this can be easily addressed and cleanup using something like:

`kubectl delete namespaces -l osmTest`

Additionally, with Kind, will avoid K8s test cleanup if the kind setup
is about to be trashed anyway (saving some precious time on big tests).

**Affected area**:

- Tests                  [X]
- CI System              [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No