### PR TITLE
feat(pkg/catalog): Add routesFromRules func

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -431,7 +431,6 @@ func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, traffic
 				log.Debug().Msgf("No matching trafficpolicy.HTTPRoute found for match name %s in Traffic Spec %s (in namespace %s)", match, trafficSpecName, trafficTargetNamespace)
 			}
 		}
-
 	}
 
 	return routes, nil

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -406,8 +406,9 @@ func (mc *MeshCatalog) listTrafficTargetPermutations(trafficTarget target.Traffi
 	return trafficPolicies, nil
 }
 
-// routesFromRules takes a set of traffic target rules and a namespace and returns a list of http routes (trafficpolicy.HTTPRoute)
-func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, namespace string) ([]trafficpolicy.HTTPRoute, error) {
+// routesFromRules takes a set of traffic target rules and the namespace of the traffic target and returns a list of
+//	http routes (trafficpolicy.HTTPRoute)
+func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, trafficTargetNamespace string) ([]trafficpolicy.HTTPRoute, error) {
 	routes := []trafficpolicy.HTTPRoute{}
 
 	specMatchRoute, err := mc.getHTTPPathsPerRoute() // returns map[traffic_spec_name]map[match_name]trafficpolicy.HTTPRoute
@@ -421,13 +422,13 @@ func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, namespa
 	}
 
 	for _, rule := range rules {
-		trafficSpecName := mc.getTrafficSpecName("HTTPRouteGroup", namespace, rule.Name)
+		trafficSpecName := mc.getTrafficSpecName("HTTPRouteGroup", trafficTargetNamespace, rule.Name)
 		for _, match := range rule.Matches {
 			matchedRoute, found := specMatchRoute[trafficSpecName][trafficpolicy.TrafficSpecMatchName(match)]
 			if found {
 				routes = append(routes, matchedRoute)
 			} else {
-				log.Debug().Msgf("No matching trafficpolicy.HTTPRoute found for match name %s in Traffic Spec %s (in namespace %s)", match, trafficSpecName, namespace)
+				log.Debug().Msgf("No matching trafficpolicy.HTTPRoute found for match name %s in Traffic Spec %s (in namespace %s)", match, trafficSpecName, trafficTargetNamespace)
 			}
 		}
 

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -66,9 +66,7 @@ func TestRoutesFromRules(t *testing.T) {
 			assert.Nil(err)
 			assert.EqualValues(tc.expectedRoutes, routes)
 		})
-
 	}
-
 }
 
 func TestListTrafficPolicies(t *testing.T) {

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -27,6 +27,7 @@ func TestRoutesFromRules(t *testing.T) {
 		expectedRoutes []trafficpolicy.HTTPRoute
 	}{
 		{
+			name: "http route group and match name exist",
 			rules: []target.TrafficTargetRule{
 				{
 					Kind:    "HTTPRouteGroup",
@@ -46,6 +47,7 @@ func TestRoutesFromRules(t *testing.T) {
 			},
 		},
 		{
+			name: "http route group and match name do not exist",
 			rules: []target.TrafficTargetRule{
 				{
 					Kind:    "HTTPRouteGroup",
@@ -59,9 +61,12 @@ func TestRoutesFromRules(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		routes, err := mc.routesFromRules(tc.rules, tc.namespace)
-		assert.Nil(err)
-		assert.EqualValues(tc.expectedRoutes, routes)
+		t.Run(fmt.Sprintf("Testing routesFromRules where %s", tc.name), func(t *testing.T) {
+			routes, err := mc.routesFromRules(tc.rules, tc.namespace)
+			assert.Nil(err)
+			assert.EqualValues(tc.expectedRoutes, routes)
+		})
+
 	}
 
 }


### PR DESCRIPTION
This func allows one to get a list of trafficpolicy.HTTPRoute objects from a set of rules from an SMI Traffic Target resource. The larger change can be seen in #2035 where routesFromRules is named HTTPRoutesFromRules (renamed to allow for the function to later also return TCPRoutes from rules in the future).

There are no functional changes to the system in this PR. It is part of #2034 and a chunk of #2035.


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
