### PR TITLE
ref(build): consolidate version Makefile variables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: version
     env:
-      CLI_VERSION: ${{ needs.version.outputs.version }}
+      VERSION: ${{ needs.version.outputs.version }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
@@ -53,43 +53,43 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-darwin-amd64.zip"
-          asset_name: "osm-${{ env.CLI_VERSION }}-darwin-amd64.zip"
+          asset_path: "_dist/osm-${{ env.VERSION }}-darwin-amd64.zip"
+          asset_name: "osm-${{ env.VERSION }}-darwin-amd64.zip"
           asset_content_type: application/zip
       - name: Upload macOS .tar.gz
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-darwin-amd64.tar.gz"
-          asset_name: "osm-${{ env.CLI_VERSION }}-darwin-amd64.tar.gz"
+          asset_path: "_dist/osm-${{ env.VERSION }}-darwin-amd64.tar.gz"
+          asset_name: "osm-${{ env.VERSION }}-darwin-amd64.tar.gz"
           asset_content_type: application/gzip
       - name: Upload Linux .zip
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-linux-amd64.zip"
-          asset_name: "osm-${{ env.CLI_VERSION }}-linux-amd64.zip"
+          asset_path: "_dist/osm-${{ env.VERSION }}-linux-amd64.zip"
+          asset_name: "osm-${{ env.VERSION }}-linux-amd64.zip"
           asset_content_type: application/zip
       - name: Upload Linux .tar.gz
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-linux-amd64.tar.gz"
-          asset_name: "osm-${{ env.CLI_VERSION }}-linux-amd64.tar.gz"
+          asset_path: "_dist/osm-${{ env.VERSION }}-linux-amd64.tar.gz"
+          asset_name: "osm-${{ env.VERSION }}-linux-amd64.tar.gz"
           asset_content_type: application/gzip
       - name: Upload Windows .zip
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-windows-amd64.zip"
-          asset_name: "osm-${{ env.CLI_VERSION }}-windows-amd64.zip"
+          asset_path: "_dist/osm-${{ env.VERSION }}-windows-amd64.zip"
+          asset_name: "osm-${{ env.VERSION }}-windows-amd64.zip"
           asset_content_type: application/zip
       - name: Upload Windows .tar.gz
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: "_dist/osm-${{ env.CLI_VERSION }}-windows-amd64.tar.gz"
-          asset_name: "osm-${{ env.CLI_VERSION }}-windows-amd64.tar.gz"
+          asset_path: "_dist/osm-${{ env.VERSION }}-windows-amd64.tar.gz"
+          asset_name: "osm-${{ env.VERSION }}-windows-amd64.tar.gz"
           asset_content_type: application/gzip
       - name: Upload Checksums
         uses: actions/upload-release-asset@v1

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,14 @@ GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 GOX    = go run github.com/mitchellh/gox
 
-CLI_VERSION ?= dev
-CONTROLLER_VERSION = $$(git describe --abbrev=0 --tags --match "v*")
+VERSION ?= dev
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
 GIT_SHA=$$(git rev-parse HEAD)
 BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate
 BUILD_VERSION_VAR := github.com/openservicemesh/osm/pkg/version.Version
 BUILD_GITCOMMIT_VAR := github.com/openservicemesh/osm/pkg/version.GitCommit
 
-LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CLI_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X main.chartTGZSource=$$(cat -) -s -w"
+LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X main.chartTGZSource=$$(cat -) -s -w"
 
 # These two values are combined and passed to go test
 E2E_FLAGS ?= -kindCluster
@@ -46,7 +45,7 @@ build: build-osm-controller
 
 .PHONY: build-osm-controller
 build-osm-controller: clean-osm-controller
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(CONTROLLER_VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w" ./cmd/osm-controller
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w" ./cmd/osm-controller
 
 .PHONY: build-osm
 build-osm:
@@ -169,8 +168,8 @@ dist:
 		cd _dist && \
 		$(DIST_DIRS) cp ../LICENSE {} \; && \
 		$(DIST_DIRS) cp ../README.md {} \; && \
-		$(DIST_DIRS) tar -zcf osm-${CLI_VERSION}-{}.tar.gz {} \; && \
-		$(DIST_DIRS) zip -r osm-${CLI_VERSION}-{}.zip {} \; && \
+		$(DIST_DIRS) tar -zcf osm-${VERSION}-{}.tar.gz {} \; && \
+		$(DIST_DIRS) zip -r osm-${VERSION}-{}.zip {} \; && \
 		sha256sum osm-* > sha256sums.txt \
 	)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change combines the `CLI_VERSION` and `CONTROLLER_VERSION` Makefile variables into a single `VERSION` variable since they were being used for the same purpose.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No