### PR TITLE
pkg/*: rename APIs used to retrieve protocol mapping for port and tar…

### DIFF
--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -69,21 +69,6 @@ func (mr *MockMeshCatalogerMockRecorder) GetIngressRoutesPerHost(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressRoutesPerHost", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressRoutesPerHost), arg0)
 }
 
-// GetPortToProtocolMappingForResolvableService mocks base method
-func (m *MockMeshCataloger) GetPortToProtocolMappingForResolvableService(arg0 service.MeshService) (map[uint32]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPortToProtocolMappingForResolvableService", arg0)
-	ret0, _ := ret[0].(map[uint32]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetPortToProtocolMappingForResolvableService indicates an expected call of GetPortToProtocolMappingForResolvableService
-func (mr *MockMeshCatalogerMockRecorder) GetPortToProtocolMappingForResolvableService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortToProtocolMappingForResolvableService", reflect.TypeOf((*MockMeshCataloger)(nil).GetPortToProtocolMappingForResolvableService), arg0)
-}
-
 // GetPortToProtocolMappingForService mocks base method
 func (m *MockMeshCataloger) GetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
 	m.ctrl.T.Helper()
@@ -97,6 +82,21 @@ func (m *MockMeshCataloger) GetPortToProtocolMappingForService(arg0 service.Mesh
 func (mr *MockMeshCatalogerMockRecorder) GetPortToProtocolMappingForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortToProtocolMappingForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetPortToProtocolMappingForService), arg0)
+}
+
+// GetTargetPortToProtocolMappingForService mocks base method
+func (m *MockMeshCataloger) GetTargetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTargetPortToProtocolMappingForService", arg0)
+	ret0, _ := ret[0].(map[uint32]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTargetPortToProtocolMappingForService indicates an expected call of GetTargetPortToProtocolMappingForService
+func (mr *MockMeshCatalogerMockRecorder) GetTargetPortToProtocolMappingForService(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTargetPortToProtocolMappingForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetTargetPortToProtocolMappingForService), arg0)
 }
 
 // GetResolvableHostnamesForUpstreamService mocks base method

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -44,16 +44,16 @@ func (mc *MeshCatalog) ListServiceAccountsForService(svc service.MeshService) ([
 	return mc.kubeController.ListServiceAccountsForService(svc)
 }
 
-// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
+// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
 // The ports returned are the actual ports on which the application exposes the service derived from the service's endpoints,
 // ie. 'spec.ports[].targetPort' instead of 'spec.ports[].port' for a Kubernetes service.
 // The function ensures the port:protocol mapping is the same across different endpoint providers for the service, and returns
 // an error otherwise.
-func (mc *MeshCatalog) GetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
+func (mc *MeshCatalog) GetTargetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
 	var portToProtocolMap, previous map[uint32]string
 
 	for _, provider := range mc.endpointsProviders {
-		current, err := provider.GetPortToProtocolMappingForService(svc)
+		current, err := provider.GetTargetPortToProtocolMappingForService(svc)
 		if err != nil {
 			return nil, err
 		}
@@ -72,10 +72,10 @@ func (mc *MeshCatalog) GetPortToProtocolMappingForService(svc service.MeshServic
 	return portToProtocolMap, nil
 }
 
-// GetPortToProtocolMappingForResolvableService returns a mapping of the service's ports to their corresponding application protocol,
+// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
 // where the ports returned are the ones used by downstream clients in their requests. This can be different from the ports
 // actually exposed by the application binary, ie. 'spec.ports[].port' instead of 'spec.ports[].targetPort' for a Kubernetes service.
-func (mc *MeshCatalog) GetPortToProtocolMappingForResolvableService(svc service.MeshService) (map[uint32]string, error) {
+func (mc *MeshCatalog) GetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
 	portToProtocolMap := make(map[uint32]string)
 
 	k8sSvc := mc.kubeController.GetService(svc)

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -142,14 +142,14 @@ func TestGetPortToProtocolMappingForService(t *testing.T) {
 			var allProviders []endpoint.Provider
 			for _, providerConfig := range tc.providerConfigs {
 				allProviders = append(allProviders, providerConfig.provider)
-				providerConfig.provider.EXPECT().GetPortToProtocolMappingForService(testSvc).Return(providerConfig.portToProtocolMap, providerConfig.err).Times(1)
+				providerConfig.provider.EXPECT().GetTargetPortToProtocolMappingForService(testSvc).Return(providerConfig.portToProtocolMap, providerConfig.err).Times(1)
 			}
 
 			mc := &MeshCatalog{
 				endpointsProviders: allProviders,
 			}
 
-			actualPortToProtocolMap, err := mc.GetPortToProtocolMappingForService(testSvc)
+			actualPortToProtocolMap, err := mc.GetTargetPortToProtocolMappingForService(testSvc)
 
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedPortToProtocolMap, actualPortToProtocolMap)
@@ -262,7 +262,7 @@ func TestGetPortToProtocolMappingForResolvableService(t *testing.T) {
 
 			mockKubeController.EXPECT().GetService(svc).Return(tc.service).Times(1)
 
-			actualPortToProtocolMap, err := mc.GetPortToProtocolMappingForResolvableService(svc)
+			actualPortToProtocolMap, err := mc.GetPortToProtocolMappingForService(svc)
 
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedPortToProtocolMap, actualPortToProtocolMap)

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -116,15 +116,15 @@ type MeshCataloger interface {
 	// ListMonitoredNamespaces lists namespaces monitored by the control plane
 	ListMonitoredNamespaces() []string
 
-	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
+	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
 	// The ports returned are the actual ports on which the application exposes the service derived from the service's endpoints,
 	// ie. 'spec.ports[].targetPort' instead of 'spec.ports[].port' for a Kubernetes service.
-	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
+	GetTargetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
 
-	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
+	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
 	// where the ports returned are the ones used by downstream clients in their requests. This can be different from the ports
 	// actually exposed by the application binary, ie. 'spec.ports[].port' instead of 'spec.ports[].targetPort' for a Kubernetes service.
-	GetPortToProtocolMappingForResolvableService(service.MeshService) (map[uint32]string, error)
+	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
 
 	// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects componsed of its routes for the given destination service account
 	ListInboundTrafficTargetsWithRoutes(service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error)

--- a/pkg/endpoint/mock_provider.go
+++ b/pkg/endpoint/mock_provider.go
@@ -64,19 +64,19 @@ func (mr *MockProviderMockRecorder) GetServicesForServiceAccount(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServicesForServiceAccount", reflect.TypeOf((*MockProvider)(nil).GetServicesForServiceAccount), arg0)
 }
 
-// GetPortToProtocolMappingForService mocks base method
-func (m *MockProvider) GetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
+// GetTargetPortToProtocolMappingForService mocks base method
+func (m *MockProvider) GetTargetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPortToProtocolMappingForService", arg0)
+	ret := m.ctrl.Call(m, "GetTargetPortToProtocolMappingForService", arg0)
 	ret0, _ := ret[0].(map[uint32]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetPortToProtocolMappingForService indicates an expected call of GetPortToProtocolMappingForService
-func (mr *MockProviderMockRecorder) GetPortToProtocolMappingForService(arg0 interface{}) *gomock.Call {
+// GetTargetPortToProtocolMappingForService indicates an expected call of GetTargetPortToProtocolMappingForService
+func (mr *MockProviderMockRecorder) GetTargetPortToProtocolMappingForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortToProtocolMappingForService", reflect.TypeOf((*MockProvider)(nil).GetPortToProtocolMappingForService), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTargetPortToProtocolMappingForService", reflect.TypeOf((*MockProvider)(nil).GetTargetPortToProtocolMappingForService), arg0)
 }
 
 // GetResolvableEndpointsForService mocks base method

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -119,8 +119,8 @@ func (c Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccoun
 	return servicesSlice, nil
 }
 
-// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
-func (c Client) GetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
+// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
+func (c Client) GetTargetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
 	portToProtocolMap := make(map[uint32]string)
 
 	endpoints, err := c.kubeController.GetEndpoints(svc)

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 			},
 		}, nil)
 
-		portToProtocolMap, err := provider.GetPortToProtocolMappingForService(tests.BookbuyerService)
+		portToProtocolMap, err := provider.GetTargetPortToProtocolMappingForService(tests.BookbuyerService)
 		Expect(err).To(BeNil())
 
 		expectedPortToProtocolMap := map[uint32]string{88: appProtoTCP, 80: appProtoHTTP}

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -47,7 +47,7 @@ func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAc
 	return services, nil
 }
 
-func (f fakeClient) GetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
+func (f fakeClient) GetTargetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
 	return map[uint32]string{uint32(tests.Endpoint.Port): defaultAppProtocol}, nil
 }
 

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -15,8 +15,8 @@ type Provider interface {
 	// Retrieve the namespaced services for a given service account
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
-	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
-	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
+	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
+	GetTargetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
 
 	// Returns the expected endpoints that are to be reached when the service FQDN is resolved under
 	// the scope of the provider

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -68,7 +68,7 @@ func newIngressHTTPFilterChain(cfg configurator.Configurator, svc service.MeshSe
 func (lb *listenerBuilder) getIngressFilterChains(svc service.MeshService) []*xds_listener.FilterChain {
 	var ingressFilterChains []*xds_listener.FilterChain
 
-	protocolToPortMap, err := lb.meshCatalog.GetPortToProtocolMappingForService(svc)
+	protocolToPortMap, err := lb.meshCatalog.GetTargetPortToProtocolMappingForService(svc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error retrieving port to protocol mapping for service %s", svc)
 		return ingressFilterChains

--- a/pkg/envoy/lds/ingress_test.go
+++ b/pkg/envoy/lds/ingress_test.go
@@ -98,7 +98,7 @@ func TestGetIngressFilterChains(t *testing.T) {
 			}
 
 			// Mock catalog call to get port:protocol mapping for service
-			mockCatalog.EXPECT().GetPortToProtocolMappingForService(proxyService).Return(tc.svcPortToProtocolMap, tc.portToProtocolErr).Times(1)
+			mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(proxyService).Return(tc.svcPortToProtocolMap, tc.portToProtocolErr).Times(1)
 			// Mock configurator calls to determine HTTP vs HTTPS ingress
 			mockConfigurator.EXPECT().UseHTTPSIngress().Return(tc.httpsIngress).AnyTimes()
 			// Mock calls used to build the HTTP connection manager

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -39,7 +39,7 @@ var (
 func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshService) []*xds_listener.FilterChain {
 	var filterChains []*xds_listener.FilterChain
 
-	protocolToPortMap, err := lb.meshCatalog.GetPortToProtocolMappingForService(proxyService)
+	protocolToPortMap, err := lb.meshCatalog.GetTargetPortToProtocolMappingForService(proxyService)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error retrieving port to protocol mapping for service %s", proxyService)
 		return filterChains


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Renames the APIs to disambiguate between the port and targetPort
when retrieving the protocol mapping.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`