### PR TITLE
cli: encode error along with message for additional context

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -121,12 +121,12 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			kubeconfig, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(kubeconfig)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig, %s", err)
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			inst.clientSet = clientset
 			return inst.run(config)

--- a/cmd/cli/mesh_list.go
+++ b/cmd/cli/mesh_list.go
@@ -37,11 +37,11 @@ func newMeshList(out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			meshList.clientSet = clientset
 			return meshList.run()

--- a/cmd/cli/metrics_disable.go
+++ b/cmd/cli/metrics_disable.go
@@ -39,12 +39,12 @@ func newMetricsDisable(out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			disableCmd.clientSet = clientset
 			return disableCmd.run()

--- a/cmd/cli/metrics_enable.go
+++ b/cmd/cli/metrics_enable.go
@@ -42,12 +42,12 @@ func newMetricsEnable(out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			enableCmd.clientSet = clientset
 			return enableCmd.run()

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -51,12 +51,12 @@ func newNamespaceAdd(out io.Writer) *cobra.Command {
 			namespaceAdd.namespaces = args
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			namespaceAdd.clientSet = clientset
 			return namespaceAdd.run()

--- a/cmd/cli/namespace_ignore.go
+++ b/cmd/cli/namespace_ignore.go
@@ -43,12 +43,12 @@ func newNamespaceIgnore(out io.Writer) *cobra.Command {
 			ignoreCmd.namespaces = args
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			ignoreCmd.clientSet = clientset
 			return ignoreCmd.run()

--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -41,12 +41,12 @@ func newNamespaceList(out io.Writer) *cobra.Command {
 
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			namespaceList.clientSet = clientset
 			return namespaceList.run()

--- a/cmd/cli/namespace_remove.go
+++ b/cmd/cli/namespace_remove.go
@@ -40,12 +40,12 @@ func newNamespaceRemove(out io.Writer) *cobra.Command {
 			namespaceRemove.namespace = args[0]
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			namespaceRemove.clientSet = clientset
 			return namespaceRemove.run()

--- a/cmd/cli/proxy_configdump.go
+++ b/cmd/cli/proxy_configdump.go
@@ -52,13 +52,13 @@ func newProxyDumpConfig(config *action.Configuration, out io.Writer) *cobra.Comm
 			dumpConfigCmd.pod = args[0]
 			conf, err := config.RESTClientGetter.ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig")
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
 			}
 			dumpConfigCmd.config = conf
 
 			clientset, err := kubernetes.NewForConfig(conf)
 			if err != nil {
-				return errors.Errorf("Could not access Kubernetes cluster. Check kubeconfig")
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
 			}
 			dumpConfigCmd.clientSet = clientset
 			return dumpConfigCmd.run()


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Encodes the actual error when a command fails due to kubeconfig
issues or the cluster not being accessible. Without this, it is
difficult to understand the actual cause of the error.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`