### PR TITLE
charts/osm: Increase max memory limit

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           resources:
             limits:
               cpu: 1.5
-              memory: 128M
+              memory: 256M
             requests:
               cpu: 0.5
               memory: 32M


### PR DESCRIPTION
Recent findings show OSM to hit early max limits (128MB)
with as much as 100~120 pods.

It's hard to estimate the memory used per envoy as it
will also very much depend on the traffic structrues used
by the deployment (service and trafficspec caches, etc).

On the specific tests, it showed a 0.5~0.6 MB/envoy.


**Affected area**:

- Install                [X]
- Control Plane          [X]
- Performance            [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No