### PR TITLE
catalog: Convert connectedProxies to sync.Map

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -25,7 +25,6 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 		configurator:       cfg,
 
 		expectedProxies:     make(map[certificate.CommonName]expectedProxy),
-		connectedProxies:    make(map[certificate.CommonName]connectedProxy),
 		disconnectedProxies: make(map[certificate.CommonName]disconnectedProxy),
 
 		// Kubernetes needed to determine what Services a pod that connects to XDS belongs to.

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -18,20 +18,16 @@ func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
 
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
 func (mc *MeshCatalog) RegisterProxy(p *envoy.Proxy) {
-	mc.connectedProxiesLock.Lock()
-	mc.connectedProxies[p.CommonName] = connectedProxy{
+	mc.connectedProxies.Store(p.CommonName, connectedProxy{
 		proxy:       p,
 		connectedAt: time.Now(),
-	}
-	mc.connectedProxiesLock.Unlock()
+	})
 	log.Info().Msgf("Registered new proxy: CN=%v, ip=%v", p.GetCommonName(), p.GetIP())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
 func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	mc.connectedProxiesLock.Lock()
-	delete(mc.connectedProxies, p.CommonName)
-	mc.connectedProxiesLock.Unlock()
+	mc.connectedProxies.Delete(p.CommonName)
 
 	mc.disconnectedProxiesLock.Lock()
 	mc.disconnectedProxies[p.CommonName] = disconnectedProxy{

--- a/pkg/catalog/repeater.go
+++ b/pkg/catalog/repeater.go
@@ -57,14 +57,14 @@ func (mc *MeshCatalog) getCases() ([]reflect.SelectCase, []string) {
 }
 
 func (mc *MeshCatalog) broadcastToAllProxies(message announcements.Announcement) {
-	mc.connectedProxiesLock.Lock()
-	for _, connectedEnvoy := range mc.connectedProxies {
+	mc.connectedProxies.Range(func(_, connectedEnvoyInterface interface{}) bool {
+		connectedEnvoy := connectedEnvoyInterface.(connectedProxy)
 		log.Debug().Msgf("[repeater] Broadcast announcement to Envoy with CN %s", connectedEnvoy.proxy.GetCommonName())
 		select {
 		// send the message if possible - do not block
 		case connectedEnvoy.proxy.GetAnnouncementsChannel() <- message:
 		default:
 		}
-	}
-	mc.connectedProxiesLock.Unlock()
+		return true
+	})
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -38,8 +38,7 @@ type MeshCatalog struct {
 	expectedProxies     map[certificate.CommonName]expectedProxy
 	expectedProxiesLock sync.Mutex
 
-	connectedProxies     map[certificate.CommonName]connectedProxy
-	connectedProxiesLock sync.Mutex
+	connectedProxies sync.Map
 
 	disconnectedProxies     map[certificate.CommonName]disconnectedProxy
 	disconnectedProxiesLock sync.Mutex


### PR DESCRIPTION
To simplify things, this PR changes the 

```go
	connectedProxies     map[certificate.CommonName]connectedProxy		
	connectedProxiesLock sync.Mutex
```

with 

```
	connectedProxies sync.Map
```

There are 2 other similar fields that will be changed with another PR to keep things simple and clean.

---


Ran a quick test to verify the debug server works as expected;

![image](https://user-images.githubusercontent.com/49918230/99135384-d6171c80-25d6-11eb-8b18-ce4ae4f6dd3b.png)

---



**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
