### PR TITLE
bookstore: Adding liveness + readiness probes to bookstore Deployment

### DIFF
--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -89,6 +89,19 @@ spec:
             - name: BOOKWAREHOUSE_NAMESPACE
               value: ${BOOKWAREHOUSE_NAMESPACE}
 
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /readiness
+              port: 80
+              scheme: HTTP
+
       imagePullSecrets:
         - name: $CTR_REGISTRY_CREDS_NAME
 EOF

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -89,6 +89,19 @@ spec:
             - name: BOOKWAREHOUSE_NAMESPACE
               value: ${BOOKWAREHOUSE_NAMESPACE}
 
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /readiness
+              port: 80
+              scheme: HTTP
+
       imagePullSecrets:
         - name: $CTR_REGISTRY_CREDS_NAME
 EOF


### PR DESCRIPTION
This PR adds liveness and readiness to the Bookstore Deployment

The web server endpoints are implemented in https://github.com/openservicemesh/osm/pull/2209

ref https://github.com/openservicemesh/osm/issues/2207

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `yes` - using the definitions from https://github.com/Azure/application-gateway-kubernetes-ingress/blob/60ec56bd06e1f9cafa50918d0b403c463f742821/scripts/e2e/cmd/runner/testdata/one-namespace-one-ingress/container-readiness-probe/app.yaml#L22-L33
