### PR TITLE
envoy/ads/stream.go: Force full config of an envoy when it connects

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -55,7 +55,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	// Register to Envoy global broadcast updates
 	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
 
-	// Isusue a send all response on a connecting envoy
+	// Issues a send all response on a connecting envoy
 	// If this were to fail, it most likely just means we still have configuration being applied on flight,
 	// which will get triggered by the dispatcher anyway
 	s.sendAllResponses(proxy, &server, s.cfg)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -55,6 +55,11 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	// Register to Envoy global broadcast updates
 	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
 
+	// Isusue a send all response on a connecting envoy
+	// If this were to fail, it most likely just means we still have configuration being applied on flight,
+	// which will get triggered by the dispatcher anyway
+	s.sendAllResponses(proxy, &server, s.cfg)
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This commit adds back the `sendAllResponse` that was removed [here](https://github.com/openservicemesh/osm/pull/213/files#diff-a85c2c3be39b51ce94870509935533e4eb8de6dec7111bf672c5bfdcdd238353L38)

On a controller re/start, the controller synchronizes all kubernetes
objects and only after starts the ADS server.

When an envoy reconnects to the new ctrl plane, there might be no event
or trigger that pushes a new configuration to the envoy, which in the case
of a restart, new service certificates need to be issued and pushed.

For the time being, we will mandatorily push a full config on a
connecting envoy, which will guarantee it gets the new certs in case
of a restart, and in case no new events are generated by config.

Fixes: #2131

- Control Plane          [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No