### PR TITLE
tests/e2e: add e2e test for TCP traffic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
         with:
           go-version: 1.15
       - name: Build test dependencies
-        run: make docker-build-osm-controller docker-build-init build-osm
+        run: make docker-build-osm-controller docker-build-init build-osm docker-build-tcp-echo-server
       - name: Run PR tests
         if: ${{ github.event_name == 'pull_request' }}
         run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Tier 1\]\[Bucket ${{ matrix.bucket }}\]'

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ kind-reset:
 	kind delete cluster --name osm
 
 .PHONY: test-e2e
-test-e2e: docker-build-osm-controller docker-build-init build-osm
+test-e2e: docker-build-osm-controller docker-build-init build-osm docker-build-tcp-echo-server
 	go test ./tests/e2e $(E2E_FLAGS_DEFAULT) $(E2E_FLAGS)
 
 .env:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -8,11 +8,11 @@
   - [Flags](#flags)
 
 ## Overview
-End-to-end tests verify the behavior of the entire system. For OSM, e2e tests will install a control plane, install test workloads and SMI policies, and check that the workload is behaving as expected. 
+End-to-end tests verify the behavior of the entire system. For OSM, e2e tests will install a control plane, install test workloads and SMI policies, and check that the workload is behaving as expected.
 
 ## Files and structure
 OSM's e2e tests are located in `tests/e2e`.
-The tests are written using Ginkgo and Gomega so they may also be directly invoked using `go test`. Be sure to build the `osm-controller` and `init` container images and `osm` CLI before directly invoking the tests ([see instructions below](#running-the-tests)). 
+The tests are written using Ginkgo and Gomega so they may also be directly invoked using `go test`. Be sure to build the `osm-controller` and `init` container images and `osm` CLI before directly invoking the tests ([see instructions below](#running-the-tests)).
 
 OSM's framework, helpers and related files are located under `tests/framework`.
 Once imported, it automatically sets up an init mechanism which will automatically initialize and parse flags and variables from both `env` and `go test flags` if any are passed to the test. The hooks for initialization and cleanup are set at Ginkgo's `BeforeEach` at the top level of test execution (between Ginkgo `Describes`); we henceforth recommend keeping every test in its own `Describe` section, as well as on a separate file for clarity. You can refer to [common.go](tests/framework/common.go) for more details about the init, setup and cleanup processes.
@@ -51,7 +51,7 @@ Note: If you use `latest` tag, K8s will try to pull the image by default. If the
 Have your Kubeconfig file point to your testing cluster of choice.
 The following code uses `latest` tag by default. Non-Kind deployments do not push the images on the nodes, so make sure to set the registry accordingly.
 ```
-export CTR_REGISTRY=<myacr>.dockerhub.io # if needed, set CTR_REGISTRY_USER and CTR_REGISTRY_PASSWORD 
+export CTR_REGISTRY=<myacr>.dockerhub.io # if needed, set CTR_REGISTRY_USER and CTR_REGISTRY_PASSWORD
 make build-osm
 make docker-push
 go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress
@@ -59,7 +59,7 @@ go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress
 
 ### Flags
 #### (TODO) Kubeconf selection
-Currently, test init will load a `Kubeconf` based on Defalut Kubeconf Loading rules. 
+Currently, test init will load a `Kubeconf` based on Defalut Kubeconf Loading rules.
 If Kind is used, the kubeconf is temporarily replaced and Kind's kubeconf is used instead.
 
 #### Container registry
@@ -81,7 +81,7 @@ export CTR_REGISTRY_PASSWORD=<password>        # opt
 ```
 
 #### OSM Tag
-The following flag will refer to the version of the OSM platform containers (OSM and init) for test to use:
+The following flag will refer to the image version of the OSM platform containers (`osm-controller` and `init`) and `tcp-echo-server` for the tests to use:
 ```
 -osmImageTag string
 		OSM image tag (default "latest")
@@ -93,7 +93,7 @@ export CTR_TAG=mytag               # Optional, 'latest' used by default
 make docker-push-init docker-push-osm-controller.    # Use docker-build-* targets instead when using kind
 ```
 
-#### Use Kind for testing 
+#### Use Kind for testing
 Testing implements support for Kind. If `kindCluster` is enabled, a new Kind cluster will be provisioned and it will be automatically used for the test.
 ```
 -kindCluster

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -167,7 +167,7 @@ func testTCPTraffic(withSourceKubernetesService bool) {
 				SimplePodAppDef{
 					Name:        destName,
 					Namespace:   destName,
-					Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag), // FIXME
+					Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag),
 					Command:     []string{"/tcp-echo-server"},
 					Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
 					Ports:       []int{destinationPort},

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -21,12 +21,16 @@ var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 		Bucket: 1,
 	},
 	func() {
-		Context("SimpleClientServer with a Kubernetes Service for the Source", func() {
+		Context("SimpleClientServer with a Kubernetes Service for the Source: HTTP", func() {
 			testTraffic(true)
 		})
 
-		Context("SimpleClientServer without a Kubernetes Service for the Source", func() {
+		Context("SimpleClientServer without a Kubernetes Service for the Source: HTTP", func() {
 			testTraffic(false)
+		})
+
+		Context("SimpleClientServer without a Kubernetes Service for the Source: TCP", func() {
+			testTCPTraffic(false)
 		})
 	})
 
@@ -57,9 +61,9 @@ func testTraffic(withSourceKubernetesService bool) {
 
 			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := Td.CreatePod(destName, podDef)
+			_, err = Td.CreatePod(destName, podDef)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreateService(destName, svcDef)
+			dstSvc, err := Td.CreateService(destName, svcDef)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
@@ -93,7 +97,7 @@ func testTraffic(withSourceKubernetesService bool) {
 				SourcePod:       srcPod.Name,
 				SourceContainer: sourceName,
 
-				Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+				Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 			}
 
 			srcToDestStr := fmt.Sprintf("%s -> %s",
@@ -136,14 +140,133 @@ func testTraffic(withSourceKubernetesService bool) {
 	}
 }
 
+func testTCPTraffic(withSourceKubernetesService bool) {
+	{
+		const sourceName = "client"
+		const destName = "server"
+		var ns = []string{sourceName, destName}
+
+		It("Tests TCP traffic for client pod -> server pod", func() {
+			installOpts := Td.GetOSMInstallOpts()
+			// Install OSM
+			Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+			// Load TCP server image
+			Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
+
+			// Create Test NS
+			for _, n := range ns {
+				Expect(Td.CreateNs(n, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+			}
+
+			destinationPort := 80
+
+			// Get simple pod definitions for the TCP server
+			svcAccDef, podDef, svcDef := Td.SimplePodApp(
+				SimplePodAppDef{
+					Name:        destName,
+					Namespace:   destName,
+					Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag), // FIXME
+					Command:     []string{"/tcp-echo-server"},
+					Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
+					Ports:       []int{destinationPort},
+					AppProtocol: AppProtocolTCP,
+				})
+
+			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreatePod(destName, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			dstSvc, err := Td.CreateService(destName, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
+
+			srcPod := setupSource(sourceName, withSourceKubernetesService)
+
+			By("Creating SMI policies")
+			// Deploy allow rule client->server
+			trafficTarget := Td.CreateSimpleTCPAllowPolicy(
+				SimpleAllowPolicy{
+					RouteGroupName:    "routes",
+					TrafficTargetName: "test-target",
+
+					SourceNamespace:      sourceName,
+					SourceSVCAccountName: sourceName,
+
+					DestinationNamespace:      destName,
+					DestinationSvcAccountName: destName,
+				})
+
+			// Configs have to be put into a monitored NS
+			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+			Expect(err).NotTo(HaveOccurred())
+
+			// All ready. Expect client to reach server
+			requestMsg := "test request"
+			clientToServer := TCPRequestDef{
+				SourceNs:        sourceName,
+				SourcePod:       srcPod.Name,
+				SourceContainer: sourceName,
+
+				DestinationHost: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+				DestinationPort: destinationPort,
+				Message:         requestMsg,
+			}
+
+			srcToDestStr := fmt.Sprintf("%s -> %s:%d",
+				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+				clientToServer.DestinationHost, clientToServer.DestinationPort)
+
+			cond := Td.WaitForRepeatedSuccess(func() bool {
+				result := Td.TCPRequest(clientToServer)
+
+				if result.Err != nil {
+					Td.T.Logf("> (%s) TCP Req failed, response: %s, err: %s",
+						srcToDestStr, result.Response, result.Err)
+					return false
+				}
+
+				// Ensure the echo response contains request message
+				if !strings.Contains(result.Response, requestMsg) {
+					Td.T.Logf("> (%s) Unexpected response: %s.\n Response expected to contain: %s", result.Response, requestMsg)
+					return false
+				}
+				Td.T.Logf("> (%s) TCP Req succeeded, response: %s", srcToDestStr, result.Response)
+				return true
+			}, 5, 90*time.Second)
+
+			sourceService := map[bool]string{true: "with", false: "without"}[withSourceKubernetesService]
+			Expect(cond).To(BeTrue(), "Failed testing TCP traffic from source pod %s Kubernetes Service to a destination", sourceService)
+
+			By("Deleting SMI policies")
+			Expect(Td.SmiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+
+			// Expect client not to reach server
+			cond = Td.WaitForRepeatedSuccess(func() bool {
+				result := Td.TCPRequest(clientToServer)
+
+				if result.Err == nil {
+					Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
+					return false
+				}
+				Td.T.Logf("> (%s) TCP Req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
+				return true
+			}, 5, 150*time.Second)
+			Expect(cond).To(BeTrue())
+		})
+	}
+}
+
 func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {
 	// Get simple Pod definitions for the client
 	svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
 		Name:      sourceName,
 		Namespace: sourceName,
-		Command:   []string{"/bin/bash", "-c", "--"},
-		Args:      []string{"while true; do sleep 30; done;"},
-		Image:     "songrgg/alpine-debug",
+		Command:   []string{"sleep", "365d"},
+		Image:     "curlimages/curl",
 		Ports:     []int{80},
 	})
 

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -38,8 +38,15 @@ const (
 
 	// MemRSSPanel is the ID of the MemRSS panel on OSM's MeshDetails dashboard
 	MemRSSPanel int = 13
+
 	// CPUPanel is the ID of the CPU panel on OSM's MeshDetails dashboard
 	CPUPanel int = 14
+
+	// AppProtocolHTTP is the HTTP application protocol
+	AppProtocolHTTP = "http"
+
+	// AppProtocolTCP is the TCP application protocol
+	AppProtocolTCP = "tcp"
 )
 
 // CreateServiceAccount is a wrapper to create a service account
@@ -127,12 +134,13 @@ func (td *OsmTestData) GetPodsForLabel(ns string, labelSel metav1.LabelSelector)
 
 // SimplePodAppDef defines some parametrization to create a pod-based application from template
 type SimplePodAppDef struct {
-	Namespace string
-	Name      string
-	Image     string
-	Command   []string
-	Args      []string
-	Ports     []int
+	Namespace   string
+	Name        string
+	Image       string
+	Command     []string
+	Args        []string
+	Ports       []int
+	AppProtocol string
 }
 
 // SimplePodApp creates returns a set of k8s typed definitions for a pod-based k8s definition.
@@ -207,9 +215,16 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 					ContainerPort: int32(p),
 				},
 			)
+
+			appProtocol := AppProtocolHTTP // default
+			if def.AppProtocol != "" {
+				appProtocol = def.AppProtocol
+			}
+
 			serviceDefinition.Spec.Ports = append(serviceDefinition.Spec.Ports, corev1.ServicePort{
-				Port:       int32(p),
-				TargetPort: intstr.FromInt(p),
+				Port:        int32(p),
+				TargetPort:  intstr.FromInt(p),
+				AppProtocol: &appProtocol,
 			})
 		}
 	}

--- a/tests/framework/common_smi.go
+++ b/tests/framework/common_smi.go
@@ -132,6 +132,39 @@ func (td *OsmTestData) CreateSimpleAllowPolicy(def SimpleAllowPolicy) (smiSpecs.
 	return routeGroup, trafficTarget
 }
 
+// CreateSimpleTCPAllowPolicy returns an allow policy to allow all TCP traffic from source to destination
+func (td *OsmTestData) CreateSimpleTCPAllowPolicy(def SimpleAllowPolicy) smiAccess.TrafficTarget {
+	trafficTarget := smiAccess.TrafficTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: def.TrafficTargetName,
+		},
+		Spec: smiAccess.TrafficTargetSpec{
+			Sources: []smiAccess.IdentityBindingSubject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      def.SourceSVCAccountName,
+					Namespace: def.SourceNamespace,
+				},
+			},
+			Destination: smiAccess.IdentityBindingSubject{
+				Kind:      "ServiceAccount",
+				Name:      def.DestinationSvcAccountName,
+				Namespace: def.DestinationNamespace,
+			},
+			/* TODO: add TCP rule when supported by SMI
+			Rules: []smiAccess.TrafficTargetRule{
+				{
+					Kind: "TCPRoute",
+					Name: def.RouteGroupName,
+				},
+			},
+			*/
+		},
+	}
+
+	return trafficTarget
+}
+
 // TrafficSplitBackend is a simple define to refer to a TrafficSplit backend
 type TrafficSplitBackend struct {
 	Name   string

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -106,7 +106,6 @@ func (td *OsmTestData) TCPRequest(req TCPRequestDef) TCPRequestResult {
 	stdout, stderr, err := td.RunRemote(req.SourceNs, req.SourcePod, req.SourceContainer, command)
 	if err != nil {
 		// Error codes from the execution come through err
-		// Curl 'Connection refused' err code = 7
 		return TCPRequestResult{
 			stdout,
 			fmt.Errorf("Remote exec err: %v | stderr: %s | cmd: %s", err, stderr, command),

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -28,6 +28,21 @@ type HTTPRequestDef struct {
 	Destination string
 }
 
+// TCPRequestDef defines a remote TCP request intent
+type TCPRequestDef struct {
+	// Source pod where to run the HTTP request from
+	SourceNs        string
+	SourcePod       string
+	SourceContainer string
+
+	// The destination server host (FQDN or IP address) and port the request is directed to
+	DestinationHost string
+	DestinationPort int
+
+	// Message to send as a part of the request
+	Message string
+}
+
 // HTTPRequestResult represents results of an HTTPRequest call
 type HTTPRequestResult struct {
 	StatusCode int
@@ -35,12 +50,19 @@ type HTTPRequestResult struct {
 	Err        error
 }
 
+// TCPRequestResult represents the result of a TCPRequest call
+type TCPRequestResult struct {
+	Response string
+	Err      error
+}
+
 // HTTPRequest runs a synchronous call to run the HTTPRequestDef and return a HTTPRequestResult
 func (td *OsmTestData) HTTPRequest(ht HTTPRequestDef) HTTPRequestResult {
 	// -s silent progress, -o output to devnull, '-D -' dump headers to "-" (stdout), -i Status code
 	// -I skip body download, '-w StatusCode:%{http_code}' prints Status code label-like for easy parsing
 	// -L follow redirects
-	command := fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} -L %s", StatusCodeWord, ht.Destination)
+	commandStr := fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} -L %s", StatusCodeWord, ht.Destination)
+	command := strings.Fields(commandStr)
 
 	stdout, stderr, err := td.RunRemote(ht.SourceNs, ht.SourcePod, ht.SourceContainer, command)
 	if err != nil {
@@ -72,6 +94,31 @@ func (td *OsmTestData) HTTPRequest(ht HTTPRequestDef) HTTPRequestResult {
 	return HTTPRequestResult{
 		statusCode,
 		curlMappedReturn,
+		nil,
+	}
+}
+
+// TCPRequest runs a synchronous TCP request to run the TCPRequestDef and return a TCPRequestResult
+func (td *OsmTestData) TCPRequest(req TCPRequestDef) TCPRequestResult {
+	commandArgs := fmt.Sprintf("echo \"%s\" | nc %s %d", req.Message, req.DestinationHost, req.DestinationPort)
+	command := []string{"sh", "-c", commandArgs}
+
+	stdout, stderr, err := td.RunRemote(req.SourceNs, req.SourcePod, req.SourceContainer, command)
+	if err != nil {
+		// Error codes from the execution come through err
+		// Curl 'Connection refused' err code = 7
+		return TCPRequestResult{
+			stdout,
+			fmt.Errorf("Remote exec err: %v | stderr: %s | cmd: %s", err, stderr, command),
+		}
+	}
+	if len(stderr) > 0 {
+		// no error from execution and proper exit code, we got some stderr though
+		td.T.Logf("[warn] Stderr: %v", stderr)
+	}
+
+	return TCPRequestResult{
+		stdout,
 		nil,
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds an e2e test for TCP traffic. The test verifies
that the inbound and outbound TCP filtering and proxying works
as expected. It uses `netcat` to initiate TCP connections
to the `tcp-echo-server` that echoes back the response.

Due to the absence of TCPRoute spec support at this moment, the
test uses a TrafficTarget without specific TCP rules to verify
inbound and outbound proxying of TCP traffic. The test will need
to be updated to be able to perform RBAC on TCP routes when the
TCPRoute spec is available to use.

It also updates the client container image for the test to rely
on an image with additional tools (ex. netcat in this case).

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`