### PR TITLE
clean-up : fixing test naming

### DIFF
--- a/ci/cmd/suite_test.go
+++ b/ci/cmd/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestMaestro(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Maestro Test Suite")
 }

--- a/cmd/cli/suite_test.go
+++ b/cmd/cli/suite_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestCLI(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "CLI Test Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/cmd/osm-controller/suite_test.go
+++ b/cmd/osm-controller/suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestADSMain(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "ADSMain Test Suite")
 }

--- a/pkg/apis/suite_test.go
+++ b/pkg/apis/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "APIs Test Suite")
 }

--- a/pkg/certificate/providers/vault/suite_test.go
+++ b/pkg/certificate/providers/vault/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestVault(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Hashicorp Vault Test Suite")
 }

--- a/pkg/certificate/suite_test.go
+++ b/pkg/certificate/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestCertificates(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Certificate Test Suite")
 }

--- a/pkg/cli/suite_test.go
+++ b/pkg/cli/suite_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCLIUtils(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "CLI-Utils Test Suite")
 }
 
 var oldEnv *string

--- a/pkg/configurator/suite_test.go
+++ b/pkg/configurator/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestConfigurator(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Configurator Test Suite")
 }

--- a/pkg/constants/suite_test.go
+++ b/pkg/constants/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestConstants(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Constants Test Suite")
 }

--- a/pkg/endpoint/providers/azure/suite_test.go
+++ b/pkg/endpoint/providers/azure/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestProvider(t *testing.T) {
+func TestAzureProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Azure Endpoints Provider Suite")
 }

--- a/pkg/endpoint/providers/kube/suite_test.go
+++ b/pkg/endpoint/providers/kube/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestKubeProvider(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Kube Provider Test Suite")
 }

--- a/pkg/endpoint/providers/suite_test.go
+++ b/pkg/endpoint/providers/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEndpointProviders(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "EndpointProviers Test Suite")
 }

--- a/pkg/endpoint/suite_test.go
+++ b/pkg/endpoint/suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestEndpoints(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Endpoints Test Suite")
 }

--- a/pkg/envoy/ads/suite_test.go
+++ b/pkg/envoy/ads/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoyAds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Envoy ADS Test Suite")
 }

--- a/pkg/envoy/cds/suite_test.go
+++ b/pkg/envoy/cds/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoyCds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "CDS Test Suite")
+	RunSpecs(t, "Envoy CDS Test Suite")
 }

--- a/pkg/envoy/eds/suite_test.go
+++ b/pkg/envoy/eds/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoyEds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Envoy EDS Test Suite")
 }

--- a/pkg/envoy/lds/suite_test.go
+++ b/pkg/envoy/lds/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoyLds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Envoy LDS Test Suite")
 }

--- a/pkg/envoy/rds/suite_test.go
+++ b/pkg/envoy/rds/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoyRds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RDS Test Suite")
+	RunSpecs(t, "Envoy RDS Test Suite")
 }

--- a/pkg/envoy/sds/suite_test.go
+++ b/pkg/envoy/sds/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoySds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Envoy SDS Test Suite")
 }

--- a/pkg/envoy/suite_test.go
+++ b/pkg/envoy/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEnvoySds(t *testing.T) {
+func TestEnvoy(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Envoy SDS Test Suite")
+	RunSpecs(t, "Envoy Test Suite")
 }

--- a/pkg/envoy/suite_test.go
+++ b/pkg/envoy/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestEnvoySds(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Envoy SDS Test Suite")
 }

--- a/pkg/featureflags/suite_test.go
+++ b/pkg/featureflags/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestFEatureFlags(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Feature flags Test Suite")
 }

--- a/pkg/health/suite_test.go
+++ b/pkg/health/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestHealth(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Health Test Suite")
 }

--- a/pkg/httpserver/suite_test.go
+++ b/pkg/httpserver/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestHttpServer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Http Server Test Suite")
 }

--- a/pkg/injector/suite_test.go
+++ b/pkg/injector/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestInjector(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Injector Test Suite")
 }

--- a/pkg/metricsstore/suite_test.go
+++ b/pkg/metricsstore/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestMetricsStore(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Metrics Store Test Suite")
 }

--- a/pkg/smi/suite_test.go
+++ b/pkg/smi/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestSMI(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "SMI Test Suite")
 }

--- a/pkg/version/suite_test.go
+++ b/pkg/version/suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEndpoints(t *testing.T) {
+func TestVersion(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Test Suite")
+	RunSpecs(t, "Version Test Suite")
 }


### PR DESCRIPTION
**Description**:
Most of the tests in `suite_test.go`  were named as `TestEndpoints`, this PR cleans up and fixes the naming of the tests in the various packages appropriately. No functional changes, only renaming

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
