### PR TITLE
kubernetes/events: Fix race on event handler test

### DIFF
--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -40,8 +40,8 @@ var _ = Describe("Testing event handlers", func() {
 			}
 			handlers := GetKubernetesEventHandlers(testInformer, testProvider, shouldObserve, eventTypes)
 			handlers.AddFunc(&pod)
-			Expect(len(podAddChannel)).To(Equal(1))
 			an := <-podAddChannel
+			Expect(len(podAddChannel)).To(Equal(0))
 
 			// Pubsub msg
 			pubsubMsg, castOk := an.(events.PubSubMessage)


### PR DESCRIPTION
Race checking the size of a channel, in which the event might
or might have not arrived.

- Control Plane          [X]
- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No