### PR TITLE
kubernetes: Log the informer and provider names w/ debug log messages

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -33,7 +33,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if !shouldObserve(obj) {
-				logNotObservedNamespace(obj, eventTypes.Add)
+				logNotObservedNamespace(obj, eventTypes.Add, informerName, providerName)
 				return
 			}
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
@@ -45,7 +45,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			if !shouldObserve(newObj) {
-				logNotObservedNamespace(newObj, eventTypes.Update)
+				logNotObservedNamespace(newObj, eventTypes.Update, informerName, providerName)
 				return
 			}
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
@@ -57,7 +57,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 
 		DeleteFunc: func(obj interface{}) {
 			if !shouldObserve(obj) {
-				logNotObservedNamespace(obj, eventTypes.Delete)
+				logNotObservedNamespace(obj, eventTypes.Delete, informerName, providerName)
 				return
 			}
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
@@ -73,8 +73,8 @@ func getNamespace(obj interface{}) string {
 	return reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 }
 
-func logNotObservedNamespace(obj interface{}, eventType a.AnnouncementType) {
+func logNotObservedNamespace(obj interface{}, eventType a.AnnouncementType, informerName, providerName string) {
 	if emitLogs {
-		log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring %s event", getNamespace(obj), eventType)
+		log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring %s event; informer=%s; provider=%s", getNamespace(obj), eventType, informerName, providerName)
 	}
 }


### PR DESCRIPTION
I noticed the `informerName` and `providerName` function params were unused and was going to remove them. But they are important context - should be preserved. Decided to add them to the debug log message. I suspect we'll use them in other debugging tools we build around this

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
