### PR TITLE
catalog: Rename broadcast to broadcastToAllProxies for context and clarity

### DIFF
--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -25,7 +25,7 @@ func (mc *MeshCatalog) repeater() {
 					log.Trace().Msgf("Received announcement from %s", caseNames[chosenIdx])
 					delta := time.Since(lastUpdateAt)
 					if delta >= updateAtMostEvery {
-						mc.broadcast(ann)
+						mc.broadcastToAllProxies(ann)
 						lastUpdateAt = time.Now()
 					}
 				}
@@ -51,10 +51,10 @@ func (mc *MeshCatalog) getCases() ([]reflect.SelectCase, []string) {
 	return cases, caseNames
 }
 
-func (mc *MeshCatalog) broadcast(message announcements.Announcement) {
+func (mc *MeshCatalog) broadcastToAllProxies(message announcements.Announcement) {
 	mc.connectedProxiesLock.Lock()
 	for _, connectedEnvoy := range mc.connectedProxies {
-		log.Debug().Msgf("[repeater] Broadcast announcement to envoy %s", connectedEnvoy.proxy.GetCommonName())
+		log.Debug().Msgf("[repeater] Broadcast announcement to Envoy with CN %s", connectedEnvoy.proxy.GetCommonName())
 		select {
 		// send the message if possible - do not block
 		case connectedEnvoy.proxy.GetAnnouncementsChannel() <- message:


### PR DESCRIPTION
This PR renames the `broadcast()` function to `broadcastToAllProxies()` to add context and clarity -- upon reading one would know **to what** this is sending messages.

---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
