### PR TITLE
fix(maestro): cleanup helm releases in deleted namespaces

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -50,7 +50,6 @@ var (
 
 	maxPodWaitString = utils.GetEnv(maestro.WaitForPodTimeSecondsEnvVar, "30")
 	maxOKWaitString  = utils.GetEnv(maestro.WaitForOKSecondsEnvVar, "30")
-	meshName         = osmNamespace
 
 	// Mesh namespaces
 	namespaces = []string{

--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -83,7 +83,8 @@ func main() {
 	}
 
 	if allTestsResults.Equal(maestro.TestsPassed) {
-		cleanUp(kubeClient)
+		log.Info().Msg("Test succeeded")
+		maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
 		os.Exit(0) // Tests passed!  WE ARE DONE !!!
 	}
 
@@ -188,13 +189,6 @@ func getPodNames(kubeClient kubernetes.Interface) (string, string, string, strin
 	}
 
 	return bookBuyerPodName, bookThiefPodName, bookWarehousePodName, osmControllerPodName
-}
-
-func cleanUp(kubeClient *kubernetes.Clientset) {
-	log.Info().Msg("Test succeeded")
-	maestro.DeleteNamespaces(kubeClient, append(namespaces, osmNamespace)...)
-	webhookConfigName := fmt.Sprintf("osm-webhook-%s", meshName)
-	maestro.DeleteWebhookConfiguration(kubeClient, webhookConfigName)
 }
 
 func printLogsForInitContainers(kubeClient kubernetes.Interface, pod v1.Pod) {

--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -14,10 +14,13 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	mapset "github.com/deckarep/golang-set"
+	"helm.sh/helm/v3/pkg/action"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openservicemesh/osm/pkg/cli"
 )
 
 // We are going to wait for the Pod certain amount of time if it is in one of these statuses
@@ -48,13 +51,36 @@ func GetPodLogs(kubeClient kubernetes.Interface, namespace string, podName strin
 	return buf.String()
 }
 
-// DeleteNamespaces deletes the namespaces listed.
+// DeleteNamespaces deletes the namespaces listed and any Helm releases within
+// them.
 func DeleteNamespaces(client *kubernetes.Clientset, namespaces ...string) {
+	env := cli.New()
+
 	deleteOptions := metav1.DeleteOptions{
 		GracePeriodSeconds: to.Int64Ptr(0),
 	}
 
 	for _, ns := range namespaces {
+		// Delete all helm releases in the namespace
+		helmCfg := &action.Configuration{}
+		if err := helmCfg.Init(env.RESTClientGetter(), ns, "secret", log.Info().Msgf); err != nil {
+			log.Warn().Err(err).Msg("Failed to initialize Helm, skipping release cleanup")
+		} else {
+			uninstall := action.NewUninstall(helmCfg)
+			list := action.NewList(helmCfg)
+			list.All = true
+			releases, err := list.Run()
+			if err != nil {
+				log.Warn().Err(err).Msgf("Failed to list releases in namespace %s, skipping release cleanup", ns)
+			} else {
+				for _, release := range releases {
+					if _, err := uninstall.Run(release.Name); err != nil {
+						log.Warn().Err(err).Msgf("Failed to uninstall release %s in namespace %s", release.Name, ns)
+					}
+				}
+			}
+		}
+
 		if err := client.CoreV1().Namespaces().Delete(context.Background(), ns, deleteOptions); err != nil {
 			log.Error().Err(err).Msgf("Error deleting namespace %s", ns)
 			continue


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds Helm release deletion to the `DeleteNamespaces` function called
by the maestro to cleanup resources to prevent any cluster-wide
resources from lingering after the rest of the installation is gone.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No