### PR TITLE
catalog/routes: Change log level for ListTrafficPolicies from Info to Trace

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -24,7 +24,7 @@ const (
 
 // ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
 func (mc *MeshCatalog) ListTrafficPolicies(service service.MeshService) ([]trafficpolicy.TrafficTarget, error) {
-	log.Info().Msgf("Listing traffic policies for service: %s", service)
+	log.Trace().Msgf("Listing traffic policies for service: %s", service)
 
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
 		// Build traffic policies from service discovery for allow-all policy
@@ -35,7 +35,7 @@ func (mc *MeshCatalog) ListTrafficPolicies(service service.MeshService) ([]traff
 	// Build traffic policies from SMI
 	allRoutes, err := mc.getHTTPPathsPerRoute()
 	if err != nil {
-		log.Error().Err(err).Msgf("Could not get all routes")
+		log.Error().Err(err).Msgf("Error getting all paths per route while working on service %s", service)
 		return nil, err
 	}
 


### PR DESCRIPTION
I noticed that `ListTrafficPolicies` was emiting a bit too many log lines.  To lower the noise, I propose we emit `Listing traffic policies for service...` at `Trace` level.

This PR also adds more detail to the `getHTTPPathsPerRoute()` error message.

---


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`no`