### PR TITLE
Reduce default number of bits used per RSA certificate key to 2048

### DIFF
--- a/cmd/osm-controller/osm-controller_test.go
+++ b/cmd/osm-controller/osm-controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Test creation of CA bundle k8s secret", func() {
 
 			actual, err := k8sClient.CoreV1().Secrets(namespace).Get(context.Background(), secretName, v1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			expected := "-----BEGIN CERTIFICATE-----\nMIIF"
+			expected := "-----BEGIN CERTIFICATE-----\nMIID"
 			stringPEM := string(actual.Data[constants.KubernetesOpaqueSecretCAKey])[:len(expected)]
 			Expect(stringPEM).To(Equal(expected))
 

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -16,7 +16,7 @@ const (
 	rootCertificateName = "root-certificate"
 
 	// How many bits to use for the RSA key
-	rsaBits = 4096
+	rsaBits = 2048
 
 	// How many bits in the certificate serial number
 	certSerialNumberBits = 128


### PR DESCRIPTION
Trading off bits on RSA key size for performance.

Shows a 12x to 15x less time spent generating certificates, which right
now is synchronous inside webhook handling.

see #1931 for additional context
fixes #1931

**Affected area**:

- Control Plane          [X]
- Certificate Management [X]
- Security               [X]
- Performance            [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No