### PR TITLE
envoy/lds: use listenerBuilder type to build listener and filters

### DIFF
--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -8,8 +8,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 
-	"github.com/openservicemesh/osm/pkg/catalog"
-	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/kubernetes"
@@ -21,8 +19,8 @@ const (
 	singleIpv4Mask                = 32
 )
 
-func newOutboundListener(catalog catalog.MeshCataloger, cfg configurator.Configurator, downstreamSvc []service.MeshService) (*xds_listener.Listener, error) {
-	serviceFilterChains, err := getOutboundFilterChains(catalog, cfg, downstreamSvc)
+func (lb *listenerBuilder) newOutboundListener(downstreamSvc []service.MeshService) (*xds_listener.Listener, error) {
+	serviceFilterChains, err := lb.getOutboundFilterChains(downstreamSvc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting filter chains for outbound listener")
 		return nil, err
@@ -115,14 +113,14 @@ func buildEgressFilterChain() (*xds_listener.FilterChain, error) {
 	}, nil
 }
 
-func getOutboundFilterChains(catalog catalog.MeshCataloger, cfg configurator.Configurator, downstreamSvc []service.MeshService) ([]*xds_listener.FilterChain, error) {
+func (lb *listenerBuilder) getOutboundFilterChains(downstreamSvc []service.MeshService) ([]*xds_listener.FilterChain, error) {
 	var filterChains []*xds_listener.FilterChain
 	var dstServicesSet map[service.MeshService]struct{} = make(map[service.MeshService]struct{}) // Set, avoid dups
 
 	// Assuming single service in pod till #1682, #1575 get addressed
-	outboundSvc, err := catalog.ListAllowedOutboundServices(downstreamSvc[0])
+	outboundSvc, err := lb.meshCatalog.ListAllowedOutboundServices(downstreamSvc[0])
 	if err != nil {
-		log.Error().Err(err).Msgf("Error getting allowed outbound services for %s", downstreamSvc[0].String())
+		log.Error().Err(err).Msgf("Error getting allowed outbound services for %q", downstreamSvc[0].String())
 		return nil, err
 	}
 
@@ -134,7 +132,7 @@ func getOutboundFilterChains(catalog catalog.MeshCataloger, cfg configurator.Con
 	// Getting apex services referring to the outbound services
 	// We get possible apexes which could traffic split to any of the possible
 	// outbound services
-	splitServices := catalog.GetSMISpec().ListTrafficSplitServices()
+	splitServices := lb.meshCatalog.GetSMISpec().ListTrafficSplitServices()
 	for _, svc := range splitServices {
 		for _, outSvc := range outboundSvc {
 			if svc.Service == outSvc {
@@ -153,14 +151,14 @@ func getOutboundFilterChains(catalog catalog.MeshCataloger, cfg configurator.Con
 	// Iterate all destination services
 	for keyService := range dstServicesSet {
 		// Get HTTP filter for service
-		filter, err := getOutboundHTTPFilter(cfg)
+		filter, err := lb.getOutboundHTTPFilter()
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting filter for dst service %s", keyService.String())
 			return nil, err
 		}
 
 		// Get filter match criteria for destination service
-		filterChainMatch, err := getOutboundHTTPFilterChainMatchForService(keyService, catalog, cfg)
+		filterChainMatch, err := lb.getOutboundHTTPFilterChainMatchForService(keyService)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting Chain Match for service %s", keyService.String())
 			return nil, err
@@ -179,7 +177,7 @@ func getOutboundFilterChains(catalog catalog.MeshCataloger, cfg configurator.Con
 
 	// This filterchain matches any traffic not filtered by allow rules, it will be treated as egress
 	// traffic when enabled
-	if cfg.IsEgressEnabled() {
+	if lb.cfg.IsEgressEnabled() {
 		egressFilterChgain, err := buildEgressFilterChain()
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting filter chain for Egress")

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -43,10 +43,10 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		TypeUrl: string(envoy.TypeLDS),
 	}
 
-	lb := newListenerBuilder(meshCatalog, svcAccount)
+	lb := newListenerBuilder(meshCatalog, svcAccount, cfg)
 
 	// --- OUTBOUND -------------------
-	outboundListener, err := newOutboundListener(meshCatalog, cfg, svcList)
+	outboundListener, err := lb.newOutboundListener(svcList)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error making outbound listener config for proxy %s", proxyServiceName)
 	} else {
@@ -123,9 +123,10 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	return resp, nil
 }
 
-func newListenerBuilder(meshCatalog catalog.MeshCataloger, svcAccount service.K8sServiceAccount) *listenerBuilder {
+func newListenerBuilder(meshCatalog catalog.MeshCataloger, svcAccount service.K8sServiceAccount, cfg configurator.Configurator) *listenerBuilder {
 	return &listenerBuilder{
 		meshCatalog: meshCatalog,
 		svcAccount:  svcAccount,
+		cfg:         cfg,
 	}
 }

--- a/pkg/envoy/lds/types.go
+++ b/pkg/envoy/lds/types.go
@@ -2,6 +2,7 @@ package lds
 
 import (
 	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -14,4 +15,5 @@ var (
 type listenerBuilder struct {
 	svcAccount  service.K8sServiceAccount
 	meshCatalog catalog.MeshCataloger
+	cfg         configurator.Configurator
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change consolidates functions used to build the listener
component as method receivers for the `listenerBuilder` type.
This results in better organization of related code and avoids
passing MeshCataloger and Configurator objects repeatedly
between different functions.

This is in preparation for #2056 and #1521.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`