### PR TITLE
envoy/rbac: support destination port permission in rules

### DIFF
--- a/pkg/envoy/rbac/types.go
+++ b/pkg/envoy/rbac/types.go
@@ -10,6 +10,12 @@ const (
 	DownstreamAuthPrincipal RuleAttribute = "downstreamAuthPrincipal"
 )
 
+// Supported attributes for an RBAC permission
+const (
+	// DestinationPort is the key used for the destination port as a permission in a policy Rule
+	DestinationPort RuleAttribute = "destinationPort"
+)
+
 // Rule is a type that can represent a policy's Permission and Principal rules
 type Rule struct {
 	Attribute RuleAttribute


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, the rbac policy generator only support programming
principal rules, with the permission set to ANY, if not specified
in the rule spec. This change allows programming destination ports
as permissions in RBAC rules.

This is required to enable TCP port based filtering.

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`