### PR TITLE
ads/metrics: implement xds path time metrics

### DIFF
--- a/pkg/envoy/ads/profile.go
+++ b/pkg/envoy/ads/profile.go
@@ -1,0 +1,21 @@
+package ads
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/metricsstore"
+)
+
+func xdsPathTimeTrack(t time.Time, tURIStr string, commonNameStr string, success *bool) {
+	elapsed := time.Since(t)
+
+	log.Debug().Msgf("[%s] proxy %s took %s",
+		tURIStr,
+		commonNameStr,
+		elapsed)
+
+	metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime.
+		WithLabelValues(commonNameStr, tURIStr, fmt.Sprintf("%t", *success)).
+		Observe(elapsed.Seconds())
+}

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// fullUpdateStr is a constant string value to identify full XDS update times on metric labels
-	fullXDSUpdateStr = "FULL"
+	ADSUpdateStr = "ADS"
 )
 
 // Wrapper to create and send a discovert response to an envoy server

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// fullUpdateStr is a constant string value to identify full XDS update times on metric labels
+	// ADSUpdateStr is a constant string value to identify full XDS update times on metric labels
 	ADSUpdateStr = "ADS"
 )
 
@@ -48,7 +48,7 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.Aggr
 	// Tracks the success of this full update of all its XDS paths. If a single XDS response path fails for this full update,
 	// the full updated will be considered as failed for metric purposes (success = false)
 	success := true
-	defer xdsPathTimeTrack(time.Now(), fullXDSUpdateStr, proxy.GetCommonName().String(), &success)
+	defer xdsPathTimeTrack(time.Now(), ADSUpdateStr, proxy.GetCommonName().String(), &success)
 
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -1,9 +1,7 @@
 package ads
 
 import (
-	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -13,17 +11,49 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
+const (
+	// fullUpdateStr is a constant string value to identify full XDS update times on metric labels
+	fullXDSUpdateStr = "FULL"
+)
+
+// Wrapper to create and send a discovert response to an envoy server
+func (s *Server) sendTypeResponse(tURI envoy.TypeURI,
+	proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer,
+	req *xds_discovery.DiscoveryRequest, cfg configurator.Configurator) error {
+
+	// Tracks the success of this TypeURI response operation; accounts also for receipt on envoy server side
+	success := false
+	defer xdsPathTimeTrack(time.Now(), tURI.String(), proxy.GetCommonName().String(), &success)
+
+	xdsShortName := envoy.XDSShortURINames[tURI]
+	log.Trace().Msgf("[%s] Creating response for proxy with CN=%s", xdsShortName, proxy.GetCommonName())
+
+	discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, req, cfg)
+	if err != nil {
+		log.Error().Err(err).Msgf("[%s] Failed to create response for proxy with CN=%s", xdsShortName, proxy.GetCommonName())
+		return err
+	}
+
+	if err := (*server).Send(discoveryResponse); err != nil {
+		log.Error().Err(err).Msgf("[%s] Error sending to proxy with CN=%s", xdsShortName, proxy.GetCommonName())
+		return err
+	}
+
+	success = true // read by deferred function
+	return nil
+}
+
 func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, cfg configurator.Configurator) {
 	log.Trace().Msgf("A change announcement triggered *DS update for proxy with CN=%s", proxy.GetCommonName())
-	fullUpdateStartTime := time.Now()
+
+	// Tracks the success of this full update of all its XDS paths. If a single XDS response path fails for this full update,
+	// the full updated will be considered as failed for metric purposes (success = false)
+	success := true
+	defer xdsPathTimeTrack(time.Now(), fullXDSUpdateStr, proxy.GetCommonName().String(), &success)
 
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
-	for idx, typeURI := range envoy.XDSResponseOrder {
-		prefix := fmt.Sprintf("[*DS %d/%d]", idx+1, len(envoy.XDSResponseOrder))
-		log.Trace().Msgf("%s Creating %s response for proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
-		updateStartTime := time.Now()
-
+	for _, typeURI := range envoy.XDSResponseOrder {
 		// For SDS we need to add ResourceNames
 		var request *xds_discovery.DiscoveryRequest
 		if typeURI == envoy.TypeSDS {
@@ -35,22 +65,13 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.Aggr
 			request = &xds_discovery.DiscoveryRequest{TypeUrl: string(typeURI)}
 		}
 
-		discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, request, cfg)
+		err := s.sendTypeResponse(typeURI, proxy, server, request, cfg)
 		if err != nil {
-			log.Error().Err(err).Msgf("%s Failed to create %s discovery response for proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
-		} else {
-			if err := (*server).Send(discoveryResponse); err != nil {
-				log.Error().Err(err).Msgf("%s Error sending %s to proxy with CN=%s", prefix, typeURI, proxy.GetCommonName())
-			}
+			log.Error().Err(err).Msgf("Failed to create and send %s update to Proxy %s",
+				envoy.XDSShortURINames[typeURI], proxy.GetCommonName())
+			success = false
 		}
-		log.Debug().Msgf("%s (%s) proxy %s took %s",
-			prefix,
-			typeURI.String()[strings.LastIndex(typeURI.String(), ".")+1:], // Last word of typeUri
-			proxy.GetCommonName(),
-			time.Since(updateStartTime))
 	}
-
-	log.Info().Msgf("Full update for %s took %s", proxy.GetCommonName(), time.Since(fullUpdateStartTime))
 }
 
 // makeRequestForAllSecrets constructs an SDS request AS IF an Envoy proxy sent it.

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -20,7 +20,6 @@ const (
 func (s *Server) sendTypeResponse(tURI envoy.TypeURI,
 	proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer,
 	req *xds_discovery.DiscoveryRequest, cfg configurator.Configurator) error {
-
 	// Tracks the success of this TypeURI response operation; accounts also for receipt on envoy server side
 	success := false
 	defer xdsPathTimeTrack(time.Now(), tURI.String(), proxy.GetCommonName().String(), &success)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -150,14 +150,10 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			}
 			log.Info().Msgf("Received discovery request <%s> for resources (%v) from Envoy <%s> with Nonce=%s", discoveryRequest.TypeUrl, discoveryRequest.ResourceNames, proxy, discoveryRequest.ResponseNonce)
 
-			resp, err := s.newAggregatedDiscoveryResponse(proxy, &discoveryRequest, s.cfg)
+			err := s.sendTypeResponse(typeURL, proxy, &server, &discoveryRequest, s.cfg)
 			if err != nil {
-				log.Error().Err(err).Msgf("Error composing a DiscoveryResponse")
-				continue
-			}
-
-			if err := server.Send(resp); err != nil {
-				log.Error().Err(err).Msgf("Error sending DiscoveryResponse")
+				log.Error().Err(err).Msgf("Failed to create and send %s update to Proxy %s",
+					envoy.XDSShortURINames[typeURL], proxy.GetCommonName())
 			}
 
 		case <-broadcastUpdate:

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -30,6 +30,15 @@ var ValidURI = map[string]TypeURI{
 	string(TypeZipkinConfig):       TypeZipkinConfig,
 }
 
+// XDSShortURINames are shortened versions of the URI types
+var XDSShortURINames = map[TypeURI]string{
+	TypeSDS: "SDS",
+	TypeCDS: "CDS",
+	TypeLDS: "LDS",
+	TypeRDS: "RDS",
+	TypeEDS: "EDS",
+}
+
 const (
 	// TypeSDS is the SDS type URI.
 	TypeSDS TypeURI = "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -83,9 +83,9 @@ func init() {
 			Help:      "Histogram to track time spent for proxy configuration",
 		},
 		[]string{
-			"proxy_cn",    // proxy_cn is the common name of the proxy
+			"proxy_cn",      // proxy_cn is the common name of the proxy
 			"resource_type", // identifies a typeURI resource
-			"success",      // further labels if the operation succeeded or not
+			"success",       // further labels if the operation succeeded or not
 		})
 
 	/*

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -85,7 +85,7 @@ func init() {
 		[]string{
 			"proxyName",    // proxyName is the common name of the proxy
 			"resourceType", // identifies a typeURI resource
-			"success",      // further labels if the operation suceeded or not
+			"success",      // further labels if the operation succeeded or not
 		})
 
 	/*

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -83,8 +83,8 @@ func init() {
 			Help:      "Histogram to track time spent for proxy configuration",
 		},
 		[]string{
-			"proxyName",    // proxyName is the common name of the proxy
-			"resourceType", // identifies a typeURI resource
+			"proxy_cn",    // proxy_cn is the common name of the proxy
+			"resource_type", // identifies a typeURI resource
 			"success",      // further labels if the operation succeeded or not
 		})
 


### PR DESCRIPTION
- Added proxy config_update_time, histogram which keeps track of
how much time does individual XDS paths take to compute.

- The use of `newAggregatedDiscoveryResponse` + `s.send` has been abstracted
into a single function, to allow collection of metrics in both `stream.go` (request triggered)
and `response.go` (full config triggered). This is in order to account for being able to confirm
receipt of the configuration on envoy's side.

Some examples:
```
// Full update that no errors were seen
ProxyConfigUpdateTime["CDS", "svc_8491...", "true"] = 0.2792
ProxyConfigUpdateTime["EDS", "svc_8491...", "true"] = 0.122 
ProxyConfigUpdateTime["LDS", "svc_8491...", "true"] = 0.5445
ProxyConfigUpdateTime["RDS", "svc_8491...", "true"] = 0.921
ProxyConfigUpdateTime["SDS", "svc_8491...", "true"] = 1.2565
ProxyConfigUpdateTime["ADS", "svc_8491...", "true"] = 3.1232

// Envoy server later requests a specific CDS update, which is handled in stream.go alone
ProxyConfigUpdateTime["CDS", "svc_8491...", "true"] = 0.352 

// Full config but LDS failed due to some error
ProxyConfigUpdateTime["CDS", "svc_8491...", "true"] = 0.2792
ProxyConfigUpdateTime["EDS", "svc_8491...", "true"] = 0.122
ProxyConfigUpdateTime["LDS", "svc_8491...", "false"] = 0.5445
ProxyConfigUpdateTime["RDS", "svc_8491...", "true"] = 0.921
ProxyConfigUpdateTime["SDS", "svc_8491...", "true"] = 1.2565
ProxyConfigUpdateTime["ADS", "svc_8491...", "false"] = 3.1232
```

**Affected area**:

- Metrics                [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No