### PR TITLE
tests(debug server): fix race condition

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -238,27 +238,36 @@ func main() {
 		debugServer:        httpserver.NewDebugHTTPServer(debugConfig, constants.DebugPort),
 	}
 
-	go c.configureDebugServer(cfg)
+	errs := make(chan error)
+	go c.configureDebugServer(cfg, errs)
 
-	// Wait for exit handler signal
-	<-stop
+	done := false
+	for !done {
+		select {
+		case <-stop:
+			done = true
+		case err := <-errs:
+			if err != nil {
+				log.Error().Err(err)
+			}
+		}
+	}
 
 	log.Info().Msg("Goodbye!")
 }
 
-func (c *controller) configureDebugServer(cfg configurator.Configurator) {
+func (c *controller) configureDebugServer(cfg configurator.Configurator, errs chan<- error) {
 	//GetAnnouncementsChannel will check ConfigMap every 3 * time.Second
 	var mutex = &sync.Mutex{}
 	for range cfg.GetAnnouncementsChannel() {
 		if c.debugServerRunning && !cfg.IsDebugServerEnabled() {
 			mutex.Lock()
 			err := c.debugServer.Stop()
-			if err != nil {
-				log.Error().Err(err).Msg("Unable to stop debug server")
-			} else {
+			if err == nil {
 				c.debugServer = nil
 			}
 			c.debugServerRunning = false
+			errs <- errors.Wrap(err, "unable to stop debug server")
 			mutex.Unlock()
 		} else if !c.debugServerRunning && cfg.IsDebugServerEnabled() {
 			mutex.Lock()
@@ -267,6 +276,7 @@ func (c *controller) configureDebugServer(cfg configurator.Configurator) {
 			}
 			c.debugServer.Start()
 			c.debugServerRunning = true
+			errs <- nil
 			mutex.Unlock()
 		}
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, the tests that dynamically start/stop the debug HTTP server
rely on a `sync.WaitGroup` that signals when a mocked debug server has
been started or stopped. `TestConfigureDebugServerErr` was failing
occasionally because `configureDebugServer` wasn't guaranteed to finish
stopping the server before the test's `sync.WaitGroup` signalled it was
done.

This change removes the `sync.WaitGroup` from the tests and instead adds
a new channel parameter to `configureDebugServer` that will emit errors
(or nil if successful) whenever the server is started or stopped. Then,
the tests can be sure that `configureDebugServer` has finished before
checking any values.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No