### PR TITLE
tests/e2e: make SMI resource deployment namespace

### DIFF
--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -84,10 +84,10 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 						DestinationSvcAccountName: "server",
 					})
 
-				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				// SMI is formally deployed on destination NS
+				_, err = td.CreateHTTPRouteGroup(destNs, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = td.CreateTrafficTarget(destNs, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -114,10 +114,10 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 							DestinationSvcAccountName: destApp,
 						})
 
-					// Configs have to be put into a monitored NS, and osm-system can't be by cli
-					_, err = td.CreateHTTPRouteGroup(srcClient, httpRG)
+					// SMI is formally deployed on destination NS
+					_, err = td.CreateHTTPRouteGroup(destApp, httpRG)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					_, err = td.CreateTrafficTarget(destApp, trafficTarget)
 					Expect(err).NotTo(HaveOccurred())
 				}
 

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -84,10 +84,10 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 						DestinationSvcAccountName: "server",
 					})
 
-				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				// SMI is formally deployed on destination NS
+				_, err = td.CreateHTTPRouteGroup(destNs, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = td.CreateTrafficTarget(destNs, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -114,8 +114,8 @@ func testTraffic(withSourceKubernetesService bool) {
 			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s Kubernetes Service to a destination", sourceService)
 
 			By("Deleting SMI policies")
-			Expect(td.smiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
-			Expect(td.smiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
+			Expect(td.smiClients.AccessClient.AccessV1alpha2().TrafficTargets(destName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+			Expect(td.smiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(destName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
 
 			// Expect client not to reach server
 			cond = td.WaitForRepeatedSuccess(func() bool {

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -79,10 +79,10 @@ func testTraffic(withSourceKubernetesService bool) {
 					DestinationSvcAccountName: destName,
 				})
 
-			// Configs have to be put into a monitored NS
-			_, err = td.CreateHTTPRouteGroup(sourceName, httpRG)
+			// SMI is formally deployed on destination NS
+			_, err = td.CreateHTTPRouteGroup(destName, httpRG)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateTrafficTarget(sourceName, trafficTarget)
+			_, err = td.CreateTrafficTarget(destName, trafficTarget)
 			Expect(err).NotTo(HaveOccurred())
 
 			// All ready. Expect client to reach server

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -153,9 +153,10 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							DestinationSvcAccountName: svcAcc.Name,
 						})
 
-					_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+					// SMI is formally deployed on destination NS
+					_, err := td.CreateHTTPRouteGroup(serverNamespace, httpRG)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					_, err = td.CreateTrafficTarget(serverNamespace, trafficTarget)
 					Expect(err).NotTo(HaveOccurred())
 				}
 
@@ -190,7 +191,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
 				Expect(err).To(BeNil())
 
-				// Push them in K8s
+				// Push them in K8s, SMI is formally deployed on destination NS
 				_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
 				Expect(err).To(BeNil())
 

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -145,9 +145,10 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 								DestinationSvcAccountName: dstServer,
 							})
 
-						_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+						// SMI is formally deployed on destination NS
+						_, err := td.CreateHTTPRouteGroup(serverNamespace, httpRG)
 						Expect(err).NotTo(HaveOccurred())
-						_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+						_, err = td.CreateTrafficTarget(serverNamespace, trafficTarget)
 						Expect(err).NotTo(HaveOccurred())
 					}
 				}
@@ -183,7 +184,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 				tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
 				Expect(err).To(BeNil())
 
-				// Push them in K8s
+				// Push them in K8s, SMI is formally deployed on destination NS
 				_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
 				Expect(err).To(BeNil())
 


### PR DESCRIPTION
SMI might expect to be formally deployed at destination namespace.
Our testing was just deploying into a monitored namespace, which
could potentially miss some correctness assumptions in the long run.

- Tests                  [X]
- CI System              [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No