### PR TITLE
identity: add abstraction for service identity

### DIFF
--- a/pkg/identity/kubernetes.go
+++ b/pkg/identity/kubernetes.go
@@ -1,0 +1,17 @@
+package identity
+
+import (
+	"strings"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+const (
+	identityDelimiter = "."
+)
+
+// GetKubernetesServiceIdentity returns the ServiceIdentity based on Kubernetes ServiceAccount and a trust domain
+func GetKubernetesServiceIdentity(svcAccount service.K8sServiceAccount, trustDomain string) ServiceIdentity {
+	si := strings.Join([]string{svcAccount.Name, svcAccount.Namespace, trustDomain}, identityDelimiter)
+	return ServiceIdentity(si)
+}

--- a/pkg/identity/kubernetes_test.go
+++ b/pkg/identity/kubernetes_test.go
@@ -1,0 +1,38 @@
+package identity
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+func TestGetKubernetesServiceIdentity(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		svcAccount              service.K8sServiceAccount
+		trustDomain             string
+		expectedServiceIdentity ServiceIdentity
+	}{
+		{
+			service.K8sServiceAccount{Name: "foo", Namespace: "bar"},
+			"cluster.local",
+			ServiceIdentity("foo.bar.cluster.local"),
+		},
+		{
+			service.K8sServiceAccount{Name: "foo", Namespace: "bar"},
+			"cluster.baz",
+			ServiceIdentity("foo.bar.cluster.baz"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing GetKubernetesServiceIdentity for test case: %v", tc), func(t *testing.T) {
+			si := GetKubernetesServiceIdentity(tc.svcAccount, tc.trustDomain)
+			assert.Equal(si, tc.expectedServiceIdentity)
+		})
+	}
+}

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -1,0 +1,4 @@
+package identity
+
+// ServiceIdentity is the type used to represent the identity for a service
+type ServiceIdentity string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a new `ServiceIdentity` type that is to be used to provide
identity to services managed by OSM. Provides an API to use
Kubernetes ServiceAccount as service identities.

The kubernetes based service identity makes use of a trust domain
that determines the domain within which an identity can be trusted.
Within the same cluster, a Kubernetes service identity would be
"service-account.namespace.cluster.local". The trust domain provides
the ability to extend a `ServiceIdentity` beyond kubernetes domains.

Part of #1965

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`