### PR TITLE
fix(fluent bit): allow httpProxy or httpsProxy value to be empty

### DIFF
--- a/charts/osm/templates/proxy-config.yaml
+++ b/charts/osm/templates/proxy-config.yaml
@@ -5,6 +5,6 @@ metadata:
   name: proxy-config
   namespace: {{ include "osm.namespace" . }}
 stringData:
-  HTTP_PROXY: {{ .Values.OpenServiceMesh.fluentBit.httpProxy }}
-  HTTPS_PROXY: {{ .Values.OpenServiceMesh.fluentBit.httpsProxy }}
+  HTTP_PROXY: {{ .Values.OpenServiceMesh.fluentBit.httpProxy | quote }}
+  HTTPS_PROXY: {{ .Values.OpenServiceMesh.fluentBit.httpsProxy | quote }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
* Updates fluent bit proxy secret to allow http or https proxy value to be empty when the other is in use
* Resolves #2229 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [x]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No, no