### PR TITLE
fix(demo/README.md): Fixing the OSM controller debug port in README

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -69,7 +69,7 @@ The Bookstore, Bookbuyer, and Bookthief apps have simple web UI visualizing the 
   - To see the UI for BookThief run `./scripts/port-forward-bookthief-ui.sh` and open [http://localhost:8083/](http://localhost:8083/)
   - To see Jaeger run `./scripts/port-forward-jaeger.sh` and open [http://localhost:16686/](http://localhost:16686/)
   - To see Grafana run `./scripts/port-forward-grafana.sh` and open [http://localhost:3000/](http://localhost:3000/) - default username and password for Grafana is `admin`/`admin`
-  - OSM controller has a simple debugging web endpoint - run `./scripts/port-forward-osm-debug.sh` and open [http://localhost:9091/debug](http://localhost:9091/debug)
+  - OSM controller has a simple debugging web endpoint - run `./scripts/port-forward-osm-debug.sh` and open [http://localhost:9092/debug](http://localhost:9092/debug)
 
 To expose web UI ports of all components of the service mesh the local workstation use the following helper script: `/scripts/port-forward-all.sh`
 

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -7,7 +7,7 @@
 - [Install OSM Control Plane](#install-osm-control-plane)
 - [Deploying the Bookstore Demo Applications](#deploying-the-bookstore-demo-applications)
   - [Create the Bookstore Applications Namespaces](#create-the-bookstore-application-namespaces)
-  - [Onboard the Namespaces to the OSM Mesh](#onboard-the-namespaces-to-the-osm-mesh)
+  - [Onboard the Namespaces to the OSM Mesh and enable sidecar injection](#onboard-the-namespaces-to-the-osm-mesh-and-enable-sidecar-injection-on-the-namespaces)
   - [Deploy the Bookstore Application](#deploy-the-bookstore-application)
   - [Checkpoint: What got installed?](#checkpoint-what-got-installed)
   - [View the Applications UIs](#view-the-application-uis)


### PR DESCRIPTION
Signed-off-by: aisuko <urakiny@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

The `./scripts/port-forward-osm-debug.sh` `port-forward` the container port to localhost `9092`, so changed the port from `http://localhost:9091/debug` to `http://localhost:9092/debug` in the `demo/README.md`

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [x]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
