### PR TITLE
cli,configurator: reuse api to parse osm-config ConfigMap

### DIFF
--- a/cmd/cli/trafficpolicy_check_test.go
+++ b/cmd/cli/trafficpolicy_check_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -63,7 +64,7 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 					Name:      osmConfigMapName,
 				},
 				Data: map[string]string{
-					permissiveTrafficPolicyModeKey: "true",
+					configurator.PermissiveTrafficPolicyModeKey: "true",
 				},
 			},
 			true,
@@ -76,7 +77,7 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 					Name:      osmConfigMapName,
 				},
 				Data: map[string]string{
-					permissiveTrafficPolicyModeKey: "false",
+					configurator.PermissiveTrafficPolicyModeKey: "false",
 				},
 			},
 			false,
@@ -89,7 +90,7 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 					Name:      osmConfigMapName,
 				},
 				Data: map[string]string{
-					permissiveTrafficPolicyModeKey: "invalid-value",
+					configurator.PermissiveTrafficPolicyModeKey: "invalid-value",
 				},
 			},
 			false,
@@ -193,7 +194,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 					Name:      osmConfigMapName,
 				},
 				Data: map[string]string{
-					permissiveTrafficPolicyModeKey: "false",
+					configurator.PermissiveTrafficPolicyModeKey: "false",
 				},
 			},
 			false,
@@ -249,7 +250,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 					Name:      osmConfigMapName,
 				},
 				Data: map[string]string{
-					permissiveTrafficPolicyModeKey: "false",
+					configurator.PermissiveTrafficPolicyModeKey: "false",
 				},
 			},
 			false,
@@ -306,7 +307,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 					Name:      osmConfigMapName,
 				},
 				Data: map[string]string{
-					permissiveTrafficPolicyModeKey: "true",
+					configurator.PermissiveTrafficPolicyModeKey: "true",
 				},
 			},
 			false,

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 
 		It("Tag matches const key for all fields of OSM ConfigMap struct", func() {
 			fieldNameTag := map[string]string{
-				"PermissiveTrafficPolicyMode": permissiveTrafficPolicyModeKey,
+				"PermissiveTrafficPolicyMode": PermissiveTrafficPolicyModeKey,
 				"Egress":                      egressKey,
 				"EnableDebugServer":           enableDebugServer,
 				"PrometheusScraping":          prometheusScrapingKey,
@@ -63,31 +63,44 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				f, _ := t.FieldByName("PermissiveTrafficPolicyMode")
 				actualtag := f.Tag.Get("yaml")
 				Expect(actualtag).To(
-					Equal(permissiveTrafficPolicyModeKey),
+					Equal(PermissiveTrafficPolicyModeKey),
 					fmt.Sprintf("Field %s expected to have tag %s; fuond %s instead", fieldName, expectedTag, actualtag))
 			}
 		})
 
-		It("Test getBoolValueForKey()", func() {
+		It("Test GetBoolValueForKey()", func() {
 			cm := &v1.ConfigMap{Data: map[string]string{tracingEnableKey: "true"}}
-			Expect(getBoolValueForKey(cm, tracingEnableKey)).To(BeTrue())
-			Expect(getBoolValueForKey(cm, egressKey)).To(BeFalse())
+			val, err := GetBoolValueForKey(cm, tracingEnableKey)
+			Expect(val).To(BeTrue())
+			Expect(err).To(BeNil())
+
+			val, err = GetBoolValueForKey(cm, egressKey)
+			Expect(val).To(BeFalse())
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("Test getIntValueForKey()", func() {
+		It("Test GetIntValueForKey()", func() {
 			cm := &v1.ConfigMap{Data: map[string]string{tracingPortKey: "12345"}}
-			Expect(getIntValueForKey(cm, tracingPortKey)).To(Equal(12345))
+			val, err := GetIntValueForKey(cm, tracingPortKey)
+			Expect(val).To(Equal(12345))
+			Expect(err).To(BeNil())
 
 			cm0 := &v1.ConfigMap{Data: map[string]string{}}
-			Expect(getIntValueForKey(cm0, egressKey)).To(Equal(0))
+			val, err = GetIntValueForKey(cm0, egressKey)
+			Expect(val).To(Equal(0))
+			Expect(err).To(HaveOccurred())
 		})
 
-		It("Test getStringValueForKey()", func() {
+		It("Test GetStringValueForKey()", func() {
 			cm := &v1.ConfigMap{Data: map[string]string{tracingEndpointKey: "foo"}}
-			Expect(getStringValueForKey(cm, tracingEndpointKey)).To(Equal("foo"))
+			val, err := GetStringValueForKey(cm, tracingEndpointKey)
+			Expect(val).To(Equal("foo"))
+			Expect(err).To(BeNil())
 
 			cm0 := &v1.ConfigMap{Data: map[string]string{}}
-			Expect(getStringValueForKey(cm0, tracingEndpointKey)).To(Equal(""))
+			strval, err := GetStringValueForKey(cm0, tracingEndpointKey)
+			Expect(strval).To(Equal(""))
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -14,8 +14,9 @@ import (
 
 var _ = Describe("Test Envoy configuration creation", func() {
 	testErrorEnvoyLogLevel := "error"
+	//noling: goconst
 	defaultConfigMap := map[string]string{
-		permissiveTrafficPolicyModeKey: "false",
+		PermissiveTrafficPolicyModeKey: "false",
 		egressKey:                      "true",
 		enableDebugServer:              "true",
 		prometheusScrapingKey:          "true",
@@ -83,7 +84,7 @@ var _ = Describe("Test Envoy configuration creation", func() {
 
 		It("correctly identifies that permissive_traffic_policy_mode is enabled", func() {
 			Expect(cfg.IsPermissiveTrafficPolicyMode()).To(BeFalse())
-			defaultConfigMap[permissiveTrafficPolicyModeKey] = "true"
+			defaultConfigMap[PermissiveTrafficPolicyModeKey] = "true"
 			configMap := v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,
@@ -105,7 +106,7 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		})
 
 		It("correctly identifies that permissive_traffic_policy_mode is disabled", func() {
-			defaultConfigMap[permissiveTrafficPolicyModeKey] = "false"
+			defaultConfigMap[PermissiveTrafficPolicyModeKey] = "false" //nolint: goconst
 			configMap := v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Reuses the configurator package to parse the permissive mode
config key in the ConfigMap as a part of osm cli.
Functionally, this change does not change the existing behavior
of the configurator client in osm-controller, which ignores errors
while initializing parsing the keys in the osm-config ConfigMap to
use default values where applicable.

Resolves #1962

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`