### PR TITLE
injector: Test all Envoy config functions

### DIFF
--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -2,8 +2,10 @@ package injector
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,6 +13,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -21,224 +24,34 @@ import (
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
-var _ = Describe("Test Envoy configuration creation", func() {
-	marshal := func(someStruct interface{}) string {
-		jsonBytes, _ := json.MarshalIndent(someStruct, "-", "    ")
-		return string(jsonBytes)
-	}
+var _ = Describe("Test functions creating Envoy bootstrap configuration", func() {
+	const (
+		containerName = "-container-name-"
+		envoyImage    = "-envoy-image-"
+		nodeID        = "-node-id-"
+		clusterID     = "-cluster-id-"
 
-	getExpectedXDSClusterStruct := func() map[string]interface{} {
-		return map[string]interface{}{
-			"name":                   "osm-controller",
-			"connect_timeout":        "0.25s",
-			"type":                   "LOGICAL_DNS",
-			"http2_protocol_options": map[string]interface{}{},
-			"transport_socket": map[string]interface{}{
-				"name": "envoy.transport_sockets.tls",
-				"typed_config": map[string]interface{}{
-					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-					"common_tls_context": map[string]interface{}{
-						"alpn_protocols": []string{
-							"h2",
-						},
-						"validation_context": map[string]interface{}{
-							"trusted_ca": map[string]interface{}{
-								"inline_bytes": "eHg=",
-							},
-						},
-						"tls_params": map[string]interface{}{
-							"tls_minimum_protocol_version": "TLSv1_2",
-							"tls_maximum_protocol_version": "TLSv1_3",
-						},
-						"tls_certificates": []map[string]interface{}{
-							{
-								"certificate_chain": map[string]interface{}{
-									"inline_bytes": "eHg=",
-								},
-								"private_key": map[string]interface{}{
-									"inline_bytes": "eXk=",
-								},
-							},
-						},
-					},
-				}},
-			"load_assignment": map[string]interface{}{
-				"endpoints": []map[string]interface{}{
-					{
-						"lb_endpoints": []map[string]interface{}{
-							{
-								"endpoint": map[string]interface{}{
-									"address": map[string]interface{}{
-										"socket_address": map[string]interface{}{
-											"address":    "osm-controller.b.svc.cluster.local",
-											"port_value": 15128,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				"cluster_name": "osm-controller",
-			},
-		}
-	}
+		// This file contains the Bootstrap YAML generated for all of the Envoy proxies in OSM.
+		// This is provisioned by the MutatingWebhook during the addition of a sidecar
+		// to every new Pod that is being created in a namespace participating in the service mesh.
+		// We deliberately leave this entire string literal here to document and visualize what the
+		// generated YAML looks like!
+		expectedEnvoyBootstrapConfigFileName        = "expected_envoy_bootstrap_config.yaml"
+		actualGeneratedEnvoyBootstrapConfigFileName = "actual_envoy_bootstrap_config.yaml"
 
-	var (
-		mockCtrl         *gomock.Controller
-		mockConfigurator *configurator.MockConfigurator
+		expectedXDSClusterWithoutProbesFileName = "expected_xds_cluster_without_probes.yaml"
+		actualXDSClusterWithoutProbesFileName   = "actual_xds_cluster_without_probes.yaml"
+
+		expectedXDSClusterWithProbesFileName = "expected_xds_cluster_with_probes.yaml"
+		actualXDSClusterWithProbesFileName   = "actual_xds_cluster_with_probes.yaml"
+
+		expectedXDSStaticResourcesWithProbesFileName = "expected_xds_static_resources_with_probes.yaml"
+		actualXDSStaticResourcesWithProbesFileName   = "actual_xds_static_resources_with_probes.yaml"
+
+		// All the YAML files listed above are in this sub-directory
+		directoryForYAMLFiles = "test_fixtures"
 	)
 
-	// This is the Bootstrap YAML generated for the Envoy proxies.
-	// This is provisioned by the MutatingWebhook during the addition of a sidecar
-	// to every new Pod that is being created in a namespace participating in the service mesh.
-	// We deliberately leave this entire string literal here to document and visualize what the
-	// generated YAML looks like!
-	const expectedEnvoyConfig = `admin:
-  access_log_path: /dev/stdout
-  address:
-    socket_address:
-      address: 0.0.0.0
-      port_value: "15000"
-dynamic_resources:
-  ads_config:
-    api_type: GRPC
-    grpc_services:
-    - envoy_grpc:
-        cluster_name: osm-controller
-    set_node_on_first_message_only: true
-    transport_api_version: V3
-  cds_config:
-    ads: {}
-    resource_api_version: V3
-  lds_config:
-    ads: {}
-    resource_api_version: V3
-static_resources:
-  clusters:
-  - connect_timeout: 0.25s
-    http2_protocol_options: {}
-    load_assignment:
-      cluster_name: osm-controller
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: osm-controller.b.svc.cluster.local
-                port_value: 15128
-    name: osm-controller
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        common_tls_context:
-          alpn_protocols:
-          - h2
-          tls_certificates:
-          - certificate_chain:
-              inline_bytes: eHg=
-            private_key:
-              inline_bytes: eXk=
-          tls_params:
-            tls_maximum_protocol_version: TLSv1_3
-            tls_minimum_protocol_version: TLSv1_2
-          validation_context:
-            trusted_ca:
-              inline_bytes: eHg=
-    type: LOGICAL_DNS
-`
-
-	cert := tresor.NewFakeCertificate()
-
-	mockCtrl = gomock.NewController(GinkgoT())
-	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
-
-	config := envoyBootstrapConfigMeta{
-		RootCert: base64.StdEncoding.EncodeToString(cert.GetIssuingCA()),
-		Cert:     base64.StdEncoding.EncodeToString(cert.GetCertificateChain()),
-		Key:      base64.StdEncoding.EncodeToString(cert.GetPrivateKey()),
-
-		EnvoyAdminPort: 15000,
-
-		XDSClusterName: "osm-controller",
-		XDSHost:        "osm-controller.b.svc.cluster.local",
-		XDSPort:        15128,
-	}
-
-	Context("create envoy config", func() {
-		It("creates envoy config", func() {
-			actual, err := getEnvoyConfigYAML(config, mockConfigurator)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(string(actual)).To(Equal(expectedEnvoyConfig),
-				fmt.Sprintf("Expected:\n%s\nActual:\n%s\n", expectedEnvoyConfig, string(actual)))
-		})
-
-		It("Creates bootstrap config for the Envoy proxy", func() {
-			wh := &mutatingWebhook{
-				kubeClient:          fake.NewSimpleClientset(),
-				kubeController:      k8s.NewMockController(gomock.NewController(GinkgoT())),
-				nonInjectNamespaces: mapset.NewSet(),
-			}
-			name := uuid.New().String()
-			namespace := "a"
-			osmNamespace := "b"
-
-			secret, err := wh.createEnvoyBootstrapConfig(name, namespace, osmNamespace, cert, healthProbes{})
-			Expect(err).ToNot(HaveOccurred())
-
-			expected := corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-				},
-				Data: map[string][]byte{
-					envoyBootstrapConfigFile: []byte(expectedEnvoyConfig),
-				},
-			}
-
-			// Contains only the "bootstrap.yaml" key
-			Expect(len(secret.Data)).To(Equal(1))
-
-			Expect(secret.Data[envoyBootstrapConfigFile]).To(Equal(expected.Data[envoyBootstrapConfigFile]),
-				fmt.Sprintf("Expected YAML: %s;\nActual YAML: %s\n", expected.Data, secret.Data))
-
-			// Now check the entire struct
-			Expect(*secret).To(Equal(expected))
-		})
-	})
-
-	Context("Test getStaticResources()", func() {
-		It("Creates static_resources Envoy struct", func() {
-			actual := getXdsCluster(config)
-			expected := getExpectedXDSClusterStruct()
-
-			expectedJSON := marshal(expected)
-			actualJSON := marshal(actual)
-
-			Expect(actualJSON).To(Equal(expectedJSON), fmt.Sprintf("Expected: %s\nActual struct: %s", expectedJSON, actualJSON))
-		})
-	})
-
-	Context("Test getStaticResources()", func() {
-		It("Creates static_resources Envoy struct", func() {
-			actual := getStaticResources(config)
-			expected := map[string]interface{}{
-				"clusters": []map[string]interface{}{
-					getExpectedXDSClusterStruct(),
-				},
-			}
-
-			expectedJSON := marshal(expected)
-			actualJSON := marshal(actual)
-
-			Expect(actualJSON).To(Equal(expectedJSON), fmt.Sprintf("Expected: %s\nActual struct: %s", expectedJSON, actualJSON))
-		})
-	})
-})
-
-var _ = Describe("Test Envoy sidecar", func() {
 	isTrue := true
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -259,15 +72,173 @@ var _ = Describe("Test Envoy sidecar", func() {
 			ServiceAccountName: "svcacc",
 		},
 	}
-	const envoyImage = "-envoy-image-"
 
+	cert := tresor.NewFakeCertificate()
 	mockCtrl := gomock.NewController(GinkgoT())
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
-	Context("create Envoy sidecar", func() {
-		It("creates correct Envoy sidecar spec", func() {
+	originalHealthProbes := healthProbes{
+		liveness:  &healthProbe{path: "/liveness", port: 81},
+		readiness: &healthProbe{path: "/readiness", port: 82},
+		startup:   &healthProbe{path: "/startup", port: 83},
+	}
+
+	expectedRewrittenContainerPorts := []corev1.ContainerPort{
+		{Name: "proxy-admin", HostPort: 0, ContainerPort: 15000, Protocol: "", HostIP: ""},
+		{Name: "proxy-inbound", HostPort: 0, ContainerPort: 15003, Protocol: "", HostIP: ""},
+		{Name: "proxy-metrics", HostPort: 0, ContainerPort: 15010, Protocol: "", HostIP: ""},
+		{Name: "liveness-port", HostPort: 0, ContainerPort: 15901, Protocol: "", HostIP: ""},
+		{Name: "readiness-port", HostPort: 0, ContainerPort: 15902, Protocol: "", HostIP: ""},
+		{Name: "startup-port", HostPort: 0, ContainerPort: 15903, Protocol: "", HostIP: ""},
+	}
+
+	getExpectedEnvoyYAML := func(filename string) string {
+		expectedEnvoyConfig, err := ioutil.ReadFile(filepath.Clean(path.Join(directoryForYAMLFiles, filename)))
+		if err != nil {
+			log.Err(err).Msgf("Error reading expected Envoy bootstrap YAML from file %s", filename)
+		}
+		Expect(err).ToNot(HaveOccurred())
+		return string(expectedEnvoyConfig)
+	}
+
+	saveActualEnvoyYAML := func(filename string, actualContent []byte) {
+		err := ioutil.WriteFile(filepath.Clean(path.Join(directoryForYAMLFiles, filename)), actualContent, 0600)
+		if err != nil {
+			log.Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filename)
+		}
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	marshalAndSaveToFile := func(someStruct interface{}, filename string) string {
+		yamlBytes, err := yaml.Marshal(someStruct)
+		Expect(err).ToNot(HaveOccurred())
+		saveActualEnvoyYAML(filename, yamlBytes)
+		return string(yamlBytes)
+	}
+
+	probes := healthProbes{
+		liveness:  &healthProbe{path: "/liveness", port: 81},
+		readiness: &healthProbe{path: "/readiness", port: 82},
+		startup:   &healthProbe{path: "/startup", port: 83},
+	}
+
+	config := envoyBootstrapConfigMeta{
+		RootCert: base64.StdEncoding.EncodeToString(cert.GetIssuingCA()),
+		Cert:     base64.StdEncoding.EncodeToString(cert.GetCertificateChain()),
+		Key:      base64.StdEncoding.EncodeToString(cert.GetPrivateKey()),
+
+		EnvoyAdminPort: 15000,
+
+		XDSClusterName: "osm-controller",
+		XDSHost:        "osm-controller.b.svc.cluster.local",
+		XDSPort:        15128,
+
+		OriginalHealthProbes: probes,
+	}
+
+	Context("Test getEnvoyConfigYAML()", func() {
+		It("creates Envoy bootstrap config", func() {
+			config.OriginalHealthProbes = probes
+			actual, err := getEnvoyConfigYAML(config, mockConfigurator)
+			Expect(err).ToNot(HaveOccurred())
+			saveActualEnvoyYAML(actualGeneratedEnvoyBootstrapConfigFileName, actual)
+
+			expectedEnvoyConfig := getExpectedEnvoyYAML(expectedEnvoyBootstrapConfigFileName)
+
+			Expect(string(actual)).To(Equal(expectedEnvoyConfig),
+				fmt.Sprintf("Compare files %s and %s\nExpected:\n%s\nActual:\n%s\n",
+					expectedEnvoyBootstrapConfigFileName, actualGeneratedEnvoyBootstrapConfigFileName, expectedEnvoyConfig, string(actual)))
+		})
+
+		It("Creates bootstrap config for the Envoy proxy", func() {
+			wh := &mutatingWebhook{
+				kubeClient:          fake.NewSimpleClientset(),
+				kubeController:      k8s.NewMockController(gomock.NewController(GinkgoT())),
+				nonInjectNamespaces: mapset.NewSet(),
+			}
+			name := uuid.New().String()
+			namespace := "a"
+			osmNamespace := "b"
+
+			secret, err := wh.createEnvoyBootstrapConfig(name, namespace, osmNamespace, cert, probes)
+			Expect(err).ToNot(HaveOccurred())
+
+			expected := corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Data: map[string][]byte{
+					envoyBootstrapConfigFile: []byte(getExpectedEnvoyYAML(expectedEnvoyBootstrapConfigFileName)),
+				},
+			}
+
+			// Contains only the "bootstrap.yaml" key
+			Expect(len(secret.Data)).To(Equal(1))
+
+			Expect(secret.Data[envoyBootstrapConfigFile]).To(Equal(expected.Data[envoyBootstrapConfigFile]),
+				fmt.Sprintf("Expected YAML: %s;\nActual YAML: %s\n", expected.Data, secret.Data))
+
+			// Now check the entire struct
+			Expect(*secret).To(Equal(expected))
+		})
+	})
+
+	Context("Test getXdsCluster()", func() {
+		It("creates XDS Cluster struct without health probes", func() {
+			config.OriginalHealthProbes = probes
+			actual := getXdsCluster(config)
+
+			// The "marshalAndSaveToFile" function converts the complex struct into a human readable text, which helps us spot the
+			// difference when there is a discrepancy.
+			expectedYAML := getExpectedEnvoyYAML(expectedXDSClusterWithoutProbesFileName)
+			actualYAML := marshalAndSaveToFile(actual, actualXDSClusterWithoutProbesFileName)
+
+			Expect(actualYAML).To(Equal(expectedYAML),
+				fmt.Sprintf("Compare files %s and %s\nExpected: %s\nActual struct: %s",
+					expectedXDSClusterWithoutProbesFileName, actualXDSClusterWithoutProbesFileName, expectedYAML, actualYAML))
+		})
+
+		It("creates XDS Cluster struct with health probes", func() {
+			config.OriginalHealthProbes = probes
+			actual := getXdsCluster(config)
+
+			// The "marshalAndSaveToFile" function converts the complex struct into a human readable text, which helps us spot the
+			// difference when there is a discrepancy.
+			expectedYAML := getExpectedEnvoyYAML(expectedXDSClusterWithProbesFileName)
+			actualYAML := marshalAndSaveToFile(actual, actualXDSClusterWithProbesFileName)
+
+			Expect(actualYAML).To(Equal(expectedYAML),
+				fmt.Sprintf("Compare files %s and %s\nExpected: %s\nActual struct: %s",
+					expectedXDSClusterWithProbesFileName, actualXDSClusterWithProbesFileName, expectedYAML, actualYAML))
+		})
+	})
+
+	Context("Test getStaticResources()", func() {
+		It("Creates static_resources Envoy struct", func() {
+			config.OriginalHealthProbes = healthProbes{}
+			actual := getStaticResources(config)
+
+			expectedYAML := getExpectedEnvoyYAML(expectedXDSStaticResourcesWithProbesFileName)
+			actualYAML := marshalAndSaveToFile(actual, actualXDSStaticResourcesWithProbesFileName)
+
+			Expect(actualYAML).To(Equal(expectedYAML),
+				fmt.Sprintf("Compare files %s and %s\nExpected: %s\nActual struct: %s",
+					expectedXDSStaticResourcesWithProbesFileName, actualXDSStaticResourcesWithProbesFileName, expectedYAML, actualYAML))
+		})
+	})
+
+	Context("Test getEnvoyContainerPorts()", func() {
+		It("creates container port list", func() {
+			actualRewrittenContainerPorts := getEnvoyContainerPorts(originalHealthProbes)
+			Expect(actualRewrittenContainerPorts).To(Equal(expectedRewrittenContainerPorts))
+		})
+	})
+
+	Context("test getEnvoySidecarContainerSpec()", func() {
+		It("creates Envoy sidecar spec", func() {
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("debug").Times(1)
-			actual := getEnvoySidecarContainerSpec(pod, envoyImage, mockConfigurator, healthProbes{})
+			actual := getEnvoySidecarContainerSpec(pod, envoyImage, mockConfigurator, originalHealthProbes)
 
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,
@@ -279,20 +250,7 @@ var _ = Describe("Test Envoy sidecar", func() {
 						return &uid
 					}(),
 				},
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          constants.EnvoyAdminPortName,
-						ContainerPort: constants.EnvoyAdminPort,
-					},
-					{
-						Name:          constants.EnvoyInboundListenerPortName,
-						ContainerPort: constants.EnvoyInboundListenerPort,
-					},
-					{
-						Name:          constants.EnvoyInboundPrometheusListenerPortName,
-						ContainerPort: constants.EnvoyPrometheusInboundListenerPort,
-					},
-				},
+				Ports: expectedRewrittenContainerPorts,
 				VolumeMounts: []corev1.VolumeMount{
 					{
 						Name:      envoyBootstrapConfigVolume,
@@ -378,6 +336,7 @@ var _ = Describe("Test Envoy sidecar", func() {
 					},
 				},
 			}
+
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/injector/test_fixtures/.gitignore
+++ b/pkg/injector/test_fixtures/.gitignore
@@ -1,0 +1,4 @@
+actual_envoy_bootstrap_config.yaml
+actual_xds_cluster_without_probes.yaml
+actual_xds_cluster_with_probes.yaml
+actual_xds_static_resources_with_probes.yaml

--- a/pkg/injector/test_fixtures/README.md
+++ b/pkg/injector/test_fixtures/README.md
@@ -1,0 +1,1 @@
+This directory contains YAML files used for testing functions generating Envoy bootstrap XDS config.

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -1,0 +1,249 @@
+admin:
+  access_log_path: /dev/stdout
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: "15000"
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: osm-controller
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+static_resources:
+  clusters:
+  - connect_timeout: 0.25s
+    http2_protocol_options: {}
+    load_assignment:
+      cluster_name: osm-controller
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: osm-controller.b.svc.cluster.local
+                port_value: 15128
+    name: osm-controller
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          alpn_protocols:
+          - h2
+          tls_certificates:
+          - certificate_chain:
+              inline_bytes: eHg=
+            private_key:
+              inline_bytes: eXk=
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+            tls_minimum_protocol_version: TLSv1_2
+          validation_context:
+            trusted_ca:
+              inline_bytes: eHg=
+    type: LOGICAL_DNS
+  - connect_timeout: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: liveness_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 81
+    name: liveness_cluster
+    type: STATIC
+  - connect_timeout: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: readiness_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 82
+    name: readiness_cluster
+    type: STATIC
+  - connect_timeout: 1s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: startup_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 0.0.0.0
+                port_value: 83
+    name: startup_cluster
+    type: STATIC
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 15901
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              log_format:
+                json_format:
+                  authority: '%REQ(:AUTHORITY)%'
+                  bytes_received: '%BYTES_RECEIVED%'
+                  bytes_sent: '%BYTES_SENT%'
+                  duration: '%DURATION%'
+                  method: '%REQ(:METHOD)%'
+                  path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+                  protocol: '%PROTOCOL%'
+                  request_id: '%REQ(X-REQUEST-ID)%'
+                  requested_server_name: '%REQUESTED_SERVER_NAME%'
+                  response_code: '%RESPONSE_CODE%'
+                  response_code_details: '%RESPONSE_CODE_DETAILS%'
+                  response_flags: '%RESPONSE_FLAGS%'
+                  start_time: '%START_TIME%'
+                  time_to_first_byte: '%RESPONSE_DURATION%'
+                  upstream_cluster: '%UPSTREAM_CLUSTER%'
+                  upstream_host: '%UPSTREAM_HOST%'
+                  upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
+                  user_agent: '%REQ(USER-AGENT)%'
+                  x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
+              path: /dev/stdout
+          codec_type: AUTO
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: local_service
+              routes:
+              - match:
+                  prefix: /osm-liveness-probe
+                route:
+                  cluster: liveness_cluster
+                  prefix_rewrite: /liveness
+          stat_prefix: health_probes_http
+    name: liveness_listener
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 15902
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              log_format:
+                json_format:
+                  authority: '%REQ(:AUTHORITY)%'
+                  bytes_received: '%BYTES_RECEIVED%'
+                  bytes_sent: '%BYTES_SENT%'
+                  duration: '%DURATION%'
+                  method: '%REQ(:METHOD)%'
+                  path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+                  protocol: '%PROTOCOL%'
+                  request_id: '%REQ(X-REQUEST-ID)%'
+                  requested_server_name: '%REQUESTED_SERVER_NAME%'
+                  response_code: '%RESPONSE_CODE%'
+                  response_code_details: '%RESPONSE_CODE_DETAILS%'
+                  response_flags: '%RESPONSE_FLAGS%'
+                  start_time: '%START_TIME%'
+                  time_to_first_byte: '%RESPONSE_DURATION%'
+                  upstream_cluster: '%UPSTREAM_CLUSTER%'
+                  upstream_host: '%UPSTREAM_HOST%'
+                  upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
+                  user_agent: '%REQ(USER-AGENT)%'
+                  x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
+              path: /dev/stdout
+          codec_type: AUTO
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: local_service
+              routes:
+              - match:
+                  prefix: /osm-readiness-probe
+                route:
+                  cluster: readiness_cluster
+                  prefix_rewrite: /readiness
+          stat_prefix: health_probes_http
+    name: readiness_listener
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 15903
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              log_format:
+                json_format:
+                  authority: '%REQ(:AUTHORITY)%'
+                  bytes_received: '%BYTES_RECEIVED%'
+                  bytes_sent: '%BYTES_SENT%'
+                  duration: '%DURATION%'
+                  method: '%REQ(:METHOD)%'
+                  path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+                  protocol: '%PROTOCOL%'
+                  request_id: '%REQ(X-REQUEST-ID)%'
+                  requested_server_name: '%REQUESTED_SERVER_NAME%'
+                  response_code: '%RESPONSE_CODE%'
+                  response_code_details: '%RESPONSE_CODE_DETAILS%'
+                  response_flags: '%RESPONSE_FLAGS%'
+                  start_time: '%START_TIME%'
+                  time_to_first_byte: '%RESPONSE_DURATION%'
+                  upstream_cluster: '%UPSTREAM_CLUSTER%'
+                  upstream_host: '%UPSTREAM_HOST%'
+                  upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
+                  user_agent: '%REQ(USER-AGENT)%'
+                  x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
+              path: /dev/stdout
+          codec_type: AUTO
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - domains:
+              - '*'
+              name: local_service
+              routes:
+              - match:
+                  prefix: /osm-startup-probe
+                route:
+                  cluster: startup_cluster
+                  prefix_rewrite: /startup
+          stat_prefix: health_probes_http
+    name: startup_listener

--- a/pkg/injector/test_fixtures/expected_xds_cluster_with_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_cluster_with_probes.yaml
@@ -1,0 +1,31 @@
+connect_timeout: 0.25s
+http2_protocol_options: {}
+load_assignment:
+  cluster_name: osm-controller
+  endpoints:
+  - lb_endpoints:
+    - endpoint:
+        address:
+          socket_address:
+            address: osm-controller.b.svc.cluster.local
+            port_value: 15128
+name: osm-controller
+transport_socket:
+  name: envoy.transport_sockets.tls
+  typed_config:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    common_tls_context:
+      alpn_protocols:
+      - h2
+      tls_certificates:
+      - certificate_chain:
+          inline_bytes: eHg=
+        private_key:
+          inline_bytes: eXk=
+      tls_params:
+        tls_maximum_protocol_version: TLSv1_3
+        tls_minimum_protocol_version: TLSv1_2
+      validation_context:
+        trusted_ca:
+          inline_bytes: eHg=
+type: LOGICAL_DNS

--- a/pkg/injector/test_fixtures/expected_xds_cluster_without_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_cluster_without_probes.yaml
@@ -1,0 +1,31 @@
+connect_timeout: 0.25s
+http2_protocol_options: {}
+load_assignment:
+  cluster_name: osm-controller
+  endpoints:
+  - lb_endpoints:
+    - endpoint:
+        address:
+          socket_address:
+            address: osm-controller.b.svc.cluster.local
+            port_value: 15128
+name: osm-controller
+transport_socket:
+  name: envoy.transport_sockets.tls
+  typed_config:
+    '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+    common_tls_context:
+      alpn_protocols:
+      - h2
+      tls_certificates:
+      - certificate_chain:
+          inline_bytes: eHg=
+        private_key:
+          inline_bytes: eXk=
+      tls_params:
+        tls_maximum_protocol_version: TLSv1_3
+        tls_minimum_protocol_version: TLSv1_2
+      validation_context:
+        trusted_ca:
+          inline_bytes: eHg=
+type: LOGICAL_DNS

--- a/pkg/injector/test_fixtures/expected_xds_static_resources_with_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_static_resources_with_probes.yaml
@@ -1,0 +1,32 @@
+clusters:
+- connect_timeout: 0.25s
+  http2_protocol_options: {}
+  load_assignment:
+    cluster_name: osm-controller
+    endpoints:
+    - lb_endpoints:
+      - endpoint:
+          address:
+            socket_address:
+              address: osm-controller.b.svc.cluster.local
+              port_value: 15128
+  name: osm-controller
+  transport_socket:
+    name: envoy.transport_sockets.tls
+    typed_config:
+      '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+      common_tls_context:
+        alpn_protocols:
+        - h2
+        tls_certificates:
+        - certificate_chain:
+            inline_bytes: eHg=
+          private_key:
+            inline_bytes: eXk=
+        tls_params:
+          tls_maximum_protocol_version: TLSv1_3
+          tls_minimum_protocol_version: TLSv1_2
+        validation_context:
+          trusted_ca:
+            inline_bytes: eHg=
+  type: LOGICAL_DNS


### PR DESCRIPTION
This PR adds unit tests for the Pod payload rewrite functions added with https://github.com/openservicemesh/osm/pull/2233

The functions tested here mostly generate Envoy YAML config.  For that reason - I added a helper function to marshal the structs and compare them with expectations saved in YAML files in this repo.

I believe having the expected YAML in a file makes it 
  a) easy to load and compare the output of the functions (vs in code) and 
  b) documents the Envoy config we'd ship to enable health probes through Envoy


This PR is stacked on https://github.com/openservicemesh/osm/pull/2233 (it contains the changes from https://github.com/openservicemesh/osm/pull/2233)

---

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
