### PR TITLE
metrics : exposing metric for time take to issue xds certificates 

### DIFF
--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -33,9 +33,10 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 		return nil, err
 	}
 	elapsed := time.Since(startTime)
-	certXdsIssueTimeTrack(elapsed, cn.String(), &certIssuanceSuccess)
 
-	metricsstore.DefaultMetricsStore.CertsXdsIssuedCounter.Inc()
+	metricsstore.DefaultMetricsStore.CertXdsIssuedCount.Inc()
+	metricsstore.DefaultMetricsStore.CertXdsIssuedTime.
+		WithLabelValues(cn.String(), fmt.Sprintf("%t", certIssuanceSuccess)).Observe(elapsed.Seconds())
 	originalHealthProbes := rewriteHealthProbes(pod)
 
 	wh.meshCatalog.ExpectProxy(cn)

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -36,7 +36,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 
 	metricsstore.DefaultMetricsStore.CertXdsIssuedCount.Inc()
 	metricsstore.DefaultMetricsStore.CertXdsIssuedTime.
-		WithLabelValues(cn.String(), fmt.Sprintf("%t", certIssuanceSuccess)).Observe(elapsed.Seconds())
+		WithLabelValues(cn.String(), strconv.FormatBool(certIssuanceSuccess)).Observe(elapsed.Seconds())
 	originalHealthProbes := rewriteHealthProbes(pod)
 
 	wh.meshCatalog.ExpectProxy(cn)

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -35,8 +35,9 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 	elapsed := time.Since(startTime)
 
 	metricsstore.DefaultMetricsStore.CertXdsIssuedCount.Inc()
+	certIssuanceSuccessString := strconv.FormatBool(certIssuanceSuccess)
 	metricsstore.DefaultMetricsStore.CertXdsIssuedTime.
-		WithLabelValues(cn.String(), strconv.FormatBool(certIssuanceSuccess)).Observe(elapsed.Seconds())
+		WithLabelValues(cn.String(), certIssuanceSuccessString).Observe(elapsed.Seconds())
 	originalHealthProbes := rewriteHealthProbes(pod)
 
 	wh.meshCatalog.ExpectProxy(cn)

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"gomodules.xyz/jsonpatch/v2"
@@ -19,12 +20,16 @@ import (
 func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRequest, proxyUUID uuid.UUID) ([]byte, error) {
 	namespace := req.Namespace
 
+	// Tracks the success of the current certificate issued for envoy to connect to XDS
+	success := true
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
 	cn := catalog.NewCertCommonNameWithProxyID(proxyUUID, pod.Spec.ServiceAccountName, namespace)
+	defer certXdsIssueTimeTrack(time.Now(), cn.String(), &success)
 	log.Info().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN=%s", pod.Spec.ServiceAccountName, namespace, cn)
 	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn, constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing bootstrap certificate for Envoy with CN=%s", cn)
+		success = false
 		return nil, err
 	}
 

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -41,3 +41,15 @@ func webhookTimeTrack(start time.Time, timeout time.Duration, success *bool) {
 	metricsstore.DefaultMetricsStore.InjectorRqTime.
 		WithLabelValues(fmt.Sprintf("%t", *success)).Observe(elapsed.Seconds())
 }
+
+// Time tracking function for xds certificate issuance.
+// Will calculate time taken to issue an xds certificate
+func certXdsIssueTimeTrack(t time.Time, commonName string, success *bool) {
+	elapsed := time.Since(t)
+
+	log.Debug().Msgf("Time taken to issue xds certificate %s is %v",
+		commonName, elapsed)
+
+	metricsstore.DefaultMetricsStore.CertsXdsIssuedTime.
+		WithLabelValues(commonName, fmt.Sprintf("%t", *success)).Observe(elapsed.Seconds())
+}

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -43,10 +43,8 @@ func webhookTimeTrack(start time.Time, timeout time.Duration, success *bool) {
 }
 
 // Time tracking function for xds certificate issuance.
-// Will calculate time taken to issue an xds certificate
-func certXdsIssueTimeTrack(t time.Time, commonName string, success *bool) {
-	elapsed := time.Since(t)
-
+// Will report the time taken to issue an xds certificate
+func certXdsIssueTimeTrack(elapsed time.Duration, commonName string, success *bool) {
 	log.Debug().Msgf("Time taken to issue xds certificate %s is %v",
 		commonName, elapsed)
 

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -41,13 +41,3 @@ func webhookTimeTrack(start time.Time, timeout time.Duration, success *bool) {
 	metricsstore.DefaultMetricsStore.InjectorRqTime.
 		WithLabelValues(fmt.Sprintf("%t", *success)).Observe(elapsed.Seconds())
 }
-
-// Time tracking function for xds certificate issuance.
-// Will report the time taken to issue an xds certificate
-func certXdsIssueTimeTrack(elapsed time.Duration, commonName string, success *bool) {
-	log.Debug().Msgf("Time taken to issue xds certificate %s is %v",
-		commonName, elapsed)
-
-	metricsstore.DefaultMetricsStore.CertsXdsIssuedTime.
-		WithLabelValues(commonName, fmt.Sprintf("%t", *success)).Observe(elapsed.Seconds())
-}

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -139,7 +139,6 @@ func init() {
 		},
 		[]string{
 			"common_name", // common_name is the common name of the certificate
-			"success",
 		})
 	defaultMetricsStore.registry = prometheus.NewRegistry()
 }

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -42,11 +42,11 @@ type MetricsStore struct {
 	/*
 	 * Certificate metrics
 	 */
-	// CertsXdsIssuedCounter is the metric counter for the number of xds certificates issued
-	CertsXdsIssuedCounter prometheus.Counter
+	// CertXdsIssuedCount is the metric counter for the number of xds certificates issued
+	CertXdsIssuedCount prometheus.Counter
 
-	// CertsXdsIssuedCounter the histogram to track the time to issue xds certificates
-	CertsXdsIssuedTime *prometheus.HistogramVec
+	// CertXdsIssuedCounter the histogram to track the time to issue xds certificates
+	CertXdsIssuedTime *prometheus.HistogramVec
 
 	/*
 	 * MetricsStore internals should be defined below --------------
@@ -122,14 +122,14 @@ func init() {
 	/*
 	 * Certificate metrics
 	 */
-	defaultMetricsStore.CertsXdsIssuedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	defaultMetricsStore.CertXdsIssuedCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metricsRootNamespace,
 		Subsystem: "cert",
 		Name:      "xds_issued_count",
 		Help:      "represents the total number of XDS certificates issued to proxies",
 	})
 
-	defaultMetricsStore.CertsXdsIssuedTime = prometheus.NewHistogramVec(
+	defaultMetricsStore.CertXdsIssuedTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsRootNamespace,
 			Subsystem: "cert",
@@ -151,8 +151,8 @@ func (ms *MetricsStore) Start() {
 	ms.registry.MustRegister(ms.ProxyConfigUpdateTime)
 	ms.registry.MustRegister(ms.InjectorSidecarCount)
 	ms.registry.MustRegister(ms.InjectorRqTime)
-	ms.registry.MustRegister(ms.CertsXdsIssuedCounter)
-	ms.registry.MustRegister(ms.CertsXdsIssuedTime)
+	ms.registry.MustRegister(ms.CertXdsIssuedCount)
+	ms.registry.MustRegister(ms.CertXdsIssuedTime)
 }
 
 // Stop store
@@ -162,8 +162,8 @@ func (ms *MetricsStore) Stop() {
 	ms.registry.Unregister(ms.ProxyConfigUpdateTime)
 	ms.registry.Unregister(ms.InjectorSidecarCount)
 	ms.registry.Unregister(ms.InjectorRqTime)
-	ms.registry.Unregister(ms.CertsXdsIssuedCounter)
-	ms.registry.Unregister(ms.CertsXdsIssuedTime)
+	ms.registry.Unregister(ms.CertXdsIssuedCount)
+	ms.registry.Unregister(ms.CertXdsIssuedTime)
 }
 
 // Handler return the registry


### PR DESCRIPTION
Description:

Adds a metric for the time take to issue of xds certificates.


Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`