### PR TITLE
configurator: add specific ConfigMap handler

### DIFF
--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -29,8 +29,7 @@ func (mc *MeshCatalog) dispatcher() {
 	// to take ownership of certain events, and just notify dispatcher through
 	// ScheduleBroadcastUpdate announcement type
 	subChannel := events.GetPubSubInstance().Subscribe(
-		a.ScheduleProxyBroadcast,                                 // Other modules requesting a global envoy update
-		a.ConfigMapAdded, a.ConfigMapDeleted, a.ConfigMapUpdated, // config
+		a.ScheduleProxyBroadcast,                              // Other modules requesting a global envoy update
 		a.EndpointAdded, a.EndpointDeleted, a.EndpointUpdated, // endpoint
 		a.NamespaceAdded, a.NamespaceDeleted, a.NamespaceUpdated, // namespace
 		a.PodAdded, a.PodDeleted, a.PodUpdated, // pod


### PR DESCRIPTION
Currently, dispatcher listens to ConfigMap changes and triggers
global envoy update based on any changes on OSM's config map.

A more specific handler for ConfigMap could identify specific changes
that require a global config update and notify dispatcher instead,
avoiding full configs for things that are not needed.

- Control Plane          [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No