### PR TITLE
cli: enable sidecar injection by default with namespace add command

### DIFF
--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -16,30 +16,24 @@ import (
 )
 
 const namespaceAddDescription = `
-This command will add a namespace or a set of namespaces 
+This command will add a namespace or a set of namespaces
 to the mesh so that osm-controller can observe resources belonging
-to mesh namespaces, automatic sidecar injection is disabled by 
-default. Optionally, the namespaces can be configured for 
-automatic sidecar injection which enables pods in the 
-added namespaces to be injected with a sidecar upon creation.
+to mesh namespaces, automatic sidecar injection is disabled by
+default. The namespaces will be configured for automatic sidecar,
+which can be optionally disabled.
 `
 const namespaceAddExample = `
-# Add namespace 'test' to the mesh without enabling automatic sidecar injection. If sidecar injection was previously enabled, it will not be disabled by this command.
+# Add namespace 'test' to the mesh with automatic sidecar injection enabled.
 osm namespace add test
 
-# Add namespace 'test' to the mesh while enabling automatic sidecar injection
-osm namespace add test --enable-sidecar-injection 
-osm namespace add test --enable-sidecar-injection=true
-
 # Add namespace 'test' to the mesh while disabling automatic sidecar injection. If sidecar injection was previously enabled, it will be disabled by this command.
-osm namespace add test --enable-sidecar-injection=false`
+osm namespace add test --disable-sidecar-injection`
 
 type namespaceAddCmd struct {
 	out                     io.Writer
 	namespaces              []string
 	meshName                string
-	sidecarInjectionFlagSet bool
-	enableSidecarInjection  bool
+	disableSidecarInjection bool
 	clientSet               kubernetes.Interface
 }
 
@@ -55,7 +49,6 @@ func newNamespaceAdd(out io.Writer) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespaceAdd.namespaces = args
-			namespaceAdd.sidecarInjectionFlagSet = cmd.Flags().Changed("enable-sidecar-injection")
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
 				return errors.Errorf("Error fetching kubeconfig")
@@ -76,7 +69,7 @@ func newNamespaceAdd(out io.Writer) *cobra.Command {
 	f.StringVar(&namespaceAdd.meshName, "mesh-name", "osm", "Name of the service mesh")
 
 	//add sidecar injection flag
-	f.BoolVar(&namespaceAdd.enableSidecarInjection, "enable-sidecar-injection", true, "Enable or disable automatic sidecar injection, disabling requires explicitly setting this flag to false.")
+	f.BoolVar(&namespaceAdd.disableSidecarInjection, "disable-sidecar-injection", false, "Disable automatic sidecar injection")
 
 	return cmd
 }
@@ -101,18 +94,20 @@ func (a *namespaceAddCmd) run() error {
 		}
 
 		var patch string
-		if !a.sidecarInjectionFlagSet {
-			// Patch the namespace with monitoring label
-			// Do not enable sidecar injection. If sidecar injection has been set, please do not disable it.
+		if a.disableSidecarInjection {
+			// Patch the namespace with monitoring label and disable sidecar injection if previously enabled.
 			patch = fmt.Sprintf(`
 {
 	"metadata": {
 		"labels": {
 			"%s": "%s"
+		},
+		"annotations": {
+			"%s": null
 		}
 	}
-}`, constants.OSMKubeResourceMonitorAnnotation, a.meshName)
-		} else if a.enableSidecarInjection {
+}`, constants.OSMKubeResourceMonitorAnnotation, a.meshName, constants.SidecarInjectionAnnotation)
+		} else {
 			// Patch the namespace with the monitoring label.
 			// Enable sidecar injection.
 			patch = fmt.Sprintf(`
@@ -126,21 +121,8 @@ func (a *namespaceAddCmd) run() error {
 		}
 	}
 }`, constants.OSMKubeResourceMonitorAnnotation, a.meshName, constants.SidecarInjectionAnnotation)
-		} else {
-			// Do not enable sidecar injection.
-			// Remove annotations
-			patch = fmt.Sprintf(`
-{
-	"metadata": {
-		"labels": {
-			"%s": "%s"
-		},
-		"annotations": {
-			"%s": null
 		}
-	}
-}`, constants.OSMKubeResourceMonitorAnnotation, a.meshName, constants.SidecarInjectionAnnotation)
-		}
+
 		_, err := a.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 		if err != nil {
 			return errors.Errorf("Could not add namespace [%s] to mesh [%s]: %v", ns, a.meshName, err)

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -65,10 +65,10 @@ var _ = Describe("Running the namespace add command", func() {
 				Expect(ns.Labels[constants.OSMKubeResourceMonitorAnnotation]).To(Equal(testMeshName))
 			})
 
-			It("should correctly not add an inject annotation to the namespace", func() {
+			It("should correctly add an inject annotation to the namespace", func() {
 				ns, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				Expect(ns.Annotations).ShouldNot(HaveKey(constants.SidecarInjectionAnnotation))
+				Expect(ns.Annotations[constants.SidecarInjectionAnnotation]).To(Equal("enabled"))
 			})
 		})
 
@@ -83,12 +83,10 @@ var _ = Describe("Running the namespace add command", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				namespaceAddCmd := &namespaceAddCmd{
-					out:                     out,
-					meshName:                testMeshName,
-					namespaces:              []string{testNamespace},
-					sidecarInjectionFlagSet: true,
-					enableSidecarInjection:  true,
-					clientSet:               fakeClientSet,
+					out:        out,
+					meshName:   testMeshName,
+					namespaces: []string{testNamespace},
+					clientSet:  fakeClientSet,
 				}
 
 				err = namespaceAddCmd.run()
@@ -129,8 +127,7 @@ var _ = Describe("Running the namespace add command", func() {
 					out:                     out,
 					meshName:                testMeshName,
 					namespaces:              []string{testNamespace},
-					sidecarInjectionFlagSet: true,
-					enableSidecarInjection:  false,
+					disableSidecarInjection: true,
 					clientSet:               fakeClientSet,
 				}
 

--- a/demo/configure-app-namespaces.sh
+++ b/demo/configure-app-namespaces.sh
@@ -11,7 +11,7 @@ for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPAC
 done
 
 # Add namespaces to the mesh
-bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" --enable-sidecar-injection
+bin/osm namespace add --mesh-name "$MESH_NAME" "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE"
 
 # Enable metrics for pods belonging to app namespaces
 bin/osm metrics enable --namespace "$BOOKWAREHOUSE_NAMESPACE, $BOOKBUYER_NAMESPACE, $BOOKSTORE_NAMESPACE, $BOOKTHIEF_NAMESPACE"

--- a/demo/join-namespaces.sh
+++ b/demo/join-namespaces.sh
@@ -13,10 +13,10 @@ set -aueo pipefail
 source .env
 
 
-./bin/osm namespace add "${BOOKBUYER_NAMESPACE:-bookbuyer}"         --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
-./bin/osm namespace add "${BOOKSTORE_NAMESPACE:-bookstore}"         --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
-./bin/osm namespace add "${BOOKTHIEF_NAMESPACE:-bookthief}"         --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
-./bin/osm namespace add "${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}" --mesh-name "${MESH_NAME:-osm}" --enable-sidecar-injection
+./bin/osm namespace add "${BOOKBUYER_NAMESPACE:-bookbuyer}"         --mesh-name "${MESH_NAME:-osm}"
+./bin/osm namespace add "${BOOKSTORE_NAMESPACE:-bookstore}"         --mesh-name "${MESH_NAME:-osm}"
+./bin/osm namespace add "${BOOKTHIEF_NAMESPACE:-bookthief}"         --mesh-name "${MESH_NAME:-osm}"
+./bin/osm namespace add "${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}" --mesh-name "${MESH_NAME:-osm}"
 
 
 kubectl apply -f - <<EOF

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -50,7 +50,7 @@ for i in bookstore bookbuyer bookthief bookwarehouse; do kubectl create ns $i; d
 ```
 ### Onboard the Namespaces to the OSM Mesh and enable sidecar injection on the namespaces
 ```bash
-osm namespace add bookstore bookbuyer bookthief bookwarehouse --enable-sidecar-injection
+osm namespace add bookstore bookbuyer bookthief bookwarehouse
 ```
 ### Deploy the Bookstore Application
 Install `Bookstore`, `Bookbuyer`, `Bookthief`, `Bookwarehouse`.

--- a/docs/onboard_services.md
+++ b/docs/onboard_services.md
@@ -19,12 +19,15 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
     $ kubectl label namespace <namespace> openservicemesh.io/monitored-by=<mesh-name>
     ```
 
-    By default, the `osm namespace add` command does not enable the namespace for automatic sidecar injection. To enable automatic sidecar injection as a part of enrolling a namespace into the mesh, use `osm namespace add <namespace> --enable-sidecar-injection`. This does the equivalent of the following:
+    By default, the `osm namespace add` command enables automatic sidecar injection for pods in the namespace.
+    This does the equivalent of the following:
 
     ```console
     $ kubectl label namespace <namespace> openservicemesh.io/monitored-by=<mesh-name>
     $ kubectl annotate namespace <namespace> openservicemesh.io/sidecar-injection=enabled
     ```
+
+    To disable automatic sidecar injection as a part of enrolling a namespace into the mesh, use `osm namespace add <namespace> --disable-sidecar-injection`.
 
     Once a namespace has been onboarded, pods can be enrolled in the mesh by configuring automatic sidecar injection. See the [Sidecar Injection](patterns/sidecar_injection.md) document for more details.
 

--- a/docs/patterns/sidecar_injection.md
+++ b/docs/patterns/sidecar_injection.md
@@ -15,7 +15,8 @@ Prerequisites:
 
 Automatic Sidecar injection can be enabled in the following ways:
 
-- While enrolling a namespace into the mesh using `osm` cli: `osm namespace add <namespace> --enable-sidecar-injection`
+- While enrolling a namespace into the mesh using `osm` cli: `osm namespace add <namespace>`:
+  Automatic sidecar injection is enabled by default with this command.
 
 - Using `kubectl` to annotate individual namespaces and pods to enable sidecar injection:
 
@@ -40,6 +41,20 @@ Automatic Sidecar injection can be enabled in the following ways:
   Pods will be injected with a sidecar only if the following conditions are met:
   1. The namespace to which the pod belongs is a monitored namespace.
   2. The pod is explicitly enabled for the sidecar injection, OR the namespace to which the pod belongs is enabled for the sidecar injection and the pod is not explicitly disabled for sidecar injection.
+
+### Explicitly Disabling Automatic Sidecar Injection on Namespaces
+
+Namespaces can be disabled for automatic sidecar injection in the following ways:
+
+- While enrolling a namespace into the mesh using `osm` cli: `osm namespace add <namespace> --disable-sidecar-injection`:
+  If the namespace was previously enabled for sidecar injection, it will be disabled after running this command.
+
+- Using `kubectl` to annotate individual namespaces to disable sidecar injection:
+
+  ```console
+  # Disable sidecar injection on a namespace
+  $ kubectl annotate namespace <namespace> openservicemesh.io/sidecar-injection=disabled
+  ```
 
 ### Explicitly Disabling Automatic Sidecar Injection on Pods
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -571,8 +571,8 @@ func (td *OsmTestData) AddNsToMesh(sidecardInject bool, ns ...string) error {
 	td.T.Logf("Adding Namespaces [+%s] to the mesh", ns)
 	for _, namespace := range ns {
 		args := []string{"namespace", "add", namespace}
-		if sidecardInject {
-			args = append(args, "--enable-sidecar-injection")
+		if !sidecardInject {
+			args = append(args, "--disable-sidecar-injection")
 		}
 
 		stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Based on usability feedback, we want sidecar injection to be enabled
by default with the `osm namespace add` command. This change flips
the flag to `--disable-sidecar-injection` to explicitly disable
sidecar injection only if the flag is specified.

Refer to #1896 for more details.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
