### PR TITLE
Use _ for unused function params

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -85,7 +85,7 @@ func getHandlers() []handler {
 	}
 }
 
-func reset(w http.ResponseWriter, r *http.Request) {
+func reset(w http.ResponseWriter, _ *http.Request) {
 	atomic.StoreInt64(&booksBought, 0)
 	atomic.StoreInt64(&booksBoughtV1, 0)
 	atomic.StoreInt64(&booksBoughtV2, 0)

--- a/demo/cmd/bookstore/bookstore.go
+++ b/demo/cmd/bookstore/bookstore.go
@@ -127,12 +127,12 @@ func getHandlers() []handler {
 	}
 }
 
-func reset(w http.ResponseWriter, r *http.Request) {
+func reset(w http.ResponseWriter, _ *http.Request) {
 	booksSold = 0
 	renderTemplate(w)
 }
 
-func ok(w http.ResponseWriter, r *http.Request) {
+func ok(w http.ResponseWriter, _ *http.Request) {
 	renderTemplate(w)
 }
 

--- a/demo/cmd/bookthief/bookthief.go
+++ b/demo/cmd/bookthief/bookthief.go
@@ -67,7 +67,7 @@ func getHandlers() []handler {
 	}
 }
 
-func reset(w http.ResponseWriter, r *http.Request) {
+func reset(w http.ResponseWriter, _ *http.Request) {
 	booksStolen = 0
 	booksStolenV1 = 0
 	booksStolenV2 = 0

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -18,7 +18,7 @@ import (
 type CallerHook struct{}
 
 // Run adds additional context
-func (h CallerHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+func (h CallerHook) Run(e *zerolog.Event, _ zerolog.Level, _ string) {
 	if _, file, line, ok := runtime.Caller(3); ok {
 		e.Str("file", fmt.Sprintf("%s:%d", path.Base(file), line))
 	}

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -73,7 +73,7 @@ func (f fakeMeshSpec) ListTrafficTargets() []*target.TrafficTarget {
 	return f.trafficTargets
 }
 
-func (f fakeMeshSpec) GetBackpressurePolicy(svc service.MeshService) *backpressure.Backpressure {
+func (f fakeMeshSpec) GetBackpressurePolicy(_ service.MeshService) *backpressure.Backpressure {
 	return nil
 }
 

--- a/pkg/tests/stream.go
+++ b/pkg/tests/stream.go
@@ -91,7 +91,7 @@ func (s *XDSServer) Context() context.Context {
 // It is safe to have a goroutine calling SendMsg and another goroutine
 // calling RecvMsg on the same stream at the same time, but it is not safe
 // to call SendMsg on the same stream in different goroutines.
-func (s *XDSServer) SendMsg(m interface{}) error {
+func (s *XDSServer) SendMsg(_ interface{}) error {
 	return nil
 }
 
@@ -103,6 +103,6 @@ func (s *XDSServer) SendMsg(m interface{}) error {
 // It is safe to have a goroutine calling SendMsg and another goroutine
 // calling RecvMsg on the same stream at the same time, but it is not
 // safe to call RecvMsg on the same stream in different goroutines.
-func (s *XDSServer) RecvMsg(m interface{}) error {
+func (s *XDSServer) RecvMsg(_ interface{}) error {
 	return nil
 }

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -77,4 +77,4 @@ func TestAdmissionError(t *testing.T) {
 
 type err int
 
-func (err) Read(b []byte) (i int, err error) { return 1, errorTest }
+func (err) Read(_ []byte) (i int, err error) { return 1, errorTest }


### PR DESCRIPTION
Use `_` for unused fn params.

No functional code changes in this PR.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

---

**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
