### PR TITLE
changed from connectvault to certmanager in osm_deployment

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -13,7 +13,6 @@ A Helm chart to install the OSM control plane on Kubernetes
 | OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager"` |  |
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` |  |
 | OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` |  |
-| OpenServiceMesh.connectVault | bool | `true` |  |
 | OpenServiceMesh.controllerLogLevel | string | `"trace"` |  |
 | OpenServiceMesh.deployGrafana | bool | `false` |  |
 | OpenServiceMesh.deployJaeger | bool | `false` |  |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             "--webhook-config-name", "{{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
-            {{- if .Values.OpenServiceMesh.connectVault }}
+            {{ if eq .Values.OpenServiceMesh.certificateManager "vault" }}
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
             "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -401,15 +401,6 @@
                         ""
                     ]
                 },
-                "connectVault": {
-                    "$id": "#/properties/OpenServiceMesh/properties/connectVault",
-                    "type": "boolean",
-                    "title": "Connect to vault for cert manager",
-                    "description": "Specifies whether OSM deployment needs vault connection for cert-manager support",
-                    "examples": [
-                        true
-                    ]
-                },
                 "osmNamespace": {
                     "$id": "#/properties/OpenServiceMesh/properties/osmNamespace",
                     "type": "string",

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -33,8 +33,7 @@
                 "enforceSingleMesh",
                 "deployJaeger",
                 "tracing",
-                "webhookConfigNamePrefix",
-                "connectVault"
+                "webhookConfigNamePrefix"
             ],
             "properties": {
                 "replicaCount": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -19,7 +19,6 @@ OpenServiceMesh:
     protocol: http
     token:
     role: openservicemesh
-  connectVault: true
   certmanager:
     issuerName: osm-ca
     issuerKind: Issuer


### PR DESCRIPTION
<!--

Remove connectVault variable as it is unnecessary.

-->
**Description**:

<!--

Removed connectVault variable. Now only install osm-deployments if certificateManager is set to "vault" 
-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No