### PR TITLE
certificate: Adding GetSerialNumber() to Certificater interface

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -537,6 +537,9 @@ type Certificater interface {
 
 	// GetExpiration() returns the expiration of the certificate
 	GetExpiration() time.Time
+
+ 	// GetSerialNumber returns the serial number of the given certificate.
+ 	GetSerialNumber() string
 }
 ```
 

--- a/pkg/certificate/mock_certificate.go
+++ b/pkg/certificate/mock_certificate.go
@@ -91,6 +91,14 @@ func (mr *MockCertificaterMockRecorder) GetIssuingCA() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIssuingCA", reflect.TypeOf((*MockCertificater)(nil).GetIssuingCA))
 }
 
+// GetSerialNumber mocks base method
+func (m *MockCertificater) GetSerialNumber() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSerialNumber")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
 // GetExpiration mocks base method
 func (m *MockCertificater) GetExpiration() time.Time {
 	m.ctrl.T.Helper()

--- a/pkg/certificate/providers/certmanager/certificate.go
+++ b/pkg/certificate/providers/certmanager/certificate.go
@@ -30,3 +30,8 @@ func (c Certificate) GetIssuingCA() []byte {
 func (c Certificate) GetExpiration() time.Time {
 	return c.expiration
 }
+
+// GetSerialNumber returns the serial number of the given certificate.
+func (c Certificate) GetSerialNumber() string {
+	panic("NotImplemented")
+}

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -38,6 +38,11 @@ func (c Certificate) GetExpiration() time.Time {
 	return c.expiration
 }
 
+// GetSerialNumber returns the serial number of the given certificate.
+func (c Certificate) GetSerialNumber() string {
+	panic("NotImplemented")
+}
+
 // LoadCA loads the certificate and its key from the supplied PEM files.
 func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
 	pemCert, err := certificate.LoadCertificateFromFile(certFilePEM)

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -235,5 +235,5 @@ func newCert(cn certificate.CommonName, secret *api.Secret, expiration time.Time
 
 // GetSerialNumber returns the serial number of the given certificate.
 func (c Certificate) GetSerialNumber() string {
-	panic("NotImplemented")
+	return c.serialNumber
 }

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -225,3 +225,8 @@ func newCert(cn certificate.CommonName, secret *api.Secret, expiration time.Time
 		issuingCA:  pem.RootCertificate(secret.Data[issuingCAField].(string)),
 	}
 }
+
+// GetSerialNumber returns the serial number of the given certificate.
+func (c Certificate) GetSerialNumber() string {
+	panic("NotImplemented")
+}

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -18,9 +18,12 @@ import (
 var log = logger.New("vault")
 
 const (
-	certificateField = "certificate"
-	privateKeyField  = "private_key"
-	issuingCAField   = "issuing_ca"
+	// The string value of the JSON key containing the certificate's Serial Number.
+	// See: https://www.vaultproject.io/api-docs/secret/pki#sample-response-8
+	serialNumberField = "serial_number"
+	certificateField  = "certificate"
+	privateKeyField   = "private_key"
+	issuingCAField    = "issuing_ca"
 
 	checkCertificateExpirationInterval = 5 * time.Second
 	tmpCertValidityPeriod              = 1 * time.Second
@@ -189,6 +192,9 @@ type Certificate struct {
 
 	// Certificate authority signing this certificate.
 	issuingCA pem.RootCertificate
+
+	// serialNumber is the serial_number value in the Data filed assigned to the Certificate Hashicorp Vault issued
+	serialNumber string
 }
 
 // GetCommonName returns the common name of the given certificate.
@@ -218,11 +224,12 @@ func (c Certificate) GetExpiration() time.Time {
 
 func newCert(cn certificate.CommonName, secret *api.Secret, expiration time.Time) *Certificate {
 	return &Certificate{
-		commonName: cn,
-		expiration: expiration,
-		certChain:  pem.Certificate(secret.Data[certificateField].(string)),
-		privateKey: []byte(secret.Data[privateKeyField].(string)),
-		issuingCA:  pem.RootCertificate(secret.Data[issuingCAField].(string)),
+		commonName:   cn,
+		expiration:   expiration,
+		certChain:    pem.Certificate(secret.Data[certificateField].(string)),
+		privateKey:   []byte(secret.Data[privateKeyField].(string)),
+		issuingCA:    pem.RootCertificate(secret.Data[issuingCAField].(string)),
+		serialNumber: secret.Data[serialNumberField].(string),
 	}
 }
 

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -193,7 +193,7 @@ type Certificate struct {
 	// Certificate authority signing this certificate.
 	issuingCA pem.RootCertificate
 
-	// serialNumber is the serial_number value in the Data filed assigned to the Certificate Hashicorp Vault issued
+	// serialNumber is the serial_number value in the Data field assigned to the Certificate Hashicorp Vault issued
 	serialNumber string
 }
 

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -75,9 +75,10 @@ var _ = Describe("Test client helpers", func() {
 
 			secret := &api.Secret{
 				Data: map[string]interface{}{
-					certificateField: "xx",
-					privateKeyField:  "yy",
-					issuingCAField:   "zz",
+					certificateField:  "xx",
+					privateKeyField:   "yy",
+					issuingCAField:    "zz",
+					serialNumberField: "123",
 				},
 			}
 
@@ -86,11 +87,12 @@ var _ = Describe("Test client helpers", func() {
 			actual := newCert(cn, secret, expiration)
 
 			expected := &Certificate{
-				issuingCA:  pem.RootCertificate("zz"),
-				privateKey: pem.PrivateKey("yy"),
-				certChain:  pem.Certificate("xx"),
-				expiration: expiration,
-				commonName: "foo.bar.co.uk",
+				issuingCA:    pem.RootCertificate("zz"),
+				privateKey:   pem.PrivateKey("yy"),
+				certChain:    pem.Certificate("xx"),
+				expiration:   expiration,
+				commonName:   "foo.bar.co.uk",
+				serialNumber: "123",
 			}
 
 			Expect(actual).To(Equal(expected))

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -43,6 +43,9 @@ type Certificater interface {
 
 	// GetExpiration returns the time the certificate would expire.
 	GetExpiration() time.Time
+
+	// GetSerialNumber returns the serial number of the given certificate.
+	GetSerialNumber() string
 }
 
 // Manager is the interface declaring the methods for the Certificate Manager.

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -102,6 +102,7 @@ func (mc mockCertificate) GetCertificateChain() []byte           { return []byte
 func (mc mockCertificate) GetPrivateKey() []byte                 { return []byte("key") }
 func (mc mockCertificate) GetIssuingCA() []byte                  { return []byte("ca") }
 func (mc mockCertificate) GetExpiration() time.Time              { return time.Now() }
+func (mc mockCertificate) GetSerialNumber() string               { return "serial_number" }
 
 var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when the inject annotation is one of enabled/yes/true", func() {


### PR DESCRIPTION
For some cert issuers, like Hashicorp Vault, the `serial_number` of the certificate is important and we need to keep track of that.

The `serial_number` is used, for instance, to revoke a given cert.

This PR adds `GetSerialNumber()` to the `Certificater` interface.  Other PRs will implement `serial_number` where necessary.

In this PR we also add `serialNumber string` for the Hashicorp Vault `Certificate{}` and implement `GetSerialNumber()` based on that field.

ref https://github.com/openservicemesh/osm/pull/2070 https://github.com/openservicemesh/osm/issues/507


--- 

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [X]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
