### PR TITLE
feat(pkg/trafficpolicy): add routes to outbound traffic policy

### DIFF
--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	set "github.com/deckarep/golang-set"
+	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -26,4 +27,32 @@ func (in *InboundTrafficPolicy) AddRule(route RouteWeightedClusters, allowedServ
 			AllowedServiceAccounts: set.NewSet(allowedServiceAccount),
 		})
 	}
+}
+
+// AddRoute adds a route to an OutboundTrafficPolicy given an HTTP route match and weighted cluster. If a Route with the given HTTP route match
+//	already exists, an error will be returned. If a Route with the given HTTP route match does not exist,
+//	a Route with the given HTTP route match and weighted clusters will be added to the Routes on the OutboundTrafficPolicy
+func (out *OutboundTrafficPolicy) AddRoute(httpRouteMatch HTTPRouteMatch, weightedClusters ...service.WeightedCluster) error {
+	routeExists := false
+	wc := set.NewSet()
+	for _, c := range weightedClusters {
+		wc.Add(c)
+	}
+
+	for _, existingRoute := range out.Routes {
+		if reflect.DeepEqual(existingRoute.HTTPRouteMatch, httpRouteMatch) {
+			if existingRoute.WeightedClusters.Equal(wc) {
+				return nil
+			}
+			return errors.Errorf("Route for HTTP Route Match: %v already exists: %v for outbound traffic policy: %s", existingRoute.HTTPRouteMatch, existingRoute, out.Name)
+		}
+	}
+
+	if !routeExists {
+		out.Routes = append(out.Routes, &RouteWeightedClusters{
+			HTTPRouteMatch:   httpRouteMatch,
+			WeightedClusters: wc,
+		})
+	}
+	return nil
 }


### PR DESCRIPTION
**Description**:
feat(pkg/trafficpolicy): add routes to outbound traffic policy

* adds AddRoute method + test to outbound traffic policy
* part of #2034
Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
