### PR TITLE
envoy: use ptypes.MarshalAny directly instead of unnecessary wrapper

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -26,7 +26,7 @@ const (
 // getUpstreamServiceCluster returns an Envoy Cluster corresponding to the given upstream service
 func getUpstreamServiceCluster(upstreamSvc, downstreamSvc service.MeshService, cfg configurator.Configurator) (*xds_cluster.Cluster, error) {
 	clusterName := upstreamSvc.String()
-	marshalledUpstreamTLSContext, err := envoy.MessageToAny(
+	marshalledUpstreamTLSContext, err := ptypes.MarshalAny(
 		envoy.GetUpstreamTLSContext(downstreamSvc, upstreamSvc))
 	if err != nil {
 		return nil, err

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -187,7 +187,7 @@ var _ = Describe("CDS Response", func() {
 
 			// Checking for the value by generating the same value the same way is reduntant
 			// Nonetheless, as getUpstreamServiceCluster logic gets more complicated, this might just be ok to have
-			upstreamTLSProto, err := envoy.MessageToAny(envoy.GetUpstreamTLSContext(proxyService, upstreamSvc))
+			upstreamTLSProto, err := ptypes.MarshalAny(envoy.GetUpstreamTLSContext(proxyService, upstreamSvc))
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedCluster := xds_cluster.Cluster{

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -27,7 +27,7 @@ func getIngressTransportProtocol(cfg configurator.Configurator) string {
 }
 
 func newIngressFilterChain(cfg configurator.Configurator, svc service.MeshService) *xds_listener.FilterChain {
-	marshalledDownstreamTLSContext, err := envoy.MessageToAny(envoy.GetDownstreamTLSContext(svc, false /* TLS */))
+	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(svc, false /* TLS */))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext object for proxy %s", svc)
 		return nil

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -28,7 +28,7 @@ var (
 )
 
 func getInboundInMeshFilterChain(proxyServiceName service.MeshService, cfg configurator.Configurator) (*xds_listener.FilterChain, error) {
-	marshalledDownstreamTLSContext, err := envoy.MessageToAny(envoy.GetDownstreamTLSContext(proxyServiceName, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(proxyServiceName, true /* mTLS */))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext object for proxy %s", proxyServiceName)
 		return nil, err
@@ -81,7 +81,7 @@ func getOutboundFilterForService(dstSvc service.MeshService, cfg configurator.Co
 	var marshalledFilter *any.Any
 	var err error
 
-	marshalledFilter, err = envoy.MessageToAny(
+	marshalledFilter, err = ptypes.MarshalAny(
 		getHTTPConnectionManager(route.OutboundRouteConfigName, cfg))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling HTTPConnManager object")

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -98,7 +98,7 @@ func buildEgressFilterChain() (*xds_listener.FilterChain, error) {
 		StatPrefix:       envoy.OutboundPassthroughCluster,
 		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: envoy.OutboundPassthroughCluster},
 	}
-	marshalledTCPProxy, err := envoy.MessageToAny(tcpProxy)
+	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling TcpProxy object for egress HTTPS filter chain")
 		return nil, err

--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -7,8 +7,8 @@ import (
 	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	xds_network_rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
 
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -23,7 +23,7 @@ func (lb *listenerBuilder) buildRBACFilter() (*xds_listener.Filter, error) {
 		return nil, err
 	}
 
-	marshalledNetworkRBACPolicy, err := envoy.MessageToAny(networkRBACPolicy)
+	marshalledNetworkRBACPolicy, err := ptypes.MarshalAny(networkRBACPolicy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling RBAC policy: %v", networkRBACPolicy)
 		return nil, err

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -10,10 +10,7 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
-	"github.com/golang/protobuf/proto" //ignore SA1019
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/jinzhu/copier"
@@ -231,15 +228,6 @@ func getCommonTLSContext(tlsSDSCert, peerValidationSDSCert SDSCert) *xds_auth.Co
 			},
 		},
 	}
-}
-
-// MessageToAny converts from proto message to proto Any and returns an error if any
-func MessageToAny(pb proto.Message) (*any.Any, error) {
-	msg, err := ptypes.MarshalAny(pb)
-	if err != nil {
-		return nil, err
-	}
-	return msg, nil
 }
 
 // GetDownstreamTLSContext creates a downstream Envoy TLS Context


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Uses `ptypes.MarshalAny` directly instead of wrapper api that doesn't
add value.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`