### PR TITLE
demo: Tweaking join/unjoin demo scripts

### DIFF
--- a/demo/join-namespaces.sh
+++ b/demo/join-namespaces.sh
@@ -19,19 +19,31 @@ source .env
 ./bin/osm namespace add "${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}" --mesh-name "${MESH_NAME:-osm}"
 
 
+kubectl patch ConfigMap \
+        -n "${K8S_NAMESPACE}" osm-config \
+        --type merge \
+        --patch '{"data":{"permissive_traffic_policy_mode":"false"}}'
+
+
+# Create a top level service
+echo -e "Deploy bookstore Service"
 kubectl apply -f - <<EOF
 apiVersion: v1
-kind: ConfigMap
-
+kind: Service
 metadata:
-  name: osm-config
-  namespace: $K8S_NAMESPACE
-
-data:
-  permissive_traffic_policy_mode: "true"
-
+  labels:
+    app: bookstore
+  name: bookstore
+  namespace: bookstore
+spec:
+  ports:
+  - name: bookstore-port
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: bookstore
 EOF
-
 
 sleep 3
 

--- a/demo/unjoin-namespaces.sh
+++ b/demo/unjoin-namespaces.sh
@@ -23,19 +23,10 @@ BOOKWAREHOUSE_NAMESPACE="${BOOKWAREHOUSE_NAMESPACE:-bookwarehouse}"
 ./bin/osm namespace remove "${BOOKTHIEF_NAMESPACE:-bookbuyer}"     --mesh-name "${MESH_NAME:-osm}"
 
 
-kubectl apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-
-metadata:
-  name: osm-config
-  namespace: $K8S_NAMESPACE
-
-data:
-
-  permissive_traffic_policy_mode: "true"
-
-EOF
+kubectl patch ConfigMap \
+        -n "${K8S_NAMESPACE}" osm-config \
+        --type merge \
+        --patch '{"data":{"permissive_traffic_policy_mode":"true"}}'
 
 
 # Create a top level service


### PR DESCRIPTION
This PR changes:
 - how we change the `osm-config` ConfigMap - tweak only the `permissive_traffic_policy_mode` instead of the entire Configmap
 - applies a different `bookstore` service depending on whether we are in the mesh or not - this Service reflects the current state of the mesh in order to make the demo work - it should ideally be the exact same YAML

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
