### PR TITLE
feat(pkg/catalog): Add GetServicesForServiceAccounts func 

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -439,7 +439,7 @@ func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, traffic
 // GetServicesForServiceAccounts returns a list of services corresponding to a list service accounts
 //	TODO: Consider merging this function and mc.GetServicesForServiceAccount in future (#2038)
 func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sServiceAccount) []service.MeshService {
-	serviceList := []service.MeshService{}
+	serviceMap := map[service.MeshService]int{}
 
 	for _, sa := range saList {
 		services, err := mc.GetServicesForServiceAccount(sa)
@@ -447,8 +447,15 @@ func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sService
 			log.Error().Msgf("Error getting services linked to Service Account %s: %v", sa, err)
 			continue
 		} else {
-			serviceList = append(serviceList, services...)
+			for _, s := range services {
+				serviceMap[s] = 1
+			}
 		}
+	}
+
+	serviceList := []service.MeshService{}
+	for k := range serviceMap {
+		serviceList = append(serviceList, k)
 	}
 
 	return serviceList

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -437,6 +437,7 @@ func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, traffic
 }
 
 // GetServicesForServiceAccounts returns a list of services corresponding to a list service accounts
+//	TODO: Consider merging this function and mc.GetServicesForServiceAccount in future (#2038)
 func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sServiceAccount) []service.MeshService {
 	serviceList := []service.MeshService{}
 

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -435,3 +435,19 @@ func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, traffic
 
 	return routes, nil
 }
+
+// GetServicesForServiceAccounts returns a list of services corresponding to a list service accounts
+func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sServiceAccount) []service.MeshService {
+	serviceList := []service.MeshService{}
+
+	for _, sa := range saList {
+		services, err := mc.GetServicesForServiceAccount(sa)
+		if err != nil {
+			log.Error().Msgf("Error getting services linked to Service Account %s: %v", sa, err)
+			continue
+		}
+		serviceList = append(serviceList, services...)
+	}
+
+	return serviceList
+}

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -439,7 +439,7 @@ func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, traffic
 // GetServicesForServiceAccounts returns a list of services corresponding to a list service accounts
 //	TODO: Consider merging this function and mc.GetServicesForServiceAccount in future (#2038)
 func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sServiceAccount) []service.MeshService {
-	serviceMap := map[service.MeshService]int{}
+	serviceMap := map[service.MeshService]bool{}
 
 	for _, sa := range saList {
 		services, err := mc.GetServicesForServiceAccount(sa)
@@ -448,7 +448,7 @@ func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sService
 			continue
 		} else {
 			for _, s := range services {
-				serviceMap[s] = 1
+				serviceMap[s] = true
 			}
 		}
 	}

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -446,8 +446,9 @@ func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sService
 		if err != nil {
 			log.Error().Msgf("Error getting services linked to Service Account %s: %v", sa, err)
 			continue
+		} else {
+			serviceList = append(serviceList, services...)
 		}
-		serviceList = append(serviceList, services...)
 	}
 
 	return serviceList

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -35,16 +35,8 @@ func TestRoutesFromRules(t *testing.T) {
 					Matches: []string{tests.BuyBooksMatchName},
 				},
 			},
-			namespace: tests.Namespace,
-			expectedRoutes: []trafficpolicy.HTTPRoute{
-				{
-					PathRegex: tests.BookstoreBuyPath,
-					Methods:   []string{"GET"},
-					Headers: map[string]string{
-						"user-agent": tests.HTTPUserAgent,
-					},
-				},
-			},
+			namespace:      tests.Namespace,
+			expectedRoutes: []trafficpolicy.HTTPRoute{tests.BookstoreBuyHTTPRoute},
 		},
 		{
 			name: "http route group and match name do not exist",

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -35,6 +35,14 @@ func TestGetServicesForServiceAccounts(t *testing.T) {
 			input:    []service.K8sServiceAccount{tests.BookbuyerServiceAccount},
 			expected: []service.MeshService{tests.BookbuyerService},
 		},
+		{
+			name: "service account does not exist",
+			input: []service.K8sServiceAccount{service.K8sServiceAccount{
+				Name:      "DoesNotExist",
+				Namespace: "default",
+			}},
+			expected: []service.MeshService{},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -16,6 +16,35 @@ import (
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
+func TestGetServicesForServiceAccounts(t *testing.T) {
+	assert := assert.New(t)
+	mc := newFakeMeshCatalog()
+
+	testCases := []struct {
+		name     string
+		input    []service.K8sServiceAccount
+		expected []service.MeshService
+	}{
+		{
+			name:     "multiple service accounts and services",
+			input:    []service.K8sServiceAccount{tests.BookstoreServiceAccount, tests.BookbuyerServiceAccount},
+			expected: []service.MeshService{tests.BookbuyerService, tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
+		},
+		{
+			name:     "single service account and service",
+			input:    []service.K8sServiceAccount{tests.BookbuyerServiceAccount},
+			expected: []service.MeshService{tests.BookbuyerService},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing GetServicesForServiceAccounts where %s", tc.name), func(t *testing.T) {
+			actual := mc.GetServicesForServiceAccounts(tc.input)
+			assert.ElementsMatch(tc.expected, actual)
+		})
+	}
+}
+
 func TestRoutesFromRules(t *testing.T) {
 	assert := assert.New(t)
 	mc := MeshCatalog{meshSpec: smi.NewFakeMeshSpecClient()}

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -37,11 +37,16 @@ func TestGetServicesForServiceAccounts(t *testing.T) {
 		},
 		{
 			name: "service account does not exist",
-			input: []service.K8sServiceAccount{service.K8sServiceAccount{
+			input: []service.K8sServiceAccount{{
 				Name:      "DoesNotExist",
 				Namespace: "default",
 			}},
 			expected: []service.MeshService{},
+		},
+		{
+			name:     "duplicate service accounts and services",
+			input:    []service.K8sServiceAccount{tests.BookbuyerServiceAccount, tests.BookbuyerServiceAccount},
+			expected: []service.MeshService{tests.BookbuyerService},
 		},
 	}
 

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -3,6 +3,8 @@ package kube
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -41,7 +43,7 @@ func (f fakeClient) ListEndpointsForService(svc service.MeshService) []endpoint.
 func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {
 	services, ok := f.services[svcAccount]
 	if !ok {
-		panic(fmt.Sprintf("ServiceAccount %s is not in cache: %+v", svcAccount, f.services))
+		return nil, errors.Errorf("ServiceAccount %s is not in cache: %+v", svcAccount, f.services)
 	}
 	return services, nil
 }


### PR DESCRIPTION
- This PR contains a function called GetServicesForServiceAccounts that returns a list of services corresponding
to a list service accounts. Part of #2034. See this change as part of the bigger change in #2035. There
are no functional changes to the system in this PR.
- This PR also updates and existing test to use an existing var



Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
