### PR TITLE
catalog: correctly program shorthand service FQDN

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -335,8 +335,8 @@ type MeshCataloger interface {
 	// GetServicesForServiceAccount returns a list of services corresponding to a service account
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
-	// GetHostnamesForService returns the hostnames for a service
-	GetHostnamesForService(service service.MeshService) (string, error)
+	// GetResolvableHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
+	GetResolvableHostnamesForUpstreamService(downstream, upstream service.MeshService) (string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -5,6 +5,8 @@
 package catalog
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
@@ -15,7 +17,6 @@ import (
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	reflect "reflect"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface
@@ -68,21 +69,6 @@ func (mr *MockMeshCatalogerMockRecorder) GetCertificateForService(arg0 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertificateForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetCertificateForService), arg0)
 }
 
-// GetHostnamesForService mocks base method
-func (m *MockMeshCataloger) GetHostnamesForService(arg0 service.MeshService) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHostnamesForService", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetHostnamesForService indicates an expected call of GetHostnamesForService
-func (mr *MockMeshCatalogerMockRecorder) GetHostnamesForService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostnamesForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetHostnamesForService), arg0)
-}
-
 // GetIngressRoutesPerHost mocks base method
 func (m *MockMeshCataloger) GetIngressRoutesPerHost(arg0 service.MeshService) (map[string][]trafficpolicy.HTTPRoute, error) {
 	m.ctrl.T.Helper()
@@ -96,6 +82,21 @@ func (m *MockMeshCataloger) GetIngressRoutesPerHost(arg0 service.MeshService) (m
 func (mr *MockMeshCatalogerMockRecorder) GetIngressRoutesPerHost(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressRoutesPerHost", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressRoutesPerHost), arg0)
+}
+
+// GetResolvableHostnamesForUpstreamService mocks base method
+func (m *MockMeshCataloger) GetResolvableHostnamesForUpstreamService(arg0, arg1 service.MeshService) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResolvableHostnamesForUpstreamService", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResolvableHostnamesForUpstreamService indicates an expected call of GetResolvableHostnamesForUpstreamService
+func (mr *MockMeshCatalogerMockRecorder) GetResolvableHostnamesForUpstreamService(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvableHostnamesForUpstreamService", reflect.TypeOf((*MockMeshCataloger)(nil).GetResolvableHostnamesForUpstreamService), arg0, arg1)
 }
 
 // GetResolvableServiceEndpoints mocks base method

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -201,22 +201,51 @@ func TestGetServiceHostnames(t *testing.T) {
 	assert := assert.New(t)
 
 	mc := newFakeMeshCatalog()
-	actual, err := mc.getServiceHostnames(tests.BookstoreV1Service)
-	assert.Nil(err)
 
-	expected := []string{
-		"bookstore-v1",
-		"bookstore-v1.default",
-		"bookstore-v1.default.svc",
-		"bookstore-v1.default.svc.cluster",
-		"bookstore-v1.default.svc.cluster.local",
-		"bookstore-v1:8888",
-		"bookstore-v1.default:8888",
-		"bookstore-v1.default.svc:8888",
-		"bookstore-v1.default.svc.cluster:8888",
-		"bookstore-v1.default.svc.cluster.local:8888",
+	testCases := []struct {
+		svc           service.MeshService
+		sameNamespace bool
+		expected      []string
+	}{
+		{
+			tests.BookstoreV1Service,
+			true,
+			[]string{
+				"bookstore-v1",
+				"bookstore-v1.default",
+				"bookstore-v1.default.svc",
+				"bookstore-v1.default.svc.cluster",
+				"bookstore-v1.default.svc.cluster.local",
+				"bookstore-v1:8888",
+				"bookstore-v1.default:8888",
+				"bookstore-v1.default.svc:8888",
+				"bookstore-v1.default.svc.cluster:8888",
+				"bookstore-v1.default.svc.cluster.local:8888",
+			},
+		},
+		{
+			tests.BookstoreV1Service,
+			false,
+			[]string{
+				"bookstore-v1.default",
+				"bookstore-v1.default.svc",
+				"bookstore-v1.default.svc.cluster",
+				"bookstore-v1.default.svc.cluster.local",
+				"bookstore-v1.default:8888",
+				"bookstore-v1.default.svc:8888",
+				"bookstore-v1.default.svc.cluster:8888",
+				"bookstore-v1.default.svc.cluster.local:8888",
+			},
+		},
 	}
-	assert.ElementsMatch(actual, expected)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing hostnames for svc %s with sameNamespace=%t", tc.svc, tc.sameNamespace), func(t *testing.T) {
+			actual, err := mc.getServiceHostnames(tc.svc, tc.sameNamespace)
+			assert.Nil(err)
+			assert.ElementsMatch(actual, tc.expected)
+		})
+	}
 }
 
 func TestHostnamesTostr(t *testing.T) {
@@ -237,30 +266,60 @@ func TestGetDefaultWeightedClusterForService(t *testing.T) {
 	assert.Equal(actual, expected)
 }
 
-func TestGetHostnamesForService(t *testing.T) {
+func TestGetResolvableHostnamesForUpstreamService(t *testing.T) {
 	assert := assert.New(t)
 
 	mc := newFakeMeshCatalog()
 
-	actual, err := mc.GetHostnamesForService(tests.BookstoreV1Service)
-	assert.Nil(err)
-
-	expected := strings.Join(
-		[]string{
-			"bookstore-apex",
-			"bookstore-apex.default",
-			"bookstore-apex.default.svc",
-			"bookstore-apex.default.svc.cluster",
-			"bookstore-apex.default.svc.cluster.local",
-			"bookstore-apex:8888",
-			"bookstore-apex.default:8888",
-			"bookstore-apex.default.svc:8888",
-			"bookstore-apex.default.svc.cluster:8888",
-			"bookstore-apex.default.svc.cluster.local:8888",
+	testCases := []struct {
+		downstream        service.MeshService
+		expectedHostnames string
+	}{
+		{
+			downstream: service.MeshService{
+				Namespace: "default",
+				Name:      "foo",
+			},
+			expectedHostnames: strings.Join(
+				[]string{
+					"bookstore-apex",
+					"bookstore-apex.default",
+					"bookstore-apex.default.svc",
+					"bookstore-apex.default.svc.cluster",
+					"bookstore-apex.default.svc.cluster.local",
+					"bookstore-apex:8888",
+					"bookstore-apex.default:8888",
+					"bookstore-apex.default.svc:8888",
+					"bookstore-apex.default.svc.cluster:8888",
+					"bookstore-apex.default.svc.cluster.local:8888",
+				}, ","),
 		},
-		",")
+		{
+			downstream: service.MeshService{
+				Namespace: "bar",
+				Name:      "foo",
+			},
+			expectedHostnames: strings.Join(
+				[]string{
+					"bookstore-apex.default",
+					"bookstore-apex.default.svc",
+					"bookstore-apex.default.svc.cluster",
+					"bookstore-apex.default.svc.cluster.local",
+					"bookstore-apex.default:8888",
+					"bookstore-apex.default.svc:8888",
+					"bookstore-apex.default.svc.cluster:8888",
+					"bookstore-apex.default.svc.cluster.local:8888",
+				}, ","),
+		},
+	}
 
-	assert.Equal(actual, expected)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing hostnames when %s svc reaches %s svc", tc.downstream, tests.BookstoreV1Service), func(t *testing.T) {
+			actual, err := mc.GetResolvableHostnamesForUpstreamService(tc.downstream, tests.BookstoreV1Service)
+			assert.Nil(err)
+			assert.Equal(actual, tc.expectedHostnames)
+		})
+	}
 }
 
 func TestBuildAllowAllTrafficPolicies(t *testing.T) {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -101,9 +101,9 @@ type MeshCataloger interface {
 	// GetServicesForServiceAccount returns a list of services corresponding to a service account
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
-	// GetHostnamesForService returns the hostnames for a service
-	// TODO(ref: PR #1316): return a list of strings
-	GetHostnamesForService(service service.MeshService) (string, error)
+	// GetResolvableHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
+	// TODO(ref: Issue #1316): return a list of strings
+	GetResolvableHostnamesForUpstreamService(downstream, upstream service.MeshService) (string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -45,7 +45,7 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 		isSourceService := trafficPolicy.Source.Equals(proxyServiceName)
 		isDestinationService := trafficPolicy.Destination.Equals(proxyServiceName)
 		svc := trafficPolicy.Destination
-		hostnames, err := catalog.GetHostnamesForService(svc)
+		hostnames, err := catalog.GetResolvableHostnamesForUpstreamService(proxyServiceName, svc)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed listing domains")
 			return nil, err

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -2,8 +2,6 @@ package rds
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	set "github.com/deckarep/golang-set"
 	corev1 "k8s.io/api/core/v1"
@@ -238,60 +236,6 @@ var _ = Describe("RDS Response", func() {
 
 	meshCatalog := catalog.NewMeshCatalog(mockKubeController, kubeClient, smi.NewFakeMeshSpecClient(), certManager,
 		mockIngressMonitor, make(<-chan struct{}), cfg, endpointProviders...)
-
-	Context("Test GetHostnamesForService", func() {
-		contains := func(domains []string, expected string) bool {
-			for _, entry := range domains {
-				if entry == expected {
-					return true
-				}
-			}
-			return false
-		}
-		It("returns the domain for a service when traffic split is specified for the given service", func() {
-
-			actual, err := meshCatalog.GetHostnamesForService(tests.BookstoreV1Service)
-			Expect(err).ToNot(HaveOccurred())
-
-			domainList := strings.Split(actual, ",")
-			Expect(len(domainList)).To(Equal(10))
-			Expect(contains(domainList, tests.BookstoreApexServiceName)).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s:%d", tests.BookstoreApexServiceName, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s", tests.BookstoreApexServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s:%d", tests.BookstoreApexServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc", tests.BookstoreApexServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc:%d", tests.BookstoreApexServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster", tests.BookstoreApexServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookstoreApexServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookstoreApexServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookstoreApexServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-		})
-
-		It("returns a list of domains for a service when traffic split is not specified for the given service", func() {
-
-			actual, err := meshCatalog.GetHostnamesForService(tests.BookbuyerService)
-			Expect(err).ToNot(HaveOccurred())
-
-			domainList := strings.Split(actual, ",")
-			Expect(len(domainList)).To(Equal(10))
-
-			Expect(contains(domainList, tests.BookbuyerServiceName)).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s:%d", tests.BookbuyerServiceName, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-		})
-
-		It("No service found when mesh does not have service", func() {
-			_, err := meshCatalog.GetHostnamesForService(tests.BookwarehouseService)
-			Expect(err).To(HaveOccurred())
-		})
-	})
 
 	Context("GetWeightedClusterForService", func() {
 		It("returns weighted cluster for service from traffic split", func() {

--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -11,9 +11,9 @@ const (
 	clusterDomain = "cluster.local"
 )
 
-// GetHostnamesForService returns a list of hostnames over which the service
-// can be accessed within the local cluster.
-func GetHostnamesForService(service *corev1.Service) []string {
+// GetHostnamesForService returns a list of hostnames over which the service can be accessed within the local cluster.
+// If 'sameNamespace' is set to true, then the shorthand hostnames service and service:port are also returned.
+func GetHostnamesForService(service *corev1.Service, sameNamespace bool) []string {
 	var domains []string
 	if service == nil {
 		return domains
@@ -22,14 +22,23 @@ func GetHostnamesForService(service *corev1.Service) []string {
 	serviceName := service.Name
 	namespace := service.Namespace
 
-	domains = append(domains, serviceName)                                                        // service
+	if sameNamespace {
+		// Within the same namespace, service name is resolvable to its address
+		domains = append(domains, serviceName) // service
+	}
+
 	domains = append(domains, fmt.Sprintf("%s.%s", serviceName, namespace))                       // service.namespace
 	domains = append(domains, fmt.Sprintf("%s.%s.svc", serviceName, namespace))                   // service.namespace.svc
 	domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster", serviceName, namespace))           // service.namespace.svc.cluster
 	domains = append(domains, fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomain)) // service.namespace.svc.cluster.local
 	for _, portSpec := range service.Spec.Ports {
 		port := portSpec.Port
-		domains = append(domains, fmt.Sprintf("%s:%d", serviceName, port))                                     // service:port
+
+		if sameNamespace {
+			// Within the same namespace, service name is resolvable to its address
+			domains = append(domains, fmt.Sprintf("%s:%d", serviceName, port)) // service:port
+		}
+
 		domains = append(domains, fmt.Sprintf("%s.%s:%d", serviceName, namespace, port))                       // service.namespace:port
 		domains = append(domains, fmt.Sprintf("%s.%s.svc:%d", serviceName, namespace, port))                   // service.namespace.svc:port
 		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster:%d", serviceName, namespace, port))           // service.namespace.svc.cluster:port

--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -11,31 +11,40 @@ import (
 
 var _ = Describe("Hostnames for a kubernetes service", func() {
 	Context("Testing GethostnamesForService", func() {
-		contains := func(hostnames []string, expected string) bool {
-			for _, entry := range hostnames {
-				if entry == expected {
-					return true
-				}
-			}
-			return false
-		}
-		It("Returns a list of hostnames corresponding to the service", func() {
+		It("Should correctly return a list of hostnames corresponding to a service in the same namespace", func() {
 			selectors := map[string]string{
 				tests.SelectorKey: tests.SelectorValue,
 			}
 			service := tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, selectors)
-			hostnames := GetHostnamesForService(service)
+			hostnames := GetHostnamesForService(service, true)
 			Expect(len(hostnames)).To(Equal(10))
-			Expect(contains(hostnames, tests.BookbuyerServiceName)).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s:%d", tests.BookbuyerServiceName, tests.ServicePort))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s.svc", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s.svc:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s.svc.cluster", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookbuyerServiceName, tests.Namespace))).To(BeTrue())
-			Expect(contains(hostnames, fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
+			Expect(tests.BookbuyerServiceName).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s:%d", tests.BookbuyerServiceName, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+		})
+
+		It("Should correctly return a list of hostnames corresponding to a service not in the same namespace", func() {
+			selectors := map[string]string{
+				tests.SelectorKey: tests.SelectorValue,
+			}
+			service := tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, selectors)
+			hostnames := GetHostnamesForService(service, false)
+			Expect(len(hostnames)).To(Equal(8))
+			Expect(fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookbuyerServiceName, tests.Namespace)).To(BeElementOf(hostnames))
+			Expect(fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort)).To(BeElementOf(hostnames))
 		})
 	})
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, while programming the service FQDNs for an
upstream service in the downstream envoy's virtual_host config
the shorthand service FQDN using the service name without the namespace
is always programmed. This is incorrect because the same service (name)
could exist in multiple namespaces. The service FQDN without the
namespace should only be programmed on downstream clients that are
in the same namespace. If the downstream client is in a different namespace,
then shorthand FQDNs without the namespace for the upstream service 
should not be programmed.

Consider the following example:
Imagine the following 3 services of the form `namespace/service`:
`foo/bookbuyer, foo/bookstore, bar/bookstore`
bookbuyer is allowed to reach the bookstore service in both namespaces foo and bar.

Previously:
-  the virtual_host config on bookbuyer to reach `foo/bookstore`
would be `bookstore, bookstore.foo, bookstore.foo.svc.cluster.local ....`
- the virtual_host config on bookbuyer to reach `bar/bookstore`
would be `bookstore, bookstore.bar, bookstore.bar.svc.cluster.local ....`

The above config would result in an error because the same hostname `bookstore`
is programmed for 2 different destinations in the outbound route.

With this change, the `bookstore` hostname will only be programmed for the
`foo/bookstore` destination because `foo/bookbuyer` is in the same namespace,
and is allowed to use shorthand FQDN to make a request of the form `http://bookstore/`,
without resulting in invalid virtual_host configurations on `bookbuyer` envoy.


This change addresses this bug and adds tests for the same. It also
removes a duplicated test copied into an unrelated package.

Resolves #951

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`