### PR TITLE
ci: Refactor to simplify maestro

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -9,24 +9,29 @@ import (
 	"sync"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/ci/cmd/maestro"
 	"github.com/openservicemesh/osm/demo/cmd/common"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/logger"
+	osmStrings "github.com/openservicemesh/osm/pkg/strings"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 var log = logger.NewPretty("ci/maestro")
 
 const (
+	// Pod labels
 	bookBuyerLabel     = "bookbuyer"
 	bookThiefLabel     = "bookthief"
 	bookstoreV1Label   = "bookstore-v1"
 	bookstoreV2Label   = "bookstore-v2"
 	bookWarehouseLabel = "bookwarehouse"
-	selectorKey        = "app"
+
+	selectorKey = "app"
 )
 
 var (
@@ -61,127 +66,47 @@ func main() {
 
 	kubeClient := maestro.GetKubernetesClient()
 
-	// Wait for pods to be ready
-	{
-		var wg sync.WaitGroup
+	bookBuyerPodName, bookThiefPodName, bookWarehousePodName, osmControllerPodName := getPodNames(kubeClient)
 
-		wg.Add(1)
-		go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookthiefNS, bookThiefSelector, &wg)
-
-		wg.Add(1)
-		go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookbuyerNS, bookBuyerSelector, &wg)
-
-		wg.Add(1)
-		go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookstoreNS, bookstoreV1Selector, &wg)
-
-		wg.Add(1)
-		go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookstoreNS, bookstoreV2Selector, &wg)
-
-		wg.Add(1)
-		go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookWarehouseNS, bookWarehouseSelector, &wg)
-
-		wg.Wait()
+	// Tail the logs of the pods participating in the service mesh concurrently and watch for success or failure.
+	didItSucceed := func(ns, podName, label string) chan string {
+		result := make(chan string)
+		maestro.SearchLogsForSuccess(kubeClient, ns, podName, label, maxWaitForOK(), result, common.Success, common.Failure)
+		return result
 	}
-
-	bookBuyerPodName, err := maestro.GetPodName(kubeClient, bookbuyerNS, bookBuyerSelector)
-	if err != nil {
-		fmt.Println("Error getting bookbuyer pod after pod being ready: ", err)
-		os.Exit(1)
-	}
-
-	bookThiefPodName, err := maestro.GetPodName(kubeClient, bookthiefNS, bookThiefSelector)
-	if err != nil {
-		fmt.Println("Error getting bookthief pod after pod being ready: ", err)
-		os.Exit(1)
-	}
-
-	bookWarehousePodName, err := maestro.GetPodName(kubeClient, bookWarehouseNS, bookWarehouseSelector)
-	if err != nil {
-		fmt.Println("Error getting bookWarehouse pod after pod being ready: ", err)
-		os.Exit(1)
-	}
-
-	// Tail the logs of the BookBuyer and BookThief pods concurrently and watch for success or failure.
-	bookBuyerCh := make(chan maestro.TestResult)
-	bookThiefCh := make(chan maestro.TestResult)
-
-	maestro.SearchLogsForSuccess(kubeClient, bookbuyerNS, bookBuyerPodName, bookBuyerLabel, maxWaitForOK(), bookBuyerCh, common.Success, common.Failure)
-	maestro.SearchLogsForSuccess(kubeClient, bookthiefNS, bookThiefPodName, bookThiefLabel, maxWaitForOK(), bookThiefCh, common.Success, common.Failure)
-
-	bookWarehouseCh := make(chan maestro.TestResult)
-	maestro.SearchLogsForSuccess(kubeClient, bookWarehouseNS, bookWarehousePodName, bookWarehouseLabel, maxWaitForOK(), bookWarehouseCh, common.Success, common.Failure)
-
-	bookBuyerTestResult := <-bookBuyerCh
-	bookThiefTestResult := <-bookThiefCh
-	bookWarehouseTestResult := <-bookWarehouseCh
 
 	// When both pods return success - easy - we are good to go! CI passed!
-	if bookBuyerTestResult == maestro.TestsPassed && bookThiefTestResult == maestro.TestsPassed && bookWarehouseTestResult == maestro.TestsPassed {
-		log.Info().Msg("Test succeeded")
-		maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
-		webhookConfigName := fmt.Sprintf("osm-webhook-%s", meshName)
-		maestro.DeleteWebhookConfiguration(kubeClient, webhookConfigName)
-		os.Exit(0)
+	allTestsResults := osmStrings.All{
+		<-didItSucceed(bookbuyerNS, bookBuyerPodName, bookBuyerLabel),
+		<-didItSucceed(bookthiefNS, bookThiefPodName, bookThiefLabel),
+		<-didItSucceed(bookWarehouseNS, bookWarehousePodName, bookWarehouseLabel),
 	}
 
-	// One or both of the pods did not return success.
-	// Figure out what happened and print an informative message.
-	humanize := map[maestro.TestResult]string{
-		maestro.TestsFailed:   "failed",
-		maestro.TestsTimedOut: "timedout",
+	if allTestsResults.Equal(maestro.TestsPassed) {
+		cleanUp(kubeClient)
+		os.Exit(0) // Tests passed!  WE ARE DONE !!!
 	}
 
-	if bookBuyerTestResult != maestro.TestsPassed {
-		log.Error().Msgf("Bookbuyer test %s", humanize[bookBuyerTestResult])
+	if failedTests := osmStrings.Which(allTestsResults).NotEqual(maestro.TestsPassed); len(failedTests) != 0 {
+		log.Error().Msgf("%s did not pass; Retrieving pod logs", strings.Join(failedTests, ","))
 	}
-
-	if bookThiefTestResult != maestro.TestsPassed {
-		log.Error().Msgf("BookThief test %s", humanize[bookThiefTestResult])
-	}
-
-	if bookWarehouseTestResult != maestro.TestsPassed {
-		log.Error().Msgf("BookWarehouse test %s", humanize[bookWarehouseTestResult])
-	}
-
-	fmt.Println("The integration test failed -- Getting Logs")
 
 	// Walk mesh-participant namespaces
 	for _, ns := range namespaces {
 		pods, err := kubeClient.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
-			log.Error().Msgf("Could not get Pods for Namespace %s", ns)
+			log.Error().Err(err).Msgf("Could not get Pods for Namespace %s", ns)
 			continue
 		}
 
-		for _, podObj := range pods.Items {
-			for _, initContainer := range podObj.Spec.InitContainers {
-				initLogs := maestro.GetPodLogs(kubeClient, ns, podObj.Name, initContainer.Name, maestro.FailureLogsFromTimeSince)
-				fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  InitContainer: %s --------\n",
-					ns, podObj.Name, initContainer.Name), cutIt(initLogs))
-			}
-
-			for _, containerObj := range podObj.Spec.Containers {
-				initLogs := maestro.GetPodLogs(kubeClient, ns, podObj.Name, containerObj.Name, maestro.FailureLogsFromTimeSince)
-				switch containerObj.Name {
-				case constants.EnvoyContainerName:
-					fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Envoy Logs: --------\n",
-						ns, podObj.Name), initLogs)
-				default:
-					fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Container: %s --------\n",
-						ns, podObj.Name, containerObj.Name), cutIt(initLogs))
-				}
-			}
+		for _, pod := range pods.Items {
+			printLogsForInitContainers(kubeClient, pod)
+			printLogsForContainers(kubeClient, pod)
 		}
 	}
 
-	// Targeting osm-controller specifically might be ok for now
-	osmPodName, err := maestro.GetPodName(kubeClient, osmNamespace, osmControllerPodSelector)
-
-	if err != nil {
-		log.Fatal().Err(err).Msgf("Error getting OSM-Controller pods with selector %s in namespace %s", osmPodName, osmNamespace)
-	}
-
-	fmt.Println("-------- OSM-Controller LOGS --------\n", maestro.GetPodLogs(kubeClient, osmNamespace, osmPodName, "", maestro.FailureLogsFromTimeSince))
+	fmt.Println("-------- OSM-Controller LOGS --------\n",
+		maestro.GetPodLogs(kubeClient, osmNamespace, osmControllerPodName, "", maestro.FailureLogsFromTimeSince))
 
 	os.Exit(1)
 }
@@ -216,4 +141,80 @@ func maxWaitForOK() time.Duration {
 		log.Fatal().Err(err).Msgf("Could not convert environment variable %s='%s' to int", maestro.WaitForOKSecondsEnvVar, maxOKWaitString)
 	}
 	return time.Duration(maxWaitInt) * time.Second
+}
+
+func getPodNames(kubeClient kubernetes.Interface) (string, string, string, string) {
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookthiefNS, bookThiefSelector, &wg)
+
+	wg.Add(1)
+	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookbuyerNS, bookBuyerSelector, &wg)
+
+	wg.Add(1)
+	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookstoreNS, bookstoreV1Selector, &wg)
+
+	wg.Add(1)
+	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookstoreNS, bookstoreV2Selector, &wg)
+
+	wg.Add(1)
+	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookWarehouseNS, bookWarehouseSelector, &wg)
+
+	wg.Wait()
+
+	bookBuyerPodName, err := maestro.GetPodName(kubeClient, bookbuyerNS, bookBuyerSelector)
+	if err != nil {
+		fmt.Println("Error getting bookbuyer pod after pod being ready: ", err)
+		os.Exit(1)
+	}
+
+	bookThiefPodName, err := maestro.GetPodName(kubeClient, bookthiefNS, bookThiefSelector)
+	if err != nil {
+		fmt.Println("Error getting bookthief pod after pod being ready: ", err)
+		os.Exit(1)
+	}
+
+	bookWarehousePodName, err := maestro.GetPodName(kubeClient, bookWarehouseNS, bookWarehouseSelector)
+	if err != nil {
+		fmt.Println("Error getting bookWarehouse pod after pod being ready: ", err)
+		os.Exit(1)
+	}
+
+	osmControllerPodName, err := maestro.GetPodName(kubeClient, osmNamespace, osmControllerPodSelector)
+	if err != nil {
+		fmt.Println("Error getting bookWarehouse pod after pod being ready: ", err)
+		os.Exit(1)
+	}
+
+	return bookBuyerPodName, bookThiefPodName, bookWarehousePodName, osmControllerPodName
+}
+
+func cleanUp(kubeClient *kubernetes.Clientset) {
+	log.Info().Msg("Test succeeded")
+	maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
+	webhookConfigName := fmt.Sprintf("osm-webhook-%s", meshName)
+	maestro.DeleteWebhookConfiguration(kubeClient, webhookConfigName)
+}
+
+func printLogsForInitContainers(kubeClient kubernetes.Interface, pod v1.Pod) {
+	for _, initContainer := range pod.Spec.InitContainers {
+		initLogs := maestro.GetPodLogs(kubeClient, pod.Namespace, pod.Name, initContainer.Name, maestro.FailureLogsFromTimeSince)
+		fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  InitContainer: %s --------\n",
+			pod.Namespace, pod.Name, initContainer.Name), cutIt(initLogs))
+	}
+}
+
+func printLogsForContainers(kubeClient kubernetes.Interface, pod v1.Pod) {
+	for _, containerObj := range pod.Spec.Containers {
+		initLogs := maestro.GetPodLogs(kubeClient, pod.Namespace, pod.Name, containerObj.Name, maestro.FailureLogsFromTimeSince)
+		switch containerObj.Name {
+		case constants.EnvoyContainerName:
+			fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Envoy Logs: --------\n",
+				pod.Namespace, pod.Name), initLogs)
+		default:
+			fmt.Println(fmt.Sprintf("---- NS: %s  Pod: %s  Container: %s --------\n",
+				pod.Namespace, pod.Name, containerObj.Name), cutIt(initLogs))
+		}
+	}
 }

--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -105,7 +105,7 @@ func GetPodName(kubeClient kubernetes.Interface, namespace, selector string) (st
 
 // SearchLogsForSuccess tails logs until success enum is found.
 // The pod/container we are observing is responsible for sending the SUCCESS/FAIL token based on local heuristic.
-func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, podName string, containerName string, totalWait time.Duration, result chan TestResult, successToken, failureToken string) {
+func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, podName string, containerName string, totalWait time.Duration, result chan string, successToken, failureToken string) {
 	sinceTime := metav1.NewTime(time.Now().Add(-PollLogsFromTimeSince))
 	options := &corev1.PodLogOptions{
 		Container: containerName,

--- a/ci/cmd/maestro/types.go
+++ b/ci/cmd/maestro/types.go
@@ -7,18 +7,15 @@ import (
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
-// TestResult is the type for the test result enum
-type TestResult int
-
 const (
 	// TestsPassed is used for tests that passed.
-	TestsPassed TestResult = iota + 1
+	TestsPassed = "passed"
 
 	// TestsFailed is used for tests that failed.
-	TestsFailed
+	TestsFailed = "failed"
 
 	// TestsTimedOut is used for tests that timed out.
-	TestsTimedOut
+	TestsTimedOut = "timedout"
 
 	// OSMNamespaceEnvVar is the environment variable for the OSM namespace.
 	OSMNamespaceEnvVar = "K8S_NAMESPACE"

--- a/pkg/strings/all.go
+++ b/pkg/strings/all.go
@@ -1,0 +1,12 @@
+package strings
+
+type All []string
+
+func (all All) Equal(rightSide string) bool {
+	for _, leftSide := range all {
+		if leftSide != rightSide {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/strings/all_test.go
+++ b/pkg/strings/all_test.go
@@ -1,0 +1,18 @@
+package strings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllEqual(t *testing.T) {
+	assertion := assert.New(t)
+
+	listOfAlpha := All{"a", "a"}
+	listOfStuff := All{"a", "b"}
+
+	assertion.Equal(listOfAlpha.Equal("a"), true)
+	assertion.Equal(listOfAlpha.Equal("b"), false)
+	assertion.Equal(listOfStuff.Equal("a"), false)
+}

--- a/pkg/strings/which.go
+++ b/pkg/strings/which.go
@@ -1,0 +1,13 @@
+package strings
+
+type Which []string
+
+func (which Which) NotEqual(rightSide string) []string {
+	notEqual := []string{}
+	for _, leftSide := range which {
+		if leftSide != rightSide {
+			notEqual = append(notEqual, leftSide)
+		}
+	}
+	return notEqual
+}

--- a/pkg/strings/which_test.go
+++ b/pkg/strings/which_test.go
@@ -1,0 +1,18 @@
+package strings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhichNotEqual(t *testing.T) {
+	assertion := assert.New(t)
+
+	listOfAlpha := Which{"a", "a"}
+	listOfStuff := Which{"a", "b"}
+
+	assertion.Equal(listOfAlpha.NotEqual("a"), []string{})
+	assertion.Equal(listOfAlpha.NotEqual("b"), []string{"a", "a"})
+	assertion.Equal(listOfStuff.NotEqual("a"), []string{"b"})
+}


### PR DESCRIPTION
The goal of this PR is to simplify `maestro` so that it is really easy at a first glance to understand what this is doing.

Changes in this PR that (I believe) achieve that goal:

  - created a new package `strings` in OSM to help with iterating over list of strings and finding certain thruths about these - inspired by fn langs
  - removed the `type TestResult int` and using `string` instead -- `passed`, `failed`, `timedout` -- love type aliases, but I believe this actually makes things much simpler
  - carved out a few large and repetetive blocks of code into helper functions; Naming the functions helps eliminate comments and gives us a high-level overview of what is happening:
    - `getPodNames()`
    - `printLogsForInitContainers()`
    - `printLogsForContainers()`
    - `cleanUp()`


Overall no functional changes to what maestro does or even how it does it - purely rearranging things to make room for more (want to add another pod via https://github.com/openservicemesh/osm/pull/1932)

---


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
