### PR TITLE
fix(chart): allow empty OpenServiceMesh.image.pullPolicy

### DIFF
--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -78,7 +78,7 @@
                             "type": "string",
                             "title": "The pullPolicy schema",
                             "description": "The image pull policy.",
-                            "pattern": "^(Always|Never|IfNotPresent)$",
+                            "pattern": "^(Always|Never|IfNotPresent)?$",
                             "examples": [
                                 "IfNotPresent"
                             ]


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates values.schema.json to allow defining an empty
OpenServiceMesh.image.pullPolicy, which behaves as described here:
https://kubernetes.io/docs/concepts/containers/images/#updating-images


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No