### PR TITLE
endponit/providers/kube: Adding the name of the endpoint provider to the log messages

### DIFF
--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -65,8 +65,8 @@ func (c *Client) GetID() string {
 
 // ListEndpointsForService retrieves the list of IP addresses for the given service
 func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
-	log.Info().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
-	var endpoints []endpoint.Endpoint = []endpoint.Endpoint{}
+	log.Trace().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
+	var endpoints []endpoint.Endpoint
 	endpointsInterface, exist, err := c.caches.Endpoints.GetByKey(svc.String())
 	if err != nil {
 		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache", c.providerIdent)
@@ -89,7 +89,7 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 				for _, port := range kubernetesEndpoint.Ports {
 					ip := net.ParseIP(address.IP)
 					if ip == nil {
-						log.Error().Msgf("Error parsing IP address %s", address.IP)
+						log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, address.IP)
 						break
 					}
 					ept := endpoint.Endpoint{
@@ -106,7 +106,6 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 
 // GetServicesForServiceAccount retrieves a list of services for the given service account.
 func (c Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {
-	log.Info().Msgf("[%s] Getting Services for service account %s on Kubernetes", c.providerIdent, svcAccount)
 	services := mapset.NewSet()
 
 	for _, podInterface := range c.caches.Pods.List() {
@@ -127,7 +126,7 @@ func (c Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccoun
 
 		k8sServices, err := c.getServicesByLabels(podLabels, pod.Namespace)
 		if err != nil {
-			log.Error().Err(err).Msgf("Error retrieving service matching labels %v in namespace %s", podLabels, pod.Namespace)
+			log.Error().Err(err).Msgf("[%s] Error retrieving service matching labels %v in namespace %s", c.providerIdent, podLabels, pod.Namespace)
 			return nil, err
 		}
 
@@ -144,9 +143,9 @@ func (c Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccoun
 		// This will ensure that all pods in the service account are represented as one service.
 		synthService := svcAccount.GetSyntheticService()
 		services.Add(synthService)
-		log.Info().Msgf("No services for service account %s in namespace %s; Adding synthetic service %s", svcAccount.Name, svcAccount.Namespace, synthService)
+		log.Trace().Msgf("[%s] No services for service account %s/%s; Adding synthetic service %s", c.providerIdent, svcAccount.Name, svcAccount.Namespace, synthService)
 	} else {
-		log.Info().Msgf("[%s] Services %v observed on service account %s on Kubernetes", c.providerIdent, services, svcAccount)
+		log.Trace().Msgf("[%s] Services for service account %s: %+v", c.providerIdent, svcAccount, services)
 	}
 
 	servicesSlice := make([]service.MeshService, 0, services.Cardinality())
@@ -181,12 +180,12 @@ func (c *Client) run(stop <-chan struct{}) error {
 			continue
 		}
 		names = append(names, name)
-		log.Debug().Msgf("Starting informer %s", name)
+		log.Info().Msgf("[%s] Starting informer %s", c.providerIdent, name)
 		go informer.Run(stop)
 		hasSynced = append(hasSynced, informer.HasSynced)
 	}
 
-	log.Info().Msgf("Waiting for informer's cache to sync: %+v", strings.Join(names, ", "))
+	log.Info().Msgf("[%s] Waiting for informer's cache to sync: %+v", c.providerIdent, strings.Join(names, ", "))
 	if !cache.WaitForCacheSync(stop, hasSynced...) {
 		return errSyncingCaches
 	}
@@ -194,7 +193,7 @@ func (c *Client) run(stop <-chan struct{}) error {
 	// Closing the cacheSynced channel signals to the rest of the system that... caches have been synced.
 	close(c.cacheSynced)
 
-	log.Info().Msgf("Cache sync finished for %+v", names)
+	log.Info().Msgf("[%s] Cache sync finished for %+v", c.providerIdent, names)
 	return nil
 }
 
@@ -229,7 +228,7 @@ func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]en
 	// Check if the service has been given Cluster IP
 	kubeService := c.kubeController.GetService(svc)
 	if kubeService == nil {
-		log.Error().Msgf("Could not find service %s", svc.String())
+		log.Error().Msgf("[%s] Could not find service %s", c.providerIdent, svc.String())
 		return nil, errServiceNotFound
 	}
 
@@ -241,7 +240,7 @@ func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]en
 	// Cluster IP is present
 	ip := net.ParseIP(kubeService.Spec.ClusterIP)
 	if ip == nil {
-		log.Error().Msgf("Could not parse Cluster IP %s", kubeService.Spec.ClusterIP)
+		log.Error().Msgf("[%s] Could not parse Cluster IP %s", c.providerIdent, kubeService.Spec.ClusterIP)
 		return nil, errParseClusterIP
 	}
 

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Test Kube Client Provider", func() {
 
 		It("should correctly return a list of endpoints for a service", func() {
 			// Should be empty for now
-			Expect(cli.ListEndpointsForService(tests.BookbuyerService)).To(Equal([]endpoint.Endpoint{}))
+			Expect(cli.ListEndpointsForService(tests.BookbuyerService)).To(BeNil())
 
 			// Create bookbuyer endpoint in Bookbuyer namespace
 			endp := &corev1.Endpoints{


### PR DESCRIPTION
Because these log messages may be emitted by a number of instances of the kubernetes endpoints provider, prepending the name of the particular provider would be helpful.

For some messages changing log level to `Trace()`.
For the log statements that are emitted only on launch of the OSM Controller pod - changing from `Debug` to `Info`

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
