### PR TITLE
fix(ci): workaround DCO requirement for gh-pages branch

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Workaround DCO requirement for gh-pages branch
+      - run: git config alias.commit "commit -s"
       - name: Publish Helm charts
         uses: stefanprodan/helm-gh-pages@v1.1.0
         with:


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a step to the chart release CI workflow to force git to
signoff commits to pass the DCO check.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No