### PR TITLE
eds: Remove unused variables and inline usage of ListAllowedOutboundServicesForIdentity() in for loop

### DIFF
--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -30,14 +30,9 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with CN=%q", proxy.GetCommonName())
 		return nil, err
 	}
-	outboundServices := meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity)
-	if err != nil {
-		log.Error().Err(err).Msgf("Error listing outbound services for proxy %q", proxyServiceName)
-		return nil, err
-	}
 
 	outboundServicesEndpoints := make(map[service.MeshService][]endpoint.Endpoint)
-	for _, dstSvc := range outboundServices {
+	for _, dstSvc := range meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity) {
 		endpoints, err := meshCatalog.ListEndpointsForService(dstSvc)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed listing endpoints for service %s", dstSvc)


### PR DESCRIPTION
This PR removes a few unused variables and also inlines `ListAllowedOutboundServicesForIdentity()` in the for loop where it is needed.

This started with the observation that the `err` used immediately after `ListAllowedOutboundServicesForIdentity()` is not from `ListAllowedOutboundServicesForIdentity` and will never be `nil` - so it is not needed.

It turns out `outboundServices` could be removed too.


Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
