### PR TITLE
envoy/lds: remove duplicated address_prefix

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -274,9 +274,25 @@ func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.
 		return nil, err
 	}
 
+	contains := func(s []string, t string) bool {
+		for _, a := range s {
+			if a == t {
+				return true
+			}
+		}
+		return false
+	}
+
+	var endpointSet []string
 	for _, endp := range endpoints {
+		if !contains(endpointSet, endp.IP.String()) {
+			endpointSet = append(endpointSet, endp.IP.String())
+		}
+	}
+
+	for _, ip := range endpointSet {
 		filterMatch.PrefixRanges = append(filterMatch.PrefixRanges, &xds_core.CidrRange{
-			AddressPrefix: endp.IP.String(),
+			AddressPrefix: ip,
 			PrefixLen: &wrapperspb.UInt32Value{
 				Value: singleIpv4Mask,
 			},

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -356,6 +356,33 @@ func TestGetOutboundFilterChainMatchForService(t *testing.T) {
 			expectedFilterChainMatch: nil,
 			expectError:              true,
 		},
+
+		{
+			// test case 5
+			name: "outbound TCP filter chain for service with duplicated endpoints",
+			endpoints: []endpoint.Endpoint{
+				{
+					IP:   net.IPv4(192, 168, 10, 1),
+					Port: 8080,
+				},
+				{
+					IP:   net.IPv4(192, 168, 10, 1),
+					Port: 8090,
+				},
+			},
+			appProtocol: tcpAppProtocol,
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				PrefixRanges: []*xds_core.CidrRange{
+					{
+						AddressPrefix: "192.168.10.1",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: 32,
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Remove duplicated IP ranges for a single filter chain which
occurs from multiple ports per service.

Part of #2237 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No