### PR TITLE
certificate: Adding ReleaseCertificate() to the Manager interface

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -502,6 +502,10 @@ type Manager interface {
 	// ListCertificates lists all certificates issued
 	ListCertificates() ([]Certificater, error)
 
+	// ReleaseCertificate informs the underlying certificate issuer that the given cert will no longer be needed.
+	// This method could be called when a given payload is terminated. Calling this should remove certs from cache and free memory if possible.
+	ReleaseCertificate(CommonName)
+
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the issued certificates.
 	GetAnnouncementsChannel() <-chan interface{}
 }

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -40,12 +40,23 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	return cert, nil
 }
 
+// ReleaseCertificate is called when a cert will no longer be needed and should be removed from the system.
+func (cm *CertManager) ReleaseCertificate(cn certificate.CommonName) {
+	cm.deleteFromCache(cn)
+}
+
 // GetCertificate returns a certificate given its Common Name (CN)
 func (cm *CertManager) GetCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
 	if cert := cm.getFromCache(cn); cert != nil {
 		return cert, nil
 	}
 	return nil, fmt.Errorf("failed to find certificate with CN=%s", cn)
+}
+
+func (cm *CertManager) deleteFromCache(cn certificate.CommonName) {
+	cm.cacheLock.RLock()
+	delete(cm.cache, cn)
+	cm.cacheLock.RUnlock()
 }
 
 func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certificater {

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -89,6 +89,12 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 	return cert, nil
 }
 
+func (cm *CertManager) deleteFromCache(cn certificate.CommonName) {
+	cm.cacheLock.Lock()
+	delete(*cm.cache, cn)
+	cm.cacheLock.Unlock()
+}
+
 func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certificater {
 	cm.cacheLock.Lock()
 	defer cm.cacheLock.Unlock()
@@ -123,6 +129,11 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	log.Info().Msgf("It took %+v to issue certificate with CN=%s", time.Since(start), cn)
 
 	return cert, nil
+}
+
+// ReleaseCertificate is called when a cert will no longer be needed and should be removed from the system.
+func (cm *CertManager) ReleaseCertificate(cn certificate.CommonName) {
+	cm.deleteFromCache(cn)
 }
 
 // GetCertificate returns a certificate given its Common Name (CN)

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -75,6 +75,12 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 	return newCert(cn, secret, time.Now().Add(validityPeriod)), nil
 }
 
+func (cm *CertManager) deleteFromCache(cn certificate.CommonName) {
+	cm.cacheLock.Lock()
+	delete(*cm.cache, cn)
+	cm.cacheLock.Unlock()
+}
+
 func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certificater {
 	cm.cacheLock.Lock()
 	defer cm.cacheLock.Unlock()
@@ -111,6 +117,11 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	log.Info().Msgf("Issuing new certificate for CN=%s took %+v", cn, time.Since(start))
 
 	return cert, nil
+}
+
+// ReleaseCertificate is called when a cert will no longer be needed and should be removed from the system.
+func (cm *CertManager) ReleaseCertificate(cn certificate.CommonName) {
+	cm.deleteFromCache(cn)
 }
 
 // ListCertificates lists all certificates issued

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -61,6 +61,10 @@ type Manager interface {
 	// ListCertificates lists all certificates issued
 	ListCertificates() ([]Certificater, error)
 
+	// ReleaseCertificate informs the underlying certificate issuer that the given cert will no longer be needed.
+	// This method could be called when a given payload is terminated. Calling this should remove certs from cache and free memory if possible.
+	ReleaseCertificate(CommonName)
+
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the issued certificates.
 	GetAnnouncementsChannel() <-chan interface{}
 }


### PR DESCRIPTION
This PR introduces `ReleaseCertificate()` into the `certificate.Manager{}` interface.

This new method will inform the underlying certificate issuer that the given cert will no longer be needed. This method could be called when a Kubernetes Pod is terminated for instance. Calling this should remove certs from cache and free memory if possible -- dependent on the certificate manager implementation.

This a step forward towards addressing https://github.com/openservicemesh/osm/issues/1719


---

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
