### PR TITLE
webhooks: fix webhook ports and deletion

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -11,7 +11,7 @@ webhooks:
       name: osm-controller
       namespace: {{ include "osm.namespace" . }}
       path: /mutate-pod-creation
-      port: 443
+      port: 9090
   # failurePolicy should always be set to Fail to ensure no new resources get created without a sidecar
   #   (and bypass TrafficTarget policies) if the webhook server is down
   failurePolicy: Fail

--- a/charts/osm/templates/osm-service.yaml
+++ b/charts/osm/templates/osm-service.yaml
@@ -11,10 +11,13 @@ spec:
       port: 15128
       targetPort: 15128
     - name: sidecar-injector
-      port: 443
+      port: 9090
       targetPort: 9090
     - name: debug-port
       port: 9092
       targetPort: 9092
+    - name: config-validator
+      port: 9093
+      targetPort: 9093
   selector:
     app: osm-controller

--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -10,8 +10,8 @@ webhooks:
     service:
       name: osm-controller
       namespace: {{ include "osm.namespace" . }}
-      path: /validate-webhook
-      port: 443
+      path: /validate-config
+      port: 9093
   failurePolicy: Fail
   matchPolicy: Exact
   namespaceSelector:
@@ -25,6 +25,5 @@ webhooks:
       operations:
         - CREATE
         - UPDATE
-        - DELETE
       resources:
         - configmaps

--- a/pkg/configurator/validating_webhook.go
+++ b/pkg/configurator/validating_webhook.go
@@ -42,7 +42,7 @@ const (
 	ValidatingWebhookName = "osm-config-webhook.k8s.io"
 
 	// webhookUpdateConfigMapis the HTTP path at which the webhook expects to receive configmap update events
-	webhookUpdateConfigMap = "/validate-webhook"
+	webhookUpdateConfigMap = "/validate-config"
 
 	// listenPort is the validating webhook server port
 	listenPort = 9093
@@ -152,6 +152,7 @@ func (whc *webhookConfig) runValidatingWebhook(stop <-chan struct{}) {
 		log.Info().Msg("Done shutting down validating webhook HTTP server")
 	}
 }
+
 func (whc *webhookConfig) configMapHandler(w http.ResponseWriter, req *http.Request) {
 	log.Trace().Msgf("Received validating webhook request: Method=%v, URL=%v", req.Method, req.URL)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updates the osm-controller's ports for webhook
reachability. The validating webhook was not reachable.
Also removes the DELETE operation since this breaks the
uninstall workflow where the controller serving the webhook
gets deleted before the validating webhook config, resulting
in the webhook deletion to fail.

Also updates the validating webhook's path to make it more
explicit.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`