### PR TITLE
envoy/lds: build outound service filter chains per service port

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"
+	"github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -26,14 +27,6 @@ const (
 	outboundMeshTCPFilterChainPrefix  = "outbound-mesh-tcp-filter-chain"
 	httpAppProtocol                   = "http"
 	tcpAppProtocol                    = "tcp"
-)
-
-var (
-	// supportedDownstreamHTTPProtocols is the list of allowed HTTP protocols that the
-	// downstream can use in an HTTP request. Since the downstream client is only allowed
-	// to send plaintext traffic to an in-mesh destinations, we do not include HTTP2 over
-	// TLS (h2) in this list.
-	supportedDownstreamHTTPProtocols = []string{"http/1.0", "http/1.1", "h2c"}
 )
 
 func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshService) []*xds_listener.FilterChain {
@@ -254,14 +247,12 @@ func (lb *listenerBuilder) getOutboundHTTPFilter() (*xds_listener.Filter, error)
 // getOutboundFilterChainMatchForService builds a filter chain to match the HTTP or TCP based destination traffic.
 // Filter Chain currently matches on the following:
 // 1. Destination IP of service endpoints
-// 2. HTTP application protocols if protocol is http
-func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.MeshService, protocol string) (*xds_listener.FilterChainMatch, error) {
-	filterMatch := &xds_listener.FilterChainMatch{}
-
-	if protocol == httpAppProtocol {
-		// HTTP filter chain should only match on supported HTTP protocols that the downstream can use
-		// to originate a request.
-		filterMatch.ApplicationProtocols = supportedDownstreamHTTPProtocols
+// 2. Destination port of the service
+func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.MeshService, port uint32) (*xds_listener.FilterChainMatch, error) {
+	filterMatch := &xds_listener.FilterChainMatch{
+		DestinationPort: &wrapperspb.UInt32Value{
+			Value: port,
+		},
 	}
 
 	endpoints, err := lb.meshCatalog.GetResolvableServiceEndpoints(dstSvc)
@@ -301,7 +292,7 @@ func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.
 	return filterMatch, nil
 }
 
-func (lb *listenerBuilder) getOutboundHTTPFilterChainForService(upstream service.MeshService) (*xds_listener.FilterChain, error) {
+func (lb *listenerBuilder) getOutboundHTTPFilterChainForService(upstream service.MeshService, port uint32) (*xds_listener.FilterChain, error) {
 	// Get HTTP filter for service
 	filter, err := lb.getOutboundHTTPFilter()
 	if err != nil {
@@ -310,7 +301,7 @@ func (lb *listenerBuilder) getOutboundHTTPFilterChainForService(upstream service
 	}
 
 	// Get filter match criteria for destination service
-	filterChainMatch, err := lb.getOutboundFilterChainMatchForService(upstream, httpAppProtocol)
+	filterChainMatch, err := lb.getOutboundFilterChainMatchForService(upstream, port)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting HTTP filter chain match for upstream service %s", upstream)
 		return nil, err
@@ -324,7 +315,7 @@ func (lb *listenerBuilder) getOutboundHTTPFilterChainForService(upstream service
 	}, nil
 }
 
-func (lb *listenerBuilder) getOutboundTCPFilterChainForService(upstream service.MeshService) (*xds_listener.FilterChain, error) {
+func (lb *listenerBuilder) getOutboundTCPFilterChainForService(upstream service.MeshService, port uint32) (*xds_listener.FilterChain, error) {
 	// Get TCP filter for service
 	filter, err := lb.getOutboundTCPFilter(upstream)
 	if err != nil {
@@ -333,7 +324,7 @@ func (lb *listenerBuilder) getOutboundTCPFilterChainForService(upstream service.
 	}
 
 	// Get filter match criteria for destination service
-	filterChainMatch, err := lb.getOutboundFilterChainMatchForService(upstream, tcpAppProtocol)
+	filterChainMatch, err := lb.getOutboundFilterChainMatchForService(upstream, port)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting HTTP filter chain match for upstream service %s", upstream)
 		return nil, err
@@ -362,4 +353,76 @@ func (lb *listenerBuilder) getOutboundTCPFilter(upstream service.MeshService) (*
 		Name:       wellknown.TCPProxy,
 		ConfigType: &xds_listener.Filter_TypedConfig{TypedConfig: marshalledTCPProxy},
 	}, nil
+}
+
+// getOutboundFilterChainPerUpstream returns a list of filter chains corresponding to upstream services
+func (lb *listenerBuilder) getOutboundFilterChainPerUpstream() []*xds_listener.FilterChain {
+	var filterChains []*xds_listener.FilterChain
+
+	outboundSvc := lb.meshCatalog.ListAllowedOutboundServicesForIdentity(lb.svcAccount)
+	if len(outboundSvc) == 0 {
+		log.Debug().Msgf("Proxy with identity %s does not have any allowed upstream services", lb.svcAccount)
+		return filterChains
+	}
+
+	var dstServicesSet map[service.MeshService]struct{} = make(map[service.MeshService]struct{}) // Set, avoid duplicates
+	// Transform into set, when listing apex services we might face repetitions
+	for _, meshSvc := range outboundSvc {
+		dstServicesSet[meshSvc] = struct{}{}
+	}
+
+	// Getting apex services referring to the outbound services
+	// We get possible apexes which could traffic split to any of the possible
+	// outbound services
+	splitServices := lb.meshCatalog.GetSMISpec().ListTrafficSplitServices()
+	for _, svc := range splitServices {
+		for _, outSvc := range outboundSvc {
+			if svc.Service == outSvc {
+				rootServiceName := kubernetes.GetServiceFromHostname(svc.RootService)
+				rootMeshService := service.MeshService{
+					Namespace: outSvc.Namespace,
+					Name:      rootServiceName,
+				}
+
+				// Add this root service into the set
+				dstServicesSet[rootMeshService] = struct{}{}
+			}
+		}
+	}
+
+	// Iterate all destination services
+	for upstream := range dstServicesSet {
+		log.Trace().Msgf("Building outbound filter chain for upstream service %s for proxy with identity %s", upstream, lb.svcAccount)
+		protocolToPortMap, err := lb.meshCatalog.GetPortToProtocolMappingForService(upstream)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error retrieving port to protocol mapping for upstream service %s", upstream)
+			continue
+		}
+
+		// Create protocol specific inbound filter chains per port to handle different ports serving different protocols
+		for port, appProtocol := range protocolToPortMap {
+			switch appProtocol {
+			case httpAppProtocol:
+				// Construct HTTP filter chain
+				if httpFilterChain, err := lb.getOutboundHTTPFilterChainForService(upstream, port); err != nil {
+					log.Error().Err(err).Msgf("Error constructing outbound HTTP filter chain for upstream service %s on proxy with identity %s", upstream, lb.svcAccount)
+				} else {
+					filterChains = append(filterChains, httpFilterChain)
+				}
+
+			case tcpAppProtocol:
+				// Construct TCP filter chain
+				if tcpFilterChain, err := lb.getOutboundTCPFilterChainForService(upstream, port); err != nil {
+					log.Error().Err(err).Msgf("Error constructing outbound TCP filter chain for upstream service %s on proxy with identity %s", upstream, lb.svcAccount)
+				} else {
+					filterChains = append(filterChains, tcpFilterChain)
+				}
+
+			default:
+				log.Error().Msgf("Cannot build outbound filter chain, unsupported protocol %s for upstream:port %s:%d", appProtocol, upstream, port)
+			}
+		}
+	}
+
+	return filterChains
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates how the outbound filter chains are built
per upstream service on the downstream proxy. Instead of
relying on the http_inspector listner_filter to inspect
the application protocol, filter chains use the destination
port of the service as a match, and the type of filter (http,
tcp etc.) is determined by the application protocol for that
port. The port-protocol mapping is already leveraged for
protocol specific filtering and proxying on the inbound
listener, this is now being leveraged for outbound filtering
as well.

This is also beneficial for the following reasons:
1. Application protocols such as mySQL where the server
   initiates the application protocol handshake will result
   in listener filters such as tls_inspector and
   http_inspector to time out since it will wait for data
   from the client. With the removal of the http_inspector
   for protocol based filtering, this problem is avoided.

2. By leveraging the appProtocol specified on a port, new
   application protocols can be easily supported via
   corresponding Envoy filters. Ex. an appProtocol=mySQL
   or appProtocol=gRPC can be used to determine the type
   of filter to leverage. This will not be possible
   with using the http_inspector alone as before.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`