### PR TITLE
pkg/*: add api to list traffic targets composed of associated routes

### DIFF
--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -5,17 +5,19 @@
 package catalog
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
 	envoy "github.com/openservicemesh/osm/pkg/envoy"
+	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	reflect "reflect"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface
@@ -244,6 +246,21 @@ func (m *MockMeshCataloger) ListEndpointsForService(arg0 service.MeshService) ([
 func (mr *MockMeshCatalogerMockRecorder) ListEndpointsForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEndpointsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListEndpointsForService), arg0)
+}
+
+// ListInboundTrafficTargetsWithRoutes mocks base method
+func (m *MockMeshCataloger) ListInboundTrafficTargetsWithRoutes(arg0 identity.ServiceIdentity) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInboundTrafficTargetsWithRoutes", arg0)
+	ret0, _ := ret[0].([]trafficpolicy.TrafficTargetWithRoutes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInboundTrafficTargetsWithRoutes indicates an expected call of ListInboundTrafficTargetsWithRoutes
+func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficTargetsWithRoutes(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInboundTrafficTargetsWithRoutes", reflect.TypeOf((*MockMeshCataloger)(nil).ListInboundTrafficTargetsWithRoutes), arg0)
 }
 
 // ListMonitoredNamespaces mocks base method

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -60,7 +60,7 @@ func (mc *MeshCatalog) ListInboundTrafficTargetsWithRoutes(upstreamIdentity iden
 
 		// TCP routes for this traffic target
 		if tcpRouteMatches, err := mc.getTCPRouteMatchesFromTrafficTarget(*t); err != nil {
-			log.Error().Err(err).Msgf("Error fetting TCP Routes for TrafficTarget %s/%s", t.Namespace, t.Name)
+			log.Error().Err(err).Msgf("Error fetching TCP Routes for TrafficTarget %s/%s", t.Namespace, t.Name)
 		} else {
 			// Add this traffic target to the final list
 			trafficTarget.TCPRouteMatches = tcpRouteMatches

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -1,14 +1,19 @@
 package catalog
 
 import (
+	"fmt"
+
 	mapset "github.com/deckarep/golang-set"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 const (
 	serviceAccountKind = "ServiceAccount"
+	tcpRouteKind       = "TCPRoute"
 )
 
 // ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given upstream service account
@@ -19,6 +24,51 @@ func (mc *MeshCatalog) ListAllowedInboundServiceAccounts(upstream service.K8sSer
 // ListAllowedOutboundServiceAccounts lists the upstream service accounts the given downstream service account can connect to
 func (mc *MeshCatalog) ListAllowedOutboundServiceAccounts(downstream service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
 	return mc.getAllowedDirectionalServiceAccounts(downstream, outbound)
+}
+
+// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects componsed of its routes for the given destination identity
+func (mc *MeshCatalog) ListInboundTrafficTargetsWithRoutes(upstreamIdentity identity.ServiceIdentity) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
+	var trafficTargets []trafficpolicy.TrafficTargetWithRoutes
+
+	if mc.configurator.IsPermissiveTrafficPolicyMode() {
+		return nil, nil
+	}
+
+	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
+		if !isValidTrafficTarget(t) {
+			continue
+		}
+
+		destinationIdentity := trafficTargetIdentityToServiceIdentity(t.Spec.Destination)
+		if destinationIdentity != upstreamIdentity {
+			continue
+		}
+
+		// Create a traffic target for this destination indentity
+		trafficTarget := trafficpolicy.TrafficTargetWithRoutes{
+			Name:        t.Name,
+			Destination: destinationIdentity,
+		}
+
+		// Source identies for this traffic target
+		var sourceIdentities []identity.ServiceIdentity
+		for _, source := range t.Spec.Sources {
+			srcIdentity := trafficTargetIdentityToServiceIdentity(source)
+			sourceIdentities = append(sourceIdentities, srcIdentity)
+		}
+		trafficTarget.Sources = sourceIdentities
+
+		// TCP routes for this traffic target
+		if tcpRouteMatches, err := mc.getTCPRouteMatchesFromTrafficTarget(*t); err != nil {
+			log.Error().Err(err).Msgf("Error fetting TCP Routes for TrafficTarget %s/%s", t.Namespace, t.Name)
+		} else {
+			// Add this traffic target to the final list
+			trafficTarget.TCPRouteMatches = tcpRouteMatches
+			trafficTargets = append(trafficTargets, trafficTarget)
+		}
+	}
+
+	return trafficTargets, nil
 }
 
 func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcAccount service.K8sServiceAccount, direction trafficDirection) ([]service.K8sServiceAccount, error) {
@@ -78,11 +128,15 @@ func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcAccount service.K
 	return allowedSvcAccounts, nil
 }
 
-func trafficTargetIdentityToSvcAccount(identity smiAccess.IdentityBindingSubject) service.K8sServiceAccount {
+func trafficTargetIdentityToSvcAccount(identitySubject smiAccess.IdentityBindingSubject) service.K8sServiceAccount {
 	return service.K8sServiceAccount{
-		Name:      identity.Name,
-		Namespace: identity.Namespace,
+		Name:      identitySubject.Name,
+		Namespace: identitySubject.Namespace,
 	}
+}
+
+func trafficTargetIdentityToServiceIdentity(identitySubject smiAccess.IdentityBindingSubject) identity.ServiceIdentity {
+	return identity.ServiceIdentity(fmt.Sprintf("%s/%s", identitySubject.Namespace, identitySubject.Name))
 }
 
 // trafficTargetIdentitiesToSvcAccounts returns a list of Service Accounts from the given list of identities from a Traffic Target
@@ -100,4 +154,28 @@ func trafficTargetIdentitiesToSvcAccounts(identities []smiAccess.IdentityBinding
 	}
 
 	return serviceAccounts
+}
+
+func (mc *MeshCatalog) getTCPRouteMatchesFromTrafficTarget(trafficTarget smiAccess.TrafficTarget) ([]trafficpolicy.TCPRouteMatch, error) {
+	var matches []trafficpolicy.TCPRouteMatch
+
+	for _, rule := range trafficTarget.Spec.Rules {
+		if rule.Kind != tcpRouteKind {
+			continue
+		}
+
+		// A route referenced in a traffic target must belong to the same namespace as the traffic target
+		tcpRouteName := fmt.Sprintf("%s/%s", trafficTarget.Namespace, rule.Name)
+
+		tcpRoute := mc.meshSpec.GetTCPRoute(tcpRouteName)
+		if tcpRoute == nil {
+			return nil, errNoTrafficSpecFoundForTrafficPolicy
+		}
+
+		// TODO(#1521): Create an actual TCP route match once v1alpha4 TCPRoute spec is available
+		tcpRouteMatch := trafficpolicy.TCPRouteMatch{ /* allow all ports */ }
+		matches = append(matches, tcpRouteMatch)
+	}
+
+	return matches, nil
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -119,6 +120,9 @@ type MeshCataloger interface {
 
 	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
 	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
+
+	// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects componsed of its routes for the given destination identity
+	ListInboundTrafficTargetsWithRoutes(identity.ServiceIdentity) ([]trafficpolicy.TrafficTargetWithRoutes, error)
 }
 
 type announcementChannel struct {

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -232,6 +232,17 @@ func (c *Client) ListTCPTrafficSpecs() []*smiSpecs.TCPRoute {
 	return tcpRouteSpec
 }
 
+// GetTCPRoute returns an SMI TCPRoute resource given its name of the form <namespace>/<name>
+func (c *Client) GetTCPRoute(namespacedName string) *smiSpecs.TCPRoute {
+	// client-go cache uses <namespace>/<name> as key
+	routeIf, exists, err := c.caches.TCPRoute.GetByKey(namespacedName)
+	if exists && err == nil {
+		route := routeIf.(*smiSpecs.TCPRoute)
+		return route
+	}
+	return nil
+}
+
 // ListTrafficTargets implements mesh.Topology by returning the list of traffic targets.
 func (c *Client) ListTrafficTargets() []*smiAccess.TrafficTarget {
 	var trafficTargets []*smiAccess.TrafficTarget

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -63,6 +63,11 @@ func (f fakeMeshSpec) ListTCPTrafficSpecs() []*spec.TCPRoute {
 	return f.tcpRoutes
 }
 
+// GetTCPRoute returns an SMI TCPRoute resource given its name of the form <namespace>/<name>s
+func (f fakeMeshSpec) GetTCPRoute(_ string) *spec.TCPRoute {
+	return nil
+}
+
 // ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListTrafficTargets() []*target.TrafficTarget {
 	return f.trafficTargets

--- a/pkg/smi/mock_meshspec.go
+++ b/pkg/smi/mock_meshspec.go
@@ -8,13 +8,12 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1alpha1 "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
+	announcements "github.com/openservicemesh/osm/pkg/announcements"
+	service "github.com/openservicemesh/osm/pkg/service"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha3"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-
-	v1alpha1 "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
-	"github.com/openservicemesh/osm/pkg/announcements"
-	service "github.com/openservicemesh/osm/pkg/service"
 )
 
 // MockMeshSpec is a mock of MeshSpec interface
@@ -66,6 +65,20 @@ func (m *MockMeshSpec) GetBackpressurePolicy(arg0 service.MeshService) *v1alpha1
 func (mr *MockMeshSpecMockRecorder) GetBackpressurePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackpressurePolicy", reflect.TypeOf((*MockMeshSpec)(nil).GetBackpressurePolicy), arg0)
+}
+
+// GetTCPRoute mocks base method
+func (m *MockMeshSpec) GetTCPRoute(arg0 string) *v1alpha3.TCPRoute {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTCPRoute", arg0)
+	ret0, _ := ret[0].(*v1alpha3.TCPRoute)
+	return ret0
+}
+
+// GetTCPRoute indicates an expected call of GetTCPRoute
+func (mr *MockMeshSpecMockRecorder) GetTCPRoute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoute", reflect.TypeOf((*MockMeshSpec)(nil).GetTCPRoute), arg0)
 }
 
 // ListHTTPTrafficSpecs mocks base method

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -64,6 +64,9 @@ type MeshSpec interface {
 	// ListTCPTrafficSpecs lists SMI TCPRoute resources
 	ListTCPTrafficSpecs() []*spec.TCPRoute
 
+	// GetTCPRoute returns an SMI TCPRoute resource given its name of the form <namespace>/<name>
+	GetTCPRoute(string) *spec.TCPRoute
+
 	// ListTrafficTargets lists SMI TrafficTarget resources
 	ListTrafficTargets() []*target.TrafficTarget
 

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -3,6 +3,7 @@ package trafficpolicy
 import (
 	set "github.com/deckarep/golang-set"
 
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -17,6 +18,11 @@ type HTTPRouteMatch struct {
 	PathRegex string            `json:"path_regex:omitempty"`
 	Methods   []string          `json:"methods:omitempty"`
 	Headers   map[string]string `json:"headers:omitempty"`
+}
+
+// TCPRouteMatch is a struct to represent a TCP route matching based on ports
+type TCPRouteMatch struct {
+	Ports []int `json:"ports:omitempty"`
 }
 
 // TrafficTarget is a struct to represent a traffic policy between a source and destination along with its routes
@@ -52,4 +58,12 @@ type OutboundTrafficPolicy struct {
 	Name      string                   `json:"name:omitempty"`
 	Hostnames []string                 `json:"hostnames"`
 	Routes    []*RouteWeightedClusters `json:"routes:omitempty"`
+}
+
+// TrafficTargetWithRoutes is a struct to represent an SMI TrafficTarget resource composed of its associated routes
+type TrafficTargetWithRoutes struct {
+	Name            string                     `json:"name:omitempty"`
+	Destination     identity.ServiceIdentity   `json:"destination:omitempty"`
+	Sources         []identity.ServiceIdentity `json:"sources:omitempty"`
+	TCPRouteMatches []TCPRouteMatch            `json:"tcp_route_matches:omitempty"`
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an API to retrieve a list of traffic target objects along
with their associated routes (limited to TCP). The traffic target
objects will be used to directly map to RBAC policies configured
on the upstream proxy.

This API will be leveraged to implement RBAC policies for TCP traffic.
For ex., the following TrafficTarget policy and TCPRoute will generate
an RBAC policy as seen below.

```
kind: TCPRoute
metadata:
  name: tcp-route
  namespace: default
spec:
  matches:
    ports:
    - 8080
---
kind: TrafficTarget
metadata:
  name: test
  namespace: default
spec:
  destination:
    kind: ServiceAccount
    name: sa-1
    namespace: default
  rules:
  - kind: TCPRoute
    name: tcp-route
  sources:
  - kind: ServiceAccount
    name: sa-2
    namespace: default
---
```

rbac_policy on proxy with identity `default/sa-1`
```
{
	{
		name: "test"
		principals: {"default/sa-2"},
		permissions: {destination_port: 8080},
	},
}
```

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`