### PR TITLE
envoy: update to v1.17 to leverage default_filter_chain matching

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -49,7 +49,7 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` |  |
 | OpenServiceMesh.replicaCount | int | `1` |  |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` |  |
-| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.15.0"` |  |
+| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.0"` |  |
 | OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` |  |
 | OpenServiceMesh.tracing.enable | bool | `true` |  |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` |  |

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -32,8 +32,8 @@
                 "envoyLogLevel",
                 "enforceSingleMesh",
                 "deployJaeger",
-                "tracing", 
-                "webhookConfigNamePrefix", 
+                "tracing",
+                "webhookConfigNamePrefix",
                 "connectVault"
             ],
             "properties": {
@@ -101,7 +101,7 @@
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
                     "examples": [
-                        "envoyproxy/envoy-alpine:v1.15.0"
+                        "envoyproxy/envoy-alpine:v1.17.0"
                     ]
                 },
                 "certificateManager": {
@@ -391,7 +391,7 @@
                         }
                     },
                     "additionalProperties": true
-                }, 
+                },
                 "webhookConfigNamePrefix": {
                     "$id": "#/properties/OpenServiceMesh/properties/webhookConfigNamePrefix",
                     "type": "string",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -8,7 +8,7 @@ OpenServiceMesh:
     pullPolicy: IfNotPresent
     tag: v0.6.1
   imagePullSecrets: []
-  sidecarImage: envoyproxy/envoy-alpine:v1.15.0
+  sidecarImage: envoyproxy/envoy-alpine:v1.17.0
   prometheus:
     port: 7070
     retention:
@@ -57,7 +57,7 @@ OpenServiceMesh:
   enforceSingleMesh: false
   webhookConfigNamePrefix: osm-webhook
 
-  # Optional parameter. If not specified, the release namespace is 
+  # Optional parameter. If not specified, the release namespace is
   # used to deploy the osm components.
   osmNamespace: ""
 

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,11 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.1.0
 	github.com/Azure/go-autorest/autorest/to v0.3.0
 	github.com/axw/gocov v1.0.0
-	github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354 // indirect
 	github.com/cskr/pubsub v1.0.2
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/dustin/go-humanize v1.0.0
-	github.com/envoyproxy/go-control-plane v0.9.6
+	github.com/envoyproxy/go-control-plane v0.9.8
 	github.com/fatih/color v1.10.0
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -152,10 +152,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.8.5/go.mod h1:8KhU6K+zHUEWOSU++mEQYf7D9UZOcQcibUoSm6vCUz4=
-github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533 h1:8wZizuKuZVu5COB7EsBYxBQz8nRcXXn5d4Gt91eJLvU=
-github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354 h1:9kRtNpqLHbZVO/NNxhHp2ymxFxsHOe3x2efJGn//Tas=
-github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
+github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f h1:tSNMc+rJDfmYntojat8lljbt1mgKNpTxUZJsSzJ9Y1s=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
@@ -250,8 +248,8 @@ github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.6 h1:GgblEiDzxf5ajlAZY4aC8xp7DwkrGfauFNMGdB2bBv0=
-github.com/envoyproxy/go-control-plane v0.9.6/go.mod h1:GFqM7v0B62MraO4PWRedIbhThr/Rf7ev6aHOOPXeaDA=
+github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
+github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -44,6 +44,8 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		log.Error().Err(err).Msgf("Error making outbound listener config for proxy %s", proxyServiceName)
 	} else {
 		if outboundListener == nil {
+			// This check is important to prevent attempting to configure a listener without a filter chain which
+			// otherwise results in an error.
 			log.Debug().Msgf("Not programming Outbound listener for proxy %s", proxyServiceName)
 		} else {
 			if marshalledOutbound, err := ptypes.MarshalAny(outboundListener); err != nil {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently the egress filter chain is a part of `listener.filter_chains`
config. While this works for now, there is the risk of egress traffic
matching in-mesh filter chains due to the way envoy performs
filter chain matching as we augment the service filter chains
with additional match criteria such as ports. The `listener.default_filter_chain` 
was specifically introduced to avoid such unintentional matching.

This is also required to be able to do port:protocol matching
on the oundbound filter chains with the introduction of TCP
support to distinguish between protocol specific traffic by
its port.

Resolves #2096

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`