### PR TITLE
cli: expose portforwarding capability and refactor dashboard cmd

### DIFF
--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -106,7 +106,10 @@ func (d *dashboardCmd) run() error {
 	// Select pod/s given the service data available
 	set := labels.Set(svc.Spec.Selector)
 	listOptions := metav1.ListOptions{LabelSelector: set.AsSelector().String()}
-	pods, _ := v1ClientSet.Pods(settings.Namespace()).List(context.TODO(), listOptions)
+	pods, err := v1ClientSet.Pods(settings.Namespace()).List(context.TODO(), listOptions)
+	if err != nil {
+		return errors.Errorf("Error listing pods: %s", err)
+	}
 
 	// Will select first running Pod available
 	var grafanaPod *corev1.Pod

--- a/cmd/cli/portforward.go
+++ b/cmd/cli/portforward.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+// PortForwarder is a type that implements port forwarding to a pod
+type PortForwarder struct {
+	forwarder *portforward.PortForwarder
+	stopChan  chan struct{}
+	readyChan <-chan struct{}
+}
+
+// NewPortForwarder creates a new port forwarder to a pod
+func NewPortForwarder(conf *rest.Config, clientSet kubernetes.Interface, podName string, namespace string, localPort uint16, remotePort uint16) (*PortForwarder, error) {
+	roundTripper, upgrader, err := spdy.RoundTripperFor(conf)
+	if err != nil {
+		return nil, errors.Errorf("Error setting up round tripper for port forwarding: %s", err)
+	}
+
+	serverURL := clientSet.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(settings.Namespace()).
+		Name(podName).
+		SubResource("portforward").URL()
+
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: roundTripper}, http.MethodPost, serverURL)
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, remotePort)}, stopChan, readyChan, ioutil.Discard, os.Stderr)
+	if err != nil {
+		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+	}
+
+	// Check if the pod exists in the given namespace
+	pod, err := clientSet.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, errors.Errorf("Error retrieving pod %s in namespace %s: %s", podName, namespace, err)
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		return nil, errors.Errorf("Pod %s in namespace %s needs to be running before port forwarding, status is %s", podName, namespace, pod.Status.Phase)
+	}
+
+	return &PortForwarder{
+		forwarder: forwarder,
+		stopChan:  stopChan,
+		readyChan: readyChan,
+	}, nil
+}
+
+// Start starts the port forwarding and calls the readyFunc callback function when port forwarding is ready
+func (pf *PortForwarder) Start(readyFunc func(pf *PortForwarder) error) error {
+	// Set up a channel to process OS signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	defer signal.Stop(sigChan)
+
+	// Set up a channel to process forwarding errors
+	errChan := make(chan error, 1)
+
+	// Set up forwarding, and relay errors to errChan so that caller is able to handle it
+	go func() {
+		err := pf.forwarder.ForwardPorts()
+		errChan <- err
+	}()
+
+	// Stop forwarding in case OS signals are received
+	go func() {
+		<-sigChan
+		if pf.stopChan != nil {
+			close(pf.stopChan)
+		}
+	}()
+
+	// Process signals and call readyFunc
+	select {
+	case <-pf.readyChan:
+		if err := readyFunc(pf); err != nil {
+			return err
+		}
+		return nil
+
+	case err := <-errChan:
+		return errors.Errorf("Error during port forwarding: %s", err)
+
+	case <-pf.stopChan:
+		return nil
+	}
+}
+
+// Stop stops the port forwarding if not stopped already
+func (pf *PortForwarder) Stop() {
+	if pf.stopChan != nil {
+		close(pf.stopChan)
+	}
+}

--- a/cmd/cli/portforward.go
+++ b/cmd/cli/portforward.go
@@ -89,10 +89,7 @@ func (pf *PortForwarder) Start(readyFunc func(pf *PortForwarder) error) error {
 	// Process signals and call readyFunc
 	select {
 	case <-pf.readyChan:
-		if err := readyFunc(pf); err != nil {
-			return err
-		}
-		return nil
+		return readyFunc(pf)
 
 	case err := <-errChan:
 		return errors.Errorf("Error during port forwarding: %s", err)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change exposes port forwarding capability generically
(previously implemented in the dashboard cmd) 
so that other commands that require to port forward to a pod
can leverage this. It updates the dashboard cmd to leverage
the generic port forwarder.

A subsequent change that requires port forwarding from the cli
will also leverage the newly added port forwarding APIs.

There also doesn't seem to be a trivial way to mock
port forwarding to a pod, so this will likely have to be
tested using e2e for automated tests.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`