### PR TITLE
kubernetes: add api to retrieve pods backing a service

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -245,3 +245,25 @@ func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]servic
 	}
 	return svcAccounts, nil
 }
+
+// ListPodsForService lists the pods associated with a service
+func (c Client) ListPodsForService(svc corev1.Service) []*corev1.Pod {
+	var pods []*corev1.Pod
+
+	svcSelector := svc.Spec.Selector
+	allPods := c.ListPods()
+
+	for _, pod := range allPods {
+		if svc.Namespace != pod.Namespace {
+			continue
+		}
+
+		podLabels := pod.ObjectMeta.Labels
+		selector := labels.Set(svcSelector).AsSelector()
+		if selector.Matches(labels.Set(podLabels)) {
+			pods = append(pods, pod)
+		}
+	}
+
+	return pods
+}

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -368,6 +368,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 		})
 
 		It("should correctly return the pods associated with a service", func() {
+			// Test creates 2 pods whose labels match the service's selectors
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
@@ -448,6 +449,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 		})
 
 		It("should correctly return the pods associated with a service", func() {
+			// Test creates 2 pods, only one whose labels match the service's selectors
 			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)

--- a/pkg/kubernetes/mock_controller.go
+++ b/pkg/kubernetes/mock_controller.go
@@ -8,10 +8,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/announcements"
+	announcements "github.com/openservicemesh/osm/pkg/announcements"
 	service "github.com/openservicemesh/osm/pkg/service"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockController is a mock of Controller interface
@@ -134,6 +133,20 @@ func (m *MockController) ListPods() []*v1.Pod {
 func (mr *MockControllerMockRecorder) ListPods() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPods", reflect.TypeOf((*MockController)(nil).ListPods))
+}
+
+// ListPodsForService mocks base method
+func (m *MockController) ListPodsForService(arg0 v1.Service) []*v1.Pod {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPodsForService", arg0)
+	ret0, _ := ret[0].([]*v1.Pod)
+	return ret0
+}
+
+// ListPodsForService indicates an expected call of ListPodsForService
+func (mr *MockControllerMockRecorder) ListPodsForService(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodsForService", reflect.TypeOf((*MockController)(nil).ListPodsForService), arg0)
 }
 
 // ListServiceAccountsForService mocks base method

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -90,6 +90,9 @@ type Controller interface {
 	// ListPods returns a list of pods part of the mesh
 	ListPods() []*corev1.Pod
 
+	// ListPodsForService lists the pods associated with a service
+	ListPodsForService(corev1.Service) []*corev1.Pod
+
 	// ListServiceAccountsForService lists ServiceAccounts associated with the given service
 	ListServiceAccountsForService(svc service.MeshService) ([]service.K8sServiceAccount, error)
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an api to the kubernetes.Controller interface to retreive
pods backing a service. This will be used by a subsequent change
to fetch the kubernetes ports for a service that used named
target ports.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`