### PR TITLE
fix(docs/Design.md): Fix the wrong title links of document contents

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -107,9 +107,9 @@ This component:
 
 This section outlines the conventions adopted and guiding the development of the Open Service Mesh (OSM). Components discussed in this section:
   - (A) Proxy [sidecar](https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar) - Envoy or other reverse-proxy with service-mesh capabilities
-  - (B) [Proxy Certificate](#proxy-tls-certificate) - unique X.509 certificate issued to the specific proxy by the [Certificate Manager](#2-certificate-manager)
+  - (B) [Proxy Certificate](#b-proxy-tls-certificate) - unique X.509 certificate issued to the specific proxy by the [Certificate Manager](#2-certificate-manager)
   - (C) Service - [Kubernetes service resource](https://kubernetes.io/docs/concepts/services-networking/service/) referenced in SMI Spec
-  - (D) [Service Certificate](#service-tls-certificate) - X.509 certificate issued to the service
+  - (D) [Service Certificate](#d-service-tls-certificate) - X.509 certificate issued to the service
   - (E) Policy - [SMI Spec](https://smi-spec.io/) traffic policy enforced by the target service's proxy
   - Examples of service endpoints handling traffic for the given service:
     - (F) Azure VM - process running on an Azure VM, listening for connections on IP 1.2.3.11, port 81.


### PR DESCRIPTION
Signed-off-by: aisuko <urakiny@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

   Hi guys, I'm working on https://github.com/layer5io/meshery-osm, the adapter for deploying `OSM`, and I'd like to find some more native way to deploy OSM to the Kubernetes cluster(We are deploying OSM by executing the bash script, which may not a good way for me). So, I came here and find a more native way and hit little issues of the `Design.md`.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [x]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
