### PR TITLE
charts/validatingwebhook: allow webhook deletion

### DIFF
--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -25,6 +25,5 @@ webhooks:
       operations:
         - CREATE
         - UPDATE
-        - DELETE
       resources:
         - configmaps


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
With the deletion being monitored, uninstall fails
because the webhook gets deleted only after the
controller serving the webhook gets deleted.

Since delete is not tested yet with uninstall workflows,
remove this, otherwise mesh deletion and install
gets impacted.

Resolves #2244

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`