### PR TITLE
docs: fix typos in observability document links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ OSM runs an Envoy based control plane on Kubernetes, can be configured with SMI 
 1. Easily and transparently configure [traffic shifting][3] for deployments
 1. Secure service to service communication by [enabling mTLS](docs/patterns/certificates.md)
 1. Define and execute fine grained [access control][4] policies for services
-1. [Observability](docs/patterns/observability.md) and insights into application metrics for debugging and monitoring services
+1. [Observability](docs/patterns/observability/README.md) and insights into application metrics for debugging and monitoring services
 1. Integrate with [external certificate management](docs/patterns/certificates.md) services/solutions with a pluggable interface
 1. Onboard applications onto the mesh by enabling [automatic sidecar injection](docs/patterns/sidecar_injection.md) of Envoy proxy
 
@@ -108,7 +108,7 @@ After installing OSM, [onboard a microservice application](docs/onboard_services
 ### OSM Usage Patterns
 
 1. [Ingress](docs/patterns/ingress.md) and [Egress](docs/patterns/egress.md)
-1. [Observability](docs/patterns/observability.md)
+1. [Observability](docs/patterns/observability/README.md)
 1. [Certificates](docs/patterns/certificates.md)
 1. [Sidecar Injection](docs/patterns/sidecar_injection.md)
 

--- a/docs/onboard_services.md
+++ b/docs/onboard_services.md
@@ -43,7 +43,7 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
 
 1. Verify the new behavior
 
-    The OSM control plane installs Prometheus and Grafana instances by default that can be used to help make sure the application is working properly. More details can be found in the [Observability](patterns/observability.md) document.
+    The OSM control plane installs Prometheus and Grafana instances by default that can be used to help make sure the application is working properly. More details can be found in the [Observability](patterns/observability/README.md) document.
 
 
 #### Note: Removing Namespaces


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixed the typo errors in the links to Observability section which was throwing 404 Page Not Found error
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No this doesn't contain any code changes
