### PR TITLE
catalog/repeater: Change noisy log statement from Info to Trace

### DIFF
--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -23,7 +23,7 @@ func (mc *MeshCatalog) repeater() {
 					mc.handleAnnouncement(ann)
 				}
 
-				log.Info().Msgf("[repeater] Received announcement from %s", caseNames[chosenIdx])
+				log.Trace().Msgf("Received announcement from %s", caseNames[chosenIdx])
 				delta := time.Since(lastUpdateAt)
 				if delta >= updateAtMostEvery {
 					mc.broadcast(message)


### PR DESCRIPTION
This PR changes a log statement from `Info()` to `Trace()` to lower the noise in logs.  Also removing `[repeater]`, which is already included in the `file` field of the JSON log message:

```json
{
  "level": "info",
  "component": "mesh-catalog",
  "time": "2020-11-04T23:10:04Z",
  "file": "repeater.go:20",
  "message": "[repeater] Received announcement from Namespace"
}
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
