### PR TITLE
envoy/lds: update error handling while building HTTP filter chain

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -6,6 +6,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -106,13 +107,14 @@ func (lb *listenerBuilder) getOutboundHTTPFilterChainMatchForService(dstSvc serv
 
 	endpoints, err := lb.meshCatalog.GetResolvableServiceEndpoints(dstSvc)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error getting GetResolvableServiceEndpoints for %s", dstSvc.String())
+		log.Error().Err(err).Msgf("Error getting GetResolvableServiceEndpoints for %q", dstSvc)
 		return nil, err
 	}
 
 	if len(endpoints) == 0 {
-		log.Info().Msgf("No resolvable endpoints retured for service %s", dstSvc.String())
-		return nil, nil
+		err := errors.Errorf("Endpoints not found for service %q", dstSvc)
+		log.Error().Err(err).Msgf("Error constructing HTTP filter chain match for service %q", dstSvc)
+		return nil, err
 	}
 
 	for _, endp := range endpoints {

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -154,17 +154,13 @@ func (lb *listenerBuilder) getOutboundFilterChains(downstreamSvc []service.MeshS
 		filter, err := lb.getOutboundHTTPFilter()
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting filter for dst service %s", keyService.String())
-			return nil, err
+			continue
 		}
 
 		// Get filter match criteria for destination service
 		filterChainMatch, err := lb.getOutboundHTTPFilterChainMatchForService(keyService)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting Chain Match for service %s", keyService.String())
-			return nil, err
-		}
-		if filterChainMatch == nil {
-			log.Info().Msgf("No endpoints found for dst service %s. Not adding filterchain.", keyService)
 			continue
 		}
 

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -108,7 +108,7 @@ func TestGetFilterChainMatchForService(t *testing.T) {
 	)
 
 	filterChainMatch, err = lb.getOutboundHTTPFilterChainMatchForService(tests.BookstoreApexService)
-	assert.NoError(err)
+	assert.Error(err)
 	assert.Nil(filterChainMatch)
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
To be able to construct the outbound filter chain for an upstream
service, the upstream service needs to have endpoints. If endpoints
are missing, then the filter chain cannot be constructed.

This change logs an error in the case when the filter chain for
an upstream cannot be constructed. It also continues building
the filter chains for other services so that connectivity to
other upstream services are not impacted when a particular
upstream filter chain cannot be constructed.

Signed-off-by: Shashank Ram <shashank08@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`