### PR TITLE
pubsub: introduce pubsub chan Unsub(), fix few sync tests

### DIFF
--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -142,6 +142,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
+			defer events.GetPubSubInstance().Close(serviceChannel)
 
 			// Create monitored namespace for this service
 			testNamespace := &corev1.Namespace{
@@ -190,6 +191,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
+			defer events.GetPubSubInstance().Close(serviceChannel)
 			testSvcs := []service.MeshService{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
@@ -260,9 +262,11 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
+			defer events.GetPubSubInstance().Close(serviceChannel)
 			podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
 				announcements.PodDeleted,
 				announcements.PodUpdated)
+			defer events.GetPubSubInstance().Close(podsChannel)
 
 			// Create a namespace
 			testNamespace := &corev1.Namespace{

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Close(serviceChannel)
+			defer events.GetPubSubInstance().Unsub(serviceChannel)
 
 			// Create monitored namespace for this service
 			testNamespace := &corev1.Namespace{
@@ -191,7 +191,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Close(serviceChannel)
+			defer events.GetPubSubInstance().Unsub(serviceChannel)
 			testSvcs := []service.MeshService{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
@@ -262,11 +262,11 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Close(serviceChannel)
+			defer events.GetPubSubInstance().Unsub(serviceChannel)
 			podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
 				announcements.PodDeleted,
 				announcements.PodUpdated)
-			defer events.GetPubSubInstance().Close(podsChannel)
+			defer events.GetPubSubInstance().Unsub(podsChannel)
 
 			// Create a namespace
 			testNamespace := &corev1.Namespace{

--- a/pkg/kubernetes/events/event_pubsub.go
+++ b/pkg/kubernetes/events/event_pubsub.go
@@ -46,7 +46,7 @@ func (c *osmPubsub) Unsub(unsubChan chan interface{}) {
 
 	syncCh := make(chan struct{})
 	go func() {
-		// This should close the channel on the pubsub backend
+		// This will close the channel on the pubsub backend
 		// https://github.com/cskr/pubsub/blob/v1.0.2/pubsub.go#L264
 		c.pSub.Unsub(unsubChan)
 

--- a/pkg/kubernetes/events/event_pubsub.go
+++ b/pkg/kubernetes/events/event_pubsub.go
@@ -36,26 +36,22 @@ func (c *osmPubsub) Publish(message PubSubMessage) {
 	c.pSub.Pub(message, message.AnnouncementType.String())
 }
 
-// Close is the Close implementation for PubSub.
+// Unsub is the Unsub implementation for PubSub.
 // It is synchronized, upon exit the channel is guaranteed to be both
 // unsubbed to all topics and closed.
 // This is a necessary step to guarantee garbage collection
-func (c *osmPubsub) Close(unsubChan chan interface{}) {
+func (c *osmPubsub) Unsub(unsubChan chan interface{}) {
 	// implementation has several requirements (including different goroutine context)
-	// https://github.com/cskr/pubsub/blob/master/pubsub.go#L102
+	// https://github.com/cskr/pubsub/blob/v1.0.2/pubsub.go#L102
 
 	syncCh := make(chan struct{})
 	go func() {
 		// This should close the channel on the pubsub backend
-		// https://github.com/cskr/pubsub/blob/master/pubsub.go#L264
+		// https://github.com/cskr/pubsub/blob/v1.0.2/pubsub.go#L264
 		c.pSub.Unsub(unsubChan)
 
-		for {
-			_, ok := <-unsubChan
-			if !ok {
-				// Channel closed from pubsub
-				break
-			}
+		for range unsubChan {
+			// Drain channel, read til close
 		}
 		syncCh <- struct{}{}
 	}()

--- a/pkg/kubernetes/events/event_pubsub_test.go
+++ b/pkg/kubernetes/events/event_pubsub_test.go
@@ -60,3 +60,23 @@ func TestPubSubEvents(t *testing.T) {
 		}
 	}
 }
+
+func TestPubSubClose(t *testing.T) {
+	assert := assert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	subChannel := GetPubSubInstance().Subscribe(announcements.BackpressureUpdated)
+
+	// publish something
+	GetPubSubInstance().Publish(PubSubMessage{
+		AnnouncementType: announcements.BackpressureUpdated,
+	})
+
+	// make sure channel is drained and closed
+	GetPubSubInstance().Close(subChannel)
+
+	// Channel has to have been already emptied and closed
+	_, ok := <-subChannel
+	assert.False(ok)
+}

--- a/pkg/kubernetes/events/event_pubsub_test.go
+++ b/pkg/kubernetes/events/event_pubsub_test.go
@@ -74,7 +74,7 @@ func TestPubSubClose(t *testing.T) {
 	})
 
 	// make sure channel is drained and closed
-	GetPubSubInstance().Close(subChannel)
+	GetPubSubInstance().Unsub(subChannel)
 
 	// Channel has to have been already emptied and closed
 	_, ok := <-subChannel

--- a/pkg/kubernetes/events/types.go
+++ b/pkg/kubernetes/events/types.go
@@ -41,8 +41,8 @@ type PubSub interface {
 	// Publish publishes the message to all subscribers that have subscribed to <message.AnnouncementType> topic
 	Publish(message PubSubMessage)
 
-	// Close unsubscribes and closes the channel on pubsub backend
+	// Unsub unsubscribes and closes the channel on pubsub backend
 	// Note this is a necessary step to ensure a channel can be
 	// garbage collected when it is freed.
-	Close(unsubChan chan interface{})
+	Unsub(unsubChan chan interface{})
 }

--- a/pkg/kubernetes/events/types.go
+++ b/pkg/kubernetes/events/types.go
@@ -40,4 +40,9 @@ type PubSub interface {
 
 	// Publish publishes the message to all subscribers that have subscribed to <message.AnnouncementType> topic
 	Publish(message PubSubMessage)
+
+	// Close unsubscribes and closes the channel on pubsub backend
+	// Note this is a necessary step to ensure a channel can be
+	// garbage collected when it is freed.
+	Close(unsubChan chan interface{})
 }

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -17,9 +17,11 @@ import (
 
 	osmPolicy "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	osmPolicyClient "github.com/openservicemesh/osm/experimental/pkg/client/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/featureflags"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -98,6 +100,11 @@ var _ = Describe("When listing TrafficSplit", func() {
 	})
 
 	It("should return a list of traffic split resources", func() {
+		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
+			announcements.TrafficSplitDeleted,
+			announcements.TrafficSplitUpdated)
+		defer events.GetPubSubInstance().Close(tsChannel)
+
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-ListTrafficSplits",
@@ -120,7 +127,7 @@ var _ = Describe("When listing TrafficSplit", func() {
 
 		_, err := fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha2().TrafficSplits(testNamespaceName).Create(context.TODO(), split, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-tsChannel
 
 		splits := meshSpec.ListTrafficSplits()
 		Expect(len(splits)).To(Equal(1))
@@ -128,7 +135,7 @@ var _ = Describe("When listing TrafficSplit", func() {
 
 		err = fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha2().TrafficSplits(testNamespaceName).Delete(context.TODO(), split.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-tsChannel
 	})
 })
 
@@ -144,6 +151,11 @@ var _ = Describe("When listing TrafficSplit services", func() {
 	})
 
 	It("should return a list of weighted services corresponding to the traffic split backends", func() {
+		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
+			announcements.TrafficSplitDeleted,
+			announcements.TrafficSplitUpdated)
+		defer events.GetPubSubInstance().Close(tsChannel)
+
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-ListTrafficSplitServices",
@@ -166,7 +178,7 @@ var _ = Describe("When listing TrafficSplit services", func() {
 
 		_, err := fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha2().TrafficSplits(testNamespaceName).Create(context.TODO(), split, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-tsChannel
 
 		weightedServices := meshSpec.ListTrafficSplitServices()
 		Expect(len(weightedServices)).To(Equal(len(split.Spec.Backends)))
@@ -178,7 +190,7 @@ var _ = Describe("When listing TrafficSplit services", func() {
 
 		err = fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha2().TrafficSplits(testNamespaceName).Delete(context.TODO(), split.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-tsChannel
 	})
 })
 
@@ -194,6 +206,11 @@ var _ = Describe("When listing ServiceAccounts", func() {
 	})
 
 	It("should return a list of service accounts specified in TrafficTarget resources", func() {
+		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
+			announcements.TrafficTargetDeleted,
+			announcements.TrafficTargetUpdated)
+		defer events.GetPubSubInstance().Close(ttChannel)
+
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "access.smi-spec.io/v1alpha2",
@@ -224,7 +241,7 @@ var _ = Describe("When listing ServiceAccounts", func() {
 
 		_, err := fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Create(context.TODO(), trafficTarget, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-ttChannel
 
 		svcAccounts := meshSpec.ListServiceAccounts()
 
@@ -233,7 +250,7 @@ var _ = Describe("When listing ServiceAccounts", func() {
 
 		err = fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-ttChannel
 	})
 })
 
@@ -249,6 +266,11 @@ var _ = Describe("When listing TrafficTargets", func() {
 	})
 
 	It("Returns a list of TrafficTarget resources", func() {
+		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
+			announcements.TrafficTargetDeleted,
+			announcements.TrafficTargetUpdated)
+		defer events.GetPubSubInstance().Close(ttChannel)
+
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "access.smi-spec.io/v1alpha2",
@@ -279,14 +301,14 @@ var _ = Describe("When listing TrafficTargets", func() {
 
 		_, err := fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Create(context.TODO(), trafficTarget, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-ttChannel
 
 		targets := meshSpec.ListTrafficTargets()
 		Expect(len(targets)).To(Equal(1))
 
 		err = fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-ttChannel
 	})
 })
 
@@ -307,6 +329,11 @@ var _ = Describe("When listing ListHTTPTrafficSpecs", func() {
 	})
 
 	It("should return a list of ListHTTPTrafficSpecs resources", func() {
+		rgChannel := events.GetPubSubInstance().Subscribe(announcements.RouteGroupAdded,
+			announcements.RouteGroupDeleted,
+			announcements.RouteGroupUpdated)
+		defer events.GetPubSubInstance().Close(rgChannel)
+
 		routeSpec := &smiSpecs.HTTPRouteGroup{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha3",
@@ -343,7 +370,7 @@ var _ = Describe("When listing ListHTTPTrafficSpecs", func() {
 
 		_, err := fakeClientSet.smiTrafficSpecClientSet.SpecsV1alpha3().HTTPRouteGroups(testNamespaceName).Create(context.TODO(), routeSpec, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-rgChannel
 
 		httpRoutes := meshSpec.ListHTTPTrafficSpecs()
 		Expect(len(httpRoutes)).To(Equal(1))
@@ -351,7 +378,7 @@ var _ = Describe("When listing ListHTTPTrafficSpecs", func() {
 
 		err = fakeClientSet.smiTrafficSpecClientSet.SpecsV1alpha3().HTTPRouteGroups(testNamespaceName).Delete(context.TODO(), routeSpec.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-rgChannel
 	})
 })
 
@@ -372,6 +399,10 @@ var _ = Describe("When listing TCP routes", func() {
 	})
 
 	It("should return a list of TCPRoute resources", func() {
+		trChannel := events.GetPubSubInstance().Subscribe(announcements.TCPRouteAdded,
+			announcements.TCPRouteDeleted,
+			announcements.TCPRouteUpdated)
+		defer events.GetPubSubInstance().Close(trChannel)
 		routeSpec := &smiSpecs.TCPRoute{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha2",
@@ -386,7 +417,7 @@ var _ = Describe("When listing TCP routes", func() {
 
 		_, err := fakeClientSet.smiTrafficSpecClientSet.SpecsV1alpha3().TCPRoutes(testNamespaceName).Create(context.TODO(), routeSpec, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-trChannel
 
 		tcpRoutes := meshSpec.ListTCPTrafficSpecs()
 		Expect(len(tcpRoutes)).To(Equal(1))
@@ -394,7 +425,7 @@ var _ = Describe("When listing TCP routes", func() {
 
 		err = fakeClientSet.smiTrafficSpecClientSet.SpecsV1alpha3().TCPRoutes(testNamespaceName).Delete(context.TODO(), routeSpec.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-trChannel
 	})
 })
 
@@ -435,6 +466,11 @@ var _ = Describe("When fetching BackpressurePolicy for the given MeshService", f
 	})
 
 	It("should return the Backpresure policy for the given service", func() {
+		bpChannel := events.GetPubSubInstance().Subscribe(announcements.BackpressureAdded,
+			announcements.BackpressureDeleted,
+			announcements.BackpressureUpdated)
+		defer events.GetPubSubInstance().Close(bpChannel)
+
 		meshSvc := service.MeshService{
 			Namespace: testNamespaceName,
 			Name:      "test-GetBackpressurePolicy",
@@ -456,7 +492,7 @@ var _ = Describe("When fetching BackpressurePolicy for the given MeshService", f
 
 		_, err := fakeClientSet.osmPolicyClientSet.PolicyV1alpha1().Backpressures(testNamespaceName).Create(context.TODO(), backpressurePolicy, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-bpChannel
 
 		backpressurePolicyInCache := meshSpec.GetBackpressurePolicy(meshSvc)
 		Expect(backpressurePolicyInCache).ToNot(BeNil())
@@ -464,10 +500,15 @@ var _ = Describe("When fetching BackpressurePolicy for the given MeshService", f
 
 		err = fakeClientSet.osmPolicyClientSet.PolicyV1alpha1().Backpressures(testNamespaceName).Delete(context.TODO(), backpressurePolicy.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-bpChannel
 	})
 
 	It("should return nil when the app label is missing for the given service", func() {
+		bpChannel := events.GetPubSubInstance().Subscribe(announcements.BackpressureAdded,
+			announcements.BackpressureDeleted,
+			announcements.BackpressureUpdated)
+		defer events.GetPubSubInstance().Close(bpChannel)
+
 		meshSvc := service.MeshService{
 			Namespace: testNamespaceName,
 			Name:      "test-GetBackpressurePolicy",
@@ -488,14 +529,14 @@ var _ = Describe("When fetching BackpressurePolicy for the given MeshService", f
 
 		_, err := fakeClientSet.osmPolicyClientSet.PolicyV1alpha1().Backpressures(testNamespaceName).Create(context.TODO(), backpressurePolicy, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-bpChannel
 
 		backpressurePolicyInCache := meshSpec.GetBackpressurePolicy(meshSvc)
 		Expect(backpressurePolicyInCache).To(BeNil())
 
 		err = fakeClientSet.osmPolicyClientSet.PolicyV1alpha1().Backpressures(testNamespaceName).Delete(context.TODO(), backpressurePolicy.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		<-meshSpec.GetAnnouncementsChannel()
+		<-bpChannel
 	})
 })
 

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -103,7 +103,7 @@ var _ = Describe("When listing TrafficSplit", func() {
 		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
 			announcements.TrafficSplitDeleted,
 			announcements.TrafficSplitUpdated)
-		defer events.GetPubSubInstance().Close(tsChannel)
+		defer events.GetPubSubInstance().Unsub(tsChannel)
 
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +154,7 @@ var _ = Describe("When listing TrafficSplit services", func() {
 		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
 			announcements.TrafficSplitDeleted,
 			announcements.TrafficSplitUpdated)
-		defer events.GetPubSubInstance().Close(tsChannel)
+		defer events.GetPubSubInstance().Unsub(tsChannel)
 
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
@@ -209,7 +209,7 @@ var _ = Describe("When listing ServiceAccounts", func() {
 		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
 			announcements.TrafficTargetDeleted,
 			announcements.TrafficTargetUpdated)
-		defer events.GetPubSubInstance().Close(ttChannel)
+		defer events.GetPubSubInstance().Unsub(ttChannel)
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
@@ -269,7 +269,7 @@ var _ = Describe("When listing TrafficTargets", func() {
 		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
 			announcements.TrafficTargetDeleted,
 			announcements.TrafficTargetUpdated)
-		defer events.GetPubSubInstance().Close(ttChannel)
+		defer events.GetPubSubInstance().Unsub(ttChannel)
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
@@ -332,7 +332,7 @@ var _ = Describe("When listing ListHTTPTrafficSpecs", func() {
 		rgChannel := events.GetPubSubInstance().Subscribe(announcements.RouteGroupAdded,
 			announcements.RouteGroupDeleted,
 			announcements.RouteGroupUpdated)
-		defer events.GetPubSubInstance().Close(rgChannel)
+		defer events.GetPubSubInstance().Unsub(rgChannel)
 
 		routeSpec := &smiSpecs.HTTPRouteGroup{
 			TypeMeta: metav1.TypeMeta{
@@ -402,7 +402,7 @@ var _ = Describe("When listing TCP routes", func() {
 		trChannel := events.GetPubSubInstance().Subscribe(announcements.TCPRouteAdded,
 			announcements.TCPRouteDeleted,
 			announcements.TCPRouteUpdated)
-		defer events.GetPubSubInstance().Close(trChannel)
+		defer events.GetPubSubInstance().Unsub(trChannel)
 		routeSpec := &smiSpecs.TCPRoute{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha2",
@@ -469,7 +469,7 @@ var _ = Describe("When fetching BackpressurePolicy for the given MeshService", f
 		bpChannel := events.GetPubSubInstance().Subscribe(announcements.BackpressureAdded,
 			announcements.BackpressureDeleted,
 			announcements.BackpressureUpdated)
-		defer events.GetPubSubInstance().Close(bpChannel)
+		defer events.GetPubSubInstance().Unsub(bpChannel)
 
 		meshSvc := service.MeshService{
 			Namespace: testNamespaceName,
@@ -507,7 +507,7 @@ var _ = Describe("When fetching BackpressurePolicy for the given MeshService", f
 		bpChannel := events.GetPubSubInstance().Subscribe(announcements.BackpressureAdded,
 			announcements.BackpressureDeleted,
 			announcements.BackpressureUpdated)
-		defer events.GetPubSubInstance().Close(bpChannel)
+		defer events.GetPubSubInstance().Unsub(bpChannel)
 
 		meshSvc := service.MeshService{
 			Namespace: testNamespaceName,


### PR DESCRIPTION
- Introduces Unsub() to pubsub
- adds a Unsub() test
- moves few tests to use pubsub and not read from individual channels

fixes #2108

- Control Plane          [X]
- Tests                  [X]
----

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No