### PR TITLE
envoy/lds: add support for inbound TCP proxying

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -5,6 +5,7 @@ import (
 
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
@@ -17,8 +18,10 @@ import (
 )
 
 const (
-	inboundMeshFilterChainName = "inbound-mesh-filter-chain"
-	httpAppProtocol            = "http"
+	inboundMeshHTTPFilterChainName = "inbound-mesh-http-filter-chain"
+	inboundMeshTCPFilterChain      = "inbound-mesh-tcp-filter-chain"
+	httpAppProtocol                = "http"
+	tcpAppProtocol                 = "tcp"
 )
 
 var (
@@ -46,6 +49,14 @@ func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshS
 			filterChainForPort, err := lb.getInboundMeshHTTPFilterChain(proxyService, port)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error building inbound HTTP filter chain for proxy:port %s:%d", proxyService, port)
+				continue // continue building filter chains for other ports on the service
+			}
+			filterChains = append(filterChains, filterChainForPort)
+
+		case tcpAppProtocol:
+			filterChainForPort, err := lb.getInboundMeshTCPFilterChain(proxyService, port)
+			if err != nil {
+				log.Error().Err(err).Msgf("Error building inbound TCP filter chain for proxy:port %s:%d", proxyService, port)
 				continue // continue building filter chains for other ports on the service
 			}
 			filterChains = append(filterChains, filterChainForPort)
@@ -106,7 +117,7 @@ func (lb *listenerBuilder) getInboundMeshHTTPFilterChain(proxyService service.Me
 		return nil, err
 	}
 
-	filterchainName := fmt.Sprintf("%s:%d", inboundMeshFilterChainName, servicePort)
+	filterchainName := fmt.Sprintf("%s:%d", inboundMeshHTTPFilterChainName, servicePort)
 	filterChain := &xds_listener.FilterChain{
 		Name:    filterchainName,
 		Filters: filters,
@@ -138,6 +149,84 @@ func (lb *listenerBuilder) getInboundMeshHTTPFilterChain(proxyService service.Me
 	}
 
 	return filterChain, nil
+}
+
+func (lb *listenerBuilder) getInboundMeshTCPFilterChain(proxyService service.MeshService, servicePort uint32) (*xds_listener.FilterChain, error) {
+	// Construct TCP filters
+	filters, err := lb.getInboundTCPFilters(proxyService)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error constructing inbound TCP filters for proxy service %s", proxyService)
+		return nil, err
+	}
+
+	// Construct downstream TLS context
+	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(proxyService, true /* mTLS */))
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
+		return nil, err
+	}
+
+	filterchainName := fmt.Sprintf("%s:%d", inboundMeshTCPFilterChain, servicePort)
+	return &xds_listener.FilterChain{
+		Name: filterchainName,
+		FilterChainMatch: &xds_listener.FilterChainMatch{
+			// The DestinationPort is the service port the downstream directs traffic to
+			DestinationPort: &wrapperspb.UInt32Value{
+				Value: servicePort,
+			},
+
+			// The ServerName is the SNI set by the downstream in the UptreamTlsContext by GetUpstreamTLSContext()
+			// This is not a field obtained from the mTLS Certificate.
+			ServerNames: []string{proxyService.ServerName()},
+
+			// Only match when transport protocol is TLS
+			TransportProtocol: envoy.TransportProtocolTLS,
+
+			// In-mesh proxies will advertise this, set in the UpstreamTlsContext by GetUpstreamTLSContext()
+			ApplicationProtocols: envoy.ALPNInMesh,
+		},
+		Filters: filters,
+		TransportSocket: &xds_core.TransportSocket{
+			Name: wellknown.TransportSocketTls,
+			ConfigType: &xds_core.TransportSocket_TypedConfig{
+				TypedConfig: marshalledDownstreamTLSContext,
+			},
+		},
+	}, nil
+}
+
+func (lb *listenerBuilder) getInboundTCPFilters(proxyService service.MeshService) ([]*xds_listener.Filter, error) {
+	var filters []*xds_listener.Filter
+
+	// Apply an RBAC filter when permissive mode is disabled. The RBAC filter must be the first filter in the list of filters.
+	if !lb.cfg.IsPermissiveTrafficPolicyMode() {
+		// Apply RBAC policies on the inbound filters based on configured policies
+		rbacFilter, err := lb.buildRBACFilter()
+		if err != nil {
+			log.Error().Err(err).Msgf("Error applying RBAC filter for proxy service %s", proxyService)
+			return nil, err
+		}
+		// RBAC filter should be the very first filter in the filter chain
+		filters = append(filters, rbacFilter)
+	}
+
+	// Apply the TCP Proxy Filter
+	tcpProxy := &xds_tcp_proxy.TcpProxy{
+		StatPrefix:       "inbound-mesh-tcp-proxy",
+		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: envoy.GetLocalClusterNameForService(proxyService)},
+	}
+	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshalling TcpProxy object for egress HTTPS filter chain")
+		return nil, err
+	}
+	tcpProxyFilter := &xds_listener.Filter{
+		Name:       wellknown.TCPProxy,
+		ConfigType: &xds_listener.Filter_TypedConfig{TypedConfig: marshalledTCPProxy},
+	}
+	filters = append(filters, tcpProxyFilter)
+
+	return filters, nil
 }
 
 // getOutboundHTTPFilter returns an HTTP connection manager network filter used to filter outbound HTTP traffic


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the plumbing necessary to be able to
proxy indbound TCP traffic for a service. Similar to
the inbound HTTP filter chain, a TCP filter chain
is adder per TCP port exposed on the service. This
is the first change in the series to support TCP traffic.
Subsequent changes will enable enforcing TCP port based
rules as a part of the RBAC policies.

Note that this change will not allow TCP clients to access
TCP based services yet because outbound TCP proxying with
TLS still needs to be implemented. This change does not
affect HTTP traffic.

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`