### PR TITLE
fix(fluent bit): make input plugin read from head of file

### DIFF
--- a/charts/osm/templates/fluentbit-configmap.yaml
+++ b/charts/osm/templates/fluentbit-configmap.yaml
@@ -16,6 +16,7 @@ data:
       Tag     kube.*
       Path    /var/log/containers/osm-controller-*_{{ .Release.Namespace }}_osm-controller-*.log
       Parser  cri
+      Read_from_Head  on
     [FILTER]
       name       grep
       match      *


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: This change updates the Fluent Bit input plugin to make it read from the head of the log file rather than the tail. Reading from the tail was causing the first few logs to be missed.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [x]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
no, no