### PR TITLE
metrics : exposing metric for number for xds certificates issued

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -38,6 +38,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 
 	log.Info().Msgf("Client %s connected: Subject CN=%s; Service=%s", ip, cn, namespacedService)
 	metricsstore.DefaultMetricsStore.ProxyConnectCount.Inc()
+	metricsstore.DefaultMetricsStore.CertsXdsIssuedCounter.Inc()
 
 	// This is the Envoy proxy that just connected to the control plane.
 	proxy := envoy.NewProxy(cn, ip)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -38,7 +38,6 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 
 	log.Info().Msgf("Client %s connected: Subject CN=%s; Service=%s", ip, cn, namespacedService)
 	metricsstore.DefaultMetricsStore.ProxyConnectCount.Inc()
-	metricsstore.DefaultMetricsStore.CertsXdsIssuedCounter.Inc()
 
 	// This is the Envoy proxy that just connected to the control plane.
 	proxy := envoy.NewProxy(cn, ip)

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
 func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRequest, proxyUUID uuid.UUID) ([]byte, error) {
@@ -27,6 +28,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 		return nil, err
 	}
 
+	metricsstore.DefaultMetricsStore.CertsXdsIssuedCounter.Inc()
 	originalHealthProbes := rewriteHealthProbes(pod)
 
 	wh.meshCatalog.ExpectProxy(cn)

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -42,7 +42,7 @@ type MetricsStore struct {
 	/*
 	 * Certificate metrics
 	 */
-	//CertsXdsIssuedCounter is the metric counter for the number of xds certificates issued
+	// CertsXdsIssuedCounter is the metric counter for the number of xds certificates issued
 	CertsXdsIssuedCounter prometheus.Counter
 
 	/*

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -40,6 +40,12 @@ type MetricsStore struct {
 	InjectorRqTime *prometheus.HistogramVec
 
 	/*
+	 * Certificate metrics
+	 */
+	//CertsXdsIssuedCounter is the metric counter for the number of xds certificates issued
+	CertsXdsIssuedCounter prometheus.Counter
+
+	/*
 	 * MetricsStore internals should be defined below --------------
 	 */
 	registry *prometheus.Registry
@@ -110,6 +116,16 @@ func init() {
 			"success",
 		})
 
+	/*
+	 * Certificate metrics
+	 */
+	defaultMetricsStore.CertsXdsIssuedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "cert",
+		Name:      "xds_issued_count",
+		Help:      "Counts the number xds certificates issued to the proxies",
+	})
+
 	defaultMetricsStore.registry = prometheus.NewRegistry()
 }
 
@@ -120,6 +136,7 @@ func (ms *MetricsStore) Start() {
 	ms.registry.MustRegister(ms.ProxyConfigUpdateTime)
 	ms.registry.MustRegister(ms.InjectorSidecarCount)
 	ms.registry.MustRegister(ms.InjectorRqTime)
+	ms.registry.MustRegister(ms.CertsXdsIssuedCounter)
 }
 
 // Stop store
@@ -129,6 +146,7 @@ func (ms *MetricsStore) Stop() {
 	ms.registry.Unregister(ms.ProxyConfigUpdateTime)
 	ms.registry.Unregister(ms.InjectorSidecarCount)
 	ms.registry.Unregister(ms.InjectorRqTime)
+	ms.registry.Unregister(ms.CertsXdsIssuedCounter)
 }
 
 // Handler return the registry

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -123,7 +123,7 @@ func init() {
 		Namespace: metricsRootNamespace,
 		Subsystem: "cert",
 		Name:      "xds_issued_count",
-		Help:      "Counts the number xds certificates issued to the proxies",
+		Help:      "represents the total number of XDS certificates issued to proxies",
 	})
 
 	defaultMetricsStore.registry = prometheus.NewRegistry()


### PR DESCRIPTION
Description:

Adds a metric for the number of connected proxies.

Part of #902

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

Sample output for demo : 

![image](https://user-images.githubusercontent.com/59101963/104528675-c0b17500-55bc-11eb-9a30-473176ed5e93.png)



**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `No`
