### PR TITLE
envoy/rbac: add generic RBAC policy builder

### DIFF
--- a/pkg/envoy/rbac/policy.go
+++ b/pkg/envoy/rbac/policy.go
@@ -1,0 +1,117 @@
+package rbac
+
+import (
+	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/pkg/errors"
+)
+
+// Generate constructs an RBAC policy for the policy object on which this method is called
+func (p *Policy) Generate() (*xds_rbac.Policy, error) {
+	policy := &xds_rbac.Policy{}
+
+	// Construct the Principals ------------------------
+	var finalPrincipals []*xds_rbac.Principal
+
+	// Each RuleList follows OR semantics with other RuleList in the list of RuleList
+	for _, principalRuleList := range p.Principals {
+		// 'principalRuleList' corresponds to a single Principal in an RBAC policy.
+		// This Principal can be defined in terms of one of AND or OR rules.
+		// When AND/OR semantics are not required to define multiple rules corresponding
+		// to this principal, a single Rule in either the AndRules or OrRules will suffice.
+
+		if len(principalRuleList.AndRules) != 0 && len(principalRuleList.OrRules) != 0 {
+			return nil, errors.New("Principal rule cannot have both AND & OR rules at the same time")
+		}
+
+		var currentPrincipal *xds_rbac.Principal
+
+		if len(principalRuleList.AndRules) != 0 {
+			// Combine all the AND rules for this Principal rule with AND semantics
+			var andPrincipalRules []*xds_rbac.Principal
+			for _, andPrincipalRule := range principalRuleList.AndRules {
+				// Fill in the authenticated principal types
+				if andPrincipalRule.Attribute == DownstreamAuthPrincipal {
+					authPrincipal := getPrincipalAuthenticated(andPrincipalRule.Value)
+					andPrincipalRules = append(andPrincipalRules, authPrincipal)
+				}
+			}
+			currentPrincipal = getPrincipalAnd(andPrincipalRules)
+		} else if len(principalRuleList.OrRules) != 0 {
+			// Combine all the OR rules for this Principal rule with OR semantics
+			var orPrincipalRules []*xds_rbac.Principal
+			for _, orPrincipalRule := range principalRuleList.OrRules {
+				// Fill in the authenticated principal types
+				if orPrincipalRule.Attribute == DownstreamAuthPrincipal {
+					authPrincipal := getPrincipalAuthenticated(orPrincipalRule.Value)
+					orPrincipalRules = append(orPrincipalRules, authPrincipal)
+				}
+			}
+			currentPrincipal = getPrincipalOr(orPrincipalRules)
+		} else {
+			// Neither AND/OR rules set, set principal to Any
+			currentPrincipal = getPrincipalAny()
+		}
+
+		finalPrincipals = append(finalPrincipals, currentPrincipal)
+	}
+	if len(p.Principals) == 0 {
+		// No principals specified for this policy, allow ANY
+		finalPrincipals = append(finalPrincipals, getPrincipalAny())
+	}
+
+	policy.Principals = finalPrincipals
+
+	// Construct the Permissions ---------------------------
+	// Currently an RBAC policy grants all permissions.
+	// This will be extended in the future as a part of TCP policy support
+	// where permission will only be granted to select ports.
+	policy.Permissions = []*xds_rbac.Permission{
+		{
+			// Grant the given principal all access
+			Rule: &xds_rbac.Permission_Any{Any: true},
+		},
+	}
+
+	return policy, nil
+}
+
+func getPrincipalAuthenticated(principalName string) *xds_rbac.Principal {
+	return &xds_rbac.Principal{
+		Identifier: &xds_rbac.Principal_Authenticated_{
+			Authenticated: &xds_rbac.Principal_Authenticated{
+				PrincipalName: &xds_matcher.StringMatcher{
+					MatchPattern: &xds_matcher.StringMatcher_Exact{
+						Exact: principalName,
+					},
+				},
+			},
+		},
+	}
+}
+
+func getPrincipalOr(principals []*xds_rbac.Principal) *xds_rbac.Principal {
+	return &xds_rbac.Principal{
+		Identifier: &xds_rbac.Principal_OrIds{
+			OrIds: &xds_rbac.Principal_Set{
+				Ids: principals,
+			},
+		},
+	}
+}
+
+func getPrincipalAnd(principals []*xds_rbac.Principal) *xds_rbac.Principal {
+	return &xds_rbac.Principal{
+		Identifier: &xds_rbac.Principal_AndIds{
+			AndIds: &xds_rbac.Principal_Set{
+				Ids: principals,
+			},
+		},
+	}
+}
+
+func getPrincipalAny() *xds_rbac.Principal {
+	return &xds_rbac.Principal{
+		Identifier: &xds_rbac.Principal_Any{Any: true},
+	}
+}

--- a/pkg/envoy/rbac/policy_test.go
+++ b/pkg/envoy/rbac/policy_test.go
@@ -1,0 +1,200 @@
+package rbac
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+)
+
+func TestGenerate(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name                string
+		p                   *Policy
+		expectedPrincipals  []*xds_rbac.Principal
+		expectedPermissions []*xds_rbac.Permission
+		expectError         bool
+	}{
+		{
+			name: "testing AND rules for single principal",
+			p: &Policy{
+				Principals: []RulesList{
+					{
+						AndRules: []Rule{
+							{Attribute: DownstreamAuthPrincipal, Value: "foo.domain"},
+							{Attribute: DownstreamAuthPrincipal, Value: "bar.domain"},
+						},
+					},
+				},
+			},
+			expectedPrincipals: []*xds_rbac.Principal{
+				{
+					Identifier: &xds_rbac.Principal_AndIds{
+						AndIds: &xds_rbac.Principal_Set{
+							Ids: []*xds_rbac.Principal{
+								getPrincipalAuthenticated("foo.domain"),
+								getPrincipalAuthenticated("bar.domain"),
+							},
+						},
+					},
+				},
+			},
+			expectedPermissions: []*xds_rbac.Permission{
+				{
+					Rule: &xds_rbac.Permission_Any{Any: true},
+				},
+			},
+			expectError: false,
+		},
+
+		{
+			name: "testing OR rules for single principal",
+			p: &Policy{
+				Principals: []RulesList{
+					{
+						OrRules: []Rule{
+							{Attribute: DownstreamAuthPrincipal, Value: "foo.domain"},
+							{Attribute: DownstreamAuthPrincipal, Value: "bar.domain"},
+						},
+					},
+				},
+			},
+			expectedPrincipals: []*xds_rbac.Principal{
+				{
+					Identifier: &xds_rbac.Principal_OrIds{
+						OrIds: &xds_rbac.Principal_Set{
+							Ids: []*xds_rbac.Principal{
+								getPrincipalAuthenticated("foo.domain"),
+								getPrincipalAuthenticated("bar.domain"),
+							},
+						},
+					},
+				},
+			},
+			expectedPermissions: []*xds_rbac.Permission{
+				{
+					Rule: &xds_rbac.Permission_Any{Any: true},
+				},
+			},
+			expectError: false,
+		},
+
+		{
+			name: "testing rule for ANY principal when no AND/OR rules specified",
+			p: &Policy{
+				Principals: []RulesList{
+					{}, // No AND/OR rules
+				},
+			},
+			expectedPrincipals: []*xds_rbac.Principal{
+				getPrincipalAny(),
+			},
+			expectedPermissions: []*xds_rbac.Permission{
+				{
+					Rule: &xds_rbac.Permission_Any{Any: true},
+				},
+			},
+			expectError: false,
+		},
+
+		{
+			name: "testing rule for no principal specified",
+			p:    &Policy{},
+			expectedPrincipals: []*xds_rbac.Principal{
+				getPrincipalAny(),
+			},
+			expectedPermissions: []*xds_rbac.Permission{
+				{
+					Rule: &xds_rbac.Permission_Any{Any: true},
+				},
+			},
+			expectError: false,
+		},
+
+		{
+			name: "testing AND/OR rules for multiple principals",
+			p: &Policy{
+				Principals: []RulesList{
+					{
+						AndRules: []Rule{
+							{Attribute: DownstreamAuthPrincipal, Value: "foo.domain"},
+							{Attribute: DownstreamAuthPrincipal, Value: "bar.domain"},
+						},
+					},
+					{
+						OrRules: []Rule{
+							{Attribute: DownstreamAuthPrincipal, Value: "foo.domain"},
+							{Attribute: DownstreamAuthPrincipal, Value: "bar.domain"},
+						},
+					},
+				},
+			},
+			expectedPrincipals: []*xds_rbac.Principal{
+				{
+					Identifier: &xds_rbac.Principal_AndIds{
+						AndIds: &xds_rbac.Principal_Set{
+							Ids: []*xds_rbac.Principal{
+								getPrincipalAuthenticated("foo.domain"),
+								getPrincipalAuthenticated("bar.domain"),
+							},
+						},
+					},
+				},
+				{
+					Identifier: &xds_rbac.Principal_OrIds{
+						OrIds: &xds_rbac.Principal_Set{
+							Ids: []*xds_rbac.Principal{
+								getPrincipalAuthenticated("foo.domain"),
+								getPrincipalAuthenticated("bar.domain"),
+							},
+						},
+					},
+				},
+			},
+			expectedPermissions: []*xds_rbac.Permission{
+				{
+					Rule: &xds_rbac.Permission_Any{Any: true},
+				},
+			},
+			expectError: false,
+		},
+
+		{
+			name: "testing error when both AND and OR rules are specified for a single principal",
+			p: &Policy{
+				Principals: []RulesList{
+					{
+						AndRules: []Rule{
+							{Attribute: DownstreamAuthPrincipal, Value: "foo.domain"},
+						},
+						OrRules: []Rule{
+							{Attribute: DownstreamAuthPrincipal, Value: "bar.domain"},
+						},
+					},
+				},
+			},
+			expectedPrincipals:  nil,
+			expectedPermissions: nil,
+			expectError:         true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			policy, err := tc.p.Generate()
+
+			assert.Equal(err != nil, tc.expectError)
+			if err != nil {
+				assert.Nil(policy)
+			} else {
+				assert.NotNil(policy)
+				assert.Equal(policy.Principals, tc.expectedPrincipals)
+				assert.Equal(policy.Permissions, tc.expectedPermissions)
+			}
+		})
+	}
+}

--- a/pkg/envoy/rbac/types.go
+++ b/pkg/envoy/rbac/types.go
@@ -1,0 +1,29 @@
+// Package rbac implements Envoy XDS RBAC policies.
+package rbac
+
+// RuleAttribute is the key used for the name of an attribute in a policy Rule
+type RuleAttribute string
+
+// Supported attributes for an RBAC principal
+const (
+	// DownstreamAuthPrincipal is the key used for the name of the downstream principal in a policy Rule
+	DownstreamAuthPrincipal RuleAttribute = "downstreamAuthPrincipal"
+)
+
+// Rule is a type that can represent a policy's Permission and Principal rules
+type Rule struct {
+	Attribute RuleAttribute
+	Value     string
+}
+
+// RulesList is a list of Rule types represented using AND or OR semantics
+type RulesList struct {
+	AndRules []Rule
+	OrRules  []Rule
+}
+
+// Policy is a type used to represent an RBAC policy with rules corresponding to Principals and their associated Permissions
+type Policy struct {
+	Permissions []RulesList
+	Principals  []RulesList
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a new rbac pkg to build RBAC policies.
Currently this change doesn't affect existing functionality
and the goal is to have a generic rbac policy builder
that can be used when an RBAC policy needs to be built.

LDS builds RBAC policies to enforce RBAC on inbound
connections from downstreams. RDS will require to enable
RBAC on a per route basis in the future. This pkg will
serve as a modeler for RBAC policies.

Part of #2088

Signed-off-by: Shashank Ram <shashank08@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`