### PR TITLE
main: Print feature flags in use on OSM Controller start-up

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -107,6 +108,13 @@ func main() {
 	if err := logger.SetLogLevel(verbosity); err != nil {
 		log.Fatal().Err(err).Msg("Error setting log level")
 	}
+
+	if featureFlagsJSON, err := json.Marshal(featureflags.Features); err != nil {
+		log.Error().Err(err).Msgf("Error marshaling feature flags struct: %+v", featureflags.Features)
+	} else {
+		log.Info().Msgf("Feature flags: %s", string(featureFlagsJSON))
+	}
+
 	featureflags.Initialize(optionalFeatures)
 
 	// Initialize kube config and client


### PR DESCRIPTION
This PR augments the OSM Controller so that on startup it emits all feature flags in use in logs in JSON format.

This is very helpful in debugging the OSM Controller.

---


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`