### PR TITLE
feat(*): add TrafficPolicy struct and helpers

### DIFF
--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -1,0 +1,136 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	specs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
+	"github.com/openservicemesh/osm/pkg/ingress"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+func newFakeMeshCatalogForRoutes(t *testing.T) *MeshCatalog {
+	mockCtrl := gomock.NewController(t)
+	kubeClient := testclient.NewSimpleClientset()
+
+	mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	mockKubeController := k8s.NewMockController(mockCtrl)
+	mockIngressMonitor := ingress.NewMockMonitor(mockCtrl)
+
+	endpointProviders := []endpoint.Provider{
+		kube.NewFakeProvider(),
+	}
+	stop := make(chan struct{})
+
+	cache := make(map[certificate.CommonName]certificate.Certificater)
+	certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
+
+	// Create a bookstoreV1 pod
+	bookstoreV1Pod := tests.NewPodTestFixtureWithOptions(tests.BookstoreV1Service.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName)
+	if _, err := kubeClient.CoreV1().Pods(tests.BookstoreV1Service.Namespace).Create(context.TODO(), &bookstoreV1Pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new pod: %s", err.Error())
+	}
+
+	// Create a bookstoreV2 pod
+	bookstoreV2Pod := tests.NewPodTestFixtureWithOptions(tests.BookstoreV2Service.Namespace, tests.BookstoreV2Service.Name, tests.BookstoreServiceAccountName)
+	if _, err := kubeClient.CoreV1().Pods(tests.BookstoreV2Service.Namespace).Create(context.TODO(), &bookstoreV2Pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new pod: %s", err.Error())
+	}
+
+	// Create a bookbuyer pod
+	bookbuyerPod := tests.NewPodTestFixtureWithOptions(tests.BookbuyerService.Namespace, tests.BookbuyerService.Name, tests.BookbuyerServiceAccountName)
+	if _, err := kubeClient.CoreV1().Pods(tests.BookbuyerService.Namespace).Create(context.TODO(), &bookbuyerPod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new pod: %s", err.Error())
+	}
+
+	// Create Bookstore-v1 Service
+	svc := tests.NewServiceFixture(tests.BookstoreV1Service.Name, tests.BookstoreV1Service.Namespace, map[string]string{"app": "bookstore", "version": "v1"})
+	if _, err := kubeClient.CoreV1().Services(tests.BookstoreV1Service.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new Bookstore v1 service: %s", err.Error())
+	}
+
+	// Create Bookstore-v2 Service
+	svc = tests.NewServiceFixture(tests.BookstoreV2Service.Name, tests.BookstoreV2Service.Namespace, map[string]string{"app": "bookstore", "version": "v2"})
+	if _, err := kubeClient.CoreV1().Services(tests.BookstoreV2Service.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new Bookstore v2 service: %s", err.Error())
+	}
+
+	// Create Bookstore-apex Service
+	svc = tests.NewServiceFixture(tests.BookstoreApexService.Name, tests.BookstoreApexService.Namespace, map[string]string{"app": "bookstore"})
+	if _, err := kubeClient.CoreV1().Services(tests.BookstoreApexService.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new Bookstore Apex service: %s", err.Error())
+	}
+
+	// Create Bookbuyer Service
+	svc = tests.NewServiceFixture(tests.BookbuyerService.Name, tests.BookbuyerService.Namespace, nil)
+	if _, err := kubeClient.CoreV1().Services(tests.BookbuyerService.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating new Bookbuyer service: %s", err.Error())
+	}
+
+	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
+	listExpectedNs := tests.GetUnique([]string{
+		tests.BookstoreV1Service.Namespace,
+		tests.BookbuyerService.Namespace,
+		tests.BookstoreApexService.Namespace,
+	})
+
+	announcementsChan := make(chan announcements.Announcement)
+
+	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsChan).AnyTimes()
+	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(getFakeIngresses(), nil).AnyTimes()
+
+	// #1683 tracks potential improvements to the following dynamic mocks
+	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {
+		// play pretend this call queries a controller cache
+		var services []*corev1.Service
+
+		for _, ns := range listExpectedNs {
+			// simulate lookup on controller cache
+			svcList, _ := kubeClient.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
+			for serviceIdx := range svcList.Items {
+				services = append(services, &svcList.Items[serviceIdx])
+			}
+		}
+
+		return services
+	}).AnyTimes()
+	mockKubeController.EXPECT().GetService(gomock.Any()).DoAndReturn(func(msh service.MeshService) *v1.Service {
+		// simulate lookup on controller cache
+		vv, err := kubeClient.CoreV1().Services(msh.Namespace).Get(context.TODO(), msh.Name, metav1.GetOptions{})
+
+		if err != nil {
+			return nil
+		}
+
+		return vv
+	}).AnyTimes()
+	mockKubeController.EXPECT().GetAnnouncementsChannel(k8s.Services).Return(announcementsChan).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
+	mockKubeController.EXPECT().ListMonitoredNamespaces().Return(listExpectedNs, nil).AnyTimes()
+
+	mockMeshSpec.EXPECT().GetAnnouncementsChannel().Return(announcementsChan).AnyTimes()
+	mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*target.TrafficTarget{&tests.TrafficTarget}).AnyTimes()
+	mockMeshSpec.EXPECT().ListHTTPTrafficSpecs().Return([]*specs.HTTPRouteGroup{&tests.HTTPRouteGroup}).AnyTimes()
+
+	return NewMeshCatalog(mockKubeController, kubeClient, mockMeshSpec, certManager,
+		mockIngressMonitor, stop, mockConfigurator, endpointProviders...)
+}

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -486,6 +486,9 @@ func (mc *MeshCatalog) buildTrafficPolicies(sourceServices, destServices []servi
 				continue
 			}
 			routesClusters := []trafficpolicy.RouteWeightedClusters{}
+			// When TrafficSplit v1alpha3 is implemented (#705), weighted clusters information should be passed into this function as a parameter
+			//	but since we are not implementing TrafficSplit v1alpha3 and only dealing with TrafficTargets for the initial routes refactor(#2034),
+			//	we use the default weighted clusters configuration for the given destination service (destService)
 			weightedClusters := mapset.NewSet(getDefaultWeightedClusterForService(destService))
 
 			for _, route := range routes {

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -460,3 +460,48 @@ func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sService
 
 	return serviceList
 }
+
+// GetHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
+// The hostname is the FQDN for the service, and can include ports as well.
+// Ex. bookstore.default, bookstore.default:80, bookstore.default.svc, bookstore.default.svc:80 etc.
+// TODO: replace GetResolvableHostnamesForUpstreamService with this func once routes refactor is complete (#issue)
+func (mc *MeshCatalog) GetHostnamesForUpstreamService(downstream, upstream service.MeshService) ([]string, error) {
+	sameNamespace := downstream.Namespace == upstream.Namespace
+	// The hostnames for this service are the Kubernetes service DNS names
+	hostnames, err := mc.getServiceHostnames(upstream, sameNamespace)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting service hostnames for upstream service %s", upstream)
+		return nil, err
+	}
+
+	return hostnames, nil
+}
+
+// buildTrafficPolicies takes a list of source services, destination services and routes and returns a list of traffic policies for all
+//	combinations of the given source and destination services
+func (mc *MeshCatalog) buildTrafficPolicies(sourceServices, destServices []service.MeshService, routes []trafficpolicy.HTTPRoute) (policies []*trafficpolicy.TrafficPolicy) {
+	for _, sourceService := range sourceServices {
+		for _, destService := range destServices {
+			if sourceService == destService {
+				continue
+			}
+			routesClusters := []trafficpolicy.RouteWeightedClusters{}
+			weightedClusters := mapset.NewSet(getDefaultWeightedClusterForService(destService))
+
+			for _, route := range routes {
+				routesClusters = append(routesClusters, trafficpolicy.RouteWeightedClusters{
+					HTTPRoute:        trafficpolicy.HTTPRoute(route),
+					WeightedClusters: weightedClusters,
+				})
+			}
+
+			hostnames, err := mc.GetHostnamesForUpstreamService(sourceService, destService)
+			if err != nil {
+				log.Error().Msgf("Err getting resolvable hostnames for source %v and destination %v service : %s", sourceService, destService, err)
+				continue
+			}
+			policies = append(policies, trafficpolicy.NewTrafficPolicy(sourceService, destService, routesClusters, hostnames))
+		}
+	}
+	return policies
+}

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -122,6 +122,34 @@ var (
 		Name:      BookwarehouseServiceName,
 	}
 
+	// BookstoreV1Hostnames are the hostnames for bookstore-v1 service
+	BookstoreV1Hostnames = []string{
+		"bookstore-v1",
+		"bookstore-v1.default",
+		"bookstore-v1.default.svc",
+		"bookstore-v1.default.svc.cluster",
+		"bookstore-v1.default.svc.cluster.local",
+		"bookstore-v1:8888",
+		"bookstore-v1.default:8888",
+		"bookstore-v1.default.svc:8888",
+		"bookstore-v1.default.svc.cluster:8888",
+		"bookstore-v1.default.svc.cluster.local:8888",
+	}
+
+	// BookstoreV2Hostnames are the hostnames for the bookstore-v2 service
+	BookstoreV2Hostnames = []string{
+		"bookstore-v2",
+		"bookstore-v2.default",
+		"bookstore-v2.default.svc",
+		"bookstore-v2.default.svc.cluster",
+		"bookstore-v2.default.svc.cluster.local",
+		"bookstore-v2:8888",
+		"bookstore-v2.default:8888",
+		"bookstore-v2.default.svc:8888",
+		"bookstore-v2.default.svc.cluster:8888",
+		"bookstore-v2.default.svc.cluster.local:8888",
+	}
+
 	// BookstoreBuyHTTPRoute is an HTTP route to buy books
 	BookstoreBuyHTTPRoute = trafficpolicy.HTTPRoute{
 		PathRegex: BookstoreBuyPath,

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -1,0 +1,18 @@
+package trafficpolicy
+
+import (
+	"fmt"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+// NewTrafficPolicy returns a new Traffic Policy given a source and destination service, a list of RouteWeightedClusters and hostnames
+func NewTrafficPolicy(source, dest service.MeshService, routesClusters []RouteWeightedClusters, hostnames []string) *TrafficPolicy {
+	return &TrafficPolicy{
+		Name:               fmt.Sprintf("%s-%s", dest.Name, dest.Namespace),
+		Source:             source,
+		Destination:        dest,
+		HTTPRoutesClusters: routesClusters,
+		Hostnames:          hostnames,
+	}
+}

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -1,0 +1,46 @@
+package trafficpolicy
+
+import (
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+func TestNewTrafficPolicy(t *testing.T) {
+	assert := assert.New(t)
+
+	source := service.MeshService{
+		Name:      "source-service",
+		Namespace: "source-ns",
+	}
+	dest := service.MeshService{
+		Name:      "dest-service",
+		Namespace: "dest-ns",
+	}
+	routesClusters := []RouteWeightedClusters{
+		{
+			HTTPRoute: HTTPRoute{
+				PathRegex: "/hello",
+			},
+			WeightedClusters: mapset.NewSet(service.WeightedCluster{
+				ClusterName: "dest-ns/dest-service",
+				Weight:      100,
+			}),
+		},
+	}
+	hostnames := []string{"dest-service.dest-ns"}
+
+	expected := &TrafficPolicy{
+		Name:               "dest-service-dest-ns",
+		Source:             source,
+		Destination:        dest,
+		HTTPRoutesClusters: routesClusters,
+		Hostnames:          hostnames,
+	}
+
+	actual := NewTrafficPolicy(source, dest, routesClusters, hostnames)
+	assert.Equal(expected, actual)
+}

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -27,6 +27,15 @@ type TrafficTarget struct {
 	HTTPRoutes  []HTTPRoute         `json:"http_route:omitempty"`
 }
 
+// TrafficPolicy represents route configuration from a source to a destination with an associated set of hostnames
+type TrafficPolicy struct {
+	Name               string                  `json:"name:omitempty"`
+	Destination        service.MeshService     `json:"destination:omitempty"`
+	Source             service.MeshService     `json:"source:omitempty"`
+	HTTPRoutesClusters []RouteWeightedClusters `json:"http_routes:omitempty"`
+	Hostnames          []string                `json:"hostnames:omitempty"`
+}
+
 // RouteWeightedClusters is a struct of an HTTPRoute, associated weighted clusters and the domains
 type RouteWeightedClusters struct {
 	HTTPRoute        HTTPRoute `json:"http_route:omitempty"`


### PR DESCRIPTION
- adds TrafficPolicy object to represent route configuration
between a source and a destination
- adds a buildTrafficPolicies function that takes a list of source services,
destination services, and routes and returns a list of traffic policies for each
source + destination combination
- adds a GetHostnamesForUpstreamService func to get a list of resolvable hostnames
for traffic policy

This PR includes no functional changes to the system. It is part of #2034. See #2035 for how it will integrate into the overall routes refactor work. As a follow up, `GetHostnamesForUpstreamService` should replace `GetResolvableHostnamesForUpstreamService` but the latter is left in the codebase for now to ensure nothing breaks during non functional changes and a clean transition to the new route programming logic (tracked via #2048) 


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
