### PR TITLE
catalog: Make the re-configuration ticker actually tick

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -64,7 +64,10 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 	// See Github Issue: https://github.com/openservicemesh/osm/issues/1501
 	go func() {
 		ticker := time.NewTicker(updateAtLeastEvery)
-		ticking <- ticker.C
+		for {
+			<-ticker.C
+			ticking <- nil
+		}
 	}()
 
 	return announcementChannels


### PR DESCRIPTION
This PR fixes the re-configuration ticker, which makes sure that every X seconds we update proxies w/ the latest config, regardless of other events that may have triggered that.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
