### PR TITLE
fix(e2e): fix typo in method name

### DIFF
--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -376,9 +376,9 @@ func (td *OsmTestData) GetPrometheusPodHandle(ns string, prometheusPodName strin
 	}, nil
 }
 
-// GetOSMPrometheusaHandle convenience wrapper, will get the Prometheus instance regularly deployed
+// GetOSMPrometheusHandle convenience wrapper, will get the Prometheus instance regularly deployed
 // by OSM installation in test <OsmNamespace>
-func (td *OsmTestData) GetOSMPrometheusaHandle() (*Prometheus, error) {
+func (td *OsmTestData) GetOSMPrometheusHandle() (*Prometheus, error) {
 	prometheusPod, err := Td.GetPodsForLabel(Td.OsmNamespace, metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			"app": OsmPrometheusAppLabel,

--- a/tests/scale/README.md
+++ b/tests/scale/README.md
@@ -54,7 +54,7 @@ It("Deploys OSM and scales traffic Splits indefinitely", func() {
 	Td.InstallOSM(t)
 
 	// Helpers to get OSM's install handlers, but arbitrary ones can be provided
-	pHandle := Td.GetOSMPrometheusaHandle()
+	pHandle := Td.GetOSMPrometheusHandle()
 	gHandle := Td.GetOSMGrafanaHandle()
 
 	// This could/should be called on `Context`, subject to when are resources available


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: `s/GetOSMPrometheusaHandle/GetOSMPrometheusHandle/`

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No