### PR TITLE
catalog: add an api to retrieve service accounts for a service

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -315,6 +315,9 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
+	// ListServiceAccountsForService lists the service accounts associated with the given service
+	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
+
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
 

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -265,6 +265,21 @@ func (mr *MockMeshCatalogerMockRecorder) ListSMIPolicies() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSMIPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListSMIPolicies))
 }
 
+// ListServiceAccountsForService mocks base method
+func (m *MockMeshCataloger) ListServiceAccountsForService(arg0 service.MeshService) ([]service.K8sServiceAccount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServiceAccountsForService", arg0)
+	ret0, _ := ret[0].([]service.K8sServiceAccount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServiceAccountsForService indicates an expected call of ListServiceAccountsForService
+func (mr *MockMeshCatalogerMockRecorder) ListServiceAccountsForService(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListServiceAccountsForService), arg0)
+}
+
 // ListTrafficPolicies mocks base method
 func (m *MockMeshCataloger) ListTrafficPolicies(arg0 service.MeshService) ([]trafficpolicy.TrafficTarget, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -29,3 +29,9 @@ func (mc *MeshCatalog) GetServicesForServiceAccount(sa service.K8sServiceAccount
 
 	return services, nil
 }
+
+// ListServiceAccountsForService lists the service accounts associated with the given service
+func (mc *MeshCatalog) ListServiceAccountsForService(svc service.MeshService) ([]service.K8sServiceAccount, error) {
+	// Currently OSM uses kubernetes service accounts as service identities
+	return mc.kubeController.ListServiceAccountsForService(svc)
+}

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -1,0 +1,56 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+func TestListServiceAccountsForService(t *testing.T) {
+	assert := assert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockKubeController := kubernetes.NewMockController(mockCtrl)
+	mc := &MeshCatalog{
+		kubeController: mockKubeController,
+	}
+
+	testCases := []struct {
+		svc                 service.MeshService
+		expectedSvcAccounts []service.K8sServiceAccount
+		expectedError       error
+	}{
+		{
+			service.MeshService{Name: "foo", Namespace: "ns-1"},
+			[]service.K8sServiceAccount{{Name: "sa-1", Namespace: "ns-1"}, {Name: "sa-2", Namespace: "ns-1"}},
+			nil,
+		},
+		{
+			service.MeshService{Name: "foo", Namespace: "ns-1"},
+			[]service.K8sServiceAccount{{Name: "sa-1", Namespace: "ns-1"}, {Name: "sa-2", Namespace: "ns-1"}},
+			nil,
+		},
+		{
+			service.MeshService{Name: "foo", Namespace: "ns-1"},
+			nil,
+			errors.New("test error"),
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
+			mockKubeController.EXPECT().ListServiceAccountsForService(tc.svc).Return(tc.expectedSvcAccounts, tc.expectedError).Times(1)
+
+			svcAccounts, err := mc.ListServiceAccountsForService(tc.svc)
+			assert.ElementsMatch(svcAccounts, tc.expectedSvcAccounts)
+			assert.Equal(err, tc.expectedError)
+		})
+	}
+}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -73,6 +73,9 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
+	// ListServiceAccountsForService lists the service accounts associated with the given service
+	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
+
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an api to MeshCataloger interface to retrieve a list of service
accounts associated with the given service.

This api will be used by clients to correctly validate the identity
of upstream services they are connecting to via the validation
context specified in the SDS secrets.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`