### PR TITLE
catalog: add api to retrieve port:protocol mapping

### DIFF
--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -10,4 +10,5 @@ var (
 	errNamespaceDoesNotMatchCertificate      = errors.New("namespace does not match certificate")
 	errServiceNotFoundForAnyProvider         = errors.New("no service found for service account with any of the mesh supported providers")
 	errNoTrafficSpecFoundForTrafficPolicy    = errors.New("no traffic spec found for the traffic policy")
+	errServiceNotFound                       = errors.New("service not found")
 )

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -69,6 +69,21 @@ func (mr *MockMeshCatalogerMockRecorder) GetIngressRoutesPerHost(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressRoutesPerHost", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressRoutesPerHost), arg0)
 }
 
+// GetPortToProtocolMappingForResolvableService mocks base method
+func (m *MockMeshCataloger) GetPortToProtocolMappingForResolvableService(arg0 service.MeshService) (map[uint32]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPortToProtocolMappingForResolvableService", arg0)
+	ret0, _ := ret[0].(map[uint32]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPortToProtocolMappingForResolvableService indicates an expected call of GetPortToProtocolMappingForResolvableService
+func (mr *MockMeshCatalogerMockRecorder) GetPortToProtocolMappingForResolvableService(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortToProtocolMappingForResolvableService", reflect.TypeOf((*MockMeshCataloger)(nil).GetPortToProtocolMappingForResolvableService), arg0)
+}
+
 // GetPortToProtocolMappingForService mocks base method
 func (m *MockMeshCataloger) GetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/kubernetes"
@@ -147,6 +150,119 @@ func TestGetPortToProtocolMappingForService(t *testing.T) {
 			}
 
 			actualPortToProtocolMap, err := mc.GetPortToProtocolMappingForService(testSvc)
+
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedPortToProtocolMap, actualPortToProtocolMap)
+		})
+	}
+}
+
+func TestGetPortToProtocolMappingForResolvableService(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	svc := service.MeshService{
+		Namespace: "foo",
+		Name:      "bar",
+	}
+	appProtocolTCP := "tcp"
+	appProtocolHTTP := "http"
+
+	testCases := []struct {
+		name                      string
+		service                   *corev1.Service
+		expectedPortToProtocolMap map[uint32]string
+		expectError               bool
+	}{
+		{
+			// Test case 1
+			name: "service with no appProtocol specified",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svc.Name,
+					Namespace: svc.Namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "port1",
+							TargetPort: intstr.IntOrString{
+								Type:   intstr.String,
+								IntVal: 8080,
+							},
+							Port: 80,
+						},
+						{
+							Name: "port2",
+							TargetPort: intstr.IntOrString{
+								Type:   intstr.String,
+								IntVal: 9090,
+							},
+							Protocol: corev1.ProtocolTCP,
+							Port:     90,
+						},
+					},
+				},
+			},
+			expectedPortToProtocolMap: map[uint32]string{80: "http", 90: "http"},
+			expectError:               false,
+		},
+
+		{
+			// Test case 2
+			name: "service with appProtocol specified",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svc.Name,
+					Namespace: svc.Namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "port1",
+							TargetPort: intstr.IntOrString{
+								Type:   intstr.String,
+								IntVal: 8080,
+							},
+							AppProtocol: &appProtocolHTTP,
+							Port:        80,
+						},
+						{
+							Name: "port2",
+							TargetPort: intstr.IntOrString{
+								Type:   intstr.String,
+								IntVal: 9090,
+							},
+							Port:        90,
+							AppProtocol: &appProtocolTCP,
+						},
+					},
+				},
+			},
+			expectedPortToProtocolMap: map[uint32]string{80: "http", 90: "tcp"},
+			expectError:               false,
+		},
+
+		{
+			// Test case 3
+			name:                      "service doesn't exist",
+			service:                   nil,
+			expectedPortToProtocolMap: nil,
+			expectError:               true,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockKubeController := kubernetes.NewMockController(mockCtrl)
+			mc := &MeshCatalog{
+				kubeController: mockKubeController,
+			}
+
+			mockKubeController.EXPECT().GetService(svc).Return(tc.service).Times(1)
+
+			actualPortToProtocolMap, err := mc.GetPortToProtocolMappingForResolvableService(svc)
 
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedPortToProtocolMap, actualPortToProtocolMap)

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -116,8 +116,15 @@ type MeshCataloger interface {
 	// ListMonitoredNamespaces lists namespaces monitored by the control plane
 	ListMonitoredNamespaces() []string
 
-	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
+	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
+	// The ports returned are the actual ports on which the application exposes the service derived from the service's endpoints,
+	// ie. 'spec.ports[].targetPort' instead of 'spec.ports[].port' for a Kubernetes service.
 	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
+
+	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
+	// where the ports returned are the ones used by downstream clients in their requests. This can be different from the ports
+	// actually exposed by the application binary, ie. 'spec.ports[].port' instead of 'spec.ports[].targetPort' for a Kubernetes service.
+	GetPortToProtocolMappingForResolvableService(service.MeshService) (map[uint32]string, error)
 
 	// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects componsed of its routes for the given destination service account
 	ListInboundTrafficTargetsWithRoutes(service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error)


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds an api to retrieve a service's port
to application protocol mapping, where the port is
the one used by clients to send requests to. This
port can be different than the actual ports exposed
by the service's application binary, ie. the api
returns the a service's `port` as opposed to its
`targetPort`.

This api will be used to program outbound filter chains
for upstream services which need to match on the ports
the clients send traffic to, and the protocol mapping
to be used for determining the type of traffic being
sent on that port.

For backwards compatibility, the default appProtocol
for a port is assumed to be `http` if not specified,
similar to other usages of the `appProtocol` field.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`