### PR TITLE
tests/e2e: envoy log level for testing

### DIFF
--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -65,6 +65,8 @@ var (
 	defaultDeployJaeger = false
 	// default deploy Fluentbit
 	defaultDeployFluentbit = false
+	// default envoy loglevel
+	defaultEnvoyLogLevel = "debug"
 )
 
 type OSMDescribeInfo struct {
@@ -250,6 +252,7 @@ type InstallOSMOpts struct {
 
 	egressEnabled        bool
 	enablePermissiveMode bool
+	envoyLogLevel        string
 }
 
 // GetOSMInstallOpts initializes install options for OSM
@@ -273,6 +276,7 @@ func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 		certmanagerIssuerGroup: "cert-manager.io",
 		certmanagerIssuerKind:  "Issuer",
 		certmanagerIssuerName:  "osm-ca",
+		envoyLogLevel:          defaultEnvoyLogLevel,
 	}
 }
 
@@ -378,6 +382,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		"--enable-egress="+strconv.FormatBool(instOpts.egressEnabled),
 		"--enable-permissive-traffic-policy="+strconv.FormatBool(instOpts.enablePermissiveMode),
 		"--enable-debug-server",
+		"--envoy-log-level="+instOpts.envoyLogLevel,
 	)
 
 	switch instOpts.certManager {


### PR DESCRIPTION
Defaulted to debug for e2e.

- Debugging          [X]
- Tests                  [X]
- CI System              [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No