### PR TITLE
fix(e2e): gracefully stop port forwarding to Prometheus/Grafana

### DIFF
--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -344,6 +344,7 @@ func (td *OsmTestData) GetGrafanaPodHandle(ns string, grafanaPodName string, por
 		Port:     port,
 		User:     "admin", // default value of grafana deployment
 		Password: "admin", // default value of grafana deployment
+		pfwd:     portForwarder,
 	}, nil
 }
 
@@ -373,6 +374,7 @@ func (td *OsmTestData) GetPrometheusPodHandle(ns string, prometheusPodName strin
 	return &Prometheus{
 		Client: client,
 		API:    v1api,
+		pfwd:   portForwarder,
 	}, nil
 }
 

--- a/tests/framework/common_metrics.go
+++ b/tests/framework/common_metrics.go
@@ -13,6 +13,8 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
+
+	"github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 var (
@@ -23,6 +25,13 @@ var (
 type Prometheus struct {
 	Client api.Client
 	API    v1.API
+
+	pfwd *kubernetes.PortForwarder
+}
+
+// Stop gracefully stops the port forwarding to Prometheus
+func (p *Prometheus) Stop() {
+	p.pfwd.Stop()
 }
 
 // VectorQuery runs a query at time <t>, expects single vector type and single result.
@@ -110,6 +119,13 @@ type Grafana struct {
 	Port     uint16
 	User     string
 	Password string
+
+	pfwd *kubernetes.PortForwarder
+}
+
+// Stop gracefully stops the port forwarding to Grafana
+func (g *Grafana) Stop() {
+	g.pfwd.Stop()
 }
 
 // PanelPNGSnapshot takes a snapshot from a Grafana dashboard or panel


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the ability to stop the port-forward that happens when
getting a handle to Prometheus or Grafana to support detaching and
reattaching in the middle of a test.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No