### PR TITLE
RFC: Add announcements package & mesage handler

### DIFF
--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -1,0 +1,12 @@
+package announcements
+
+type AnnouncementType int
+
+const (
+	EndpointDeleted AnnouncementType = iota + 1
+)
+
+type Announcement struct {
+	Type               AnnouncementType
+	ReferencedObjectID interface{}
+}

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -36,6 +36,7 @@ func (mc *MeshCatalog) repeater() {
 
 func (mc *MeshCatalog) handleAnnouncement(ann announcements.Announcement) {
 	if ann.Type == announcements.EndpointDeleted {
+		log.Trace().Msgf("Handling announcement: %+v", ann)
 		// TODO: implement (https://github.com/openservicemesh/osm/issues/1719)
 	}
 }

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -3,6 +3,8 @@ package catalog
 import (
 	"reflect"
 	"time"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
 )
 
 const (
@@ -17,6 +19,10 @@ func (mc *MeshCatalog) repeater() {
 		cases, caseNames := mc.getCases()
 		for {
 			if chosenIdx, message, ok := reflect.Select(cases); ok {
+				if ann, ok := message.Interface().(announcements.Announcement); ok {
+					mc.handleAnnouncement(ann)
+				}
+
 				log.Info().Msgf("[repeater] Received announcement from %s", caseNames[chosenIdx])
 				delta := time.Since(lastUpdateAt)
 				if delta >= updateAtMostEvery {
@@ -25,6 +31,12 @@ func (mc *MeshCatalog) repeater() {
 				}
 			}
 		}
+	}
+}
+
+func (mc *MeshCatalog) handleAnnouncement(ann announcements.Announcement) {
+	if ann.Type == announcements.EndpointDeleted {
+		// TODO: implement (https://github.com/openservicemesh/osm/issues/1719)
 	}
 }
 


### PR DESCRIPTION
This PR adds the skeleton of a new package `pkg/announcements`.  This package is intended to contain the types for the messages that will be passed around via the announcement system OSM employs.

In this PR we also include an example of how this may be used: every announcement `interface{}` is examined / type asserted to see if it is `Announcement{}`.  When it is - it is passed to a handler, which could further examine the properties of the message and do something specific.

The first use case for this more specific messaging system would be https://github.com/openservicemesh/osm/issues/1719, where we need to react to Pod Deletion events and clean-up relevant certificates.

For more context on how this could be used - see draft PR here: https://github.com/openservicemesh/osm/pull/1956

---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
