### PR TITLE
announcements: Convert all messages from interface{} to Announcement type

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -385,7 +385,7 @@ type Proxy struct {
 	certificate.CommonName
 	net.IP
 	ServiceName   service.MeshService
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 
 	lastSentVersion    map[TypeURI]uint64
 	lastAppliedVersion map[TypeURI]uint64

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -44,7 +45,7 @@ func (mc *MeshCatalog) GetSMISpec() smi.MeshSpec {
 }
 
 func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
-	ticking := make(chan interface{})
+	ticking := make(chan announcements.Announcement)
 	announcementChannels := []announcementChannel{
 		{"MeshSpec", mc.meshSpec.GetAnnouncementsChannel()},
 		{"CertManager", mc.certManager.GetAnnouncementsChannel()},
@@ -66,7 +67,7 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		ticker := time.NewTicker(updateAtLeastEvery)
 		for {
 			<-ticker.C
-			ticking <- nil
+			ticking <- announcements.Announcement{}
 		}
 	}()
 

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -48,10 +49,10 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	cache := make(map[certificate.CommonName]certificate.Certificater)
 	certManager := tresor.NewFakeCertManager(&cache, cfg)
 
-	testChan := make(chan interface{})
+	announcementsCh := make(chan announcements.Announcement)
 
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(nil, nil).AnyTimes()
-	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(testChan).AnyTimes()
+	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsCh).AnyTimes()
 
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {
@@ -88,7 +89,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 		return podRet
 	}).AnyTimes()
 
-	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
+	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(announcementsCh).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -3,10 +3,10 @@ package catalog
 import (
 	"context"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -100,9 +101,9 @@ func newFakeMeshCatalog() *MeshCatalog {
 		GinkgoT().Fatalf("Error creating new Bookstire Apex service", err.Error())
 	}
 
-	testChan := make(chan interface{})
+	announcementsChan := make(chan announcements.Announcement)
 
-	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(testChan).AnyTimes()
+	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsChan).AnyTimes()
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(getFakeIngresses(), nil).AnyTimes()
 
 	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
@@ -137,7 +138,7 @@ func newFakeMeshCatalog() *MeshCatalog {
 
 		return vv
 	}).AnyTimes()
-	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(testChan).AnyTimes()
+	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(announcementsChan).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -21,13 +21,13 @@ func (mc *MeshCatalog) repeater() {
 			if chosenIdx, message, ok := reflect.Select(cases); ok {
 				if ann, ok := message.Interface().(announcements.Announcement); ok {
 					mc.handleAnnouncement(ann)
-				}
 
-				log.Trace().Msgf("Received announcement from %s", caseNames[chosenIdx])
-				delta := time.Since(lastUpdateAt)
-				if delta >= updateAtMostEvery {
-					mc.broadcast(message)
-					lastUpdateAt = time.Now()
+					log.Trace().Msgf("Received announcement from %s", caseNames[chosenIdx])
+					delta := time.Since(lastUpdateAt)
+					if delta >= updateAtMostEvery {
+						mc.broadcast(ann)
+						lastUpdateAt = time.Now()
+					}
 				}
 			}
 		}
@@ -51,7 +51,7 @@ func (mc *MeshCatalog) getCases() ([]reflect.SelectCase, []string) {
 	return cases, caseNames
 }
 
-func (mc *MeshCatalog) broadcast(message interface{}) {
+func (mc *MeshCatalog) broadcast(message announcements.Announcement) {
 	mc.connectedProxiesLock.Lock()
 	for _, connectedEnvoy := range mc.connectedProxies {
 		log.Debug().Msgf("[repeater] Broadcast announcement to envoy %s", connectedEnvoy.proxy.GetCommonName())

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -10,6 +10,7 @@ import (
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -118,7 +119,7 @@ type MeshCataloger interface {
 
 type announcementChannel struct {
 	announcer string
-	channel   <-chan interface{}
+	channel   <-chan announcements.Announcement
 }
 
 type expectedProxy struct {

--- a/pkg/certificate/mock_certificate.go
+++ b/pkg/certificate/mock_certificate.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/openservicemesh/osm/pkg/announcements"
 )
 
 // MockCertificater is a mock of Certificater interface
@@ -215,10 +216,10 @@ func (mr *MockManagerMockRecorder) ReleaseCertificate(arg0 interface{}) *gomock.
 }
 
 // GetAnnouncementsChannel mocks base method
-func (m *MockManager) GetAnnouncementsChannel() <-chan interface{} {
+func (m *MockManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan interface{})
+	ret0, _ := ret[0].(<-chan announcements.Announcement)
 	return ret0
 }
 

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -15,6 +15,7 @@ import (
 	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -89,7 +90,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	cm.cacheLock.Lock()
 	cm.cache[cn] = cert
 	cm.cacheLock.Unlock()
-	cm.announcements <- nil
+	cm.announcements <- announcements.Announcement{}
 
 	log.Info().Msgf("Rotating certificate CN=%s took %+v", cn, time.Since(start))
 
@@ -114,7 +115,7 @@ func (cm *CertManager) ListCertificates() ([]certificate.Certificater, error) {
 
 // GetAnnouncementsChannel returns a channel, which is used to announce when
 // changes have been made to the issued certificates.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan interface{} {
+func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return cm.announcements
 }
 
@@ -245,7 +246,7 @@ func NewCertManager(
 	cm := &CertManager{
 		ca:            ca,
 		cache:         make(map[certificate.CommonName]certificate.Certificater),
-		announcements: make(chan interface{}),
+		announcements: make(chan announcements.Announcement),
 		namespace:     namespace,
 		client:        client.CertmanagerV1beta1().CertificateRequests(namespace),
 		issuerRef:     issuerRef,

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -8,6 +8,7 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1beta1"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1beta1"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -40,7 +41,7 @@ type CertManager struct {
 
 	// The channel announcing to the rest of the system when a certificate has
 	// changed.
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 
 	certificatesOrganization string
 

--- a/pkg/certificate/providers/keyvault/client.go
+++ b/pkg/certificate/providers/keyvault/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	az "github.com/Azure/go-autorest/autorest/azure"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/providers/azure"
 )
 
@@ -28,7 +29,7 @@ func newKeyVaultClient(keyVaultName string, azureAuthFile string) (*client, erro
 	return &client{
 		client:        &keyVaultClient,
 		vaultURL:      getKeyVaultURL(keyVaultName),
-		announcements: make(chan interface{}),
+		announcements: make(chan announcements.Announcement),
 	}, nil
 }
 

--- a/pkg/certificate/providers/keyvault/types.go
+++ b/pkg/certificate/providers/keyvault/types.go
@@ -3,6 +3,7 @@ package keyvault
 import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -13,5 +14,5 @@ var (
 type client struct {
 	client        *keyvault.BaseClient
 	vaultURL      string
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 }

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -3,6 +3,7 @@ package tresor
 import (
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -78,7 +79,7 @@ func NewCertManager(ca certificate.Certificater, certificatesOrganization string
 		ca: ca,
 
 		// Channel used to inform other components of cert changes (rotation etc.)
-		announcements: make(chan interface{}),
+		announcements: make(chan announcements.Announcement),
 
 		// Certificate cache
 		cache: &cache,

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 )
@@ -158,7 +159,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	cm.cacheLock.Lock()
 	(*cm.cache)[cn] = cert
 	cm.cacheLock.Unlock()
-	cm.announcements <- nil
+	cm.announcements <- announcements.Announcement{}
 
 	log.Info().Msgf("Rotating certificate CN=%s took %+v", cn, time.Since(start))
 
@@ -182,6 +183,6 @@ func (cm *CertManager) GetRootCertificate() (certificate.Certificater, error) {
 }
 
 // GetAnnouncementsChannel implements certificate.Manager and returns the channel on which the certificate manager announces changes made to certificates.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan interface{} {
+func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return cm.announcements
 }

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -3,6 +3,7 @@ package tresor
 import (
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -20,7 +21,7 @@ func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificat
 
 	return &CertManager{
 		ca:            ca.(*Certificate),
-		announcements: make(chan interface{}),
+		announcements: make(chan announcements.Announcement),
 		cache:         cache,
 		cfg:           cfg,
 	}

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -33,7 +34,7 @@ type CertManager struct {
 	ca certificate.Certificater
 
 	// The channel announcing to the rest of the system when a certificate has changed
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 
 	// Cache for all the certificates issued
 	cache     *map[certificate.CommonName]certificate.Certificater

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/vault/api"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
@@ -15,7 +16,7 @@ type CertManager struct {
 	ca certificate.Certificater
 
 	// The channel announcing to the rest of the system when a certificate has changed
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 
 	// Cache for all the certificates issued
 	cache     *map[certificate.CommonName]certificate.Certificater

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -3,6 +3,7 @@ package certificate
 import (
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -66,7 +67,7 @@ type Manager interface {
 	ReleaseCertificate(CommonName)
 
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the issued certificates.
-	GetAnnouncementsChannel() <-chan interface{}
+	GetAnnouncementsChannel() <-chan announcements.Announcement
 }
 
 var (

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
@@ -66,7 +67,7 @@ func newConfigurator(kubeClient kubernetes.Interface, stop <-chan struct{}, osmN
 		informer:         informer,
 		cache:            informer.GetStore(),
 		cacheSynced:      make(chan interface{}),
-		announcements:    make(chan interface{}),
+		announcements:    make(chan announcements.Announcement),
 		osmNamespace:     osmNamespace,
 		osmConfigMapName: osmConfigMapName,
 	}

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -104,7 +105,7 @@ func (c *Client) GetEnvoyLogLevel() string {
 }
 
 // GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap.
-func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
+func (c *Client) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return c.announcements
 }
 

--- a/pkg/configurator/mock_client.go
+++ b/pkg/configurator/mock_client.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/openservicemesh/osm/pkg/announcements"
 )
 
 // MockConfigurator is a mock of Configurator interface
@@ -35,10 +36,10 @@ func (m *MockConfigurator) EXPECT() *MockConfiguratorMockRecorder {
 }
 
 // GetAnnouncementsChannel mocks base method
-func (m *MockConfigurator) GetAnnouncementsChannel() <-chan interface{} {
+func (m *MockConfigurator) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan interface{})
+	ret0, _ := ret[0].(<-chan announcements.Announcement)
 	return ret0
 }
 

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -16,7 +17,7 @@ var (
 type Client struct {
 	osmNamespace     string
 	osmConfigMapName string
-	announcements    chan interface{}
+	announcements    chan announcements.Announcement
 	informer         cache.SharedIndexInformer
 	cache            cache.Store
 	cacheSynced      chan interface{}
@@ -61,7 +62,7 @@ type Configurator interface {
 	GetEnvoyLogLevel() string
 
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the OSM ConfigMap
-	GetAnnouncementsChannel() <-chan interface{}
+	GetAnnouncementsChannel() <-chan announcements.Announcement
 
 	// GetServiceCertValidityPeriod returns the validity duration for service certificates
 	GetServiceCertValidityPeriod() time.Duration

--- a/pkg/endpoint/providers/azure/client.go
+++ b/pkg/endpoint/providers/azure/client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/pkg/errors"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/providers/azure"
 )
@@ -43,7 +44,7 @@ func NewProvider(subscriptionID string, azureAuthFile string, stop chan struct{}
 		// into an Azure URI. (Example: resolve "webService" to an IP of a VM.)
 		azureResourceClient: azureResourceClient,
 
-		announcements: make(chan interface{}),
+		announcements: make(chan announcements.Announcement),
 	}
 
 	az.publicIPsClient.Authorizer = az.authorizer

--- a/pkg/endpoint/providers/azure/kubernetes/client.go
+++ b/pkg/endpoint/providers/azure/kubernetes/client.go
@@ -8,10 +8,10 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/configurator"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	osmClient "github.com/openservicemesh/osm/pkg/osm_client/clientset/versioned"
 	osmInformers "github.com/openservicemesh/osm/pkg/osm_client/informers/externalversions"
 )
@@ -48,7 +48,7 @@ func newClient(kubeClient kubernetes.Interface, azureResourceClient *osmClient.C
 		informers:      &informerCollection,
 		caches:         &cacheCollection,
 		cacheSynced:    make(chan interface{}),
-		announcements:  make(chan interface{}),
+		announcements:  make(chan announcements.Announcement),
 		kubeController: kubeController,
 	}
 

--- a/pkg/endpoint/providers/azure/kubernetes/types.go
+++ b/pkg/endpoint/providers/azure/kubernetes/types.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -29,6 +30,6 @@ type Client struct {
 	kubeClient     kubernetes.Interface
 	informers      *InformerCollection
 	providerIdent  string
-	announcements  chan interface{}
+	announcements  chan announcements.Announcement
 	kubeController k8s.Controller
 }

--- a/pkg/endpoint/providers/azure/provider.go
+++ b/pkg/endpoint/providers/azure/provider.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -65,7 +66,7 @@ func (az Client) run(stop <-chan struct{}) error {
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the Azure endponits provider.
-func (az Client) GetAnnouncementsChannel() <-chan interface{} {
+func (az Client) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return az.announcements
 }
 

--- a/pkg/endpoint/providers/azure/types.go
+++ b/pkg/endpoint/providers/azure/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	osm "github.com/openservicemesh/osm/pkg/apis/azureresource/v1"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -63,7 +64,7 @@ type Client struct {
 	// will convert a service name to an Azure resource URI.
 	azureResourceClient ResourceClient
 
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 }
 
 // ResourceClient is an interface defining necessary functions to list the AzureResources.

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
@@ -39,7 +40,7 @@ func NewProvider(kubeClient kubernetes.Interface, kubeController k8s.Controller,
 		informers:      &informerCollection,
 		caches:         &cacheCollection,
 		cacheSynced:    make(chan interface{}),
-		announcements:  make(chan interface{}),
+		announcements:  make(chan announcements.Announcement),
 		kubeController: kubeController,
 	}
 
@@ -157,7 +158,7 @@ func (c Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccoun
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the Kubernetes endpoints provider.
-func (c Client) GetAnnouncementsChannel() <-chan interface{} {
+func (c Client) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return c.announcements
 }
 

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"fmt"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -51,8 +52,8 @@ func (f fakeClient) GetID() string {
 }
 
 // GetAnnouncementsChannel obtains the channel on which providers will announce changes to the infrastructure.
-func (f fakeClient) GetAnnouncementsChannel() <-chan interface{} {
-	return make(chan interface{})
+func (f fakeClient) GetAnnouncementsChannel() <-chan announcements.Announcement {
+	return make(chan announcements.Announcement)
 }
 
 func (f fakeClient) GetResolvableEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {

--- a/pkg/endpoint/providers/kube/types.go
+++ b/pkg/endpoint/providers/kube/types.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -31,6 +32,6 @@ type Client struct {
 	providerIdent  string
 	kubeClient     kubernetes.Interface
 	informers      *InformerCollection
-	announcements  chan interface{}
+	announcements  chan announcements.Announcement
 	kubeController k8s.Controller
 }

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -23,7 +24,7 @@ type Provider interface {
 	GetID() string
 
 	// GetAnnouncementsChannel obtains the channel on which providers will announce changes to the infrastructure.
-	GetAnnouncementsChannel() <-chan interface{}
+	GetAnnouncementsChannel() <-chan announcements.Announcement
 }
 
 // Endpoint is a tuple of IP and Port representing an instance of a service

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
@@ -13,7 +14,7 @@ import (
 type Proxy struct {
 	certificate.CommonName
 	net.Addr
-	announcements chan interface{}
+	announcements chan announcements.Announcement
 
 	// The time this Proxy connected to the OSM control plane
 	connectedAt time.Time
@@ -120,7 +121,7 @@ func (p Proxy) GetIP() net.Addr {
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the given Envoy proxy.
-func (p Proxy) GetAnnouncementsChannel() chan interface{} {
+func (p Proxy) GetAnnouncementsChannel() chan announcements.Announcement {
 	return p.announcements
 }
 
@@ -132,7 +133,7 @@ func NewProxy(cn certificate.CommonName, ip net.Addr) *Proxy {
 
 		connectedAt: time.Now(),
 
-		announcements:      make(chan interface{}),
+		announcements:      make(chan announcements.Announcement),
 		lastNonce:          make(map[TypeURI]string),
 		lastSentVersion:    make(map[TypeURI]uint64),
 		lastAppliedVersion: make(map[TypeURI]uint64),

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -22,7 +23,7 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 		informer:       informer,
 		cache:          informer.GetStore(),
 		cacheSynced:    make(chan interface{}),
-		announcements:  make(chan interface{}),
+		announcements:  make(chan announcements.Announcement),
 		kubeController: kubeController,
 	}
 
@@ -62,7 +63,7 @@ func (c *Client) run(stop <-chan struct{}) error {
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the Ingress client
-func (c Client) GetAnnouncementsChannel() <-chan interface{} {
+func (c Client) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return c.announcements
 }
 

--- a/pkg/ingress/mock_client.go
+++ b/pkg/ingress/mock_client.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/openservicemesh/osm/pkg/announcements"
 	service "github.com/openservicemesh/osm/pkg/service"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 )
@@ -36,10 +37,10 @@ func (m *MockMonitor) EXPECT() *MockMonitorMockRecorder {
 }
 
 // GetAnnouncementsChannel mocks base method
-func (m *MockMonitor) GetAnnouncementsChannel() <-chan interface{} {
+func (m *MockMonitor) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan interface{})
+	ret0, _ := ret[0].(<-chan announcements.Announcement)
 	return ret0
 }
 

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -4,6 +4,7 @@ import (
 	extensionsV1beta "k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -18,7 +19,7 @@ type Client struct {
 	informer       cache.SharedIndexInformer
 	cache          cache.Store
 	cacheSynced    chan interface{}
-	announcements  chan interface{}
+	announcements  chan announcements.Announcement
 	kubeController k8s.Controller
 }
 
@@ -28,5 +29,5 @@ type Monitor interface {
 	GetIngressResources(service.MeshService) ([]*extensionsV1beta.Ingress, error)
 
 	// GetAnnouncementsChannel returns the channel on which Ingress Monitor makes annoucements
-	GetAnnouncementsChannel() <-chan interface{}
+	GetAnnouncementsChannel() <-chan announcements.Announcement
 }

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -24,7 +25,7 @@ func NewKubernetesController(kubeClient kubernetes.Interface, meshName string, s
 		kubeClient:    kubeClient,
 		meshName:      meshName,
 		informers:     InformerCollection{},
-		announcements: make(map[InformerKey]chan interface{}),
+		announcements: make(map[InformerKey]chan announcements.Announcement),
 		cacheSynced:   make(chan interface{}),
 	}
 
@@ -71,7 +72,7 @@ func (c *Client) initServicesMonitor() {
 	}
 
 	// Announcement channel for Services
-	c.announcements[Services] = make(chan interface{})
+	c.announcements[Services] = make(chan announcements.Announcement)
 
 	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.announcements[Services], shouldObserve))
 }
@@ -87,7 +88,7 @@ func (c *Client) initPodMonitor() {
 	}
 
 	// Announcement channel for Pods
-	c.announcements[Pods] = make(chan interface{})
+	c.announcements[Pods] = make(chan announcements.Announcement)
 
 	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Pods], shouldObserve))
 }
@@ -171,7 +172,7 @@ func (c Client) ListServices() []*corev1.Service {
 }
 
 // GetAnnouncementsChannel gets the Announcements channel back
-func (c Client) GetAnnouncementsChannel(informerID InformerKey) <-chan interface{} {
+func (c Client) GetAnnouncementsChannel(informerID InformerKey) <-chan announcements.Announcement {
 	return c.announcements[informerID]
 }
 

--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -26,19 +27,19 @@ var _ = Describe("Testing event handlers", func() {
 		}
 
 		It("Should add the event to the announcement channel", func() {
-			announcements := make(chan interface{}, 1)
+			ann := make(chan announcements.Announcement, 1)
 			pod := tests.NewPodTestFixture(testNamespace, "pod-name")
-			addEvent(testInformer, testProvider, announcements, shouldObserve, "ADD")(&pod)
-			Expect(len(announcements)).To(Equal(1))
-			<-announcements
+			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD")(&pod)
+			Expect(len(ann)).To(Equal(1))
+			<-ann
 		})
 
 		It("Should not add the event to the announcement channel", func() {
-			announcements := make(chan interface{}, 1)
+			ann := make(chan announcements.Announcement, 1)
 			var pod corev1.Pod
 			pod.Namespace = "not-a-monitored-namespace"
-			addEvent(testInformer, testProvider, announcements, shouldObserve, "ADD")(&pod)
-			Expect(len(announcements)).To(Equal(0))
+			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD")(&pod)
+			Expect(len(ann)).To(Equal(0))
 		})
 	})
 

--- a/pkg/kubernetes/mock_controller.go
+++ b/pkg/kubernetes/mock_controller.go
@@ -8,8 +8,10 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	service "github.com/openservicemesh/osm/pkg/service"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	service "github.com/openservicemesh/osm/pkg/service"
 )
 
 // MockController is a mock of Controller interface
@@ -107,10 +109,10 @@ func (mr *MockControllerMockRecorder) GetNamespace(ns interface{}) *gomock.Call 
 }
 
 // GetAnnouncementsChannel mocks base method
-func (m *MockController) GetAnnouncementsChannel(informerID InformerKey) <-chan interface{} {
+func (m *MockController) GetAnnouncementsChannel(informerID InformerKey) <-chan announcements.Announcement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAnnouncementsChannel", informerID)
-	ret0, _ := ret[0].(<-chan interface{})
+	ret0, _ := ret[0].(<-chan announcements.Announcement)
 	return ret0
 }
 

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -37,12 +38,6 @@ const (
 	ProviderName = "Kubernetes"
 )
 
-// Event is the combined type and actual object we received from Kubernetes
-type Event struct {
-	Type  EventType
-	Value interface{}
-}
-
 // InformerKey stores the different Informers we keep for K8s resources
 type InformerKey string
 
@@ -64,7 +59,7 @@ type Client struct {
 	kubeClient    kubernetes.Interface
 	informers     InformerCollection
 	cacheSynced   chan interface{}
-	announcements map[InformerKey]chan interface{}
+	announcements map[InformerKey]chan announcements.Announcement
 }
 
 // Controller is the controller interface for K8s services
@@ -86,7 +81,7 @@ type Controller interface {
 	GetNamespace(ns string) *corev1.Namespace
 
 	// Returns the announcement channel for a certain Informer ID
-	GetAnnouncementsChannel(informerID InformerKey) <-chan interface{}
+	GetAnnouncementsChannel(informerID InformerKey) <-chan announcements.Announcement
 
 	// ListPods returns a list of pods part of the mesh
 	ListPods() []*corev1.Pod

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -21,6 +21,7 @@ import (
 	osmPolicy "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	osmPolicyClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned"
 	backpressureInformers "github.com/openservicemesh/osm/experimental/pkg/client/informers/externalversions"
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/featureflags"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -99,7 +100,7 @@ func (c *Client) run(stop <-chan struct{}) error {
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the SMI client.
-func (c *Client) GetAnnouncementsChannel() <-chan interface{} {
+func (c *Client) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	return c.announcements
 }
 
@@ -134,7 +135,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		informers:      &informerCollection,
 		caches:         &cacheCollection,
 		cacheSynced:    make(chan interface{}),
-		announcements:  make(chan interface{}),
+		announcements:  make(chan announcements.Announcement),
 		osmNamespace:   osmNamespace,
 		kubeController: kubeController,
 	}

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -6,6 +6,7 @@ import (
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
 	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -72,6 +73,6 @@ func (f fakeMeshSpec) GetBackpressurePolicy(svc service.MeshService) *backpressu
 }
 
 // GetAnnouncementsChannel returns the channel on which SMI makes announcements for the fake Mesh Spec.
-func (f fakeMeshSpec) GetAnnouncementsChannel() <-chan interface{} {
-	return make(chan interface{})
+func (f fakeMeshSpec) GetAnnouncementsChannel() <-chan announcements.Announcement {
+	return make(chan announcements.Announcement)
 }

--- a/pkg/smi/mock_meshspec.go
+++ b/pkg/smi/mock_meshspec.go
@@ -8,11 +8,13 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1alpha1 "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
-	service "github.com/openservicemesh/osm/pkg/service"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+
+	v1alpha1 "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/announcements"
+	service "github.com/openservicemesh/osm/pkg/service"
 )
 
 // MockMeshSpec is a mock of MeshSpec interface
@@ -39,10 +41,10 @@ func (m *MockMeshSpec) EXPECT() *MockMeshSpecMockRecorder {
 }
 
 // GetAnnouncementsChannel mocks base method
-func (m *MockMeshSpec) GetAnnouncementsChannel() <-chan interface{} {
+func (m *MockMeshSpec) GetAnnouncementsChannel() <-chan announcements.Announcement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan interface{})
+	ret0, _ := ret[0].(<-chan announcements.Announcement)
 	return ret0
 }
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	backpressure "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/announcements"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -41,7 +42,7 @@ type Client struct {
 	cacheSynced    chan interface{}
 	providerIdent  string
 	informers      *InformerCollection
-	announcements  chan interface{}
+	announcements  chan announcements.Announcement
 	osmNamespace   string
 	kubeController k8s.Controller
 }
@@ -70,5 +71,5 @@ type MeshSpec interface {
 	GetBackpressurePolicy(service.MeshService) *backpressure.Backpressure
 
 	// GetAnnouncementsChannel returns the channel on which SMI client makes announcements
-	GetAnnouncementsChannel() <-chan interface{}
+	GetAnnouncementsChannel() <-chan announcements.Announcement
 }


### PR DESCRIPTION
This PR replaces all usages of announcements messages of type `interface{}` with the new `announcements.Announcement` type.

This includes all `GetAnnouncementsChannel()` functions.

This PR sets the stage for increasing the specificity of the various events passed through the system.  This will allow us to have finer granularity over what parts of the system re-create configuration when event (with certain type) flows through OSM.

An example of how the new `Announcement` struct will be used can be seen in this *draft* PR: https://github.com/openservicemesh/osm/pull/1956/files#diff-68b0a836736cca1396a46ae7bb7b9ddc8212cb354136b26db6f08aa3ae5efd47R32-R63

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
