### PR TITLE
metrics: use event type value as the metric label

### DIFF
--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -25,12 +25,6 @@ type EventTypes struct {
 	Delete a.AnnouncementType
 }
 
-const (
-	addEvent    = "add"
-	deleteEvent = "delete"
-	updateEvent = "update"
-)
-
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
 func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve observeFilter, eventTypes EventTypes) cache.ResourceEventHandlerFuncs {
 	if shouldObserve == nil {
@@ -49,7 +43,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				OldObj:           nil,
 			})
 			ns := getNamespace(obj)
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(addEvent, ns).Inc()
+			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(eventTypes.Add.String(), ns).Inc()
 		},
 
 		UpdateFunc: func(oldObj, newObj interface{}) {
@@ -63,7 +57,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				OldObj:           newObj,
 			})
 			ns := getNamespace(newObj)
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(updateEvent, ns).Inc()
+			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(eventTypes.Update.String(), ns).Inc()
 		},
 
 		DeleteFunc: func(obj interface{}) {
@@ -77,7 +71,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				OldObj:           obj,
 			})
 			ns := getNamespace(obj)
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(deleteEvent, ns).Inc()
+			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(eventTypes.Delete.String(), ns).Inc()
 		},
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Instead of add/update/delete values for the `type`
label for the metric, use the event type that is
a part of the announcement.

Part of #902

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`