### PR TITLE
demo/tcp: adds simple tcp client server demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ kind-demo: .env kind-up clean-osm
 	./demo/run-osm-demo.sh
 
 # build-bookbuyer, etc
-DEMO_TARGETS = bookbuyer bookthief bookstore bookwarehouse
+DEMO_TARGETS = bookbuyer bookthief bookstore bookwarehouse tcp-echo-server tcp-client
 DEMO_BUILD_TARGETS = $(addprefix build-, $(DEMO_TARGETS))
 .PHONY: $(DEMO_BUILD_TARGETS)
 $(DEMO_BUILD_TARGETS): NAME=$(@:build-%=%)

--- a/demo/cmd/tcp-client/tcp-client.go
+++ b/demo/cmd/tcp-client/tcp-client.go
@@ -1,0 +1,79 @@
+// package main implements a TCP client that sends TCP data to a TCP echo server and prints the response.
+// The clients does the following:
+// 1. opens a connection to the server
+// 2. sends a fixed number of messages per connection and prints the server's response
+// 3. closes the connection
+// 4. Repeats step 1, 2, 3
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var (
+	log                   = logger.NewPretty("tcp-client")
+	serverAddress         = flag.String("server-address", "", "address (ip:port) to connect to")
+	requestPrefix         = "request:"
+	connectRetryDelay     = 3 * time.Second
+	nextMsgDelay          = 5 * time.Second
+	msgCountPerConnection = 10
+)
+
+func main() {
+	flag.Parse()
+
+	connectionCounter := 0
+
+	for {
+		connectionCounter++
+		conn, err := net.Dial("tcp", *serverAddress)
+		if err != nil {
+			fmt.Printf("Error connecting to %s: %s, retrying in %s time\n", *serverAddress, err, connectRetryDelay)
+			time.Sleep(connectRetryDelay)
+			continue
+		}
+
+		fmt.Printf("Started connection #%d -------------------------\n", connectionCounter)
+
+		// Send as many messages determined by 'msgCountPerConnection' before creating a new connection
+		response := bufio.NewReader(conn)
+		for msgCounter := 1; msgCounter <= msgCountPerConnection; msgCounter++ {
+			time.Sleep(nextMsgDelay)
+			requestMsg := fmt.Sprintf("%s #connection=%d, #msg-counter=%d, msg=client hello\n", requestPrefix, connectionCounter, msgCounter)
+
+			// write on the connection
+			if bytesWritten, writeErr := conn.Write([]byte(requestMsg)); err != nil {
+				log.Error().Err(writeErr).Msg("Write error")
+				continue
+			} else {
+				fmt.Printf("Wrote %d bytes, msg written: [%s]\n", bytesWritten, requestMsg)
+			}
+
+			// read response from server
+			responseMsg, err := response.ReadString(byte('\n'))
+			switch err {
+			case nil:
+				fmt.Printf("Received response: [%s]\n", responseMsg)
+
+			case io.EOF:
+				fmt.Printf("Received EOF from server\n")
+
+			default:
+				// unexpected error
+				fmt.Printf("Unexpected error: %s\n", err)
+			}
+
+			fmt.Println()
+		}
+
+		conn.Close() //nolint: errcheck,gosec
+		fmt.Printf("Ended connection #%d ---------------------------\n\n", connectionCounter)
+	}
+}

--- a/demo/cmd/tcp-echo-server/tcp-echo-server.go
+++ b/demo/cmd/tcp-echo-server/tcp-echo-server.go
@@ -1,0 +1,74 @@
+// package main implements a TCP echo server that echoes back the TCP client's request as a part of its response.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var (
+	log            = logger.NewPretty("tcp-echo-server")
+	port           = flag.Int("port", 9090, "port on which this app is serving TCP connections")
+	responsePrefix = "echo response:"
+)
+
+func main() {
+	flag.Parse()
+
+	listenAddr := fmt.Sprintf(":%d", *port)
+
+	// Create a tcp listener
+	listener, err := net.Listen("tcp", listenAddr)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Error creating TCP listener on address %q", listenAddr)
+	}
+	log.Info().Msgf("Server listening on address %q", listenAddr)
+
+	// listen for new connections
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Error().Err(err).Msg("Error accepting connection")
+			continue
+		}
+
+		go echoResponse(conn)
+	}
+}
+
+func echoResponse(conn net.Conn) {
+	defer conn.Close() //nolint: errcheck,gosec
+	reader := bufio.NewReader(conn)
+
+	for {
+		requestMsg, err := reader.ReadString(byte('\n'))
+		requestMsg = strings.TrimSuffix(requestMsg, "\n") // trim trailing newline character
+
+		switch err {
+		case nil:
+			// respond to the request, prepend the prefix to the response
+			fmt.Printf("Received request: [%s]\n", requestMsg)
+			response := fmt.Sprintf("%s %s\n", responsePrefix, requestMsg)
+			if bytesWritten, writeErr := conn.Write([]byte(response)); err != nil {
+				log.Error().Err(writeErr).Msg("Write error")
+			} else {
+				log.Debug().Msgf("Wrote %d bytes", bytesWritten)
+			}
+			fmt.Printf("Response sent: [%s]\n", response)
+
+		case io.EOF:
+			return
+
+		default:
+			// unexpected error
+			fmt.Printf("Unexpected error: %s\n", err)
+			return
+		}
+	}
+}

--- a/demo/deploy-tcp-client.sh
+++ b/demo/deploy-tcp-client.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This script deploys the resources corresponding to the tcp-client.
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+CTR_TAG="${CTR_TAG:-latest}"
+
+echo -e "Create tcp-client service account"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tcp-client
+  namespace: tcp-demo
+EOF
+
+echo -e "Create tcp-client deployment"
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-client-v1
+  namespace: tcp-demo
+  labels:
+    app: tcp-client
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-client
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: tcp-client
+        version: v1
+    spec:
+      containers:
+      - name: tcp-client
+        image: "${CTR_REGISTRY}/tcp-client:${CTR_TAG}"
+        imagePullPolicy: Always
+        command: ["/tcp-client"]
+        args: [ "--server-address", "tcp-echo:9000" ]
+      imagePullSecrets:
+        - name: $CTR_REGISTRY_CREDS_NAME
+EOF

--- a/demo/deploy-tcp-echo-service.sh
+++ b/demo/deploy-tcp-echo-service.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# This script deploys the resources corresponding to the tcp-echo service.
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+
+CTR_TAG="${CTR_TAG:-latest}"
+
+echo -e "Create tcp-echo service"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+  labels:
+    app: tcp-echo
+spec:
+  ports:
+  - name: tcp
+    port: 9000
+    appProtocol: tcp
+  selector:
+    app: tcp-echo
+EOF
+
+echo -e "Create tcp-echo service account"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+EOF
+
+echo -e "Create tcp-echo deployment"
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo-v1
+  namespace: tcp-demo
+  labels:
+    app: tcp-echo
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-echo
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v1
+    spec:
+      containers:
+      - name: tcp-echo-server
+        image: "${CTR_REGISTRY}/tcp-echo-server:${CTR_TAG}"
+        imagePullPolicy: Always
+        command: ["/tcp-echo-server"]
+        args: [ "--port", "9000" ]
+        ports:
+        - containerPort: 9000
+          name: tcp-echo-server
+      imagePullSecrets:
+        - name: $CTR_REGISTRY_CREDS_NAME
+EOF

--- a/dockerfiles/Dockerfile.tcp-client
+++ b/dockerfiles/Dockerfile.tcp-client
@@ -1,0 +1,2 @@
+FROM gcr.io/distroless/static
+COPY tcp-client /

--- a/dockerfiles/Dockerfile.tcp-echo-server
+++ b/dockerfiles/Dockerfile.tcp-echo-server
@@ -1,0 +1,2 @@
+FROM gcr.io/distroless/static
+COPY tcp-echo-server /


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds simple tcp client and server apps to
demo tcp support in OSM. The client opens a connection,
sends a number of messages, and prints the server response.
The server simply echoes back the client's message.

Part of #1521, to be used as a simple demo to showcase TCP
traffic when OSM supports TCP. TCP support is still in progress
but the apps don't depend on it.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`