### PR TITLE
fix(e2e): cleanup helm releases in e2e

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -635,6 +635,25 @@ func (td *OsmTestData) CreateNs(nsName string, labels map[string]string) error {
 
 // DeleteNs deletes a test NS
 func (td *OsmTestData) DeleteNs(nsName string) error {
+	// Delete Helm releases created in the namespace
+	helm := &action.Configuration{}
+	if err := helm.Init(td.env.RESTClientGetter(), nsName, "secret", td.T.Logf); err != nil {
+		td.T.Logf("WARNING: failed to initialize helm config, skipping helm cleanup: %v", err)
+	} else {
+		list := action.NewList(helm)
+		list.All = true
+		if releases, err := list.Run(); err != nil {
+			td.T.Logf("WARNING: failed to list helm releases in namespace %s, skipping release cleanup: %v", nsName, err)
+		} else {
+			del := action.NewUninstall(helm)
+			for _, release := range releases {
+				if _, err := del.Run(release.Name); err != nil {
+					td.T.Logf("WARNING: failed to delete helm release %s in namespace %s: %v", release.Name, nsName, err)
+				}
+			}
+		}
+	}
+
 	var backgroundDelete metav1.DeletionPropagation = metav1.DeletePropagationBackground
 
 	td.T.Logf("Deleting namespace %v", nsName)
@@ -820,26 +839,7 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 		}
 
 		for _, ns := range testNs.Items {
-			// Delete Helm releases created in the namespace
-			helm := &action.Configuration{}
-			if err := helm.Init(td.env.RESTClientGetter(), ns.Name, "secret", td.T.Logf); err != nil {
-				td.T.Logf("WARNING: failed to initialize helm config, skipping helm cleanup: %v", err)
-			} else {
-				list := action.NewList(helm)
-				list.All = true
-				if releases, err := list.Run(); err != nil {
-					td.T.Logf("WARNING: failed to list helm releases in namespace %s, skipping release cleanup: %v", ns.Name, err)
-				} else {
-					del := action.NewUninstall(helm)
-					for _, release := range releases {
-						if _, err := del.Run(release.Name); err != nil {
-							td.T.Logf("WARNING: failed to delete helm release %s in namespace %s: %v", release.Name, ns.Name, err)
-						}
-					}
-				}
-			}
-
-			err = td.DeleteNs(ns.Name)
+			err := td.DeleteNs(ns.Name)
 			if err != nil {
 				td.T.Logf("Err deleting ns %s: %v", ns.Name, err)
 				continue

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -15,8 +15,6 @@ var _ = Describe("1 Client pod -> 1 Server pod test using cert-manager", func() 
 		var ns []string = []string{sourceNs, destNs}
 
 		It("Tests HTTP traffic for client pod -> server pod", func() {
-			Skip("Needs fix: https://github.com/openservicemesh/osm/issues/1880")
-
 			// Install OSM
 			installOpts := td.GetOSMInstallOpts()
 			installOpts.certManager = "cert-manager"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change will uninstall all Helm releases in the namespaces being
cleaned up before deleting the namespaces to avoid the namespaces
getting stuck in a Terminating state.

Fixes #1880
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No