### PR TITLE
pkg/*: use mutliple value case statement instead of fallthrough

### DIFF
--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -120,11 +120,7 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 			envoySecrets = append(envoySecrets, envoySecret)
 
 		// A root certificate used to validate a service certificate is requested
-		case envoy.RootCertTypeForMTLSInbound:
-			fallthrough
-		case envoy.RootCertTypeForMTLSOutbound:
-			fallthrough
-		case envoy.RootCertTypeForHTTPS:
+		case envoy.RootCertTypeForMTLSInbound, envoy.RootCertTypeForMTLSOutbound, envoy.RootCertTypeForHTTPS:
 			envoySecret, err := s.getRootCert(cert, *sdsCert, proxyService)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error creating cert %s for proxy %s for service %s", requestedCertificate, s.proxy.GetCommonName(), proxyService)

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -370,11 +370,7 @@ func TestGetSDSSecrets(t *testing.T) {
 			// verify different cert types
 			switch tc.sdsCertType {
 			// Verify SAN for inbound and outbound MTLS certs
-			case envoy.RootCertTypeForMTLSInbound:
-				fallthrough
-			case envoy.RootCertTypeForMTLSOutbound:
-				fallthrough
-			case envoy.RootCertTypeForHTTPS:
+			case envoy.RootCertTypeForMTLSInbound, envoy.RootCertTypeForMTLSOutbound, envoy.RootCertTypeForHTTPS:
 				// Check SANs
 				actualSANs := subjectAltNamesToStr(sdsSecret.GetValidationContext().GetMatchSubjectAltNames())
 				assert.ElementsMatch(actualSANs, tc.expectedSANs)

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -136,11 +136,7 @@ const (
 // Verifies the instType string flag option is a valid enum type
 func verifyValidInstallType(t InstallType) error {
 	switch t {
-	case SelfInstall:
-		fallthrough
-	case KindCluster:
-		fallthrough
-	case NoInstall:
+	case SelfInstall, KindCluster, NoInstall:
 		return nil
 	default:
 		return errors.Errorf("%s is not a valid OSM install type", string(t))


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Use of fallthrough statement is unnecessary in these cases because
we don't have multiple different statements for these cases. Cases
with the same underlying statements should simply be grouped under
the same case clause.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`