### PR TITLE
Grafana/dashboards: change rate to irate

### DIFF
--- a/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
+++ b/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
@@ -526,7 +526,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(apiserver_watch_events_total[5m])",
+          "expr": "irate(apiserver_watch_events_total[1m])",
           "hide": false,
           "interval": "",
           "legendFormat": "{{kind}}",
@@ -637,7 +637,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_usage_seconds_total{namespace=\"osm-system\", container!~\"POD\", container!~\"\"}[1m])",
+          "expr": "irate(container_cpu_usage_seconds_total{namespace=\"osm-system\", container!~\"POD\", container!~\"\"}[1m])",
           "interval": "",
           "legendFormat": "{{container}}",
           "refId": "A"
@@ -893,7 +893,7 @@
           "refId": "A"
         },
         {
-          "expr": "rate(apiserver_admission_webhook_admission_duration_seconds_bucket[1m])",
+          "expr": "irate(apiserver_admission_webhook_admission_duration_seconds_bucket[1m])",
           "interval": "",
           "legendFormat": "{{le}}-{{rejected}}",
           "refId": "B"
@@ -1004,7 +1004,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(apiserver_admission_webhook_rejection_count[1m])",
+          "expr": "irate(apiserver_admission_webhook_rejection_count[1m])",
           "interval": "",
           "legendFormat": "",
           "refId": "B"


### PR DESCRIPTION
For display purposes, and for quickly changing values, `rate` properly
gives an average but this gets diluted if multiple values with
high variance appear in the same bucket.

For measures which have high variance and might be of interest
to understand the deltas with as much precision possible,
irate will always compute the delta between previous and current point,
regardless of bucket size, which makes sense to understand sudden
changes of trend which could get diluted/avgd otherwise.

- Metrics                [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No