### PR TITLE
kubernetes/client: use correct channel for pod announcements

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -89,7 +89,7 @@ func (c *Client) initPodMonitor() {
 	// Announcement channel for Pods
 	c.announcements[Pods] = make(chan interface{})
 
-	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Services], shouldObserve))
+	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Pods], shouldObserve))
 }
 
 func (c *Client) run(stop <-chan struct{}) error {

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -325,9 +325,14 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 			_, err := kubeClient.CoreV1().Services(testNamespaceName).Create(context.TODO(), svc, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
+
+			// Wait for both pods and the service to be created
+			<-kubeController.GetAnnouncementsChannel(Pods)
+			<-kubeController.GetAnnouncementsChannel(Pods)
 			<-kubeController.GetAnnouncementsChannel(Services)
 
 			meshSvc := service.MeshService{Name: svc.Name, Namespace: svc.Namespace}
+
 			svcAccounts, err := kubeController.ListServiceAccountsForService(meshSvc)
 
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Pod announcements were incorrectly being announced on the channel
meant for the Service resource. This change fixes it and also
adds additional safety checks in a test that caught the failure.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`