### PR TITLE
demo: Adding /liveness, /readiness, /startup paths to the bookstore web server

### DIFF
--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -121,11 +121,18 @@ func getHandlers() []handler {
 		{"/books-bought", updateBooksSold, "POST"},
 		{"/buy-a-book/new", sellBook, "GET"},
 		{"/reset", reset, "GET"},
+		{"/liveness", ok, "GET"},
+		{"/readiness", ok, "GET"},
+		{"/startup", ok, "GET"},
 	}
 }
 
 func reset(w http.ResponseWriter, r *http.Request) {
 	booksSold = 0
+	renderTemplate(w)
+}
+
+func ok(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(w)
 }
 


### PR DESCRIPTION
This PR adds 3 new paths to the bookstore web server

  - `/liveness`
  - `/readiness`
  - `/startup`

These are going to be part of the test for the solution (n/a) for https://github.com/openservicemesh/osm/issues/2207

---


Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
