### PR TITLE
tcp: add outbound proxying support and update tcp demo

### DIFF
--- a/demo/cmd/tcp-client/tcp-client.go
+++ b/demo/cmd/tcp-client/tcp-client.go
@@ -22,8 +22,8 @@ var (
 	serverAddress         = flag.String("server-address", "", "address (ip:port) to connect to")
 	requestPrefix         = "request:"
 	connectRetryDelay     = 3 * time.Second
-	nextMsgDelay          = 5 * time.Second
-	msgCountPerConnection = 10
+	nextMsgDelay          = 3 * time.Second
+	msgCountPerConnection = 3
 )
 
 func main() {
@@ -40,7 +40,7 @@ func main() {
 			continue
 		}
 
-		fmt.Printf("Started connection #%d -------------------------\n", connectionCounter)
+		fmt.Printf("Started connection #%d to %s -----------------------\n", connectionCounter, *serverAddress)
 
 		// Send as many messages determined by 'msgCountPerConnection' before creating a new connection
 		response := bufio.NewReader(conn)

--- a/demo/deploy-tcp-client.sh
+++ b/demo/deploy-tcp-client.sh
@@ -40,6 +40,7 @@ spec:
         app: tcp-client
         version: v1
     spec:
+      serviceAccountName: tcp-client
       containers:
       - name: tcp-client
         image: "${CTR_REGISTRY}/tcp-client:${CTR_TAG}"

--- a/demo/deploy-tcp-echo-service.sh
+++ b/demo/deploy-tcp-echo-service.sh
@@ -58,6 +58,7 @@ spec:
         app: tcp-echo
         version: v1
     spec:
+      serviceAccountName: tcp-echo
       containers:
       - name: tcp-echo-server
         image: "${CTR_REGISTRY}/tcp-echo-server:${CTR_TAG}"

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -15,6 +15,9 @@ import (
 )
 
 const (
+	inboundListenerName           = "inbound-listener"
+	outboundListenerName          = "outbound-listener"
+	prometheusListenerName        = "inbound-prometheus-listener"
 	outboundEgressFilterChainName = "outbound-egress-filter-chain"
 	singleIpv4Mask                = 32
 )
@@ -178,9 +181,16 @@ func (lb *listenerBuilder) getOutboundFilterChainPerUpstream() []*xds_listener.F
 	for upstream := range dstServicesSet {
 		// Construct HTTP filter chain
 		if httpFilterChain, err := lb.getOutboundHTTPFilterChainForService(upstream); err != nil {
-			log.Error().Err(err).Msgf("Error constructing outbount HTTP filter chain for upstream service %q", upstream)
+			log.Error().Err(err).Msgf("Error constructing outbound HTTP filter chain for upstream service %s on proxy with identity %s", upstream, lb.svcAccount)
 		} else {
 			filterChains = append(filterChains, httpFilterChain)
+		}
+
+		// Construct TCP filter chain
+		if tcpFilterChain, err := lb.getOutboundTCPFilterChainForService(upstream); err != nil {
+			log.Error().Err(err).Msgf("Error constructing outbound TCP filter chain for upstream service %s on proxy with identity %s", upstream, lb.svcAccount)
+		} else {
+			filterChains = append(filterChains, tcpFilterChain)
 		}
 	}
 

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -1,26 +1,20 @@
 package lds
 
 import (
-	"net"
 	"testing"
 
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"
-	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 // Tests TestGetFilterForService checks that a proper filter type is properly returned
@@ -52,64 +46,6 @@ func TestGetFilterForService(t *testing.T) {
 	filter, err = lb.getOutboundHTTPFilter()
 	assert.NoError(err)
 	assert.Equal(filter.Name, wellknown.HTTPConnectionManager)
-}
-
-// Tests TestGetFilterChainMatchForService checks that a proper filter chain match is returned
-// for a given service
-func TestGetFilterChainMatchForService(t *testing.T) {
-	assert := assert.New(t)
-	mockCtrl := gomock.NewController(t)
-
-	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
-
-	lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceAccount, mockConfigurator)
-
-	mockCatalog.EXPECT().GetResolvableServiceEndpoints(tests.BookstoreApexService).Return(
-		[]endpoint.Endpoint{
-			tests.Endpoint,
-			{
-				// Adding another IP to test multiple-endpoint filter chain
-				IP: net.IPv4(192, 168, 0, 1),
-			},
-		},
-		nil,
-	)
-
-	filterChainMatch, err := lb.getOutboundHTTPFilterChainMatchForService(tests.BookstoreApexService)
-
-	assert.NoError(err)
-
-	expectedFilterChainMatch := &xds_listener.FilterChainMatch{
-		// HTTP filter chain should only match on supported HTTP protocols that the downstream can use
-		// to originate a request.
-		ApplicationProtocols: []string{"http/1.0", "http/1.1", "h2c"},
-		PrefixRanges: []*xds_core.CidrRange{
-			{
-				AddressPrefix: tests.Endpoint.IP.String(),
-				PrefixLen: &wrapperspb.UInt32Value{
-					Value: 32,
-				},
-			},
-			{
-				AddressPrefix: "192.168.0.1",
-				PrefixLen: &wrapperspb.UInt32Value{
-					Value: 32,
-				},
-			},
-		},
-	}
-	assert.Equal(filterChainMatch, expectedFilterChainMatch)
-
-	// Test negative getOutboundHTTPFilterChainMatchForService when no endpoints are present
-	mockCatalog.EXPECT().GetResolvableServiceEndpoints(tests.BookstoreApexService).Return(
-		[]endpoint.Endpoint{},
-		nil,
-	)
-
-	filterChainMatch, err = lb.getOutboundHTTPFilterChainMatchForService(tests.BookstoreApexService)
-	assert.Error(err)
-	assert.Nil(filterChainMatch)
 }
 
 var _ = Describe("Construct inbound listeners", func() {

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -12,12 +12,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-const (
-	inboundListenerName    = "inbound_listener"
-	outboundListenerName   = "outbound_listener"
-	prometheusListenerName = "inbound_prometheus_listener"
-)
-
 // NewResponse creates a new Listener Discovery Response.
 // The response build 3 Listeners:
 // 1. Inbound listener to handle incoming traffic


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds support proxying outbound TCP traffic.
Similar to the HTTP filter chain per upstream, a TCP proxy
filter chain is creater per upstream on the client.

Also updates the TCP app specs and client's connection and
messages per connection paramters to see more new connections
periodically.

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`