### PR TITLE
maestro: Always print human readable logs in lieu of JSON

### DIFF
--- a/ci/cmd/maestro/types.go
+++ b/ci/cmd/maestro/types.go
@@ -52,6 +52,6 @@ var (
 	// FailureLogsFromTimeSince is the interval we go back in time to get pod logs
 	FailureLogsFromTimeSince = 10 * time.Minute
 
-	log            = logger.New("ci/maestro")
+	log            = logger.NewPretty("ci/maestro")
 	errNoPodsFound = errors.New("no pods found")
 )


### PR DESCRIPTION
This PR permanently switches the logs coming out of the maestro CI module into human-readable logs.

---


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
