### PR TITLE
osm-deployment: parametrize osm log level in values.yaml

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -28,7 +28,7 @@ spec:
               containerPort: 15128
           command: ['/osm-controller']
           args: [
-            "--verbosity", "trace",
+            "--verbosity", "{{.Values.OpenServiceMesh.osmLogLevel}}",
             "--osm-namespace", "{{.Release.Namespace}}",
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--init-container-image", "{{.Values.OpenServiceMesh.image.registry}}/init:{{ .Values.OpenServiceMesh.image.tag }}",

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -28,7 +28,7 @@ spec:
               containerPort: 15128
           command: ['/osm-controller']
           args: [
-            "--verbosity", "{{.Values.OpenServiceMesh.osmLogLevel}}",
+            "--verbosity", "{{.Values.OpenServiceMesh.controllerLogLevel}}",
             "--osm-namespace", "{{.Release.Namespace}}",
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--init-container-image", "{{.Values.OpenServiceMesh.image.registry}}/init:{{ .Values.OpenServiceMesh.image.tag }}",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -43,7 +43,7 @@ OpenServiceMesh:
   meshName: osm
   useHTTPSIngress: false
   envoyLogLevel: error
-  osmLogLevel: trace
+  controllerLogLevel: trace
   enforceSingleMesh: false
 
   # Set deployJaeger to true to deploy a Jaeger cluster in the

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -43,6 +43,7 @@ OpenServiceMesh:
   meshName: osm
   useHTTPSIngress: false
   envoyLogLevel: error
+  osmLogLevel: trace
   enforceSingleMesh: false
 
   # Set deployJaeger to true to deploy a Jaeger cluster in the


### PR DESCRIPTION
Currently it's hardcoded in deployment.

This gives at least some short term flexibility till we add
configMap update, which has some ongoing discussion as
how to tackle.

- Install                [X]
- Control Plane          [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No