### PR TITLE
certificate: Implement GetSerialNumber() for all certificate issuers/providers

### DIFF
--- a/cmd/osm-controller/certificates_test.go
+++ b/cmd/osm-controller/certificates_test.go
@@ -19,15 +19,66 @@ import (
 
 var _ = Describe("Test CMD tools", func() {
 
+	keyPEM := []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDD3+gqR5tLq3w2
+KZOVCJRaQ2+0bdDmqvWf4YZjsYlIWUMSxQNhX9fm6u/X/fUbwVMpDP3t2A7ArgJP
+iakti8676Ws7utVbYi2PvjLfcVtsM0UBtAqXfHN2Rg+Ne7B9AanepUeJIfzs+/jr
+6MAhuhTZA/RquhLbRGJKrmHsgnGuAyGn581TXiL52HUvbJ89BbexpcQtUnqFUj8J
+hnHWKTuoNPcLlDMRL5fRX08Zyhzxiyg66ALoZduHNu6HV/Z0YXHlxePKZCIRrbx5
+8a74q6zYBTWdWqkKhKF1wFYWBwi2ppIPW2U47TOV0IsnWs9o7DsWkFMpf97SpE7v
+SyxpPefNAgMBAAECggEATsKJp/aDCzo5B85P+W0pueHD2NkPVrEHcvJMB2oruVur
+DLELWuwe9EsjhcYn+LETrz36HNjzlaZiZ3kC/b1ps0V4SNwnTkd76oCgFBiQmkFD
+ThwG5kK0aqphNpK1tI4mr8/lo8521RO8U5+TIfygxWJBtWh8jI5Ct6TG20LYUw9a
+QMhgmEFVXaBRyoIhccuWahJHSwZzlxlmLTj06Gf+Uv9Snhwy7LJe81i9CNWVn8E0
+zW+77vUWQ1/AXIyh0fLmQhisHs6d/wbVr9E8GBAyyzN21uzoXNSyWxnwlGk/K1IQ
+76KrRVw7zIQ7iqrEsycMtY8uoW8CkRHZOYvtAS5OQQKBgQD4IllwZRbiWFaRXN04
+bUgiFjBQjkCMKyPk1b9MryaG4kIgxN9YQRiwwFWueaW4p+HyujT8pAl4xo5RbH37
+xKPqgPCQ1XzH9mPo7Mx0OCyv9GaAXlq4FqiJU5T5xF6SoWSgJTKgVPfNtGLAzWaX
+l/BRY+19ATAL1kSRXKq7cHpJjwKBgQDKFXZpq5QPXk37CE1hpN6cs8cKkvfU4oaq
+V4lC+4TlAah8JjtzXNyAbKtGdV9Q9kgsgDBeaTBY4MZrtnhh6JVY3twGaRBq6pcv
+0IleaVVhp7eOwMA4W5AYSnZ6LahFY0YFyzFeEgyzqwbQlFX+A9ovXX+DJlBoM6pn
+gcowfqNy4wKBgAVs8tmzTCnM1q+9ARVPxmkAZTQNuDmYY+OIDPPHTKdcYSfIRj3u
+xnRu8DCtdkMwYI9nJOt1RsO+S7RaE/MiXJcvFJOGJ4FT0OFx9BKCe++o/2jFJ2Sp
+EixWiIZhldPM9Z9O0OmSkgyMajBfDWQ5LUcKUVIPaZaIq90l0pHgprvfAoGBALBc
+eMIR3p5m8/FQNpAv3aOuddfxmV5t74675GvTrBBcGRl4GEw+z6U4sWVFS9ERjr1f
+hlbuwCXgzOn2DiuMWsJ7hFQH3y8f2p/9A9WkYcJfJ5/q8hZ9Ok0otys7q24bDGJE
+CaqKYBFxAfqIal/MJt9NXtorVuMJq/63U6hs7OJ3AoGAAz5s2BEJQ4V5eD3U2ybn
+pxtNBGA9nxmM8LZlg80XdhBfrWp44rCPOWsZEUlI800gy3qerF1bZywpWkDydJrX
+TDO2ZGgoxQvaQfdAhjYKeD+7/Y9M/AacQSDaYOeXAdR9f6hJrf+1SHAGjqbaUXuR
+sIpZJboKv7uhHDhGJsdP/8Y=
+-----END PRIVATE KEY-----
+`)
+
+	// Source: https://golang.org/src/crypto/x509/example_test.go
+	certPEM := []byte(`-----BEGIN CERTIFICATE-----
+MIIDujCCAqKgAwIBAgIIE31FZVaPXTUwDQYJKoZIhvcNAQEFBQAwSTELMAkGA1UE
+BhMCVVMxEzARBgNVBAoTCkdvb2dsZSBJbmMxJTAjBgNVBAMTHEdvb2dsZSBJbnRl
+cm5ldCBBdXRob3JpdHkgRzIwHhcNMTQwMTI5MTMyNzQzWhcNMTQwNTI5MDAwMDAw
+WjBpMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwN
+TW91bnRhaW4gVmlldzETMBEGA1UECgwKR29vZ2xlIEluYzEYMBYGA1UEAwwPbWFp
+bC5nb29nbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfRrObuSW5T7q
+5CnSEqefEmtH4CCv6+5EckuriNr1CjfVvqzwfAhopXkLrq45EQm8vkmf7W96XJhC
+7ZM0dYi1/qOCAU8wggFLMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAa
+BgNVHREEEzARgg9tYWlsLmdvb2dsZS5jb20wCwYDVR0PBAQDAgeAMGgGCCsGAQUF
+BwEBBFwwWjArBggrBgEFBQcwAoYfaHR0cDovL3BraS5nb29nbGUuY29tL0dJQUcy
+LmNydDArBggrBgEFBQcwAYYfaHR0cDovL2NsaWVudHMxLmdvb2dsZS5jb20vb2Nz
+cDAdBgNVHQ4EFgQUiJxtimAuTfwb+aUtBn5UYKreKvMwDAYDVR0TAQH/BAIwADAf
+BgNVHSMEGDAWgBRK3QYWG7z2aLV29YG2u2IaulqBLzAXBgNVHSAEEDAOMAwGCisG
+AQQB1nkCBQEwMAYDVR0fBCkwJzAloCOgIYYfaHR0cDovL3BraS5nb29nbGUuY29t
+L0dJQUcyLmNybDANBgkqhkiG9w0BAQUFAAOCAQEAH6RYHxHdcGpMpFE3oxDoFnP+
+gtuBCHan2yE2GRbJ2Cw8Lw0MmuKqHlf9RSeYfd3BXeKkj1qO6TVKwCh+0HdZk283
+TZZyzmEOyclm3UGFYe82P/iDFt+CeQ3NpmBg+GoaVCuWAARJN/KfglbLyyYygcQq
+0SgeDh8dRKUiaW3HQSoYvTvdTuqzwK4CXsr3b5/dAOY8uMuG/IAR3FgwTbZ1dtoW
+RvOTa8hYiU6A475WuZKyEHcwnGYe57u2I2KbMgcKjPniocj4QzgYsVAVKW3IwaOh
+yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
+-----END CERTIFICATE-----`)
+
 	Context("Testing getCertFromKubernetes", func() {
 		It("obtained root cert from k8s", func() {
 			kubeClient := testclient.NewSimpleClientset()
 
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
-
-			certPEM := []byte(uuid.New().String())
-			keyPEM := []byte(uuid.New().String())
 
 			secret := &corev1.Secret{
 				ObjectMeta: v1.ObjectMeta{
@@ -102,8 +153,6 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certPEM := []byte(uuid.New().String())
-
 			secret := &corev1.Secret{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      secretName,
@@ -159,9 +208,6 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certPEM := []byte(uuid.New().String())
-			keyPEM := []byte(uuid.New().String())
-
 			expected := &corev1.Secret{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      secretName,
@@ -207,9 +253,6 @@ var _ = Describe("Test CMD tools", func() {
 					"123": []byte("456"),
 				},
 			})
-
-			certPEM := []byte(uuid.New().String())
-			keyPEM := []byte(uuid.New().String())
 
 			expected := &corev1.Secret{
 				ObjectMeta: v1.ObjectMeta{

--- a/pkg/certificate/mock_certificate.go
+++ b/pkg/certificate/mock_certificate.go
@@ -92,10 +92,10 @@ func (mr *MockCertificaterMockRecorder) GetIssuingCA() *gomock.Call {
 }
 
 // GetSerialNumber mocks base method
-func (m *MockCertificater) GetSerialNumber() string {
+func (m *MockCertificater) GetSerialNumber() SerialNumber {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSerialNumber")
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(SerialNumber)
 	return ret0
 }
 

--- a/pkg/certificate/providers/certmanager/certificate.go
+++ b/pkg/certificate/providers/certmanager/certificate.go
@@ -32,6 +32,6 @@ func (c Certificate) GetExpiration() time.Time {
 }
 
 // GetSerialNumber returns the serial number of the given certificate.
-func (c Certificate) GetSerialNumber() string {
-	panic("NotImplemented")
+func (c Certificate) GetSerialNumber() certificate.SerialNumber {
+	return c.serialNumber
 }

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -132,11 +132,12 @@ func (cm *CertManager) certificaterFromCertificateRequest(cr *cmapi.CertificateR
 	}
 
 	return Certificate{
-		commonName: certificate.CommonName(cert.Subject.CommonName),
-		expiration: cert.NotAfter,
-		certChain:  cr.Status.Certificate,
-		privateKey: privateKey,
-		issuingCA:  cm.ca.GetIssuingCA(),
+		commonName:   certificate.CommonName(cert.Subject.CommonName),
+		serialNumber: certificate.SerialNumber(cert.SerialNumber.String()),
+		expiration:   cert.NotAfter,
+		certChain:    cr.Status.Certificate,
+		privateKey:   privateKey,
+		issuingCA:    cm.ca.GetIssuingCA(),
 	}, nil
 }
 

--- a/pkg/certificate/providers/certmanager/debugger_test.go
+++ b/pkg/certificate/providers/certmanager/debugger_test.go
@@ -13,11 +13,12 @@ import (
 var _ = Describe("Test cert-manager Debugger", func() {
 	Context("test ListIssuedCertificates()", func() {
 		cert := &Certificate{
-			issuingCA:  pem.RootCertificate("zz"),
-			privateKey: pem.PrivateKey("yy"),
-			certChain:  pem.Certificate("xx"),
-			expiration: time.Now(),
-			commonName: "foo.bar.co.uk",
+			issuingCA:    pem.RootCertificate("zz"),
+			privateKey:   pem.PrivateKey("yy"),
+			certChain:    pem.Certificate("xx"),
+			expiration:   time.Now(),
+			commonName:   "foo.bar.co.uk",
+			serialNumber: "-certificate-serial-number-",
 		}
 		cache := map[certificate.CommonName]certificate.Certificater{
 			"foo": cert,

--- a/pkg/certificate/providers/certmanager/helpers.go
+++ b/pkg/certificate/providers/certmanager/helpers.go
@@ -22,10 +22,11 @@ func NewRootCertificateFromPEM(pemCert pem.Certificate) (certificate.Certificate
 	}
 
 	return Certificate{
-		commonName: certificate.CommonName(cert.Subject.CommonName),
-		certChain:  pemCert,
-		expiration: cert.NotAfter,
-		issuingCA:  pem.RootCertificate(pemCert),
+		commonName:   certificate.CommonName(cert.Subject.CommonName),
+		serialNumber: certificate.SerialNumber(cert.SerialNumber.String()),
+		certChain:    pemCert,
+		expiration:   cert.NotAfter,
+		issuingCA:    pem.RootCertificate(pemCert),
 	}, nil
 }
 

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -63,6 +63,9 @@ type Certificate struct {
 	// The commonName of the certificate
 	commonName certificate.CommonName
 
+	// The serial number of the certificate
+	serialNumber certificate.SerialNumber
+
 	// When the cert expires
 	expiration time.Time
 

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -62,10 +62,11 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 	}
 
 	rootCertificate := Certificate{
-		commonName: rootCertificateName,
-		certChain:  pemCert,
-		privateKey: pemKey,
-		expiration: template.NotAfter,
+		commonName:   rootCertificateName,
+		serialNumber: certificate.SerialNumber(serialNumber.String()),
+		certChain:    pemCert,
+		privateKey:   pemKey,
+		expiration:   template.NotAfter,
 	}
 
 	rootCertificate.issuingCA = rootCertificate.GetCertificateChain()
@@ -75,11 +76,17 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 
 // NewCertificateFromPEM is a helper returning a certificate.Certificater from the PEM components given.
 func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expiration time.Time) (certificate.Certificater, error) {
+	x509Cert, err := certificate.DecodePEMCertificate(pemCert)
+	if err != nil {
+		log.Err(err).Msg("Error converting PEM cert to x509 to obtain serial number")
+		return nil, err
+	}
 	rootCertificate := Certificate{
-		commonName: rootCertificateName,
-		certChain:  pemCert,
-		privateKey: pemKey,
-		expiration: expiration,
+		commonName:   rootCertificateName,
+		serialNumber: certificate.SerialNumber(x509Cert.SerialNumber.String()),
+		certChain:    pemCert,
+		privateKey:   pemKey,
+		expiration:   expiration,
 	}
 
 	rootCertificate.issuingCA = rootCertificate.GetCertificateChain()

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -39,8 +39,8 @@ func (c Certificate) GetExpiration() time.Time {
 }
 
 // GetSerialNumber returns the serial number of the given certificate.
-func (c Certificate) GetSerialNumber() string {
-	panic("NotImplemented")
+func (c Certificate) GetSerialNumber() certificate.SerialNumber {
+	return c.serialNumber
 }
 
 // LoadCA loads the certificate and its key from the supplied PEM files.
@@ -63,10 +63,11 @@ func LoadCA(certFilePEM string, keyFilePEM string) (*Certificate, error) {
 	}
 
 	rootCertificate := Certificate{
-		commonName: rootCertificateName,
-		certChain:  pemCert,
-		privateKey: pemKey,
-		expiration: x509RootCert.NotAfter,
+		commonName:   rootCertificateName,
+		serialNumber: certificate.SerialNumber(x509RootCert.SerialNumber.String()),
+		certChain:    pemCert,
+		privateKey:   pemKey,
+		expiration:   x509RootCert.NotAfter,
 	}
 	return &rootCertificate, nil
 }

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -78,11 +78,12 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 	}
 
 	cert := Certificate{
-		commonName: cn,
-		certChain:  certPEM,
-		privateKey: privKeyPEM,
-		issuingCA:  cm.ca.GetCertificateChain(),
-		expiration: template.NotAfter,
+		commonName:   cn,
+		serialNumber: certificate.SerialNumber(serialNumber.String()),
+		certChain:    certPEM,
+		privateKey:   privKeyPEM,
+		issuingCA:    cm.ca.GetCertificateChain(),
+		expiration:   template.NotAfter,
 	}
 
 	log.Info().Msgf("Created new certificate for CN=%s; validity=%+v; expires on %+v; serial: %x", cn, validityPeriod, template.NotAfter, template.SerialNumber)

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -31,10 +31,11 @@ func NewFakeCertManager(cfg configurator.Configurator) *CertManager {
 // NewFakeCertificate is a helper creating Certificates for unit tests.
 func NewFakeCertificate() *Certificate {
 	cert := Certificate{
-		privateKey: pem.PrivateKey("yy"),
-		certChain:  pem.Certificate("xx"),
-		expiration: time.Now(),
-		commonName: "foo.bar.co.uk",
+		privateKey:   pem.PrivateKey("yy"),
+		certChain:    pem.Certificate("xx"),
+		expiration:   time.Now(),
+		commonName:   "foo.bar.co.uk",
+		serialNumber: "-the-certificate-serial-number-",
 	}
 
 	// It is acceptable in the context of a unit test (so far) for

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -50,6 +50,9 @@ type Certificate struct {
 	// The commonName of the certificate
 	commonName certificate.CommonName
 
+	// The serial number of the certificate
+	serialNumber certificate.SerialNumber
+
 	// When the cert expires
 	expiration time.Time
 

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -27,29 +27,32 @@ var _ = Describe("Test client helpers", func() {
 
 	expiredCertCN := certificate.CommonName("this.has.expired")
 	expiredCert := &Certificate{
-		issuingCA:  pem.RootCertificate("zz"),
-		privateKey: pem.PrivateKey("yy"),
-		certChain:  pem.Certificate("xx"),
-		expiration: time.Now(), // This certificate has ALREADY expired
-		commonName: expiredCertCN,
+		issuingCA:    pem.RootCertificate("zz"),
+		privateKey:   pem.PrivateKey("yy"),
+		certChain:    pem.Certificate("xx"),
+		expiration:   time.Now(), // This certificate has ALREADY expired
+		commonName:   expiredCertCN,
+		serialNumber: "-serial-number-",
 	}
 
 	validCertCN := certificate.CommonName("valid.certificate")
 	validCert := &Certificate{
-		issuingCA:  issuingCA,
-		privateKey: pem.PrivateKey("yy"),
-		certChain:  pem.Certificate("xx"),
-		expiration: time.Now().Add(24 * time.Hour),
-		commonName: validCertCN,
+		issuingCA:    issuingCA,
+		privateKey:   pem.PrivateKey("yy"),
+		certChain:    pem.Certificate("xx"),
+		expiration:   time.Now().Add(24 * time.Hour),
+		commonName:   validCertCN,
+		serialNumber: "-serial-number-",
 	}
 
 	rootCertCN := certificate.CommonName("root.cert")
 	rootCert := &Certificate{
-		issuingCA:  pem.RootCertificate("zz"),
-		privateKey: pem.PrivateKey("yy"),
-		certChain:  pem.Certificate("xx"),
-		expiration: time.Now().Add(24 * time.Hour),
-		commonName: rootCertCN,
+		issuingCA:    pem.RootCertificate("zz"),
+		privateKey:   pem.PrivateKey("yy"),
+		certChain:    pem.Certificate("xx"),
+		expiration:   time.Now().Add(24 * time.Hour),
+		commonName:   rootCertCN,
+		serialNumber: "-serial-number-",
 	}
 
 	Context("Test NewCertManager()", func() {
@@ -118,6 +121,7 @@ var _ = Describe("Test client helpers", func() {
 		}
 
 		It("gets issuing CA public part", func() {
+			certSerialNum := certificate.SerialNumber(uuid.New().String())
 			expectedNumberOfCertsInCache := 2
 			Expect(len(getCachedCertificateCNs())).To(Equal(expectedNumberOfCertsInCache))
 			Expect(getCachedCertificateCNs()).To(ContainElement(certificate.CommonName("this.has.expired")))
@@ -125,11 +129,12 @@ var _ = Describe("Test client helpers", func() {
 			certBytes := uuid.New().String()
 			issue := func(certificate.CommonName, time.Duration) (certificate.Certificater, error) {
 				cert := Certificate{
-					issuingCA: pem.RootCertificate(certBytes),
+					issuingCA:    pem.RootCertificate(certBytes),
+					serialNumber: certSerialNum,
 				}
 				return cert, nil
 			}
-			issuingCA, err := cm.getIssuingCA(issue)
+			issuingCA, serialNumber, err := cm.getIssuingCA(issue)
 			Expect(err).ToNot(HaveOccurred())
 
 			// Ensure that cache is NOT affected
@@ -137,6 +142,7 @@ var _ = Describe("Test client helpers", func() {
 			Expect(len(getCachedCertificateCNs())).To(Equal(expectedNumberOfCertsInCache))
 			Expect(getCachedCertificateCNs()).To(ContainElement(certificate.CommonName("this.has.expired")))
 			Expect(getCachedCertificateCNs()).To(ContainElement(certificate.CommonName("valid.certificate")))
+			Expect(serialNumber).To(Equal(certSerialNum))
 		})
 
 		It("gets certs from cache", func() {

--- a/pkg/certificate/providers/vault/debugger_test.go
+++ b/pkg/certificate/providers/vault/debugger_test.go
@@ -13,11 +13,12 @@ import (
 var _ = Describe("Test Vault Debugger", func() {
 	Context("test ListIssuedCertificates()", func() {
 		cert := &Certificate{
-			issuingCA:  pem.RootCertificate("zz"),
-			privateKey: pem.PrivateKey("yy"),
-			certChain:  pem.Certificate("xx"),
-			expiration: time.Now(),
-			commonName: "foo.bar.co.uk",
+			issuingCA:    pem.RootCertificate("zz"),
+			privateKey:   pem.PrivateKey("yy"),
+			certChain:    pem.Certificate("xx"),
+			expiration:   time.Now(),
+			commonName:   "foo.bar.co.uk",
+			serialNumber: "-cert-serial-number-",
 		}
 		cm := CertManager{}
 		cm.cache.Store("foo", cert)

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -19,6 +19,13 @@ const (
 	TypeCertificateRequest = "CERTIFICATE REQUEST"
 )
 
+// SerialNumber is the Serial Number of the given certificate.
+type SerialNumber string
+
+func (sn SerialNumber) String() string {
+	return string(sn)
+}
+
 // CommonName is the Subject Common Name from a given SSL certificate.
 type CommonName string
 
@@ -45,7 +52,7 @@ type Certificater interface {
 	GetExpiration() time.Time
 
 	// GetSerialNumber returns the serial number of the given certificate.
-	GetSerialNumber() string
+	GetSerialNumber() SerialNumber
 }
 
 // Manager is the interface declaring the methods for the Certificate Manager.

--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -414,9 +414,9 @@ func TestUpdateValidatingWebhookCABundle(t *testing.T) {
 
 type mockCertificate struct{}
 
-func (mc mockCertificate) GetCommonName() certificate.CommonName { return "" }
-func (mc mockCertificate) GetCertificateChain() []byte           { return []byte("chain") }
-func (mc mockCertificate) GetPrivateKey() []byte                 { return []byte("key") }
-func (mc mockCertificate) GetIssuingCA() []byte                  { return []byte("ca") }
-func (mc mockCertificate) GetExpiration() time.Time              { return time.Now() }
-func (mc mockCertificate) GetSerialNumber() string               { return "serial_number" }
+func (mc mockCertificate) GetCommonName() certificate.CommonName     { return "" }
+func (mc mockCertificate) GetCertificateChain() []byte               { return []byte("chain") }
+func (mc mockCertificate) GetPrivateKey() []byte                     { return []byte("key") }
+func (mc mockCertificate) GetIssuingCA() []byte                      { return []byte("ca") }
+func (mc mockCertificate) GetExpiration() time.Time                  { return time.Now() }
+func (mc mockCertificate) GetSerialNumber() certificate.SerialNumber { return "serial_number" }

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -96,12 +96,12 @@ var _ = Describe("Test MutatingWebhookConfiguration patch", func() {
 
 type mockCertificate struct{}
 
-func (mc mockCertificate) GetCommonName() certificate.CommonName { return "" }
-func (mc mockCertificate) GetCertificateChain() []byte           { return []byte("chain") }
-func (mc mockCertificate) GetPrivateKey() []byte                 { return []byte("key") }
-func (mc mockCertificate) GetIssuingCA() []byte                  { return []byte("ca") }
-func (mc mockCertificate) GetExpiration() time.Time              { return time.Now() }
-func (mc mockCertificate) GetSerialNumber() string               { return "serial_number" }
+func (mc mockCertificate) GetCommonName() certificate.CommonName     { return "" }
+func (mc mockCertificate) GetCertificateChain() []byte               { return []byte("chain") }
+func (mc mockCertificate) GetPrivateKey() []byte                     { return []byte("key") }
+func (mc mockCertificate) GetIssuingCA() []byte                      { return []byte("ca") }
+func (mc mockCertificate) GetExpiration() time.Time                  { return time.Now() }
+func (mc mockCertificate) GetSerialNumber() certificate.SerialNumber { return "serial_number" }
 
 var _ = Describe("Testing isAnnotatedForInjection", func() {
 	Context("when the inject annotation is one of enabled/yes/true", func() {


### PR DESCRIPTION
This PR implements `GetSerialNumber()` which is a member of the `Certificater` interface.

This function was stubbed and panicked.  Also returned string.

This PR:
  - introduces `certificate.SerialNumber` type, which is an alias to string.
  - changes `GetSerialNumber()` to return `SerialNumber` type instead of `string`
  - adds `serialNumber` to Certificate structs and initializes it

This will fix https://github.com/openservicemesh/osm/issues/2312

---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
