### PR TITLE
catalog/test: ignore ordering of elements in test

### DIFF
--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -187,7 +187,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 
 			actual, err := meshCatalog.ListAllowedInboundServiceAccounts(tc.svcAccount)
 			assert.Equal(err != nil, tc.expectError)
-			assert.Equal(actual, tc.expectedInboundSvcAccounts)
+			assert.ElementsMatch(actual, tc.expectedInboundSvcAccounts)
 		})
 	}
 }
@@ -370,7 +370,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 
 			actual, err := meshCatalog.ListAllowedOutboundServiceAccounts(tc.svcAccount)
 			assert.Equal(err != nil, tc.expectError)
-			assert.Equal(actual, tc.expectedOutboundSvcAccounts)
+			assert.ElementsMatch(actual, tc.expectedOutboundSvcAccounts)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the test to not rely on ordering of elements
in the expected list of elements.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
