### PR TITLE
fix(build): ensure controller version is not a chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOBIN  = $(GOPATH)/bin
 GOX    = go run github.com/mitchellh/gox
 
 CLI_VERSION ?= dev
-CONTROLLER_VERSION = $$(git describe --abbrev=0 --tags)
+CONTROLLER_VERSION = $$(git describe --abbrev=0 --tags --match "v*")
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
 GIT_SHA=$$(git rev-parse HEAD)
 BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, we make tags of the form `v.X.Y.Z` for binary releases and
`chart/X.Y.Z` for the Helm chart. The version is passed to the
osm-controller binary via a linker flag. If both a chart and regular
semver tag exist on the same commit, the chart tag may be passed instead
of the regular version tag. This change ensures only our regular semver
tags are used for the versions embedded in the binaries.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X] (Build)


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No