### PR TITLE
kube: Refactor Event Types

### DIFF
--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -17,17 +17,21 @@ var (
 )
 
 // EventType is the type of event we have received from Kubernetes
-type EventType int
+type EventType string
+
+func (et EventType) String() string {
+	return string(et)
+}
 
 const (
-	// CreateEvent is a type of a Kubernetes API event.
-	CreateEvent EventType = iota + 1
+	// AddEvent is a type of a Kubernetes API event.
+	AddEvent EventType = "ADD"
 
 	// UpdateEvent is a type of a Kubernetes API event.
-	UpdateEvent
+	UpdateEvent EventType = "UPDATE"
 
 	// DeleteEvent is a type of a Kubernetes API event.
-	DeleteEvent
+	DeleteEvent EventType = "DELETE"
 )
 
 const (


### PR DESCRIPTION
This PR is a small refactor of the Kubernetes eventing system;  Goal is to remove unused code and specialize a type. This PR:

  - removes the unused `EventType int` type and creates a new `EventType string`
  - changes the type of the ADD/DELETE/UPDATE constants to `EventType`
  - changes the signatures of the functions using these (from `string`, to `EventType`)

This PR is in preparation for https://github.com/openservicemesh/osm/pull/2028 and https://github.com/openservicemesh/osm/pull/1956 and is a small step forward towards solving GitHub issue https://github.com/openservicemesh/osm/issues/1719

---


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
