### PR TITLE
kubernetes/client: remove announcement channel for namespace informer

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -50,7 +50,6 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		{"CertManager", mc.certManager.GetAnnouncementsChannel()},
 		{"IngressMonitor", mc.ingressMonitor.GetAnnouncementsChannel()},
 		{"Ticker", ticking},
-		{"Namespace", mc.kubeController.GetAnnouncementsChannel(k8s.Namespaces)},
 		{"Services", mc.kubeController.GetAnnouncementsChannel(k8s.Services)},
 	}
 

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Test catalog functions", func() {
 			chans := mc.getAnnouncementChannels()
 
 			// Currently returns len(Channels), see getAnnouncementChannels implementation for details.
-			expectedNumberOfChannels := 7
+			expectedNumberOfChannels := 6
 			Expect(len(chans)).To(Equal(expectedNumberOfChannels))
 		})
 	})

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -88,13 +88,11 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 		return podRet
 	}).AnyTimes()
 
-	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
 		mockIngressMonitor, stop, cfg, endpointProviders...)

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -137,7 +137,6 @@ func newFakeMeshCatalog() *MeshCatalog {
 
 		return vv
 	}).AnyTimes()
-	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -237,7 +237,6 @@ var _ = Describe("RDS Response", func() {
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Namespaces).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
 	mockKubeController.EXPECT().ListMonitoredNamespaces().Return(listExpectedNs, nil).AnyTimes()
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -52,11 +52,8 @@ func (c *Client) initNamespaceMonitor() {
 	// Add informer
 	c.informers[Namespaces] = informerFactory.Core().V1().Namespaces().Informer()
 
-	// Announcement channel for Namespaces
-	c.announcements[Namespaces] = make(chan interface{})
-
 	// Add event handler to informer
-	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, c.announcements[Namespaces], nil))
+	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, nil, nil))
 }
 
 // Initializes Service monitoring

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -70,7 +70,6 @@ func bootstrapClient() (MeshSpec, *fakeKubeClientSet, error) {
 	if _, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), &testNamespace, metav1.CreateOptions{}); err != nil {
 		GinkgoT().Fatalf("Error creating Namespace %v: %s", testNamespace, err.Error())
 	}
-	<-kubernetesClient.GetAnnouncementsChannel(k8s.Namespaces)
 
 	meshSpec, err := newSMIClient(
 		kubeClient,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The namespace informer is only necessary to check if namespaces are
monitored (via the monitoring label), which is done via the cache
store provided by client-go.

We do not need to trigger events to catalog when a namespace is
is added/updated/deleted for a few reasons:

1. Envoy configuration updates are not concerned with individual
   namespace resources events. Adding a new namespace or updating
   the namespace (ex with a label/annotation) does not concern
   proxy configurations. Deleting a namespace however does affect
   proxy configurations, but since the catalog subscribes to pod
   and service specific events, a namespace deletion event would
   also result in pod/service deletion events in such a namespace
   which will suffice to recompute proxy configs for proxies
   fronting affected pods/services.

2. Because of 1, annoucements specific to the namespace resource are
   not very meaningful to catalog/XDS verticals. As such, the APIs
   to check if namespaces are monitored leverage the cache store and
   don't need to announce events.

3. Triggering announcements for resources that don't affect the proxy
   configuration directly incurs a huge performance overhead, since
   a single announcement will result in configurations being recomputed
   for every single connected proxy. Moreover, as users label/annotate
   their namespaces, the performance will exponentially degrade with
   the number of number of updates on a per namespace basis.

This change also updates the tests that rely on the namespace cache
store to be asynchronously checked. Adding an announcement just for
the test will result in issues in the controller when there are
no readers for the channel, with the events being blocked and causing
subsequent ones to be stalled.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [X]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`