### PR TITLE
debugger: Expose all feature flags via /debug/feature-flags endpoint

### DIFF
--- a/pkg/debugger/feature_flags.go
+++ b/pkg/debugger/feature_flags.go
@@ -1,0 +1,19 @@
+package debugger
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/openservicemesh/osm/pkg/featureflags"
+)
+
+func (ds debugServer) getFeatureFlags() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if featureFlagsJSON, err := json.Marshal(featureflags.Features); err != nil {
+			log.Error().Err(err).Msgf("Error marshaling feature flags struct: %+v", featureflags.Features)
+		} else {
+			_, _ = fmt.Fprint(w, string(featureFlagsJSON))
+		}
+	})
+}

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -14,12 +14,14 @@ import (
 // GetHandlers implements DebugServer interface and returns the rest of URLs and the handling functions.
 func (ds debugServer) GetHandlers() map[string]http.Handler {
 	handlers := map[string]http.Handler{
-		"/debug/certs":      ds.getCertHandler(),
-		"/debug/xds":        ds.getXDSHandler(),
-		"/debug/proxy":      ds.getProxies(),
-		"/debug/policies":   ds.getSMIPoliciesHandler(),
-		"/debug/config":     ds.getOSMConfigHandler(),
-		"/debug/namespaces": ds.getMonitoredNamespacesHandler(),
+		"/debug/certs":         ds.getCertHandler(),
+		"/debug/xds":           ds.getXDSHandler(),
+		"/debug/proxy":         ds.getProxies(),
+		"/debug/policies":      ds.getSMIPoliciesHandler(),
+		"/debug/config":        ds.getOSMConfigHandler(),
+		"/debug/namespaces":    ds.getMonitoredNamespacesHandler(),
+		"/debug/feature-flags": ds.getFeatureFlags(),
+
 		// Pprof handlers
 		"/debug/pprof/":        http.HandlerFunc(pprof.Index),
 		"/debug/pprof/cmdline": http.HandlerFunc(pprof.Cmdline),


### PR DESCRIPTION
This PR adds the `/debug/feature-flags` endpoint to the debug server, which shows current enabled feature flags.

---

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`no`