### PR TITLE
doc(charts): doc why failurePolicy must be Fail

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -12,6 +12,8 @@ webhooks:
       namespace: {{.Release.Namespace}}
       path: /mutate-pod-creation
       port: 443
+  # failurePolicy should always be set to Fail to ensure no new resources get created without a sidecar
+  #   (and bypass TrafficTarget policies) if the webhook server is down
   failurePolicy: Fail
   matchPolicy: Exact
   namespaceSelector:


### PR DESCRIPTION
**Description**:

failurePolicy in the MutatingWebhookConfiguration should
always be set to Fail so that no new resources get created
and thus bypass SMI Traffic Target policies if the for some
reason the webhook server is down. This is intentional and
guarentees that new pods in the monitored namespaces and those
intended to be injected with the sidecar are indeed injected.
Setting this value to Ignore may expose Pods to traffic
they should not be exposed to.



<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No