### PR TITLE
prometheus: drop time-bucket series, increase ram limit to 2G

### DIFF
--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -22,7 +22,11 @@ data:
           # TODO need to remove this when the CA and SAN match 
           insecure_skip_verify: true
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-        relabel_configs:
+        metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: .*bucket.*
+          action: drop   
+        relabel_configs: 
         - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
           action: keep
           regex: default;kubernetes;https
@@ -47,7 +51,11 @@ data:
       - job_name: 'kubernetes-pods'
         kubernetes_sd_configs:
         - role: pod
-        relabel_configs:
+        metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: .*bucket.*
+          action: drop   
+        relabel_configs: 
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
           action: keep
           regex: true
@@ -100,7 +108,7 @@ data:
           - __meta_kubernetes_pod_controller_name
           action: replace
           regex: ^ReplicaSet;(.*)-[^-]+$
-          target_label: source_workload_name       
+          target_label: source_workload_name    
 
       - job_name: 'kubernetes-cadvisor'
         scheme: https

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 512M
+            memory: 2G
           requests:
             cpu: 100m
             memory: 256M


### PR DESCRIPTION
(tentative)

We are using large amounts of labels to tag our metrics with addtional
dimensions of interest. This is good for visibility, however this explodes
in RAM consumption on Prometheus once scraped.

Most of the heavily unscaling metrics are the time-bucket series, which
already have large number of dimensions due to the buckets themselves.

- By filtering out time-bucket series (which might contain latency and
request total time buckets), we can cut the memory consumption around
66~70%, allowing larger scales to work under 2Gb, compared with same
scale crashing at 4Gb).
- Additionally, rose the RAM limit for prometheus to 2Gb.

Purely tentative, proper discussion on relabeling has to happen, this
is however required to even support slightly larger number of pods for
the time being.

More info:
#1934 

Signed-off-by: Eduard Serra <eduser25@gmail.com>

- Metrics                [X]
- Performance            [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No