### PR TITLE
tests/e2e: add requests to individual backends in traffic split test

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -336,7 +336,7 @@ type MeshCataloger interface {
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
 	// GetHostnamesForService returns the hostnames for a service
-	GetHostnamesForService(service service.MeshService) (string, error)
+	GetHostnamesForService(service service.MeshService) ([]string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -69,10 +69,10 @@ func (mr *MockMeshCatalogerMockRecorder) GetCertificateForService(arg0 interface
 }
 
 // GetHostnamesForService mocks base method
-func (m *MockMeshCataloger) GetHostnamesForService(arg0 service.MeshService) (string, error) {
+func (m *MockMeshCataloger) GetHostnamesForService(arg0 service.MeshService) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostnamesForService", arg0)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -260,7 +260,24 @@ func TestGetHostnamesForService(t *testing.T) {
 		},
 		",")
 
-	assert.Equal(actual, expected)
+	assert.Equal(actual[0], expected)
+
+	expected = strings.Join(
+		[]string{
+			"bookstore-v1",
+			"bookstore-v1.default",
+			"bookstore-v1.default.svc",
+			"bookstore-v1.default.svc.cluster",
+			"bookstore-v1.default.svc.cluster.local",
+			"bookstore-v1:8888",
+			"bookstore-v1.default:8888",
+			"bookstore-v1.default.svc:8888",
+			"bookstore-v1.default.svc.cluster:8888",
+			"bookstore-v1.default.svc.cluster.local:8888",
+		},
+		",")
+
+	assert.Equal(actual[1], expected)
 }
 
 func TestBuildAllowAllTrafficPolicies(t *testing.T) {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -103,7 +103,7 @@ type MeshCataloger interface {
 
 	// GetHostnamesForService returns the hostnames for a service
 	// TODO(ref: PR #1316): return a list of strings
-	GetHostnamesForService(service service.MeshService) (string, error)
+	GetHostnamesForService(service service.MeshService) ([]string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -56,7 +56,7 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 			return nil, err
 		}
 
-		// if the service is referenced in a traffic split there will be more than one host name (root service and backend)
+		// if the service is referenced in a traffic split there will be more than one hostname (root service and backend)
 		for _, hostname := range hostnames {
 			// All routes from a given source to destination are part of 1 traffic policy between the source and destination.
 			for _, httpRoute := range trafficPolicy.HTTPRoutes {

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -56,14 +56,17 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 			return nil, err
 		}
 
-		// All routes from a given source to destination are part of 1 traffic policy between the source and destination.
-		for _, httpRoute := range trafficPolicy.HTTPRoutes {
-			if isSourceService {
-				aggregateRoutesByHost(outboundAggregatedRoutesByHostnames, httpRoute, weightedCluster, hostnames)
-			}
+		// if the service is referenced in a traffic split there will be more than one host name (root service and backend)
+		for _, hostname := range hostnames {
+			// All routes from a given source to destination are part of 1 traffic policy between the source and destination.
+			for _, httpRoute := range trafficPolicy.HTTPRoutes {
+				if isSourceService {
+					aggregateRoutesByHost(outboundAggregatedRoutesByHostnames, httpRoute, weightedCluster, hostname)
+				}
 
-			if isDestinationService {
-				aggregateRoutesByHost(inboundAggregatedRoutesByHostnames, httpRoute, weightedCluster, hostnames)
+				if isDestinationService {
+					aggregateRoutesByHost(inboundAggregatedRoutesByHostnames, httpRoute, weightedCluster, hostname)
+				}
 			}
 		}
 	}

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -252,8 +252,9 @@ var _ = Describe("RDS Response", func() {
 
 			actual, err := meshCatalog.GetHostnamesForService(tests.BookstoreV1Service)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(len(actual)).To(Equal(2))
 
-			domainList := strings.Split(actual, ",")
+			domainList := strings.Split(actual[0], ",")
 			Expect(len(domainList)).To(Equal(10))
 			Expect(contains(domainList, tests.BookstoreApexServiceName)).To(BeTrue())
 			Expect(contains(domainList, fmt.Sprintf("%s:%d", tests.BookstoreApexServiceName, tests.ServicePort))).To(BeTrue())
@@ -265,14 +266,28 @@ var _ = Describe("RDS Response", func() {
 			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookstoreApexServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
 			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookstoreApexServiceName, tests.Namespace))).To(BeTrue())
 			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookstoreApexServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
+
+			domainList = strings.Split(actual[1], ",")
+			Expect(len(domainList)).To(Equal(10))
+			Expect(contains(domainList, tests.BookstoreV1ServiceName)).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s:%d", tests.BookstoreV1ServiceName, tests.ServicePort))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s", tests.BookstoreV1ServiceName, tests.Namespace))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s:%d", tests.BookstoreV1ServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc", tests.BookstoreV1ServiceName, tests.Namespace))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc:%d", tests.BookstoreV1ServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster", tests.BookstoreV1ServiceName, tests.Namespace))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookstoreV1ServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookstoreV1ServiceName, tests.Namespace))).To(BeTrue())
+			Expect(contains(domainList, fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookstoreV1ServiceName, tests.Namespace, tests.ServicePort))).To(BeTrue())
 		})
 
 		It("returns a list of domains for a service when traffic split is not specified for the given service", func() {
 
 			actual, err := meshCatalog.GetHostnamesForService(tests.BookbuyerService)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(len(actual)).To(Equal(1))
 
-			domainList := strings.Split(actual, ",")
+			domainList := strings.Split(actual[0], ",")
 			Expect(len(domainList)).To(Equal(10))
 
 			Expect(contains(domainList, tests.BookbuyerServiceName)).To(BeTrue())

--- a/tests/e2e/common_traffic.go
+++ b/tests/e2e/common_traffic.go
@@ -104,7 +104,7 @@ type HTTPMultipleRequest struct {
 }
 
 // HTTPMultipleResults represents results from a multiple HTTP request call
-// results come back as a map[namespace][pod] -> HTTPResults
+// results come back as a map["srcNs/srcPod"]["dstNs/dstPod"] -> HTTPResults
 type HTTPMultipleResults map[string]map[string]HTTPRequestResult
 
 // MultipleHTTPRequest will issue a list of requests concurrently and return results when all requests have returned
@@ -115,13 +115,17 @@ func (td *OsmTestData) MultipleHTTPRequest(requests *HTTPMultipleRequest) HTTPMu
 
 	// Prepare results
 	for idx, r := range requests.Sources {
-		if _, ok := results[r.SourceNs]; !ok {
-			results[r.SourceNs] = map[string]HTTPRequestResult{}
+		srcKey := fmt.Sprintf("%s/%s", r.SourceNs, r.SourcePod)
+		dstKey := r.Destination
+
+		if _, ok := results[srcKey]; !ok {
+			results[srcKey] = map[string]HTTPRequestResult{}
 		}
-		if _, ok := results[r.SourceNs][r.SourcePod]; !ok {
-			results[r.SourceNs][r.SourcePod] = HTTPRequestResult{}
+		if _, ok := results[srcKey][dstKey]; !ok {
+			results[srcKey][dstKey] = HTTPRequestResult{}
 		} else {
-			td.T.Logf("WARN: Multiple requests from same pod %s. Results will overwrite.", r.SourcePod)
+			td.T.Logf("WARN: Requests from same pod %s to same dst %s. Ignoring.", srcKey, dstKey)
+			continue
 		}
 
 		wg.Add(1)
@@ -133,7 +137,7 @@ func (td *OsmTestData) MultipleHTTPRequest(requests *HTTPMultipleRequest) HTTPMu
 			mtx.Lock()
 			results[ns][podname] = r
 			mtx.Unlock()
-		}(r.SourceNs, r.SourcePod, (*requests).Sources[idx])
+		}(srcKey, dstKey, (*requests).Sources[idx])
 	}
 	wg.Wait()
 


### PR DESCRIPTION
To verify new RDS changes:
https://github.com/openservicemesh/osm/pull/1929

- Tests                  [x]
- CI System              [x]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No