### PR TITLE
tests/e2e: set AppProto only if definition has it set

### DIFF
--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -216,16 +216,16 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 				},
 			)
 
-			appProtocol := AppProtocolHTTP // default
-			if def.AppProtocol != "" {
-				appProtocol = def.AppProtocol
+			svcPort := corev1.ServicePort{
+				Port:       int32(p),
+				TargetPort: intstr.FromInt(p),
 			}
 
-			serviceDefinition.Spec.Ports = append(serviceDefinition.Spec.Ports, corev1.ServicePort{
-				Port:        int32(p),
-				TargetPort:  intstr.FromInt(p),
-				AppProtocol: &appProtocol,
-			})
+			if def.AppProtocol != "" {
+				svcPort.AppProtocol = &def.AppProtocol
+			}
+
+			serviceDefinition.Spec.Ports = append(serviceDefinition.Spec.Ports, svcPort)
 		}
 	}
 


### PR DESCRIPTION
On setups ~<1.18 setting AppProtocol can throw issues if the AppProtocol
is present but it has not been enabled on the setup as a gate flag (for the
ones that support it) :

```
99 Unexpected error:
100 <*errors.errorString | 0xc0004192b0>: {​​​​​​​​
101 s: "Could not create Service: Service \"traffic-split\" is invalid: spec.ports[0].appProtocol: Forbidden: This field can be enabled with the ServiceAppProtocol feature gate",
```

- Tests                  [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No