### PR TITLE
sds: Correct comments and tests - remove mentions of non-existent requestedCertType function

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Test ADS response functions", func() {
 		Name:      serviceName,
 	}
 
-	Context("Test getRequestedCertType()", func() {
+	Context("Test makeRequestForAllSecrets()", func() {
 		It("returns service cert", func() {
 
 			actual := makeRequestForAllSecrets(proxy, mc)

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -55,7 +55,7 @@ func (s *sdsImpl) createDiscoveryResponse(request *xds_discovery.DiscoveryReques
 	// Resources corresponding to SDS secrets returned as a part of the DiscoveryResponse
 	var resources []*any.Any
 
-	// The DisvoceryRequest contains the requested certs
+	// The DiscoveryRequest contains the requested certs
 	requestedCerts := request.ResourceNames
 	log.Trace().Msgf("Received SDS request for ResourceNames (certificates) %+v on proxy %s, services: %v", requestedCerts, s.proxy.GetCommonName(), s.proxyServices)
 
@@ -100,7 +100,6 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 
 	// The Envoy makes a request for a list of resources (aka certificates), which we will send as a response to the SDS request.
 	for _, requestedCertificate := range requestedCerts {
-		// requestedCertType could be either "service-cert" or "root-cert"
 		sdsCert, err := envoy.UnmarshalSDSCert(requestedCertificate)
 		if err != nil {
 			log.Error().Err(err).Msgf("Invalid resource kind requested: %q", requestedCertificate)
@@ -110,8 +109,8 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 		log.Debug().Msgf("proxy %s (member of service %s) requested %s", s.proxy.GetCommonName(), proxyService, requestedCertificate)
 
 		switch sdsCert.CertType {
+		// A service certificate is requested
 		case envoy.ServiceCertType:
-			// A service certificate is requested
 			envoySecret, err := getServiceCertSecret(cert, requestedCertificate)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error creating cert %s for proxy %s for service %s", requestedCertificate, s.proxy.GetCommonName(), proxyService)

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -39,6 +39,7 @@ func (ct SDSCertType) String() string {
 	return string(ct)
 }
 
+// SDSCertType enums
 const (
 	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:webservice"
 	ServiceCertType SDSCertType = "service-cert"
@@ -51,13 +52,9 @@ const (
 
 	// RootCertTypeForHTTPS is the prefix for the HTTPS root certificate resource name. Example: "root-cert-https:webservice"
 	RootCertTypeForHTTPS SDSCertType = "root-cert-https"
+)
 
-	// Outbound refers to Envoy upstream connectivity direction for TLS certs
-	Outbound SDSDirection = true
-
-	// Inbound refers to Envoy downstream connectivity direction for TLS certs
-	Inbound SDSDirection = false
-
+const (
 	// Separator is the separator between the prefix and the name of the certificate.
 	Separator = ":"
 

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Test Envoy tools", func() {
 			addr := "blah"
 			port := uint32(95346)
 			actual := GetAddress(addr, port)
+
 			expected := &core.Address{
 				Address: &core.Address_SocketAddress{
 					SocketAddress: &core.SocketAddress{
@@ -34,7 +35,7 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 	})
 
-	Context("Test CertName interface", func() {
+	Context("Test UnmarshalSDSCert()", func() {
 		It("Interface marshals and unmarshals preserving the exact same data", func() {
 			InitialObj := SDSCert{
 				CertType: ServiceCertType,
@@ -53,9 +54,7 @@ var _ = Describe("Test Envoy tools", func() {
 			// First and final object must be equal
 			Expect(*finalObj).To(Equal(InitialObj))
 		})
-	})
 
-	Context("Test getRequestedCertType()", func() {
 		It("returns service cert", func() {
 			actual, err := UnmarshalSDSCert("service-cert:namespace-test/blahBlahBlahCert")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This PR removes mentions of a `requestedCertType` variable and `getRequestedCertType()` function, which no longer exist.

This PR also removes `Outbound` and `Inbound` constants, which are not used.


Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
