### PR TITLE
ref(e2e): divide tests into buckets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,9 +113,12 @@ jobs:
     name: Go test e2e
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        bucket: [1, 2]
     env:
       CTR_TAG: ${{ github.sha }}
-      CTR_REGISTRY: "localhost:5000"   # unused for kind, but currently required in framework
+      CTR_REGISTRY: "localhost:5000" # unused for kind, but currently required in framework
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -139,10 +142,10 @@ jobs:
         run: make docker-build-osm-controller docker-build-init build-osm
       - name: Run PR tests
         if: ${{ github.event_name == 'pull_request' }}
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Tier 1\]'
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Tier 1\]\[Bucket ${{ matrix.bucket }}\]'
       - name: Run tests for push to main
         if: ${{ github.event_name == 'push' }}
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\]'
 
   integration-tresor:
     name: Integration Test with Tresor, SMI traffic policies, and egress disabled

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,9 +21,11 @@ Tests are organized by top-level `Describe` blocks into tiers based on priority.
 - Tier 1: run against every PR and should pass before being merged
 - Tier 2: run against every merge into the main branch
 
-**Note**: These tiers and which tests fall into each are likely to change as the test suite grows.
+Independent of tiers, tests are also organized into buckets. Each bucket runs in parallel, and individual tests in the bucket run sequentially.
 
-To help organize the tests, custom `Describe` blocks named after the tiers like `DescribeTier1` are provided to help name tests accordingly and should be used in place of Ginkgo's original `Describe` to ensure the right tests are run at the right times in CI.
+**Note**: These tiers and buckets and which tests fall into each are likely to change as the test suite grows.
+
+To help organize the tests, a custom `Describe` block named `OSMDescribe` is provided which accepts an additional struct parameter which contains fields for test metadata like tier and bucket. `OSMDescribe` will construct a well-formatted name including the test metadata which can be used in CI to run tests accordingly. Ginkgo's original `Describe` should not be used directly at the top-level and `OSMDescribe` should be used instead.
 
 ## Running the tests
 Running the tests will require a running Kubernetes cluster. If you do not have a Kubernetes cluster to run the tests onto, you can choose to run them using `Kind`, which will make the test framework initialize a cluster on a local accessible docker client.

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -67,14 +67,22 @@ var (
 	defaultDeployFluentbit = false
 )
 
-func DescribeTierN(tier uint) func(string, func()) bool {
-	return func(name string, body func()) bool {
-		return Describe(fmt.Sprintf("[Tier %d] %s", tier, name), body)
-	}
+type OSMDescribeInfo struct {
+	// tier represents the priority of the test. Lower value indicates higher priority.
+	tier int
+
+	// bucket indicates in which test bucket the test will run in for CI. Each
+	// bucket is run in parallel while tests in the same bucket run sequentially.
+	bucket int
 }
 
-var DescribeTier1 = DescribeTierN(1)
-var DescribeTier2 = DescribeTierN(2)
+func (o OSMDescribeInfo) String() string {
+	return fmt.Sprintf("[Tier %d][Bucket %d]", o.tier, o.bucket)
+}
+
+func OSMDescribe(name string, opts OSMDescribeInfo, body func()) bool {
+	return Describe(opts.String()+" "+name, body)
+}
 
 // InstallType defines several OSM test deployment scenarios
 type InstallType string

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -8,103 +8,108 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = DescribeTier2("1 Client pod -> 1 Server pod test using cert-manager", func() {
-	Context("CertManagerSimpleClientServer", func() {
-		const sourceNs = "client"
-		const destNs = "server"
-		var ns []string = []string{sourceNs, destNs}
+var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
+	OSMDescribeInfo{
+		tier:   2,
+		bucket: 2,
+	},
+	func() {
+		Context("CertManagerSimpleClientServer", func() {
+			const sourceNs = "client"
+			const destNs = "server"
+			var ns []string = []string{sourceNs, destNs}
 
-		It("Tests HTTP traffic for client pod -> server pod", func() {
-			// Install OSM
-			installOpts := td.GetOSMInstallOpts()
-			installOpts.certManager = "cert-manager"
-			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 4)).To(Succeed())
+			It("Tests HTTP traffic for client pod -> server pod", func() {
+				// Install OSM
+				installOpts := td.GetOSMInstallOpts()
+				installOpts.certManager = "cert-manager"
+				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 4)).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(td.CreateNs(n, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, n)).To(Succeed())
-			}
+				// Create Test NS
+				for _, n := range ns {
+					Expect(td.CreateNs(n, nil)).To(Succeed())
+					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+				}
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := td.SimplePodApp(
-				SimplePodAppDef{
-					name:      "server",
-					namespace: destNs,
-					image:     "kennethreitz/httpbin",
+				// Get simple pod definitions for the HTTP server
+				svcAccDef, podDef, svcDef := td.SimplePodApp(
+					SimplePodAppDef{
+						name:      "server",
+						namespace: destNs,
+						image:     "kennethreitz/httpbin",
+						ports:     []int{80},
+					})
+
+				_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				dstPod, err := td.CreatePod(destNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(destNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
+					name:      "client",
+					namespace: sourceNs,
+					command:   []string{"/bin/bash", "-c", "--"},
+					args:      []string{"while true; do sleep 30; done;"},
+					image:     "songrgg/alpine-debug",
 					ports:     []int{80},
 				})
 
-			_, err := td.CreateServiceAccount(destNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := td.CreatePod(destNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(destNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := td.CreatePod(sourceNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(sourceNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
 
-			// Get simple Pod definitions for the client
-			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-				name:      "client",
-				namespace: sourceNs,
-				command:   []string{"/bin/bash", "-c", "--"},
-				args:      []string{"while true; do sleep 30; done;"},
-				image:     "songrgg/alpine-debug",
-				ports:     []int{80},
-			})
+				// Deploy allow rule client->server
+				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+					SimpleAllowPolicy{
+						RouteGroupName:    "routes",
+						TrafficTargetName: "test-target",
 
-			_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			srcPod, err := td.CreatePod(sourceNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(sourceNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+						SourceNamespace:      sourceNs,
+						SourceSVCAccountName: "client",
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
-
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    "routes",
-					TrafficTargetName: "test-target",
-
-					SourceNamespace:      sourceNs,
-					SourceSVCAccountName: "client",
-
-					DestinationNamespace:      destNs,
-					DestinationSvcAccountName: "server",
-				})
-
-			// Configs have to be put into a monitored NS, and osm-system can't be by cli
-			_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// All ready. Expect client to reach server
-			// Need to get the pod though.
-			cond := td.WaitForRepeatedSuccess(func() bool {
-				result :=
-					td.HTTPRequest(HTTPRequestDef{
-						SourceNs:        srcPod.Namespace,
-						SourcePod:       srcPod.Name,
-						SourceContainer: "client",
-
-						Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+						DestinationNamespace:      destNs,
+						DestinationSvcAccountName: "server",
 					})
 
-				if result.Err != nil || result.StatusCode != 200 {
-					td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
-					return false
-				}
-				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
-				return true
-			}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
-			Expect(cond).To(BeTrue())
+				// Configs have to be put into a monitored NS, and osm-system can't be by cli
+				_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+				Expect(err).NotTo(HaveOccurred())
+
+				// All ready. Expect client to reach server
+				// Need to get the pod though.
+				cond := td.WaitForRepeatedSuccess(func() bool {
+					result :=
+						td.HTTPRequest(HTTPRequestDef{
+							SourceNs:        srcPod.Namespace,
+							SourcePod:       srcPod.Name,
+							SourceContainer: "client",
+
+							Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+						})
+
+					if result.Err != nil || result.StatusCode != 200 {
+						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						return false
+					}
+					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					return true
+				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+				Expect(cond).To(BeTrue())
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -12,149 +12,154 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = DescribeTier1("Test HTTP traffic from N deployment client -> 1 deployment server", func() {
-	Context("DeploymentsClientServer", func() {
-		destApp := "server"
-		sourceAppBaseName := "client"
-		var sourceNamespaces []string = []string{}
+var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment server",
+	OSMDescribeInfo{
+		tier:   1,
+		bucket: 1,
+	},
+	func() {
+		Context("DeploymentsClientServer", func() {
+			const destApp = "server"
+			const sourceAppBaseName = "client"
+			var sourceNamespaces []string = []string{}
 
-		// Total (numberOfClientApps x replicaSetPerApp) pods
-		numberOfClientServices := 5
-		replicaSetPerService := 5
+			// Total (numberOfClientApps x replicaSetPerApp) pods
+			numberOfClientServices := 5
+			replicaSetPerService := 5
 
-		// Used across the test to wait for concurrent steps to finish
-		var wg sync.WaitGroup
+			// Used across the test to wait for concurrent steps to finish
+			var wg sync.WaitGroup
 
-		for i := 0; i < numberOfClientServices; i++ {
-			// base names for each client service
-			sourceNamespaces = append(sourceNamespaces, fmt.Sprintf("%s%d", sourceAppBaseName, i))
-		}
-
-		It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
-			// Install OSM
-			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-
-			// Server NS
-			Expect(td.CreateNs(destApp, nil)).To(Succeed())
-			Expect(td.AddNsToMesh(true, destApp)).To(Succeed())
-
-			// Client Applications
-			for _, srcClient := range sourceNamespaces {
-				Expect(td.CreateNs(srcClient, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, srcClient)).To(Succeed())
+			for i := 0; i < numberOfClientServices; i++ {
+				// base names for each client service
+				sourceNamespaces = append(sourceNamespaces, fmt.Sprintf("%s%d", sourceAppBaseName, i))
 			}
 
-			// Use a deployment with multiple replicaset at serverside
-			svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
-				SimpleDeploymentAppDef{
-					name:         "server",
-					namespace:    destApp,
-					replicaCount: int32(replicaSetPerService),
-					image:        "kennethreitz/httpbin",
-					ports:        []int{80},
-				})
+			It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
+				// Install OSM
+				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
 
-			_, err := td.CreateServiceAccount(destApp, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateDeployment(destApp, deploymentDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(destApp, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+				// Server NS
+				Expect(td.CreateNs(destApp, nil)).To(Succeed())
+				Expect(td.AddNsToMesh(true, destApp)).To(Succeed())
 
-			wg.Add(1)
-			go func(wg *sync.WaitGroup, srcClient string) {
-				defer wg.Done()
-				Expect(td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService)).To(Succeed())
-			}(&wg, destApp)
+				// Client Applications
+				for _, srcClient := range sourceNamespaces {
+					Expect(td.CreateNs(srcClient, nil)).To(Succeed())
+					Expect(td.AddNsToMesh(true, srcClient)).To(Succeed())
+				}
 
-			// Create all client deployments, also with replicaset
-			for _, srcClient := range sourceNamespaces {
-				svcAccDef, deploymentDef, svcDef = td.SimpleDeploymentApp(
+				// Use a deployment with multiple replicaset at serverside
+				svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
-						name:         srcClient,
-						namespace:    srcClient,
+						name:         "server",
+						namespace:    destApp,
 						replicaCount: int32(replicaSetPerService),
-						command:      []string{"/bin/bash", "-c", "--"},
-						args:         []string{"while true; do sleep 30; done;"},
-						image:        "songrgg/alpine-debug",
-						ports:        []int{80}, // Can't deploy services with empty/no ports
+						image:        "kennethreitz/httpbin",
+						ports:        []int{80},
 					})
-				_, err = td.CreateServiceAccount(srcClient, &svcAccDef)
+
+				_, err := td.CreateServiceAccount(destApp, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateDeployment(srcClient, deploymentDef)
+				_, err = td.CreateDeployment(destApp, deploymentDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(srcClient, svcDef)
+				_, err = td.CreateService(destApp, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				wg.Add(1)
 				go func(wg *sync.WaitGroup, srcClient string) {
 					defer wg.Done()
-					Expect(td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService)).To(Succeed())
-				}(&wg, srcClient)
-			}
-			wg.Wait()
+					Expect(td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService)).To(Succeed())
+				}(&wg, destApp)
 
-			// Create traffic rules
-			// Deploy allow rules (10x)clients -> server
-			for _, srcClient := range sourceNamespaces {
-				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
-					SimpleAllowPolicy{
-						RouteGroupName:    srcClient,
-						TrafficTargetName: srcClient,
+				// Create all client deployments, also with replicaset
+				for _, srcClient := range sourceNamespaces {
+					svcAccDef, deploymentDef, svcDef = td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							name:         srcClient,
+							namespace:    srcClient,
+							replicaCount: int32(replicaSetPerService),
+							command:      []string{"/bin/bash", "-c", "--"},
+							args:         []string{"while true; do sleep 30; done;"},
+							image:        "songrgg/alpine-debug",
+							ports:        []int{80}, // Can't deploy services with empty/no ports
+						})
+					_, err = td.CreateServiceAccount(srcClient, &svcAccDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateDeployment(srcClient, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateService(srcClient, svcDef)
+					Expect(err).NotTo(HaveOccurred())
 
-						SourceNamespace:      srcClient,
-						SourceSVCAccountName: srcClient,
-
-						DestinationNamespace:      destApp,
-						DestinationSvcAccountName: destApp,
-					})
-
-				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = td.CreateHTTPRouteGroup(srcClient, httpRG)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
-				Expect(err).NotTo(HaveOccurred())
-			}
-
-			// Create Multiple HTTP request structure and fill it with appropriate details
-			requests := HTTPMultipleRequest{
-				Sources: []HTTPRequestDef{},
-			}
-			for _, ns := range sourceNamespaces {
-				pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
-				Expect(err).To(BeNil())
-
-				for _, pod := range pods.Items {
-					requests.Sources = append(requests.Sources, HTTPRequestDef{
-						SourceNs:        ns,
-						SourcePod:       pod.Name,
-						SourceContainer: ns, // container_name == NS for this test
-
-						Destination: fmt.Sprintf("%s.%s", destApp, destApp),
-					})
+					wg.Add(1)
+					go func(wg *sync.WaitGroup, srcClient string) {
+						defer wg.Done()
+						Expect(td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService)).To(Succeed())
+					}(&wg, srcClient)
 				}
-			}
+				wg.Wait()
 
-			var results HTTPMultipleResults
-			success := td.WaitForRepeatedSuccess(func() bool {
-				// Issue all calls, get results
-				results = td.MultipleHTTPRequest(&requests)
+				// Create traffic rules
+				// Deploy allow rules (10x)clients -> server
+				for _, srcClient := range sourceNamespaces {
+					httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+						SimpleAllowPolicy{
+							RouteGroupName:    srcClient,
+							TrafficTargetName: srcClient,
 
-				// Care, depending on variables there could be a lot of results
-				td.PrettyPrintHTTPResults(&results)
+							SourceNamespace:      srcClient,
+							SourceSVCAccountName: srcClient,
 
-				// Verify success conditions
-				for _, ns := range results {
-					for _, podResult := range ns {
-						if podResult.Err != nil || podResult.StatusCode != 200 {
-							return false
-						}
+							DestinationNamespace:      destApp,
+							DestinationSvcAccountName: destApp,
+						})
+
+					// Configs have to be put into a monitored NS, and osm-system can't be by cli
+					_, err = td.CreateHTTPRouteGroup(srcClient, httpRG)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				// Create Multiple HTTP request structure and fill it with appropriate details
+				requests := HTTPMultipleRequest{
+					Sources: []HTTPRequestDef{},
+				}
+				for _, ns := range sourceNamespaces {
+					pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					Expect(err).To(BeNil())
+
+					for _, pod := range pods.Items {
+						requests.Sources = append(requests.Sources, HTTPRequestDef{
+							SourceNs:        ns,
+							SourcePod:       pod.Name,
+							SourceContainer: ns, // container_name == NS for this test
+
+							Destination: fmt.Sprintf("%s.%s", destApp, destApp),
+						})
 					}
 				}
-				return true
-			}, 5, 150*time.Second)
 
-			Expect(success).To(BeTrue())
+				var results HTTPMultipleResults
+				success := td.WaitForRepeatedSuccess(func() bool {
+					// Issue all calls, get results
+					results = td.MultipleHTTPRequest(&requests)
+
+					// Care, depending on variables there could be a lot of results
+					td.PrettyPrintHTTPResults(&results)
+
+					// Verify success conditions
+					for _, ns := range results {
+						for _, podResult := range ns {
+							if podResult.Err != nil || podResult.StatusCode != 200 {
+								return false
+							}
+						}
+					}
+					return true
+				}, 5, 150*time.Second)
+
+				Expect(success).To(BeTrue())
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -8,99 +8,104 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = DescribeTier1("HTTP and HTTPS Egress", func() {
-	Context("Egress", func() {
-		sourceNs := "client"
+var _ = OSMDescribe("HTTP and HTTPS Egress",
+	OSMDescribeInfo{
+		tier:   1,
+		bucket: 1,
+	},
+	func() {
+		Context("Egress", func() {
+			const sourceNs = "client"
 
-		It("Allows egress traffic when enabled", func() {
-			// Install OSM
-			installOpts := td.GetOSMInstallOpts()
-			installOpts.egressEnabled = true
-			Expect(td.InstallOSM(installOpts)).To(Succeed())
+			It("Allows egress traffic when enabled", func() {
+				// Install OSM
+				installOpts := td.GetOSMInstallOpts()
+				installOpts.egressEnabled = true
+				Expect(td.InstallOSM(installOpts)).To(Succeed())
 
-			// Create Test NS
-			Expect(td.CreateNs(sourceNs, nil)).To(Succeed())
-			Expect(td.AddNsToMesh(true, sourceNs)).To(Succeed())
+				// Create Test NS
+				Expect(td.CreateNs(sourceNs, nil)).To(Succeed())
+				Expect(td.AddNsToMesh(true, sourceNs)).To(Succeed())
 
-			// Get simple Pod definitions for the client
-			svcAccDef, podDef, svcDef := td.SimplePodApp(SimplePodAppDef{
-				name:      "client",
-				namespace: sourceNs,
-				command:   []string{"/bin/bash", "-c", "--"},
-				args:      []string{"while true; do sleep 30; done;"},
-				image:     "songrgg/alpine-debug",
-				ports:     []int{80},
-			})
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef := td.SimplePodApp(SimplePodAppDef{
+					name:      "client",
+					namespace: sourceNs,
+					command:   []string{"/bin/bash", "-c", "--"},
+					args:      []string{"while true; do sleep 30; done;"},
+					image:     "songrgg/alpine-debug",
+					ports:     []int{80},
+				})
 
-			_, err := td.CreateServiceAccount(sourceNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			srcPod, err := td.CreatePod(sourceNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(sourceNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+				_, err := td.CreateServiceAccount(sourceNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := td.CreatePod(sourceNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(sourceNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
 
-			protocols := []string{
-				"http://",
-				"https://",
-			}
-			egressURLs := []string{
-				"edition.cnn.com",
-				"github.com",
-			}
-			var urls []string
-			for _, protocol := range protocols {
-				for _, test := range egressURLs {
-					urls = append(urls, protocol+test)
+				protocols := []string{
+					"http://",
+					"https://",
 				}
-			}
-
-			for _, url := range urls {
-				cond := td.WaitForRepeatedSuccess(func() bool {
-					result := td.HTTPRequest(HTTPRequestDef{
-						SourceNs:        srcPod.Namespace,
-						SourcePod:       srcPod.Name,
-						SourceContainer: "client",
-
-						Destination: url,
-					})
-
-					if result.Err != nil || result.StatusCode != 200 {
-						td.T.Logf("%s > REST req failed (status: %d) %v", url, result.StatusCode, result.Err)
-						return false
+				egressURLs := []string{
+					"edition.cnn.com",
+					"github.com",
+				}
+				var urls []string
+				for _, protocol := range protocols {
+					for _, test := range egressURLs {
+						urls = append(urls, protocol+test)
 					}
-					td.T.Logf("%s > REST req succeeded: %d", url, result.StatusCode)
-					return true
-				}, 5, 60*time.Second)
-				Expect(cond).To(BeTrue())
-			}
+				}
 
-			By("Disabling Egress")
+				for _, url := range urls {
+					cond := td.WaitForRepeatedSuccess(func() bool {
+						result := td.HTTPRequest(HTTPRequestDef{
+							SourceNs:        srcPod.Namespace,
+							SourcePod:       srcPod.Name,
+							SourceContainer: "client",
 
-			err = td.UpdateOSMConfig("egress", "false")
-			Expect(err).NotTo(HaveOccurred())
+							Destination: url,
+						})
 
-			for _, url := range urls {
-				cond := td.WaitForRepeatedSuccess(func() bool {
-					result := td.HTTPRequest(HTTPRequestDef{
-						SourceNs:        srcPod.Namespace,
-						SourcePod:       srcPod.Name,
-						SourceContainer: "client",
+						if result.Err != nil || result.StatusCode != 200 {
+							td.T.Logf("%s > REST req failed (status: %d) %v", url, result.StatusCode, result.Err)
+							return false
+						}
+						td.T.Logf("%s > REST req succeeded: %d", url, result.StatusCode)
+						return true
+					}, 5, 60*time.Second)
+					Expect(cond).To(BeTrue())
+				}
 
-						Destination: url,
-					})
+				By("Disabling Egress")
 
-					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-						td.T.Logf("%s > REST req failed incorrectly (status: %d) %v", url, result.StatusCode, result.Err)
-						return false
-					}
-					td.T.Logf("%s > REST req failed correctly: %v", url, result.Err)
-					return true
-				}, 5 /*success count threshold*/, 60*time.Second /*timeout*/)
-				Expect(cond).To(BeTrue())
-			}
+				err = td.UpdateOSMConfig("egress", "false")
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, url := range urls {
+					cond := td.WaitForRepeatedSuccess(func() bool {
+						result := td.HTTPRequest(HTTPRequestDef{
+							SourceNs:        srcPod.Namespace,
+							SourcePod:       srcPod.Name,
+							SourceContainer: "client",
+
+							Destination: url,
+						})
+
+						if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+							td.T.Logf("%s > REST req failed incorrectly (status: %d) %v", url, result.StatusCode, result.Err)
+							return false
+						}
+						td.T.Logf("%s > REST req failed correctly: %v", url, result.Err)
+						return true
+					}, 5 /*success count threshold*/, 60*time.Second /*timeout*/)
+					Expect(cond).To(BeTrue())
+				}
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_fluentbit_test.go
+++ b/tests/e2e/e2e_fluentbit_test.go
@@ -11,53 +11,58 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-var _ = DescribeTier2("Test deployment of Fluent Bit sidecar", func() {
-	Context("Fluentbit", func() {
-		It("Deploys a Fluent Bit sidecar only when enabled", func() {
-			// Install OSM with Fluentbit
-			installOpts := td.GetOSMInstallOpts()
-			installOpts.deployFluentbit = true
-			Expect(td.InstallOSM(installOpts)).To(Succeed())
+var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
+	OSMDescribeInfo{
+		tier:   2,
+		bucket: 2,
+	},
+	func() {
+		Context("Fluentbit", func() {
+			It("Deploys a Fluent Bit sidecar only when enabled", func() {
+				// Install OSM with Fluentbit
+				installOpts := td.GetOSMInstallOpts()
+				installOpts.deployFluentbit = true
+				Expect(td.InstallOSM(installOpts)).To(Succeed())
 
-			pods, err := td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
-				LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),
-			})
+				pods, err := td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),
+				})
 
-			Expect(err).NotTo(HaveOccurred())
-			cond := false
-			for _, pod := range pods.Items {
-				for _, container := range pod.Spec.Containers {
-					if strings.Contains(container.Image, "fluent-bit") {
-						cond = true
+				Expect(err).NotTo(HaveOccurred())
+				cond := false
+				for _, pod := range pods.Items {
+					for _, container := range pod.Spec.Containers {
+						if strings.Contains(container.Image, "fluent-bit") {
+							cond = true
+						}
 					}
 				}
-			}
-			Expect(cond).To(BeTrue())
+				Expect(cond).To(BeTrue())
 
-			err = td.DeleteNs(td.osmNamespace)
-			Expect(err).NotTo(HaveOccurred())
-			err = td.WaitForNamespacesDeleted([]string{td.osmNamespace}, 60*time.Second)
-			Expect(err).NotTo(HaveOccurred())
+				err = td.DeleteNs(td.osmNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				err = td.WaitForNamespacesDeleted([]string{td.osmNamespace}, 60*time.Second)
+				Expect(err).NotTo(HaveOccurred())
 
-			// Install OSM without Fluentbit (default)
-			installOpts = td.GetOSMInstallOpts()
-			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
+				// Install OSM without Fluentbit (default)
+				installOpts = td.GetOSMInstallOpts()
+				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
 
-			pods, err = td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
-				LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),
-			})
+				pods, err = td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),
+				})
 
-			Expect(err).NotTo(HaveOccurred())
-			cond = false
-			for _, pod := range pods.Items {
-				for _, container := range pod.Spec.Containers {
-					if strings.Contains(container.Image, "fluent-bit") {
-						cond = true
+				Expect(err).NotTo(HaveOccurred())
+				cond = false
+				for _, pod := range pods.Items {
+					for _, container := range pod.Spec.Containers {
+						if strings.Contains(container.Image, "fluent-bit") {
+							cond = true
+						}
 					}
 				}
-			}
-			Expect(cond).To(BeFalse())
+				Expect(cond).To(BeFalse())
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -8,103 +8,108 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = DescribeTier2("1 Client pod -> 1 Server pod test using Vault", func() {
-	Context("HashivaultSimpleClientServer", func() {
-		sourceNs := "client"
-		destNs := "server"
-		var ns []string = []string{sourceNs, destNs}
+var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
+	OSMDescribeInfo{
+		tier:   2,
+		bucket: 1,
+	},
+	func() {
+		Context("HashivaultSimpleClientServer", func() {
+			sourceNs := "client"
+			destNs := "server"
+			var ns []string = []string{sourceNs, destNs}
 
-		It("Tests HTTP traffic for client pod -> server pod", func() {
-			// Install OSM
-			installOpts := td.GetOSMInstallOpts()
-			installOpts.certManager = "vault"
-			Expect(td.InstallOSM(installOpts)).To(Succeed())
-			Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 2)).To(Succeed())
+			It("Tests HTTP traffic for client pod -> server pod", func() {
+				// Install OSM
+				installOpts := td.GetOSMInstallOpts()
+				installOpts.certManager = "vault"
+				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 2)).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(td.CreateNs(n, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, n)).To(Succeed())
-			}
+				// Create Test NS
+				for _, n := range ns {
+					Expect(td.CreateNs(n, nil)).To(Succeed())
+					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+				}
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := td.SimplePodApp(
-				SimplePodAppDef{
-					name:      "server",
-					namespace: destNs,
-					image:     "kennethreitz/httpbin",
+				// Get simple pod definitions for the HTTP server
+				svcAccDef, podDef, svcDef := td.SimplePodApp(
+					SimplePodAppDef{
+						name:      "server",
+						namespace: destNs,
+						image:     "kennethreitz/httpbin",
+						ports:     []int{80},
+					})
+
+				_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				dstPod, err := td.CreatePod(destNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(destNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
+					name:      "client",
+					namespace: sourceNs,
+					command:   []string{"/bin/bash", "-c", "--"},
+					args:      []string{"while true; do sleep 30; done;"},
+					image:     "songrgg/alpine-debug",
 					ports:     []int{80},
 				})
 
-			_, err := td.CreateServiceAccount(destNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := td.CreatePod(destNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(destNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := td.CreatePod(sourceNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(sourceNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
 
-			// Get simple Pod definitions for the client
-			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-				name:      "client",
-				namespace: sourceNs,
-				command:   []string{"/bin/bash", "-c", "--"},
-				args:      []string{"while true; do sleep 30; done;"},
-				image:     "songrgg/alpine-debug",
-				ports:     []int{80},
-			})
+				// Deploy allow rule client->server
+				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+					SimpleAllowPolicy{
+						RouteGroupName:    "routes",
+						TrafficTargetName: "test-target",
 
-			_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			srcPod, err := td.CreatePod(sourceNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(sourceNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+						SourceNamespace:      sourceNs,
+						SourceSVCAccountName: "client",
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
-
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    "routes",
-					TrafficTargetName: "test-target",
-
-					SourceNamespace:      sourceNs,
-					SourceSVCAccountName: "client",
-
-					DestinationNamespace:      destNs,
-					DestinationSvcAccountName: "server",
-				})
-
-			// Configs have to be put into a monitored NS, and osm-system can't be by cli
-			_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// All ready. Expect client to reach server
-			// Need to get the pod though.
-			cond := td.WaitForRepeatedSuccess(func() bool {
-				result :=
-					td.HTTPRequest(HTTPRequestDef{
-						SourceNs:        srcPod.Namespace,
-						SourcePod:       srcPod.Name,
-						SourceContainer: "client", // We can do better
-
-						Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+						DestinationNamespace:      destNs,
+						DestinationSvcAccountName: "server",
 					})
 
-				if result.Err != nil || result.StatusCode != 200 {
-					td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
-					return false
-				}
-				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
-				return true
-			}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
-			Expect(cond).To(BeTrue())
+				// Configs have to be put into a monitored NS, and osm-system can't be by cli
+				_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+				Expect(err).NotTo(HaveOccurred())
+
+				// All ready. Expect client to reach server
+				// Need to get the pod though.
+				cond := td.WaitForRepeatedSuccess(func() bool {
+					result :=
+						td.HTTPRequest(HTTPRequestDef{
+							SourceNs:        srcPod.Namespace,
+							SourcePod:       srcPod.Name,
+							SourceContainer: "client", // We can do better
+
+							Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+						})
+
+					if result.Err != nil || result.StatusCode != 200 {
+						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						return false
+					}
+					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					return true
+				}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
+				Expect(cond).To(BeTrue())
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -15,8 +15,8 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 	},
 	func() {
 		Context("HashivaultSimpleClientServer", func() {
-			sourceNs := "client"
-			destNs := "server"
+			const sourceNs = "client"
+			const destNs = "server"
 			var ns []string = []string{sourceNs, destNs}
 
 			It("Tests HTTP traffic for client pod -> server pod", func() {

--- a/tests/e2e/e2e_helm_install_test.go
+++ b/tests/e2e/e2e_helm_install_test.go
@@ -5,36 +5,41 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = DescribeTier2("Test osm control plane installation with Helm", func() {
-	Context("Using default values", func() {
-		It("installs osm control plane successfully", func() {
-			if td.instType == NoInstall {
-				Skip("Test is not going through InstallOSM, hence cannot be automatically skipped with NoInstall (#1908)")
-			}
+var _ = OSMDescribe("Test osm control plane installation with Helm",
+	OSMDescribeInfo{
+		tier:   2,
+		bucket: 1,
+	},
+	func() {
+		Context("Using default values", func() {
+			It("installs osm control plane successfully", func() {
+				if td.instType == NoInstall {
+					Skip("Test is not going through InstallOSM, hence cannot be automatically skipped with NoInstall (#1908)")
+				}
 
-			namespace := "helm-install-namespace"
-			release := "helm-install-osm"
+				namespace := "helm-install-namespace"
+				release := "helm-install-osm"
 
-			// Install OSM with Helm
-			Expect(td.HelmInstallOSM(release, namespace)).To(Succeed())
+				// Install OSM with Helm
+				Expect(td.HelmInstallOSM(release, namespace)).To(Succeed())
 
-			configmap, err := td.GetConfigMap("osm-config", namespace)
-			Expect(err).ShouldNot(HaveOccurred())
+				configmap, err := td.GetConfigMap("osm-config", namespace)
+				Expect(err).ShouldNot(HaveOccurred())
 
-			// validate osm configmap
-			Expect(configmap.Data["permissive_traffic_policy_mode"]).Should(Equal("false"))
-			Expect(configmap.Data["egress"]).Should(Equal("false"))
-			Expect(configmap.Data["envoy_log_level"]).Should(Equal("error"))
-			Expect(configmap.Data["enable_debug_server"]).Should(Equal("false"))
-			Expect(configmap.Data["prometheus_scraping"]).Should(Equal("true"))
-			Expect(configmap.Data["tracing_enable"]).Should(Equal("true"))
-			Expect(configmap.Data["tracing_address"]).Should(Equal("jaeger.osm-system.svc.cluster.local"))
-			Expect(configmap.Data["tracing_port"]).Should(Equal("9411"))
-			Expect(configmap.Data["tracing_endpoint"]).Should(Equal("/api/v2/spans"))
-			Expect(configmap.Data["use_https_ingress"]).Should(Equal("false"))
-			Expect(configmap.Data["service_cert_validity_duration"]).Should(Equal("24h"))
+				// validate osm configmap
+				Expect(configmap.Data["permissive_traffic_policy_mode"]).Should(Equal("false"))
+				Expect(configmap.Data["egress"]).Should(Equal("false"))
+				Expect(configmap.Data["envoy_log_level"]).Should(Equal("error"))
+				Expect(configmap.Data["enable_debug_server"]).Should(Equal("false"))
+				Expect(configmap.Data["prometheus_scraping"]).Should(Equal("true"))
+				Expect(configmap.Data["tracing_enable"]).Should(Equal("true"))
+				Expect(configmap.Data["tracing_address"]).Should(Equal("jaeger.osm-system.svc.cluster.local"))
+				Expect(configmap.Data["tracing_port"]).Should(Equal("9411"))
+				Expect(configmap.Data["tracing_endpoint"]).Should(Equal("/api/v2/spans"))
+				Expect(configmap.Data["use_https_ingress"]).Should(Equal("false"))
+				Expect(configmap.Data["service_cert_validity_duration"]).Should(Equal("24h"))
 
-			Expect(td.DeleteHelmRelease(release, namespace)).To(Succeed())
+				Expect(td.DeleteHelmRelease(release, namespace)).To(Succeed())
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -9,98 +9,103 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = DescribeTier1("Permissive Traffic Policy Mode", func() {
-	Context("PermissiveMode", func() {
-		const sourceNs = "client"
-		const destNs = "server"
-		var ns []string = []string{sourceNs, destNs}
+var _ = OSMDescribe("Permissive Traffic Policy Mode",
+	OSMDescribeInfo{
+		tier:   1,
+		bucket: 2,
+	},
+	func() {
+		Context("PermissiveMode", func() {
+			const sourceNs = "client"
+			const destNs = "server"
+			var ns []string = []string{sourceNs, destNs}
 
-		It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
-			// Install OSM
-			installOpts := td.GetOSMInstallOpts()
-			installOpts.enablePermissiveMode = true
-			Expect(td.InstallOSM(installOpts)).To(Succeed())
+			It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
+				// Install OSM
+				installOpts := td.GetOSMInstallOpts()
+				installOpts.enablePermissiveMode = true
+				Expect(td.InstallOSM(installOpts)).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(td.CreateNs(n, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, n)).To(Succeed())
-			}
+				// Create Test NS
+				for _, n := range ns {
+					Expect(td.CreateNs(n, nil)).To(Succeed())
+					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+				}
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := td.SimplePodApp(
-				SimplePodAppDef{
-					name:      "server",
-					namespace: destNs,
-					image:     "kennethreitz/httpbin",
+				// Get simple pod definitions for the HTTP server
+				svcAccDef, podDef, svcDef := td.SimplePodApp(
+					SimplePodAppDef{
+						name:      "server",
+						namespace: destNs,
+						image:     "kennethreitz/httpbin",
+						ports:     []int{80},
+					})
+
+				_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				dstPod, err := td.CreatePod(destNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(destNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
+
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
+					name:      "client",
+					namespace: sourceNs,
+					command:   []string{"/bin/bash", "-c", "--"},
+					args:      []string{"while true; do sleep 30; done;"},
+					image:     "songrgg/alpine-debug",
 					ports:     []int{80},
 				})
 
-			_, err := td.CreateServiceAccount(destNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := td.CreatePod(destNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(destNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := td.CreatePod(sourceNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(sourceNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
 
-			Expect(td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
+				Expect(td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
 
-			// Get simple Pod definitions for the client
-			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-				name:      "client",
-				namespace: sourceNs,
-				command:   []string{"/bin/bash", "-c", "--"},
-				args:      []string{"while true; do sleep 30; done;"},
-				image:     "songrgg/alpine-debug",
-				ports:     []int{80},
+				req := HTTPRequestDef{
+					SourceNs:        srcPod.Namespace,
+					SourcePod:       srcPod.Name,
+					SourceContainer: "client",
+
+					Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+				}
+
+				By("Ensuring traffic is allowed when permissive mode is enabled")
+
+				cond := td.WaitForRepeatedSuccess(func() bool {
+					result := td.HTTPRequest(req)
+
+					if result.Err != nil || result.StatusCode != 200 {
+						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						return false
+					}
+					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					return true
+				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+				Expect(cond).To(BeTrue())
+
+				By("Ensuring traffic is not allowed when permissive mode is disabled")
+
+				Expect(td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
+
+				cond = td.WaitForRepeatedSuccess(func() bool {
+					result := td.HTTPRequest(req)
+
+					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+						td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
+						return false
+					}
+					td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
+					return true
+				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+				Expect(cond).To(BeTrue())
 			})
-
-			_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			srcPod, err := td.CreatePod(sourceNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(sourceNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
-
-			req := HTTPRequestDef{
-				SourceNs:        srcPod.Namespace,
-				SourcePod:       srcPod.Name,
-				SourceContainer: "client",
-
-				Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
-			}
-
-			By("Ensuring traffic is allowed when permissive mode is enabled")
-
-			cond := td.WaitForRepeatedSuccess(func() bool {
-				result := td.HTTPRequest(req)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
-					return false
-				}
-				td.T.Logf("> REST req succeeded: %d", result.StatusCode)
-				return true
-			}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
-			Expect(cond).To(BeTrue())
-
-			By("Ensuring traffic is not allowed when permissive mode is disabled")
-
-			Expect(td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
-
-			cond = td.WaitForRepeatedSuccess(func() bool {
-				result := td.HTTPRequest(req)
-
-				if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-					td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
-					return false
-				}
-				td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
-				return true
-			}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
-			Expect(cond).To(BeTrue())
 		})
 	})
-})

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -20,8 +20,8 @@ var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 	},
 	func() {
 		Context("SimpleClientServer", func() {
-			sourceName := "client"
-			destName := "server"
+			const sourceName = "client"
+			const destName = "server"
 			var ns = []string{sourceName, destName}
 
 			It("Tests HTTP traffic for client pod -> server pod", func() {

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -11,124 +11,129 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = DescribeTier1("Test HTTP traffic from 1 pod client -> 1 pod server", func() {
-	Context("SimpleClientServer", func() {
-		sourceName := "client"
-		destName := "server"
-		var ns []string = []string{sourceName, destName}
+var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
+	OSMDescribeInfo{
+		tier:   1,
+		bucket: 1,
+	},
+	func() {
+		Context("SimpleClientServer", func() {
+			sourceName := "client"
+			destName := "server"
+			var ns []string = []string{sourceName, destName}
 
-		It("Tests HTTP traffic for client pod -> server pod", func() {
-			// Install OSM
-			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+			It("Tests HTTP traffic for client pod -> server pod", func() {
+				// Install OSM
+				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(td.CreateNs(n, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, n)).To(Succeed())
-			}
+				// Create Test NS
+				for _, n := range ns {
+					Expect(td.CreateNs(n, nil)).To(Succeed())
+					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+				}
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := td.SimplePodApp(
-				SimplePodAppDef{
-					name:      destName,
-					namespace: destName,
-					image:     "kennethreitz/httpbin",
+				// Get simple pod definitions for the HTTP server
+				svcAccDef, podDef, svcDef := td.SimplePodApp(
+					SimplePodAppDef{
+						name:      destName,
+						namespace: destName,
+						image:     "kennethreitz/httpbin",
+						ports:     []int{80},
+					})
+
+				_, err := td.CreateServiceAccount(destName, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				dstPod, err := td.CreatePod(destName, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(destName, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
+					name:      sourceName,
+					namespace: sourceName,
+					command:   []string{"/bin/bash", "-c", "--"},
+					args:      []string{"while true; do sleep 30; done;"},
+					image:     "songrgg/alpine-debug",
 					ports:     []int{80},
 				})
 
-			_, err := td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateServiceAccount(sourceName, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := td.CreatePod(sourceName, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateService(sourceName, svcDef)
+				Expect(err).NotTo(HaveOccurred())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+				// Expect it to be up and running in it's receiver namespace
+				Expect(td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
 
-			// Get simple Pod definitions for the client
-			svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-				name:      sourceName,
-				namespace: sourceName,
-				command:   []string{"/bin/bash", "-c", "--"},
-				args:      []string{"while true; do sleep 30; done;"},
-				image:     "songrgg/alpine-debug",
-				ports:     []int{80},
+				By("Creating SMI policies")
+				// Deploy allow rule client->server
+				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+					SimpleAllowPolicy{
+						RouteGroupName:    "routes",
+						TrafficTargetName: "test-target",
+
+						SourceNamespace:      sourceName,
+						SourceSVCAccountName: sourceName,
+
+						DestinationNamespace:      destName,
+						DestinationSvcAccountName: destName,
+					})
+
+				// Configs have to be put into a monitored NS
+				_, err = td.CreateHTTPRouteGroup(sourceName, httpRG)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = td.CreateTrafficTarget(sourceName, trafficTarget)
+				Expect(err).NotTo(HaveOccurred())
+
+				// All ready. Expect client to reach server
+				clientToServer := HTTPRequestDef{
+					SourceNs:        sourceName,
+					SourcePod:       srcPod.Name,
+					SourceContainer: sourceName,
+
+					Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+				}
+
+				srcToDestStr := fmt.Sprintf("%s -> %s",
+					fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+					clientToServer.Destination)
+
+				cond := td.WaitForRepeatedSuccess(func() bool {
+					result := td.HTTPRequest(clientToServer)
+
+					if result.Err != nil || result.StatusCode != 200 {
+						td.T.Logf("> (%s) HTTP Req failed %d %v",
+							srcToDestStr, result.StatusCode, result.Err)
+						return false
+					}
+					td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+					return true
+				}, 5, 90*time.Second)
+				Expect(cond).To(BeTrue())
+
+				By("Deleting SMI policies")
+				Expect(td.smiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+				Expect(td.smiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
+
+				// Expect client not to reach server
+				cond = td.WaitForRepeatedSuccess(func() bool {
+					result := td.HTTPRequest(clientToServer)
+
+					// Curl exit code 7 == Conn refused
+					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+						td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
+						return false
+					}
+					td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
+					return true
+				}, 5, 150*time.Second)
+				Expect(cond).To(BeTrue())
 			})
-
-			_, err = td.CreateServiceAccount(sourceName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			srcPod, err := td.CreatePod(sourceName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(sourceName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
-
-			By("Creating SMI policies")
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    "routes",
-					TrafficTargetName: "test-target",
-
-					SourceNamespace:      sourceName,
-					SourceSVCAccountName: sourceName,
-
-					DestinationNamespace:      destName,
-					DestinationSvcAccountName: destName,
-				})
-
-			// Configs have to be put into a monitored NS
-			_, err = td.CreateHTTPRouteGroup(sourceName, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateTrafficTarget(sourceName, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// All ready. Expect client to reach server
-			clientToServer := HTTPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
-			}
-
-			srcToDestStr := fmt.Sprintf("%s -> %s",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToServer.Destination)
-
-			cond := td.WaitForRepeatedSuccess(func() bool {
-				result := td.HTTPRequest(clientToServer)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 5, 90*time.Second)
-			Expect(cond).To(BeTrue())
-
-			By("Deleting SMI policies")
-			Expect(td.smiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
-			Expect(td.smiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
-
-			// Expect client not to reach server
-			cond = td.WaitForRepeatedSuccess(func() bool {
-				result := td.HTTPRequest(clientToServer)
-
-				// Curl exit code 7 == Conn refused
-				if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-					td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
-				return true
-			}, 5, 150*time.Second)
-			Expect(cond).To(BeTrue())
 		})
 	})
-})

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -18,8 +18,8 @@ var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 	},
 	func() {
 		Context("SimpleClientServer", func() {
-			sourceName := "client"
-			destName := "server"
+			const sourceName = "client"
+			const destName = "server"
 			var ns []string = []string{sourceName, destName}
 
 			It("Tests HTTP traffic for client pod -> server pod", func() {

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -14,238 +14,243 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = DescribeTier1("Test TrafficSplit where each backend shares the same ServiceAccount", func() {
-	Context("ClientServerTrafficSplitSameSA", func() {
-		const (
-			// to name the header we will use to identify the server that replies
-			HTTPHeaderName = "podname"
-		)
-		clientAppBaseName := "client"
-		serverNamespace := "server"
-		trafficSplitName := "traffic-split"
+var _ = OSMDescribe("Test TrafficSplit where each backend shares the same ServiceAccount",
+	OSMDescribeInfo{
+		tier:   1,
+		bucket: 2,
+	},
+	func() {
+		Context("ClientServerTrafficSplitSameSA", func() {
+			const (
+				// to name the header we will use to identify the server that replies
+				HTTPHeaderName = "podname"
+			)
+			clientAppBaseName := "client"
+			serverNamespace := "server"
+			trafficSplitName := "traffic-split"
 
-		// Scale number of client services/pods here
-		numberOfClientServices := 2
-		clientReplicaSet := 5
+			// Scale number of client services/pods here
+			numberOfClientServices := 2
+			clientReplicaSet := 5
 
-		// Scale number of server services/pods here
-		numberOfServerServices := 5
-		serverReplicaSet := 2
+			// Scale number of server services/pods here
+			numberOfServerServices := 5
+			serverReplicaSet := 2
 
-		clientServices := []string{}
-		serverServices := []string{}
-		allNamespaces := []string{}
+			clientServices := []string{}
+			serverServices := []string{}
+			allNamespaces := []string{}
 
-		for i := 0; i < numberOfClientServices; i++ {
-			clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
-		}
-
-		for i := 0; i < numberOfServerServices; i++ {
-			serverServices = append(serverServices, fmt.Sprintf("%s%d", serverNamespace, i))
-		}
-
-		allNamespaces = append(allNamespaces, clientServices...)
-		allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
-
-		// Used across the test to wait for concurrent steps to finish
-		var wg sync.WaitGroup
-
-		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
-			// Install OSM
-			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-
-			// Create NSs
-			Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())
-			Expect(td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
-
-			// Create server apps
-			svcAcc := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "server",
-				},
+			for i := 0; i < numberOfClientServices; i++ {
+				clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
 			}
-			_, err := td.CreateServiceAccount(serverNamespace, svcAcc)
-			Expect(err).NotTo(HaveOccurred())
 
-			for _, serverApp := range serverServices {
-				_, deploymentDef, svcDef := td.SimpleDeploymentApp(
-					SimpleDeploymentAppDef{
-						name:         serverApp,
-						namespace:    serverNamespace,
-						replicaCount: int32(serverReplicaSet),
-						image:        "simonkowallik/httpbin",
-						ports:        []int{80},
-					})
+			for i := 0; i < numberOfServerServices; i++ {
+				serverServices = append(serverServices, fmt.Sprintf("%s%d", serverNamespace, i))
+			}
 
-				// Expose an env variable such as XHTTPBIN_X_POD_NAME:
-				// This httpbin fork will pick certain env variable formats and reply the values as headers.
-				// We will expose pod name as one of these env variables, and will use it
-				// to identify the pod that replies to the request, and validate the test
-				deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
-					{
-						Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
-						ValueFrom: &v1.EnvVarSource{
-							FieldRef: &v1.ObjectFieldSelector{
-								FieldPath: "metadata.name",
+			allNamespaces = append(allNamespaces, clientServices...)
+			allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
+
+			// Used across the test to wait for concurrent steps to finish
+			var wg sync.WaitGroup
+
+			It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
+				// Install OSM
+				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+
+				// Create NSs
+				Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+				Expect(td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+
+				// Create server apps
+				svcAcc := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "server",
+					},
+				}
+				_, err := td.CreateServiceAccount(serverNamespace, svcAcc)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, serverApp := range serverServices {
+					_, deploymentDef, svcDef := td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							name:         serverApp,
+							namespace:    serverNamespace,
+							replicaCount: int32(serverReplicaSet),
+							image:        "simonkowallik/httpbin",
+							ports:        []int{80},
+						})
+
+					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
+					// This httpbin fork will pick certain env variable formats and reply the values as headers.
+					// We will expose pod name as one of these env variables, and will use it
+					// to identify the pod that replies to the request, and validate the test
+					deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+						{
+							Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
 							},
 						},
-					},
+					}
+
+					deploymentDef.Spec.Template.Spec.ServiceAccountName = svcAcc.Name
+
+					_, err = td.CreateDeployment(serverNamespace, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateService(serverNamespace, svcDef)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					Expect(td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+				}()
+
+				// Client apps
+				for _, clientApp := range clientServices {
+					svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							name:         clientApp,
+							namespace:    clientApp,
+							replicaCount: int32(clientReplicaSet),
+							command:      []string{"/bin/bash", "-c", "--"},
+							args:         []string{"while true; do sleep 30; done;"},
+							image:        "songrgg/alpine-debug",
+							ports:        []int{80},
+						})
+
+					_, err := td.CreateServiceAccount(clientApp, &svcAccDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateDeployment(clientApp, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateService(clientApp, svcDef)
+					Expect(err).NotTo(HaveOccurred())
+
+					wg.Add(1)
+					go func(app string) {
+						defer wg.Done()
+						Expect(td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+					}(clientApp)
 				}
 
-				deploymentDef.Spec.Template.Spec.ServiceAccountName = svcAcc.Name
+				wg.Wait()
 
-				_, err = td.CreateDeployment(serverNamespace, deploymentDef)
+				// Put allow traffic target rules
+				for _, srcClient := range clientServices {
+					httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+						SimpleAllowPolicy{
+							RouteGroupName:    srcClient + "-server",
+							TrafficTargetName: srcClient + "-server",
+
+							SourceNamespace:      srcClient,
+							SourceSVCAccountName: srcClient,
+
+							DestinationNamespace:      serverNamespace,
+							DestinationSvcAccountName: svcAcc.Name,
+						})
+
+					_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				// Create traffic split service. Use simple Pod to create a simple service definition
+				_, _, trafficSplitService := td.SimplePodApp(SimplePodAppDef{
+					name:      trafficSplitName,
+					namespace: serverNamespace,
+					ports:     []int{80},
+				})
+
+				// Creating trafficsplit service in K8s
+				_, err = td.CreateService(serverNamespace, trafficSplitService)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(serverNamespace, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				Expect(td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
-			}()
 
-			// Client apps
-			for _, clientApp := range clientServices {
-				svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
-					SimpleDeploymentAppDef{
-						name:         clientApp,
-						namespace:    clientApp,
-						replicaCount: int32(clientReplicaSet),
-						command:      []string{"/bin/bash", "-c", "--"},
-						args:         []string{"while true; do sleep 30; done;"},
-						image:        "songrgg/alpine-debug",
-						ports:        []int{80},
-					})
-
-				_, err := td.CreateServiceAccount(clientApp, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateDeployment(clientApp, deploymentDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(clientApp, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				wg.Add(1)
-				go func(app string) {
-					defer wg.Done()
-					Expect(td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
-				}(clientApp)
-			}
-
-			wg.Wait()
-
-			// Put allow traffic target rules
-			for _, srcClient := range clientServices {
-				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
-					SimpleAllowPolicy{
-						RouteGroupName:    srcClient + "-server",
-						TrafficTargetName: srcClient + "-server",
-
-						SourceNamespace:      srcClient,
-						SourceSVCAccountName: srcClient,
-
-						DestinationNamespace:      serverNamespace,
-						DestinationSvcAccountName: svcAcc.Name,
-					})
-
-				_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
-				Expect(err).NotTo(HaveOccurred())
-			}
-
-			// Create traffic split service. Use simple Pod to create a simple service definition
-			_, _, trafficSplitService := td.SimplePodApp(SimplePodAppDef{
-				name:      trafficSplitName,
-				namespace: serverNamespace,
-				ports:     []int{80},
-			})
-
-			// Creating trafficsplit service in K8s
-			_, err = td.CreateService(serverNamespace, trafficSplitService)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Create Traffic split with all server processes as backends
-			trafficSplit := TrafficSplitDef{
-				Name:                    trafficSplitName,
-				Namespace:               serverNamespace,
-				TrafficSplitServiceName: trafficSplitName,
-				Backends:                []TrafficSplitBackend{},
-			}
-			assignation := 100 / len(serverServices) // Spreading equitatively
-			for _, dstServer := range serverServices {
-				trafficSplit.Backends = append(trafficSplit.Backends,
-					TrafficSplitBackend{
-						Name:   dstServer,
-						Weight: assignation,
-					},
-				)
-			}
-			// Get the Traffic split structures
-			tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
-			Expect(err).To(BeNil())
-
-			// Push them in K8s
-			_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
-			Expect(err).To(BeNil())
-
-			// Test traffic
-			// Create Multiple HTTP request structure
-			requests := HTTPMultipleRequest{
-				Sources: []HTTPRequestDef{},
-			}
-			for _, ns := range clientServices {
-				pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+				// Create Traffic split with all server processes as backends
+				trafficSplit := TrafficSplitDef{
+					Name:                    trafficSplitName,
+					Namespace:               serverNamespace,
+					TrafficSplitServiceName: trafficSplitName,
+					Backends:                []TrafficSplitBackend{},
+				}
+				assignation := 100 / len(serverServices) // Spreading equitatively
+				for _, dstServer := range serverServices {
+					trafficSplit.Backends = append(trafficSplit.Backends,
+						TrafficSplitBackend{
+							Name:   dstServer,
+							Weight: assignation,
+						},
+					)
+				}
+				// Get the Traffic split structures
+				tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
 				Expect(err).To(BeNil())
 
-				for _, pod := range pods.Items {
-					requests.Sources = append(requests.Sources, HTTPRequestDef{
-						SourceNs:        ns,
-						SourcePod:       pod.Name,
-						SourceContainer: ns, // container_name == NS for this test
+				// Push them in K8s
+				_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
+				Expect(err).To(BeNil())
 
-						// Targeting the trafficsplit FQDN
-						Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
-					})
+				// Test traffic
+				// Create Multiple HTTP request structure
+				requests := HTTPMultipleRequest{
+					Sources: []HTTPRequestDef{},
 				}
-			}
+				for _, ns := range clientServices {
+					pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					Expect(err).To(BeNil())
 
-			var results HTTPMultipleResults
-			var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
-			success := td.WaitForRepeatedSuccess(func() bool {
-				curlSuccess := true
+					for _, pod := range pods.Items {
+						requests.Sources = append(requests.Sources, HTTPRequestDef{
+							SourceNs:        ns,
+							SourcePod:       pod.Name,
+							SourceContainer: ns, // container_name == NS for this test
 
-				// Get results
-				results = td.MultipleHTTPRequest(&requests)
+							// Targeting the trafficsplit FQDN
+							Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
+						})
+					}
+				}
 
-				// Print results
-				td.PrettyPrintHTTPResults(&results)
+				var results HTTPMultipleResults
+				var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+				success := td.WaitForRepeatedSuccess(func() bool {
+					curlSuccess := true
 
-				// Verify REST status code results
-				for _, ns := range results {
-					for _, podResult := range ns {
-						if podResult.Err != nil || podResult.StatusCode != 200 {
-							curlSuccess = false
-						} else {
-							// We should see pod header populated
-							dstPod, ok := podResult.Headers[HTTPHeaderName]
-							if ok {
-								// Store and mark that we have seen a response for this server pod
-								serversSeen[dstPod] = true
+					// Get results
+					results = td.MultipleHTTPRequest(&requests)
+
+					// Print results
+					td.PrettyPrintHTTPResults(&results)
+
+					// Verify REST status code results
+					for _, ns := range results {
+						for _, podResult := range ns {
+							if podResult.Err != nil || podResult.StatusCode != 200 {
+								curlSuccess = false
+							} else {
+								// We should see pod header populated
+								dstPod, ok := podResult.Headers[HTTPHeaderName]
+								if ok {
+									// Store and mark that we have seen a response for this server pod
+									serversSeen[dstPod] = true
+								}
 							}
 						}
 					}
-				}
-				td.T.Logf("Unique servers replied %d/%d",
-					len(serversSeen), numberOfServerServices*serverReplicaSet)
+					td.T.Logf("Unique servers replied %d/%d",
+						len(serversSeen), numberOfServerServices*serverReplicaSet)
 
-				// Success conditions:
-				// - All clients have been answered consecutively 5 successful HTTP requests
-				// - We have seen all servers from the traffic split reply at least once
-				return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
-			}, 5, 150*time.Second)
+					// Success conditions:
+					// - All clients have been answered consecutively 5 successful HTTP requests
+					// - We have seen all servers from the traffic split reply at least once
+					return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
+				}, 5, 150*time.Second)
 
-			Expect(success).To(BeTrue())
+				Expect(success).To(BeTrue())
+			})
 		})
 	})
-})

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -13,232 +13,237 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = DescribeTier1("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test", func() {
-	Context("ClientServerTrafficSplit", func() {
-		const (
-			// to name the header we will use to identify the server that replies
-			HTTPHeaderName = "podname"
-		)
-		clientAppBaseName := "client"
-		serverNamespace := "server"
-		trafficSplitName := "traffic-split"
+var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test",
+	OSMDescribeInfo{
+		tier:   1,
+		bucket: 2,
+	},
+	func() {
+		Context("ClientServerTrafficSplit", func() {
+			const (
+				// to name the header we will use to identify the server that replies
+				HTTPHeaderName = "podname"
+			)
+			clientAppBaseName := "client"
+			serverNamespace := "server"
+			trafficSplitName := "traffic-split"
 
-		// Scale number of client services/pods here
-		numberOfClientServices := 2
-		clientReplicaSet := 5
+			// Scale number of client services/pods here
+			numberOfClientServices := 2
+			clientReplicaSet := 5
 
-		// Scale number of server services/pods here
-		numberOfServerServices := 5
-		serverReplicaSet := 2
+			// Scale number of server services/pods here
+			numberOfServerServices := 5
+			serverReplicaSet := 2
 
-		clientServices := []string{}
-		serverServices := []string{}
-		allNamespaces := []string{}
+			clientServices := []string{}
+			serverServices := []string{}
+			allNamespaces := []string{}
 
-		for i := 0; i < numberOfClientServices; i++ {
-			clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
-		}
-
-		for i := 0; i < numberOfServerServices; i++ {
-			serverServices = append(serverServices, fmt.Sprintf("%s%d", serverNamespace, i))
-		}
-
-		allNamespaces = append(allNamespaces, clientServices...)
-		allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
-
-		// Used across the test to wait for concurrent steps to finish
-		var wg sync.WaitGroup
-
-		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
-			// Install OSM
-			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
-
-			// Create NSs
-			Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())
-			Expect(td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
-
-			// Create server apps
-			for _, serverApp := range serverServices {
-				svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
-					SimpleDeploymentAppDef{
-						name:         serverApp,
-						namespace:    serverNamespace,
-						replicaCount: int32(serverReplicaSet),
-						image:        "simonkowallik/httpbin",
-						ports:        []int{80},
-					})
-
-				// Expose an env variable such as XHTTPBIN_X_POD_NAME:
-				// This httpbin fork will pick certain env variable formats and reply the values as headers.
-				// We will expose pod name as one of these env variables, and will use it
-				// to identify the pod that replies to the request, and validate the test
-				deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
-					{
-						Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
-						ValueFrom: &v1.EnvVarSource{
-							FieldRef: &v1.ObjectFieldSelector{
-								FieldPath: "metadata.name",
-							},
-						},
-					},
-				}
-
-				_, err := td.CreateServiceAccount(serverNamespace, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateDeployment(serverNamespace, deploymentDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(serverNamespace, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				Expect(td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
-			}()
-
-			// Client apps
-			for _, clientApp := range clientServices {
-				svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
-					SimpleDeploymentAppDef{
-						name:         clientApp,
-						namespace:    clientApp,
-						replicaCount: int32(clientReplicaSet),
-						command:      []string{"/bin/bash", "-c", "--"},
-						args:         []string{"while true; do sleep 30; done;"},
-						image:        "songrgg/alpine-debug",
-						ports:        []int{80},
-					})
-
-				_, err := td.CreateServiceAccount(clientApp, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateDeployment(clientApp, deploymentDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(clientApp, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				wg.Add(1)
-				go func(app string) {
-					defer wg.Done()
-					Expect(td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
-				}(clientApp)
+			for i := 0; i < numberOfClientServices; i++ {
+				clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
 			}
 
-			wg.Wait()
+			for i := 0; i < numberOfServerServices; i++ {
+				serverServices = append(serverServices, fmt.Sprintf("%s%d", serverNamespace, i))
+			}
 
-			// Put allow traffic target rules
-			for _, srcClient := range clientServices {
-				for _, dstServer := range serverServices {
-					httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
-						SimpleAllowPolicy{
-							RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
-							TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+			allNamespaces = append(allNamespaces, clientServices...)
+			allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
 
-							SourceNamespace:      srcClient,
-							SourceSVCAccountName: srcClient,
+			// Used across the test to wait for concurrent steps to finish
+			var wg sync.WaitGroup
 
-							DestinationNamespace:      serverNamespace,
-							DestinationSvcAccountName: dstServer,
+			It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
+				// Install OSM
+				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+
+				// Create NSs
+				Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+				Expect(td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+
+				// Create server apps
+				for _, serverApp := range serverServices {
+					svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							name:         serverApp,
+							namespace:    serverNamespace,
+							replicaCount: int32(serverReplicaSet),
+							image:        "simonkowallik/httpbin",
+							ports:        []int{80},
 						})
 
-					_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
+					// This httpbin fork will pick certain env variable formats and reply the values as headers.
+					// We will expose pod name as one of these env variables, and will use it
+					// to identify the pod that replies to the request, and validate the test
+					deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+						{
+							Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+					}
+
+					_, err := td.CreateServiceAccount(serverNamespace, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					_, err = td.CreateDeployment(serverNamespace, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateService(serverNamespace, svcDef)
 					Expect(err).NotTo(HaveOccurred())
 				}
-			}
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					Expect(td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+				}()
 
-			// Create traffic split service. Use simple Pod to create a simple service definition
-			_, _, trafficSplitService := td.SimplePodApp(SimplePodAppDef{
-				name:      trafficSplitName,
-				namespace: serverNamespace,
-				ports:     []int{80},
-			})
+				// Client apps
+				for _, clientApp := range clientServices {
+					svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							name:         clientApp,
+							namespace:    clientApp,
+							replicaCount: int32(clientReplicaSet),
+							command:      []string{"/bin/bash", "-c", "--"},
+							args:         []string{"while true; do sleep 30; done;"},
+							image:        "songrgg/alpine-debug",
+							ports:        []int{80},
+						})
 
-			// Creating trafficsplit service in K8s
-			_, err := td.CreateService(serverNamespace, trafficSplitService)
-			Expect(err).NotTo(HaveOccurred())
+					_, err := td.CreateServiceAccount(clientApp, &svcAccDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateDeployment(clientApp, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = td.CreateService(clientApp, svcDef)
+					Expect(err).NotTo(HaveOccurred())
 
-			// Create Traffic split with all server processes as backends
-			trafficSplit := TrafficSplitDef{
-				Name:                    trafficSplitName,
-				Namespace:               serverNamespace,
-				TrafficSplitServiceName: trafficSplitName,
-				Backends:                []TrafficSplitBackend{},
-			}
-			assignation := 100 / len(serverServices) // Spreading equitatively
-			for _, dstServer := range serverServices {
-				trafficSplit.Backends = append(trafficSplit.Backends,
-					TrafficSplitBackend{
-						Name:   dstServer,
-						Weight: assignation,
-					},
-				)
-			}
-			// Get the Traffic split structures
-			tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
-			Expect(err).To(BeNil())
+					wg.Add(1)
+					go func(app string) {
+						defer wg.Done()
+						Expect(td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+					}(clientApp)
+				}
 
-			// Push them in K8s
-			_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
-			Expect(err).To(BeNil())
+				wg.Wait()
 
-			// Test traffic
-			// Create Multiple HTTP request structure
-			requests := HTTPMultipleRequest{
-				Sources: []HTTPRequestDef{},
-			}
-			for _, ns := range clientServices {
-				pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+				// Put allow traffic target rules
+				for _, srcClient := range clientServices {
+					for _, dstServer := range serverServices {
+						httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+							SimpleAllowPolicy{
+								RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
+								TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+
+								SourceNamespace:      srcClient,
+								SourceSVCAccountName: srcClient,
+
+								DestinationNamespace:      serverNamespace,
+								DestinationSvcAccountName: dstServer,
+							})
+
+						_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+						Expect(err).NotTo(HaveOccurred())
+						_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+
+				// Create traffic split service. Use simple Pod to create a simple service definition
+				_, _, trafficSplitService := td.SimplePodApp(SimplePodAppDef{
+					name:      trafficSplitName,
+					namespace: serverNamespace,
+					ports:     []int{80},
+				})
+
+				// Creating trafficsplit service in K8s
+				_, err := td.CreateService(serverNamespace, trafficSplitService)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Create Traffic split with all server processes as backends
+				trafficSplit := TrafficSplitDef{
+					Name:                    trafficSplitName,
+					Namespace:               serverNamespace,
+					TrafficSplitServiceName: trafficSplitName,
+					Backends:                []TrafficSplitBackend{},
+				}
+				assignation := 100 / len(serverServices) // Spreading equitatively
+				for _, dstServer := range serverServices {
+					trafficSplit.Backends = append(trafficSplit.Backends,
+						TrafficSplitBackend{
+							Name:   dstServer,
+							Weight: assignation,
+						},
+					)
+				}
+				// Get the Traffic split structures
+				tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
 				Expect(err).To(BeNil())
 
-				for _, pod := range pods.Items {
-					requests.Sources = append(requests.Sources, HTTPRequestDef{
-						SourceNs:        ns,
-						SourcePod:       pod.Name,
-						SourceContainer: ns, // container_name == NS for this test
+				// Push them in K8s
+				_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
+				Expect(err).To(BeNil())
 
-						// Targeting the trafficsplit FQDN
-						Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
-					})
+				// Test traffic
+				// Create Multiple HTTP request structure
+				requests := HTTPMultipleRequest{
+					Sources: []HTTPRequestDef{},
 				}
-			}
+				for _, ns := range clientServices {
+					pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					Expect(err).To(BeNil())
 
-			var results HTTPMultipleResults
-			var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
-			success := td.WaitForRepeatedSuccess(func() bool {
-				curlSuccess := true
+					for _, pod := range pods.Items {
+						requests.Sources = append(requests.Sources, HTTPRequestDef{
+							SourceNs:        ns,
+							SourcePod:       pod.Name,
+							SourceContainer: ns, // container_name == NS for this test
 
-				// Get results
-				results = td.MultipleHTTPRequest(&requests)
+							// Targeting the trafficsplit FQDN
+							Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
+						})
+					}
+				}
 
-				// Print results
-				td.PrettyPrintHTTPResults(&results)
+				var results HTTPMultipleResults
+				var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+				success := td.WaitForRepeatedSuccess(func() bool {
+					curlSuccess := true
 
-				// Verify REST status code results
-				for _, ns := range results {
-					for _, podResult := range ns {
-						if podResult.Err != nil || podResult.StatusCode != 200 {
-							curlSuccess = false
-						} else {
-							// We should see pod header populated
-							dstPod, ok := podResult.Headers[HTTPHeaderName]
-							if ok {
-								// Store and mark that we have seen a response for this server pod
-								serversSeen[dstPod] = true
+					// Get results
+					results = td.MultipleHTTPRequest(&requests)
+
+					// Print results
+					td.PrettyPrintHTTPResults(&results)
+
+					// Verify REST status code results
+					for _, ns := range results {
+						for _, podResult := range ns {
+							if podResult.Err != nil || podResult.StatusCode != 200 {
+								curlSuccess = false
+							} else {
+								// We should see pod header populated
+								dstPod, ok := podResult.Headers[HTTPHeaderName]
+								if ok {
+									// Store and mark that we have seen a response for this server pod
+									serversSeen[dstPod] = true
+								}
 							}
 						}
 					}
-				}
-				td.T.Logf("Unique servers replied %d/%d",
-					len(serversSeen), numberOfServerServices*serverReplicaSet)
+					td.T.Logf("Unique servers replied %d/%d",
+						len(serversSeen), numberOfServerServices*serverReplicaSet)
 
-				// Success conditions:
-				// - All clients have been answered consecutively 5 successful HTTP requests
-				// - We have seen all servers from the traffic split reply at least once
-				return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
-			}, 5, 150*time.Second)
+					// Success conditions:
+					// - All clients have been answered consecutively 5 successful HTTP requests
+					// - We have seen all servers from the traffic split reply at least once
+					return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
+				}, 5, 150*time.Second)
 
-			Expect(success).To(BeTrue())
+				Expect(success).To(BeTrue())
+			})
 		})
 	})
-})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the capability to run e2e tests in parallel in CI.
Tests are now organized into buckets, where each bucket runs in parallel
and tests within each bucket run sequentially. How e2e tests are defined
at the top-level has been refactored to include a new parameter
identifying in which bucket a test should run.

Tests were not organized into buckets initially based on any heuristic,
so rebalancing may be necessary. Adding more buckets is also simple.

All of the changes to the tests themselves aside from adding the bucket ID are whitespace as they're indented by one extra level.

Fixes #1877
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No