### PR TITLE
envoy: use an api to retrieve the local cluster name

### DIFF
--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -1,8 +1,6 @@
 package cds
 
 import (
-	"fmt"
-
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes"
@@ -12,7 +10,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/featureflags"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // NewResponse creates a new Cluster Discovery Response.
@@ -59,7 +56,7 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 
 	// Create a local cluster for the service.
 	// The local cluster will be used for incoming traffic.
-	localClusterName := getLocalClusterName(proxyServiceName)
+	localClusterName := envoy.GetLocalClusterNameForService(proxyServiceName)
 	localCluster, err := getLocalServiceCluster(catalog, proxyServiceName, localClusterName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
@@ -104,8 +101,4 @@ func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 	}
 
 	return resp, nil
-}
-
-func getLocalClusterName(proxyServiceName service.MeshService) string {
-	return fmt.Sprintf("%s%s", proxyServiceName, envoy.LocalClusterSuffix)
 }

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -98,11 +98,11 @@ var _ = Describe("CDS Response", func() {
 
 	Context("Test cds clusters", func() {
 		It("Returns a local cluster object", func() {
-			localCluster, err := getLocalServiceCluster(catalog, proxyService, getLocalClusterName(proxyService))
+			localCluster, err := getLocalServiceCluster(catalog, proxyService, envoy.GetLocalClusterNameForService(proxyService))
 			Expect(err).ToNot(HaveOccurred())
 
 			expectedClusterLoadAssignment := &xds_endpoint.ClusterLoadAssignment{
-				ClusterName: getLocalClusterName(proxyService),
+				ClusterName: envoy.GetLocalClusterNameForService(proxyService),
 				Endpoints: []*xds_endpoint.LocalityLbEndpoints{
 					{
 						Locality: nil,
@@ -132,8 +132,8 @@ var _ = Describe("CDS Response", func() {
 
 			expectedCluster := xds_cluster.Cluster{
 				TransportSocketMatches: nil,
-				Name:                   getLocalClusterName(proxyService),
-				AltStatName:            getLocalClusterName(proxyService),
+				Name:                   envoy.GetLocalClusterNameForService(proxyService),
+				AltStatName:            envoy.GetLocalClusterNameForService(proxyService),
 				ClusterDiscoveryType:   &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STATIC},
 				EdsClusterConfig:       nil,
 				ConnectTimeout:         ptypes.DurationProto(1 * time.Second),

--- a/pkg/envoy/route/config.go
+++ b/pkg/envoy/route/config.go
@@ -171,13 +171,13 @@ func getWeightedCluster(weightedClusters set.Set, totalClustersWeight int, direc
 	var total int
 	for clusterInterface := range weightedClusters.Iter() {
 		cluster := clusterInterface.(service.WeightedCluster)
-		clusterName := string(cluster.ClusterName)
+		clusterName := cluster.ClusterName.String()
 		total += cluster.Weight
 		if direction == InboundRoute {
 			// An inbound route is associated with a local cluster. The inbound route is applied
 			// on the destination cluster, and the destination clusters that accept inbound
 			// traffic have the name of the form 'someClusterName-local`.
-			clusterName += envoy.LocalClusterSuffix
+			clusterName = envoy.GetLocalClusterNameForServiceCluster(clusterName)
 		}
 		wc.Clusters = append(wc.Clusters, &xds_route.WeightedCluster_ClusterWeight{
 			Name:   clusterName,

--- a/pkg/envoy/route/config_test.go
+++ b/pkg/envoy/route/config_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Weighted clusters", func() {
 			weightsExpected := set.NewSet()
 			for weightedClusterInterface := range weightedClusters.Iter() {
 				cluster := weightedClusterInterface.(service.WeightedCluster)
-				clustersExpected.Add(string(cluster.ClusterName + envoy.LocalClusterSuffix))
+				clustersExpected.Add(string(envoy.GetLocalClusterNameForServiceCluster(cluster.ClusterName.String())))
 				weightsExpected.Add(uint32(cluster.Weight))
 			}
 
@@ -140,7 +140,7 @@ var _ = Describe("Routes with weighted clusters", func() {
 		weightsExpected := set.NewSet()
 		for weightedClusterInterface := range weightedClusters.Iter() {
 			cluster := weightedClusterInterface.(service.WeightedCluster)
-			clustersExpected.Add(string(cluster.ClusterName + envoy.LocalClusterSuffix))
+			clustersExpected.Add(string(envoy.GetLocalClusterNameForServiceCluster(cluster.ClusterName.String())))
 			weightsExpected.Add(uint32(cluster.Weight))
 		}
 

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -54,6 +54,7 @@ const (
 
 	accessLogPath = "/dev/stdout"
 
-	//LocalClusterSuffix is the tag to append to local clusters
-	LocalClusterSuffix = "-local"
+	// localClusterSuffix is the tag to append to the local cluster name corresponding to a service cluster.
+	// The local cluster refers to the cluster corresponding to the service the proxy is fronting, accessible over localhost by the proxy.
+	localClusterSuffix = "-local"
 )

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -327,3 +327,15 @@ func ParseEnvoyServiceNodeID(serviceNodeID string) (*PodMetadata, error) {
 		EnvoyNodeID:    chunks[4],
 	}, nil
 }
+
+// GetLocalClusterNameForService returns the name of the local cluster for the given service.
+// The local cluster refers to the cluster corresponding to the service the proxy is fronting, accessible over localhost by the proxy.
+func GetLocalClusterNameForService(proxyService service.MeshService) string {
+	return GetLocalClusterNameForServiceCluster(proxyService.String())
+}
+
+// GetLocalClusterNameForServiceCluster returns the name of the local cluster for the given service cluster.
+// The local cluster refers to the cluster corresponding to the service the proxy is fronting, accessible over localhost by the proxy.
+func GetLocalClusterNameForServiceCluster(clusterName string) string {
+	return fmt.Sprintf("%s%s", clusterName, localClusterSuffix)
+}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -82,6 +82,11 @@ func (sa K8sServiceAccount) GetSyntheticService() MeshService {
 // ClusterName is a type for a service name
 type ClusterName string
 
+// String returns the given ClusterName type as a string
+func (c ClusterName) String() string {
+	return string(c)
+}
+
 //WeightedService is a struct of a service name, its weight and its root service
 type WeightedService struct {
 	Service     MeshService `json:"service_name:omitempty"`


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Instead of leaking local cluster syntax across pkgs, using
an api makes the code cleaner. This api will be used to
retrieve the local cluster name for a given service cluster.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`