### PR TITLE
envoy: Augment Envoy's Node ID with Pod metadata

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -133,6 +133,10 @@ const (
 
 	// InitContainerName is the name of the init container
 	InitContainerName = "osm-init"
+
+	// EnvoyServiceNodeSeparator is the character separating the strings used to create an Envoy service node parameter.
+	// Example use: envoy --service-node 52883c80-6e0d-4c64-b901-cbcb75134949/bookstore/10.144.2.91/bookstore-v1/bookstore-v1
+	EnvoyServiceNodeSeparator = "/"
 )
 
 // Annotations used by the controller

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -21,6 +21,39 @@ type Proxy struct {
 	lastSentVersion    map[TypeURI]uint64
 	lastAppliedVersion map[TypeURI]uint64
 	lastNonce          map[TypeURI]string
+
+	// Records metadata around the Kubernetes Pod on which this Envoy Proxy is installed.
+	// This could be nil if the Envoy is not operating in a Kubernetes cluster (VM for example)
+	// NOTE: This field may be not be set at the time Proxy struct is initialized. This would
+	// eventually be set when the metadata arrives via the xDS protocol.
+	podMetadata *PodMetadata
+}
+
+// PodMetadata is a struct holding information on the Pod on which a given Envoy proxy is installed
+// This struct is initialized *eventually*, when the metadata arrives via xDS.
+type PodMetadata struct {
+	UID            string
+	Namespace      string
+	IP             string
+	ServiceAccount string
+	Cluster        string
+	EnvoyNodeID    string
+}
+
+// HasPodMetadata answers the question - has the Pod metadata been recorded for the given Envoy proxy
+func (p *Proxy) HasPodMetadata() bool {
+	return p.podMetadata != nil
+}
+
+func (p *Proxy) SetMetadata(podUID, podNamespace, podIP, podServiceAccountName, envoyNodeID string) {
+	p.podMetadata = &PodMetadata{
+		UID:            podUID,
+		Namespace:      podNamespace,
+		IP:             podIP,
+		ServiceAccount: podServiceAccountName,
+		Cluster:        "", // TODO
+		EnvoyNodeID:    envoyNodeID,
+	}
 }
 
 // SetLastAppliedVersion records the version of the given Envoy proxy that was last acknowledged.

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -1,6 +1,7 @@
 package envoy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/jinzhu/copier"
 
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -291,4 +293,33 @@ func GetADSConfigSource() *xds_core.ConfigSource {
 		},
 		ResourceApiVersion: xds_core.ApiVersion_V3,
 	}
+}
+
+// GetEnvoyServiceNodeIDForCLI creates the string for Envoy's "--service-node" CLI argument for the Kubernetes sidecar container Command/Args
+func GetEnvoyServiceNodeIDForCLI(nodeID string) string {
+	items := []string{
+		"$(POD_UID)",
+		"$(POD_NAMESPACE)",
+		"$(POD_IP)",
+		"$(SERVICE_ACCOUNT)",
+		nodeID,
+	}
+
+	return strings.Join(items, constants.EnvoyServiceNodeSeparator)
+}
+
+func ParseEnvoyServiceNodeID(serviceNodeID string) (podUID, podNamespace, podIP, serviceAccountName, nodeID string, err error) {
+	chunks := strings.Split(serviceNodeID, constants.EnvoyServiceNodeSeparator)
+
+	if len(chunks) != 5 {
+		return podUID, podNamespace, podIP, serviceAccountName, nodeID, errors.New("invalid envoy service node id format")
+	}
+
+	podUID = chunks[0]
+	podNamespace = chunks[1]
+	podIP = chunks[2]
+	serviceAccountName = chunks[3]
+	nodeID = chunks[4]
+
+	return podUID, podNamespace, podIP, serviceAccountName, nodeID, nil
 }

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -295,8 +295,8 @@ func GetADSConfigSource() *xds_core.ConfigSource {
 	}
 }
 
-// GetEnvoyServiceNodeIDForCLI creates the string for Envoy's "--service-node" CLI argument for the Kubernetes sidecar container Command/Args
-func GetEnvoyServiceNodeIDForCLI(nodeID string) string {
+// GetEnvoyServiceNodeID creates the string for Envoy's "--service-node" CLI argument for the Kubernetes sidecar container Command/Args
+func GetEnvoyServiceNodeID(nodeID string) string {
 	items := []string{
 		"$(POD_UID)",
 		"$(POD_NAMESPACE)",

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -333,9 +333,9 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 	})
 
-	Context("Test GetEnvoyServiceNodeIDForCLI()", func() {
+	Context("Test GetEnvoyServiceNodeID()", func() {
 		It("", func() {
-			actual := GetEnvoyServiceNodeIDForCLI("-nodeID-")
+			actual := GetEnvoyServiceNodeID("-nodeID-")
 			expected := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-"
 			Expect(actual).To(Equal(expected))
 		})
@@ -343,7 +343,7 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test ParseEnvoyServiceNodeID()", func() {
 		It("", func() {
-			serviceNodeID := GetEnvoyServiceNodeIDForCLI("-nodeID-")
+			serviceNodeID := GetEnvoyServiceNodeID("-nodeID-")
 			podUID, podNamespace, podIP, serviceAccountName, nodeID, err := ParseEnvoyServiceNodeID(serviceNodeID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(podUID).To(Equal("$(POD_UID)"))

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -332,4 +332,25 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(actual).To(Equal(expected))
 		})
 	})
+
+	Context("Test GetEnvoyServiceNodeIDForCLI()", func() {
+		It("", func() {
+			actual := GetEnvoyServiceNodeIDForCLI("-nodeID-")
+			expected := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-"
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test ParseEnvoyServiceNodeID()", func() {
+		It("", func() {
+			serviceNodeID := GetEnvoyServiceNodeIDForCLI("-nodeID-")
+			podUID, podNamespace, podIP, serviceAccountName, nodeID, err := ParseEnvoyServiceNodeID(serviceNodeID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(podUID).To(Equal("$(POD_UID)"))
+			Expect(podNamespace).To(Equal("$(POD_NAMESPACE)"))
+			Expect(podIP).To(Equal("$(POD_IP)"))
+			Expect(serviceAccountName).To(Equal("$(SERVICE_ACCOUNT)"))
+			Expect(nodeID).To(Equal("-nodeID-"))
+		})
+	})
 })

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -201,9 +201,63 @@ var _ = Describe("Test Envoy sidecar", func() {
 				Args: []string{
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
-					"--service-node", nodeID,
+					"--service-node", "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-node-id-",
 					"--service-cluster", clusterID,
 					"--bootstrap-version 3",
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "POD_UID",
+						Value: "",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								APIVersion: "",
+								FieldPath:  "metadata.uid",
+							},
+							ResourceFieldRef: nil,
+							ConfigMapKeyRef:  nil,
+							SecretKeyRef:     nil,
+						},
+					},
+					{
+						Name:  "POD_NAMESPACE",
+						Value: "",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								APIVersion: "",
+								FieldPath:  "metadata.namespace",
+							},
+							ResourceFieldRef: nil,
+							ConfigMapKeyRef:  nil,
+							SecretKeyRef:     nil,
+						},
+					},
+					{
+						Name:  "POD_IP",
+						Value: "",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								APIVersion: "",
+								FieldPath:  "status.podIP",
+							},
+							ResourceFieldRef: nil,
+							ConfigMapKeyRef:  nil,
+							SecretKeyRef:     nil,
+						},
+					},
+					{
+						Name:  "SERVICE_ACCOUNT",
+						Value: "",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{
+								APIVersion: "",
+								FieldPath:  "spec.serviceAccountName",
+							},
+							ResourceFieldRef: nil,
+							ConfigMapKeyRef:  nil,
+							SecretKeyRef:     nil,
+						},
+					},
 				},
 			}
 			Expect(actual[0]).To(Equal(expected))

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 const (
@@ -44,9 +45,43 @@ func getEnvoySidecarContainerSpec(containerName, envoyImage, nodeID, clusterID s
 		Args: []string{
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),
-			"--service-node", nodeID,
+			"--service-node", envoy.GetEnvoyServiceNodeIDForCLI(nodeID),
 			"--service-cluster", clusterID,
 			"--bootstrap-version 3",
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name: "POD_UID",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.uid",
+					},
+				},
+			},
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.namespace",
+					},
+				},
+			},
+			{
+				Name: "POD_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "status.podIP",
+					},
+				},
+			},
+			{
+				Name: "SERVICE_ACCOUNT",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "spec.serviceAccountName",
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -45,7 +45,7 @@ func getEnvoySidecarContainerSpec(containerName, envoyImage, nodeID, clusterID s
 		Args: []string{
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),
-			"--service-node", envoy.GetEnvoyServiceNodeIDForCLI(nodeID),
+			"--service-node", envoy.GetEnvoyServiceNodeID(nodeID),
 			"--service-cluster", clusterID,
 			"--bootstrap-version 3",
 		},


### PR DESCRIPTION
The metadata of the Pod on which a given Envoy is installed would be of immense value to OSM.  There are a few ways to link an Envoy to the Pod metadata - this PR prososes one.

Using the Envoy `--service-node` bootstrap param, we pass some of the metadata of the Pod to the OSM control plane.

Here is a log line as an example of the data that we get from Envoy:
```json
{
  "level": "trace",
  "component": "envoy",
  "time": "2020-11-05T02:59:07Z",
  "file": "proxy.go:34",
  "message": "Recorded metadata for Envoy 785c9a2e-63d1-4306-bbf5-9fc886232513.bookthief.bookthief: podUID=d2384c3e-0b25-44b1-af62-218e34286f7f, podNamespace=bookthief, podIP=10.244.2.181, podServiceAccountName=bookthief, envoyNodeID=bookthief"
}
```

So we now know that Pod with CN `785c9a2e-63d1-4306-bbf5-9fc886232513.bookthief.bookthief` has:
  - pod UID of `d2384c3e-0b25-44b1-af62-218e34286f7f`
  - pod Namespace `bookthief`
  - podIP `10.244.2.181`
  - pod Service Account Name `bookthief`

This information augments the proxy struct;  Next steps are to use it in the debug server, but most importantly - use this metadata to identify a pod - so that when a pod terminats we can clean up certs etc.

This PR is a step towards resolving https://github.com/openservicemesh/osm/issues/1719

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
