### PR TITLE
injector: Augment log message with object kind and name

### DIFF
--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -292,7 +292,7 @@ func (wh *webhook) mustInject(pod *corev1.Pod, namespace string) (bool, error) {
 	}
 
 	// Check if the pod is annotated for injection
-	podInjectAnnotationExists, podInject, err := isAnnotatedForInjection(pod.Annotations)
+	podInjectAnnotationExists, podInject, err := isAnnotatedForInjection(pod.Annotations, pod.Kind, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
 	if err != nil {
 		log.Error().Err(err).Msg("Error determining if the pod is enabled for sidecar injection")
 		return false, err
@@ -304,7 +304,7 @@ func (wh *webhook) mustInject(pod *corev1.Pod, namespace string) (bool, error) {
 		log.Error().Err(errNamespaceNotFound).Msgf("Error retrieving namespace %s", namespace)
 		return false, err
 	}
-	nsInjectAnnotationExists, nsInject, err := isAnnotatedForInjection(ns.Annotations)
+	nsInjectAnnotationExists, nsInject, err := isAnnotatedForInjection(ns.Annotations, ns.Kind, ns.Name)
 	if err != nil {
 		log.Error().Err(err).Msg("Error determining if namespace %s is enabled for sidecar injection")
 		return false, err
@@ -325,9 +325,9 @@ func (wh *webhook) mustInject(pod *corev1.Pod, namespace string) (bool, error) {
 	return false, nil
 }
 
-func isAnnotatedForInjection(annotations map[string]string) (exists bool, enabled bool, err error) {
+func isAnnotatedForInjection(annotations map[string]string, objectKind string, objectName string) (exists bool, enabled bool, err error) {
 	inject := strings.ToLower(annotations[constants.SidecarInjectionAnnotation])
-	log.Trace().Msgf("Sidecar injection annotation: '%s:%s'", constants.SidecarInjectionAnnotation, inject)
+	log.Trace().Msgf("%s %s has sidecar injection annotation: '%s:%s'", objectKind, objectName, constants.SidecarInjectionAnnotation, inject)
 	if inject != "" {
 		exists = true
 		switch inject {

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when the inject annotation is one of enabled/yes/true", func() {
 		It("should return true to enable sidecar injection", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "enabled"}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeTrue())
 			Expect(enabled).To(BeTrue())
 			Expect(err).To(BeNil())
@@ -115,7 +115,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 
 		It("should return true to enable sidecar injection", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "yes"}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeTrue())
 			Expect(enabled).To(BeTrue())
 			Expect(err).To(BeNil())
@@ -123,7 +123,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 
 		It("should return true to enable sidecar injection", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "true"}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeTrue())
 			Expect(enabled).To(BeTrue())
 			Expect(err).To(BeNil())
@@ -133,7 +133,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when the inject annotation is one of disabled/no/false", func() {
 		It("should return false to disable sidecar injection", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "disabled"}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeTrue())
 			Expect(enabled).To(BeFalse())
 			Expect(err).To(BeNil())
@@ -141,7 +141,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 
 		It("should return false to disable sidecar injection", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "no"}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeTrue())
 			Expect(enabled).To(BeFalse())
 			Expect(err).To(BeNil())
@@ -149,7 +149,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 
 		It("should return false to disable sidecar injection", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "false"}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeTrue())
 			Expect(enabled).To(BeFalse())
 			Expect(err).To(BeNil())
@@ -159,7 +159,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when the inject annotation does not exist", func() {
 		It("should return false to indicate the annotation does not exist", func() {
 			annotation := map[string]string{}
-			exists, enabled, err := isAnnotatedForInjection(annotation)
+			exists, enabled, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(exists).To(BeFalse())
 			Expect(enabled).To(BeFalse())
 			Expect(err).To(BeNil())
@@ -169,7 +169,7 @@ var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when an invalid inject annotation is specified", func() {
 		It("should return an error", func() {
 			annotation := map[string]string{constants.SidecarInjectionAnnotation: "invalid-value"}
-			_, _, err := isAnnotatedForInjection(annotation)
+			_, _, err := isAnnotatedForInjection(annotation, "-kind-", "-name-")
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
While working on an unrelated area, I noticed that one of the `pkg/injector` log messages provided insufficient context to understand exactly what is happening. The message is not useful without the context of the kind and name of object for which we are observing an annotation.

Example:
```
{"level":"trace","component":"sidecar-injector","time":"2020-11-03T00:21:56Z","file":"webhook.go:330","message":"Sidecar injection annotation: 'openservicemesh.io/sidecar-injection:'"}
```

This PR augments this message to add the kind and name of the object.

With this PR the message would look like this: `pod a/b has sidecar injection annotation: 'openservicemesh.io/sidecar-injection:"true"'`

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
