### PR TITLE
Adding Phillip Gibson as OWNER for public record

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,5 +10,6 @@ maintainers:
   - shalier
   - shashankram
   - snehachhabria
+  - phillipgibson
 emeritus:
   -


### PR DESCRIPTION
I am told (as of today) that the CNCF uses this file to determine who can open service desk tickets for a given project. Phillip is definitely someone who should be able to do such, as the PM on the project.


Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
