### PR TITLE
pkg/kubernetes: reduce warn log to trace

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -58,7 +58,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, announce chan
 			// Since pubsub introduction, there's a chance we start seeing full channels which
 			// will slowly become unused in favour of pub-sub subscriptions.
 			// We are making sure here ResourceEventHandlerFuncs never locks due to a push on a full channel.
-			log.Warn().Msgf("Channel for provider %s is full, dropping channel notify %s ", providerName, eventType)
+			log.Trace().Msgf("Channel for provider %s is full, dropping channel notify %s ", providerName, eventType)
 		}
 	}
 


### PR DESCRIPTION
As an increasing number of packages' channels are becoming unused
in favor of pubsub channels, these logs are quickly becoming a hog as warn.

We will however keep them as trace if we ever need them.

```
kubectl logs osm-controller-7545bfb54c-8x7vl | grep "Channel for provider Kubernetes is full" | wc -l
5069
```
- Other                  [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No