### PR TITLE
envoy/lds: name the inbound filter chains

### DIFF
--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -14,6 +14,11 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
+const (
+	inboundIngressHTTPSFilterChain = "inbound-ingress-https-filter-chain"
+	inboundIngressHTTPFilterChain  = "inbound-ingress-http-filter-chain"
+)
+
 func getIngressTransportProtocol(cfg configurator.Configurator) string {
 	if cfg.UseHTTPSIngress() {
 		return envoy.TransportProtocolTLS
@@ -58,12 +63,14 @@ func getIngressFilterChains(svc service.MeshService, cfg configurator.Configurat
 	if cfg.UseHTTPSIngress() {
 		// Filter chain with SNI matching enabled for HTTPS clients that set the SNI
 		ingressFilterChainWithSNI := newIngressFilterChain(cfg, svc)
+		ingressFilterChainWithSNI.Name = inboundIngressHTTPSFilterChain
 		ingressFilterChainWithSNI.FilterChainMatch.ServerNames = []string{svc.GetCommonName().String()}
 		ingressFilterChains = append(ingressFilterChains, ingressFilterChainWithSNI)
 	}
 
 	// Filter chain without SNI matching enabled for HTTP clients and HTTPS clients that don't set the SNI
 	ingressFilterChainWithoutSNI := newIngressFilterChain(cfg, svc)
+	ingressFilterChainWithoutSNI.Name = inboundIngressHTTPFilterChain
 	ingressFilterChains = append(ingressFilterChains, ingressFilterChainWithoutSNI)
 
 	return ingressFilterChains

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -13,6 +13,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
+const (
+	inboundMeshFilterChainName = "inbound-mesh-filter-chain"
+)
+
 func getInboundInMeshFilterChain(proxyServiceName service.MeshService, cfg configurator.Configurator) (*xds_listener.FilterChain, error) {
 	marshalledDownstreamTLSContext, err := envoy.MessageToAny(envoy.GetDownstreamTLSContext(proxyServiceName, true /* mTLS */))
 	if err != nil {
@@ -28,6 +32,7 @@ func getInboundInMeshFilterChain(proxyServiceName service.MeshService, cfg confi
 	}
 
 	filterChain := &xds_listener.FilterChain{
+		Name: inboundMeshFilterChainName,
 		Filters: []*xds_listener.Filter{
 			{
 				Name: wellknown.HTTPConnectionManager,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Names the inbound filter chains used for in-mesh and ingress
traffic. Naming it makes it easier to examine the envoy config
dump and logs.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`