### PR TITLE
envoy/rbac: rename rbac policy helper functions

### DIFF
--- a/pkg/envoy/lds/rbac_test.go
+++ b/pkg/envoy/lds/rbac_test.go
@@ -51,7 +51,7 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 						Identifier: &xds_rbac.Principal_OrIds{
 							OrIds: &xds_rbac.Principal_Set{
 								Ids: []*xds_rbac.Principal{
-									rbac.GetPrincipalAuthenticated("sa-2.ns-2.cluster.local"),
+									rbac.GetAuthenticatedPrincipal("sa-2.ns-2.cluster.local"),
 								},
 							},
 						},
@@ -60,7 +60,7 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 						Identifier: &xds_rbac.Principal_OrIds{
 							OrIds: &xds_rbac.Principal_Set{
 								Ids: []*xds_rbac.Principal{
-									rbac.GetPrincipalAuthenticated("sa-3.ns-3.cluster.local"),
+									rbac.GetAuthenticatedPrincipal("sa-3.ns-3.cluster.local"),
 								},
 							},
 						},
@@ -96,8 +96,8 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 						Rule: &xds_rbac.Permission_OrRules{
 							OrRules: &xds_rbac.Permission_Set{
 								Rules: []*xds_rbac.Permission{
-									rbac.GetPermissionDestinationPort(1000),
-									rbac.GetPermissionDestinationPort(2000),
+									rbac.GetDestinationPortPermission(1000),
+									rbac.GetDestinationPortPermission(2000),
 								},
 							},
 						},
@@ -106,7 +106,7 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 						Rule: &xds_rbac.Permission_OrRules{
 							OrRules: &xds_rbac.Permission_Set{
 								Rules: []*xds_rbac.Permission{
-									rbac.GetPermissionDestinationPort(3000),
+									rbac.GetDestinationPortPermission(3000),
 								},
 							},
 						},
@@ -117,7 +117,7 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 						Identifier: &xds_rbac.Principal_OrIds{
 							OrIds: &xds_rbac.Principal_Set{
 								Ids: []*xds_rbac.Principal{
-									rbac.GetPrincipalAuthenticated("sa-2.ns-2.cluster.local"),
+									rbac.GetAuthenticatedPrincipal("sa-2.ns-2.cluster.local"),
 								},
 							},
 						},
@@ -126,7 +126,7 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 						Identifier: &xds_rbac.Principal_OrIds{
 							OrIds: &xds_rbac.Principal_Set{
 								Ids: []*xds_rbac.Principal{
-									rbac.GetPrincipalAuthenticated("sa-3.ns-3.cluster.local"),
+									rbac.GetAuthenticatedPrincipal("sa-3.ns-3.cluster.local"),
 								},
 							},
 						},

--- a/pkg/envoy/rbac/policy.go
+++ b/pkg/envoy/rbac/policy.go
@@ -35,11 +35,11 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 			for _, andPrincipalRule := range principalRuleList.AndRules {
 				// Fill in the authenticated principal types
 				if andPrincipalRule.Attribute == DownstreamAuthPrincipal {
-					authPrincipal := GetPrincipalAuthenticated(andPrincipalRule.Value)
+					authPrincipal := GetAuthenticatedPrincipal(andPrincipalRule.Value)
 					andPrincipalRules = append(andPrincipalRules, authPrincipal)
 				}
 			}
-			currentPrincipal = getPrincipalAnd(andPrincipalRules)
+			currentPrincipal = andPrincipals(andPrincipalRules)
 
 		case len(principalRuleList.OrRules) != 0:
 			// Combine all the OR rules for this Principal rule with OR semantics
@@ -47,22 +47,22 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 			for _, orPrincipalRule := range principalRuleList.OrRules {
 				// Fill in the authenticated principal types
 				if orPrincipalRule.Attribute == DownstreamAuthPrincipal {
-					authPrincipal := GetPrincipalAuthenticated(orPrincipalRule.Value)
+					authPrincipal := GetAuthenticatedPrincipal(orPrincipalRule.Value)
 					orPrincipalRules = append(orPrincipalRules, authPrincipal)
 				}
 			}
-			currentPrincipal = getPrincipalOr(orPrincipalRules)
+			currentPrincipal = orPrincipals(orPrincipalRules)
 
 		default:
 			// Neither AND/OR rules set, set principal to Any
-			currentPrincipal = getPrincipalAny()
+			currentPrincipal = getAnyPrincipal()
 		}
 
 		finalPrincipals = append(finalPrincipals, currentPrincipal)
 	}
 	if len(p.Principals) == 0 {
 		// No principals specified for this policy, allow ANY
-		finalPrincipals = append(finalPrincipals, getPrincipalAny())
+		finalPrincipals = append(finalPrincipals, getAnyPrincipal())
 	}
 
 	policy.Principals = finalPrincipals
@@ -94,11 +94,11 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 					if err != nil {
 						return nil, errors.Errorf("Error parsing destination port value %s", andPermissionRule.Value)
 					}
-					portPermission := GetPermissionDestinationPort(uint32(port))
+					portPermission := GetDestinationPortPermission(uint32(port))
 					andPermissionRules = append(andPermissionRules, portPermission)
 				}
 			}
-			currentPermission = getPermissionAnd(andPermissionRules)
+			currentPermission = andPermissions(andPermissionRules)
 
 		case len(permissionRuleList.OrRules) != 0:
 			// Combine all the OR rules for this Permission rule with OR semantics
@@ -110,22 +110,22 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 					if err != nil {
 						return nil, errors.Errorf("Error parsing destination port value %s", orPermissionRule.Value)
 					}
-					portPermission := GetPermissionDestinationPort(uint32(port))
+					portPermission := GetDestinationPortPermission(uint32(port))
 					orPermissionRules = append(orPermissionRules, portPermission)
 				}
 			}
-			currentPermission = getPermissionOr(orPermissionRules)
+			currentPermission = orPermissions(orPermissionRules)
 
 		default:
 			// Neither AND/OR rules set, set permission to Any
-			currentPermission = getPermissionAny()
+			currentPermission = getAnyPermission()
 		}
 
 		finalPermissions = append(finalPermissions, currentPermission)
 	}
 	if len(p.Permissions) == 0 {
 		// No permissions specified for this policy, allow ANY
-		finalPermissions = append(finalPermissions, getPermissionAny())
+		finalPermissions = append(finalPermissions, getAnyPermission())
 	}
 
 	policy.Permissions = finalPermissions
@@ -133,8 +133,8 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 	return policy, nil
 }
 
-// GetPrincipalAuthenticated returns an authenticated RBAC principal object for the given principal
-func GetPrincipalAuthenticated(principalName string) *xds_rbac.Principal {
+// GetAuthenticatedPrincipal returns an authenticated RBAC principal object for the given principal
+func GetAuthenticatedPrincipal(principalName string) *xds_rbac.Principal {
 	return &xds_rbac.Principal{
 		Identifier: &xds_rbac.Principal_Authenticated_{
 			Authenticated: &xds_rbac.Principal_Authenticated{
@@ -148,7 +148,7 @@ func GetPrincipalAuthenticated(principalName string) *xds_rbac.Principal {
 	}
 }
 
-func getPrincipalOr(principals []*xds_rbac.Principal) *xds_rbac.Principal {
+func orPrincipals(principals []*xds_rbac.Principal) *xds_rbac.Principal {
 	return &xds_rbac.Principal{
 		Identifier: &xds_rbac.Principal_OrIds{
 			OrIds: &xds_rbac.Principal_Set{
@@ -158,7 +158,7 @@ func getPrincipalOr(principals []*xds_rbac.Principal) *xds_rbac.Principal {
 	}
 }
 
-func getPrincipalAnd(principals []*xds_rbac.Principal) *xds_rbac.Principal {
+func andPrincipals(principals []*xds_rbac.Principal) *xds_rbac.Principal {
 	return &xds_rbac.Principal{
 		Identifier: &xds_rbac.Principal_AndIds{
 			AndIds: &xds_rbac.Principal_Set{
@@ -168,19 +168,19 @@ func getPrincipalAnd(principals []*xds_rbac.Principal) *xds_rbac.Principal {
 	}
 }
 
-func getPrincipalAny() *xds_rbac.Principal {
+func getAnyPrincipal() *xds_rbac.Principal {
 	return &xds_rbac.Principal{
 		Identifier: &xds_rbac.Principal_Any{Any: true},
 	}
 }
 
-func getPermissionAny() *xds_rbac.Permission {
+func getAnyPermission() *xds_rbac.Permission {
 	return &xds_rbac.Permission{
 		Rule: &xds_rbac.Permission_Any{Any: true},
 	}
 }
 
-func getPermissionOr(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
+func orPermissions(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
 	return &xds_rbac.Permission{
 		Rule: &xds_rbac.Permission_OrRules{
 			OrRules: &xds_rbac.Permission_Set{
@@ -190,7 +190,7 @@ func getPermissionOr(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
 	}
 }
 
-func getPermissionAnd(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
+func andPermissions(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
 	return &xds_rbac.Permission{
 		Rule: &xds_rbac.Permission_AndRules{
 			AndRules: &xds_rbac.Permission_Set{
@@ -200,8 +200,8 @@ func getPermissionAnd(permissions []*xds_rbac.Permission) *xds_rbac.Permission {
 	}
 }
 
-// GetPermissionDestinationPort returns an RBAC permission for the given destination port
-func GetPermissionDestinationPort(port uint32) *xds_rbac.Permission {
+// GetDestinationPortPermission returns an RBAC permission for the given destination port
+func GetDestinationPortPermission(port uint32) *xds_rbac.Permission {
 	return &xds_rbac.Permission{
 		Rule: &xds_rbac.Permission_DestinationPort{
 			DestinationPort: port,

--- a/pkg/envoy/rbac/policy_test.go
+++ b/pkg/envoy/rbac/policy_test.go
@@ -36,8 +36,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								GetPrincipalAuthenticated("foo.domain"),
-								GetPrincipalAuthenticated("bar.domain"),
+								GetAuthenticatedPrincipal("foo.domain"),
+								GetAuthenticatedPrincipal("bar.domain"),
 							},
 						},
 					},
@@ -68,8 +68,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_OrIds{
 						OrIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								GetPrincipalAuthenticated("foo.domain"),
-								GetPrincipalAuthenticated("bar.domain"),
+								GetAuthenticatedPrincipal("foo.domain"),
+								GetAuthenticatedPrincipal("bar.domain"),
 							},
 						},
 					},
@@ -91,7 +91,7 @@ func TestGenerate(t *testing.T) {
 				},
 			},
 			expectedPrincipals: []*xds_rbac.Principal{
-				getPrincipalAny(),
+				getAnyPrincipal(),
 			},
 			expectedPermissions: []*xds_rbac.Permission{
 				{
@@ -105,7 +105,7 @@ func TestGenerate(t *testing.T) {
 			name: "testing rule for no principal specified",
 			p:    &Policy{},
 			expectedPrincipals: []*xds_rbac.Principal{
-				getPrincipalAny(),
+				getAnyPrincipal(),
 			},
 			expectedPermissions: []*xds_rbac.Permission{
 				{
@@ -138,8 +138,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								GetPrincipalAuthenticated("foo.domain"),
-								GetPrincipalAuthenticated("bar.domain"),
+								GetAuthenticatedPrincipal("foo.domain"),
+								GetAuthenticatedPrincipal("bar.domain"),
 							},
 						},
 					},
@@ -148,8 +148,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_OrIds{
 						OrIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								GetPrincipalAuthenticated("foo.domain"),
-								GetPrincipalAuthenticated("bar.domain"),
+								GetAuthenticatedPrincipal("foo.domain"),
+								GetAuthenticatedPrincipal("bar.domain"),
 							},
 						},
 					},
@@ -207,8 +207,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								GetPrincipalAuthenticated("foo.domain"),
-								GetPrincipalAuthenticated("bar.domain"),
+								GetAuthenticatedPrincipal("foo.domain"),
+								GetAuthenticatedPrincipal("bar.domain"),
 							},
 						},
 					},
@@ -219,8 +219,8 @@ func TestGenerate(t *testing.T) {
 					Rule: &xds_rbac.Permission_AndRules{
 						AndRules: &xds_rbac.Permission_Set{
 							Rules: []*xds_rbac.Permission{
-								GetPermissionDestinationPort(80),
-								GetPermissionDestinationPort(90),
+								GetDestinationPortPermission(80),
+								GetDestinationPortPermission(90),
 							},
 						},
 					},
@@ -253,8 +253,8 @@ func TestGenerate(t *testing.T) {
 					Identifier: &xds_rbac.Principal_AndIds{
 						AndIds: &xds_rbac.Principal_Set{
 							Ids: []*xds_rbac.Principal{
-								GetPrincipalAuthenticated("foo.domain"),
-								GetPrincipalAuthenticated("bar.domain"),
+								GetAuthenticatedPrincipal("foo.domain"),
+								GetAuthenticatedPrincipal("bar.domain"),
 							},
 						},
 					},
@@ -265,7 +265,7 @@ func TestGenerate(t *testing.T) {
 					Rule: &xds_rbac.Permission_OrRules{
 						OrRules: &xds_rbac.Permission_Set{
 							Rules: []*xds_rbac.Permission{
-								GetPermissionDestinationPort(80),
+								GetDestinationPortPermission(80),
 							},
 						},
 					},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Renames the helper functions used for RBAC principals
and permissions to make them sound better.

Based on suggestion in https://github.com/openservicemesh/osm/pull/2224#discussion_r546144684.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`