### PR TITLE
metrics: expose metrics for number of connected proxies

### DIFF
--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -21,6 +21,12 @@ type MetricsStore struct {
 	// K8sAPIEventCounter is the metric counter for the number of K8s API events
 	K8sAPIEventCounter prometheus.Counter
 
+	/*
+	 * Proxy metrics
+	 */
+	// ProxyConnectCount is the metric for the total number of proxies connected to the controller
+	ProxyConnectCount prometheus.Gauge
+
 	// MetricsStore internals should be defined below --------
 	registry *prometheus.Registry
 }
@@ -31,11 +37,24 @@ var defaultMetricsStore MetricsStore
 var DefaultMetricsStore = &defaultMetricsStore
 
 func init() {
+	/*
+	 * K8s metrics
+	 */
 	defaultMetricsStore.K8sAPIEventCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metricsRootNamespace,
 		Subsystem: "k8s",
 		Name:      "api_event_count",
-		Help:      "This counter represents the number of events received from the Kubernetes API Server",
+		Help:      "represents the number of events received from the Kubernetes API Server",
+	})
+
+	/*
+	 * Proxy metrics
+	 */
+	defaultMetricsStore.ProxyConnectCount = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "connect_count",
+		Help:      "represents the number of proxies connected to OSM controller",
 	})
 
 	defaultMetricsStore.registry = prometheus.NewRegistry()
@@ -44,11 +63,13 @@ func init() {
 // Start store
 func (ms *MetricsStore) Start() {
 	ms.registry.MustRegister(ms.K8sAPIEventCounter)
+	ms.registry.MustRegister(ms.ProxyConnectCount)
 }
 
 // Stop store
 func (ms *MetricsStore) Stop() {
 	ms.registry.Unregister(ms.K8sAPIEventCounter)
+	ms.registry.Unregister(ms.ProxyConnectCount)
 }
 
 // Handler return the registry

--- a/pkg/metricsstore/metricsstore_test.go
+++ b/pkg/metricsstore/metricsstore_test.go
@@ -43,10 +43,40 @@ func TestK8sAPIEventCounter(t *testing.T) {
 
 		assert.Equal(http.StatusOK, rr.Code)
 
-		expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count This counter represents the number of events received from the Kubernetes API Server
+		expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count represents the number of events received from the Kubernetes API Server
 # TYPE osm_k8s_api_event_count counter
 osm_k8s_api_event_count %d
 `, i /* api event count */)
 		assert.Contains(rr.Body.String(), expectedResp)
 	}
+}
+
+func TestProxyConnectCount(t *testing.T) {
+	assert := tassert.New(t)
+
+	proxiesConnected := 5
+	proxiesDisconnected := 2
+
+	for i := 1; i <= proxiesConnected; i++ {
+		DefaultMetricsStore.ProxyConnectCount.Inc()
+	}
+	for i := 1; i <= proxiesDisconnected; i++ {
+		DefaultMetricsStore.ProxyConnectCount.Dec()
+	}
+
+	handler := DefaultMetricsStore.Handler()
+
+	req, err := http.NewRequest("GET", "/metrics", nil)
+	assert.Nil(err)
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(http.StatusOK, rr.Code)
+
+	expectedResp := fmt.Sprintf(`# HELP osm_proxy_connect_count represents the number of proxies connected to OSM controller
+# TYPE osm_proxy_connect_count gauge
+osm_proxy_connect_count %d
+`, proxiesConnected-proxiesDisconnected)
+	assert.Contains(rr.Body.String(), expectedResp)
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds a metric for the number of connected proxies.

Part of #902

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`