### PR TITLE
Use distroless images for osm & demo

### DIFF
--- a/dockerfiles/Dockerfile.bookbuyer
+++ b/dockerfiles/Dockerfile.bookbuyer
@@ -1,5 +1,2 @@
-FROM alpine:3.12
-ADD bookbuyer /
-ADD bookbuyer.html.template /
-RUN apk add --no-cache curl openssl ca-certificates
-RUN chmod +x /bookbuyer
+FROM gcr.io/distroless/base
+COPY bookbuyer bookbuyer.html.template /

--- a/dockerfiles/Dockerfile.bookstore
+++ b/dockerfiles/Dockerfile.bookstore
@@ -1,4 +1,2 @@
-FROM alpine:3.12
-ADD bookstore /
-ADD bookstore.html.template /
-RUN chmod +x /bookstore
+FROM gcr.io/distroless/static
+COPY bookstore bookstore.html.template /

--- a/dockerfiles/Dockerfile.bookthief
+++ b/dockerfiles/Dockerfile.bookthief
@@ -1,5 +1,2 @@
-FROM alpine:3.12
-ADD bookthief /
-ADD bookthief.html.template /
-RUN apk add --no-cache curl openssl ca-certificates
-RUN chmod +x /bookthief
+FROM gcr.io/distroless/base
+COPY bookthief bookthief.html.template /

--- a/dockerfiles/Dockerfile.bookwarehouse
+++ b/dockerfiles/Dockerfile.bookwarehouse
@@ -1,3 +1,2 @@
-FROM alpine:3.12
-ADD bookwarehouse /
-RUN chmod +x /bookwarehouse
+FROM gcr.io/distroless/static
+COPY bookwarehouse /

--- a/dockerfiles/Dockerfile.osm-controller
+++ b/dockerfiles/Dockerfile.osm-controller
@@ -1,4 +1,2 @@
-FROM alpine:3.12
-
-ADD osm-controller /
-RUN chmod +x /osm-controller
+FROM gcr.io/distroless/static
+COPY osm-controller /


### PR DESCRIPTION
Use distroless base & static images (depending on openssl requirements)
Replace ADD with COPY instructions & remove unnecessary layers
Remove chmod since built binaries are executable

Fix #1538

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [X]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No.
