### PR TITLE
endpoint/providers: add api to retrieve port:protocol mapping for ser…

### DIFF
--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -193,6 +193,11 @@ func (c Client) GetPortToProtocolMappingForService(svc service.MeshService) (map
 		return nil, errors.Errorf("Error fetching endpoints for service %s, namespace %s is not monitored", svc, endpoints.Namespace)
 	}
 
+	// A given port can only map to a single application protocol. Even if the same
+	// port appears as a separate endpoint 'ip:port', the application protocol is
+	// derived from the Service that fronts these endpoints, and a service's port
+	// can only have one application protocol. So for the same port we don't have
+	// to worry about different application protocols being set.
 	for _, endpointSet := range endpoints.Subsets {
 		for _, port := range endpointSet.Ports {
 			appProtocol := defaultAppProtocol

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -48,6 +48,10 @@ func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAc
 	return services, nil
 }
 
+func (f fakeClient) GetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
+	return map[uint32]string{uint32(tests.Endpoint.Port): defaultAppProtocol}, nil
+}
+
 // GetID returns the unique identifier of the EndpointsProvider.
 func (f fakeClient) GetID() string {
 	return "Fake Kubernetes Client"

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -16,6 +16,9 @@ type Provider interface {
 	// Retrieve the namespaced services for a given service account
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
+	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
+	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
+
 	// Returns the expected endpoints that are to be reached when the service FQDN is resolved under
 	// the scope of the provider
 	GetResolvableEndpointsForService(service.MeshService) ([]Endpoint, error)


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an api to retrieve the port to protocol mapping for a service.
If an `AppProtocol` is unspecfied, it will default to `http` in lieu
of current OSM protocol support.
This will be used later to correctly filter inbound
traffic arriving on a port, as described in commit ff54bd77.

This change also refactors the tests which were relying on objects
created by previous tests causing test pollution, and some additional
cleanup.

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`