### PR TITLE
injector: Augment log messages with admission request details

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -10,7 +10,7 @@ webhooks:
     service:
       name: osm-controller
       namespace: {{.Release.Namespace}}
-      path: /mutate
+      path: /create/pod
       port: 443
   failurePolicy: Fail
   matchPolicy: Exact

--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -10,7 +10,7 @@ webhooks:
     service:
       name: osm-controller
       namespace: {{.Release.Namespace}}
-      path: /create/pod
+      path: /mutate-pod-creation
       port: 443
   failurePolicy: Fail
   matchPolicy: Exact

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -785,7 +785,7 @@ var _ = Describe("Resolving values for install command with vault parameters", f
 			enableGrafana:               false,
 			enableFluentbit:             false,
 
-			envoyLogLevel:               testEnvoyLogLevel,
+			envoyLogLevel: testEnvoyLogLevel,
 		}
 
 		vals, err = installCmd.resolveValues()

--- a/pkg/injector/config_test.go
+++ b/pkg/injector/config_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -113,8 +114,9 @@ static_resources:
 
 		It("Creates bootstrap config for the Envoy proxy", func() {
 			wh := &webhook{
-				kubeClient:     fake.NewSimpleClientset(),
-				kubeController: k8s.NewMockController(gomock.NewController(GinkgoT())),
+				kubeClient:          fake.NewSimpleClientset(),
+				kubeController:      k8s.NewMockController(gomock.NewController(GinkgoT())),
+				nonInjectNamespaces: mapset.NewSet(),
 			}
 			name := uuid.New().String()
 			namespace := "a"

--- a/pkg/injector/errors.go
+++ b/pkg/injector/errors.go
@@ -3,7 +3,8 @@ package injector
 import "github.com/pkg/errors"
 
 var (
-	errNamespaceNotFound   = errors.New("namespace not found")
-	errParseWebhookTimeout = errors.New("could not read webhook timeout")
-	errNilAdmissionRequest = errors.New("nil admission request")
+	errNamespaceNotFound         = errors.New("namespace not found")
+	errParseWebhookTimeout       = errors.New("could not read webhook timeout")
+	errNilAdmissionRequest       = errors.New("nil admission request")
+	errEmptyAdmissionRequestBody = errors.New("empty request admission request body")
 )

--- a/pkg/injector/errors.go
+++ b/pkg/injector/errors.go
@@ -5,4 +5,5 @@ import "github.com/pkg/errors"
 var (
 	errNamespaceNotFound   = errors.New("namespace not found")
 	errParseWebhookTimeout = errors.New("could not read webhook timeout")
+	errNilAdmissionRequest = errors.New("nil admission request")
 )

--- a/pkg/injector/metrics_test.go
+++ b/pkg/injector/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -67,8 +68,9 @@ func TestIsMetricsEnabled(t *testing.T) {
 
 	mockController := k8s.NewMockController(gomock.NewController(t))
 	wh := &webhook{
-		kubeClient:     fakeClient,
-		kubeController: mockController,
+		kubeClient:          fakeClient,
+		kubeController:      mockController,
+		nonInjectNamespaces: mapset.NewSet(),
 	}
 
 	mockController.EXPECT().GetNamespace("ns-1").Return(nsWithMetrics)

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
@@ -184,11 +185,12 @@ var _ = Describe("Test all patch operations", func() {
 			cache := make(map[certificate.CommonName]certificate.Certificater)
 
 			wh := &webhook{
-				kubeClient:     client,
-				kubeController: mockNsController,
-				certManager:    tresor.NewFakeCertManager(&cache, mockConfigurator),
-				meshCatalog:    catalog.NewFakeMeshCatalog(client),
-				configurator:   mockConfigurator,
+				kubeClient:          client,
+				kubeController:      mockNsController,
+				certManager:         tresor.NewFakeCertManager(&cache, mockConfigurator),
+				meshCatalog:         catalog.NewFakeMeshCatalog(client),
+				configurator:        mockConfigurator,
+				nonInjectNamespaces: mapset.NewSet(),
 			}
 
 			pod := tests.NewPodTestFixture(namespace, podName)

--- a/pkg/injector/profiling_test.go
+++ b/pkg/injector/profiling_test.go
@@ -15,12 +15,12 @@ func TestReadTimeout(t *testing.T) {
 	assert := assert.New(t)
 
 	expectedResults := map[string]bool{
-		"/mutate?timeout=30s":            true,
-		"/mutate?timeout=20h":            true,
-		"/mutate?timeout=s":              false,
-		"/mutate?":                       false,
-		"/mutate?timeout=20&timeout=30m": false,
-		"randomString":                   false,
+		"/create/pod?timeout=30s":            true,
+		"/create/pod?timeout=20h":            true,
+		"/create/pod?timeout=s":              false,
+		"/create/pod?":                       false,
+		"/create/pod?timeout=20&timeout=30m": false,
+		"randomString":                       false,
 	}
 
 	for url, expectedRes := range expectedResults {

--- a/pkg/injector/profiling_test.go
+++ b/pkg/injector/profiling_test.go
@@ -15,12 +15,12 @@ func TestReadTimeout(t *testing.T) {
 	assert := assert.New(t)
 
 	expectedResults := map[string]bool{
-		"/create/pod?timeout=30s":            true,
-		"/create/pod?timeout=20h":            true,
-		"/create/pod?timeout=s":              false,
-		"/create/pod?":                       false,
-		"/create/pod?timeout=20&timeout=30m": false,
-		"randomString":                       false,
+		"/mutate-pod-creation?timeout=30s":            true,
+		"/mutate-pod-creation?timeout=20h":            true,
+		"/mutate-pod-creation?timeout=s":              false,
+		"/mutate-pod-creation?":                       false,
+		"/mutate-pod-creation?timeout=20&timeout=30m": false,
+		"randomString":                                false,
 	}
 
 	for url, expectedRes := range expectedResults {

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -1,6 +1,7 @@
 package injector
 
 import (
+	mapset "github.com/deckarep/golang-set"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -26,6 +27,8 @@ type webhook struct {
 	osmNamespace   string
 	cert           certificate.Certificater
 	configurator   configurator.Configurator
+
+	nonInjectNamespaces mapset.Set
 }
 
 // Config is the type used to represent the config options for the sidecar injection
@@ -41,7 +44,7 @@ type Config struct {
 	SidecarImage string
 }
 
-// JSONPatchOperation is the type used to represenet a JSON Patch operation
+// JSONPatchOperation defines a Kubernetes JSON Patch operation
 type JSONPatchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -94,8 +94,11 @@ func (wh *webhook) run(stop <-chan struct{}) {
 	defer cancel()
 
 	mux := http.DefaultServeMux
+
 	mux.HandleFunc(WebhookHealthPath, healthHandler)
-	// We know that the events arriving
+
+	// We know that the events arriving at this handler are CREATE POD only
+	// because of the specifics of MutatingWebhookConfiguration template in this repository.
 	mux.HandleFunc(webhookCreatePod, wh.podCreationHandler)
 
 	server := &http.Server{

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -41,7 +41,7 @@ const (
 	mutatingWebhookName = "osm-inject.k8s.io"
 
 	// webhookCreatePod is the HTTP path at which the webhook expects to receive pod creation events
-	webhookCreatePod = "/create/pod"
+	webhookCreatePod = "/mutate-pod-creation"
 
 	// WebhookHealthPath is the HTTP path at which the health of the webhook can be queried
 	WebhookHealthPath = "/healthz"


### PR DESCRIPTION
While running OSM I noticed an `Info` level message in the OSM Controller pod:

```json
{
  "level": "info",
  "component": "sidecar-injector",
  "time": "2020-10-19T23:46:59Z",
  "file": "webhook.go:208",
  "message": "Skipping sidecar injection"
}
```

The message stated what was already obvious to me:  a newly created pod was not injected with an Envoy sidecar. 

This PR adds a bit more context to the error messages in the Injector package.  Where possible we should show the namespace and pod. A log message that contains the exact object that was skipped for annotation would make it a bit easier to then search logs for that pod name to understand why.

Examples of new augmented log messages:
```json
{
  "level": "trace",
  "component": "sidecar-injector",
  "time": "2020-10-22T01:51:07Z",
  "file": "webhook.go:222",
  "message": "Done creating patch admission response for pod with UUID 269b5308-edea-46fe-b90b-3beb7a10c867 in namespace bookstore"
}
```
---

Also in this PR:
  - changing the log level of some messages to more appropriate levels -- goal is to lower the volume of logs at level `Info`
  - renamed `toAdmissionError` to `admissionError`
  - simplified webhook health handler
  - converted `kubeSystemNamespaces` to a map
 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
