### PR TITLE
vault: Carve out fetching of Issuing CA into a function

### DIFF
--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -23,7 +23,7 @@ const (
 	issuingCAField   = "issuing_ca"
 
 	checkCertificateExpirationInterval = 5 * time.Second
-	tmpCertValidityPeriod              = 1 * time.Second
+	decade                             = 8765 * time.Hour
 )
 
 // NewCertManager implements certificate.Manager and wraps a Hashi Vault with methods to allow easy certificate issuance.
@@ -47,23 +47,37 @@ func NewCertManager(vaultAddr, token string, vaultRole string, cfg configurator.
 
 	c.client.SetToken(token)
 
-	// Create a temp certificate to determine the issuing CA
-	tmpCert, err := c.issue("localhost", tmpCertValidityPeriod)
+	issuingCA, err := c.getIssuingCA(c.issue)
 	if err != nil {
 		return nil, err
 	}
 
 	c.ca = &Certificate{
 		commonName: constants.CertificationAuthorityCommonName,
-		expiration: time.Now().Add(8765 * time.Hour), // a decade
-		certChain:  tmpCert.GetIssuingCA(),
-		issuingCA:  tmpCert.GetIssuingCA(),
+		expiration: time.Now().Add(decade),
+		certChain:  issuingCA,
+		issuingCA:  issuingCA,
 	}
 
 	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.
 	rotor.New(c).Start(checkCertificateExpirationInterval)
 
 	return c, nil
+}
+
+func (cm *CertManager) getIssuingCA(issue func(certificate.CommonName, time.Duration) (certificate.Certificater, error)) ([]byte, error) {
+	// Create a temp certificate to determine the public part of the issuing CA
+	cert, err := issue("localhost", decade)
+	if err != nil {
+		return nil, err
+	}
+
+	issuingCA := cert.GetIssuingCA()
+
+	// We are not going to need this certificate - remove it
+	cm.ReleaseCertificate(cert.GetCommonName())
+
+	return issuingCA, err
 }
 
 func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
@@ -122,6 +136,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 
 // ReleaseCertificate is called when a cert will no longer be needed and should be removed from the system.
 func (cm *CertManager) ReleaseCertificate(cn certificate.CommonName) {
+	// TODO(draychev): implement Hashicorp Vault delete-cert API here: https://github.com/openservicemesh/osm/issues/2068
 	cm.deleteFromCache(cn)
 }
 

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -4,10 +4,11 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	"github.com/hashicorp/vault/api"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -105,6 +106,24 @@ var _ = Describe("Test client helpers", func() {
 			},
 			ca: rootCert,
 		}
+
+		It("gets issuing CA public part", func() {
+			expectedNumberOfCertsInCache := 2
+			Expect(len(*cm.cache)).To(Equal(expectedNumberOfCertsInCache))
+			certBytes := uuid.New().String()
+			issue := func(certificate.CommonName, time.Duration) (certificate.Certificater, error) {
+				cert := Certificate{
+					issuingCA: pem.RootCertificate(certBytes),
+				}
+				return cert, nil
+			}
+			issuingCA, err := cm.getIssuingCA(issue)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Ensure that cache is NOT affected
+			Expect(issuingCA).To(Equal([]byte(certBytes)))
+			Expect(len(*cm.cache)).To(Equal(expectedNumberOfCertsInCache))
+		})
 
 		It("gets certs from cache", func() {
 			// This cert does not exist - returns nil


### PR DESCRIPTION
The goal of this PR is to carve out the function figuring out the Issuing CA for the connected Hashicorp Vault in a separate function.

This obviously adds more code and still does the same thing.  The idea is to eventually implement `pki/revoke` in the Hashi Vault API via the `ReleaseCertificate` function, so that the temp certificate does not linger around Vault and is never renewed etc.

The `pki/revoke` API call to Hashicorp Vault will happen as part of this GitHub Issue: https://github.com/openservicemesh/osm/issues/2068


ref https://github.com/openservicemesh/osm/pull/2070 https://github.com/openservicemesh/osm/issues/507



---



<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
