### PR TITLE
certificates/vault: Use new types vaultRole and vaultPath

### DIFF
--- a/pkg/certificate/providers/vault/tools.go
+++ b/pkg/certificate/providers/vault/tools.go
@@ -11,17 +11,17 @@ func getDurationInMinutes(validityPeriod time.Duration) string {
 	return fmt.Sprintf("%dh", validityPeriod/time.Hour)
 }
 
-func getIssueURL(vaultRole string) string {
-	return fmt.Sprintf("pki/issue/%+v", vaultRole)
+func getIssueURL(role vaultRole) vaultPath {
+	return vaultPath(fmt.Sprintf("pki/issue/%+v", role))
 }
 
-func getRoleConfigURL(vaultRole string) string {
-	return fmt.Sprintf("pki/roles/%s", vaultRole)
+func getRoleConfigURL(role vaultRole) vaultPath {
+	return vaultPath(fmt.Sprintf("pki/roles/%s", role))
 }
 
 func getIssuanceData(cn certificate.CommonName, validityPeriod time.Duration) map[string]interface{} {
 	return map[string]interface{}{
-		"common_name": cn.String(),
-		"ttl":         getDurationInMinutes(validityPeriod),
+		commonNameField: cn.String(),
+		ttlField:        getDurationInMinutes(validityPeriod),
 	}
 }

--- a/pkg/certificate/providers/vault/tools_test.go
+++ b/pkg/certificate/providers/vault/tools_test.go
@@ -7,11 +7,13 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/google/uuid"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
 var _ = Describe("Test tools", func() {
-	vaultRole := "openservicemesh"
+	role := vaultRole(uuid.New().String())
 
 	Context("Test converting duration into Vault recognizable string", func() {
 		It("converts 36 hours into correct string representation", func() {
@@ -23,16 +25,16 @@ var _ = Describe("Test tools", func() {
 
 	Context("Test cert issuance URL", func() {
 		It("creates the URL for issuing a new certificate", func() {
-			actual := getIssueURL(vaultRole)
-			expected := fmt.Sprintf("pki/issue/%s", vaultRole)
+			actual := getIssueURL(role)
+			expected := vaultPath(fmt.Sprintf("pki/issue/%s", role))
 			Expect(actual).To(Equal(expected))
 		})
 	})
 
 	Context("Test role config URL", func() {
 		It("creates the URL for role configuration", func() {
-			actual := getRoleConfigURL(vaultRole)
-			expected := fmt.Sprintf("pki/roles/%s", vaultRole)
+			actual := getRoleConfigURL(role)
+			expected := vaultPath(fmt.Sprintf("pki/roles/%s", role))
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -26,7 +26,19 @@ type CertManager struct {
 	client *api.Client
 
 	// The Vault role configured for OSM and passed as a CLI.
-	vaultRole string
+	role vaultRole
 
 	cfg configurator.Configurator
+}
+
+type vaultRole string
+
+func (vr vaultRole) String() string {
+	return string(vr)
+}
+
+type vaultPath string
+
+func (vp vaultPath) String() string {
+	return string(vp)
 }


### PR DESCRIPTION
This PR adds specialized types `vaultPath` and `vaultRole` (in lieu of strings)

This is a small chunk from the larger Draft PR https://github.com/openservicemesh/osm/pull/2070

ref  https://github.com/openservicemesh/osm/issues/507


---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
