### PR TITLE
Fix debug server and OSM Controller Manager

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -458,10 +458,13 @@ func createControllerManagerForOSMResources(certManager certificate.Manager) err
 	}
 
 	log.Info().Msg("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		log.Error().Err(err).Msg("problem running manager")
-		return err
-	}
-	log.Info().Msg("Successfully running controller manager")
+	go func() {
+		// mgr.Start() below will block until stopped
+		// See: https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.6/pkg/manager/internal.go#L507-L514
+		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+			log.Error().Err(err).Msg("problem running manager")
+		}
+	}()
+
 	return nil
 }


### PR DESCRIPTION
The `mgr.Start()` below blocks forever on line 255: https://github.com/openservicemesh/osm/compare/main...draychev:fix-controller-manager?expand=1#diff-fc4c2be496da13e6544e74c71a0fb5cc15b1f998fb1fbd471562411622ea4f8dR255


This prevents the DebugServer from ever starting.


---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
