### PR TITLE
tests/scale: pod/traffic split scaling test

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -2,7 +2,7 @@
 
 set -aueo pipefail
 
-readarray -t modules < <(go list ./... | grep -v tests/e2e | grep -v tests/scenarios)
+readarray -t modules < <(go list ./... | grep -v tests/e2e | grep -v tests/scenarios | grep -v tests/scale)
 
 go test -timeout 120s \
    -failfast \

--- a/tests/scale/osm_common_profile_resources.go
+++ b/tests/scale/osm_common_profile_resources.go
@@ -1,0 +1,101 @@
+package scale
+
+import (
+	"fmt"
+	"os"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+const (
+	defaultFilename = "results.txt"
+)
+
+// Convenience function that wraps usual installation requirements for
+// initializing a scale test (OSM install, prometheus/grafana deployment /w rendering, scale handle, etc.)
+func scaleOSMInstall() (*DataHandle, error) {
+	t := Td.GetOSMInstallOpts()
+
+	// enable Prometheus and Grafana, plus remote rendering
+	t.DeployGrafana = true
+	t.DeployPrometheus = true
+	t.SetOverrides = append(t.SetOverrides,
+		"OpenServiceMesh.grafana.enableRemoteRendering=true")
+
+	err := Td.InstallOSM(t)
+	if err != nil {
+		return nil, err
+	}
+
+	// Required to happen here, as Prometheus and Grafana are deployed with OSM install
+	pHandle, err := Td.GetOSMPrometheusHandle()
+	if err != nil {
+		return nil, err
+	}
+	gHandle, err := Td.GetOSMGrafanaHandle()
+	if err != nil {
+		return nil, err
+	}
+
+	// New test data handle. We set usual resources to track and Grafana dashboards to save.
+	sd := NewDataHandle(pHandle, gHandle, getOSMTrackResources(), getOSMGrafanaSaveDashboards())
+	// Set the file descriptors we want results to get written to
+	sd.ResultsOut = getOSMTestOutputFiles()
+
+	return sd, nil
+}
+
+// Returns the OSM grafana dashboards of interest to save after the test
+func getOSMGrafanaSaveDashboards() []GrafanaPanel {
+	return []GrafanaPanel{
+		{
+			Filename:  "cpu",
+			Dashboard: MeshDetails,
+			Panel:     CPUPanel,
+		},
+		{
+			Filename:  "mem",
+			Dashboard: MeshDetails,
+			Panel:     MemRSSPanel,
+		},
+	}
+}
+
+// Returns labels to select OSM controller and OSM-installed Prometheus.
+func getOSMTrackResources() []TrackedLabel {
+	return []TrackedLabel{
+		{
+			Namespace: Td.OsmNamespace,
+			Label: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": OsmControllerAppLabel,
+				},
+			},
+		},
+		{
+			Namespace: Td.OsmNamespace,
+			Label: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": OsmPrometheusAppLabel,
+				},
+			},
+		},
+	}
+}
+
+// Get common outputs we are interested to print in (resultsFile and stdout basically)
+func getOSMTestOutputFiles() []*os.File {
+	fName := Td.GetTestFile(defaultFilename)
+	f, err := os.Create(fName)
+	if err != nil {
+		fmt.Printf("Failed to open file: %v", err)
+		return nil
+	}
+
+	return []*os.File{
+		f,
+		os.Stdout,
+	}
+}

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -1,0 +1,278 @@
+package scale
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = Describe("Scales a setup with client-servers and traffic splits til failure", func() {
+	Context("ScaleClientServerTrafficSplit", func() {
+		// Framework data handle and hook to compute results
+		// We wait to initialize it till prom/grafana instances are available in OSM's case.
+		var sd *DataHandle
+
+		AfterEach(func() {
+			if sd != nil {
+				sd.WrapUp()
+			}
+		})
+
+		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
+			// Install OSM with all the requirements
+			var err error
+			sd, err = scaleOSMInstall()
+			Expect(err).To(BeNil())
+
+			// -- test specific data below
+
+			const (
+				// to name the header we will use to identify the server that replies
+				HTTPHeaderName = "podname"
+
+				// Base names for the resources we will generate
+				clientNamePrefix      = "client"
+				serverNamespacePrefix = "server"
+				TrafficSplitPrefix    = "traffic-split"
+			)
+
+			var (
+				// Number of client services per iteration
+				numberOfClientServices = 2
+				clientReplicaSet       = 5
+
+				// Number of server services per iteration
+				numberOfServerServices = 5
+				serverReplicaSet       = 2
+
+				// Total number of created resources, also used to name the resources we generate
+				totalNumberOfClientServices   = 0
+				totalNumberOfServerServices   = 0
+				totalNumberOfServerNamespaces = 0
+
+				// Used across the test to wait for concurrent steps to finish
+				wg = sync.WaitGroup{}
+			)
+
+			// Scale loop
+			sd.Iterate(func() {
+				// The following section computes the clients and servers (quantity and names) to be run this iteration
+				clientServices := []string{}
+				serverServices := []string{}
+				allNamespaces := []string{}
+
+				// All servers services for a traffic split live in the same namespace
+				serverNamespace := fmt.Sprintf("%s-%d", serverNamespacePrefix, totalNumberOfServerNamespaces)
+				totalNumberOfServerNamespaces++
+
+				for i := totalNumberOfClientServices; i < (totalNumberOfClientServices + numberOfClientServices); i++ {
+					clientServices = append(clientServices, fmt.Sprintf("%s-%d", clientNamePrefix, i))
+				}
+				totalNumberOfClientServices += numberOfClientServices
+
+				for i := totalNumberOfServerServices; i < (totalNumberOfServerServices + numberOfServerServices); i++ {
+					serverServices = append(serverServices, fmt.Sprintf("%s-%d", serverNamespace, i))
+				}
+				totalNumberOfServerServices += numberOfServerServices
+
+				allNamespaces = append(allNamespaces, clientServices...)
+				allNamespaces = append(allNamespaces, serverNamespace)
+
+				// Create the NSs for the services we just computed
+				Expect(Td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+
+				// Create server services
+				for _, serverApp := range serverServices {
+					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							Name:         serverApp,
+							Namespace:    serverNamespace,
+							ReplicaCount: int32(serverReplicaSet),
+							Image:        "simonkowallik/httpbin",
+							Ports:        []int{80},
+						})
+
+					// Expose pod name as a header in server services' responses
+					deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+						{
+							Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+					}
+
+					_, err := Td.CreateServiceAccount(serverNamespace, &svcAccDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateService(serverNamespace, svcDef)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+				}()
+
+				// Create sleeping client services
+				for _, clientApp := range clientServices {
+					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+						SimpleDeploymentAppDef{
+							Name:         clientApp,
+							Namespace:    clientApp,
+							ReplicaCount: int32(clientReplicaSet),
+							Command:      []string{"/bin/bash", "-c", "--"},
+							Args:         []string{"while true; do sleep 30; done;"},
+							Image:        "songrgg/alpine-debug",
+							Ports:        []int{80},
+						})
+
+					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateDeployment(clientApp, deploymentDef)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateService(clientApp, svcDef)
+					Expect(err).NotTo(HaveOccurred())
+
+					wg.Add(1)
+					go func(app string) {
+						defer wg.Done()
+						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+					}(clientApp)
+				}
+				// Wait for clients and server pods to be up
+				wg.Wait()
+
+				// Put allow traffic target rules, from clients to servers in this iteration
+				for _, srcClient := range clientServices {
+					for _, dstServer := range serverServices {
+						httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+							SimpleAllowPolicy{
+								RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
+								TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+
+								SourceNamespace:      srcClient,
+								SourceSVCAccountName: srcClient,
+
+								DestinationNamespace:      serverNamespace,
+								DestinationSvcAccountName: dstServer,
+							})
+
+						_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
+						Expect(err).NotTo(HaveOccurred())
+						_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+
+				// Create traffic split service. We are just interested in the service def
+				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
+					Name:      TrafficSplitPrefix,
+					Namespace: serverNamespace,
+					Ports:     []int{80},
+				})
+
+				// Apply service on k8s
+				_, err := Td.CreateService(serverNamespace, trafficSplitService)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Create Traffic split with all server processes as backends
+				trafficSplit := TrafficSplitDef{
+					Name:                    TrafficSplitPrefix,
+					Namespace:               serverNamespace,
+					TrafficSplitServiceName: TrafficSplitPrefix,
+					Backends:                []TrafficSplitBackend{},
+				}
+				assignation := 100 / len(serverServices) // Spread loadbalancing between backends
+				for _, dstServer := range serverServices {
+					trafficSplit.Backends = append(trafficSplit.Backends,
+						TrafficSplitBackend{
+							Name:   dstServer,
+							Weight: assignation,
+						},
+					)
+				}
+				// Get the Traffic split structures
+				tSplit, err := Td.CreateSimpleTrafficSplit(trafficSplit)
+				Expect(err).To(BeNil())
+
+				// Apply them in k8s
+				_, err = Td.CreateTrafficSplit(serverNamespace, tSplit)
+				Expect(err).To(BeNil())
+
+				By("Issuing http requests from clients to the traffic split FQDN")
+
+				// Traffic validation below
+				// Create Multiple HTTP request structure
+				requests := HTTPMultipleRequest{
+					Sources: []HTTPRequestDef{},
+				}
+				// From this iteration's clients to the traffic-split
+				for _, ns := range clientServices {
+					pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+					Expect(err).To(BeNil())
+
+					for _, pod := range pods.Items {
+						requests.Sources = append(requests.Sources, HTTPRequestDef{
+							SourceNs:        ns,
+							SourcePod:       pod.Name,
+							SourceContainer: ns, // container_name == NS for this test
+
+							// Targeting the trafficsplit FQDN
+							Destination: fmt.Sprintf("%s.%s", TrafficSplitPrefix, serverNamespace),
+						})
+					}
+				}
+
+				var results HTTPMultipleResults
+				var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+				success := Td.WaitForRepeatedSuccess(func() bool {
+					curlSuccess := true
+
+					// Get results
+					results = Td.MultipleHTTPRequest(&requests)
+
+					// Print results
+					Td.PrettyPrintHTTPResults(&results)
+
+					// Verify REST status code results
+					for _, ns := range results {
+						for _, podResult := range ns {
+							if podResult.Err != nil || podResult.StatusCode != 200 {
+								curlSuccess = false
+							} else {
+								// We should see pod header populated
+								dstPod, ok := podResult.Headers[HTTPHeaderName]
+								if ok {
+									// Store and mark that we have seen a response for this server pod
+									serversSeen[dstPod] = true
+								}
+							}
+						}
+					}
+					Td.T.Logf("Unique servers replied %d/%d",
+						len(serversSeen), numberOfServerServices*serverReplicaSet)
+
+					// Success conditions:
+					// - All clients have been answered consecutively 5 successful HTTP requests
+					// - We have seen all servers from the traffic split reply at least once
+					return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
+				}, 5, 150*time.Second)
+
+				Expect(success).To(BeTrue())
+			})
+		})
+	})
+})

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -195,12 +195,12 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 					TrafficSplitServiceName: TrafficSplitPrefix,
 					Backends:                []TrafficSplitBackend{},
 				}
-				assignation := 100 / len(serverServices) // Spread loadbalancing between backends
+				assignment := 100 / len(serverServices) // Spread loadbalancing between backends
 				for _, dstServer := range serverServices {
 					trafficSplit.Backends = append(trafficSplit.Backends,
 						TrafficSplitBackend{
 							Name:   dstServer,
-							Weight: assignation,
+							Weight: assignment,
 						},
 					)
 				}


### PR DESCRIPTION
Body and operation of the test is close to identical to existing
`e2e_trafficsplit_test.go`, with few differences to be able to 
iterate repetitively over the body of the test itself.

Test will repeat the test operation till a failure is observed.
At each iteration, the timestamps are recorded, and later statistics
for relevant pods are gathered and output as part of the results,
for every iteration and its duration.

Test results are stored in a test folder generated by the test itself,
if not given by parametre. 

- `tests/scale/`
  - `osm_common_profile_resources.go`: contains a set of convenience
  functions that define usual resources and outputs we are interested
  in keeping/having for OSM specific tests.
  - `scale_trafficSplit_test.go`: test implementation

Please mark with X for applicable areas.

- Metrics                [X]
- Tests                  [X]
- Performance            [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No.