### PR TITLE
Exclude tests/scenarios from test coverage tool

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -2,7 +2,7 @@
 
 set -aueo pipefail
 
-readarray -t modules < <(go list ./... | grep -v tests/e2e)
+readarray -t modules < <(go list ./... | grep -v tests/e2e | grep -v tests/scenarios)
 
 go test -timeout 120s \
    -failfast \


### PR DESCRIPTION
The `./tests/scenarios` directory appears as one with no test coverage. It should be excluded from our tool.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
