### PR TITLE
metrics: add type and namespace label to k8s event metric

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -25,6 +25,12 @@ type EventTypes struct {
 	Delete a.AnnouncementType
 }
 
+const (
+	addEvent    = "add"
+	deleteEvent = "delete"
+	updateEvent = "update"
+)
+
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
 func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve observeFilter, eventTypes EventTypes) cache.ResourceEventHandlerFuncs {
 	if shouldObserve == nil {
@@ -42,7 +48,8 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				NewObj:           obj,
 				OldObj:           nil,
 			})
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.Inc()
+			ns := getNamespace(obj)
+			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(addEvent, ns).Inc()
 		},
 
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -55,7 +62,8 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				NewObj:           oldObj,
 				OldObj:           newObj,
 			})
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.Inc()
+			ns := getNamespace(newObj)
+			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(updateEvent, ns).Inc()
 		},
 
 		DeleteFunc: func(obj interface{}) {
@@ -68,7 +76,8 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				NewObj:           nil,
 				OldObj:           obj,
 			})
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.Inc()
+			ns := getNamespace(obj)
+			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(deleteEvent, ns).Inc()
 		},
 	}
 }

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -19,7 +19,7 @@ type MetricsStore struct {
 	 * K8s metrics
 	 */
 	// K8sAPIEventCounter is the metric counter for the number of K8s API events
-	K8sAPIEventCounter prometheus.Counter
+	K8sAPIEventCounter *prometheus.CounterVec
 
 	/*
 	 * Proxy metrics
@@ -36,7 +36,9 @@ type MetricsStore struct {
 	// InjectorRqTime the histogram to track times for the injector webhook calls
 	InjectorRqTime *prometheus.HistogramVec
 
-	// MetricsStore internals should be defined below --------
+	/*
+	 * MetricsStore internals should be defined below --------------
+	 */
 	registry *prometheus.Registry
 }
 
@@ -49,12 +51,15 @@ func init() {
 	/*
 	 * K8s metrics
 	 */
-	defaultMetricsStore.K8sAPIEventCounter = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "k8s",
-		Name:      "api_event_count",
-		Help:      "represents the number of events received from the Kubernetes API Server",
-	})
+	defaultMetricsStore.K8sAPIEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricsRootNamespace,
+			Subsystem: "k8s",
+			Name:      "api_event_count",
+			Help:      "represents the number of events received from the Kubernetes API Server",
+		},
+		[]string{"type", "namespace"},
+	)
 
 	/*
 	 * Proxy metrics

--- a/pkg/metricsstore/metricsstore_test.go
+++ b/pkg/metricsstore/metricsstore_test.go
@@ -28,10 +28,10 @@ func teardown() {
 func TestK8sAPIEventCounter(t *testing.T) {
 	assert := tassert.New(t)
 
-	apiEventCount := 5
+	apiEventCount := 3
 
 	for i := 1; i <= apiEventCount; i++ {
-		DefaultMetricsStore.K8sAPIEventCounter.Inc()
+		DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues("add", "foo").Inc()
 
 		handler := DefaultMetricsStore.Handler()
 
@@ -45,7 +45,7 @@ func TestK8sAPIEventCounter(t *testing.T) {
 
 		expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count represents the number of events received from the Kubernetes API Server
 # TYPE osm_k8s_api_event_count counter
-osm_k8s_api_event_count %d
+osm_k8s_api_event_count{namespace="foo",type="add"} %d
 `, i /* api event count */)
 		assert.Contains(rr.Body.String(), expectedResp)
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change changes the osm_k8s_api_event_count metric to be
a counter vector so that the counters can be grouped as a counter
collection sharing the same description with variable labels.

Part of #902

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
