### PR TITLE
tests/e2e: adding test to individual backend services on trafficsplit

### DIFF
--- a/tests/e2e/common_traffic.go
+++ b/tests/e2e/common_traffic.go
@@ -104,7 +104,7 @@ type HTTPMultipleRequest struct {
 }
 
 // HTTPMultipleResults represents results from a multiple HTTP request call
-// results come back as a map[namespace][pod] -> HTTPResults
+// results come back as a map["srcNs/srcPod"]["dstNs/dstPod"] -> HTTPResults
 type HTTPMultipleResults map[string]map[string]HTTPRequestResult
 
 // MultipleHTTPRequest will issue a list of requests concurrently and return results when all requests have returned
@@ -115,13 +115,18 @@ func (td *OsmTestData) MultipleHTTPRequest(requests *HTTPMultipleRequest) HTTPMu
 
 	// Prepare results
 	for idx, r := range requests.Sources {
-		if _, ok := results[r.SourceNs]; !ok {
-			results[r.SourceNs] = map[string]HTTPRequestResult{}
+		srcKey := fmt.Sprintf("%s/%s", r.SourceNs, r.SourcePod)
+		dstKey := r.Destination
+
+		if _, ok := results[srcKey]; !ok {
+			results[srcKey] = map[string]HTTPRequestResult{}
 		}
-		if _, ok := results[r.SourceNs][r.SourcePod]; !ok {
-			results[r.SourceNs][r.SourcePod] = HTTPRequestResult{}
+		if _, ok := results[srcKey][dstKey]; !ok {
+			results[srcKey][dstKey] = HTTPRequestResult{}
 		} else {
-			td.T.Logf("WARN: Multiple requests from same pod %s. Results will overwrite.", r.SourcePod)
+			td.T.Logf("No support for more than one request from src to dst. (%s to %s).Ignoring.",
+				srcKey, dstKey)
+			continue
 		}
 
 		wg.Add(1)
@@ -133,7 +138,7 @@ func (td *OsmTestData) MultipleHTTPRequest(requests *HTTPMultipleRequest) HTTPMu
 			mtx.Lock()
 			results[ns][podname] = r
 			mtx.Unlock()
-		}(r.SourceNs, r.SourcePod, (*requests).Sources[idx])
+		}(srcKey, dstKey, (*requests).Sources[idx])
 	}
 	wg.Wait()
 

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -182,6 +182,8 @@ var _ = DescribeTier1("Test HTTP from N Clients deployments to 1 Server deployme
 			_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
 			Expect(err).To(BeNil())
 
+			By("Issuing http requests from clients to the traffic split FQDN")
+
 			// Test traffic
 			// Create Multiple HTTP request structure
 			requests := HTTPMultipleRequest{
@@ -237,6 +239,52 @@ var _ = DescribeTier1("Test HTTP from N Clients deployments to 1 Server deployme
 				// - We have seen all servers from the traffic split reply at least once
 				return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
 			}, 5, 150*time.Second)
+
+			Expect(success).To(BeTrue())
+
+			By("Issuing http requests from clients to the allowed individual service backends")
+
+			// Test now against the individual services, observe they should still be reachable
+			requests = HTTPMultipleRequest{
+				Sources: []HTTPRequestDef{},
+			}
+			for _, clientNs := range clientServices {
+				pods, err := td.client.CoreV1().Pods(clientNs).List(context.Background(), metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				// For each client pod
+				for _, pod := range pods.Items {
+					// reach each service
+					for _, svcNs := range serverServices {
+						requests.Sources = append(requests.Sources, HTTPRequestDef{
+							SourceNs:        pod.Namespace,
+							SourcePod:       pod.Name,
+							SourceContainer: pod.Namespace, // We generally code it like so for test purposes
+
+							// direct traffic target against the specific server service in the server namespace
+							Destination: fmt.Sprintf("%s.%s", svcNs, serverNamespace),
+						})
+					}
+				}
+			}
+
+			results = HTTPMultipleResults{}
+			success = td.WaitForRepeatedSuccess(func() bool {
+				// Get results
+				results = td.MultipleHTTPRequest(&requests)
+
+				// Print results
+				td.PrettyPrintHTTPResults(&results)
+
+				// Verify REST status code results
+				for _, ns := range results {
+					for _, podResult := range ns {
+						if podResult.Err != nil || podResult.StatusCode != 200 {
+							return false
+						}
+					}
+				}
+				return true
+			}, 2, 150*time.Second)
 
 			Expect(success).To(BeTrue())
 		})


### PR DESCRIPTION
To verify new RDS changes:
https://github.com/openservicemesh/osm/pull/1929

- Tests                  [x]
- CI System              [x]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No