### PR TITLE
catalog: Add comment to explain what a bool return does

### DIFF
--- a/pkg/catalog/announcement_handlers_test.go
+++ b/pkg/catalog/announcement_handlers_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Test Announcement Handlers", func() {
 			mc.connectedProxies.Range(func(key interface{}, value interface{}) bool {
 				connectedProxy := value.(connectedProxy)
 				connectedProxies = append(connectedProxies, *connectedProxy.proxy)
-				return true
+				return true // continue the iteration
 			})
 
 			Expect(len(connectedProxies)).To(Equal(1))

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -27,7 +27,7 @@ func (mc *MeshCatalog) ListExpectedProxies() map[certificate.CommonName]time.Tim
 			proxies[cn] = props.certificateIssuedAt
 		}
 
-		return true
+		return true // continue the iteration
 	})
 
 	return proxies
@@ -42,7 +42,7 @@ func (mc *MeshCatalog) ListConnectedProxies() map[certificate.CommonName]*envoy.
 		if _, isDisconnected := mc.disconnectedProxies.Load(cn); !isDisconnected {
 			proxies[cn] = props.proxy
 		}
-		return true
+		return true // continue the iteration
 	})
 	return proxies
 }
@@ -54,7 +54,7 @@ func (mc *MeshCatalog) ListDisconnectedProxies() map[certificate.CommonName]time
 		cn := cnInterface.(certificate.CommonName)
 		props := disconnectedProxyInterface.(disconnectedProxy)
 		proxies[cn] = props.lastSeen
-		return true
+		return true // continue the iteration
 	})
 	return proxies
 }

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -165,7 +165,7 @@ func (cm *CertManager) ListCertificates() ([]certificate.Certificater, error) {
 	var certs []certificate.Certificater
 	cm.cache.Range(func(cn interface{}, certInterface interface{}) bool {
 		certs = append(certs, certInterface.(certificate.Certificater))
-		return true
+		return true // continue the iteration
 	})
 	return certs, nil
 }

--- a/pkg/certificate/providers/tresor/debugger.go
+++ b/pkg/certificate/providers/tresor/debugger.go
@@ -7,7 +7,7 @@ func (cm *CertManager) ListIssuedCertificates() []certificate.Certificater {
 	var certs []certificate.Certificater
 	cm.cache.Range(func(cnInterface interface{}, certInterface interface{}) bool {
 		certs = append(certs, certInterface.(certificate.Certificater))
-		return true
+		return true // continue the iteration
 	})
 	return certs
 }

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -143,7 +143,7 @@ func (cm *CertManager) ListCertificates() ([]certificate.Certificater, error) {
 	var certs []certificate.Certificater
 	cm.cache.Range(func(cnInterface interface{}, certInterface interface{}) bool {
 		certs = append(certs, certInterface.(certificate.Certificater))
-		return true
+		return true // continue the iteration
 	})
 	return certs, nil
 }

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Test client helpers", func() {
 			cm.cache.Range(func(cnInterface interface{}, certInterface interface{}) bool {
 				cert := certInterface.(*Certificate)
 				commonNames = append(commonNames, cert.GetCommonName())
-				return true
+				return true // continue the iteration
 			})
 			return commonNames
 		}

--- a/pkg/certificate/providers/vault/debugger.go
+++ b/pkg/certificate/providers/vault/debugger.go
@@ -9,7 +9,7 @@ func (cm *CertManager) ListIssuedCertificates() []certificate.Certificater {
 	var certs []certificate.Certificater
 	cm.cache.Range(func(cnInterface interface{}, certInterface interface{}) bool {
 		certs = append(certs, certInterface.(certificate.Certificater))
-		return true
+		return true // continue the iteration
 	})
 	return certs
 }


### PR DESCRIPTION
This PR explains what the `return true` does.

I find myself spending a mental cycle to recollect what this `return true` does. I believe that adding this comment would make it easy for the next person who looks at this `return true` to understand that this is what makes `mapset`'s `Range()` continue the iteration until the end of the set.

No functional code changes.

---

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
