### PR TITLE
ref(pkg/catalog): add convenience functions

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -261,7 +261,7 @@ func getTrafficPoliciesForService(mc *MeshCatalog, routePolicies map[trafficpoli
 
 	for _, trafficTargets := range mc.meshSpec.ListTrafficTargets() {
 		log.Debug().Msgf("Discovered TrafficTarget resource: %s/%s", trafficTargets.Namespace, trafficTargets.Name)
-		if trafficTargets.Spec.Rules == nil || len(trafficTargets.Spec.Rules) == 0 {
+		if !isValidTrafficTarget(trafficTargets) {
 			log.Error().Msgf("TrafficTarget %s/%s has no spec routes; Skipping...", trafficTargets.Namespace, trafficTargets.Name)
 			continue
 		}
@@ -507,4 +507,11 @@ func (mc *MeshCatalog) buildTrafficPolicies(sourceServices, destServices []servi
 		}
 	}
 	return policies
+}
+
+func isValidTrafficTarget(t *target.TrafficTarget) bool {
+	if t.Spec.Rules == nil || len(t.Spec.Rules) == 0 {
+		return false
+	}
+	return true
 }

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -84,3 +84,20 @@ func trafficTargetIdentityToSvcAccount(identity smiAccess.IdentityBindingSubject
 		Namespace: identity.Namespace,
 	}
 }
+
+// trafficTargetIdentitiesToSvcAccounts returns a list of Service Accounts from the given list of identities from a Traffic Target
+func trafficTargetIdentitiesToSvcAccounts(identities []smiAccess.IdentityBindingSubject) []service.K8sServiceAccount {
+	serviceAccountsMap := map[service.K8sServiceAccount]bool{}
+
+	for _, id := range identities {
+		sa := trafficTargetIdentityToSvcAccount(id)
+		serviceAccountsMap[sa] = true
+	}
+
+	serviceAccounts := []service.K8sServiceAccount{}
+	for k := range serviceAccountsMap {
+		serviceAccounts = append(serviceAccounts, k)
+	}
+
+	return serviceAccounts
+}

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -412,4 +413,34 @@ func TestTrafficTargetIdentityToSvcAccount(t *testing.T) {
 			assert.Equal(svcAccount, tc.expectedServiceAccount)
 		})
 	}
+}
+
+func TestTrafficTargetIdentitiesToSvcAccounts(t *testing.T) {
+	assert := assert.New(t)
+	input := []target.IdentityBindingSubject{
+		{
+			Kind:      "ServiceAccount",
+			Name:      "example1",
+			Namespace: "default1",
+		},
+		{
+			Kind:      "Name",
+			Name:      "example2",
+			Namespace: "default2",
+		},
+	}
+
+	expected := []service.K8sServiceAccount{
+		{
+			Name:      "example1",
+			Namespace: "default1",
+		},
+		{
+			Name:      "example2",
+			Namespace: "default2",
+		},
+	}
+
+	actual := trafficTargetIdentitiesToSvcAccounts(input)
+	assert.ElementsMatch(expected, actual)
 }


### PR DESCRIPTION
This PR adds some convenience functions and is part of #2034. More specifically it:
* add `trafficTargetIdentitiesToSvcAccounts` func
* add `isValidTrafficTarget` func

Validation of SMI resources has come up in the past and is being tracked in #172 so in the future isValidTrafficTarget should be replaced with the overall community solution for validating SMI resources (#2052)

There are no functional changes to the system in this PR. See #2035 for how these functions play into the overall refactor.


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
