### PR TITLE
charts: disable validating webhook configuration

### DIFF
--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -1,3 +1,4 @@
+{{- /* disable validating webhook due to Issue #2264
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -27,3 +28,4 @@ webhooks:
         - UPDATE
       resources:
         - configmaps
+*/}}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Since the validating webhook has been disabled by c48acb9c due to
issue #2264, the validating webhook config needs to be disabled as
well. Otherwise config-map update will be broken.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`