### PR TITLE
feat(util): add convenience funcs to get hostnames

### DIFF
--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -11,6 +11,50 @@ const (
 	clusterDomain = "cluster.local"
 )
 
+// GetLocalNamespaceHostnamesForService returns a list of hostnames over which the service can be accessed within the same namespace
+//	on the local cluster
+func GetLocalNamespaceHostnamesForService(service *corev1.Service) []string {
+	var domains []string
+	if service == nil {
+		return domains
+	}
+
+	domains = append(domains, service.Name) // service
+
+	for _, portSpec := range service.Spec.Ports {
+		port := portSpec.Port
+
+		domains = append(domains, fmt.Sprintf("%s:%d", service.Name, port)) // service:port
+	}
+	return domains
+}
+
+// GetNamespaceScopedHostnamesForService returns a list of namespace scoped hostnames over which the service can be accessed from
+//	any namespace on the local cluster
+func GetNamespaceScopedHostnamesForService(service *corev1.Service) []string {
+	var domains []string
+	if service == nil {
+		return domains
+	}
+	serviceName := service.Name
+	namespace := service.Namespace
+
+	domains = append(domains, fmt.Sprintf("%s.%s", serviceName, namespace))                       // service.namespace
+	domains = append(domains, fmt.Sprintf("%s.%s.svc", serviceName, namespace))                   // service.namespace.svc
+	domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster", serviceName, namespace))           // service.namespace.svc.cluster
+	domains = append(domains, fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomain)) // service.namespace.svc.cluster.local
+
+	for _, portSpec := range service.Spec.Ports {
+		port := portSpec.Port
+
+		domains = append(domains, fmt.Sprintf("%s.%s:%d", serviceName, namespace, port))                       // service.namespace:port
+		domains = append(domains, fmt.Sprintf("%s.%s.svc:%d", serviceName, namespace, port))                   // service.namespace.svc:port
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster:%d", serviceName, namespace, port))           // service.namespace.svc.cluster:port
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.%s:%d", serviceName, namespace, clusterDomain, port)) // service.namespace.svc.cluster.local:port
+	}
+	return domains
+}
+
 // GetHostnamesForService returns a list of hostnames over which the service can be accessed within the local cluster.
 // If 'sameNamespace' is set to true, then the shorthand hostnames service and service:port are also returned.
 func GetHostnamesForService(service *corev1.Service, sameNamespace bool) []string {

--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -2,12 +2,39 @@ package kubernetes
 
 import (
 	"fmt"
+	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/tests"
 )
+
+func TestGetLocalNamespaceHostnamesForService(t *testing.T) {
+	assert := assert.New(t)
+	svc := tests.NewServiceFixture("testing", "test-ns", map[string]string{})
+	expectedHostnames := []string{"testing", "testing:8888"}
+	actual := GetLocalNamespaceHostnamesForService(svc)
+	assert.Equal(expectedHostnames, actual)
+}
+
+func TestGetNamespaceScopedHostnamesForService(t *testing.T) {
+	assert := assert.New(t)
+	svc := tests.NewServiceFixture("testing", "test-ns", map[string]string{})
+	expectedHostnames := []string{
+		"testing.test-ns",
+		"testing.test-ns:8888",
+		"testing.test-ns.svc",
+		"testing.test-ns.svc:8888",
+		"testing.test-ns.svc.cluster",
+		"testing.test-ns.svc.cluster:8888",
+		"testing.test-ns.svc.cluster.local",
+		"testing.test-ns.svc.cluster.local:8888",
+	}
+	actual := GetNamespaceScopedHostnamesForService(svc)
+	assert.ElementsMatch(expectedHostnames, actual)
+}
 
 var _ = Describe("Hostnames for a kubernetes service", func() {
 	Context("Testing GethostnamesForService", func() {


### PR DESCRIPTION
* These functions return hostnames based on whether you
want hostnames local to the namespace for the service or
namespace scoped hostnames. It breaks up the function
below it (GetHostnamesForService).
* These functions will make it easier to build policies
for clients running in the same namespace as service vs.
outside
* part of #2034
* see #2187 for how these will be used

Signed-off-by: Michelle Noorali <michellemolu@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
