### PR TITLE
endpoint: Create synthetic service when a pod is in the mesh without a service

### DIFF
--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -6,7 +6,6 @@ var (
 	errInvalidCertificateCN                  = errors.New("invalid cn")
 	errMoreThanOnePodForCertificate          = errors.New("found more than one pod for certificate")
 	errDidNotFindPodForCertificate           = errors.New("did not find pod for certificate")
-	errNoServicesFoundForCertificate         = errors.New("no services found for certificate")
 	errServiceAccountDoesNotMatchCertificate = errors.New("service account does not match certificate")
 	errNamespaceDoesNotMatchCertificate      = errors.New("namespace does not match certificate")
 	errServiceNotFoundForAnyProvider         = errors.New("no service found for service account with any of the mesh supported providers")

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -32,8 +32,13 @@ func (mc *MeshCatalog) GetServicesFromEnvoyCertificate(cn certificate.CommonName
 	services = mc.filterTrafficSplitServices(services)
 
 	if len(services) == 0 {
-		log.Error().Msgf("No services found for connected proxy ID %s", cn)
-		return nil, errNoServicesFoundForCertificate
+		svcAccount := service.K8sServiceAccount{
+			Namespace: pod.Namespace,
+			Name:      pod.Spec.ServiceAccountName,
+		}
+		syntheticService := []service.MeshService{svcAccount.GetSyntheticService()}
+		log.Debug().Msgf("Creating synthetic service %s since no actual services found for connected proxy ID %s", syntheticService, cn)
+		return syntheticService, nil
 	}
 
 	cnMeta, err := getCertificateCommonNameMeta(cn)

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -29,6 +29,29 @@ var _ = Describe("Test XDS certificate tooling", func() {
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookstoreServiceAccountName, tests.Namespace))
 
 	Context("Test GetServicesFromEnvoyCertificate()", func() {
+		It("", func() {
+			namespace := uuid.New().String()
+			serviceAccountName := uuid.New().String()
+			cn := certificate.CommonName(uuid.New().String())
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: serviceAccountName,
+				},
+			}
+
+			actual := makeSyntheticServiceForPod(pod, cn)
+
+			expected := service.MeshService{
+				Name:      fmt.Sprintf("%s.%s.osm.synthetic-%s", serviceAccountName, namespace, service.SyntheticServiceSuffix),
+				Namespace: namespace,
+			}
+			Expect(len(actual)).To(Equal(1))
+			Expect(actual[0]).To(Equal(expected))
+		})
+
 		It("works as expected", func() {
 			pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName)
 			_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -28,8 +28,8 @@ var _ = Describe("Test XDS certificate tooling", func() {
 	mc := NewFakeMeshCatalog(kubeClient)
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookstoreServiceAccountName, tests.Namespace))
 
-	Context("Test GetServicesFromEnvoyCertificate()", func() {
-		It("", func() {
+	Context("Test makeSyntheticServiceForPod()", func() {
+		It("creates a MeshService struct with properly formatted Name and Namespace of the synthetic service", func() {
 			namespace := uuid.New().String()
 			serviceAccountName := uuid.New().String()
 			cn := certificate.CommonName(uuid.New().String())
@@ -51,7 +51,9 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			Expect(len(actual)).To(Equal(1))
 			Expect(actual[0]).To(Equal(expected))
 		})
+	})
 
+	Context("Test GetServicesFromEnvoyCertificate()", func() {
 		It("works as expected", func() {
 			pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName)
 			_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,8 +1,11 @@
 package service
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/google/uuid"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
@@ -12,6 +15,9 @@ const (
 	// or viceversa
 	namespaceNameSeparator = "/"
 )
+
+// SyntheticServiceSuffix is a random string appended to the name of the synthetic service created for each K8s service account
+var SyntheticServiceSuffix = uuid.New().String()
 
 // MeshService is the struct defining a service (Kubernetes or otherwise) within a service mesh.
 type MeshService struct {
@@ -62,8 +68,17 @@ type K8sServiceAccount struct {
 	Name      string
 }
 
-func (ns K8sServiceAccount) String() string {
-	return strings.Join([]string{ns.Namespace, namespaceNameSeparator, ns.Name}, "")
+func (sa K8sServiceAccount) String() string {
+	return strings.Join([]string{sa.Namespace, namespaceNameSeparator, sa.Name}, "")
+}
+
+// GetSyntheticService creates a MeshService for the given K8s Service Account,
+// which has a unique name and is in lieu of an existing Kubernetes service.
+func (sa K8sServiceAccount) GetSyntheticService() MeshService {
+	return MeshService{
+		Namespace: sa.Namespace,
+		Name:      fmt.Sprintf("%s.%s.osm.synthetic-%s", sa.Name, sa.Namespace, SyntheticServiceSuffix),
+	}
 }
 
 // ClusterName is a type for a service name

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -53,6 +55,26 @@ var _ = Describe("Test types helpers", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+	})
+
+	Context("Test GetSyntheticService()", func() {
+		It("returns MeshService", func() {
+			namespace := "-namespace-"
+			serviceAccount := "-service-account-"
+
+			sa := K8sServiceAccount{
+				Namespace: namespace,
+				Name:      serviceAccount,
+			}
+
+			actual := sa.GetSyntheticService()
+
+			expected := MeshService{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("-service-account-.-namespace-.osm.synthetic-%s", SyntheticServiceSuffix),
+			}
+			Expect(actual).To(Equal(expected))
+		})
 	})
 
 })


### PR DESCRIPTION
### Context
With https://github.com/openservicemesh/osm/issues/1180 we documented the fact that there are use cases where one would want to install a Pod without a backing Kubernetes Service (perhaps some tool / jump pod etc.) and that Pod would then be used to troubleshoot to the various services in the cluster. For instance - you want to install a pod w/ `curl` in it and then `curl http://bookstore.bookstore/` in our current demo. This will not work until a kubernetes service is created for this new pod.

Current version of OSM (v0.4.2 as of this writing) requires each inbound or outbourd pod to be part of a Kubernetes service.

### Changes
This PR provides a simple solution to this limitation. With this change a Kubernetes Service is no longer required for the client / outbound service Envoy to be configured.  With this change we could delete the Bookbuyer Kubernetes Service and the demo / CI would still work: https://github.com/openservicemesh/osm/blob/release-v0.4/demo/deploy-bookbuyer.sh#L24-L41  (coming in a separate PR)

### How Sythetic Service works
When we determine that a given Service Account has no pods with an associated Kubernetes service (via `GetServicesForServiceAccount()`) we create such service.  This is referred to as `Synthetic Service` because it does not relaly exist in Kubernetes. Because OSM and Envoy configuration revolves around services - generating a namespaced service struct with a unique name for the service-less service account - allows OSM to generate all necessary Envoy configs.


fix https://github.com/openservicemesh/osm/issues/1180