### PR TITLE
cli: move portForwarder to a more generic location

### DIFF
--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/openservicemesh/osm/pkg/utils"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -16,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 const openGrafanaDashboardDesc = `

--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/openservicemesh/osm/pkg/utils"
 	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -103,12 +104,12 @@ func (d *dashboardCmd) run() error {
 		return errors.Errorf("No running Grafana pod available")
 	}
 
-	portForwarder, err := NewPortForwarder(conf, clientSet, grafanaPod.Name, grafanaPod.Namespace, d.localPort, d.remotePort)
+	portForwarder, err := utils.NewPortForwarder(conf, clientSet, grafanaPod.Name, grafanaPod.Namespace, d.localPort, d.remotePort)
 	if err != nil {
 		return errors.Errorf("Error setting up port forwarding: %s", err)
 	}
 
-	err = portForwarder.Start(func(pf *PortForwarder) error {
+	err = portForwarder.Start(func(pf *utils.PortForwarder) error {
 		if d.openBrowser {
 			url := fmt.Sprintf("http://localhost:%d", d.localPort)
 			fmt.Fprintf(d.out, "[+] Issuing open browser %s\n", url)

--- a/cmd/cli/dashboard.go
+++ b/cmd/cli/dashboard.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/openservicemesh/osm/pkg/utils"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 const openGrafanaDashboardDesc = `
@@ -105,12 +105,12 @@ func (d *dashboardCmd) run() error {
 		return errors.Errorf("No running Grafana pod available")
 	}
 
-	portForwarder, err := utils.NewPortForwarder(conf, clientSet, grafanaPod.Name, grafanaPod.Namespace, d.localPort, d.remotePort)
+	portForwarder, err := k8s.NewPortForwarder(conf, clientSet, grafanaPod.Name, grafanaPod.Namespace, d.localPort, d.remotePort)
 	if err != nil {
 		return errors.Errorf("Error setting up port forwarding: %s", err)
 	}
 
-	err = portForwarder.Start(func(pf *utils.PortForwarder) error {
+	err = portForwarder.Start(func(pf *k8s.PortForwarder) error {
 		if d.openBrowser {
 			url := fmt.Sprintf("http://localhost:%d", d.localPort)
 			fmt.Fprintf(d.out, "[+] Issuing open browser %s\n", url)

--- a/cmd/cli/proxy_configdump.go
+++ b/cmd/cli/proxy_configdump.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 const dumpConfigDescription = `
@@ -84,12 +85,12 @@ func (cmd *proxyDumpConfigCmd) run() error {
 		return errors.Errorf("Pod %s in namespace %s is not a part of a mesh", cmd.pod, cmd.namespace)
 	}
 
-	portForwarder, err := NewPortForwarder(cmd.config, cmd.clientSet, cmd.pod, cmd.namespace, cmd.localPort, constants.EnvoyAdminPort)
+	portForwarder, err := utils.NewPortForwarder(cmd.config, cmd.clientSet, cmd.pod, cmd.namespace, cmd.localPort, constants.EnvoyAdminPort)
 	if err != nil {
 		return errors.Errorf("Error setting up port forwarding: %s", err)
 	}
 
-	err = portForwarder.Start(func(pf *PortForwarder) error {
+	err = portForwarder.Start(func(pf *utils.PortForwarder) error {
 		url := fmt.Sprintf("http://localhost:%d/config_dump", cmd.localPort)
 
 		// #nosec G107: Potential HTTP request made with variable url

--- a/cmd/cli/proxy_configdump.go
+++ b/cmd/cli/proxy_configdump.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/utils"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 const dumpConfigDescription = `
@@ -85,12 +85,12 @@ func (cmd *proxyDumpConfigCmd) run() error {
 		return errors.Errorf("Pod %s in namespace %s is not a part of a mesh", cmd.pod, cmd.namespace)
 	}
 
-	portForwarder, err := utils.NewPortForwarder(cmd.config, cmd.clientSet, cmd.pod, cmd.namespace, cmd.localPort, constants.EnvoyAdminPort)
+	portForwarder, err := k8s.NewPortForwarder(cmd.config, cmd.clientSet, cmd.pod, cmd.namespace, cmd.localPort, constants.EnvoyAdminPort)
 	if err != nil {
 		return errors.Errorf("Error setting up port forwarding: %s", err)
 	}
 
-	err = portForwarder.Start(func(pf *utils.PortForwarder) error {
+	err = portForwarder.Start(func(pf *k8s.PortForwarder) error {
 		url := fmt.Sprintf("http://localhost:%d/config_dump", cmd.localPort)
 
 		// #nosec G107: Potential HTTP request made with variable url

--- a/pkg/kubernetes/portforward.go
+++ b/pkg/kubernetes/portforward.go
@@ -1,4 +1,4 @@
-package utils
+package kubernetes
 
 import (
 	"context"

--- a/pkg/utils/portforward.go
+++ b/pkg/utils/portforward.go
@@ -1,4 +1,4 @@
-package main
+package utils
 
 import (
 	"context"


### PR DESCRIPTION
This commit just moves PortForwarder to a more generic/utils
location in the repo.

Testing will require immediate use of port-forwarding; moving
it to a less bloated/more generic package hopes to reduced number
of imports and coupling between users of this feature.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

**Affected area**:

- Other                  [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No