### PR TITLE
announcements: Increase specificity of events coming from Kubernetes

### DIFF
--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -8,15 +8,6 @@ func (at AnnouncementType) String() string {
 }
 
 const (
-	// EndpointAdded is the type of announcement emitted when we observe an addition of a Kubernetes Endpoint
-	EndpointAdded AnnouncementType = "endpoint-added"
-
-	// EndpointDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Endpoint
-	EndpointDeleted AnnouncementType = "endpoint-deleted"
-
-	// EndpointUpdated is the type of announcement emitted when we observe an update to a Kubernetes Endpoint
-	EndpointUpdated AnnouncementType = "endpoint-updated"
-
 	// PodAdded is the type of announcement emitted when we observe an addition of a Kubernetes Pod
 	PodAdded AnnouncementType = "pod-added"
 
@@ -27,7 +18,7 @@ const (
 	PodUpdated AnnouncementType = "pod-updated"
 )
 
-// Announcement is a struct for accouncements
+// Announcement is a struct for messages between various components of OSM signaling a need for a change in Envoy proxy configuration
 type Announcement struct {
 	Type               AnnouncementType
 	ReferencedObjectID interface{}

--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -1,11 +1,30 @@
 package announcements
 
-// AnnouncementType is used to record the type of annoucements
-type AnnouncementType int
+// AnnouncementType is used to record the type of announcement
+type AnnouncementType string
+
+func (at AnnouncementType) String() string {
+	return string(at)
+}
 
 const (
-	// EndpointDeleted is to observe endpoint deletion announcements
-	EndpointDeleted AnnouncementType = iota + 1
+	// EndpointAdded is the type of announcement emitted when we observe an addition of a Kubernetes Endpoint
+	EndpointAdded AnnouncementType = "endpoint-added"
+
+	// EndpointDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Endpoint
+	EndpointDeleted AnnouncementType = "endpoint-deleted"
+
+	// EndpointUpdated is the type of announcement emitted when we observe an update to a Kubernetes Endpoint
+	EndpointUpdated AnnouncementType = "endpoint-updated"
+
+	// PodAdded is the type of announcement emitted when we observe an addition of a Kubernetes Pod
+	PodAdded AnnouncementType = "pod-added"
+
+	// PodDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Pod
+	PodDeleted AnnouncementType = "pod-deleted"
+
+	// PodUpdated is the type of announcement emitted when we observe an update to a Kubernetes Pod
+	PodUpdated AnnouncementType = "pod-updated"
 )
 
 // Announcement is a struct for accouncements

--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -16,6 +16,116 @@ const (
 
 	// PodUpdated is the type of announcement emitted when we observe an update to a Kubernetes Pod
 	PodUpdated AnnouncementType = "pod-updated"
+
+	// ---
+
+	// EndpointAdded is the type of announcement emitted when we observe an addition of a Kubernetes Endpoint
+	EndpointAdded AnnouncementType = "endpoint-added"
+
+	// EndpointDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Endpoint
+	EndpointDeleted AnnouncementType = "endpoint-deleted"
+
+	// EndpointUpdated is the type of announcement emitted when we observe an update to a Kubernetes Endpoint
+	EndpointUpdated AnnouncementType = "endpoint-updated"
+
+	// ---
+
+	// NamespaceAdded is the type of announcement emitted when we observe an addition of a Kubernetes Namespace
+	NamespaceAdded AnnouncementType = "namespace-added"
+
+	// NamespaceDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Namespace
+	NamespaceDeleted AnnouncementType = "namespace-deleted"
+
+	// NamespaceUpdated is the type of announcement emitted when we observe an update to a Kubernetes Namespace
+	NamespaceUpdated AnnouncementType = "namespace-updated"
+
+	// ---
+
+	// ServiceAdded is the type of announcement emitted when we observe an addition of a Kubernetes Service
+	ServiceAdded AnnouncementType = "service-added"
+
+	// ServiceDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Service
+	ServiceDeleted AnnouncementType = "service-deleted"
+
+	// ServiceUpdated is the type of announcement emitted when we observe an update to a Kubernetes Service
+	ServiceUpdated AnnouncementType = "service-updated"
+
+	// ---
+
+	// TrafficSplitAdded is the type of announcement emitted when we observe an addition of a Kubernetes TrafficSplit
+	TrafficSplitAdded AnnouncementType = "trafficsplit-added"
+
+	// TrafficSplitDeleted the type of announcement emitted when we observe the deletion of a Kubernetes TrafficSplit
+	TrafficSplitDeleted AnnouncementType = "trafficsplit-deleted"
+
+	// TrafficSplitUpdated is the type of announcement emitted when we observe an update to a Kubernetes TrafficSplit
+	TrafficSplitUpdated AnnouncementType = "trafficsplit-updated"
+
+	// ---
+
+	// RouteGroupAdded is the type of announcement emitted when we observe an addition of a Kubernetes RouteGroup
+	RouteGroupAdded AnnouncementType = "routegroup-added"
+
+	// RouteGroupDeleted the type of announcement emitted when we observe the deletion of a Kubernetes RouteGroup
+	RouteGroupDeleted AnnouncementType = "routegroup-deleted"
+
+	// RouteGroupUpdated is the type of announcement emitted when we observe an update to a Kubernetes RouteGroup
+	RouteGroupUpdated AnnouncementType = "routegroup-updated"
+
+	// ---
+
+	// TCPRouteAdded is the type of announcement emitted when we observe an addition of a Kubernetes TCPRoute
+	TCPRouteAdded AnnouncementType = "tcproute-added"
+
+	// TCPRouteDeleted the type of announcement emitted when we observe the deletion of a Kubernetes TCPRoute
+	TCPRouteDeleted AnnouncementType = "tcproute-deleted"
+
+	// TCPRouteUpdated is the type of announcement emitted when we observe an update to a Kubernetes TCPRoute
+	TCPRouteUpdated AnnouncementType = "tcproute-updated"
+
+	// ---
+
+	// TrafficTargetAdded is the type of announcement emitted when we observe an addition of a Kubernetes TrafficTarget
+	TrafficTargetAdded AnnouncementType = "traffictarget-added"
+
+	// TrafficTargetDeleted the type of announcement emitted when we observe the deletion of a Kubernetes TrafficTarget
+	TrafficTargetDeleted AnnouncementType = "traffictarget-deleted"
+
+	// TrafficTargetUpdated is the type of announcement emitted when we observe an update to a Kubernetes TrafficTarget
+	TrafficTargetUpdated AnnouncementType = "traffictarget-updated"
+
+	// ---
+
+	// BackpressureAdded is the type of announcement emitted when we observe an addition of a Kubernetes Backpressure
+	BackpressureAdded AnnouncementType = "backpressure-added"
+
+	// BackpressureDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Backpressure
+	BackpressureDeleted AnnouncementType = "backpressure-deleted"
+
+	// BackpressureUpdated is the type of announcement emitted when we observe an update to a Kubernetes Backpressure
+	BackpressureUpdated AnnouncementType = "backpressure-updated"
+
+	// ---
+
+	// ConfigMapAdded is the type of announcement emitted when we observe an addition of a Kubernetes ConfigMap
+	ConfigMapAdded AnnouncementType = "configmap-added"
+
+	// ConfigMapDeleted the type of announcement emitted when we observe the deletion of a Kubernetes ConfigMap
+	ConfigMapDeleted AnnouncementType = "configmap-deleted"
+
+	// ConfigMapUpdated is the type of announcement emitted when we observe an update to a Kubernetes ConfigMap
+	ConfigMapUpdated AnnouncementType = "configmap-updated"
+
+	// ---
+
+	// IngressAdded is the type of announcement emitted when we observe an addition of a Kubernetes Ingress
+	IngressAdded AnnouncementType = "ingress-added"
+
+	// IngressDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Ingress
+	IngressDeleted AnnouncementType = "ingress-deleted"
+
+	// IngressUpdated is the type of announcement emitted when we observe an update to a Kubernetes Ingress
+	IngressUpdated AnnouncementType = "ingress-updated"
 )
 
 // Announcement is a struct for messages between various components of OSM signaling a need for a change in Envoy proxy configuration

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -40,7 +40,7 @@ func (mc *MeshCatalog) repeater() {
 }
 
 func (mc *MeshCatalog) handleAnnouncement(ann announcements.Announcement) {
-	if ann.Type == announcements.EndpointDeleted {
+	if ann.Type == announcements.PodDeleted {
 		log.Trace().Msgf("Handling announcement: %+v", ann)
 		// TODO: implement (https://github.com/openservicemesh/osm/issues/1719)
 	}

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -74,7 +74,7 @@ func newConfigurator(kubeClient kubernetes.Interface, stop <-chan struct{}, osmN
 
 	informerName := "ConfigMap"
 	providerName := "OSMConfigMap"
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers(informerName, providerName, client.announcements, nil))
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers(informerName, providerName, client.announcements, nil, nil, nil))
 
 	client.run(stop)
 

--- a/pkg/endpoint/providers/kube/announcements.go
+++ b/pkg/endpoint/providers/kube/announcements.go
@@ -1,0 +1,42 @@
+package kube
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/kubernetes"
+)
+
+var podEventTypeRemap = map[kubernetes.EventType]announcements.AnnouncementType{
+	kubernetes.AddEvent:    announcements.PodAdded,
+	kubernetes.DeleteEvent: announcements.PodDeleted,
+	kubernetes.UpdateEvent: announcements.PodUpdated,
+}
+
+var endpointEventTypeRemap = map[kubernetes.EventType]announcements.AnnouncementType{
+	kubernetes.AddEvent:    announcements.EndpointAdded,
+	kubernetes.DeleteEvent: announcements.EndpointDeleted,
+	kubernetes.UpdateEvent: announcements.EndpointUpdated,
+}
+
+func getPodUID(obj interface{}) interface{} {
+	if pod, ok := obj.(*v1.Pod); ok {
+		return pod.ObjectMeta.UID
+	}
+	log.Error().Msgf("Expected v1.Pod; Got %+v", obj)
+	return nil
+}
+
+func getPodUIDFromEndpoint(obj interface{}) interface{} {
+	if endpoints, ok := obj.(*v1.Endpoints); ok {
+		for _, sub := range endpoints.Subsets {
+			for _, addr := range sub.Addresses {
+				if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" {
+					return addr.TargetRef.UID
+				}
+			}
+		}
+	}
+	log.Error().Msgf("Expected v1.Pod; Got %+v", obj)
+	return nil
+}

--- a/pkg/endpoint/providers/kube/announcements.go
+++ b/pkg/endpoint/providers/kube/announcements.go
@@ -7,35 +7,18 @@ import (
 	"github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
+// podEventTypeRemap provides 1:1 mapping from a Kubernetes Pod event type to an AnnouncementType
+// This will be provided to kubernetes.GetKubernetesEventHandlers() so that Announcements
+// are dispatched with appropriate type.
 var podEventTypeRemap = map[kubernetes.EventType]announcements.AnnouncementType{
 	kubernetes.AddEvent:    announcements.PodAdded,
 	kubernetes.DeleteEvent: announcements.PodDeleted,
 	kubernetes.UpdateEvent: announcements.PodUpdated,
 }
 
-var endpointEventTypeRemap = map[kubernetes.EventType]announcements.AnnouncementType{
-	kubernetes.AddEvent:    announcements.EndpointAdded,
-	kubernetes.DeleteEvent: announcements.EndpointDeleted,
-	kubernetes.UpdateEvent: announcements.EndpointUpdated,
-}
-
 func getPodUID(obj interface{}) interface{} {
 	if pod, ok := obj.(*v1.Pod); ok {
 		return pod.ObjectMeta.UID
-	}
-	log.Error().Msgf("Expected v1.Pod; Got %+v", obj)
-	return nil
-}
-
-func getPodUIDFromEndpoint(obj interface{}) interface{} {
-	if endpoints, ok := obj.(*v1.Endpoints); ok {
-		for _, sub := range endpoints.Subsets {
-			for _, addr := range sub.Addresses {
-				if addr.TargetRef != nil && addr.TargetRef.Kind == "Pod" {
-					return addr.TargetRef.UID
-				}
-			}
-		}
 	}
 	log.Error().Msgf("Expected v1.Pod; Got %+v", obj)
 	return nil

--- a/pkg/endpoint/providers/kube/announcements.go
+++ b/pkg/endpoint/providers/kube/announcements.go
@@ -2,24 +2,12 @@ package kube
 
 import (
 	v1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/kubernetes"
 )
-
-// podEventTypeRemap provides 1:1 mapping from a Kubernetes Pod event type to an AnnouncementType
-// This will be provided to kubernetes.GetKubernetesEventHandlers() so that Announcements
-// are dispatched with appropriate type.
-var podEventTypeRemap = map[kubernetes.EventType]announcements.AnnouncementType{
-	kubernetes.AddEvent:    announcements.PodAdded,
-	kubernetes.DeleteEvent: announcements.PodDeleted,
-	kubernetes.UpdateEvent: announcements.PodUpdated,
-}
 
 func getPodUID(obj interface{}) interface{} {
 	if pod, ok := obj.(*v1.Pod); ok {
 		return pod.ObjectMeta.UID
 	}
-	log.Error().Msgf("Expected v1.Pod; Got %+v", obj)
+	log.Error().Msgf("Expected a Kubernetes Pod object; Got %+v", obj)
 	return nil
 }

--- a/pkg/endpoint/providers/kube/announcements_test.go
+++ b/pkg/endpoint/providers/kube/announcements_test.go
@@ -1,0 +1,32 @@
+package kube
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Test Announcement Helper Functions", func() {
+
+	Context("Test getPodUID()", func() {
+		It("fetches Pod's UID from a Pod Kubernetes object", func() {
+			podUID := types.UID("-uid-")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: podUID,
+				},
+			}
+			actual := getPodUID(pod)
+			Expect(actual).To(Equal(podUID))
+		})
+
+		It("returns empty UID when no UID", func() {
+			pod := &corev1.Pod{}
+			actual := getPodUID(pod)
+			Expect(actual).To(Equal(types.UID("")))
+		})
+	})
+})

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -48,7 +48,7 @@ func NewProvider(kubeClient kubernetes.Interface, kubeController k8s.Controller,
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return kubeController.IsMonitoredNamespace(ns)
 	}
-	informerCollection.Endpoints.AddEventHandler(k8s.GetKubernetesEventHandlers("Endpoints", "Kubernetes", client.announcements, shouldObserve, endpointEventTypeRemap, getPodUIDFromEndpoint))
+	informerCollection.Endpoints.AddEventHandler(k8s.GetKubernetesEventHandlers("Endpoints", "Kubernetes", client.announcements, shouldObserve, nil, nil))
 	informerCollection.Pods.AddEventHandler(k8s.GetKubernetesEventHandlers("Pods", "Kubernetes", client.announcements, shouldObserve, podEventTypeRemap, getPodUID))
 
 	if err := client.run(stop); err != nil {

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -48,8 +48,8 @@ func NewProvider(kubeClient kubernetes.Interface, kubeController k8s.Controller,
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return kubeController.IsMonitoredNamespace(ns)
 	}
-	informerCollection.Endpoints.AddEventHandler(k8s.GetKubernetesEventHandlers("Endpoints", "Kubernetes", client.announcements, shouldObserve))
-	informerCollection.Pods.AddEventHandler(k8s.GetKubernetesEventHandlers("Pods", "Kubernetes", client.announcements, shouldObserve))
+	informerCollection.Endpoints.AddEventHandler(k8s.GetKubernetesEventHandlers("Endpoints", "Kubernetes", client.announcements, shouldObserve, endpointEventTypeRemap, getPodUIDFromEndpoint))
+	informerCollection.Pods.AddEventHandler(k8s.GetKubernetesEventHandlers("Pods", "Kubernetes", client.announcements, shouldObserve, podEventTypeRemap, getPodUID))
 
 	if err := client.run(stop); err != nil {
 		return nil, errors.Errorf("Failed to start Kubernetes EndpointProvider client: %+v", err)

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -31,7 +31,7 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return kubeController.IsMonitoredNamespace(ns)
 	}
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", client.announcements, shouldObserve))
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", client.announcements, shouldObserve, nil, nil))
 
 	if err := client.run(stop); err != nil {
 		log.Error().Err(err).Msg("Could not start Kubernetes Ingress client")

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -31,7 +31,13 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return kubeController.IsMonitoredNamespace(ns)
 	}
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", client.announcements, shouldObserve, nil, nil))
+
+	ingrEventTypes := k8s.EventTypes{
+		Add:    announcements.IngressAdded,
+		Update: announcements.IngressUpdated,
+		Delete: announcements.IngressDeleted,
+	}
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", client.announcements, shouldObserve, nil, ingrEventTypes))
 
 	if err := client.run(stop); err != nil {
 		log.Error().Err(err).Msg("Could not start Kubernetes Ingress client")

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -57,7 +57,7 @@ func (c *Client) initNamespaceMonitor() {
 	c.informers[Namespaces] = informerFactory.Core().V1().Namespaces().Informer()
 
 	// Add event handler to informer
-	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, nil, nil))
+	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, nil, nil, nil, nil))
 }
 
 // Initializes Service monitoring
@@ -74,7 +74,7 @@ func (c *Client) initServicesMonitor() {
 	// Announcement channel for Services
 	c.announcements[Services] = make(chan announcements.Announcement)
 
-	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.announcements[Services], shouldObserve))
+	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.announcements[Services], shouldObserve, nil, nil))
 }
 
 func (c *Client) initPodMonitor() {
@@ -90,7 +90,7 @@ func (c *Client) initPodMonitor() {
 	// Announcement channel for Pods
 	c.announcements[Pods] = make(chan announcements.Announcement)
 
-	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Pods], shouldObserve))
+	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Pods], shouldObserve, nil, nil))
 }
 
 func (c *Client) run(stop <-chan struct{}) error {

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -57,7 +57,12 @@ func (c *Client) initNamespaceMonitor() {
 	c.informers[Namespaces] = informerFactory.Core().V1().Namespaces().Informer()
 
 	// Add event handler to informer
-	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, nil, nil, nil, nil))
+	nsEventTypes := EventTypes{
+		Add:    announcements.NamespaceAdded,
+		Update: announcements.NamespaceUpdated,
+		Delete: announcements.NamespaceDeleted,
+	}
+	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, nil, nil, nil, nsEventTypes))
 }
 
 // Initializes Service monitoring
@@ -74,7 +79,12 @@ func (c *Client) initServicesMonitor() {
 	// Announcement channel for Services
 	c.announcements[Services] = make(chan announcements.Announcement)
 
-	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.announcements[Services], shouldObserve, nil, nil))
+	svcEventTypes := EventTypes{
+		Add:    announcements.ServiceAdded,
+		Update: announcements.ServiceUpdated,
+		Delete: announcements.ServiceDeleted,
+	}
+	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.announcements[Services], shouldObserve, nil, svcEventTypes))
 }
 
 func (c *Client) initPodMonitor() {
@@ -90,7 +100,12 @@ func (c *Client) initPodMonitor() {
 	// Announcement channel for Pods
 	c.announcements[Pods] = make(chan announcements.Announcement)
 
-	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Pods], shouldObserve, nil, nil))
+	podEventTypes := EventTypes{
+		Add:    announcements.PodAdded,
+		Update: announcements.PodUpdated,
+		Delete: announcements.PodDeleted,
+	}
+	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.announcements[Pods], shouldObserve, nil, podEventTypes))
 }
 
 func (c *Client) run(stop <-chan struct{}) error {

--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -6,7 +6,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
+	a "github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -16,92 +16,68 @@ var emitLogs = os.Getenv(constants.EnvVarLogKubernetesEvents) == "true"
 // This filter could be added optionally by anything using GetKubernetesEventHandlers()
 type observeFilter func(obj interface{}) bool
 
+// EventTypes is a struct helping pass the correct types to GetKubernetesEventHandlers
+type EventTypes struct {
+	Add    a.AnnouncementType
+	Update a.AnnouncementType
+	Delete a.AnnouncementType
+}
+
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
-func GetKubernetesEventHandlers(informerName string, providerName string, announcements chan announcements.Announcement, shouldObserve observeFilter, remap map[EventType]announcements.AnnouncementType, getObjID func(obj interface{}) interface{}) cache.ResourceEventHandlerFuncs {
+func GetKubernetesEventHandlers(informerName, providerName string, announce chan a.Announcement, shouldObserve observeFilter, getObjID func(obj interface{}) interface{}, eventTypes EventTypes) cache.ResourceEventHandlerFuncs {
 	if shouldObserve == nil {
 		shouldObserve = func(obj interface{}) bool { return true }
 	}
+
+	sendAnnouncement := func(eventType a.AnnouncementType, obj interface{}) {
+		if emitLogs {
+			log.Trace().Msgf("[%s][%s] %s event: %+v", providerName, informerName, eventType, obj)
+		}
+
+		if announce == nil {
+			return
+		}
+
+		ann := a.Announcement{
+			Type: eventType,
+		}
+
+		// getObjID is a function which has enough context to establish a
+		// ReferenceObjectID from the object for which this event occurred.
+		// For example the ReferenceObjectID for a Pod would be the Pod's UID.
+		// The getObjID function is optional;
+		if getObjID != nil {
+			ann.ReferencedObjectID = getObjID(obj)
+		}
+
+		announce <- ann
+	}
+
 	return cache.ResourceEventHandlerFuncs{
-		AddFunc:    addEvent(informerName, providerName, announcements, shouldObserve, AddEvent, remap, getObjID),
-		UpdateFunc: updateEvent(informerName, providerName, announcements, shouldObserve, UpdateEvent, remap, getObjID),
-		DeleteFunc: deleteEvent(informerName, providerName, announcements, shouldObserve, DeleteEvent, remap, getObjID),
-	}
-}
 
-func addEvent(informerName string, providerName string, announce chan announcements.Announcement, shouldObserve observeFilter, eventType EventType, remap map[EventType]announcements.AnnouncementType, getObjID func(obj interface{}) interface{}) func(obj interface{}) {
-	return func(obj interface{}) {
-		if !shouldObserve(obj) {
-			logNotObservedNamespace(obj, eventType)
-			return
-		}
-
-		logEvent(eventType, providerName, informerName, obj)
-		if announce == nil {
-			return
-		}
-
-		ann := announcements.Announcement{}
-		if remap != nil {
-			if announcementType, ok := remap[eventType]; ok {
-				ann.Type = announcementType
+		AddFunc: func(obj interface{}) {
+			if !shouldObserve(obj) {
+				logNotObservedNamespace(obj, eventTypes.Add)
+				return
 			}
-		}
+			sendAnnouncement(eventTypes.Add, obj)
+		},
 
-		if getObjID != nil {
-			ann.ReferencedObjectID = getObjID(obj)
-		}
-
-		announce <- ann
-	}
-}
-
-func updateEvent(informerName string, providerName string, announce chan announcements.Announcement, shouldObserve observeFilter, eventType EventType, remap map[EventType]announcements.AnnouncementType, getObjID func(obj interface{}) interface{}) func(oldObj, newObj interface{}) {
-	return func(oldObj, newObj interface{}) {
-		if !shouldObserve(newObj) {
-			logNotObservedNamespace(newObj, eventType)
-			return
-		}
-		logEvent(eventType, providerName, informerName, oldObj)
-		if announce == nil {
-			return
-		}
-		ann := announcements.Announcement{}
-		if remap != nil {
-			if announcementType, ok := remap[eventType]; ok {
-				ann.Type = announcementType
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			if !shouldObserve(newObj) {
+				logNotObservedNamespace(newObj, eventTypes.Update)
+				return
 			}
-		}
+			sendAnnouncement(eventTypes.Update, oldObj)
+		},
 
-		if getObjID != nil {
-			ann.ReferencedObjectID = getObjID(oldObj)
-		}
-
-		announce <- ann
-	}
-}
-
-func deleteEvent(informerName string, providerName string, announce chan announcements.Announcement, shouldObserve observeFilter, eventType EventType, remap map[EventType]announcements.AnnouncementType, getObjID func(obj interface{}) interface{}) func(obj interface{}) {
-	return func(obj interface{}) {
-		if !shouldObserve(obj) {
-			logNotObservedNamespace(obj, eventType)
-			return
-		}
-		logEvent(eventType, providerName, informerName, obj)
-		if announce == nil {
-			return
-		}
-		ann := announcements.Announcement{}
-		if remap != nil {
-			if announcementType, ok := remap[eventType]; ok {
-				ann.Type = announcementType
+		DeleteFunc: func(obj interface{}) {
+			if !shouldObserve(obj) {
+				logNotObservedNamespace(obj, eventTypes.Delete)
+				return
 			}
-		}
-
-		if getObjID != nil {
-			ann.ReferencedObjectID = getObjID(obj)
-		}
-
-		announce <- ann
+			sendAnnouncement(eventTypes.Delete, obj)
+		},
 	}
 }
 
@@ -109,14 +85,8 @@ func getNamespace(obj interface{}) string {
 	return reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 }
 
-func logNotObservedNamespace(obj interface{}, eventType EventType) {
+func logNotObservedNamespace(obj interface{}, eventType a.AnnouncementType) {
 	if emitLogs {
 		log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring %s event", getNamespace(obj), eventType)
-	}
-}
-
-func logEvent(eventType EventType, providerName, informerName string, obj interface{}) {
-	if emitLogs {
-		log.Trace().Msgf("[%s][%s] %s event: %+v", providerName, informerName, eventType, obj)
 	}
 }

--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Testing event handlers", func() {
 		It("Should add the event to the announcement channel", func() {
 			ann := make(chan announcements.Announcement, 1)
 			pod := tests.NewPodTestFixture(testNamespace, "pod-name")
-			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD")(&pod)
+			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD", nil, nil)(&pod)
 			Expect(len(ann)).To(Equal(1))
 			<-ann
 		})
@@ -38,7 +38,7 @@ var _ = Describe("Testing event handlers", func() {
 			ann := make(chan announcements.Announcement, 1)
 			var pod corev1.Pod
 			pod.Namespace = "not-a-monitored-namespace"
-			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD")(&pod)
+			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD", nil, nil)(&pod)
 			Expect(len(ann)).To(Equal(0))
 		})
 	})

--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -27,19 +27,32 @@ var _ = Describe("Testing event handlers", func() {
 		}
 
 		It("Should add the event to the announcement channel", func() {
-			ann := make(chan announcements.Announcement, 1)
+			annCh := make(chan announcements.Announcement, 1)
 			pod := tests.NewPodTestFixture(testNamespace, "pod-name")
-			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD", nil, nil)(&pod)
-			Expect(len(ann)).To(Equal(1))
-			<-ann
+			eventTypes := EventTypes{
+				Add:    announcements.PodAdded,
+				Update: announcements.PodUpdated,
+				Delete: announcements.PodDeleted,
+			}
+			handlers := GetKubernetesEventHandlers(testInformer, testProvider, annCh, shouldObserve, nil, eventTypes)
+			handlers.AddFunc(&pod)
+			Expect(len(annCh)).To(Equal(1))
+			announcement := <-annCh
+
+			expected := announcements.Announcement{
+				Type:               announcements.PodAdded,
+				ReferencedObjectID: nil,
+			}
+			Expect(announcement).To(Equal(expected))
 		})
 
 		It("Should not add the event to the announcement channel", func() {
-			ann := make(chan announcements.Announcement, 1)
+			annCh := make(chan announcements.Announcement, 1)
 			var pod corev1.Pod
 			pod.Namespace = "not-a-monitored-namespace"
-			addEvent(testInformer, testProvider, ann, shouldObserve, "ADD", nil, nil)(&pod)
-			Expect(len(ann)).To(Equal(0))
+			handlers := GetKubernetesEventHandlers(testInformer, testProvider, annCh, shouldObserve, nil, EventTypes{})
+			handlers.AddFunc(&pod)
+			Expect(len(annCh)).To(Equal(0))
 		})
 	})
 

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -144,13 +144,13 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 		return kubeController.IsMonitoredNamespace(ns)
 	}
-	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", client.announcements, shouldObserve))
-	informerCollection.HTTPRouteGroup.AddEventHandler(k8s.GetKubernetesEventHandlers("HTTPRouteGroup", "SMI", client.announcements, shouldObserve))
-	informerCollection.TCPRoute.AddEventHandler(k8s.GetKubernetesEventHandlers("TCPRoute", "SMI", client.announcements, shouldObserve))
-	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", client.announcements, shouldObserve))
+	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", client.announcements, shouldObserve, nil, nil))
+	informerCollection.HTTPRouteGroup.AddEventHandler(k8s.GetKubernetesEventHandlers("HTTPRouteGroup", "SMI", client.announcements, shouldObserve, nil, nil))
+	informerCollection.TCPRoute.AddEventHandler(k8s.GetKubernetesEventHandlers("TCPRoute", "SMI", client.announcements, shouldObserve, nil, nil))
+	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", client.announcements, shouldObserve, nil, nil))
 
 	if featureflags.IsBackpressureEnabled() {
-		informerCollection.Backpressure.AddEventHandler(k8s.GetKubernetesEventHandlers("Backpressure", "SMI", client.announcements, shouldObserve))
+		informerCollection.Backpressure.AddEventHandler(k8s.GetKubernetesEventHandlers("Backpressure", "SMI", client.announcements, shouldObserve, nil, nil))
 	}
 
 	err := client.run(stop)


### PR DESCRIPTION
This PR continues the work started in https://github.com/openservicemesh/osm/pull/2010 and contributes towards resolving issue https://github.com/openservicemesh/osm/issues/1719

This PR adds announcement types (add, delete, update) for Pods and Kubernetes Endpoints.
This also changes `GetKubernetesEventHandlers()` so it emits the appropriate `AnnouncementType` based on which Kubernetes object is observed.

With this change the following block of code, which handles these announcement messages will have access to a) the type and b) the UID of the relevant object:

https://github.com/openservicemesh/osm/blob/e50d75b636b29c2f052dd92e61fe0f1e6e5c21e8/pkg/catalog/repeater.go#L21-L37

This is currently only implemented for Pods and Endpoints.  The work to populate the other kind of events we observe will happen in follow-up PRs.

---



**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
