### PR TITLE
feat(pkg/catalog): list allowed outbound services for identity

### DIFF
--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -233,6 +233,20 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServices(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServices", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServices), arg0)
 }
 
+// ListAllowedOutboundServicesForIdentity mocks base method
+func (m *MockMeshCataloger) ListAllowedOutboundServicesForIdentity(arg0 service.K8sServiceAccount) []service.MeshService {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllowedOutboundServicesForIdentity", arg0)
+	ret0, _ := ret[0].([]service.MeshService)
+	return ret0
+}
+
+// ListAllowedOutboundServicesForIdentity indicates an expected call of ListAllowedOutboundServicesForIdentity
+func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServicesForIdentity(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServicesForIdentity", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServicesForIdentity), arg0)
+}
+
 // ListEndpointsForService mocks base method
 func (m *MockMeshCataloger) ListEndpointsForService(arg0 service.MeshService) ([]endpoint.Endpoint, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -102,6 +102,37 @@ func (mc *MeshCatalog) ListAllowedOutboundServices(sourceService service.MeshSer
 	return mc.getAllowedDirectionalServices(sourceService, outbound)
 }
 
+// ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
+func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(identity service.K8sServiceAccount) []service.MeshService {
+	serviceSet := mapset.NewSet()
+	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
+		for _, source := range t.Spec.Sources {
+			if source.Name == identity.Name && source.Namespace == identity.Namespace { // found outbound
+				destServices, err := mc.GetServicesForServiceAccount(service.K8sServiceAccount{
+					Name:      t.Spec.Destination.Name,
+					Namespace: t.Namespace,
+				})
+				if err != nil {
+					log.Error().Msgf("No Services found matching Service Account %s in Namespace %s", t.Spec.Destination.Name, t.Namespace)
+					break
+				}
+				destServicesSet := mapset.NewSet()
+				for _, destService := range destServices {
+					destServicesSet.Add(destService)
+				}
+				serviceSet = serviceSet.Union(destServicesSet)
+				break
+			}
+		}
+	}
+
+	serviceSlice := []service.MeshService{}
+	for elem := range serviceSet.Iter() {
+		serviceSlice = append(serviceSlice, elem.(service.MeshService))
+	}
+	return serviceSlice
+}
+
 //GetWeightedClusterForService returns the weighted cluster for a given service
 func (mc *MeshCatalog) GetWeightedClusterForService(svc service.MeshService) (service.WeightedCluster, error) {
 	log.Trace().Msgf("Finding weighted cluster for service %s", svc)

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -116,11 +116,9 @@ func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(identity service.K
 					log.Error().Msgf("No Services found matching Service Account %s in Namespace %s", t.Spec.Destination.Name, t.Namespace)
 					break
 				}
-				destServicesSet := mapset.NewSet()
 				for _, destService := range destServices {
-					destServicesSet.Add(destService)
+					serviceSet.Add(destService)
 				}
-				serviceSet = serviceSet.Union(destServicesSet)
 				break
 			}
 		}

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -389,6 +389,38 @@ func TestListAllowedOutboundServices(t *testing.T) {
 	assert.ElementsMatch(actualList, expectedList)
 }
 
+func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
+	assert := assert.New(t)
+	mc := newFakeMeshCatalog()
+
+	testCases := []struct {
+		name           string
+		serviceAccount service.K8sServiceAccount
+		expectedList   []service.MeshService
+	}{
+		{
+			name:           "traffic targets configured for service account",
+			serviceAccount: tests.BookbuyerServiceAccount,
+			expectedList:   []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
+		},
+		{
+			name: "traffic targets not configured for service account",
+			serviceAccount: service.K8sServiceAccount{
+				Name:      "some-name",
+				Namespace: "some-ns",
+			},
+			expectedList: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualList := mc.ListAllowedOutboundServicesForIdentity(tc.serviceAccount)
+			assert.ElementsMatch(actualList, tc.expectedList)
+		})
+	}
+}
+
 func TestGetWeightedClusterForService(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -66,6 +66,9 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
 	ListAllowedOutboundServices(service.MeshService) ([]service.MeshService, error)
 
+	// ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
+	ListAllowedOutboundServicesForIdentity(service.K8sServiceAccount) []service.MeshService
+
 	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
 	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 


### PR DESCRIPTION
**Description**:

This PR adds a method to pkg/catalog which assess traffic targets and queries related Kubernetes services to determine which services a workload with the given service account can access. This will be used in determining outbound routes for both TCPRoute and as part of the route refactor described n #2034 to program remote clusters via CDS.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
