### PR TITLE
feat(ci): generate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Restore Module Cache
         uses: actions/cache@v2
         with:
@@ -43,12 +45,15 @@ jobs:
       - name: Build Binaries
         run: |
           make release-artifacts
+      - name: Generate Release Notes
+        run: scripts/release-notes.sh $VERSION > release-notes.md
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
+          body_path: release-notes.md
       - name: Upload macOS .zip
         uses: actions/upload-release-asset@v1
         with:

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Generate release notes using the changes between the given tag and its
+# predecessor, calculated by git's version sorting. When a stable tag (i.e.
+# without a pre-release tag like alpha, beta, etc.) is provided, then the
+# previous tag will be the next latest stable tag, skipping any intermediate
+# pre-release tags.
+
+# This script will break or produce weird output if:
+# - Tags are not formatted in a way that can be interpreted by git tag's --sort=version:refname
+# - Pre-release tags other than "alpha", "beta", and "rc" are used.
+
+tag=$1
+
+tags=$(git -c 'versionsort.suffix=-alpha,-beta,-rc' tag -l --sort=version:refname | sed "/^$tag$/q" )
+! [[ "$tag" =~ -(alpha|beta|rc) ]] && tags=$(grep -Eve '-(alpha|beta|rc)' <<< "$tags")
+prev=$(tail -2 <<< "$tags" | head -1)
+
+changelog=$(git log "$prev".."$tag" --format="* %s %H (%aN)")
+
+cat <<EOF
+## Changelog
+
+$changelog
+EOF


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a script that will generate the release notes for a
given git tag. It will calculate the previous tag and perform a
formatted `git log $prev..$next` to generate a changelog added to the
GitHub release. More details can be found in the script.

Something with how we've been updating release branches with changes
from main is causing some commits to show in the changelog we don't
want, like changes from v0.4.1 are showing in its changelog and the one
for v0.5.0-rc.1 since the commits have the same changes but different
SHAs. This can be addressed the next time we update the release-v0.5
branch with changes from main.

Currently, the release notes only contain this changelog, but it should
be simple to add anything else that can be generated. The release notes
can always be edited manually after the initial publish step.

Fixes #1361

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No