### PR TITLE
certificate: Document kinds of certificates in OSM

### DIFF
--- a/pkg/certificate/README.md
+++ b/pkg/certificate/README.md
@@ -1,10 +1,9 @@
 # Package: Certificate
 
-This package contains tools necessary to manage certificates for the service mesh. There are 3 kinds of certificates:
+This package contains tools for issuing and renewing certificates for the service mesh.
 
-  - the Envoy-to-xDS certificates - used for Envoys to connect and identify themselves to the xDS control plane.
-  - the Envoy-to-Envoy (east-west) certificates - used for encryption and identification of sidecars in communication between services.
-  - the root certificate for the entire mesh, which signs the leaf certs above
+For design and details on mTLS and certificate issuance please see [docs/patterns/certificates.md](../../docs/patterns/certificates.md).
+
 
 ## Interfaces
 


### PR DESCRIPTION
This PR augments the `docs/patterns/certificates.md` document with the types of certificates used in OSM, where these are issued, the validity duration, and sample CN.

Also added a comment and renamed a few variables to increase verbosity and add clarity.

No functional code changes.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>


---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
