### PR TITLE
envoy: correctly validate SANs in certificate

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -94,6 +94,9 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV1Service).Return([]service.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV2Service).Return([]service.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookbuyerService).Return([]service.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
 		mockIngressMonitor, stop, cfg, endpointProviders...)

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -91,10 +91,6 @@ var _ = Describe("Test ADS response functions", func() {
 					}.String(),
 					envoy.SDSCert{
 						MeshService: meshService,
-						CertType:    envoy.RootCertTypeForMTLSOutbound,
-					}.String(),
-					envoy.SDSCert{
-						MeshService: meshService,
 						CertType:    envoy.RootCertTypeForMTLSInbound,
 					}.String(),
 					envoy.SDSCert{
@@ -150,7 +146,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect((*actualResponses)[4].VersionInfo).To(Equal("1"))
 			Expect((*actualResponses)[4].TypeUrl).To(Equal(string(envoy.TypeSDS)))
 			log.Printf("%v", len((*actualResponses)[4].Resources))
-			Expect(len((*actualResponses)[4].Resources)).To(Equal(4))
+			Expect(len((*actualResponses)[4].Resources)).To(Equal(3))
 
 			secretOne := xds_auth.Secret{}
 			firstSecret := (*actualResponses)[4].Resources[0]
@@ -165,21 +161,13 @@ var _ = Describe("Test ADS response functions", func() {
 			err = ptypes.UnmarshalAny(secondSecret, &secretTwo)
 			Expect(secretTwo.Name).To(Equal(envoy.SDSCert{
 				MeshService: meshService,
-				CertType:    envoy.RootCertTypeForMTLSOutbound,
+				CertType:    envoy.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			secretThree := xds_auth.Secret{}
 			thirdSecret := (*actualResponses)[4].Resources[2]
 			err = ptypes.UnmarshalAny(thirdSecret, &secretThree)
 			Expect(secretThree.Name).To(Equal(envoy.SDSCert{
-				MeshService: meshService,
-				CertType:    envoy.RootCertTypeForMTLSInbound,
-			}.String()))
-
-			secretFour := xds_auth.Secret{}
-			forthSecret := (*actualResponses)[4].Resources[3]
-			err = ptypes.UnmarshalAny(forthSecret, &secretFour)
-			Expect(secretFour.Name).To(Equal(envoy.SDSCert{
 				MeshService: meshService,
 				CertType:    envoy.RootCertTypeForHTTPS,
 			}.String()))

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -27,7 +27,7 @@ const (
 func getUpstreamServiceCluster(upstreamSvc, downstreamSvc service.MeshService, cfg configurator.Configurator) (*xds_cluster.Cluster, error) {
 	clusterName := upstreamSvc.String()
 	marshalledUpstreamTLSContext, err := envoy.MessageToAny(
-		envoy.GetUpstreamTLSContext(downstreamSvc, upstreamSvc.ServerName()))
+		envoy.GetUpstreamTLSContext(downstreamSvc, upstreamSvc))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -187,7 +187,7 @@ var _ = Describe("CDS Response", func() {
 
 			// Checking for the value by generating the same value the same way is reduntant
 			// Nonetheless, as getUpstreamServiceCluster logic gets more complicated, this might just be ok to have
-			upstreamTLSProto, err := envoy.MessageToAny(envoy.GetUpstreamTLSContext(proxyService, upstreamSvc.ServerName()))
+			upstreamTLSProto, err := envoy.MessageToAny(envoy.GetUpstreamTLSContext(proxyService, upstreamSvc))
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedCluster := xds_cluster.Cluster{

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Test LDS response", func() {
 
 			// Ensure the UpstreamTlsContext.Sni field from the client matches one of the strings
 			// in the servers FilterChainMatch.ServerNames
-			tlsContext := envoy.GetUpstreamTLSContext(tests.BookbuyerService, tests.BookstoreV1Service.ServerName())
+			tlsContext := envoy.GetUpstreamTLSContext(tests.BookbuyerService, tests.BookstoreV1Service)
 			Expect(tlsContext.Sni).To(Equal(filterChain.FilterChainMatch.ServerNames[0]))
 
 			// Show what that actually looks like

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -17,12 +17,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-// Used mainly for logging/translation purposes
-var directionMap = map[envoy.SDSCertType]string{
-	envoy.RootCertTypeForMTLSInbound:  "inbound",
-	envoy.RootCertTypeForMTLSOutbound: "outbound",
-}
-
 // NewResponse creates a new Secrets Discovery Response.
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, certManager certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
 	log.Info().Msgf("Composing SDS Discovery Response for proxy: %s", proxy.GetCommonName())
@@ -113,14 +107,11 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 			continue
 		}
 
-		if proxyService != sdsCert.MeshService {
-			log.Warn().Msgf("Proxy %s (service %s) requested service certificate %s; this is not allowed", s.proxy.GetCommonName(), proxyService, sdsCert.MeshService)
-			continue
-		}
+		log.Debug().Msgf("proxy %s (member of service %s) requested %s", s.proxy.GetCommonName(), proxyService, requestedCertificate)
 
 		switch sdsCert.CertType {
 		case envoy.ServiceCertType:
-			log.Info().Msgf("proxy %s (member of service %s) requested %s", s.proxy.GetCommonName(), proxyService, requestedCertificate)
+			// A service certificate is requested
 			envoySecret, err := getServiceCertSecret(cert, requestedCertificate)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error creating cert %s for proxy %s for service %s", requestedCertificate, s.proxy.GetCommonName(), proxyService)
@@ -128,12 +119,12 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 			}
 			envoySecrets = append(envoySecrets, envoySecret)
 
+		// A root certificate used to validate a service certificate is requested
 		case envoy.RootCertTypeForMTLSInbound:
 			fallthrough
 		case envoy.RootCertTypeForMTLSOutbound:
 			fallthrough
 		case envoy.RootCertTypeForHTTPS:
-			log.Info().Msgf("proxy %s (member of service %s) requested %s", s.proxy.GetCommonName(), proxyService, requestedCertificate)
 			envoySecret, err := s.getRootCert(cert, *sdsCert, proxyService)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error creating cert %s for proxy %s for service %s", requestedCertificate, s.proxy.GetCommonName(), proxyService)
@@ -194,50 +185,61 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 	// Program SAN matching based on SMI TrafficTarget policies
 	switch sdscert.CertType {
 	case envoy.RootCertTypeForMTLSOutbound:
-		fallthrough
-	case envoy.RootCertTypeForMTLSInbound:
-		var matchSANs []*xds_matcher.StringMatcher
-		var serviceAccounts []service.K8sServiceAccount
-		var err error
-
-		// This block constructs a list of Server Names (peers) that are allowed to connect to the given service.
-		// The allowed list is derived from SMI's Traffic Policy.
-		if sdscert.CertType == envoy.RootCertTypeForMTLSOutbound {
-			// Outbound
-			serviceAccounts, err = s.meshCatalog.ListAllowedOutboundServiceAccounts(s.svcAccount)
-		} else {
-			// Inbound
-			serviceAccounts, err = s.meshCatalog.ListAllowedInboundServiceAccounts(s.svcAccount)
-		}
-
+		// For outbound certificate validation context, the SAN needs to the list of service identities
+		// corresponding to the upstream service. This means, if the sdscert.MeshService points to 'X',
+		// the SANs for this certificate should correspond to the service identities of 'X'.
+		svcAccounts, err := s.meshCatalog.ListServiceAccountsForService(sdscert.MeshService)
 		if err != nil {
-			log.Error().Err(err).Msgf("Error getting %s service accounts for proxy service %s", directionMap[sdscert.CertType], proxyService)
+			log.Error().Err(err).Msgf("Error listing service accounts for service %q", sdscert.MeshService)
 			return nil, err
 		}
+		secret.GetValidationContext().MatchSubjectAltNames = getSubjectAltNamesFromSvcAccount(svcAccounts)
+		log.Trace().Msgf("Proxy for service=%s, upstream cert=%s will only allow SANs exactly matching: %v",
+			proxyService, sdscert, subjectAltNamesToStr(secret.GetValidationContext().GetMatchSubjectAltNames()))
 
-		log.Trace().Msgf("%s Service accounts for proxy service account %s: %v", directionMap[sdscert.CertType], s.svcAccount, serviceAccounts)
-		var matchingCerts []string
-		for _, svcAccount := range serviceAccounts {
-			// OSM currently relies on kubernetes ServiceAccount for service identity
-			si := identity.GetKubernetesServiceIdentity(svcAccount, identity.ClusterLocalTrustDomain)
-			matchingCerts = append(matchingCerts, si.String())
-			match := xds_matcher.StringMatcher{
-				MatchPattern: &xds_matcher.StringMatcher_Exact{
-					Exact: si.String(),
-				},
-			}
-			matchSANs = append(matchSANs, &match)
+	case envoy.RootCertTypeForMTLSInbound:
+		// For inbound certificate validation context, the SAN needs to be the list of all downstream
+		// service identities that are allowed to connect to this upstream service. This means, if sdscert.MeshService
+		// points to 'X', the SANs for this certificate should correspond to all the downstream service identities
+		// allowed to rech 'X'.
+		svcAccounts, err := s.meshCatalog.ListAllowedInboundServiceAccounts(s.svcAccount)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error listing inbound service accounts for proxy service %s", proxyService)
+			return nil, err
 		}
+		secret.GetValidationContext().MatchSubjectAltNames = getSubjectAltNamesFromSvcAccount(svcAccounts)
+		log.Trace().Msgf("Proxy for service=%s, downstream cert=%s will only allow SANs exactly matching: %v",
+			proxyService, sdscert, subjectAltNamesToStr(secret.GetValidationContext().GetMatchSubjectAltNames()))
 
-		log.Trace().Msgf("Proxy for service %s will only allow %s SANs exactly matching: %v", proxyService, directionMap[sdscert.CertType], matchingCerts)
-
-		// Ensure the Subject Alternate Names (SAN) added by CertificateManager.IssueCertificate()
-		// matches what is allowed to connect to or accept connections from, as defined in the SMI
-		// TrafficTarget policy.
-		secret.GetValidationContext().MatchSubjectAltNames = matchSANs
 	default:
-		log.Debug().Msgf("SAN matching not needed for cert type %s", sdscert.CertType.String())
+		log.Debug().Msgf("SAN matching not needed for cert %s", sdscert)
 	}
 
 	return secret, nil
+}
+
+func getSubjectAltNamesFromSvcAccount(svcAccounts []service.K8sServiceAccount) []*xds_matcher.StringMatcher {
+	var matchSANs []*xds_matcher.StringMatcher
+
+	for _, svcAccount := range svcAccounts {
+		// OSM currently relies on kubernetes ServiceAccount for service identity
+		si := identity.GetKubernetesServiceIdentity(svcAccount, identity.ClusterLocalTrustDomain)
+		match := xds_matcher.StringMatcher{
+			MatchPattern: &xds_matcher.StringMatcher_Exact{
+				Exact: si.String(),
+			},
+		}
+		matchSANs = append(matchSANs, &match)
+	}
+
+	return matchSANs
+}
+
+func subjectAltNamesToStr(sanMatchList []*xds_matcher.StringMatcher) []string {
+	var sanStr []string
+
+	for _, sanMatcher := range sanMatchList {
+		sanStr = append(sanStr, sanMatcher.GetExact())
+	}
+	return sanStr
 }

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -201,7 +201,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 		// For inbound certificate validation context, the SAN needs to be the list of all downstream
 		// service identities that are allowed to connect to this upstream service. This means, if sdscert.MeshService
 		// points to 'X', the SANs for this certificate should correspond to all the downstream service identities
-		// allowed to rech 'X'.
+		// allowed to reach 'X'.
 		svcAccounts, err := s.meshCatalog.ListAllowedInboundServiceAccounts(s.svcAccount)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error listing inbound service accounts for proxy service %s", proxyService)

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -2,13 +2,11 @@ package sds
 
 import (
 	"fmt"
-
-	"github.com/google/uuid"
-
 	"testing"
 
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/catalog"

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -7,6 +7,7 @@ import (
 
 	"testing"
 
+	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
@@ -22,18 +23,21 @@ func TestGetRootCert(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockCertificater := certificate.NewMockCertificater(mockCtrl)
+	// This is used to dynamically set expectations for each test in the list of table driven tests
+	type dynamicMock struct {
+		mockCatalog      *catalog.MockMeshCataloger
+		mockConfigurator *configurator.MockConfigurator
+		mockCertificater *certificate.MockCertificater
+	}
+
 	mockCertManager := certificate.NewMockManager(mockCtrl)
-	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
-	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
 	testCases := []struct {
-		s                             *sdsImpl
-		certCN                        certificate.CommonName
-		sdsCert                       envoy.SDSCert
-		proxyService                  service.MeshService
-		allowedDirectionalSvcAccounts []service.K8sServiceAccount
-		permissiveMode                bool
+		name            string
+		sdsCert         envoy.SDSCert
+		proxyService    service.MeshService
+		proxySvcAccount service.K8sServiceAccount
+		prepare         func(d *dynamicMock)
 
 		// expectations
 		expectedSANs []string
@@ -41,27 +45,23 @@ func TestGetRootCert(t *testing.T) {
 	}{
 		// Test case 1: tests SDS secret for inbound TLS secret -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
-			},
-			certCN: certificate.CommonName("sa-1.ns-1.cluster.local"),
+			name: "test inbound MTLS certificate validation",
 			sdsCert: envoy.SDSCert{
 				MeshService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
 				CertType:    envoy.RootCertTypeForMTLSInbound,
 			},
-			proxyService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{
-				{Name: "sa-2", Namespace: "ns-2"},
-				{Name: "sa-3", Namespace: "ns-3"},
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
+				allowedInboundSvcAccounts := []service.K8sServiceAccount{
+					{Name: "sa-2", Namespace: "ns-2"},
+					{Name: "sa-3", Namespace: "ns-3"},
+				}
+				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
-			permissiveMode: false,
 
 			// expectations
 			expectedSANs: []string{"sa-2.ns-2.cluster.local", "sa-3.ns-3.cluster.local"},
@@ -71,89 +71,85 @@ func TestGetRootCert(t *testing.T) {
 
 		// Test case 2: tests SDS secret for outbound TLS secret -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
-			},
-			certCN: certificate.CommonName("sa-1.ns-1.cluster.local"),
+			name: "test outbound MTLS certificate validation",
 			sdsCert: envoy.SDSCert{
-				MeshService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
+				MeshService: service.MeshService{Name: "service-2", Namespace: "ns-2"},
 				CertType:    envoy.RootCertTypeForMTLSOutbound,
 			},
-			proxyService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{
-				{Name: "sa-2", Namespace: "ns-2"},
-				{Name: "sa-3", Namespace: "ns-3"},
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
+				associatedSvcAccounts := []service.K8sServiceAccount{
+					{Name: "sa-2", Namespace: "ns-2"},
+					{Name: "sa-3", Namespace: "ns-2"},
+				}
+				d.mockCatalog.EXPECT().ListServiceAccountsForService(service.MeshService{Name: "service-2", Namespace: "ns-2"}).Return(associatedSvcAccounts, nil).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
-			permissiveMode: false,
 
 			// expectations
-			expectedSANs: []string{"sa-2.ns-2.cluster.local", "sa-3.ns-3.cluster.local"},
+			expectedSANs: []string{"sa-2.ns-2.cluster.local", "sa-3.ns-2.cluster.local"},
 			expectError:  false,
 		},
 		// Test case 2 end -------------------------------
 
 		// Test case 3: tests SDS secret for permissive mode -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
-			},
-			certCN: certificate.CommonName("sa-1.ns-1.cluster.local"),
+			name: "test permissive mode certificate validation",
 			sdsCert: envoy.SDSCert{
-				MeshService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
+				MeshService: service.MeshService{Name: "service-2", Namespace: "ns-2"},
 				CertType:    envoy.RootCertTypeForMTLSOutbound,
 			},
-			proxyService:                  service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{},
-			permissiveMode:                true,
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
+			},
 
 			// expectations
 			expectedSANs: []string{}, // no SAN matching in permissive mode
 			expectError:  false,
 		},
-		// Test case 2 end -------------------------------
+		// Test case 3 end -------------------------------
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			// Mock catalog calls for tests
-			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
-			if !tc.permissiveMode {
-				if tc.sdsCert.CertType == envoy.RootCertTypeForMTLSOutbound {
-					// outbound cert
-					mockCatalog.EXPECT().ListAllowedOutboundServiceAccounts(tc.s.svcAccount).Return(tc.allowedDirectionalSvcAccounts, nil).Times(1)
-				} else if tc.sdsCert.CertType == envoy.RootCertTypeForMTLSInbound {
-					// inbound cert
-					mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(tc.s.svcAccount).Return(tc.allowedDirectionalSvcAccounts, nil).Times(1)
-				}
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			// Initialize the dynamic mocks
+			d := dynamicMock{
+				mockCatalog:      catalog.NewMockMeshCataloger(mockCtrl),
+				mockConfigurator: configurator.NewMockConfigurator(mockCtrl),
+				mockCertificater: certificate.NewMockCertificater(mockCtrl),
 			}
 
-			// Mock CA cert
-			mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
+			// Prepare the dynamic mock expectations for each test case
+			if tc.prepare != nil {
+				tc.prepare(&d)
+			}
+
+			s := &sdsImpl{
+				proxyServices: []service.MeshService{tc.proxyService},
+				svcAccount:    tc.proxySvcAccount,
+				proxy:         envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
+				certManager:   mockCertManager,
+
+				// these points to the dynamic mocks which gets updated for each test
+				meshCatalog: d.mockCatalog,
+				cfg:         d.mockConfigurator,
+			}
 
 			// test the function
-			sdsSecret, err := tc.s.getRootCert(mockCertificater, tc.sdsCert, tc.proxyService)
-
-			// build the list of SAN from the returned secret
-			var actualSANs []string
-			for _, stringMatcher := range sdsSecret.GetValidationContext().GetMatchSubjectAltNames() {
-				actualSANs = append(actualSANs, stringMatcher.GetExact())
-			}
-
+			sdsSecret, err := s.getRootCert(d.mockCertificater, tc.sdsCert, tc.proxyService)
 			assert.Equal(err != nil, tc.expectError)
+
+			actualSANs := subjectAltNamesToStr(sdsSecret.GetValidationContext().GetMatchSubjectAltNames())
 			assert.ElementsMatch(actualSANs, tc.expectedSANs)
 		})
 	}
@@ -197,17 +193,20 @@ func TestGetSDSSecrets(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	mockCertificater := certificate.NewMockCertificater(mockCtrl)
 	mockCertManager := certificate.NewMockManager(mockCtrl)
-	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
-	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+
+	// This is used to dynamically set expectations for each test in the list of table driven tests
+	type dynamicMock struct {
+		mockCatalog      *catalog.MockMeshCataloger
+		mockConfigurator *configurator.MockConfigurator
+		mockCertificater *certificate.MockCertificater
+	}
 
 	testCases := []struct {
-		s                             *sdsImpl
-		certCN                        certificate.CommonName
-		proxyService                  service.MeshService
-		allowedDirectionalSvcAccounts []service.K8sServiceAccount
-		permissiveMode                bool
+		name            string
+		proxyService    service.MeshService
+		proxySvcAccount service.K8sServiceAccount
+		prepare         func(d *dynamicMock)
 
 		// sdsCertType must match the requested cert type. used by the test for business logic
 		sdsCertType envoy.SDSCertType
@@ -224,23 +223,19 @@ func TestGetSDSSecrets(t *testing.T) {
 	}{
 		// Test case 1: root-cert-for-mtls-inbound requested -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
+			name:            "test root-cert-for-mtls-inbound cert type request",
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
+				allowedInboundSvcAccounts := []service.K8sServiceAccount{
+					{Name: "sa-2", Namespace: "ns-2"},
+					{Name: "sa-3", Namespace: "ns-3"},
+				}
+				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
-			certCN:       certificate.CommonName("sa-1.ns-1.cluster.local"),
-			proxyService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{
-				{Name: "sa-2", Namespace: "ns-2"},
-				{Name: "sa-3", Namespace: "ns-3"},
-			},
-			permissiveMode: false,
 
 			sdsCertType:    envoy.RootCertTypeForMTLSInbound,
 			requestedCerts: []string{"root-cert-for-mtls-inbound:ns-1/service-1"}, // root-cert requested
@@ -253,49 +248,40 @@ func TestGetSDSSecrets(t *testing.T) {
 
 		// Test case 2: root-cert-for-mtls-outbound requested -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
+			name:            "test root-cert-for-mtls-outbound cert type request",
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
+				associatedSvcAccounts := []service.K8sServiceAccount{
+					{Name: "sa-2", Namespace: "ns-2"},
+					{Name: "sa-3", Namespace: "ns-2"},
+				}
+				d.mockCatalog.EXPECT().ListServiceAccountsForService(
+					service.MeshService{Name: "service-2", Namespace: "ns-2"}).Return(associatedSvcAccounts, nil).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
-			certCN:       certificate.CommonName("sa-1.ns-1.cluster.local"),
-			proxyService: service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{
-				{Name: "sa-2", Namespace: "ns-2"},
-				{Name: "sa-3", Namespace: "ns-3"},
-			},
-			permissiveMode: false,
 
 			sdsCertType:    envoy.RootCertTypeForMTLSOutbound,
-			requestedCerts: []string{"root-cert-for-mtls-outbound:ns-1/service-1"}, // root-cert requested
+			requestedCerts: []string{"root-cert-for-mtls-outbound:ns-2/service-2"}, // root-cert requested
 
 			// expectations
-			expectedSANs:        []string{"sa-2.ns-2.cluster.local", "sa-3.ns-3.cluster.local"},
+			expectedSANs:        []string{"sa-2.ns-2.cluster.local", "sa-3.ns-2.cluster.local"},
 			expectedSecretCount: 1,
 		},
 		// Test case 2 end -------------------------------
 
 		// Test case 3: root-cert-for-https requested -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
+			name:            "test root-cert-https cert type request",
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
-			certCN:                        certificate.CommonName("sa-1.ns-1.cluster.local"),
-			proxyService:                  service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{},
-			permissiveMode:                false,
 
 			sdsCertType:    envoy.RootCertTypeForHTTPS,
 			requestedCerts: []string{"root-cert-https:ns-1/service-1"}, // root-cert requested
@@ -308,20 +294,14 @@ func TestGetSDSSecrets(t *testing.T) {
 
 		// Test case 4: service-cert requested -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
+			name:            "test root-cert-https cert type request",
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockCertificater.EXPECT().GetCertificateChain().Return([]byte("foo")).Times(1)
+				d.mockCertificater.EXPECT().GetPrivateKey().Return([]byte("foo")).Times(1)
 			},
-			certCN:                        certificate.CommonName("sa-1.ns-1.cluster.local"),
-			proxyService:                  service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{},
-			permissiveMode:                false,
 
 			sdsCertType:    envoy.ServiceCertType,
 			requestedCerts: []string{"service-cert:ns-1/service-1"}, // service-cert requested
@@ -334,20 +314,11 @@ func TestGetSDSSecrets(t *testing.T) {
 
 		// Test case 5: invalid cert type requested -------------------------------
 		{
-			s: &sdsImpl{
-				proxyServices: []service.MeshService{
-					{Name: "service-1", Namespace: "ns-1"},
-				},
-				svcAccount:  service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
-				proxy:       envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
-				meshCatalog: mockCatalog,
-				certManager: mockCertManager,
-				cfg:         mockConfigurator,
-			},
-			certCN:                        certificate.CommonName("sa-1.ns-1.cluster.local"),
-			proxyService:                  service.MeshService{Name: "service-1", Namespace: "ns-1"},
-			allowedDirectionalSvcAccounts: []service.K8sServiceAccount{},
-			permissiveMode:                false,
+			name:            "test root-cert-https cert type request",
+			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: nil,
 
 			sdsCertType:    envoy.SDSCertType("invalid"),
 			requestedCerts: []string{"invalid:ns-1/service-1"}, // service-cert requested
@@ -360,31 +331,35 @@ func TestGetSDSSecrets(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			// Mock calls based on test case input
-			switch tc.sdsCertType {
-			// Verify SAN for inbound and outbound MTLS certs
-			case envoy.RootCertTypeForMTLSInbound:
-				mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
-				mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(tc.s.svcAccount).Return(tc.allowedDirectionalSvcAccounts, nil).Times(1)
-				mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 
-			case envoy.RootCertTypeForMTLSOutbound:
-				mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
-				mockCatalog.EXPECT().ListAllowedOutboundServiceAccounts(tc.s.svcAccount).Return(tc.allowedDirectionalSvcAccounts, nil).Times(1)
-				mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
+			// Initialize the dynamic mocks
+			d := dynamicMock{
+				mockCatalog:      catalog.NewMockMeshCataloger(mockCtrl),
+				mockConfigurator: configurator.NewMockConfigurator(mockCtrl),
+				mockCertificater: certificate.NewMockCertificater(mockCtrl),
+			}
 
-			case envoy.RootCertTypeForHTTPS:
-				mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
-				mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
+			// Prepare the dynamic mock expectations for each test case
+			if tc.prepare != nil {
+				tc.prepare(&d)
+			}
 
-			case envoy.ServiceCertType:
-				mockCertificater.EXPECT().GetCertificateChain().Return([]byte("foo")).Times(1)
-				mockCertificater.EXPECT().GetPrivateKey().Return([]byte("foo")).Times(1)
+			s := &sdsImpl{
+				proxyServices: []service.MeshService{tc.proxyService},
+				svcAccount:    tc.proxySvcAccount,
+				proxy:         envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
+				certManager:   mockCertManager,
+
+				// these points to the dynamic mocks which gets updated for each test
+				meshCatalog: d.mockCatalog,
+				cfg:         d.mockConfigurator,
 			}
 
 			// test the function
-			sdsSecrets := tc.s.getSDSSecrets(mockCertificater, tc.requestedCerts, tc.proxyService)
+			sdsSecrets := s.getSDSSecrets(d.mockCertificater, tc.requestedCerts, tc.proxyService)
 			assert.Len(sdsSecrets, tc.expectedSecretCount)
 
 			if tc.expectedSecretCount <= 0 {
@@ -394,9 +369,6 @@ func TestGetSDSSecrets(t *testing.T) {
 
 			sdsSecret := sdsSecrets[0]
 
-			// verify the returned secret corresponds to the correct cert type
-			assert.Equal(sdsSecret.Name, fmt.Sprintf("%s:%s", tc.sdsCertType, tc.proxyService))
-
 			// verify different cert types
 			switch tc.sdsCertType {
 			// Verify SAN for inbound and outbound MTLS certs
@@ -405,11 +377,8 @@ func TestGetSDSSecrets(t *testing.T) {
 			case envoy.RootCertTypeForMTLSOutbound:
 				fallthrough
 			case envoy.RootCertTypeForHTTPS:
-				// build the list of SAN from the returned secret
-				var actualSANs []string
-				for _, stringMatcher := range sdsSecret.GetValidationContext().GetMatchSubjectAltNames() {
-					actualSANs = append(actualSANs, stringMatcher.GetExact())
-				}
+				// Check SANs
+				actualSANs := subjectAltNamesToStr(sdsSecret.GetValidationContext().GetMatchSubjectAltNames())
 				assert.ElementsMatch(actualSANs, tc.expectedSANs)
 
 				// Check trusted CA
@@ -419,6 +388,76 @@ func TestGetSDSSecrets(t *testing.T) {
 				assert.NotNil(sdsSecret.GetTlsCertificate().GetCertificateChain().GetInlineBytes())
 				assert.NotNil(sdsSecret.GetTlsCertificate().GetPrivateKey().GetInlineBytes())
 			}
+		})
+	}
+}
+
+func TestGetSubjectAltNamesFromSvcAccount(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		svcAccounts         []service.K8sServiceAccount
+		expectedSANMatchers []*xds_matcher.StringMatcher
+	}{
+		{
+			svcAccounts: []service.K8sServiceAccount{
+				{Name: "sa-1", Namespace: "ns-1"},
+				{Name: "sa-2", Namespace: "ns-2"},
+			},
+			expectedSANMatchers: []*xds_matcher.StringMatcher{
+				{
+					MatchPattern: &xds_matcher.StringMatcher_Exact{
+						Exact: "sa-1.ns-1.cluster.local",
+					},
+				},
+				{
+					MatchPattern: &xds_matcher.StringMatcher_Exact{
+						Exact: "sa-2.ns-2.cluster.local",
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
+			actual := getSubjectAltNamesFromSvcAccount(tc.svcAccounts)
+			assert.ElementsMatch(actual, tc.expectedSANMatchers)
+		})
+	}
+}
+
+func TestSubjectAltNamesToStr(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		sanMatchers []*xds_matcher.StringMatcher
+		strSANs     []string
+	}{
+		{
+			sanMatchers: []*xds_matcher.StringMatcher{
+				{
+					MatchPattern: &xds_matcher.StringMatcher_Exact{
+						Exact: "sa-1.ns-1.cluster.local",
+					},
+				},
+				{
+					MatchPattern: &xds_matcher.StringMatcher_Exact{
+						Exact: "sa-2.ns-2.cluster.local",
+					},
+				},
+			},
+			strSANs: []string{
+				"sa-1.ns-1.cluster.local",
+				"sa-2.ns-2.cluster.local",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
+			actual := subjectAltNamesToStr(tc.sanMatchers)
+			assert.ElementsMatch(actual, tc.strSANs)
 		})
 	}
 }

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Test Envoy tools", func() {
 	Context("Test GetUpstreamTLSContext()", func() {
 		It("should return TLS context", func() {
 			sni := "bookstore-v1.default.svc.cluster.local"
-			tlsContext := GetUpstreamTLSContext(tests.BookstoreV1Service, sni)
+			tlsContext := GetUpstreamTLSContext(tests.BookbuyerService, tests.BookstoreV1Service)
 
 			expectedTLSContext := &auth.UpstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -205,7 +205,7 @@ var _ = Describe("Test Envoy tools", func() {
 					},
 					TlsCertificates: nil,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-						Name: "service-cert:default/bookstore-v1",
+						Name: "service-cert:default/bookbuyer",
 						SdsConfig: &core.ConfigSource{
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
@@ -215,13 +215,7 @@ var _ = Describe("Test Envoy tools", func() {
 					}},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-							Name: SDSCert{
-								MeshService: service.MeshService{
-									Namespace: "default",
-									Name:      "bookstore-v1",
-								},
-								CertType: RootCertTypeForMTLSOutbound,
-							}.String(),
+							Name: "root-cert-for-mtls-outbound:default/bookstore-v1",
 							SdsConfig: &core.ConfigSource{
 								ConfigSourceSpecifier: &core.ConfigSource_Ads{
 									Ads: &core.AggregatedConfigSource{},
@@ -232,7 +226,7 @@ var _ = Describe("Test Envoy tools", func() {
 					},
 					AlpnProtocols: ALPNInMesh,
 				},
-				Sni:                sni, // "bookstore.default.svc.cluster.local"
+				Sni:                sni, // "bookstore-v1.default.svc.cluster.local"
 				AllowRenegotiation: false,
 			}
 
@@ -250,85 +244,100 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetUpstreamTLSContext()", func() {
 		It("creates correct UpstreamTlsContext.Sni field", func() {
-			sni := "test.default.svc.cluster.local"
-			tlsContext := GetUpstreamTLSContext(tests.BookbuyerService, sni)
+			tlsContext := GetUpstreamTLSContext(tests.BookbuyerService, tests.BookstoreV1Service)
 			// To show the actual string for human comprehension
-			Expect(tlsContext.Sni).To(Equal(sni))
+			Expect(tlsContext.Sni).To(Equal(tests.BookstoreV1Service.ServerName()))
 		})
 	})
 
 	Context("Test getCommonTLSContext()", func() {
-		It("returns proper auth.CommonTlsContext for mTLS", func() {
-			namespacedService := service.MeshService{
-				Namespace: "-namespace-",
-				Name:      "-service-",
-			}
-			actual := getCommonTLSContext(namespacedService, true /* mTLS */, Inbound)
-
-			expectedServiceCertName := SDSCert{
-				MeshService: namespacedService,
+		It("returns proper auth.CommonTlsContext for outbound mTLS", func() {
+			tlsSDSCert := SDSCert{
+				MeshService: tests.BookbuyerService,
 				CertType:    ServiceCertType,
-			}.String()
-			expectedRootCertName := SDSCert{
-				MeshService: namespacedService,
-				CertType:    RootCertTypeForMTLSInbound,
-			}.String()
+			}
+			peerValidationSDSCert := SDSCert{
+				MeshService: tests.BookstoreV1Service,
+				CertType:    RootCertTypeForMTLSOutbound,
+			}
+
+			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)
 
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name:      expectedServiceCertName,
+					Name:      "service-cert:default/bookbuyer",
 					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name:      expectedRootCertName,
+						Name:      "root-cert-for-mtls-outbound:default/bookstore-v1",
 						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,
 			}
 
-			Expect(len(actual.TlsCertificateSdsSecretConfigs)).To(Equal(1))
-			Expect(actual.TlsCertificateSdsSecretConfigs[0].Name).To(Equal(expectedServiceCertName))
-			Expect(actual.GetValidationContextSdsSecretConfig().Name).To(Equal(expectedRootCertName))
 			Expect(actual).To(Equal(expected))
 		})
 
-		It("returns proper auth.CommonTlsContext for non-mTLS", func() {
-			namespacedService := service.MeshService{
-				Namespace: "-namespace-",
-				Name:      "-service-",
-			}
-			actual := getCommonTLSContext(namespacedService, false, false /* Ignored in case of non-tls */)
-
-			expectedServiceCertName := SDSCert{
-				MeshService: namespacedService,
+		It("returns proper auth.CommonTlsContext for inbound mTLS", func() {
+			tlsSDSCert := SDSCert{
+				MeshService: tests.BookstoreV1Service,
 				CertType:    ServiceCertType,
-			}.String()
-			expectedRootCertName := SDSCert{
-				MeshService: namespacedService,
-				CertType:    RootCertTypeForHTTPS,
-			}.String()
+			}
+			peerValidationSDSCert := SDSCert{
+				MeshService: tests.BookstoreV1Service,
+				CertType:    RootCertTypeForMTLSInbound,
+			}
+
+			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)
 
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name:      expectedServiceCertName,
+					Name:      "service-cert:default/bookstore-v1",
 					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name:      expectedRootCertName,
+						Name:      "root-cert-for-mtls-inbound:default/bookstore-v1",
 						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,
 			}
 
-			Expect(len(actual.TlsCertificateSdsSecretConfigs)).To(Equal(1))
-			Expect(actual.TlsCertificateSdsSecretConfigs[0].Name).To(Equal(expectedServiceCertName))
-			Expect(actual.GetValidationContextSdsSecretConfig().Name).To(Equal(expectedRootCertName))
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("returns proper auth.CommonTlsContext for non-mTLS (HTTPS)", func() {
+			tlsSDSCert := SDSCert{
+				MeshService: tests.BookstoreV1Service,
+				CertType:    ServiceCertType,
+			}
+			peerValidationSDSCert := SDSCert{
+				MeshService: tests.BookstoreV1Service,
+				CertType:    RootCertTypeForHTTPS,
+			}
+
+			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)
+
+			expected := &auth.CommonTlsContext{
+				TlsParams: GetTLSParams(),
+				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
+					Name:      "service-cert:default/bookstore-v1",
+					SdsConfig: GetADSConfigSource(),
+				}},
+				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
+					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
+						Name:      "root-cert-https:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
+					},
+				},
+				AlpnProtocols: nil,
+			}
+
 			Expect(actual).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change fixes how a client validates the service certificate presented
up an upstream server. Previously, the identity of the upstream
server was being validated against a list of upstream service
identities that the client is allowed to communicate to. This is
vulnerable to security issues where a server not authorized
to run the given upstream service the client is attempting to reach
can successfully trick the client as long as the client is allowed
to reach the unauthorized service identity for a different service.

This change prevents this by ensuring the service identities presented
by the upstream server are indeed authorized to run the service the
client is attempting to communicate to.

This change also decouples the context of validation context for an
SDS secret from the service certificate. Previously, the service
cert was used as the validation context as well.

With this change, certificate validation happens as follows.

1. Outbound
- Upstream cluster's UpstreamTlsContext points to the client's service
  cert, with validation context pointing to the upstream server root cert.

- During TLS handshake, client presents the client service cert, and
  validates server cert against the root cert validation context
  specified in the upstream cluster's UpstreamTlsContext. The upstream
  cert's SANs are matched against service identities corresponding to
  upstream service.

2. Inbound
- Inbound cluster's DownstreamTlsContext points to the local service
  cert, with validation context pointing to the local server's root
  cert.

- During TLS handshake, downstream presents its cert to the local
  cluster, and the local cluster's DownstreamTlsContext validates
  that the service identity presented by the downstream is in the
  list of allowed service identities that can communicate with the
  local (or upstream) cluster. This can be made stricter on a per
  client basis but needs a DownstreamTlsContext per client, which
  is a separate effort in intself.

This change also updates the SDS test to dynamically update mocks
for each test in the table driven test suite.

Resolves #2024 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`