### PR TITLE
cli: rename global namespace flag

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -32,10 +32,10 @@ wide Kubernetes resources.
 
 The default Kubernetes namespace that gets created on install is called
 osm-system. To create an install control plane components in a different
-namespace, use the --namespace flag.
+namespace, use the global --osm-namespace flag.
 
 Example:
-  $ osm install --namespace hello-world
+  $ osm install --osm-namespace hello-world
 
 Multiple control plane installations can exist within a cluster. Each
 control plane is given a cluster-wide unqiue identifier called mesh name.
@@ -346,5 +346,5 @@ func errMeshAlreadyExists(name string) error {
 }
 
 func errNamespaceAlreadyHasController(namespace string) error {
-	return errors.Errorf("Namespace %s has an osm controller. Please specify a new namespace using --namespace", namespace)
+	return errors.Errorf("Namespace %s has an osm controller. Please specify a new namespace using --osm-namespace", namespace)
 }

--- a/demo/clean-kubernetes.sh
+++ b/demo/clean-kubernetes.sh
@@ -5,7 +5,7 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-bin/osm mesh uninstall -f --mesh-name "$MESH_NAME" --namespace "$K8S_NAMESPACE"
+bin/osm mesh uninstall -f --mesh-name "$MESH_NAME" --osm-namespace "$K8S_NAMESPACE"
 
 for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" "$K8S_NAMESPACE"; do
     kubectl delete namespace "$ns" --ignore-not-found --wait &

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -112,7 +112,7 @@ echo "Certificate Manager in use: $CERT_MANAGER"
 if [ "$CERT_MANAGER" = "vault" ]; then
   # shellcheck disable=SC2086
   bin/osm install \
-      --namespace "$K8S_NAMESPACE" \
+      --osm-namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
       --certificate-manager="$CERT_MANAGER" \
       --vault-host="$VAULT_HOST" \
@@ -130,7 +130,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
 else
   # shellcheck disable=SC2086
   bin/osm install \
-      --namespace "$K8S_NAMESPACE" \
+      --osm-namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
       --certificate-manager="$CERT_MANAGER" \
       --container-registry "$CTR_REGISTRY" \

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -82,7 +82,7 @@ func envOr(name, defaultVal string) string {
 
 // AddFlags binds flags to the given flagset.
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&s.namespace, "namespace", "n", s.namespace, "namespace for osm control plane")
+	fs.StringVar(&s.namespace, "osm-namespace", s.namespace, "namespace for osm control plane")
 }
 
 // EnvVars returns a map of all OSM related environment variables

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -25,7 +25,8 @@ var _ = Describe("New", func() {
 	It("sets the namespace from the flag", func() {
 		settings := New()
 		settings.AddFlags(flags)
-		flags.Parse([]string{"--namespace=osm-ns"})
+		err := flags.Parse([]string{"--osm-namespace=osm-ns"})
+		Expect(err).To(BeNil())
 		Expect(settings.Namespace()).To(Equal("osm-ns"))
 	})
 
@@ -45,7 +46,8 @@ var _ = Describe("New", func() {
 
 		settings := New()
 		settings.AddFlags(flags)
-		flags.Parse([]string{"--namespace=osm-ns"})
+		err := flags.Parse([]string{"--osm-namespace=osm-ns"})
+		Expect(err).To(BeNil())
 		Expect(settings.Namespace()).To(Equal("osm-ns"))
 	})
 })

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -259,7 +259,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	args = append(args, "install",
 		"--container-registry="+instOpts.containerRegistryLoc,
 		"--osm-image-tag="+instOpts.osmImagetag,
-		"--namespace="+instOpts.controlPlaneNS,
+		"--osm-namespace="+instOpts.controlPlaneNS,
 		"--certificate-manager="+instOpts.certManager,
 		"--enable-egress="+strconv.FormatBool(instOpts.egressEnabled),
 		"--enable-permissive-traffic-policy="+strconv.FormatBool(instOpts.enablePermissiveMode),
@@ -572,7 +572,6 @@ func (td *OsmTestData) AddNsToMesh(sidecardInject bool, ns ...string) error {
 			args = append(args, "--enable-sidecar-injection")
 		}
 
-		args = append(args, "--namespace="+td.osmNamespace)
 		stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args)
 		if err != nil {
 			td.T.Logf("error running osm namespace add")


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change is an RFC to discuss the proposal
to rename the global namespace flag exposed in
osm cli, which reflects the control plane namespace.
The reason to do so is because local command flags
could also expose a namespace flag, which don't
show up in the help text for the command. Moreover,
the global namespace flag isn't used by several
commands (ex. osm metrics, osm proxy etc.).

The proposal is to rename the global flag to represent
OSM's namespace to `osm-namespace` so that local
commands wanting to expose `namespace` as a flag can
do so with command specific description.

Part of #1884

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`