### PR TITLE
rbac/tcp: support port based RBAC for tcp traffic

### DIFF
--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -16,8 +16,9 @@ import (
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 func TestGetOutboundHTTPFilterChainForService(t *testing.T) {
@@ -133,12 +134,24 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 		},
 	}
 
+	trafficTargets := []trafficpolicy.TrafficTargetWithRoutes{
+		{
+			Name:        "ns-1/test-1",
+			Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+			Sources: []identity.ServiceIdentity{
+				identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+				identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+			},
+			TCPRouteMatches: nil,
+		},
+	}
+
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
 			if !tc.permissiveMode {
 				// mock catalog calls used to build the RBAC filter
-				mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(lb.svcAccount).Return([]service.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).Times(1)
+				mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(lb.svcAccount).Return(trafficTargets, nil).Times(1)
 			}
 
 			filterChain, err := lb.getInboundMeshHTTPFilterChain(proxyService, tc.port)
@@ -211,12 +224,24 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 		},
 	}
 
+	trafficTargets := []trafficpolicy.TrafficTargetWithRoutes{
+		{
+			Name:        "ns-1/test-1",
+			Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+			Sources: []identity.ServiceIdentity{
+				identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+				identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+			},
+			TCPRouteMatches: nil,
+		},
+	}
+
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
 			if !tc.permissiveMode {
 				// mock catalog calls used to build the RBAC filter
-				mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(lb.svcAccount).Return([]service.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).Times(1)
+				mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(lb.svcAccount).Return(trafficTargets, nil).Times(1)
 			}
 
 			filterChain, err := lb.getInboundMeshTCPFilterChain(proxyService, tc.port)

--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -1,7 +1,7 @@
 package lds
 
 import (
-	"fmt"
+	"strconv"
 
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 // buildRBACFilter builds an RBAC filter based on SMI TrafficTarget policies.
@@ -39,26 +39,24 @@ func (lb *listenerBuilder) buildRBACFilter() (*xds_listener.Filter, error) {
 
 // buildInboundRBACPolicies builds the RBAC policies based on allowed principals
 func (lb *listenerBuilder) buildInboundRBACPolicies() (*xds_network_rbac.RBAC, error) {
-	allowsInboundSvcAccounts, err := lb.meshCatalog.ListAllowedInboundServiceAccounts(lb.svcAccount)
+	proxyIdentity := identity.ServiceIdentity(lb.svcAccount.String())
+	trafficTargets, err := lb.meshCatalog.ListInboundTrafficTargetsWithRoutes(lb.svcAccount)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error listing allowed inbound ServiceAccounts for ServiceAccount %q", lb.svcAccount)
+		log.Error().Err(err).Msgf("Error listing allowed inbound traffic targets for proxy identity %s", proxyIdentity)
 		return nil, err
 	}
 
-	log.Trace().Msgf("Building RBAC policies for ServiceAccount %q with allowed inbound %v", lb.svcAccount, allowsInboundSvcAccounts)
-
-	// Each downstream is a principal in the RBAC policy, which will have its own permissions
-	// based on SMI TrafficTarget policies.
 	rbacPolicies := make(map[string]*xds_rbac.Policy)
-	for _, downstreamSvcAccount := range allowsInboundSvcAccounts {
-		policyName := getPolicyName(downstreamSvcAccount, lb.svcAccount)
-		principal := identity.GetKubernetesServiceIdentity(downstreamSvcAccount, identity.ClusterLocalTrustDomain)
-		if policy, err := buildAllowAllPermissionsPolicy(principal); err != nil {
-			log.Error().Err(err).Msgf("Error building RBAC policy for ServiceAccount %q and downstream %q", lb.svcAccount, downstreamSvcAccount)
+	// Build an RBAC policies based on SMI TrafficTarget policies
+	for _, targetPolicy := range trafficTargets {
+		if policy, err := buildRBACPolicyFromTrafficTarget(targetPolicy); err != nil {
+			log.Error().Err(err).Msgf("Error building RBAC policy for proxy identity %s from TrafficTarget %s", proxyIdentity, targetPolicy.Name)
 		} else {
-			rbacPolicies[policyName] = policy
+			rbacPolicies[targetPolicy.Name] = policy
 		}
 	}
+
+	log.Debug().Msgf("RBAC policy for proxy with identity %s: %+v", proxyIdentity, rbacPolicies)
 
 	// Create an inbound RBAC policy that denies a request by default, unless a policy explicitly allows it
 	networkRBACPolicy := &xds_network_rbac.RBAC{
@@ -72,23 +70,42 @@ func (lb *listenerBuilder) buildInboundRBACPolicies() (*xds_network_rbac.RBAC, e
 	return networkRBACPolicy, nil
 }
 
-// buildAllowAllPermissionsPolicy creates an XDS RBAC policy for the given client principal to be granted all access
-func buildAllowAllPermissionsPolicy(clientPrincipal identity.ServiceIdentity) (*xds_rbac.Policy, error) {
-	policy := &rbac.Policy{
-		Principals: []rbac.RulesList{
-			{
-				OrRules: []rbac.Rule{
-					{Attribute: rbac.DownstreamAuthPrincipal, Value: clientPrincipal.String()},
-				},
+// buildRBACPolicyFromTrafficTarget creates an XDS RBAC policy from the given traffic target policy
+func buildRBACPolicyFromTrafficTarget(trafficTarget trafficpolicy.TrafficTargetWithRoutes) (*xds_rbac.Policy, error) {
+	policy := &rbac.Policy{}
+
+	// Create the list of principals for this policy
+	var principalRuleList []rbac.RulesList
+	for _, downstreamPrincipal := range trafficTarget.Sources {
+		principalRule := rbac.RulesList{
+			OrRules: []rbac.Rule{
+				{Attribute: rbac.DownstreamAuthPrincipal, Value: downstreamPrincipal.String()},
 			},
-		},
-		// Permissions set to ANY if not specified, which grants all access for the given Principals
+		}
+		principalRuleList = append(principalRuleList, principalRule)
 	}
+	policy.Principals = principalRuleList
+
+	// Create the list of permissions for this policy
+	var permissionRuleList []rbac.RulesList
+	for _, tcpRouteMatch := range trafficTarget.TCPRouteMatches {
+		// Matching ports have an OR relationship
+		var orPortRules []rbac.Rule
+		for _, port := range tcpRouteMatch.Ports {
+			portRule := rbac.Rule{
+				Attribute: rbac.DestinationPort, Value: strconv.Itoa(port),
+			}
+			orPortRules = append(orPortRules, portRule)
+		}
+
+		// Each TCP route match is its own permission in an RBAC policy
+		permissionRule := rbac.RulesList{
+			OrRules: orPortRules,
+		}
+
+		permissionRuleList = append(permissionRuleList, permissionRule)
+	}
+	policy.Permissions = permissionRuleList
 
 	return policy.Generate()
-}
-
-// getPolicyName returns a policy name for the policy used to authorize a downstream service account by the upstream
-func getPolicyName(downstream, upstream service.K8sServiceAccount) string {
-	return fmt.Sprintf("%s to %s", downstream, upstream)
 }

--- a/pkg/envoy/lds/rbac_test.go
+++ b/pkg/envoy/lds/rbac_test.go
@@ -11,8 +11,142 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/envoy/rbac"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
+
+func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name          string
+		trafficTarget trafficpolicy.TrafficTargetWithRoutes
+
+		expectedPolicy *xds_rbac.Policy
+		expectErr      bool
+	}{
+		{
+			// Test 1
+			name: "traffic target without TCP routes",
+			trafficTarget: trafficpolicy.TrafficTargetWithRoutes{
+				Name:        "ns-1/test-1",
+				Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+				Sources: []identity.ServiceIdentity{
+					identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+					identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+				},
+				TCPRouteMatches: nil,
+			},
+
+			expectedPolicy: &xds_rbac.Policy{
+				Permissions: []*xds_rbac.Permission{
+					{
+						Rule: &xds_rbac.Permission_Any{Any: true},
+					},
+				},
+				Principals: []*xds_rbac.Principal{
+					{
+						Identifier: &xds_rbac.Principal_OrIds{
+							OrIds: &xds_rbac.Principal_Set{
+								Ids: []*xds_rbac.Principal{
+									rbac.GetPrincipalAuthenticated("sa-2.ns-2.cluster.local"),
+								},
+							},
+						},
+					},
+					{
+						Identifier: &xds_rbac.Principal_OrIds{
+							OrIds: &xds_rbac.Principal_Set{
+								Ids: []*xds_rbac.Principal{
+									rbac.GetPrincipalAuthenticated("sa-3.ns-3.cluster.local"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false, // no error
+		},
+
+		{
+			// Test 2
+			name: "traffic target with TCP routes",
+			trafficTarget: trafficpolicy.TrafficTargetWithRoutes{
+				Name:        "ns-1/test-1",
+				Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+				Sources: []identity.ServiceIdentity{
+					identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+					identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+				},
+				TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
+					{
+						Ports: []int{1000, 2000},
+					},
+					{
+						Ports: []int{3000},
+					},
+				},
+			},
+
+			expectedPolicy: &xds_rbac.Policy{
+				Permissions: []*xds_rbac.Permission{
+					{
+						Rule: &xds_rbac.Permission_OrRules{
+							OrRules: &xds_rbac.Permission_Set{
+								Rules: []*xds_rbac.Permission{
+									rbac.GetPermissionDestinationPort(1000),
+									rbac.GetPermissionDestinationPort(2000),
+								},
+							},
+						},
+					},
+					{
+						Rule: &xds_rbac.Permission_OrRules{
+							OrRules: &xds_rbac.Permission_Set{
+								Rules: []*xds_rbac.Permission{
+									rbac.GetPermissionDestinationPort(3000),
+								},
+							},
+						},
+					},
+				},
+				Principals: []*xds_rbac.Principal{
+					{
+						Identifier: &xds_rbac.Principal_OrIds{
+							OrIds: &xds_rbac.Principal_Set{
+								Ids: []*xds_rbac.Principal{
+									rbac.GetPrincipalAuthenticated("sa-2.ns-2.cluster.local"),
+								},
+							},
+						},
+					},
+					{
+						Identifier: &xds_rbac.Principal_OrIds{
+							OrIds: &xds_rbac.Principal_Set{
+								Ids: []*xds_rbac.Principal{
+									rbac.GetPrincipalAuthenticated("sa-3.ns-3.cluster.local"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectErr: false, // no error
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			// Test the RBAC policies
+			policy, err := buildRBACPolicyFromTrafficTarget(tc.trafficTarget)
+
+			assert.Equal(tc.expectErr, err != nil)
+			assert.Equal(tc.expectedPolicy, policy)
+		})
+	}
+}
 
 func TestBuildInboundRBACPolicies(t *testing.T) {
 	assert := assert.New(t)
@@ -28,57 +162,75 @@ func TestBuildInboundRBACPolicies(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                      string
-		allowedInboundSvcAccounts []service.K8sServiceAccount
-		expectedPrincipals        []string
-		expectErr                 bool
+		name           string
+		trafficTargets []trafficpolicy.TrafficTargetWithRoutes
+
+		expectedPolicyKeys []string
+		expectErr          bool
 	}{
 		{
-			name: "multiple client allowed",
-			allowedInboundSvcAccounts: []service.K8sServiceAccount{
-				{Name: "sa-2", Namespace: "ns-2"},
-				{Name: "sa-3", Namespace: "ns-3"},
+			// Test 1
+			name: "traffic target without TCP routes",
+			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
+				{
+					Name:        "ns-1/test-1",
+					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Sources: []identity.ServiceIdentity{
+						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+					},
+					TCPRouteMatches: nil,
+				},
 			},
-			expectedPrincipals: []string{
-				"sa-2.ns-2.cluster.local",
-				"sa-3.ns-3.cluster.local",
-			},
+
+			expectedPolicyKeys: []string{"ns-1/test-1"},
+
 			expectErr: false, // no error
 		},
+
 		{
-			name:                      "no clients allowed",
-			allowedInboundSvcAccounts: []service.K8sServiceAccount{},
-			expectedPrincipals:        []string{},
-			expectErr:                 false, // no error
+			// Test 2
+			name: "traffic target with TCP routes",
+			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
+				{
+					Name:        "ns-1/test-1",
+					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Sources: []identity.ServiceIdentity{
+						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+					},
+				},
+				{
+					Name:        "ns-1/test-2",
+					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Sources: []identity.ServiceIdentity{
+						identity.ServiceIdentity("sa-4.ns-2.cluster.local"),
+					},
+				},
+			},
+
+			expectedPolicyKeys: []string{"ns-1/test-1", "ns-1/test-2"},
+			expectErr:          false, // no error
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			// Mock the calls to catalog
-			mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(lb.svcAccount).Return(tc.allowedInboundSvcAccounts, nil).Times(1)
+			// Mock catalog calls
+			mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(proxySvcAccount).Return(tc.trafficTargets, nil).Times(1)
 
 			// Test the RBAC policies
-			networkRBAC, err := lb.buildInboundRBACPolicies()
-			assert.Equal(err != nil, tc.expectErr)
+			policy, err := lb.buildInboundRBACPolicies()
 
-			assert.Equal(networkRBAC.Rules.GetAction(), xds_rbac.RBAC_ALLOW)
+			assert.Equal(tc.expectErr, err != nil)
+			assert.Equal(xds_rbac.RBAC_ALLOW, policy.Rules.Action)
+			assert.Len(policy.Rules.Policies, len(tc.expectedPolicyKeys))
 
-			rbacPolicies := networkRBAC.Rules.Policies
-
-			// Expect 1 policy per client principal
-			assert.Len(rbacPolicies, len(tc.expectedPrincipals))
-
-			// Loop through the policies and ensure there is a policy corresponding to each principal
-			var actualPrincipals []string
-			for _, policy := range rbacPolicies {
-				principalName := policy.Principals[0].GetOrIds().Ids[0].GetAuthenticated().PrincipalName.GetExact()
-				actualPrincipals = append(actualPrincipals, principalName)
-
-				assert.Len(policy.Permissions, 1) // Any permission
-				assert.True(policy.Permissions[0].GetAny())
+			var actualPolicyKeys []string
+			for key := range policy.Rules.Policies {
+				actualPolicyKeys = append(actualPolicyKeys, key)
 			}
-			assert.ElementsMatch(tc.expectedPrincipals, actualPrincipals)
+			assert.ElementsMatch(tc.expectedPolicyKeys, actualPolicyKeys)
 		})
 	}
 }
@@ -97,58 +249,63 @@ func TestBuildRBACFilter(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name                      string
-		allowedInboundSvcAccounts []service.K8sServiceAccount
-		expectErr                 bool
+		name           string
+		trafficTargets []trafficpolicy.TrafficTargetWithRoutes
+
+		expectErr bool
 	}{
 		{
-			name: "multiple clients allowed",
-			allowedInboundSvcAccounts: []service.K8sServiceAccount{
-				{Name: "sa-2", Namespace: "ns-2"},
-				{Name: "sa-3", Namespace: "ns-3"},
+			// Test 1
+			name: "traffic target without TCP routes",
+			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
+				{
+					Name:        "ns-1/test-1",
+					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Sources: []identity.ServiceIdentity{
+						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+					},
+					TCPRouteMatches: nil,
+				},
 			},
+
 			expectErr: false, // no error
 		},
+
 		{
-			name:                      "no clients allowed",
-			allowedInboundSvcAccounts: []service.K8sServiceAccount{},
-			expectErr:                 false, // no error
+			// Test 2
+			name: "traffic target with TCP routes",
+			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
+				{
+					Name:        "ns-1/test-1",
+					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Sources: []identity.ServiceIdentity{
+						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+					},
+				},
+				{
+					Name:        "ns-1/test-2",
+					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Sources: []identity.ServiceIdentity{
+						identity.ServiceIdentity("sa-4.ns-2.cluster.local"),
+					},
+				},
+			},
+
+			expectErr: false, // no error
 		},
 	}
 
 	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			// Mock the calls to catalog
-			mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(lb.svcAccount).Return(tc.allowedInboundSvcAccounts, nil).Times(1)
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			// Mock catalog calls
+			mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(proxySvcAccount).Return(tc.trafficTargets, nil).Times(1)
 
-			// Test the RBAC filter
 			rbacFilter, err := lb.buildRBACFilter()
 			assert.Equal(err != nil, tc.expectErr)
 
 			assert.Equal(rbacFilter.Name, wellknown.RoleBasedAccessControl)
-		})
-	}
-}
-
-func TestGetPolicyName(t *testing.T) {
-	assert := assert.New(t)
-
-	testCases := []struct {
-		downstream   service.K8sServiceAccount
-		upstream     service.K8sServiceAccount
-		expectedName string
-	}{
-		{
-			downstream:   service.K8sServiceAccount{Name: "foo", Namespace: "ns-1"},
-			upstream:     service.K8sServiceAccount{Name: "bar", Namespace: "ns-2"},
-			expectedName: "ns-1/foo to ns-2/bar",
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			actual := getPolicyName(tc.downstream, tc.upstream)
-			assert.Equal(actual, tc.expectedName)
 		})
 	}
 }

--- a/pkg/envoy/rbac/policy.go
+++ b/pkg/envoy/rbac/policy.go
@@ -35,7 +35,7 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 			for _, andPrincipalRule := range principalRuleList.AndRules {
 				// Fill in the authenticated principal types
 				if andPrincipalRule.Attribute == DownstreamAuthPrincipal {
-					authPrincipal := getPrincipalAuthenticated(andPrincipalRule.Value)
+					authPrincipal := GetPrincipalAuthenticated(andPrincipalRule.Value)
 					andPrincipalRules = append(andPrincipalRules, authPrincipal)
 				}
 			}
@@ -47,7 +47,7 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 			for _, orPrincipalRule := range principalRuleList.OrRules {
 				// Fill in the authenticated principal types
 				if orPrincipalRule.Attribute == DownstreamAuthPrincipal {
-					authPrincipal := getPrincipalAuthenticated(orPrincipalRule.Value)
+					authPrincipal := GetPrincipalAuthenticated(orPrincipalRule.Value)
 					orPrincipalRules = append(orPrincipalRules, authPrincipal)
 				}
 			}
@@ -94,7 +94,7 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 					if err != nil {
 						return nil, errors.Errorf("Error parsing destination port value %s", andPermissionRule.Value)
 					}
-					portPermission := getPermissionDestinationPort(uint32(port))
+					portPermission := GetPermissionDestinationPort(uint32(port))
 					andPermissionRules = append(andPermissionRules, portPermission)
 				}
 			}
@@ -110,7 +110,7 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 					if err != nil {
 						return nil, errors.Errorf("Error parsing destination port value %s", orPermissionRule.Value)
 					}
-					portPermission := getPermissionDestinationPort(uint32(port))
+					portPermission := GetPermissionDestinationPort(uint32(port))
 					orPermissionRules = append(orPermissionRules, portPermission)
 				}
 			}
@@ -133,7 +133,8 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 	return policy, nil
 }
 
-func getPrincipalAuthenticated(principalName string) *xds_rbac.Principal {
+// GetPrincipalAuthenticated returns an authenticated RBAC principal object for the given principal
+func GetPrincipalAuthenticated(principalName string) *xds_rbac.Principal {
 	return &xds_rbac.Principal{
 		Identifier: &xds_rbac.Principal_Authenticated_{
 			Authenticated: &xds_rbac.Principal_Authenticated{
@@ -199,7 +200,8 @@ func getPermissionAnd(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
 	}
 }
 
-func getPermissionDestinationPort(port uint32) *xds_rbac.Permission {
+// GetPermissionDestinationPort returns an RBAC permission for the given destination port
+func GetPermissionDestinationPort(port uint32) *xds_rbac.Permission {
 	return &xds_rbac.Permission{
 		Rule: &xds_rbac.Permission_DestinationPort{
 			DestinationPort: port,

--- a/pkg/envoy/rbac/policy_test.go
+++ b/pkg/envoy/rbac/policy_test.go
@@ -36,8 +36,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								getPrincipalAuthenticated("foo.domain"),
-								getPrincipalAuthenticated("bar.domain"),
+								GetPrincipalAuthenticated("foo.domain"),
+								GetPrincipalAuthenticated("bar.domain"),
 							},
 						},
 					},
@@ -68,8 +68,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_OrIds{
 						OrIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								getPrincipalAuthenticated("foo.domain"),
-								getPrincipalAuthenticated("bar.domain"),
+								GetPrincipalAuthenticated("foo.domain"),
+								GetPrincipalAuthenticated("bar.domain"),
 							},
 						},
 					},
@@ -138,8 +138,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								getPrincipalAuthenticated("foo.domain"),
-								getPrincipalAuthenticated("bar.domain"),
+								GetPrincipalAuthenticated("foo.domain"),
+								GetPrincipalAuthenticated("bar.domain"),
 							},
 						},
 					},
@@ -148,8 +148,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_OrIds{
 						OrIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								getPrincipalAuthenticated("foo.domain"),
-								getPrincipalAuthenticated("bar.domain"),
+								GetPrincipalAuthenticated("foo.domain"),
+								GetPrincipalAuthenticated("bar.domain"),
 							},
 						},
 					},
@@ -207,8 +207,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								getPrincipalAuthenticated("foo.domain"),
-								getPrincipalAuthenticated("bar.domain"),
+								GetPrincipalAuthenticated("foo.domain"),
+								GetPrincipalAuthenticated("bar.domain"),
 							},
 						},
 					},
@@ -219,8 +219,8 @@ func TestGenerate(t *testing.T) {
 					Rule: &xds_rbac.Permission_AndRules{
 						AndRules: &xds_rbac.Permission_Set{
 							Rules: []*xds_rbac.Permission{
-								getPermissionDestinationPort(80),
-								getPermissionDestinationPort(90),
+								GetPermissionDestinationPort(80),
+								GetPermissionDestinationPort(90),
 							},
 						},
 					},
@@ -253,8 +253,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								getPrincipalAuthenticated("foo.domain"),
-								getPrincipalAuthenticated("bar.domain"),
+								GetPrincipalAuthenticated("foo.domain"),
+								GetPrincipalAuthenticated("bar.domain"),
 							},
 						},
 					},
@@ -265,7 +265,7 @@ func TestGenerate(t *testing.T) {
 					Rule: &xds_rbac.Permission_OrRules{
 						OrRules: &xds_rbac.Permission_Set{
 							Rules: []*xds_rbac.Permission{
-								getPermissionDestinationPort(80),
+								GetPermissionDestinationPort(80),
 							},
 						},
 					},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change integrates the RBAC policies applied
via the RBAC network filter with the ports specified
via TCPRoutes. Only ports specified via the TCPRoute
resource will be allowed at the upstream if a TCPRoute
resource is associated as a rule in a TrafficTarget
resource.

This change also updates the TCP e2e tests to create
a TCPRoute resource with ports for the test to function
with RBAC policies.

Part of #1521

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`