### PR TITLE
cli: remove deprecated code and fix namespace usage with portforwarding

### DIFF
--- a/cmd/cli/portforward.go
+++ b/cmd/cli/portforward.go
@@ -33,7 +33,7 @@ func NewPortForwarder(conf *rest.Config, clientSet kubernetes.Interface, podName
 
 	serverURL := clientSet.CoreV1().RESTClient().Post().
 		Resource("pods").
-		Namespace(settings.Namespace()).
+		Namespace(namespace).
 		Name(podName).
 		SubResource("portforward").URL()
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes deprecated code in dashboard.go and fixes the portforwarding
code to use the correct namespace.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`