### PR TITLE
Fix typo s/namepace/namespace/g

### DIFF
--- a/cmd/cli/metrics_disable.go
+++ b/cmd/cli/metrics_disable.go
@@ -58,7 +58,7 @@ func newMetricsDisable(out io.Writer) *cobra.Command {
 }
 
 func (cmd *metricsDisableCmd) run() error {
-	// Add metrics annotation on namepaces
+	// Add metrics annotation on namespaces
 	for _, ns := range cmd.namespaces {
 		ns = strings.TrimSpace(ns)
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/cli/metrics_enable.go
+++ b/cmd/cli/metrics_enable.go
@@ -62,7 +62,7 @@ func newMetricsEnable(out io.Writer) *cobra.Command {
 }
 
 func (cmd *metricsEnableCmd) run() error {
-	// Add metrics annotation on namepaces
+	// Add metrics annotation on namespaces
 	for _, ns := range cmd.namespaces {
 		ns = strings.TrimSpace(ns)
 


### PR DESCRIPTION
This PR fixes a typo in 2 separate comments.


Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

---

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
