### PR TITLE
envoy/lds: move mesh related filter chain code to its file

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -4,9 +4,11 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"
@@ -64,4 +66,50 @@ func getInboundInMeshFilterChain(proxyServiceName service.MeshService, cfg confi
 	}
 
 	return filterChain, nil
+}
+
+// getOutboundFilterForService builds a network filter action for traffic destined to a specific service
+func getOutboundFilterForService(dstSvc service.MeshService, cfg configurator.Configurator) (*xds_listener.Filter, error) {
+	var marshalledFilter *any.Any
+	var err error
+
+	marshalledFilter, err = envoy.MessageToAny(
+		getHTTPConnectionManager(route.OutboundRouteConfigName, cfg))
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshalling HTTPConnManager object")
+		return nil, err
+	}
+
+	return &xds_listener.Filter{
+		Name:       wellknown.HTTPConnectionManager,
+		ConfigType: &xds_listener.Filter_TypedConfig{TypedConfig: marshalledFilter},
+	}, nil
+}
+
+// getOutboundFilterChainMatchForService builds a filter chain to match the destination traffic.
+// Filter Chain currently match on destination IP for possible service endpoints
+func getOutboundFilterChainMatchForService(dstSvc service.MeshService, catalog catalog.MeshCataloger, cfg configurator.Configurator) (*xds_listener.FilterChainMatch, error) {
+	filterMatch := &xds_listener.FilterChainMatch{}
+
+	endpoints, err := catalog.GetResolvableServiceEndpoints(dstSvc)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting GetResolvableServiceEndpoints for %s", dstSvc.String())
+		return nil, err
+	}
+
+	if len(endpoints) == 0 {
+		log.Info().Msgf("No resolvable endpoints retured for service %s", dstSvc.String())
+		return nil, nil
+	}
+
+	for _, endp := range endpoints {
+		filterMatch.PrefixRanges = append(filterMatch.PrefixRanges, &xds_core.CidrRange{
+			AddressPrefix: endp.IP.String(),
+			PrefixLen: &wrapperspb.UInt32Value{
+				Value: singleIpv4Mask,
+			},
+		})
+	}
+
+	return filterMatch, nil
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Moves code related to building outbound mesh filter chain
to the `inmesh.go` file which deals with in-mesh listener components.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`