### PR TITLE
bookstore: Adding /liveness + /readiness endpoints to bookstore web server

### DIFF
--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -121,11 +121,17 @@ func getHandlers() []handler {
 		{"/books-bought", updateBooksSold, "POST"},
 		{"/buy-a-book/new", sellBook, "GET"},
 		{"/reset", reset, "GET"},
+		{"/liveness", ok, "GET"},
+		{"/readiness", ok, "GET"},
 	}
 }
 
 func reset(w http.ResponseWriter, r *http.Request) {
 	booksSold = 0
+	renderTemplate(w)
+}
+
+func ok(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(w)
 }
 

--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -123,6 +123,7 @@ func getHandlers() []handler {
 		{"/reset", reset, "GET"},
 		{"/liveness", ok, "GET"},
 		{"/readiness", ok, "GET"},
+		{"/startup", ok, "GET"},
 	}
 }
 


### PR DESCRIPTION
This PR adds `/liveness` and `/readiness` to the bookstore pods. This will return the count of books sold in HTML. 

![image](https://user-images.githubusercontent.com/49918230/102390084-d1a0a380-3f88-11eb-97e0-57ed9afbbd02.png)

![image](https://user-images.githubusercontent.com/49918230/102390168-e8df9100-3f88-11eb-8d4e-4b33e692e8ef.png)

These are added to the deployment with https://github.com/openservicemesh/osm/pull/2208

ref https://github.com/openservicemesh/osm/issues/2207

---


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
