### PR TITLE
certificate/tresor: Change cache from a map to sync.Map

### DIFF
--- a/cmd/osm-controller/osm-controller_test.go
+++ b/cmd/osm-controller/osm-controller_test.go
@@ -14,7 +14,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -82,8 +81,7 @@ func TestDebugServer(t *testing.T) {
 func TestCreateCABundleKubernetesSecret(t *testing.T) {
 	assert := assert.New(t)
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, nil)
+	certManager := tresor.NewFakeCertManager(nil)
 	testName := "--secret--name--"
 	namespace := "--namespace--"
 	k8sClient := testclient.NewSimpleClientset()

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -46,8 +45,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, cfg)
+	certManager := tresor.NewFakeCertManager(cfg)
 
 	announcementsCh := make(chan announcements.Announcement)
 

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -13,7 +13,6 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -39,8 +38,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T) *MeshCatalog {
 	}
 	stop := make(chan struct{})
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
+	certManager := tresor.NewFakeCertManager(mockConfigurator)
 
 	// Create a bookstoreV1 pod
 	bookstoreV1Pod := tests.NewPodTestFixtureWithOptions(tests.BookstoreV1Service.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName)

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -15,7 +15,6 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -67,8 +66,7 @@ func newFakeMeshCatalog() *MeshCatalog {
 
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, cfg)
+	certManager := tresor.NewFakeCertManager(cfg)
 
 	// Create a pod
 	pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName)

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -77,17 +77,12 @@ func NewCertManager(ca certificate.Certificater, certificatesOrganization string
 		return nil, errNoIssuingCA
 	}
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-
 	certManager := CertManager{
 		// The root certificate signing all newly issued certificates
 		ca: ca,
 
 		// Channel used to inform other components of cert changes (rotation etc.)
 		announcements: make(chan announcements.Announcement),
-
-		// Certificate cache
-		cache: &cache,
 
 		certificatesOrganization: certificatesOrganization,
 

--- a/pkg/certificate/providers/tresor/debugger.go
+++ b/pkg/certificate/providers/tresor/debugger.go
@@ -5,10 +5,9 @@ import "github.com/openservicemesh/osm/pkg/certificate"
 // ListIssuedCertificates implements CertificateDebugger interface and returns the list of issued certificates.
 func (cm *CertManager) ListIssuedCertificates() []certificate.Certificater {
 	var certs []certificate.Certificater
-	cm.cacheLock.Lock()
-	defer cm.cacheLock.Unlock()
-	for _, cert := range *cm.cache {
-		certs = append(certs, cert)
-	}
+	cm.cache.Range(func(cnInterface interface{}, certInterface interface{}) bool {
+		certs = append(certs, certInterface.(certificate.Certificater))
+		return true
+	})
 	return certs
 }

--- a/pkg/certificate/providers/tresor/debugger_test.go
+++ b/pkg/certificate/providers/tresor/debugger_test.go
@@ -15,14 +15,10 @@ var _ = Describe("Test Tresor Debugger", func() {
 		//   3. Populate the CertManager's cache w/ cert
 		cert := NewFakeCertificate()
 		cert.issuingCA = cert.GetCertificateChain()
-		cache := map[certificate.CommonName]certificate.Certificater{
-			"foo": cert,
-		}
-		cm := CertManager{
-			cache: &cache,
-		}
+		cm := CertManager{}
+		cm.cache.Store("foo", cert)
 
-		It("lists all issued certificets", func() {
+		It("lists all issued certificates", func() {
 			actual := cm.ListIssuedCertificates()
 			expected := []certificate.Certificater{cert}
 			Expect(actual).To(Equal(expected))

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
@@ -14,7 +13,7 @@ const (
 )
 
 // NewFakeCertManager creates a fake CertManager used for testing.
-func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificater, cfg configurator.Configurator) *CertManager {
+func NewFakeCertManager(cfg configurator.Configurator) *CertManager {
 	rootCertCountry := "US"
 	rootCertLocality := "CA"
 	ca, err := NewCA("Fake Tresor CN", 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
@@ -25,7 +24,6 @@ func NewFakeCertManager(cache *map[certificate.CommonName]certificate.Certificat
 	return &CertManager{
 		ca:            ca.(*Certificate),
 		announcements: make(chan announcements.Announcement),
-		cache:         cache,
 		cfg:           cfg,
 	}
 }

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -37,8 +37,8 @@ type CertManager struct {
 	announcements chan announcements.Announcement
 
 	// Cache for all the certificates issued
-	cache     *map[certificate.CommonName]certificate.Certificater
-	cacheLock sync.Mutex
+	// Types: map[certificate.CommonName]certificate.Certificater
+	cache sync.Map
 
 	certificatesOrganization string
 

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -106,8 +106,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 	Context("Test sendAllResponses()", func() {
 
-		cache := make(map[certificate.CommonName]certificate.Certificater)
-		certManager := tresor.NewFakeCertManager(&cache, mockConfigurator)
+		certManager := tresor.NewFakeCertManager(mockConfigurator)
 		cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), serviceAccountName, tests.Namespace))
 		certDuration := 1 * time.Hour
 		certPEM, _ := certManager.IssueCertificate(cn, certDuration)

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/catalog"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -171,8 +170,7 @@ var _ = Describe("RDS Response", func() {
 	osmConfigMapName := "-test-osm-config-map-"
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, cfg)
+	certManager := tresor.NewFakeCertManager(cfg)
 
 	announcementsCh := make(chan announcements.Announcement)
 

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
@@ -155,12 +154,10 @@ var _ = Describe("Test all patch operations", func() {
 			_, err := client.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			cache := make(map[certificate.CommonName]certificate.Certificater)
-
 			wh := &webhook{
 				kubeClient:          client,
 				kubeController:      mockNsController,
-				certManager:         tresor.NewFakeCertManager(&cache, mockConfigurator),
+				certManager:         tresor.NewFakeCertManager(mockConfigurator),
 				meshCatalog:         catalog.NewFakeMeshCatalog(client),
 				configurator:        mockConfigurator,
 				nonInjectNamespaces: mapset.NewSet(),

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -504,8 +504,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		stop := make(<-chan struct{})
 		mockController := gomock.NewController(GinkgoT())
 		cfg := configurator.NewMockConfigurator(mockController)
-		cache := make(map[certificate.CommonName]certificate.Certificater)
-		certManager := tresor.NewFakeCertManager(&cache, cfg)
+		certManager := tresor.NewFakeCertManager(cfg)
 
 		actualErr := NewWebhook(injectorConfig, kubeClient, certManager, meshCatalog, kubeController, meshName, osmNamespace, webhookName, stop, cfg)
 		expectedErrorMessage := "Error configuring MutatingWebhookConfiguration -webhook-name-: mutatingwebhookconfigurations.admissionregistration.k8s.io \"-webhook-name-\" not found"

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 )
 
 func TestNewGrpc(t *testing.T) {
 	assert := assert.New(t)
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, nil)
+	certManager := tresor.NewFakeCertManager(nil)
 	adsCert, err := certManager.GetRootCertificate()
 	assert.Nil(err)
 
@@ -53,8 +51,7 @@ func TestNewGrpc(t *testing.T) {
 func TestGrpcServe(t *testing.T) {
 	assert := assert.New(t)
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, nil)
+	certManager := tresor.NewFakeCertManager(nil)
 	adsCert, err := certManager.GetRootCertificate()
 	assert.Nil(err)
 

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -29,8 +29,7 @@ func TestSetupMutualTLS(t *testing.T) {
 		expectedError string
 	}
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, nil)
+	certManager := tresor.NewFakeCertManager(nil)
 	adsCert, err := certManager.GetRootCertificate()
 	assert.Nil(err)
 
@@ -67,8 +66,7 @@ func TestValidateClient(t *testing.T) {
 		expectedError error
 	}
 
-	cache := make(map[certificate.CommonName]certificate.Certificater)
-	certManager := tresor.NewFakeCertManager(&cache, nil)
+	certManager := tresor.NewFakeCertManager(nil)
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), tests.BookstoreServiceAccountName, tests.Namespace))
 	certPEM, _ := certManager.IssueCertificate(cn, 1*time.Hour)
 	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())

--- a/tests/e2e/scenario_mutatingwebhook_reconcile_test.go
+++ b/tests/e2e/scenario_mutatingwebhook_reconcile_test.go
@@ -49,8 +49,8 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 
 				mockController := gomock.NewController(GinkgoT())
 				cfgMock := configurator.NewMockConfigurator(mockController)
-				cache := make(map[certificate.CommonName]certificate.Certificater)
-				certManager := tresor.NewFakeCertManager(&cache, cfgMock)
+
+				certManager := tresor.NewFakeCertManager(cfgMock)
 				cn := certificate.CommonName(fmt.Sprintf("%s.%s.svc", constants.OSMControllerName, testWebhookServiceNamespace))
 				validity := 1 * time.Hour
 				cert, _ := certManager.IssueCertificate(cn, validity)


### PR DESCRIPTION
Use a `sync.Map` for Tresor's cache instead of `*map[certificate.CommonName]certificate.Certificater`


ref https://github.com/openservicemesh/osm/issues/507




---

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
