### PR TITLE
injector: Reuse jsonpatch.JsonPatchOperation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
 	golang.org/x/tools v0.0.0-20201021214918-23787c007979 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.0.1
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.23.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"gomodules.xyz/jsonpatch/v2"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -45,9 +47,9 @@ var _ = Describe("Test all patch operations", func() {
 			}}
 
 			actualPatch := addVolume(target, add, basePath)
-			addVolume := JSONPatchOperation{
-				Op:   addOperation,
-				Path: "/base/path/-",
+			addVolume := jsonpatch.JsonPatchOperation{
+				Operation: addOperation,
+				Path:      "/base/path/-",
 				Value: corev1.Volume{
 					Name: volumeTwo,
 				},
@@ -69,9 +71,9 @@ var _ = Describe("Test all patch operations", func() {
 
 			actualPatches := addContainer(target, add, basePath)
 
-			expectedAddContainer := JSONPatchOperation{
-				Op:   addOperation,
-				Path: "/base/path/-",
+			expectedAddContainer := jsonpatch.JsonPatchOperation{
+				Operation: addOperation,
+				Path:      "/base/path/-",
 				Value: corev1.Container{
 					Name: containerTwo,
 				},
@@ -95,17 +97,17 @@ var _ = Describe("Test all patch operations", func() {
 
 			actual := updateMapType(target, add, basePath)
 
-			expectedReplaceTwo := JSONPatchOperation{
-				Op:    replaceOperation,
-				Path:  "/base/path/two",
-				Value: "2",
+			expectedReplaceTwo := jsonpatch.JsonPatchOperation{
+				Operation: replaceOperation,
+				Path:      "/base/path/two",
+				Value:     "2",
 			}
 			Expect(actual).To(ContainElement(expectedReplaceTwo))
 
-			expectedAddThree := JSONPatchOperation{
-				Op:    addOperation,
-				Path:  "/base/path/three",
-				Value: "3",
+			expectedAddThree := jsonpatch.JsonPatchOperation{
+				Operation: addOperation,
+				Path:      "/base/path/three",
+				Value:     "3",
 			}
 			Expect(actual).To(ContainElement(expectedAddThree))
 		})
@@ -121,19 +123,19 @@ var _ = Describe("Test all patch operations", func() {
 
 			// The first operation is "three" ("three" comes before "two" alphabetically)
 			// This is a CREATE operation since target is NIL
-			expectedCreateThree := JSONPatchOperation{
-				Op:   addOperation,
-				Path: "/base/path",
+			expectedCreateThree := jsonpatch.JsonPatchOperation{
+				Operation: addOperation,
+				Path:      "/base/path",
 				Value: map[string]string{
 					"three": "3",
 				},
 			}
 			Expect(actual).To(ContainElement(expectedCreateThree))
 
-			expectedAddTwo := JSONPatchOperation{
-				Op:    addOperation,
-				Path:  "/base/path/two",
-				Value: "2",
+			expectedAddTwo := jsonpatch.JsonPatchOperation{
+				Operation: addOperation,
+				Path:      "/base/path/two",
+				Value:     "2",
 			}
 			Expect(actual).To(ContainElement(expectedAddTwo))
 		})

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -44,13 +44,6 @@ type Config struct {
 	SidecarImage string
 }
 
-// JSONPatchOperation defines a Kubernetes JSON Patch operation
-type JSONPatchOperation struct {
-	Op    string      `json:"op"`
-	Path  string      `json:"path"`
-	Value interface{} `json:"value,omitempty"`
-}
-
 // InitContainer is the type used to represent information about the init container
 type InitContainer struct {
 	Name  string


### PR DESCRIPTION
This PR removes the `JSONPatchOperation` type and reuses `jsonpatch.JsonPatchOperation` from gomodules.xyz/jsonpatch/v2

This package is provided by https://github.com/kubernetes-sigs/controller-runtime

This will be used by https://github.com/openservicemesh/osm/pull/2215 to update the way objects are patched.