### PR TITLE
metrics: add injector webhook metrics

### DIFF
--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -1,32 +1,43 @@
 package injector
 
 import (
+	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/openservicemesh/osm/pkg/metricsstore"
+)
+
+var (
+	defaultK8sTimeout = time.Duration(30 * time.Second)
 )
 
 // Helper to parse timeout variable from webhook URL
-func readTimeout(req *http.Request) (*time.Duration, error) {
+func readTimeout(req *http.Request) (time.Duration, error) {
 	durationValue, found := req.URL.Query()[webhookMutateTimeoutKey]
 	if !found || len(durationValue) != 1 {
 		log.Error().Msgf("Webhook timeout value not found in request")
-		return nil, errParseWebhookTimeout
+		return defaultK8sTimeout, errParseWebhookTimeout
 	}
 
 	val, err := time.ParseDuration(durationValue[0])
 	if err != nil {
 		log.Error().Msgf("Error parsing timeout value as duration: %v", err)
-		return nil, errParseWebhookTimeout
+		return defaultK8sTimeout, errParseWebhookTimeout
 	}
-	return &val, nil
+	return val, nil
 }
 
 // Time tracking function for webhook processing.
 // Will calculate elapsed time since start and log debug how much time spent executing
-func webhookTimeTrack(start time.Time, timeout time.Duration) {
+func webhookTimeTrack(start time.Time, timeout time.Duration, success *bool) {
 	elapsed := time.Since(start)
 	percentOfTimeout := float64(elapsed.Microseconds()) / float64(timeout.Microseconds())
 
 	log.Debug().Msgf("Mutate Webhook took %v to execute (%.2f of it's timeout, %v)",
 		elapsed, percentOfTimeout, timeout)
+
+	metricsstore.DefaultMetricsStore.InjectorSidecarCount.Inc()
+	metricsstore.DefaultMetricsStore.InjectorRqTime.
+		WithLabelValues(fmt.Sprintf("%t", *success)).Observe(elapsed.Seconds())
 }

--- a/pkg/injector/profiling_test.go
+++ b/pkg/injector/profiling_test.go
@@ -43,13 +43,15 @@ func TestDeferredWebhookLogging(t *testing.T) {
 	logsave := log
 	var b bytes.Buffer
 	log = log.Output(&b)
+	success := false
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		timeout, _ := time.ParseDuration("30s")
-		defer webhookTimeTrack(time.Now(), timeout)
+		timeout := time.Duration(30 * time.Second)
+
+		defer webhookTimeTrack(time.Now(), timeout, &success)
 
 		time.Sleep(100 * time.Millisecond)
 	}()

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -82,7 +82,7 @@ func init() {
 			Subsystem: "injector",
 			Name:      "injector_rq_time",
 			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40},
-			Help:      "Histogram for time taken to process an injector webhooks",
+			Help:      "Histogram for time taken to perform sidecar injection",
 		},
 		[]string{
 			"success",

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -27,6 +27,15 @@ type MetricsStore struct {
 	// ProxyConnectCount is the metric for the total number of proxies connected to the controller
 	ProxyConnectCount prometheus.Gauge
 
+	/*
+	 * Injector metrics
+	 */
+	// InjectorSidecarCount counts the number of injector webhooks dealt with over time
+	InjectorSidecarCount prometheus.Counter
+
+	// InjectorRqTime the histogram to track times for the injector webhook calls
+	InjectorRqTime *prometheus.HistogramVec
+
 	// MetricsStore internals should be defined below --------
 	registry *prometheus.Registry
 }
@@ -57,6 +66,28 @@ func init() {
 		Help:      "represents the number of proxies connected to OSM controller",
 	})
 
+	/*
+	 * Injector metrics
+	 */
+	defaultMetricsStore.InjectorSidecarCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "injector",
+		Name:      "injector_sidecar_count",
+		Help:      "Counts the number of injector webhooks dealt with over time",
+	})
+
+	defaultMetricsStore.InjectorRqTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metricsRootNamespace,
+			Subsystem: "injector",
+			Name:      "injector_rq_time",
+			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+			Help:      "Histogram for time taken to process an injector webhooks",
+		},
+		[]string{
+			"success",
+		})
+
 	defaultMetricsStore.registry = prometheus.NewRegistry()
 }
 
@@ -64,12 +95,16 @@ func init() {
 func (ms *MetricsStore) Start() {
 	ms.registry.MustRegister(ms.K8sAPIEventCounter)
 	ms.registry.MustRegister(ms.ProxyConnectCount)
+	ms.registry.MustRegister(ms.InjectorSidecarCount)
+	ms.registry.MustRegister(ms.InjectorRqTime)
 }
 
 // Stop store
 func (ms *MetricsStore) Stop() {
 	ms.registry.Unregister(ms.K8sAPIEventCounter)
 	ms.registry.Unregister(ms.ProxyConnectCount)
+	ms.registry.Unregister(ms.InjectorSidecarCount)
+	ms.registry.Unregister(ms.InjectorRqTime)
 }
 
 // Handler return the registry


### PR DESCRIPTION
Adds two new metrics:
- InjectorSidecarCount: keeps track of number of sidecar injector webhooks
dealt over time.
- InjectorRqTime: time taken to process injector webhooks

**Affected area**:

- Metrics                [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No