### PR TITLE
ref(pkg/catalog): update ListAllowedOutboundServicesForIdentity

### DIFF
--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -24,7 +24,11 @@ import (
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
-func newFakeMeshCatalogForRoutes(t *testing.T) *MeshCatalog {
+type testParams struct {
+	permissiveMode bool
+}
+
+func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatalog {
 	mockCtrl := gomock.NewController(t)
 	kubeClient := testclient.NewSimpleClientset()
 
@@ -124,6 +128,8 @@ func newFakeMeshCatalogForRoutes(t *testing.T) *MeshCatalog {
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().ListMonitoredNamespaces().Return(listExpectedNs, nil).AnyTimes()
+
+	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(testParams.permissiveMode).AnyTimes()
 
 	mockMeshSpec.EXPECT().GetAnnouncementsChannel().Return(announcementsChan).AnyTimes()
 	mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*target.TrafficTarget{&tests.TrafficTarget}).AnyTimes()


### PR DESCRIPTION
**Description**:

This PR updates `ListAllowedOutboundServicesForIdentity` to handle permissive mode. When allowed outbound services are requested for a workload, all services running in the mesh will be returned.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
