### PR TITLE
pkg/*: use newer api to list outbound services and update outbound listener building

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -306,9 +306,6 @@ type MeshCataloger interface {
 	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
 	ListAllowedInboundServices(service.MeshService) ([]service.MeshService, error)
 
-	// ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
-	ListAllowedOutboundServices(service.MeshService) ([]service.MeshService, error)
-
 	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
 	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -218,21 +218,6 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServiceAccounts(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServiceAccounts", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServiceAccounts), arg0)
 }
 
-// ListAllowedOutboundServices mocks base method
-func (m *MockMeshCataloger) ListAllowedOutboundServices(arg0 service.MeshService) ([]service.MeshService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedOutboundServices", arg0)
-	ret0, _ := ret[0].([]service.MeshService)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAllowedOutboundServices indicates an expected call of ListAllowedOutboundServices
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServices", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServices), arg0)
-}
-
 // ListAllowedOutboundServicesForIdentity mocks base method
 func (m *MockMeshCataloger) ListAllowedOutboundServicesForIdentity(arg0 service.K8sServiceAccount) []service.MeshService {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -97,11 +97,6 @@ func (mc *MeshCatalog) ListAllowedInboundServices(destinationService service.Mes
 	return mc.getAllowedDirectionalServices(destinationService, inbound)
 }
 
-// ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
-func (mc *MeshCatalog) ListAllowedOutboundServices(sourceService service.MeshService) ([]service.MeshService, error) {
-	return mc.getAllowedDirectionalServices(sourceService, outbound)
-}
-
 // ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
 func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(identity service.K8sServiceAccount) []service.MeshService {
 	allowedServices := []service.MeshService{}

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -378,17 +378,6 @@ func TestBuildAllowPolicyForSourceToDest(t *testing.T) {
 	assert.ElementsMatch(trafficTarget.HTTPRouteMatches[0].Methods, expectedRoute.Methods)
 }
 
-func TestListAllowedOutboundServices(t *testing.T) {
-	assert := assert.New(t)
-
-	mc := newFakeMeshCatalog()
-	actualList, err := mc.ListAllowedOutboundServices(tests.BookbuyerService)
-	assert.Nil(err)
-
-	expectedList := []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService}
-	assert.ElementsMatch(actualList, expectedList)
-}
-
 func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
 	assert := assert.New(t)
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -63,9 +63,6 @@ type MeshCataloger interface {
 	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
 	ListAllowedInboundServices(service.MeshService) ([]service.MeshService, error)
 
-	// ListAllowedOutboundServices lists the services the given service is allowed outbound connections to.
-	ListAllowedOutboundServices(service.MeshService) ([]service.MeshService, error)
-
 	// ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
 	ListAllowedOutboundServicesForIdentity(service.K8sServiceAccount) []service.MeshService
 

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -45,7 +45,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	lb := newListenerBuilder(meshCatalog, svcAccount, cfg)
 
 	// --- OUTBOUND -------------------
-	outboundListener, err := lb.newOutboundListener(svcList)
+	outboundListener, err := lb.newOutboundListener()
 	if err != nil {
 		log.Error().Err(err).Msgf("Error making outbound listener config for proxy %s", proxyServiceName)
 	} else {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change deprecates the `ListAllowedOutboundServices` api
in favor of the newer `ListAllowedOutboundServicesForIdentity` api.
The newer api fetches the outbound services purely based on
TrafficTargets -> service mapping, while the older one constructed
all possible combinations of traffic policies for the service,
going through all SMI policies, and using the internally built
`trafficpolicy.TrafficTarget` to figure out the outbound services,
which affects performances (repeated cache access for different
k8s resources).

This also updates the moves the code related to building
outbound filter chains per service to its own function.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`