### PR TITLE
fluent bit: add identifier to help query logs in output 

### DIFF
--- a/charts/osm/templates/fluentbit-configmap.yaml
+++ b/charts/osm/templates/fluentbit-configmap.yaml
@@ -34,15 +34,12 @@ data:
       Name           grep
       Match          kube.*
       Regex          keep true
-    # Removes extra "keep: true" key/value pair once matching is complete 
+    # Removes extra "keep: true" key/value pair once matching is complete; adds controller pod name value to help users query logs in output
     [FILTER]
       Name           modify
       Match          kube.*
       Remove         keep
-    [FILTER]
-      Name    modify
-      Match   *
-      Add controller_pod_name ${CONTROLLER_POD_NAME}
+      Add            controller_pod_name ${CONTROLLER_POD_NAME}
     [OUTPUT]
       Name    {{ .Values.OpenServiceMesh.fluentBit.outputPlugin }}
       Match   *

--- a/charts/osm/templates/fluentbit-configmap.yaml
+++ b/charts/osm/templates/fluentbit-configmap.yaml
@@ -39,6 +39,10 @@ data:
       Name           modify
       Match          kube.*
       Remove         keep
+    [FILTER]
+      Name    modify
+      Match   *
+      Add controller_pod_name ${CONTROLLER_POD_NAME}
     [OUTPUT]
       Name    {{ .Values.OpenServiceMesh.fluentBit.outputPlugin }}
       Match   *

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -80,11 +80,24 @@ spec:
         - name: {{ .Values.OpenServiceMesh.fluentBit.name }}
           image: {{ .Values.OpenServiceMesh.fluentBit.registry }}/fluent-bit:{{ .Values.OpenServiceMesh.fluentBit.tag }}
           imagePullPolicy: {{ .Values.OpenServiceMesh.fluentBit.pullPolicy }}
-        {{- if .Values.OpenServiceMesh.fluentBit.enableProxySupport }}
-          envFrom:
-            - secretRef:
+          env:
+          {{- if .Values.OpenServiceMesh.fluentBit.enableProxySupport }}
+          - name: HTTP_PROXY
+            valueFrom:
+              secretKeyRef:
                 name: proxy-config
-        {{- end }}
+                key: HTTP_PROXY
+          - name: HTTPS_PROXY
+            valueFrom:
+              secretKeyRef:
+                name: proxy-config
+                key: HTTPS_PROXY
+          {{- end }}
+          - name: CONTROLLER_POD_NAME
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.name
           volumeMounts:
           - name: config
             mountPath: /fluent-bit/etc

--- a/docs/patterns/observability/logs.md
+++ b/docs/patterns/observability/logs.md
@@ -23,6 +23,8 @@ To customize log forwarding to your output, follow these steps and then reinstal
      
 4. Once you have updated the Fluent Bit configmap, you can deploy the sidecar during OSM installation using the `--enable-fluentbit` flag. You should now be able to interact with error logs in the output of your choice as they get generated.
 
+5. The `controller_pod_name` key/value pair has been added to the logs to help you query logs in your output by refining results on pod name (see example usage below).
+
 ### Example: Using Fluent Bit to send logs to Azure Monitor
 Fluent Bit has an Azure output plugin that can be used to send logs to an Azure Log Analytics workspace as follows:
 1. [Create a Log Analytics workspace](https://docs.microsoft.com/en-us/azure/azure-monitor/learn/quick-create-workspace)
@@ -35,6 +37,10 @@ Fluent Bit has an Azure output plugin that can be used to send logs to an Azure 
     ```
     fluentbit_CL
     | order by TimeGenerated desc
+    ```
+5. Refine your log results on a specific deployment of the OSM controller pod:
+    ```
+    | where controller_pod_name_s == "<desired osm controller pod name>"
     ```
 
 Once logs have been sent to Log Analytics, they can also be consumed by Application Insights as follows:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: 
* Adds the osm controller name as a key/value pair in the logs to help users query/refine log output
* Makes environment variables explicitly defined

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [x]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
no, no