### PR TITLE
feat(charts): validate chart values w/ json schema

### DIFF
--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -11,7 +11,6 @@
             "type": "object",
             "title": "The OpenServiceMesh schema",
             "description": "The top level required key in the values file.",
-            "default": {},
             "required": [
                 "replicaCount",
                 "image",
@@ -38,7 +37,6 @@
                     "type": "integer",
                     "title": "The replicaCount schema",
                     "description": "The number of replicas of the osm-controller Pod.",
-                    "default": 1,
                     "examples": [
                         1
                     ]
@@ -48,7 +46,6 @@
                     "type": "object",
                     "title": "The image schema",
                     "description": "The details of the images to run.",
-                    "default": {},
                     "examples": [
                         {
                             "registry": "openservicemesh",
@@ -67,7 +64,6 @@
                             "type": "string",
                             "title": "The registry schema",
                             "description": "The registry of the images to run.",
-                            "default": "openservicemesh",
                             "examples": [
                                 "openservicemesh"
                             ]
@@ -77,7 +73,6 @@
                             "type": "string",
                             "title": "The pullPolicy schema",
                             "description": "The image pull policy.",
-                            "default": "IfNotPresent",
                             "pattern": "^(Always|Never|IfNotPresent)$",
                             "examples": [
                                 "IfNotPresent"
@@ -88,7 +83,6 @@
                             "type": "string",
                             "title": "The tag schema",
                             "description": "The image tag to run.",
-                            "default": "",
                             "examples": [
                                 "v0.4.2"
                             ]
@@ -101,7 +95,6 @@
                     "type": "string",
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
-                    "default": "",
                     "examples": [
                         "envoyproxy/envoy-alpine:v1.15.0"
                     ]
@@ -111,7 +104,6 @@
                     "type": "string",
                     "title": "The certificateManager schema",
                     "description": "The certificate manager osm-controller should use.",
-                    "default": "",
                     "pattern": "^(tresor|vault|cert-manager)$",
                     "examples": [
                         "tresor"
@@ -122,7 +114,6 @@
                     "type": "string",
                     "title": "The serviceCertValidityDuration schema",
                     "description": "The service certificate validity duration.",
-                    "default": "24h",
                     "examples": [
                         "24h"
                     ]
@@ -132,7 +123,6 @@
                     "type": "string",
                     "title": "The caBundleSecretName schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": "osm-ca-bundle",
                     "examples": [
                         "osm-ca-bundle"
                     ]
@@ -142,7 +132,6 @@
                     "type": "boolean",
                     "title": "The enableDebugServer schema",
                     "description": "Indicates whether the Debug Server should be enabled or not.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -152,7 +141,6 @@
                     "type": "boolean",
                     "title": "The enablePermissiveTrafficPolicy schema",
                     "description": "Indicates whether permissive traffic policy should be enabled or not.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -162,7 +150,6 @@
                     "type": "boolean",
                     "title": "The enableBackpressureExperimental schema",
                     "description": "Indicates whether the experimental backpressure policy should be enabled or not.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -172,7 +159,6 @@
                     "type": "boolean",
                     "title": "The enableEgress schema",
                     "description": "Indicates whether egress should be enabled or not.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -182,7 +168,6 @@
                     "type": "boolean",
                     "title": "The enablePrometheus schema",
                     "description": "Indicates whether Prometheus should be installed and configured as part of the osm control plane.",
-                    "default": false,
                     "examples": [
                         true
                     ]
@@ -192,7 +177,6 @@
                     "type": "boolean",
                     "title": "The enableGrafana schema",
                     "description": "Indicates whether Grafana should be installed and configured as part of the osm control plane.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -202,7 +186,6 @@
                     "type": "string",
                     "title": "The meshName schema",
                     "description": "The name associated with the control plane being installed.",
-                    "default": "",
                     "examples": [
                         "osm"
                     ]
@@ -212,7 +195,6 @@
                     "type": "boolean",
                     "title": "The useHTTPSIngress schema",
                     "description": "Indicates whether HTTPS Ingress should be enabled or not.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -222,7 +204,7 @@
                     "type": "string",
                     "title": "The envoyLogLevel schema",
                     "description": "Envoy log level.",
-                    "default": "error",
+                    "pattern": "^(trace|debug|info|warning|warn|error|critical|off)$",
                     "examples": [
                         "error"
                     ]
@@ -232,7 +214,6 @@
                     "type": "boolean",
                     "title": "The enforceSingleMesh schema",
                     "description": "Enforce only running a single control plane within a cluster.",
-                    "default": false,
                     "examples": [
                         false
                     ]
@@ -242,7 +223,6 @@
                     "type": "boolean",
                     "title": "The deployJaeger schema",
                     "description": "Indicates whether Jaeger should be installed and configured as part of the control plane.",
-                    "default": false,
                     "examples": [
                         true
                     ]
@@ -252,7 +232,6 @@
                     "type": "object",
                     "title": "The tracing schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "default": {},
                     "examples": [
                         {
                             "enable": true
@@ -267,7 +246,6 @@
                             "type": "boolean",
                             "title": "The enable schema",
                             "description": "Indicates whether tracing is enabled or not.",
-                            "default": false,
                             "examples": [
                                 true
                             ]

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1,0 +1,283 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "title": "The OSM Helm chart values schema",
+    "required": [
+        "OpenServiceMesh"
+    ],
+    "properties": {
+        "OpenServiceMesh": {
+            "$id": "#/properties/OpenServiceMesh",
+            "type": "object",
+            "title": "The OpenServiceMesh schema",
+            "description": "The top level required key in the values file.",
+            "default": {},
+            "required": [
+                "replicaCount",
+                "image",
+                "sidecarImage",
+                "certificateManager",
+                "serviceCertValidityDuration",
+                "caBundleSecretName",
+                "enableDebugServer",
+                "enablePermissiveTrafficPolicy",
+                "enableBackpressureExperimental",
+                "enableEgress",
+                "enablePrometheus",
+                "enableGrafana",
+                "meshName",
+                "useHTTPSIngress",
+                "envoyLogLevel",
+                "enforceSingleMesh",
+                "deployJaeger",
+                "tracing"
+            ],
+            "properties": {
+                "replicaCount": {
+                    "$id": "#/properties/OpenServiceMesh/properties/replicaCount",
+                    "type": "integer",
+                    "title": "The replicaCount schema",
+                    "description": "The number of replicas of the osm-controller Pod.",
+                    "default": 1,
+                    "examples": [
+                        1
+                    ]
+                },
+                "image": {
+                    "$id": "#/properties/OpenServiceMesh/properties/image",
+                    "type": "object",
+                    "title": "The image schema",
+                    "description": "The details of the images to run.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "registry": "openservicemesh",
+                            "pullPolicy": "IfNotPresent",
+                            "tag": "v0.4.2"
+                        }
+                    ],
+                    "required": [
+                        "registry",
+                        "pullPolicy",
+                        "tag"
+                    ],
+                    "properties": {
+                        "registry": {
+                            "$id": "#/properties/OpenServiceMesh/properties/image/properties/registry",
+                            "type": "string",
+                            "title": "The registry schema",
+                            "description": "The registry of the images to run.",
+                            "default": "openservicemesh",
+                            "examples": [
+                                "openservicemesh"
+                            ]
+                        },
+                        "pullPolicy": {
+                            "$id": "#/properties/OpenServiceMesh/properties/image/properties/pullPolicy",
+                            "type": "string",
+                            "title": "The pullPolicy schema",
+                            "description": "The image pull policy.",
+                            "default": "IfNotPresent",
+                            "pattern": "^(Always|Never|IfNotPresent)$",
+                            "examples": [
+                                "IfNotPresent"
+                            ]
+                        },
+                        "tag": {
+                            "$id": "#/properties/OpenServiceMesh/properties/image/properties/tag",
+                            "type": "string",
+                            "title": "The tag schema",
+                            "description": "The image tag to run.",
+                            "default": "",
+                            "examples": [
+                                "v0.4.2"
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
+                },
+                "sidecarImage": {
+                    "$id": "#/properties/OpenServiceMesh/properties/sidecarImage",
+                    "type": "string",
+                    "title": "The sidecarImage schema",
+                    "description": "The proxy side car image to run.",
+                    "default": "",
+                    "examples": [
+                        "envoyproxy/envoy-alpine:v1.15.0"
+                    ]
+                },
+                "certificateManager": {
+                    "$id": "#/properties/OpenServiceMesh/properties/certificateManager",
+                    "type": "string",
+                    "title": "The certificateManager schema",
+                    "description": "The certificate manager osm-controller should use.",
+                    "default": "",
+                    "pattern": "^(tresor|vault|cert-manager)$",
+                    "examples": [
+                        "tresor"
+                    ]
+                },
+                "serviceCertValidityDuration": {
+                    "$id": "#/properties/OpenServiceMesh/properties/serviceCertValidityDuration",
+                    "type": "string",
+                    "title": "The serviceCertValidityDuration schema",
+                    "description": "The service certificate validity duration.",
+                    "default": "24h",
+                    "examples": [
+                        "24h"
+                    ]
+                },
+                "caBundleSecretName": {
+                    "$id": "#/properties/OpenServiceMesh/properties/caBundleSecretName",
+                    "type": "string",
+                    "title": "The caBundleSecretName schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": "osm-ca-bundle",
+                    "examples": [
+                        "osm-ca-bundle"
+                    ]
+                },
+                "enableDebugServer": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enableDebugServer",
+                    "type": "boolean",
+                    "title": "The enableDebugServer schema",
+                    "description": "Indicates whether the Debug Server should be enabled or not.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "enablePermissiveTrafficPolicy": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enablePermissiveTrafficPolicy",
+                    "type": "boolean",
+                    "title": "The enablePermissiveTrafficPolicy schema",
+                    "description": "Indicates whether permissive traffic policy should be enabled or not.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "enableBackpressureExperimental": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enableBackpressureExperimental",
+                    "type": "boolean",
+                    "title": "The enableBackpressureExperimental schema",
+                    "description": "Indicates whether the experimental backpressure policy should be enabled or not.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "enableEgress": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enableEgress",
+                    "type": "boolean",
+                    "title": "The enableEgress schema",
+                    "description": "Indicates whether egress should be enabled or not.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "enablePrometheus": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enablePrometheus",
+                    "type": "boolean",
+                    "title": "The enablePrometheus schema",
+                    "description": "Indicates whether Prometheus should be installed and configured as part of the osm control plane.",
+                    "default": false,
+                    "examples": [
+                        true
+                    ]
+                },
+                "enableGrafana": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enableGrafana",
+                    "type": "boolean",
+                    "title": "The enableGrafana schema",
+                    "description": "Indicates whether Grafana should be installed and configured as part of the osm control plane.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "meshName": {
+                    "$id": "#/properties/OpenServiceMesh/properties/meshName",
+                    "type": "string",
+                    "title": "The meshName schema",
+                    "description": "The name associated with the control plane being installed.",
+                    "default": "",
+                    "examples": [
+                        "osm"
+                    ]
+                },
+                "useHTTPSIngress": {
+                    "$id": "#/properties/OpenServiceMesh/properties/useHTTPSIngress",
+                    "type": "boolean",
+                    "title": "The useHTTPSIngress schema",
+                    "description": "Indicates whether HTTPS Ingress should be enabled or not.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "envoyLogLevel": {
+                    "$id": "#/properties/OpenServiceMesh/properties/envoyLogLevel",
+                    "type": "string",
+                    "title": "The envoyLogLevel schema",
+                    "description": "Envoy log level.",
+                    "default": "error",
+                    "examples": [
+                        "error"
+                    ]
+                },
+                "enforceSingleMesh": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enforceSingleMesh",
+                    "type": "boolean",
+                    "title": "The enforceSingleMesh schema",
+                    "description": "Enforce only running a single control plane within a cluster.",
+                    "default": false,
+                    "examples": [
+                        false
+                    ]
+                },
+                "deployJaeger": {
+                    "$id": "#/properties/OpenServiceMesh/properties/deployJaeger",
+                    "type": "boolean",
+                    "title": "The deployJaeger schema",
+                    "description": "Indicates whether Jaeger should be installed and configured as part of the control plane.",
+                    "default": false,
+                    "examples": [
+                        true
+                    ]
+                },
+                "tracing": {
+                    "$id": "#/properties/OpenServiceMesh/properties/tracing",
+                    "type": "object",
+                    "title": "The tracing schema",
+                    "description": "An explanation about the purpose of this instance.",
+                    "default": {},
+                    "examples": [
+                        {
+                            "enable": true
+                        }
+                    ],
+                    "required": [
+                        "enable"
+                    ],
+                    "properties": {
+                        "enable": {
+                            "$id": "#/properties/OpenServiceMesh/properties/tracing/properties/enable",
+                            "type": "boolean",
+                            "title": "The enable schema",
+                            "description": "Indicates whether tracing is enabled or not.",
+                            "default": false,
+                            "examples": [
+                                true
+                            ]
+                        }
+                    },
+                    "additionalProperties": true
+                }
+            },
+            "additionalProperties": true
+        }
+    },
+    "additionalProperties": true
+}


### PR DESCRIPTION
**Description**:
This PR adds a values.schema.json file to indicate which values are required, type, description, examples, defaults. The schema file will help prevent us from accidentally changing the values file and breaking things as well as ensuring we are specifying the required values any time this chart is installed.

From the docs (https://helm.sh/docs/topics/charts/#schema-files): 
> This schema will be applied to the values to validate it. Validation occurs when any of the following commands are invoked:
> - helm install
> - helm upgrade
> - helm lint
> - helm template

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No
