### PR TITLE
catalog: Remove the announcementChannels set field from the MeshCatalog struct

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -3,7 +3,6 @@ package catalog
 import (
 	"time"
 
-	set "github.com/deckarep/golang-set"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -17,17 +16,16 @@ import (
 // NewMeshCatalog creates a new service catalog
 func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
 	log.Info().Msg("Create a new Service MeshCatalog.")
-	sc := MeshCatalog{
+	mc := MeshCatalog{
 		endpointsProviders: endpointsProviders,
 		meshSpec:           meshSpec,
 		certManager:        certManager,
 		ingressMonitor:     ingressMonitor,
 		configurator:       cfg,
 
-		expectedProxies:      make(map[certificate.CommonName]expectedProxy),
-		connectedProxies:     make(map[certificate.CommonName]connectedProxy),
-		disconnectedProxies:  make(map[certificate.CommonName]disconnectedProxy),
-		announcementChannels: set.NewSet(),
+		expectedProxies:     make(map[certificate.CommonName]expectedProxy),
+		connectedProxies:    make(map[certificate.CommonName]connectedProxy),
+		disconnectedProxies: make(map[certificate.CommonName]disconnectedProxy),
 
 		// Kubernetes needed to determine what Services a pod that connects to XDS belongs to.
 		// In multicluster scenarios this would be a map of cluster ID to Kubernetes client.
@@ -36,12 +34,8 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 		kubeController: kubeController,
 	}
 
-	for _, announcementChannel := range sc.getAnnouncementChannels() {
-		sc.announcementChannels.Add(announcementChannel)
-	}
-
-	go sc.repeater()
-	return &sc
+	go mc.repeater()
+	return &mc
 }
 
 // GetSMISpec returns a MeshCatalog's SMI Spec
@@ -59,6 +53,8 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		{"Namespace", mc.kubeController.GetAnnouncementsChannel(k8s.Namespaces)},
 		{"Services", mc.kubeController.GetAnnouncementsChannel(k8s.Services)},
 	}
+
+	// There could be many Endpoint Providers - iterate over all of them!
 	for _, ep := range mc.endpointsProviders {
 		annCh := announcementChannel{ep.GetID(), ep.GetAnnouncementsChannel()}
 		announcementChannels = append(announcementChannels, annCh)
@@ -71,5 +67,6 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		ticker := time.NewTicker(updateAtLeastEvery)
 		ticking <- ticker.C
 	}()
+
 	return announcementChannels
 }

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -31,8 +31,7 @@ func (mc *MeshCatalog) repeater() {
 func (mc *MeshCatalog) getCases() ([]reflect.SelectCase, []string) {
 	var caseNames []string
 	var cases []reflect.SelectCase
-	for _, channelInterface := range mc.announcementChannels.ToSlice() {
-		annCh := channelInterface.(announcementChannel)
+	for _, annCh := range mc.getAnnouncementChannels() {
 		cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(annCh.channel)})
 		caseNames = append(caseNames, annCh.announcer)
 	}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	mapset "github.com/deckarep/golang-set"
 	"github.com/google/uuid"
 	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
@@ -43,8 +42,6 @@ type MeshCatalog struct {
 
 	disconnectedProxies     map[certificate.CommonName]disconnectedProxy
 	disconnectedProxiesLock sync.Mutex
-
-	announcementChannels mapset.Set
 
 	// Current assumption is that OSM is working with a single Kubernetes cluster.
 	// This is the API/REST interface to the cluster


### PR DESCRIPTION
This PR simplifies `catalog.MeshCatalog` by removing the `announcementChannels mapset.Set` field.

Instead we will be using the `mc.getAnnouncementChannels()` function.

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
