### PR TITLE
osm: disable ticker, space k8s resyncs to 5m

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -17,7 +17,8 @@ import (
 
 const (
 	// this is catalog's tick rate for ticker, which triggers global proxy updates
-	updateAtLeastEvery = 30 * time.Second
+	// 0 disables the ticker
+	updateAtLeastEvery = 0 * time.Second
 )
 
 // NewMeshCatalog creates a new service catalog
@@ -65,20 +66,19 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		announcementChannels = append(announcementChannels, annCh)
 	}
 
-	// TODO(draychev): Ticker Announcement channel should be made optional
-	// with osm-config configurable interval
-	// See Github Issue: https://github.com/openservicemesh/osm/issues/1501
-	go func() {
-		ticker := time.NewTicker(updateAtLeastEvery)
-		for {
-			<-ticker.C
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
-				AnnouncementType: announcements.ScheduleProxyBroadcast,
-				NewObj:           nil,
-				OldObj:           nil,
-			})
-		}
-	}()
+	if updateAtLeastEvery != 0 {
+		go func() {
+			ticker := time.NewTicker(updateAtLeastEvery)
+			for {
+				<-ticker.C
+				events.GetPubSubInstance().Publish(events.PubSubMessage{
+					AnnouncementType: announcements.ScheduleProxyBroadcast,
+					NewObj:           nil,
+					OldObj:           nil,
+				})
+			}
+		}()
+	}
 
 	return announcementChannels
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -66,7 +66,7 @@ func (mc *MeshCatalog) getAnnouncementChannels() []announcementChannel {
 		announcementChannels = append(announcementChannels, annCh)
 	}
 
-	if updateAtLeastEvery != 0 {
+	if updateAtLeastEvery > 0 {
 		go func() {
 			ticker := time.NewTicker(updateAtLeastEvery)
 			for {

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -36,7 +36,7 @@ const (
 
 const (
 	// DefaultKubeEventResyncInterval is the default resync interval for k8s events
-	DefaultKubeEventResyncInterval = 30 * time.Second
+	DefaultKubeEventResyncInterval = 0 * time.Second
 
 	// ProviderName is used for provider logging
 	ProviderName = "Kubernetes"

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -36,7 +36,7 @@ const (
 
 const (
 	// DefaultKubeEventResyncInterval is the default resync interval for k8s events
-	DefaultKubeEventResyncInterval = 0 * time.Second
+	DefaultKubeEventResyncInterval = 5 * time.Minute
 
 	// ProviderName is used for provider logging
 	ProviderName = "Kubernetes"


### PR DESCRIPTION
- OSM does not hard-require periodic re-configs to guarantee state
correctness in its current form. In order to help maintain this statu quo,
we will disable ticker and increase the k8s resync period, which will
help catch issues that break on-event updates at testing/CI time.

- Since we still believe periodic arbitrary resyncs could be something
that we still might want to have at later time/different circumstances, to
ensure config correctness, we will add configurability into ticker and
resync intervals in a later patch (#2103).

- Control Plane          [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No