### PR TITLE
tests/e2e: add NoInstall option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,10 +139,10 @@ jobs:
         run: make docker-build-osm-controller docker-build-init build-osm
       - name: Run PR tests
         if: ${{ github.event_name == 'pull_request' }}
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -kindCluster -test.timeout 0 -test.failfast -ginkgo.focus='\[Tier 1\]'
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Tier 1\]'
       - name: Run tests for push to main
         if: ${{ github.event_name == 'push' }}
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -kindCluster -test.timeout 0 -test.failfast
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast
 
   integration-tresor:
     name: Integration Test with Tresor, SMI traffic policies, and egress disabled

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -46,7 +46,12 @@ import (
 const (
 	// contant, default name for the Registry Secret
 	registrySecretName = "acr-creds"
-	// constant, default name for the mesh
+	// test tag prefix, for NS labeling
+	osmTest = "osmTest"
+)
+
+var (
+	// default name for the mesh
 	defaultOsmNamespace = "osm-system"
 	// default image tag
 	defaultImageTag = "latest"
@@ -60,8 +65,6 @@ const (
 	defaultDeployJaeger = false
 	// default deploy Fluentbit
 	defaultDeployFluentbit = false
-	// test tag prefix, for NS labeling
-	osmTest = "osmTest"
 )
 
 func DescribeTierN(tier uint) func(string, func()) bool {
@@ -298,10 +301,10 @@ func (td *OsmTestData) DeleteHelmRelease(name, namespace string) error {
 func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	if td.instType == NoInstall {
 		if instOpts.certManager != defaultCertManager ||
-			instOpts.deployPrometheus ||
-			instOpts.deployGrafana ||
-			instOpts.deployJaeger ||
-			instOpts.deployFluentbit {
+			instOpts.deployPrometheus != defaultDeployPrometheus ||
+			instOpts.deployGrafana != defaultDeployGrafana ||
+			instOpts.deployJaeger != defaultDeployJaeger ||
+			instOpts.deployFluentbit != defaultDeployFluentbit {
 			Skip("Skipping test: NoInstall marked on a test that requires modified install")
 		}
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -249,10 +249,10 @@ func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 		containerRegistryLoc:    td.ctrRegistryServer,
 		containerRegistrySecret: td.ctrRegistryPassword,
 		osmImagetag:             td.osmImageTag,
-		deployGrafana:           false,
-		deployPrometheus:        false,
-		deployJaeger:            false,
-		deployFluentbit:         false,
+		deployGrafana:           defaultDeployGrafana,
+		deployPrometheus:        defaultDeployPrometheus,
+		deployJaeger:            defaultDeployJaeger,
+		deployFluentbit:         defaultDeployFluentbit,
 
 		vaultHost:     "vault." + td.osmNamespace + ".svc.cluster.local",
 		vaultProtocol: "http",
@@ -298,10 +298,10 @@ func (td *OsmTestData) DeleteHelmRelease(name, namespace string) error {
 func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	if td.instType == NoInstall {
 		if instOpts.certManager != defaultCertManager ||
-			instOpts.deployPrometheus != defaultDeployPrometheus ||
-			instOpts.deployGrafana != defaultDeployGrafana ||
-			instOpts.deployJaeger != defaultDeployJaeger ||
-			instOpts.deployFluentbit != defaultDeployFluentbit {
+			instOpts.deployPrometheus ||
+			instOpts.deployGrafana ||
+			instOpts.deployJaeger ||
+			instOpts.deployFluentbit {
 			Skip("Skipping test: NoInstall marked on a test that requires modified install")
 		}
 

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -33,7 +33,6 @@ var _ = DescribeTier1("Test HTTP traffic from N deployment client -> 1 deploymen
 		It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Server NS
 			Expect(td.CreateNs(destApp, nil)).To(Succeed())

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -15,6 +15,7 @@ var _ = DescribeTier1("HTTP and HTTPS Egress", func() {
 		It("Allows egress traffic when enabled", func() {
 			// Install OSM
 			installOpts := td.GetOSMInstallOpts()
+			installOpts.egressEnabled = true
 			Expect(td.InstallOSM(installOpts)).To(Succeed())
 
 			// Create Test NS

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -15,9 +15,7 @@ var _ = DescribeTier1("HTTP and HTTPS Egress", func() {
 		It("Allows egress traffic when enabled", func() {
 			// Install OSM
 			installOpts := td.GetOSMInstallOpts()
-			installOpts.egressEnabled = true
 			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
 
 			// Create Test NS
 			Expect(td.CreateNs(sourceNs, nil)).To(Succeed())

--- a/tests/e2e/e2e_fluentbit_test.go
+++ b/tests/e2e/e2e_fluentbit_test.go
@@ -18,7 +18,6 @@ var _ = DescribeTier2("Test deployment of Fluent Bit sidecar", func() {
 			installOpts := td.GetOSMInstallOpts()
 			installOpts.deployFluentbit = true
 			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
 
 			pods, err := td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -19,6 +19,7 @@ var _ = DescribeTier2("1 Client pod -> 1 Server pod test using Vault", func() {
 			installOpts := td.GetOSMInstallOpts()
 			installOpts.certManager = "vault"
 			Expect(td.InstallOSM(installOpts)).To(Succeed())
+			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 2)).To(Succeed())
 
 			// Create Test NS
 			for _, n := range ns {

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -19,7 +19,6 @@ var _ = DescribeTier2("1 Client pod -> 1 Server pod test using Vault", func() {
 			installOpts := td.GetOSMInstallOpts()
 			installOpts.certManager = "vault"
 			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 2)).To(Succeed())
 
 			// Create Test NS
 			for _, n := range ns {

--- a/tests/e2e/e2e_helm_install_test.go
+++ b/tests/e2e/e2e_helm_install_test.go
@@ -8,6 +8,10 @@ import (
 var _ = DescribeTier2("Test osm control plane installation with Helm", func() {
 	Context("Using default values", func() {
 		It("installs osm control plane successfully", func() {
+			if td.instType == NoInstall {
+				Skip("Test is not going through InstallOSM, hence cannot be automatically skipped with NoInstall (#1908)")
+			}
+
 			namespace := "helm-install-namespace"
 			release := "helm-install-osm"
 

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -20,7 +20,6 @@ var _ = DescribeTier1("Permissive Traffic Policy Mode", func() {
 			installOpts := td.GetOSMInstallOpts()
 			installOpts.enablePermissiveMode = true
 			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Create Test NS
 			for _, n := range ns {

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -20,7 +20,6 @@ var _ = DescribeTier1("Test HTTP traffic from 1 pod client -> 1 pod server", fun
 		It("Tests HTTP traffic for client pod -> server pod", func() {
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Create Test NS
 			for _, n := range ns {

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -53,7 +53,6 @@ var _ = DescribeTier1("Test TrafficSplit where each backend shares the same Serv
 		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Create NSs
 			Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -52,7 +52,6 @@ var _ = DescribeTier1("Test HTTP from N Clients deployments to 1 Server deployme
 		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
 			// Install OSM
 			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 90*time.Second, 1)).To(Succeed())
 
 			// Create NSs
 			Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())


### PR DESCRIPTION
Adds new e2e install option `NoInstall`.

NoInstall means to run the tests assuming there is already
a running, permanent instance of OSM in namespace `osmNamespace`, part
of the test suite flags.

OSM will therefore not be installed/cleaned up between tests,
all other resources used by the tests (clients, other namespaces,
SMI defs, etc) will get cleaned though.

Since a single install is assumed, it assumes inmutability of the
install, so tests that _require_ or test specific parts of the
installation will be skipped.

Dynamic configuration (configmap) is however supported, and tests
that would usually call Install will instead set/reset the dynamic
config map values that the install command would originally set.

**Affected area**:

- New Functionality      [X]
- Tests                  [X]
- CI System              [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No