### PR TITLE
tests/e2e: isolate framework from tests, restructure files

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -14,7 +14,8 @@ End-to-end tests verify the behavior of the entire system. For OSM, e2e tests wi
 OSM's e2e tests are located in `tests/e2e`.
 The tests are written using Ginkgo and Gomega so they may also be directly invoked using `go test`. Be sure to build the `osm-controller` and `init` container images and `osm` CLI before directly invoking the tests ([see instructions below](#running-the-tests)). 
 
-OSM's framework has an init mechanism which will automatically initialize and parse flags and variables from both `env` and `go test flags` if any are passed to the test. The hooks for initialization and cleanup are set at Ginkgo's `BeforeEach` at the top level of test execution (between Ginkgo `Describes`); we henceforth recommend keeping every test in its own `Describe` section, as well as on a separate file for clarity. You can refer to [suite_test](tests/e2e/suite_test.go) for more details about the init process.
+OSM's framework, helpers and related files are located under `tests/framework`.
+Once imported, it automatically sets up an init mechanism which will automatically initialize and parse flags and variables from both `env` and `go test flags` if any are passed to the test. The hooks for initialization and cleanup are set at Ginkgo's `BeforeEach` at the top level of test execution (between Ginkgo `Describes`); we henceforth recommend keeping every test in its own `Describe` section, as well as on a separate file for clarity. You can refer to [common.go](tests/framework/common.go) for more details about the init, setup and cleanup processes.
 
 Tests are organized by top-level `Describe` blocks into tiers based on priority. A tier's tests will also be run as a part of all the tiers below it.
 

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -6,12 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 	OSMDescribeInfo{
-		tier:   2,
-		bucket: 2,
+		Tier:   2,
+		Bucket: 2,
 	},
 	func() {
 		Context("CertManagerSimpleClientServer", func() {
@@ -21,58 +22,58 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 
 			It("Tests HTTP traffic for client pod -> server pod", func() {
 				// Install OSM
-				installOpts := td.GetOSMInstallOpts()
-				installOpts.certManager = "cert-manager"
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
-				Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 4)).To(Succeed())
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.CertManager = "cert-manager"
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 4)).To(Succeed())
 
 				// Create Test NS
 				for _, n := range ns {
-					Expect(td.CreateNs(n, nil)).To(Succeed())
-					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+					Expect(Td.CreateNs(n, nil)).To(Succeed())
+					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 				}
 
 				// Get simple pod definitions for the HTTP server
-				svcAccDef, podDef, svcDef := td.SimplePodApp(
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(
 					SimplePodAppDef{
-						name:      "server",
-						namespace: destNs,
-						image:     "kennethreitz/httpbin",
-						ports:     []int{80},
+						Name:      "server",
+						Namespace: destNs,
+						Image:     "kennethreitz/httpbin",
+						Ports:     []int{80},
 					})
 
-				_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				dstPod, err := td.CreatePod(destNs, podDef)
+				dstPod, err := Td.CreatePod(destNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(destNs, svcDef)
+				_, err = Td.CreateService(destNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-					name:      "client",
-					namespace: sourceNs,
-					command:   []string{"/bin/bash", "-c", "--"},
-					args:      []string{"while true; do sleep 30; done;"},
-					image:     "songrgg/alpine-debug",
-					ports:     []int{80},
+				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+					Name:      "client",
+					Namespace: sourceNs,
+					Command:   []string{"/bin/bash", "-c", "--"},
+					Args:      []string{"while true; do sleep 30; done;"},
+					Image:     "songrgg/alpine-debug",
+					Ports:     []int{80},
 				})
 
-				_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := td.CreatePod(sourceNs, podDef)
+				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(sourceNs, svcDef)
+				_, err = Td.CreateService(sourceNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
 
 				// Deploy allow rule client->server
-				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
 					SimpleAllowPolicy{
 						RouteGroupName:    "routes",
 						TrafficTargetName: "test-target",
@@ -85,16 +86,16 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 					})
 
 				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				_, err = Td.CreateHTTPRouteGroup(sourceNs, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = Td.CreateTrafficTarget(sourceNs, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server
 				// Need to get the pod though.
-				cond := td.WaitForRepeatedSuccess(func() bool {
+				cond := Td.WaitForRepeatedSuccess(func() bool {
 					result :=
-						td.HTTPRequest(HTTPRequestDef{
+						Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
 							SourceContainer: "client",
@@ -103,10 +104,10 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 						})
 
 					if result.Err != nil || result.StatusCode != 200 {
-						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
 						return false
 					}
-					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 					return true
 				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
 				Expect(cond).To(BeTrue())

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -6,12 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 	OSMDescribeInfo{
-		tier:   2,
-		bucket: 2,
+		Tier:   2,
+		Bucket: 2,
 	},
 	func() {
 		Context("DebugServer", func() {
@@ -19,31 +20,31 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 
 			It("Starts debug server only when enableDebugServer flag is enabled", func() {
 				// Install OSM
-				installOpts := td.GetOSMInstallOpts()
-				installOpts.enableDebugServer = false
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnableDebugServer = false
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				// Create Test NS
-				Expect(td.CreateNs(sourceNs, nil)).To(Succeed())
+				Expect(Td.CreateNs(sourceNs, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef := td.SimplePodApp(SimplePodAppDef{
-					name:      "client",
-					namespace: sourceNs,
-					command:   []string{"/bin/bash", "-c", "--"},
-					args:      []string{"while true; do sleep 30; done;"},
-					image:     "songrgg/alpine-debug",
-					ports:     []int{80},
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+					Name:      "client",
+					Namespace: sourceNs,
+					Command:   []string{"/bin/bash", "-c", "--"},
+					Args:      []string{"while true; do sleep 30; done;"},
+					Image:     "songrgg/alpine-debug",
+					Ports:     []int{80},
 				})
 
-				_, err := td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err := Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := td.CreatePod(sourceNs, podDef)
+				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(sourceNs, svcDef)
+				_, err = Td.CreateService(sourceNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
 
 				req := HTTPRequestDef{
 					SourceNs:        srcPod.Namespace,
@@ -55,31 +56,31 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 
 				By("Ensuring debug server is available when enableDebugServer is enabled")
 
-				Expect(td.UpdateOSMConfig("enable_debug_server", "true"))
+				Expect(Td.UpdateOSMConfig("enable_debug_server", "true"))
 
-				cond := td.WaitForRepeatedSuccess(func() bool {
-					result := td.HTTPRequest(req)
+				cond := Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(req)
 
 					if result.Err != nil || result.StatusCode != 200 {
-						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
 						return false
 					}
-					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 					return true
 				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
 				Expect(cond).To(BeTrue())
 
 				By("Ensuring debug server is unavailable when enableDebugServer is disabled")
 
-				Expect(td.UpdateOSMConfig("enable_debug_server", "false"))
-				cond = td.WaitForRepeatedSuccess(func() bool {
-					result := td.HTTPRequest(req)
+				Expect(Td.UpdateOSMConfig("enable_debug_server", "false"))
+				cond = Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(req)
 
 					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-						td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
+						Td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
 						return false
 					}
-					td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
+					Td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
 					return true
 				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
 				Expect(cond).To(BeTrue())

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -8,14 +8,15 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment server",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 1,
+		Tier:   1,
+		Bucket: 1,
 	},
 	func() {
 		Context("DeploymentsClientServer", func() {
@@ -37,64 +38,64 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 
 			It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
 				// Install OSM
-				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
 				// Server NS
-				Expect(td.CreateNs(destApp, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, destApp)).To(Succeed())
+				Expect(Td.CreateNs(destApp, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, destApp)).To(Succeed())
 
 				// Client Applications
 				for _, srcClient := range sourceNamespaces {
-					Expect(td.CreateNs(srcClient, nil)).To(Succeed())
-					Expect(td.AddNsToMesh(true, srcClient)).To(Succeed())
+					Expect(Td.CreateNs(srcClient, nil)).To(Succeed())
+					Expect(Td.AddNsToMesh(true, srcClient)).To(Succeed())
 				}
 
 				// Use a deployment with multiple replicaset at serverside
-				svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+				svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
-						name:         "server",
-						namespace:    destApp,
-						replicaCount: int32(replicaSetPerService),
-						image:        "kennethreitz/httpbin",
-						ports:        []int{80},
+						Name:         "server",
+						Namespace:    destApp,
+						ReplicaCount: int32(replicaSetPerService),
+						Image:        "kennethreitz/httpbin",
+						Ports:        []int{80},
 					})
 
-				_, err := td.CreateServiceAccount(destApp, &svcAccDef)
+				_, err := Td.CreateServiceAccount(destApp, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateDeployment(destApp, deploymentDef)
+				_, err = Td.CreateDeployment(destApp, deploymentDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(destApp, svcDef)
+				_, err = Td.CreateService(destApp, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				wg.Add(1)
 				go func(wg *sync.WaitGroup, srcClient string) {
 					defer wg.Done()
-					Expect(td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService)).To(Succeed())
+					Expect(Td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService)).To(Succeed())
 				}(&wg, destApp)
 
 				// Create all client deployments, also with replicaset
 				for _, srcClient := range sourceNamespaces {
-					svcAccDef, deploymentDef, svcDef = td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef = Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							name:         srcClient,
-							namespace:    srcClient,
-							replicaCount: int32(replicaSetPerService),
-							command:      []string{"/bin/bash", "-c", "--"},
-							args:         []string{"while true; do sleep 30; done;"},
-							image:        "songrgg/alpine-debug",
-							ports:        []int{80}, // Can't deploy services with empty/no ports
+							Name:         srcClient,
+							Namespace:    srcClient,
+							ReplicaCount: int32(replicaSetPerService),
+							Command:      []string{"/bin/bash", "-c", "--"},
+							Args:         []string{"while true; do sleep 30; done;"},
+							Image:        "songrgg/alpine-debug",
+							Ports:        []int{80}, // Can't deploy services with empty/no ports
 						})
-					_, err = td.CreateServiceAccount(srcClient, &svcAccDef)
+					_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateDeployment(srcClient, deploymentDef)
+					_, err = Td.CreateDeployment(srcClient, deploymentDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateService(srcClient, svcDef)
+					_, err = Td.CreateService(srcClient, svcDef)
 					Expect(err).NotTo(HaveOccurred())
 
 					wg.Add(1)
 					go func(wg *sync.WaitGroup, srcClient string) {
 						defer wg.Done()
-						Expect(td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService)).To(Succeed())
+						Expect(Td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService)).To(Succeed())
 					}(&wg, srcClient)
 				}
 				wg.Wait()
@@ -102,7 +103,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				// Create traffic rules
 				// Deploy allow rules (10x)clients -> server
 				for _, srcClient := range sourceNamespaces {
-					httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+					httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
 						SimpleAllowPolicy{
 							RouteGroupName:    srcClient,
 							TrafficTargetName: srcClient,
@@ -115,9 +116,9 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 						})
 
 					// Configs have to be put into a monitored NS, and osm-system can't be by cli
-					_, err = td.CreateHTTPRouteGroup(srcClient, httpRG)
+					_, err = Td.CreateHTTPRouteGroup(srcClient, httpRG)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
 					Expect(err).NotTo(HaveOccurred())
 				}
 
@@ -126,7 +127,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 					Sources: []HTTPRequestDef{},
 				}
 				for _, ns := range sourceNamespaces {
-					pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 					Expect(err).To(BeNil())
 
 					for _, pod := range pods.Items {
@@ -141,12 +142,12 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				}
 
 				var results HTTPMultipleResults
-				success := td.WaitForRepeatedSuccess(func() bool {
+				success := Td.WaitForRepeatedSuccess(func() bool {
 					// Issue all calls, get results
-					results = td.MultipleHTTPRequest(&requests)
+					results = Td.MultipleHTTPRequest(&requests)
 
 					// Care, depending on variables there could be a lot of results
-					td.PrettyPrintHTTPResults(&results)
+					Td.PrettyPrintHTTPResults(&results)
 
 					// Verify success conditions
 					for _, ns := range results {

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -6,12 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("HTTP and HTTPS Egress",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 1,
+		Tier:   1,
+		Bucket: 1,
 	},
 	func() {
 		Context("Egress", func() {
@@ -19,33 +20,33 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 
 			It("Allows egress traffic when enabled", func() {
 				// Install OSM
-				installOpts := td.GetOSMInstallOpts()
-				installOpts.egressEnabled = true
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EgressEnabled = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				// Create Test NS
-				Expect(td.CreateNs(sourceNs, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, sourceNs)).To(Succeed())
+				Expect(Td.CreateNs(sourceNs, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, sourceNs)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef := td.SimplePodApp(SimplePodAppDef{
-					name:      "client",
-					namespace: sourceNs,
-					command:   []string{"/bin/bash", "-c", "--"},
-					args:      []string{"while true; do sleep 30; done;"},
-					image:     "songrgg/alpine-debug",
-					ports:     []int{80},
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+					Name:      "client",
+					Namespace: sourceNs,
+					Command:   []string{"/bin/bash", "-c", "--"},
+					Args:      []string{"while true; do sleep 30; done;"},
+					Image:     "songrgg/alpine-debug",
+					Ports:     []int{80},
 				})
 
-				_, err := td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err := Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := td.CreatePod(sourceNs, podDef)
+				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(sourceNs, svcDef)
+				_, err = Td.CreateService(sourceNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
 
 				protocols := []string{
 					"http://",
@@ -63,8 +64,8 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 				}
 
 				for _, url := range urls {
-					cond := td.WaitForRepeatedSuccess(func() bool {
-						result := td.HTTPRequest(HTTPRequestDef{
+					cond := Td.WaitForRepeatedSuccess(func() bool {
+						result := Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
 							SourceContainer: "client",
@@ -73,10 +74,10 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 						})
 
 						if result.Err != nil || result.StatusCode != 200 {
-							td.T.Logf("%s > REST req failed (status: %d) %v", url, result.StatusCode, result.Err)
+							Td.T.Logf("%s > REST req failed (status: %d) %v", url, result.StatusCode, result.Err)
 							return false
 						}
-						td.T.Logf("%s > REST req succeeded: %d", url, result.StatusCode)
+						Td.T.Logf("%s > REST req succeeded: %d", url, result.StatusCode)
 						return true
 					}, 5, 60*time.Second)
 					Expect(cond).To(BeTrue())
@@ -84,12 +85,12 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 
 				By("Disabling Egress")
 
-				err = td.UpdateOSMConfig("egress", "false")
+				err = Td.UpdateOSMConfig("egress", "false")
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, url := range urls {
-					cond := td.WaitForRepeatedSuccess(func() bool {
-						result := td.HTTPRequest(HTTPRequestDef{
+					cond := Td.WaitForRepeatedSuccess(func() bool {
+						result := Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
 							SourceContainer: "client",
@@ -98,10 +99,10 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 						})
 
 						if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-							td.T.Logf("%s > REST req failed incorrectly (status: %d) %v", url, result.StatusCode, result.Err)
+							Td.T.Logf("%s > REST req failed incorrectly (status: %d) %v", url, result.StatusCode, result.Err)
 							return false
 						}
-						td.T.Logf("%s > REST req failed correctly: %v", url, result.Err)
+						Td.T.Logf("%s > REST req failed correctly: %v", url, result.Err)
 						return true
 					}, 5 /*success count threshold*/, 60*time.Second /*timeout*/)
 					Expect(cond).To(BeTrue())

--- a/tests/e2e/e2e_fluentbit_test.go
+++ b/tests/e2e/e2e_fluentbit_test.go
@@ -7,9 +7,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/openservicemesh/osm/tests/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",

--- a/tests/e2e/e2e_fluentbit_test.go
+++ b/tests/e2e/e2e_fluentbit_test.go
@@ -7,24 +7,25 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
 var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 	OSMDescribeInfo{
-		tier:   2,
-		bucket: 2,
+		Tier:   2,
+		Bucket: 2,
 	},
 	func() {
 		Context("Fluentbit", func() {
 			It("Deploys a Fluent Bit sidecar only when enabled", func() {
 				// Install OSM with Fluentbit
-				installOpts := td.GetOSMInstallOpts()
-				installOpts.deployFluentbit = true
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.DeployFluentbit = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-				pods, err := td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
+				pods, err := Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),
 				})
 
@@ -39,17 +40,17 @@ var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 				}
 				Expect(cond).To(BeTrue())
 
-				err = td.DeleteNs(td.osmNamespace)
+				err = Td.DeleteNs(Td.OsmNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				err = td.WaitForNamespacesDeleted([]string{td.osmNamespace}, 60*time.Second)
+				err = Td.WaitForNamespacesDeleted([]string{Td.OsmNamespace}, 60*time.Second)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Install OSM without Fluentbit (default)
-				installOpts = td.GetOSMInstallOpts()
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
-				Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 1)).To(Succeed())
+				installOpts = Td.GetOSMInstallOpts()
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 1)).To(Succeed())
 
-				pods, err = td.client.CoreV1().Pods(td.osmNamespace).List(context.TODO(), metav1.ListOptions{
+				pods, err = Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),
 				})
 

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -6,12 +6,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 	OSMDescribeInfo{
-		tier:   2,
-		bucket: 1,
+		Tier:   2,
+		Bucket: 1,
 	},
 	func() {
 		Context("HashivaultSimpleClientServer", func() {
@@ -21,58 +22,58 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 
 			It("Tests HTTP traffic for client pod -> server pod", func() {
 				// Install OSM
-				installOpts := td.GetOSMInstallOpts()
-				installOpts.certManager = "vault"
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
-				Expect(td.WaitForPodsRunningReady(td.osmNamespace, 60*time.Second, 2)).To(Succeed())
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.CertManager = "vault"
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 2)).To(Succeed())
 
 				// Create Test NS
 				for _, n := range ns {
-					Expect(td.CreateNs(n, nil)).To(Succeed())
-					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+					Expect(Td.CreateNs(n, nil)).To(Succeed())
+					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 				}
 
 				// Get simple pod definitions for the HTTP server
-				svcAccDef, podDef, svcDef := td.SimplePodApp(
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(
 					SimplePodAppDef{
-						name:      "server",
-						namespace: destNs,
-						image:     "kennethreitz/httpbin",
-						ports:     []int{80},
+						Name:      "server",
+						Namespace: destNs,
+						Image:     "kennethreitz/httpbin",
+						Ports:     []int{80},
 					})
 
-				_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				dstPod, err := td.CreatePod(destNs, podDef)
+				dstPod, err := Td.CreatePod(destNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(destNs, svcDef)
+				_, err = Td.CreateService(destNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-					name:      "client",
-					namespace: sourceNs,
-					command:   []string{"/bin/bash", "-c", "--"},
-					args:      []string{"while true; do sleep 30; done;"},
-					image:     "songrgg/alpine-debug",
-					ports:     []int{80},
+				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+					Name:      "client",
+					Namespace: sourceNs,
+					Command:   []string{"/bin/bash", "-c", "--"},
+					Args:      []string{"while true; do sleep 30; done;"},
+					Image:     "songrgg/alpine-debug",
+					Ports:     []int{80},
 				})
 
-				_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := td.CreatePod(sourceNs, podDef)
+				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(sourceNs, svcDef)
+				_, err = Td.CreateService(sourceNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
 
 				// Deploy allow rule client->server
-				httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
 					SimpleAllowPolicy{
 						RouteGroupName:    "routes",
 						TrafficTargetName: "test-target",
@@ -85,16 +86,16 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 					})
 
 				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				_, err = Td.CreateHTTPRouteGroup(sourceNs, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = Td.CreateTrafficTarget(sourceNs, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server
 				// Need to get the pod though.
-				cond := td.WaitForRepeatedSuccess(func() bool {
+				cond := Td.WaitForRepeatedSuccess(func() bool {
 					result :=
-						td.HTTPRequest(HTTPRequestDef{
+						Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
 							SourceContainer: "client", // We can do better
@@ -103,10 +104,10 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 						})
 
 					if result.Err != nil || result.StatusCode != 200 {
-						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
 						return false
 					}
-					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 					return true
 				}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
 				Expect(cond).To(BeTrue())

--- a/tests/e2e/e2e_helm_install_test.go
+++ b/tests/e2e/e2e_helm_install_test.go
@@ -3,17 +3,18 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Test osm control plane installation with Helm",
 	OSMDescribeInfo{
-		tier:   2,
-		bucket: 1,
+		Tier:   2,
+		Bucket: 1,
 	},
 	func() {
 		Context("Using default values", func() {
 			It("installs osm control plane successfully", func() {
-				if td.instType == NoInstall {
+				if Td.InstType == NoInstall {
 					Skip("Test is not going through InstallOSM, hence cannot be automatically skipped with NoInstall (#1908)")
 				}
 
@@ -21,9 +22,9 @@ var _ = OSMDescribe("Test osm control plane installation with Helm",
 				release := "helm-install-osm"
 
 				// Install OSM with Helm
-				Expect(td.HelmInstallOSM(release, namespace)).To(Succeed())
+				Expect(Td.HelmInstallOSM(release, namespace)).To(Succeed())
 
-				configmap, err := td.GetConfigMap("osm-config", namespace)
+				configmap, err := Td.GetConfigMap("osm-config", namespace)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// validate osm configmap
@@ -39,7 +40,7 @@ var _ = OSMDescribe("Test osm control plane installation with Helm",
 				Expect(configmap.Data["use_https_ingress"]).Should(Equal("false"))
 				Expect(configmap.Data["service_cert_validity_duration"]).Should(Equal("24h"))
 
-				Expect(td.DeleteHelmRelease(release, namespace)).To(Succeed())
+				Expect(Td.DeleteHelmRelease(release, namespace)).To(Succeed())
 			})
 		})
 	})

--- a/tests/e2e/e2e_helm_install_test.go
+++ b/tests/e2e/e2e_helm_install_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -7,12 +7,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Permissive Traffic Policy Mode",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 2,
+		Tier:   1,
+		Bucket: 2,
 	},
 	func() {
 		Context("PermissiveMode", func() {
@@ -22,52 +23,52 @@ var _ = OSMDescribe("Permissive Traffic Policy Mode",
 
 			It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
 				// Install OSM
-				installOpts := td.GetOSMInstallOpts()
-				installOpts.enablePermissiveMode = true
-				Expect(td.InstallOSM(installOpts)).To(Succeed())
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnablePermissiveMode = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				// Create Test NS
 				for _, n := range ns {
-					Expect(td.CreateNs(n, nil)).To(Succeed())
-					Expect(td.AddNsToMesh(true, n)).To(Succeed())
+					Expect(Td.CreateNs(n, nil)).To(Succeed())
+					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 				}
 
 				// Get simple pod definitions for the HTTP server
-				svcAccDef, podDef, svcDef := td.SimplePodApp(
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(
 					SimplePodAppDef{
-						name:      "server",
-						namespace: destNs,
-						image:     "kennethreitz/httpbin",
-						ports:     []int{80},
+						Name:      "server",
+						Namespace: destNs,
+						Image:     "kennethreitz/httpbin",
+						Ports:     []int{80},
 					})
 
-				_, err := td.CreateServiceAccount(destNs, &svcAccDef)
+				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				dstPod, err := td.CreatePod(destNs, podDef)
+				dstPod, err := Td.CreatePod(destNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(destNs, svcDef)
+				_, err = Td.CreateService(destNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef = td.SimplePodApp(SimplePodAppDef{
-					name:      "client",
-					namespace: sourceNs,
-					command:   []string{"/bin/bash", "-c", "--"},
-					args:      []string{"while true; do sleep 30; done;"},
-					image:     "songrgg/alpine-debug",
-					ports:     []int{80},
+				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+					Name:      "client",
+					Namespace: sourceNs,
+					Command:   []string{"/bin/bash", "-c", "--"},
+					Args:      []string{"while true; do sleep 30; done;"},
+					Image:     "songrgg/alpine-debug",
+					Ports:     []int{80},
 				})
 
-				_, err = td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := td.CreatePod(sourceNs, podDef)
+				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = td.CreateService(sourceNs, svcDef)
+				_, err = Td.CreateService(sourceNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
 
 				req := HTTPRequestDef{
 					SourceNs:        srcPod.Namespace,
@@ -79,30 +80,30 @@ var _ = OSMDescribe("Permissive Traffic Policy Mode",
 
 				By("Ensuring traffic is allowed when permissive mode is enabled")
 
-				cond := td.WaitForRepeatedSuccess(func() bool {
-					result := td.HTTPRequest(req)
+				cond := Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(req)
 
 					if result.Err != nil || result.StatusCode != 200 {
-						td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
 						return false
 					}
-					td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
 					return true
 				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
 				Expect(cond).To(BeTrue())
 
 				By("Ensuring traffic is not allowed when permissive mode is disabled")
 
-				Expect(td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
+				Expect(Td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
 
-				cond = td.WaitForRepeatedSuccess(func() bool {
-					result := td.HTTPRequest(req)
+				cond = Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(req)
 
 					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-						td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
+						Td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
 						return false
 					}
-					td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
+					Td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
 					return true
 				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
 				Expect(cond).To(BeTrue())

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -8,10 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/openservicemesh/osm/tests/framework"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,8 +16,8 @@ import (
 
 var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 1,
+		Tier:   1,
+		Bucket: 1,
 	},
 	func() {
 		Context("SimpleClientServer with a Kubernetes Service for the Source", func() {
@@ -36,38 +37,38 @@ func testTraffic(withSourceKubernetesService bool) {
 
 		It("Tests HTTP traffic for client pod -> server pod", func() {
 			// Install OSM
-			Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+			Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
 			// Create Test NS
 			for _, n := range ns {
-				Expect(td.CreateNs(n, nil)).To(Succeed())
-				Expect(td.AddNsToMesh(true, n)).To(Succeed())
+				Expect(Td.CreateNs(n, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 			}
 
 			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := td.SimplePodApp(
+			svcAccDef, podDef, svcDef := Td.SimplePodApp(
 				SimplePodAppDef{
-					name:      destName,
-					namespace: destName,
-					image:     "kennethreitz/httpbin",
-					ports:     []int{80},
+					Name:      destName,
+					Namespace: destName,
+					Image:     "kennethreitz/httpbin",
+					Ports:     []int{80},
 				})
 
-			_, err := td.CreateServiceAccount(destName, &svcAccDef)
+			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := td.CreatePod(destName, podDef)
+			dstPod, err := Td.CreatePod(destName, podDef)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateService(destName, svcDef)
+			_, err = Td.CreateService(destName, svcDef)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
 
 			srcPod := setupSource(sourceName, withSourceKubernetesService)
 
 			By("Creating SMI policies")
 			// Deploy allow rule client->server
-			httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
 				SimpleAllowPolicy{
 					RouteGroupName:    "routes",
 					TrafficTargetName: "test-target",
@@ -80,9 +81,9 @@ func testTraffic(withSourceKubernetesService bool) {
 				})
 
 			// Configs have to be put into a monitored NS
-			_, err = td.CreateHTTPRouteGroup(sourceName, httpRG)
+			_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = td.CreateTrafficTarget(sourceName, trafficTarget)
+			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
 			Expect(err).NotTo(HaveOccurred())
 
 			// All ready. Expect client to reach server
@@ -98,15 +99,15 @@ func testTraffic(withSourceKubernetesService bool) {
 				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
 				clientToServer.Destination)
 
-			cond := td.WaitForRepeatedSuccess(func() bool {
-				result := td.HTTPRequest(clientToServer)
+			cond := Td.WaitForRepeatedSuccess(func() bool {
+				result := Td.HTTPRequest(clientToServer)
 
 				if result.Err != nil || result.StatusCode != 200 {
-					td.T.Logf("> (%s) HTTP Req failed %d %v",
+					Td.T.Logf("> (%s) HTTP Req failed %d %v",
 						srcToDestStr, result.StatusCode, result.Err)
 					return false
 				}
-				td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
 				return true
 			}, 5, 90*time.Second)
 
@@ -114,19 +115,19 @@ func testTraffic(withSourceKubernetesService bool) {
 			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s Kubernetes Service to a destination", sourceService)
 
 			By("Deleting SMI policies")
-			Expect(td.smiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
-			Expect(td.smiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
+			Expect(Td.SmiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+			Expect(Td.SmiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
 
 			// Expect client not to reach server
-			cond = td.WaitForRepeatedSuccess(func() bool {
-				result := td.HTTPRequest(clientToServer)
+			cond = Td.WaitForRepeatedSuccess(func() bool {
+				result := Td.HTTPRequest(clientToServer)
 
 				// Curl exit code 7 == Conn refused
 				if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-					td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
+					Td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
 					return false
 				}
-				td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
+				Td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
 				return true
 			}, 5, 150*time.Second)
 			Expect(cond).To(BeTrue())
@@ -136,29 +137,29 @@ func testTraffic(withSourceKubernetesService bool) {
 
 func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {
 	// Get simple Pod definitions for the client
-	svcAccDef, podDef, svcDef := td.SimplePodApp(SimplePodAppDef{
-		name:      sourceName,
-		namespace: sourceName,
-		command:   []string{"/bin/bash", "-c", "--"},
-		args:      []string{"while true; do sleep 30; done;"},
-		image:     "songrgg/alpine-debug",
-		ports:     []int{80},
+	svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+		Name:      sourceName,
+		Namespace: sourceName,
+		Command:   []string{"/bin/bash", "-c", "--"},
+		Args:      []string{"while true; do sleep 30; done;"},
+		Image:     "songrgg/alpine-debug",
+		Ports:     []int{80},
 	})
 
-	_, err := td.CreateServiceAccount(sourceName, &svcAccDef)
+	_, err := Td.CreateServiceAccount(sourceName, &svcAccDef)
 	Expect(err).NotTo(HaveOccurred())
 
-	srcPod, err := td.CreatePod(sourceName, podDef)
+	srcPod, err := Td.CreatePod(sourceName, podDef)
 	Expect(err).NotTo(HaveOccurred())
 
 	// In some cases we may want to skip the creation of a Kubernetes service for the source.
 	if withKubernetesService {
-		_, err = td.CreateService(sourceName, svcDef)
+		_, err = Td.CreateService(sourceName, svcDef)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
 	// Expect it to be up and running in it's receiver namespace
-	Expect(td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+	Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
 
 	return srcPod
 }

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -16,8 +17,8 @@ import (
 
 var _ = OSMDescribe("Test TrafficSplit where each backend shares the same ServiceAccount",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 2,
+		Tier:   1,
+		Bucket: 2,
 	},
 	func() {
 		Context("ClientServerTrafficSplitSameSA", func() {
@@ -57,11 +58,11 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 
 			It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
 				// Install OSM
-				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
 				// Create NSs
-				Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())
-				Expect(td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+				Expect(Td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
 
 				// Create server apps
 				svcAcc := &corev1.ServiceAccount{
@@ -69,17 +70,17 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 						Name: "server",
 					},
 				}
-				_, err := td.CreateServiceAccount(serverNamespace, svcAcc)
+				_, err := Td.CreateServiceAccount(serverNamespace, svcAcc)
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, serverApp := range serverServices {
-					_, deploymentDef, svcDef := td.SimpleDeploymentApp(
+					_, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							name:         serverApp,
-							namespace:    serverNamespace,
-							replicaCount: int32(serverReplicaSet),
-							image:        "simonkowallik/httpbin",
-							ports:        []int{80},
+							Name:         serverApp,
+							Namespace:    serverNamespace,
+							ReplicaCount: int32(serverReplicaSet),
+							Image:        "simonkowallik/httpbin",
+							Ports:        []int{80},
 						})
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -99,41 +100,41 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 
 					deploymentDef.Spec.Template.Spec.ServiceAccountName = svcAcc.Name
 
-					_, err = td.CreateDeployment(serverNamespace, deploymentDef)
+					_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateService(serverNamespace, svcDef)
+					_, err = Td.CreateService(serverNamespace, svcDef)
 					Expect(err).NotTo(HaveOccurred())
 				}
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					Expect(td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
 				}()
 
 				// Client apps
 				for _, clientApp := range clientServices {
-					svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							name:         clientApp,
-							namespace:    clientApp,
-							replicaCount: int32(clientReplicaSet),
-							command:      []string{"/bin/bash", "-c", "--"},
-							args:         []string{"while true; do sleep 30; done;"},
-							image:        "songrgg/alpine-debug",
-							ports:        []int{80},
+							Name:         clientApp,
+							Namespace:    clientApp,
+							ReplicaCount: int32(clientReplicaSet),
+							Command:      []string{"/bin/bash", "-c", "--"},
+							Args:         []string{"while true; do sleep 30; done;"},
+							Image:        "songrgg/alpine-debug",
+							Ports:        []int{80},
 						})
 
-					_, err := td.CreateServiceAccount(clientApp, &svcAccDef)
+					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateDeployment(clientApp, deploymentDef)
+					_, err = Td.CreateDeployment(clientApp, deploymentDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateService(clientApp, svcDef)
+					_, err = Td.CreateService(clientApp, svcDef)
 					Expect(err).NotTo(HaveOccurred())
 
 					wg.Add(1)
 					go func(app string) {
 						defer wg.Done()
-						Expect(td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
 					}(clientApp)
 				}
 
@@ -141,7 +142,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 
 				// Put allow traffic target rules
 				for _, srcClient := range clientServices {
-					httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+					httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
 						SimpleAllowPolicy{
 							RouteGroupName:    srcClient + "-server",
 							TrafficTargetName: srcClient + "-server",
@@ -153,21 +154,21 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							DestinationSvcAccountName: svcAcc.Name,
 						})
 
-					_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+					_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
 					Expect(err).NotTo(HaveOccurred())
 				}
 
 				// Create traffic split service. Use simple Pod to create a simple service definition
-				_, _, trafficSplitService := td.SimplePodApp(SimplePodAppDef{
-					name:      trafficSplitName,
-					namespace: serverNamespace,
-					ports:     []int{80},
+				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
+					Name:      trafficSplitName,
+					Namespace: serverNamespace,
+					Ports:     []int{80},
 				})
 
 				// Creating trafficsplit service in K8s
-				_, err = td.CreateService(serverNamespace, trafficSplitService)
+				_, err = Td.CreateService(serverNamespace, trafficSplitService)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Create Traffic split with all server processes as backends
@@ -187,11 +188,11 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 					)
 				}
 				// Get the Traffic split structures
-				tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
+				tSplit, err := Td.CreateSimpleTrafficSplit(trafficSplit)
 				Expect(err).To(BeNil())
 
 				// Push them in K8s
-				_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
+				_, err = Td.CreateTrafficSplit(serverNamespace, tSplit)
 				Expect(err).To(BeNil())
 
 				// Test traffic
@@ -200,7 +201,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 					Sources: []HTTPRequestDef{},
 				}
 				for _, ns := range clientServices {
-					pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 					Expect(err).To(BeNil())
 
 					for _, pod := range pods.Items {
@@ -217,14 +218,14 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 
 				var results HTTPMultipleResults
 				var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
-				success := td.WaitForRepeatedSuccess(func() bool {
+				success := Td.WaitForRepeatedSuccess(func() bool {
 					curlSuccess := true
 
 					// Get results
-					results = td.MultipleHTTPRequest(&requests)
+					results = Td.MultipleHTTPRequest(&requests)
 
 					// Print results
-					td.PrettyPrintHTTPResults(&results)
+					Td.PrettyPrintHTTPResults(&results)
 
 					// Verify REST status code results
 					for _, ns := range results {
@@ -241,7 +242,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							}
 						}
 					}
-					td.T.Logf("Unique servers replied %d/%d",
+					Td.T.Logf("Unique servers replied %d/%d",
 						len(serversSeen), numberOfServerServices*serverReplicaSet)
 
 					// Success conditions:

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -8,11 +8,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/openservicemesh/osm/tests/framework"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Test TrafficSplit where each backend shares the same ServiceAccount",

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,8 +16,8 @@ import (
 
 var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 2,
+		Tier:   1,
+		Bucket: 2,
 	},
 	func() {
 		Context("ClientServerTrafficSplit", func() {
@@ -56,21 +57,21 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 
 			It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
 				// Install OSM
-				Expect(td.InstallOSM(td.GetOSMInstallOpts())).To(Succeed())
+				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
 				// Create NSs
-				Expect(td.CreateMultipleNs(allNamespaces...)).To(Succeed())
-				Expect(td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+				Expect(Td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
 
 				// Create server apps
 				for _, serverApp := range serverServices {
-					svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							name:         serverApp,
-							namespace:    serverNamespace,
-							replicaCount: int32(serverReplicaSet),
-							image:        "simonkowallik/httpbin",
-							ports:        []int{80},
+							Name:         serverApp,
+							Namespace:    serverNamespace,
+							ReplicaCount: int32(serverReplicaSet),
+							Image:        "simonkowallik/httpbin",
+							Ports:        []int{80},
 						})
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -88,43 +89,43 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 						},
 					}
 
-					_, err := td.CreateServiceAccount(serverNamespace, &svcAccDef)
+					_, err := Td.CreateServiceAccount(serverNamespace, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateDeployment(serverNamespace, deploymentDef)
+					_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateService(serverNamespace, svcDef)
+					_, err = Td.CreateService(serverNamespace, svcDef)
 					Expect(err).NotTo(HaveOccurred())
 				}
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					Expect(td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
 				}()
 
 				// Client apps
 				for _, clientApp := range clientServices {
-					svcAccDef, deploymentDef, svcDef := td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							name:         clientApp,
-							namespace:    clientApp,
-							replicaCount: int32(clientReplicaSet),
-							command:      []string{"/bin/bash", "-c", "--"},
-							args:         []string{"while true; do sleep 30; done;"},
-							image:        "songrgg/alpine-debug",
-							ports:        []int{80},
+							Name:         clientApp,
+							Namespace:    clientApp,
+							ReplicaCount: int32(clientReplicaSet),
+							Command:      []string{"/bin/bash", "-c", "--"},
+							Args:         []string{"while true; do sleep 30; done;"},
+							Image:        "songrgg/alpine-debug",
+							Ports:        []int{80},
 						})
 
-					_, err := td.CreateServiceAccount(clientApp, &svcAccDef)
+					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateDeployment(clientApp, deploymentDef)
+					_, err = Td.CreateDeployment(clientApp, deploymentDef)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = td.CreateService(clientApp, svcDef)
+					_, err = Td.CreateService(clientApp, svcDef)
 					Expect(err).NotTo(HaveOccurred())
 
 					wg.Add(1)
 					go func(app string) {
 						defer wg.Done()
-						Expect(td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
 					}(clientApp)
 				}
 
@@ -133,7 +134,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 				// Put allow traffic target rules
 				for _, srcClient := range clientServices {
 					for _, dstServer := range serverServices {
-						httpRG, trafficTarget := td.CreateSimpleAllowPolicy(
+						httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
 							SimpleAllowPolicy{
 								RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
 								TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
@@ -145,22 +146,22 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 								DestinationSvcAccountName: dstServer,
 							})
 
-						_, err := td.CreateHTTPRouteGroup(srcClient, httpRG)
+						_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
 						Expect(err).NotTo(HaveOccurred())
-						_, err = td.CreateTrafficTarget(srcClient, trafficTarget)
+						_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
 						Expect(err).NotTo(HaveOccurred())
 					}
 				}
 
 				// Create traffic split service. Use simple Pod to create a simple service definition
-				_, _, trafficSplitService := td.SimplePodApp(SimplePodAppDef{
-					name:      trafficSplitName,
-					namespace: serverNamespace,
-					ports:     []int{80},
+				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
+					Name:      trafficSplitName,
+					Namespace: serverNamespace,
+					Ports:     []int{80},
 				})
 
 				// Creating trafficsplit service in K8s
-				_, err := td.CreateService(serverNamespace, trafficSplitService)
+				_, err := Td.CreateService(serverNamespace, trafficSplitService)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Create Traffic split with all server processes as backends
@@ -180,11 +181,11 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 					)
 				}
 				// Get the Traffic split structures
-				tSplit, err := td.CreateSimpleTrafficSplit(trafficSplit)
+				tSplit, err := Td.CreateSimpleTrafficSplit(trafficSplit)
 				Expect(err).To(BeNil())
 
 				// Push them in K8s
-				_, err = td.CreateTrafficSplit(serverNamespace, tSplit)
+				_, err = Td.CreateTrafficSplit(serverNamespace, tSplit)
 				Expect(err).To(BeNil())
 
 				By("Issuing http requests from clients to the traffic split FQDN")
@@ -195,7 +196,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 					Sources: []HTTPRequestDef{},
 				}
 				for _, ns := range clientServices {
-					pods, err := td.client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
 					Expect(err).To(BeNil())
 
 					for _, pod := range pods.Items {
@@ -212,14 +213,14 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 
 				var results HTTPMultipleResults
 				var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
-				success := td.WaitForRepeatedSuccess(func() bool {
+				success := Td.WaitForRepeatedSuccess(func() bool {
 					curlSuccess := true
 
 					// Get results
-					results = td.MultipleHTTPRequest(&requests)
+					results = Td.MultipleHTTPRequest(&requests)
 
 					// Print results
-					td.PrettyPrintHTTPResults(&results)
+					Td.PrettyPrintHTTPResults(&results)
 
 					// Verify REST status code results
 					for _, ns := range results {
@@ -236,7 +237,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 							}
 						}
 					}
-					td.T.Logf("Unique servers replied %d/%d",
+					Td.T.Logf("Unique servers replied %d/%d",
 						len(serversSeen), numberOfServerServices*serverReplicaSet)
 
 					// Success conditions:
@@ -254,7 +255,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 					Sources: []HTTPRequestDef{},
 				}
 				for _, clientNs := range clientServices {
-					pods, err := td.client.CoreV1().Pods(clientNs).List(context.Background(), metav1.ListOptions{})
+					pods, err := Td.Client.CoreV1().Pods(clientNs).List(context.Background(), metav1.ListOptions{})
 					Expect(err).To(BeNil())
 					// For each client pod
 					for _, pod := range pods.Items {
@@ -273,12 +274,12 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 				}
 
 				results = HTTPMultipleResults{}
-				success = td.WaitForRepeatedSuccess(func() bool {
+				success = Td.WaitForRepeatedSuccess(func() bool {
 					// Get results
-					results = td.MultipleHTTPRequest(&requests)
+					results = Td.MultipleHTTPRequest(&requests)
 
 					// Print results
-					td.PrettyPrintHTTPResults(&results)
+					Td.PrettyPrintHTTPResults(&results)
 
 					// Verify REST status code results
 					for _, ns := range results {

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -8,10 +8,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/openservicemesh/osm/tests/framework"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test",

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1,4 +1,4 @@
-package e2ef
+package framework
 
 import (
 	"bytes"
@@ -449,8 +449,8 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		args = append(args, "--container-registry-secret="+registrySecretName)
 	}
 
-	args = append(args, fmt.Sprintf("--enable-prometheus=%v", instOpts.DeployPrometheus))
-	args = append(args, fmt.Sprintf("--enable-grafana=%v", instOpts.DeployGrafana))
+	args = append(args, fmt.Sprintf("--deploy-prometheus=%v", instOpts.DeployPrometheus))
+	args = append(args, fmt.Sprintf("--deploy-grafana=%v", instOpts.DeployGrafana))
 	args = append(args, fmt.Sprintf("--deploy-jaeger=%v", instOpts.DeployJaeger))
 	args = append(args, fmt.Sprintf("--enable-fluentbit=%v", instOpts.DeployFluentbit))
 	args = append(args, fmt.Sprintf("--timeout=%v", 90*time.Second))

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1,4 +1,4 @@
-package e2e
+package e2ef
 
 import (
 	"bytes"
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/docker/docker/client"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -43,6 +44,30 @@ import (
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
+// Td the global context for test.
+var Td OsmTestData
+
+// Since parseFlags is global, this is the Ginkgo way to do it.
+// "init" is usually called by the go test runtime
+// https://github.com/onsi/ginkgo/issues/265
+func init() {
+	registerFlags(&Td)
+}
+
+// Cleanup when error
+var _ = BeforeEach(func() {
+	Expect(Td.InitTestData(GinkgoT())).To(BeNil())
+})
+
+// Cleanup when error
+var _ = AfterEach(func() {
+	Td.Cleanup(Test)
+})
+
+var _ = AfterSuite(func() {
+	Td.Cleanup(Suite)
+})
+
 const (
 	// contant, default name for the Registry Secret
 	registrySecretName = "acr-creds"
@@ -69,18 +94,18 @@ var (
 	defaultEnvoyLogLevel = "debug"
 )
 
-// OSMDescribeInfo is a struct to represent the tier and bucket of a given e2e test
+// OSMDescribeInfo is a struct to represent the Tier and Bucket of a given e2e test
 type OSMDescribeInfo struct {
-	// tier represents the priority of the test. Lower value indicates higher priority.
-	tier int
+	// Tier represents the priority of the test. Lower value indicates higher priority.
+	Tier int
 
-	// bucket indicates in which test bucket the test will run in for CI. Each
-	// bucket is run in parallel while tests in the same bucket run sequentially.
-	bucket int
+	// Bucket indicates in which test Bucket the test will run in for CI. Each
+	// Bucket is run in parallel while tests in the same Bucket run sequentially.
+	Bucket int
 }
 
 func (o OSMDescribeInfo) String() string {
-	return fmt.Sprintf("[Tier %d][Bucket %d]", o.tier, o.bucket)
+	return fmt.Sprintf("[Tier %d][Bucket %d]", o.Tier, o.Bucket)
 }
 
 // OSMDescribe givens the description of an e2e test
@@ -96,7 +121,7 @@ const (
 	SelfInstall InstallType = "SelfInstall"
 	// KindCluster Creates Kind cluster on docker and uses it as cluster, OSM installs through CLI
 	KindCluster InstallType = "KindCluster"
-	// NoInstall uses current kube cluster, assumes an OSM is present in `osmNamespace`
+	// NoInstall uses current kube cluster, assumes an OSM is present in `OsmNamespace`
 	NoInstall InstallType = "NoInstall"
 )
 
@@ -118,50 +143,50 @@ func verifyValidInstallType(t InstallType) error {
 type OsmTestData struct {
 	T GinkgoTInterface // for common test logging
 
-	cleanupTest    bool // Cleanup test-related resources once finished
-	waitForCleanup bool // Forces test to wait for effective deletion of resources upon cleanup
+	CleanupTest    bool // Cleanup test-related resources once finished
+	WaitForCleanup bool // Forces test to wait for effective deletion of resources upon cleanup
 
 	// OSM install-time variables
-	instType     InstallType // Install type.
-	osmNamespace string
-	osmImageTag  string
+	InstType     InstallType // Install type.
+	OsmNamespace string
+	OsmImageTag  string
 
 	// Container registry related vars
-	ctrRegistryUser     string // registry login
-	ctrRegistryPassword string // registry password, if any
-	ctrRegistryServer   string // server name. Has to be network reachable
+	CtrRegistryUser     string // registry login
+	CtrRegistryPassword string // registry password, if any
+	CtrRegistryServer   string // server name. Has to be network reachable
 
 	// Kind cluster related vars
-	clusterName                    string // Kind cluster name (used if kindCluster)
-	cleanupKindClusterBetweenTests bool   // Clean and re-create kind cluster between tests
-	cleanupKindCluster             bool   // Cleanup kind cluster upon test finish
+	ClusterName                    string // Kind cluster name (used if kindCluster)
+	CleanupKindClusterBetweenTests bool   // Clean and re-create kind cluster between tests
+	CleanupKindCluster             bool   // Cleanup kind cluster upon test finish
 
 	// Cluster handles and rest config
-	env             *cli.EnvSettings
-	restConfig      *rest.Config
-	client          *kubernetes.Clientset
-	smiClients      *smiClients
-	clusterProvider *cluster.Provider // provider, used when kindCluster is used
+	Env             *cli.EnvSettings
+	RestConfig      *rest.Config
+	Client          *kubernetes.Clientset
+	SmiClients      *smiClients
+	ClusterProvider *cluster.Provider // provider, used when kindCluster is used
 }
 
 // Function to run at init before Ginkgo has called parseFlags
 // See suite_test.go for details on how Ginko calls parseFlags
 func registerFlags(td *OsmTestData) {
-	flag.BoolVar(&td.cleanupTest, "cleanupTest", true, "Cleanup test resources when done")
-	flag.BoolVar(&td.waitForCleanup, "waitForCleanup", true, "Wait for effective deletion of resources")
+	flag.BoolVar(&td.CleanupTest, "cleanupTest", true, "Cleanup test resources when done")
+	flag.BoolVar(&td.WaitForCleanup, "waitForCleanup", true, "Wait for effective deletion of resources")
 
-	flag.StringVar((*string)(&td.instType), "installType", string(SelfInstall), "Type of install/deployment for OSM")
+	flag.StringVar((*string)(&td.InstType), "installType", string(SelfInstall), "Type of install/deployment for OSM")
 
-	flag.StringVar(&td.clusterName, "kindClusterName", "osm-e2e", "Name of the Kind cluster to be created")
-	flag.BoolVar(&td.cleanupKindCluster, "cleanupKindCluster", true, "Cleanup kind cluster upon exit")
-	flag.BoolVar(&td.cleanupKindClusterBetweenTests, "cleanupKindClusterBetweenTests", false, "Cleanup kind cluster between tests")
+	flag.StringVar(&td.ClusterName, "kindClusterName", "osm-e2e", "Name of the Kind cluster to be created")
+	flag.BoolVar(&td.CleanupKindCluster, "cleanupKindCluster", true, "Cleanup kind cluster upon exit")
+	flag.BoolVar(&td.CleanupKindClusterBetweenTests, "cleanupKindClusterBetweenTests", false, "Cleanup kind cluster between tests")
 
-	flag.StringVar(&td.ctrRegistryServer, "ctrRegistry", os.Getenv("CTR_REGISTRY"), "Container registry")
-	flag.StringVar(&td.ctrRegistryUser, "ctrRegistryUser", os.Getenv("CTR_REGISTRY_USER"), "Container registry")
-	flag.StringVar(&td.ctrRegistryPassword, "ctrRegistrySecret", os.Getenv("CTR_REGISTRY_PASSWORD"), "Container registry secret")
+	flag.StringVar(&td.CtrRegistryServer, "ctrRegistry", os.Getenv("CTR_REGISTRY"), "Container registry")
+	flag.StringVar(&td.CtrRegistryUser, "ctrRegistryUser", os.Getenv("CTR_REGISTRY_USER"), "Container registry")
+	flag.StringVar(&td.CtrRegistryPassword, "ctrRegistrySecret", os.Getenv("CTR_REGISTRY_PASSWORD"), "Container registry secret")
 
-	flag.StringVar(&td.osmImageTag, "osmImageTag", utils.GetEnv("CTR_TAG", defaultImageTag), "OSM image tag")
-	flag.StringVar(&td.osmNamespace, "osmNamespace", utils.GetEnv("K8S_NAMESPACE", defaultOsmNamespace), "OSM Namespace")
+	flag.StringVar(&td.OsmImageTag, "osmImageTag", utils.GetEnv("CTR_TAG", defaultImageTag), "OSM image tag")
+	flag.StringVar(&td.OsmNamespace, "OsmNamespace", utils.GetEnv("K8S_NAMESPACE", defaultOsmNamespace), "OSM Namespace")
 }
 
 // GetTestNamespaceSelectorMap returns a string-based selector used to refer/select all namespace
@@ -176,7 +201,7 @@ func (td *OsmTestData) GetTestNamespaceSelectorMap() map[string]string {
 // It's usually used to factor if a docker registry secret and ImagePullSecret
 // should be installed when creating namespaces and application templates
 func (td *OsmTestData) AreRegistryCredsPresent() bool {
-	return len(td.ctrRegistryUser) > 0 && len(td.ctrRegistryPassword) > 0
+	return len(td.CtrRegistryUser) > 0 && len(td.CtrRegistryPassword) > 0
 }
 
 // InitTestData Initializes the test structures
@@ -184,15 +209,15 @@ func (td *OsmTestData) AreRegistryCredsPresent() bool {
 func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 	td.T = t
 
-	err := verifyValidInstallType(td.instType)
+	err := verifyValidInstallType(td.InstType)
 	if err != nil {
 		return err
 	}
 
-	if (td.instType == KindCluster) && td.clusterProvider == nil {
-		td.clusterProvider = cluster.NewProvider()
+	if (td.InstType == KindCluster) && td.ClusterProvider == nil {
+		td.ClusterProvider = cluster.NewProvider()
 		td.T.Logf("Creating local kind cluster")
-		if err := td.clusterProvider.Create(td.clusterName); err != nil {
+		if err := td.ClusterProvider.Create(td.ClusterName); err != nil {
 			return errors.Wrap(err, "failed to create kind cluster")
 		}
 	}
@@ -212,9 +237,9 @@ func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 		return errors.Wrap(err, "failed to create Kubernetes client")
 	}
 
-	td.restConfig = kubeConfig
-	td.client = clientset
-	td.env = cli.New()
+	td.RestConfig = kubeConfig
+	td.Client = clientset
+	td.Env = cli.New()
 
 	if err := td.InitSMIClients(); err != nil {
 		return errors.Wrap(err, "failed to initialize SMI clients")
@@ -222,7 +247,7 @@ func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 
 	// After client creations, do a wait for kind cluster just in case it's not done yet coming up
 	// Ballparking pod number. kind has a large number of containers to run by default
-	if (td.instType == KindCluster) && td.clusterProvider != nil {
+	if (td.InstType == KindCluster) && td.ClusterProvider != nil {
 		if err := td.WaitForPodsRunningReady("kube-system", 120*time.Second, 5); err != nil {
 			return errors.Wrap(err, "failed to wait for kube-system pods")
 		}
@@ -233,65 +258,65 @@ func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 
 // InstallOSMOpts describes install options for OSM
 type InstallOSMOpts struct {
-	controlPlaneNS          string
-	certManager             string
-	containerRegistryLoc    string
-	containerRegistrySecret string
-	osmImagetag             string
-	deployGrafana           bool
-	deployPrometheus        bool
-	deployJaeger            bool
-	deployFluentbit         bool
+	ControlPlaneNS          string
+	CertManager             string
+	ContainerRegistryLoc    string
+	ContainerRegistrySecret string
+	OsmImagetag             string
+	DeployGrafana           bool
+	DeployPrometheus        bool
+	DeployJaeger            bool
+	DeployFluentbit         bool
 
-	vaultHost     string
-	vaultProtocol string
-	vaultToken    string
-	vaultRole     string
+	VaultHost     string
+	VaultProtocol string
+	VaultToken    string
+	VaultRole     string
 
-	certmanagerIssuerGroup string
-	certmanagerIssuerKind  string
-	certmanagerIssuerName  string
+	CertmanagerIssuerGroup string
+	CertmanagerIssuerKind  string
+	CertmanagerIssuerName  string
 
-	egressEnabled        bool
-	enablePermissiveMode bool
-	envoyLogLevel        string
-	enableDebugServer    bool
+	EgressEnabled        bool
+	EnablePermissiveMode bool
+	EnvoyLogLevel        string
+	EnableDebugServer    bool
 }
 
 // GetOSMInstallOpts initializes install options for OSM
 func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 	return InstallOSMOpts{
-		controlPlaneNS:          td.osmNamespace,
-		certManager:             defaultCertManager,
-		containerRegistryLoc:    td.ctrRegistryServer,
-		containerRegistrySecret: td.ctrRegistryPassword,
-		osmImagetag:             td.osmImageTag,
-		deployGrafana:           defaultDeployGrafana,
-		deployPrometheus:        defaultDeployPrometheus,
-		deployJaeger:            defaultDeployJaeger,
-		deployFluentbit:         defaultDeployFluentbit,
+		ControlPlaneNS:          td.OsmNamespace,
+		CertManager:             defaultCertManager,
+		ContainerRegistryLoc:    td.CtrRegistryServer,
+		ContainerRegistrySecret: td.CtrRegistryPassword,
+		OsmImagetag:             td.OsmImageTag,
+		DeployGrafana:           defaultDeployGrafana,
+		DeployPrometheus:        defaultDeployPrometheus,
+		DeployJaeger:            defaultDeployJaeger,
+		DeployFluentbit:         defaultDeployFluentbit,
 
-		vaultHost:     "vault." + td.osmNamespace + ".svc.cluster.local",
-		vaultProtocol: "http",
-		vaultRole:     "openservicemesh",
-		vaultToken:    "token",
+		VaultHost:     "vault." + td.OsmNamespace + ".svc.cluster.local",
+		VaultProtocol: "http",
+		VaultRole:     "openservicemesh",
+		VaultToken:    "token",
 
-		certmanagerIssuerGroup: "cert-manager.io",
-		certmanagerIssuerKind:  "Issuer",
-		certmanagerIssuerName:  "osm-ca",
-		envoyLogLevel:          defaultEnvoyLogLevel,
+		CertmanagerIssuerGroup: "cert-manager.io",
+		CertmanagerIssuerKind:  "Issuer",
+		CertmanagerIssuerName:  "osm-ca",
+		EnvoyLogLevel:          defaultEnvoyLogLevel,
 	}
 }
 
 // HelmInstallOSM installs an osm control plane using the osm chart which lives in charts/osm
 func (td *OsmTestData) HelmInstallOSM(release, namespace string) error {
-	if td.instType == KindCluster {
+	if td.InstType == KindCluster {
 		if err := td.loadOSMImagesIntoKind(); err != nil {
 			return err
 		}
 	}
 
-	values := fmt.Sprintf("OpenServiceMesh.image.registry=%s,OpenServiceMesh.image.tag=%s,OpenServiceMesh.meshName=%s", td.ctrRegistryServer, td.osmImageTag, release)
+	values := fmt.Sprintf("OpenServiceMesh.image.registry=%s,OpenServiceMesh.image.tag=%s,OpenServiceMesh.meshName=%s", td.CtrRegistryServer, td.OsmImageTag, release)
 	args := []string{"install", release, "../../charts/osm", "--set", values, "--namespace", namespace, "--create-namespace", "--wait"}
 	stdout, stderr, err := td.RunLocal("helm", args)
 	if err != nil {
@@ -315,37 +340,37 @@ func (td *OsmTestData) DeleteHelmRelease(name, namespace string) error {
 // InstallOSM installs OSM. The behavior of this function is dependant on
 // installType and instOpts
 func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
-	if td.instType == NoInstall {
-		if instOpts.certManager != defaultCertManager ||
-			instOpts.deployPrometheus != defaultDeployPrometheus ||
-			instOpts.deployGrafana != defaultDeployGrafana ||
-			instOpts.deployJaeger != defaultDeployJaeger ||
-			instOpts.deployFluentbit != defaultDeployFluentbit {
+	if td.InstType == NoInstall {
+		if instOpts.CertManager != defaultCertManager ||
+			instOpts.DeployPrometheus != defaultDeployPrometheus ||
+			instOpts.DeployGrafana != defaultDeployGrafana ||
+			instOpts.DeployJaeger != defaultDeployJaeger ||
+			instOpts.DeployFluentbit != defaultDeployFluentbit {
 			Skip("Skipping test: NoInstall marked on a test that requires modified install")
 		}
 
-		// TODO: Check there is a valid OSM instance running already in osmNamespace
+		// TODO: Check there is a valid OSM instance running already in OsmNamespace
 
 		// This resets supported dynamic configs expected by the caller
 		err := td.UpdateOSMConfig("egress",
-			fmt.Sprintf("%t", instOpts.egressEnabled))
+			fmt.Sprintf("%t", instOpts.EgressEnabled))
 		if err != nil {
 			return err
 		}
 		err = td.UpdateOSMConfig("permissive_traffic_policy_mode",
-			fmt.Sprintf("%t", instOpts.enablePermissiveMode))
+			fmt.Sprintf("%t", instOpts.EnablePermissiveMode))
 		if err != nil {
 			return err
 		}
 		err = td.UpdateOSMConfig("enable_debug_server",
-			fmt.Sprintf("%t", instOpts.enableDebugServer))
+			fmt.Sprintf("%t", instOpts.EnableDebugServer))
 		if err != nil {
 			return err
 		}
 		return nil
 	}
 
-	if td.instType == KindCluster {
+	if td.InstType == KindCluster {
 		td.T.Log("Getting image data")
 		imageNames := []string{
 			"osm-controller",
@@ -357,7 +382,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		}
 		var imageIDs []string
 		for _, name := range imageNames {
-			imageName := fmt.Sprintf("%s/%s:%s", td.ctrRegistryServer, name, td.osmImageTag)
+			imageName := fmt.Sprintf("%s/%s:%s", td.CtrRegistryServer, name, td.OsmImageTag)
 			imageIDs = append(imageIDs, imageName)
 		}
 		imageData, err := docker.ImageSave(context.TODO(), imageIDs)
@@ -365,7 +390,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 			return errors.Wrap(err, "failed to get image data")
 		}
 		defer imageData.Close() //nolint: errcheck,gosec
-		nodes, err := td.clusterProvider.ListNodes(td.clusterName)
+		nodes, err := td.ClusterProvider.ListNodes(td.ClusterName)
 		if err != nil {
 			return errors.Wrap(err, "failed to list kind nodes")
 		}
@@ -377,57 +402,57 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		}
 	}
 
-	if err := td.CreateNs(instOpts.controlPlaneNS, nil); err != nil {
-		return errors.Wrap(err, "failed to create namespace "+instOpts.controlPlaneNS)
+	if err := td.CreateNs(instOpts.ControlPlaneNS, nil); err != nil {
+		return errors.Wrap(err, "failed to create namespace "+instOpts.ControlPlaneNS)
 	}
 
 	var args []string
 	args = append(args, "install",
-		"--container-registry="+instOpts.containerRegistryLoc,
-		"--osm-image-tag="+instOpts.osmImagetag,
-		"--osm-namespace="+instOpts.controlPlaneNS,
-		"--certificate-manager="+instOpts.certManager,
-		"--enable-egress="+strconv.FormatBool(instOpts.egressEnabled),
-		"--enable-permissive-traffic-policy="+strconv.FormatBool(instOpts.enablePermissiveMode),
-		"--enable-debug-server="+strconv.FormatBool(instOpts.enableDebugServer),
-		"--envoy-log-level="+instOpts.envoyLogLevel,
+		"--container-registry="+instOpts.ContainerRegistryLoc,
+		"--osm-image-tag="+instOpts.OsmImagetag,
+		"--osm-namespace="+instOpts.ControlPlaneNS,
+		"--certificate-manager="+instOpts.CertManager,
+		"--enable-egress="+strconv.FormatBool(instOpts.EgressEnabled),
+		"--enable-permissive-traffic-policy="+strconv.FormatBool(instOpts.EnablePermissiveMode),
+		"--enable-debug-server="+strconv.FormatBool(instOpts.EnableDebugServer),
+		"--envoy-log-level="+instOpts.EnvoyLogLevel,
 	)
 
-	switch instOpts.certManager {
+	switch instOpts.CertManager {
 	case "vault":
 		if err := td.installVault(instOpts); err != nil {
 			return err
 		}
 		args = append(args,
-			"--vault-host="+instOpts.vaultHost,
-			"--vault-token="+instOpts.vaultToken,
-			"--vault-protocol="+instOpts.vaultProtocol,
-			"--vault-role="+instOpts.vaultRole,
+			"--vault-host="+instOpts.VaultHost,
+			"--vault-token="+instOpts.VaultToken,
+			"--vault-protocol="+instOpts.VaultProtocol,
+			"--vault-role="+instOpts.VaultRole,
 		)
 	case "cert-manager":
 		if err := td.installCertManager(instOpts); err != nil {
 			return err
 		}
 		args = append(args,
-			"--cert-manager-issuer-name="+instOpts.certmanagerIssuerName,
-			"--cert-manager-issuer-kind="+instOpts.certmanagerIssuerKind,
-			"--cert-manager-issuer-group="+instOpts.certmanagerIssuerGroup,
+			"--cert-manager-issuer-name="+instOpts.CertmanagerIssuerName,
+			"--cert-manager-issuer-kind="+instOpts.CertmanagerIssuerKind,
+			"--cert-manager-issuer-group="+instOpts.CertmanagerIssuerGroup,
 		)
 	}
 
-	if !(td.instType == KindCluster) {
+	if !(td.InstType == KindCluster) {
 		// Making sure the image is always pulled in registry-based testing
 		args = append(args, "--osm-image-pull-policy=Always")
 	}
 
-	if len(instOpts.containerRegistrySecret) != 0 {
+	if len(instOpts.ContainerRegistrySecret) != 0 {
 		args = append(args, "--container-registry-secret="+registrySecretName)
 	}
 
-	args = append(args, fmt.Sprintf("--deploy-prometheus=%v", instOpts.deployPrometheus))
-	args = append(args, fmt.Sprintf("--deploy-grafana=%v", instOpts.deployGrafana))
-	args = append(args, fmt.Sprintf("--deploy-jaeger=%v", instOpts.deployJaeger))
-	args = append(args, fmt.Sprintf("--enable-fluentbit=%v", instOpts.deployFluentbit))
+	args = append(args, fmt.Sprintf("--enable-prometheus=%v", instOpts.DeployPrometheus))
+	args = append(args, fmt.Sprintf("--enable-grafana=%v", instOpts.DeployGrafana))
+	args = append(args, fmt.Sprintf("--deploy-jaeger=%v", instOpts.DeployJaeger))
+	args = append(args, fmt.Sprintf("--enable-fluentbit=%v", instOpts.DeployFluentbit))
 	args = append(args, fmt.Sprintf("--timeout=%v", 90*time.Second))
 
 	td.T.Log("Installing OSM")
@@ -444,7 +469,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 
 // GetConfigMap is a wrapper to get a config map by name in a particular namespace
 func (td *OsmTestData) GetConfigMap(name, namespace string) (*corev1.ConfigMap, error) {
-	configmap, err := td.client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	configmap, err := td.Client.CoreV1().ConfigMaps(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -463,7 +488,7 @@ func (td *OsmTestData) loadOSMImagesIntoKind() error {
 	}
 	var imageIDs []string
 	for _, name := range imageNames {
-		imageName := fmt.Sprintf("%s/%s:%s", td.ctrRegistryServer, name, td.osmImageTag)
+		imageName := fmt.Sprintf("%s/%s:%s", td.CtrRegistryServer, name, td.OsmImageTag)
 		imageIDs = append(imageIDs, imageName)
 	}
 	imageData, err := docker.ImageSave(context.TODO(), imageIDs)
@@ -471,7 +496,7 @@ func (td *OsmTestData) loadOSMImagesIntoKind() error {
 		return errors.Wrap(err, "failed to get image data")
 	}
 	defer imageData.Close() //nolint: errcheck,gosec
-	nodes, err := td.clusterProvider.ListNodes(td.clusterName)
+	nodes, err := td.ClusterProvider.ListNodes(td.ClusterName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list kind nodes")
 	}
@@ -543,7 +568,7 @@ vault write pki/roles/%s allow_any_name=true allow_subdomains=true max_ttl=87700
 # Create the root certificate (See: https://www.vaultproject.io/docs/secrets/pki#setup)
 vault write pki/root/generate/internal common_name='osm.root' ttl='87700h';
 tail /dev/random;
-`, instOpts.vaultToken, instOpts.vaultToken, instOpts.vaultRole),
+`, instOpts.VaultToken, instOpts.VaultToken, instOpts.VaultRole),
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Capabilities: &corev1.Capabilities{
@@ -603,7 +628,7 @@ tail /dev/random;
 			},
 		},
 	}
-	_, err := td.client.AppsV1().Deployments(instOpts.controlPlaneNS).Create(context.TODO(), vaultDep, metav1.CreateOptions{})
+	_, err := td.Client.AppsV1().Deployments(instOpts.ControlPlaneNS).Create(context.TODO(), vaultDep, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create vault deployment")
 	}
@@ -630,7 +655,7 @@ tail /dev/random;
 			},
 		},
 	}
-	_, err = td.client.CoreV1().Services(instOpts.controlPlaneNS).Create(context.TODO(), vaultSvc, metav1.CreateOptions{})
+	_, err = td.Client.CoreV1().Services(instOpts.ControlPlaneNS).Create(context.TODO(), vaultSvc, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create vault service")
 	}
@@ -640,12 +665,12 @@ tail /dev/random;
 func (td *OsmTestData) installCertManager(instOpts InstallOSMOpts) error {
 	By("Installing cert-manager")
 	helm := &action.Configuration{}
-	if err := helm.Init(td.env.RESTClientGetter(), td.osmNamespace, "secret", td.T.Logf); err != nil {
+	if err := helm.Init(td.Env.RESTClientGetter(), td.OsmNamespace, "secret", td.T.Logf); err != nil {
 		return errors.Wrap(err, "failed to initialize helm config")
 	}
 	install := action.NewInstall(helm)
 	install.RepoURL = "https://charts.jetstack.io"
-	install.Namespace = td.osmNamespace
+	install.Namespace = td.OsmNamespace
 	install.ReleaseName = "certmanager"
 	install.Version = "v0.16.1"
 
@@ -711,22 +736,22 @@ func (td *OsmTestData) installCertManager(instOpts InstallOSMOpts) error {
 		return errors.Wrap(err, "failed to wait for cert-manager pods ready")
 	}
 
-	cmClient, err := certman.NewForConfig(td.restConfig)
+	cmClient, err := certman.NewForConfig(td.RestConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create cert-manager config")
 	}
 
-	_, err = cmClient.CertmanagerV1alpha2().Certificates(td.osmNamespace).Create(context.TODO(), cert, metav1.CreateOptions{})
+	_, err = cmClient.CertmanagerV1alpha2().Certificates(td.OsmNamespace).Create(context.TODO(), cert, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create Certificate "+cert.Name)
 	}
 
-	_, err = cmClient.CertmanagerV1alpha2().Issuers(td.osmNamespace).Create(context.TODO(), selfsigned, metav1.CreateOptions{})
+	_, err = cmClient.CertmanagerV1alpha2().Issuers(td.OsmNamespace).Create(context.TODO(), selfsigned, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create Issuer "+selfsigned.Name)
 	}
 
-	_, err = cmClient.CertmanagerV1alpha2().Issuers(td.osmNamespace).Create(context.TODO(), ca, metav1.CreateOptions{})
+	_, err = cmClient.CertmanagerV1alpha2().Issuers(td.OsmNamespace).Create(context.TODO(), ca, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create Issuer "+ca.Name)
 	}
@@ -757,7 +782,7 @@ func (td *OsmTestData) AddNsToMesh(sidecardInject bool, ns ...string) error {
 // UpdateOSMConfig updates OSM configmap
 func (td *OsmTestData) UpdateOSMConfig(key, value string) error {
 	patch := []byte(fmt.Sprintf(`{"data": {%q: %q}}`, key, value))
-	_, err := td.client.CoreV1().ConfigMaps(td.osmNamespace).Patch(context.TODO(), "osm-config", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
+	_, err := td.Client.CoreV1().ConfigMaps(td.OsmNamespace).Patch(context.TODO(), "osm-config", types.StrategicMergePatchType, patch, metav1.PatchOptions{})
 	return err
 }
 
@@ -791,7 +816,7 @@ func (td *OsmTestData) CreateNs(nsName string, labels map[string]string) error {
 	}
 
 	td.T.Logf("Creating namespace %v", nsName)
-	_, err := td.client.CoreV1().Namespaces().Create(context.Background(), namespaceObj, metav1.CreateOptions{})
+	_, err := td.Client.CoreV1().Namespaces().Create(context.Background(), namespaceObj, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create namespace "+nsName)
 	}
@@ -808,7 +833,7 @@ func (td *OsmTestData) CreateNs(nsName string, labels map[string]string) error {
 func (td *OsmTestData) DeleteNs(nsName string) error {
 	// Delete Helm releases created in the namespace
 	helm := &action.Configuration{}
-	if err := helm.Init(td.env.RESTClientGetter(), nsName, "secret", td.T.Logf); err != nil {
+	if err := helm.Init(td.Env.RESTClientGetter(), nsName, "secret", td.T.Logf); err != nil {
 		td.T.Logf("WARNING: failed to initialize helm config, skipping helm cleanup: %v", err)
 	} else {
 		list := action.NewList(helm)
@@ -828,7 +853,7 @@ func (td *OsmTestData) DeleteNs(nsName string) error {
 	var backgroundDelete metav1.DeletionPropagation = metav1.DeletePropagationBackground
 
 	td.T.Logf("Deleting namespace %v", nsName)
-	err := td.client.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{PropagationPolicy: &backgroundDelete})
+	err := td.Client.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{PropagationPolicy: &backgroundDelete})
 	if err != nil {
 		return errors.Wrap(err, "failed to delete namespace "+nsName)
 	}
@@ -846,7 +871,7 @@ func (td *OsmTestData) WaitForNamespacesDeleted(namespaces []string, timeout tim
 	//Now POLL until all namespaces have been eradicated.
 	return wait.Poll(2*time.Second, timeout,
 		func() (bool, error) {
-			nsList, err := td.client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+			nsList, err := td.Client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -878,7 +903,7 @@ func (td *OsmTestData) RunRemote(
 	command string) (string, string, error) {
 	var stdin, stdout, stderr bytes.Buffer
 
-	req := td.client.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
+	req := td.Client.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
 		Namespace(ns).SubResource("exec")
 
 	option := &corev1.PodExecOptions{
@@ -900,7 +925,7 @@ func (td *OsmTestData) RunRemote(
 		option,
 		runtime.NewParameterCodec(scheme),
 	)
-	exec, err := remotecommand.NewSPDYExecutor(td.restConfig, "POST", req.URL())
+	exec, err := remotecommand.NewSPDYExecutor(td.RestConfig, "POST", req.URL())
 	if err != nil {
 		return "", "", err
 	}
@@ -920,7 +945,7 @@ func (td *OsmTestData) RunRemote(
 func (td *OsmTestData) WaitForPodsRunningReady(ns string, timeout time.Duration, nExpectedRunningPods int) error {
 	td.T.Logf("Wait up to %v for %d pods ready in ns [%s]...", timeout, nExpectedRunningPods, ns)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(2 * time.Second) {
-		pods, err := td.client.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
+		pods, err := td.Client.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{
 			FieldSelector: "status.phase=Running",
 		})
 
@@ -988,7 +1013,7 @@ const (
 
 // Cleanup is Used to cleanup resorces once the test is done
 func (td *OsmTestData) Cleanup(ct CleanupType) {
-	if td.client == nil {
+	if td.Client == nil {
 		// Avoid any cleanup (crash) if no test is run;
 		// init doesn't happen and clientsets are nil
 		return
@@ -1000,17 +1025,17 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 	//   destroyed after this test.
 	//   The latter is a condition to speed up and not wait for k8s resources to vanish
 	//   if the current kind cluster has to be destroyed anyway.
-	if td.cleanupTest &&
-		(!(td.instType == KindCluster) ||
-			(td.instType == KindCluster &&
-				(ct == Test && !td.cleanupKindClusterBetweenTests) ||
-				(ct == Suite && !td.cleanupKindCluster))) {
+	if td.CleanupTest &&
+		(!(td.InstType == KindCluster) ||
+			(td.InstType == KindCluster &&
+				(ct == Test && !td.CleanupKindClusterBetweenTests) ||
+				(ct == Suite && !td.CleanupKindCluster))) {
 		// Use selector to refer to all namespaces used in this test
 		nsSelector := metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(td.GetTestNamespaceSelectorMap()).String(),
 		}
 
-		testNs, err := td.client.CoreV1().Namespaces().List(context.Background(), nsSelector)
+		testNs, err := td.Client.CoreV1().Namespaces().List(context.Background(), nsSelector)
 		if err != nil {
 			td.T.Fatalf("Failed to get list of test NS: %v", err)
 		}
@@ -1023,10 +1048,10 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 			}
 		}
 		By(fmt.Sprintf("[Cleanup] waiting for %s:%d test NS cleanup", osmTest, GinkgoRandomSeed()))
-		if td.waitForCleanup {
+		if td.WaitForCleanup {
 			err := wait.Poll(2*time.Second, 240*time.Second,
 				func() (bool, error) {
-					nsList, err := td.client.CoreV1().Namespaces().List(context.TODO(), nsSelector)
+					nsList, err := td.Client.CoreV1().Namespaces().List(context.TODO(), nsSelector)
 					if err != nil {
 						td.T.Logf("Err waiting for ns list to disappear: %v", err)
 						return false, err
@@ -1041,13 +1066,13 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 	}
 
 	// Kind cluster deletion, if needed
-	if (td.instType == KindCluster) && td.clusterProvider != nil {
-		if ct == Test && td.cleanupKindClusterBetweenTests || ct == Suite && td.cleanupKindCluster {
-			td.T.Logf("Deleting kind cluster: %s", td.clusterName)
-			if err := td.clusterProvider.Delete(td.clusterName, clientcmd.RecommendedHomeFile); err != nil {
+	if (td.InstType == KindCluster) && td.ClusterProvider != nil {
+		if ct == Test && td.CleanupKindClusterBetweenTests || ct == Suite && td.CleanupKindCluster {
+			td.T.Logf("Deleting kind cluster: %s", td.ClusterName)
+			if err := td.ClusterProvider.Delete(td.ClusterName, clientcmd.RecommendedHomeFile); err != nil {
 				td.T.Logf("error deleting cluster: %v", err)
 			}
-			td.clusterProvider = nil
+			td.ClusterProvider = nil
 		}
 	}
 }
@@ -1079,21 +1104,21 @@ func (td *OsmTestData) CreateDockerRegistrySecret(ns string) {
 	secret.Data = map[string][]byte{}
 
 	dockercfgAuth := DockerConfigEntry{
-		Username: td.ctrRegistryUser,
-		Password: td.ctrRegistryPassword,
+		Username: td.CtrRegistryUser,
+		Password: td.CtrRegistryPassword,
 		Email:    "osm@osm.com",
-		Auth:     base64.StdEncoding.EncodeToString([]byte(td.ctrRegistryUser + ":" + td.ctrRegistryPassword)),
+		Auth:     base64.StdEncoding.EncodeToString([]byte(td.CtrRegistryUser + ":" + td.CtrRegistryPassword)),
 	}
 
 	dockerCfgJSON := DockerConfigJSON{
-		Auths: map[string]DockerConfigEntry{td.ctrRegistryServer: dockercfgAuth},
+		Auths: map[string]DockerConfigEntry{td.CtrRegistryServer: dockercfgAuth},
 	}
 
 	json, _ := json.Marshal(dockerCfgJSON)
 	secret.Data[corev1.DockerConfigJsonKey] = json
 
 	td.T.Logf("Pushing Registry secret '%s' for namespace %s... ", registrySecretName, ns)
-	_, err := td.client.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{})
+	_, err := td.Client.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{})
 	if err != nil {
 		td.T.Fatalf("Could not add registry secret")
 	}

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -1,4 +1,4 @@
-package e2e
+package e2ef
 
 import (
 	"context"
@@ -14,7 +14,7 @@ import (
 
 // CreateServiceAccount is a wrapper to create a service account
 func (td *OsmTestData) CreateServiceAccount(ns string, svcAccount *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-	svcAc, err := td.client.CoreV1().ServiceAccounts(ns).Create(context.Background(), svcAccount, metav1.CreateOptions{})
+	svcAc, err := td.Client.CoreV1().ServiceAccounts(ns).Create(context.Background(), svcAccount, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create Service Account: %v", err)
 		return nil, err
@@ -24,7 +24,7 @@ func (td *OsmTestData) CreateServiceAccount(ns string, svcAccount *corev1.Servic
 
 // CreatePod is a wrapper to create a pod
 func (td *OsmTestData) CreatePod(ns string, pod corev1.Pod) (*corev1.Pod, error) {
-	podRet, err := td.client.CoreV1().Pods(ns).Create(context.Background(), &pod, metav1.CreateOptions{})
+	podRet, err := td.Client.CoreV1().Pods(ns).Create(context.Background(), &pod, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create Pod: %v", err)
 		return nil, err
@@ -34,7 +34,7 @@ func (td *OsmTestData) CreatePod(ns string, pod corev1.Pod) (*corev1.Pod, error)
 
 // CreateDeployment is a wrapper to create a deployment
 func (td *OsmTestData) CreateDeployment(ns string, deployment appsv1.Deployment) (*appsv1.Deployment, error) {
-	deploymentRet, err := td.client.AppsV1().Deployments(ns).Create(context.Background(), &deployment, metav1.CreateOptions{})
+	deploymentRet, err := td.Client.AppsV1().Deployments(ns).Create(context.Background(), &deployment, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create Deployment: %v", err)
 		return nil, err
@@ -44,7 +44,7 @@ func (td *OsmTestData) CreateDeployment(ns string, deployment appsv1.Deployment)
 
 // CreateService is a wrapper to create a service
 func (td *OsmTestData) CreateService(ns string, svc corev1.Service) (*corev1.Service, error) {
-	sv, err := td.client.CoreV1().Services(ns).Create(context.Background(), &svc, metav1.CreateOptions{})
+	sv, err := td.Client.CoreV1().Services(ns).Create(context.Background(), &svc, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create Service: %v", err)
 		return nil, err
@@ -54,7 +54,7 @@ func (td *OsmTestData) CreateService(ns string, svc corev1.Service) (*corev1.Ser
 
 // CreateMutatingWebhook is a wrapper to create a mutating webhook configuration
 func (td *OsmTestData) CreateMutatingWebhook(mwhc *v1beta1.MutatingWebhookConfiguration) (*v1beta1.MutatingWebhookConfiguration, error) {
-	mw, err := td.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.Background(), mwhc, metav1.CreateOptions{})
+	mw, err := td.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.Background(), mwhc, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create MutatingWebhook: %v", err)
 		return nil, err
@@ -64,7 +64,7 @@ func (td *OsmTestData) CreateMutatingWebhook(mwhc *v1beta1.MutatingWebhookConfig
 
 // GetMutatingWebhook is a wrapper to get a mutating webhook configuration
 func (td *OsmTestData) GetMutatingWebhook(mwhcName string) (*v1beta1.MutatingWebhookConfiguration, error) {
-	mwhc, err := td.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.Background(), mwhcName, metav1.GetOptions{})
+	mwhc, err := td.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.Background(), mwhcName, metav1.GetOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not get MutatingWebhook: %v", err)
 		return nil, err
@@ -81,12 +81,12 @@ func (td *OsmTestData) GetMutatingWebhook(mwhcName string) (*v1beta1.MutatingWeb
 
 // SimplePodAppDef defines some parametrization to create a pod-based application from template
 type SimplePodAppDef struct {
-	namespace string
-	name      string
-	image     string
-	command   []string
-	args      []string
-	ports     []int
+	Namespace string
+	Name      string
+	Image     string
+	Command   []string
+	Args      []string
+	Ports     []int
 }
 
 // SimplePodApp creates returns a set of k8s typed definitions for a pod-based k8s definition.
@@ -94,23 +94,23 @@ type SimplePodAppDef struct {
 func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount, corev1.Pod, corev1.Service) {
 	serviceAccountDefinition := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: def.name,
+			Name: def.Name,
 		},
 	}
 
 	podDefinition := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: def.name,
+			Name: def.Name,
 			Labels: map[string]string{
-				"app": def.name,
+				"app": def.Name,
 			},
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: def.name,
+			ServiceAccountName: def.Name,
 			Containers: []corev1.Container{
 				{
-					Name:            def.name,
-					Image:           def.image,
+					Name:            def.Name,
+					Image:           def.Image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
@@ -130,32 +130,32 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 			},
 		}
 	}
-	if def.command != nil && len(def.command) > 0 {
-		podDefinition.Spec.Containers[0].Command = def.command
+	if def.Command != nil && len(def.Command) > 0 {
+		podDefinition.Spec.Containers[0].Command = def.Command
 	}
-	if def.args != nil && len(def.args) > 0 {
-		podDefinition.Spec.Containers[0].Args = def.args
+	if def.Args != nil && len(def.Args) > 0 {
+		podDefinition.Spec.Containers[0].Args = def.Args
 	}
 
 	serviceDefinition := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: def.name,
+			Name: def.Name,
 			Labels: map[string]string{
-				"app": def.name,
+				"app": def.Name,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app": def.name,
+				"app": def.Name,
 			},
 		},
 	}
 
-	if def.ports != nil && len(def.ports) > 0 {
+	if def.Ports != nil && len(def.Ports) > 0 {
 		podDefinition.Spec.Containers[0].Ports = []corev1.ContainerPort{}
 		serviceDefinition.Spec.Ports = []corev1.ServicePort{}
 
-		for _, p := range def.ports {
+		for _, p := range def.Ports {
 			podDefinition.Spec.Containers[0].Ports = append(podDefinition.Spec.Containers[0].Ports,
 				corev1.ContainerPort{
 					ContainerPort: int32(p),
@@ -173,13 +173,13 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 
 // SimpleDeploymentAppDef defines some parametrization to create a deployment-based application from template
 type SimpleDeploymentAppDef struct {
-	namespace    string
-	name         string
-	image        string
-	replicaCount int32
-	command      []string
-	args         []string
-	ports        []int
+	Namespace    string
+	Name         string
+	Image        string
+	ReplicaCount int32
+	Command      []string
+	Args         []string
+	Ports        []int
 }
 
 // SimpleDeploymentApp creates returns a set of k8s typed definitions for a deployment-based k8s definition.
@@ -187,38 +187,38 @@ type SimpleDeploymentAppDef struct {
 func (td *OsmTestData) SimpleDeploymentApp(def SimpleDeploymentAppDef) (corev1.ServiceAccount, appsv1.Deployment, corev1.Service) {
 	serviceAccountDefinition := corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      def.name,
-			Namespace: def.namespace,
+			Name:      def.Name,
+			Namespace: def.Namespace,
 		},
 	}
 
 	// Required, as replica count is a pointer to distinguish between 0 and not specified
-	replicaCountExplicitDeclaration := def.replicaCount
+	replicaCountExplicitDeclaration := def.ReplicaCount
 
 	deploymentDefinition := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      def.name,
-			Namespace: def.namespace,
+			Name:      def.Name,
+			Namespace: def.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicaCountExplicitDeclaration,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": def.name,
+					"app": def.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": def.name,
+						"app": def.Name,
 					},
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: def.name,
+					ServiceAccountName: def.Name,
 					Containers: []corev1.Container{
 						{
-							Name:            def.name,
-							Image:           def.image,
+							Name:            def.Name,
+							Image:           def.Image,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 						},
 					},
@@ -235,33 +235,33 @@ func (td *OsmTestData) SimpleDeploymentApp(def SimpleDeploymentAppDef) (corev1.S
 		}
 	}
 
-	if def.command != nil && len(def.command) > 0 {
-		deploymentDefinition.Spec.Template.Spec.Containers[0].Command = def.command
+	if def.Command != nil && len(def.Command) > 0 {
+		deploymentDefinition.Spec.Template.Spec.Containers[0].Command = def.Command
 	}
-	if def.args != nil && len(def.args) > 0 {
-		deploymentDefinition.Spec.Template.Spec.Containers[0].Args = def.args
+	if def.Args != nil && len(def.Args) > 0 {
+		deploymentDefinition.Spec.Template.Spec.Containers[0].Args = def.Args
 	}
 
 	serviceDefinition := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      def.name,
-			Namespace: def.namespace,
+			Name:      def.Name,
+			Namespace: def.Namespace,
 			Labels: map[string]string{
-				"app": def.name,
+				"app": def.Name,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app": def.name,
+				"app": def.Name,
 			},
 		},
 	}
 
-	if def.ports != nil && len(def.ports) > 0 {
+	if def.Ports != nil && len(def.Ports) > 0 {
 		deploymentDefinition.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{}
 		serviceDefinition.Spec.Ports = []corev1.ServicePort{}
 
-		for _, p := range def.ports {
+		for _, p := range def.Ports {
 			deploymentDefinition.Spec.Template.Spec.Containers[0].Ports = append(deploymentDefinition.Spec.Template.Spec.Containers[0].Ports,
 				corev1.ContainerPort{
 					ContainerPort: int32(p),

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -1,4 +1,4 @@
-package e2ef
+package framework
 
 import (
 	"context"

--- a/tests/framework/common_smi.go
+++ b/tests/framework/common_smi.go
@@ -1,4 +1,4 @@
-package e2e
+package e2ef
 
 import (
 	"context"
@@ -22,20 +22,20 @@ type smiClients struct {
 
 // InitSMIClients initializes SMI clients on OsmTestData structure
 func (td *OsmTestData) InitSMIClients() error {
-	td.smiClients = &smiClients{}
+	td.SmiClients = &smiClients{}
 	var err error
 
-	td.smiClients.SpecClient, err = smiTrafficSpecClient.NewForConfig(td.restConfig)
+	td.SmiClients.SpecClient, err = smiTrafficSpecClient.NewForConfig(td.RestConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create traffic spec client")
 	}
 
-	td.smiClients.AccessClient, err = smiTrafficAccessClient.NewForConfig(td.restConfig)
+	td.SmiClients.AccessClient, err = smiTrafficAccessClient.NewForConfig(td.RestConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create traffic access client")
 	}
 
-	td.smiClients.SplitClient, err = smiTrafficSplitClient.NewForConfig(td.restConfig)
+	td.SmiClients.SplitClient, err = smiTrafficSplitClient.NewForConfig(td.RestConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to create traffic split client")
 	}
@@ -45,7 +45,7 @@ func (td *OsmTestData) InitSMIClients() error {
 
 // CreateHTTPRouteGroup Creates an SMI Route Group
 func (td *OsmTestData) CreateHTTPRouteGroup(ns string, rg smiSpecs.HTTPRouteGroup) (*smiSpecs.HTTPRouteGroup, error) {
-	hrg, err := td.smiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(ns).Create(context.Background(), &rg, metav1.CreateOptions{})
+	hrg, err := td.SmiClients.SpecClient.SpecsV1alpha3().HTTPRouteGroups(ns).Create(context.Background(), &rg, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create HTTPRouteGroup")
 	}
@@ -54,7 +54,7 @@ func (td *OsmTestData) CreateHTTPRouteGroup(ns string, rg smiSpecs.HTTPRouteGrou
 
 // CreateTrafficTarget Creates an SMI TrafficTarget
 func (td *OsmTestData) CreateTrafficTarget(ns string, tar smiAccess.TrafficTarget) (*smiAccess.TrafficTarget, error) {
-	tt, err := td.smiClients.AccessClient.AccessV1alpha2().TrafficTargets(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
+	tt, err := td.SmiClients.AccessClient.AccessV1alpha2().TrafficTargets(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create TrafficTarget")
 	}
@@ -63,7 +63,7 @@ func (td *OsmTestData) CreateTrafficTarget(ns string, tar smiAccess.TrafficTarge
 
 // CreateTrafficSplit Creates an SMI TrafficSplit
 func (td *OsmTestData) CreateTrafficSplit(ns string, tar smiSplit.TrafficSplit) (*smiSplit.TrafficSplit, error) {
-	tt, err := td.smiClients.SplitClient.SplitV1alpha2().TrafficSplits(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
+	tt, err := td.SmiClients.SplitClient.SplitV1alpha2().TrafficSplits(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create TrafficTarget")
 	}

--- a/tests/framework/common_smi.go
+++ b/tests/framework/common_smi.go
@@ -1,4 +1,4 @@
-package e2ef
+package framework
 
 import (
 	"context"

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -1,4 +1,4 @@
-package e2ef
+package framework
 
 import (
 	"bufio"

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -1,4 +1,4 @@
-package e2e
+package e2ef
 
 import (
 	"bufio"

--- a/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
+++ b/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
@@ -1,15 +1,18 @@
-package e2e
+package scenarios
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/openservicemesh/osm/tests/framework"
 
 	"k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -23,8 +26,8 @@ import (
 
 var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 	OSMDescribeInfo{
-		tier:   1,
-		bucket: 2,
+		Tier:   1,
+		Bucket: 2,
 	},
 	func() {
 		Context("MutatingWebhookConfigurationReconciler", func() {
@@ -42,7 +45,7 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 			BeforeEach(func() {
 				stopCh = make(chan struct{})
 
-				mgr, err := ctrl.NewManager(td.restConfig, ctrl.Options{
+				mgr, err := ctrl.NewManager(Td.RestConfig, ctrl.Options{
 					MetricsBindAddress: "0",
 				})
 				Expect(err).NotTo(HaveOccurred(), "failed to create manager")
@@ -80,11 +83,11 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 
 			It("Should add a CA bundle when OSM webhook is missing one", func() {
 				mwhc := getTestMWHC(webhookName, testWebhookServiceNamespace, testWebhookServiceName, testWebhookServicePath)
-				_, err := td.CreateMutatingWebhook(mwhc)
+				_, err := Td.CreateMutatingWebhook(mwhc)
 				Expect(err).NotTo(HaveOccurred(), "failed to create test mutating webhook")
 
 				time.Sleep(time.Second * 1)
-				actualMwhc, errMwhc := td.GetMutatingWebhook(webhookName)
+				actualMwhc, errMwhc := Td.GetMutatingWebhook(webhookName)
 				Expect(errMwhc).NotTo(HaveOccurred())
 
 				Expect(actualMwhc.Webhooks[0].ClientConfig.CABundle).NotTo(BeNil())
@@ -94,22 +97,30 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 			It("Should not add a CA bundle on a random webhook", func() {
 				webhookName = "random-webhook"
 				mwhc := getTestMWHC(webhookName, testWebhookServiceNamespace, testWebhookServiceName, testWebhookServicePath)
-				_, err := td.CreateMutatingWebhook(mwhc)
+				_, err := Td.CreateMutatingWebhook(mwhc)
 				Expect(err).NotTo(HaveOccurred(), "failed to create test mutating webhook")
 
 				time.Sleep(time.Second * 1)
-				actualMwhc, errMwhc := td.GetMutatingWebhook(webhookName)
+				actualMwhc, errMwhc := Td.GetMutatingWebhook(webhookName)
 				Expect(errMwhc).NotTo(HaveOccurred())
 
 				Expect(actualMwhc.Webhooks[0].ClientConfig.CABundle).To(BeNil())
 			})
+		})
+		AfterEach(func() {
+			// Cleanup
+			Td.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().DeleteCollection(context.Background(),
+				metav1.DeleteOptions{}, metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(Td.GetTestNamespaceSelectorMap()).String(),
+				})
 		})
 	})
 
 func getTestMWHC(webhookName, testWebhookServiceNamespace, testWebhookServiceName, testWebhookServicePath string) *v1beta1.MutatingWebhookConfiguration {
 	return &v1beta1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: webhookName,
+			Name:   webhookName,
+			Labels: Td.GetTestNamespaceSelectorMap(),
 		},
 		Webhooks: []v1beta1.MutatingWebhook{
 			{

--- a/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
+++ b/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/openservicemesh/osm/tests/framework"
-
 	"k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -22,6 +20,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/injector"
 	reconciler "github.com/openservicemesh/osm/pkg/reconciler/mutatingwebhook"
+	. "github.com/openservicemesh/osm/tests/framework"
 )
 
 var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
@@ -109,10 +108,11 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 		})
 		AfterEach(func() {
 			// Cleanup
-			Td.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().DeleteCollection(context.Background(),
+			err := Td.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().DeleteCollection(context.Background(),
 				metav1.DeleteOptions{}, metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(Td.GetTestNamespaceSelectorMap()).String(),
 				})
+			Expect(err).To(BeNil())
 		})
 	})
 

--- a/tests/scenarios/suite_test.go
+++ b/tests/scenarios/suite_test.go
@@ -1,4 +1,4 @@
-package e2e
+package scenarios
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Ginkgo e2e tests")
+	RunSpecs(t, "Scenarios")
 }


### PR DESCRIPTION
New file structure:

- tests/
  - framework/
    -  Contains framework files. Importing these will automatically
       set up init, BeaforeEach, AfterEach... hooks we usually run
        between tests.
  - e2e/
    - contains end-to-end tests.
  - scenarios/
    - Contains larger, use-case driven tests that might benefit from
      using framework itself.

Changes:
- Updated some README.md references
- Moved framework specific files to "framework" folder.
- Made most of the usable framework structures and attributess
public for importing modules/tests to use.
- Moved mutating_webhook scenario under scenarios.

**Affected area**:

- Tests                  [X]
- CI System              [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No