### PR TITLE
injector: reuse patch helper for patching labels and annotations

### DIFF
--- a/pkg/injector/init-container_test.go
+++ b/pkg/injector/init-container_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var _ = Describe("Test volume functions", func() {
-	Context("Test updateLabels", func() {
+	Context("Test getInitContainerSpec", func() {
 		It("creates volume spec", func() {
 			container := &InitContainer{
 				Name:  "-container-name-",

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -22,7 +22,9 @@ const (
 
 	volumesBasePath        = "/spec/volumes"
 	initContainersBasePath = "/spec/initContainers"
-	labelsPath             = "/metadata/labels"
+	labelsBasePath         = "/metadata/labels"
+	annotationsBasePath    = "/metadata/annotations"
+	containersBasePath     = "/spec/containers"
 )
 
 func (wh *webhook) createPatch(pod *corev1.Pod, namespace string, proxyUUID uuid.UUID) ([]byte, error) {
@@ -79,7 +81,7 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string, proxyUUID uuid
 	patches = append(patches, addContainer(
 		pod.Spec.Containers,
 		getEnvoySidecarContainerSpec(constants.EnvoyContainerName, wh.config.SidecarImage, envoyNodeID, envoyClusterID, wh.configurator),
-		"/spec/containers")...,
+		containersBasePath)...,
 	)
 
 	enableMetrics, err := wh.isMetricsEnabled(namespace)
@@ -94,14 +96,22 @@ func (wh *webhook) createPatch(pod *corev1.Pod, namespace string, proxyUUID uuid
 			constants.PrometheusPortAnnotation:   strconv.Itoa(constants.EnvoyPrometheusInboundListenerPort),
 			constants.PrometheusPathAnnotation:   constants.PrometheusScrapePath,
 		}
-		patches = append(patches, updateAnnotation(
+		patches = append(patches, updateMapType(
 			pod.Annotations,
 			prometheusAnnotations,
-			"/metadata/annotations")...,
+			annotationsBasePath)...,
 		)
 	}
 
-	patches = append(patches, *updateLabels(pod, constants.EnvoyUniqueIDLabelName, proxyUUID.String()))
+	// This will append a label to the pod, which points to the unique Envoy ID used in the
+	// xDS certificate for that Envoy. This label will help xDS match the actual pod to the Envoy that
+	// connects to xDS (with the certificate's CN matching this label).
+	labelsToAdd := map[string]string{constants.EnvoyUniqueIDLabelName: proxyUUID.String()}
+	patches = append(patches, updateMapType(
+		pod.Labels,
+		labelsToAdd,
+		labelsBasePath)...,
+	)
 
 	return json.Marshal(patches)
 }
@@ -180,7 +190,10 @@ func getSortedKeys(m map[string]string) []string {
 	return keys
 }
 
-func updateAnnotation(target, add map[string]string, basePath string) []JSONPatchOperation {
+// updateMaptType returns a list of JSONPatchOperation objects to reflect how the 'target' map should be patched
+// given the key-value pairs specified by the 'add` map and a 'basePath' corresponding to the API object.
+// It is used to patch Annotations and Labels.
+func updateMapType(target, add map[string]string, basePath string) []JSONPatchOperation {
 	var patches []JSONPatchOperation
 
 	// If the target does not exist we need to create it
@@ -205,32 +218,6 @@ func updateAnnotation(target, add map[string]string, basePath string) []JSONPatc
 	}
 
 	return patches
-}
-
-// This function will append a label to the pod, which points to the unique Envoy ID used in the
-// xDS certificate for that Envoy. This label will help xDS match the actual pod to the Envoy that
-// connects to xDS (with the certificate's CN matching this label).
-func updateLabels(pod *corev1.Pod, label, value string) *JSONPatchOperation {
-	if len(pod.Labels) == 0 {
-		return &JSONPatchOperation{
-			Op:    addOperation,
-			Path:  labelsPath,
-			Value: map[string]string{label: value},
-		}
-	}
-
-	getOp := func() string {
-		if _, exists := pod.Labels[label]; exists {
-			return replaceOperation
-		}
-		return addOperation
-	}
-
-	return &JSONPatchOperation{
-		Op:    getOp(),
-		Path:  path.Join(labelsPath, label),
-		Value: value,
-	}
 }
 
 // escapeJSONPointerValue escapes a JSON value as per https://tools.ietf.org/html/rfc6901.

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
-	"github.com/openservicemesh/osm/pkg/constants"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -36,33 +35,6 @@ var _ = Describe("Test all patch operations", func() {
 		containerTwo = "-container-two-"
 		basePath     = "/base/path"
 	)
-
-	Context("Test updateLabels() function", func() {
-		It("adds", func() {
-			pod := tests.NewPodTestFixture(namespace, podName)
-			pod.Labels = nil
-			actual := updateLabels(&pod, constants.EnvoyUniqueIDLabelName, proxyUUID.String())
-			expected := &JSONPatchOperation{
-				Op:   addOperation,
-				Path: "/metadata/labels",
-				Value: map[string]string{
-					"osm-proxy-uuid": proxyUUID.String(),
-				},
-			}
-			Expect(actual).To(Equal(expected))
-		})
-
-		It("replaces", func() {
-			pod := tests.NewPodTestFixture(namespace, podName)
-			actual := updateLabels(&pod, constants.EnvoyUniqueIDLabelName, proxyUUID.String())
-			replace := &JSONPatchOperation{
-				Op:    replaceOperation,
-				Path:  "/metadata/labels/osm-proxy-uuid",
-				Value: proxyUUID.String(),
-			}
-			Expect(actual).To(Equal(replace))
-		})
-	})
 
 	Context("test addVolume() function", func() {
 		It("adds volume", func() {
@@ -110,7 +82,7 @@ var _ = Describe("Test all patch operations", func() {
 		})
 	})
 
-	Context("test updateAnnotation() function", func() {
+	Context("test updateMapType() function", func() {
 		It("creates a list of patches", func() {
 			target := map[string]string{
 				"one": "1",
@@ -122,7 +94,7 @@ var _ = Describe("Test all patch operations", func() {
 				"three": "3",
 			}
 
-			actual := updateAnnotation(target, add, basePath)
+			actual := updateMapType(target, add, basePath)
 
 			expectedReplaceTwo := JSONPatchOperation{
 				Op:    replaceOperation,
@@ -146,7 +118,7 @@ var _ = Describe("Test all patch operations", func() {
 			}
 
 			// Target here is NIL -- this means we will be CREATING
-			actual := updateAnnotation(nil, annotationsToAdd, basePath)
+			actual := updateMapType(nil, annotationsToAdd, basePath)
 
 			// The first operation is "three" ("three" comes before "two" alphabetically)
 			// This is a CREATE operation since target is NIL

--- a/pkg/injector/volumes_test.go
+++ b/pkg/injector/volumes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var _ = Describe("Test volume functions", func() {
-	Context("Test updateLabels", func() {
+	Context("Test getVolumeSpec", func() {
 		It("creates volume spec", func() {
 			actual := getVolumeSpec("-envoy-config-")
 			expected := []v1.Volume{{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Labels and Annotations are both map types, so the same patching
code can be used for both with the patching path being the only
difference. This change reuses the helper to patch map types.
The existing tests validate patching map types, additionally
the `create_patch` function which patches labels is also tested
which ensures that patching of labels works as expected.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`