### PR TITLE
envoy: use consistent terminology for downstream and upstream service

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -23,11 +23,11 @@ const (
 	clusterConnectTimeout = 1 * time.Second
 )
 
-// getRemoteServiceCluster returns an Envoy Cluster corresponding to the remote service
-func getRemoteServiceCluster(remoteService, localService service.MeshService, cfg configurator.Configurator) (*xds_cluster.Cluster, error) {
-	clusterName := remoteService.String()
+// getUpstreamServiceCluster returns an Envoy Cluster corresponding to the given upstream service
+func getUpstreamServiceCluster(upstreamSvc, downstreamSvc service.MeshService, cfg configurator.Configurator) (*xds_cluster.Cluster, error) {
+	clusterName := upstreamSvc.String()
 	marshalledUpstreamTLSContext, err := envoy.MessageToAny(
-		envoy.GetUpstreamTLSContext(localService, remoteService.ServerName()))
+		envoy.GetUpstreamTLSContext(downstreamSvc, upstreamSvc.ServerName()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -20,13 +20,13 @@ var _ = Describe("Cluster configurations", func() {
 	mockCtrl = gomock.NewController(GinkgoT())
 	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 
-	localService := tests.BookbuyerService
-	remoteService := tests.BookstoreV1Service
-	Context("Test getRemoteServiceCluster", func() {
+	downstreamSvc := tests.BookbuyerService
+	upstreamSvc := tests.BookstoreV1Service
+	Context("Test getUpstreamServiceCluster", func() {
 		It("Returns an EDS based cluster when permissive mode is disabled", func() {
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
 
-			remoteCluster, err := getRemoteServiceCluster(remoteService, localService, mockConfigurator)
+			remoteCluster, err := getUpstreamServiceCluster(upstreamSvc, downstreamSvc, mockConfigurator)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(remoteCluster.GetType()).To(Equal(xds_cluster.Cluster_EDS))
 			Expect(remoteCluster.LbPolicy).To(Equal(xds_cluster.Cluster_ROUND_ROBIN))
@@ -36,7 +36,7 @@ var _ = Describe("Cluster configurations", func() {
 		It("Returns an Original Destination based cluster when permissive mode is enabled", func() {
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).Times(1)
 
-			remoteCluster, err := getRemoteServiceCluster(remoteService, localService, mockConfigurator)
+			remoteCluster, err := getUpstreamServiceCluster(upstreamSvc, downstreamSvc, mockConfigurator)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(remoteCluster.GetType()).To(Equal(xds_cluster.Cluster_ORIGINAL_DST))
 			Expect(remoteCluster.LbPolicy).To(Equal(xds_cluster.Cluster_CLUSTER_PROVIDED))

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -44,7 +44,7 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 			continue
 		}
 
-		remoteCluster, err := getRemoteServiceCluster(dstService, proxyServiceName, cfg)
+		remoteCluster, err := getUpstreamServiceCluster(dstService, proxyServiceName, cfg)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed to construct service cluster for proxy %s", proxyServiceName)
 			return nil, err

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -148,12 +148,12 @@ var _ = Describe("CDS Response", func() {
 		})
 
 		It("Returns a remote cluster object", func() {
-			localService := tests.BookbuyerService
-			remoteService := tests.BookstoreV1Service
+			downstreamSvc := tests.BookbuyerService
+			upstreamSvc := tests.BookstoreV1Service
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
 
-			remoteCluster, err := getRemoteServiceCluster(remoteService, localService, mockConfigurator)
+			remoteCluster, err := getUpstreamServiceCluster(upstreamSvc, downstreamSvc, mockConfigurator)
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedClusterLoadAssignment := &xds_endpoint.ClusterLoadAssignment{
@@ -186,8 +186,8 @@ var _ = Describe("CDS Response", func() {
 			}
 
 			// Checking for the value by generating the same value the same way is reduntant
-			// Nonetheless, as getRemoteServiceCluster logic gets more complicated, this might just be ok to have
-			upstreamTLSProto, err := envoy.MessageToAny(envoy.GetUpstreamTLSContext(proxyService, remoteService.ServerName()))
+			// Nonetheless, as getUpstreamServiceCluster logic gets more complicated, this might just be ok to have
+			upstreamTLSProto, err := envoy.MessageToAny(envoy.GetUpstreamTLSContext(proxyService, upstreamSvc.ServerName()))
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedCluster := xds_cluster.Cluster{
@@ -256,7 +256,7 @@ var _ = Describe("CDS Response", func() {
 					},
 					AlpnProtocols: envoy.ALPNInMesh,
 				},
-				Sni:                remoteService.ServerName(),
+				Sni:                upstreamSvc.ServerName(),
 				AllowRenegotiation: false,
 			}
 			Expect(upstreamTLSContext.CommonTlsContext.TlsParams).To(Equal(expectedTLSContext.CommonTlsContext.TlsParams))

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -26,8 +26,8 @@ const (
 	singleIpv4Mask                = 32
 )
 
-func newOutboundListener(catalog catalog.MeshCataloger, cfg configurator.Configurator, localSvc []service.MeshService) (*xds_listener.Listener, error) {
-	serviceFilterChains, err := getOutboundFilterChains(catalog, cfg, localSvc)
+func newOutboundListener(catalog catalog.MeshCataloger, cfg configurator.Configurator, downstreamSvc []service.MeshService) (*xds_listener.Listener, error) {
+	serviceFilterChains, err := getOutboundFilterChains(catalog, cfg, downstreamSvc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting filter chains for outbound listener")
 		return nil, err
@@ -161,14 +161,14 @@ func getOutboundFilterChainMatchForService(dstSvc service.MeshService, catalog c
 	return filterMatch, nil
 }
 
-func getOutboundFilterChains(catalog catalog.MeshCataloger, cfg configurator.Configurator, localSvc []service.MeshService) ([]*xds_listener.FilterChain, error) {
+func getOutboundFilterChains(catalog catalog.MeshCataloger, cfg configurator.Configurator, downstreamSvc []service.MeshService) ([]*xds_listener.FilterChain, error) {
 	var filterChains []*xds_listener.FilterChain
 	var dstServicesSet map[service.MeshService]struct{} = make(map[service.MeshService]struct{}) // Set, avoid dups
 
 	// Assuming single service in pod till #1682, #1575 get addressed
-	outboundSvc, err := catalog.ListAllowedOutboundServices(localSvc[0])
+	outboundSvc, err := catalog.ListAllowedOutboundServices(downstreamSvc[0])
 	if err != nil {
-		log.Error().Err(err).Msgf("Error getting allowed outbound services for %s", localSvc[0].String())
+		log.Error().Err(err).Msgf("Error getting allowed outbound services for %s", downstreamSvc[0].String())
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
As per #1860, uses consistent terminilogy to refer to the source/client
as downstream, and the destination/remote/server as upstream.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`