### PR TITLE
log: Replace CN with SerialNumber in log messages (where possible)

### DIFF
--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -45,19 +45,19 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 	// Self-sign the root certificate
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &rsaKey.PublicKey, rsaKey)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error issuing x509.CreateCertificate command for CN=%s", template.Subject.CommonName)
+		log.Error().Err(err).Msgf("Error issuing x509.CreateCertificate command for SerialNumber=%s", serialNumber)
 		return nil, errors.Wrap(err, errCreateCert.Error())
 	}
 
 	pemCert, err := certificate.EncodeCertDERtoPEM(derBytes)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error encoding certificate with CN=%s", template.Subject.CommonName)
+		log.Error().Err(err).Msgf("Error encoding certificate with SerialNumber=%s", serialNumber)
 		return nil, err
 	}
 
 	pemKey, err := certificate.EncodeKeyDERtoPEM(rsaKey)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error encoding private key for certificate with CN=%s", template.Subject.CommonName)
+		log.Error().Err(err).Msgf("Error encoding private key for certificate with SerialNumber=%s", serialNumber)
 		return nil, err
 	}
 

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -126,7 +126,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 
 	cm.cache.Store(cn, cert)
 
-	log.Trace().Msgf("Issued new certificate for SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
+	log.Trace().Msgf("Issued new certificate with SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
 
 	return cert, nil
 }

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -101,9 +101,9 @@ func (cm *CertManager) deleteFromCache(cn certificate.CommonName) {
 func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certificater {
 	if certificateInterface, exists := cm.cache.Load(cn); exists {
 		cert := certificateInterface.(certificate.Certificater)
-		log.Trace().Msgf("Certificate found in cache CN=%s", cn)
+		log.Trace().Msgf("Certificate found in cache SerialNumber=%s", cert.GetSerialNumber())
 		if rotor.ShouldRotate(cert) {
-			log.Trace().Msgf("Certificate found in cache but has expired CN=%s", cn)
+			log.Trace().Msgf("Certificate found in cache but has expired SerialNumber=%s", cert.GetSerialNumber())
 			return nil
 		}
 		return cert
@@ -113,8 +113,6 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 
 // IssueCertificate issues a certificate by leveraging the Hashi Vault CertManager.
 func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
-	log.Info().Msgf("Issuing new certificate for CN=%s", cn)
-
 	start := time.Now()
 
 	if cert := cm.getFromCache(cn); cert != nil {
@@ -128,7 +126,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 
 	cm.cache.Store(cn, cert)
 
-	log.Info().Msgf("Issuing new certificate for CN=%s took %+v", cn, time.Since(start))
+	log.Trace().Msgf("Issued new certificate for SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
 
 	return cert, nil
 }
@@ -169,8 +167,6 @@ func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announceme
 
 // RotateCertificate implements certificate.Manager and rotates an existing certificate.
 func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
-	log.Info().Msgf("Rotating certificate for CN=%s", cn)
-
 	start := time.Now()
 
 	cert, err := cm.issue(cn, cm.cfg.GetServiceCertValidityPeriod())
@@ -181,7 +177,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	cm.cache.Store(cn, cert)
 	cm.announcements <- announcements.Announcement{}
 
-	log.Info().Msgf("Rotating certificate CN=%s took %+v", cn, time.Since(start))
+	log.Trace().Msgf("Rotated certificate with new SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
 
 	return cert, nil
 }

--- a/pkg/certificate/rotor/rotor.go
+++ b/pkg/certificate/rotor/rotor.go
@@ -58,10 +58,10 @@ func (r *CertRotor) checkAndRotate() {
 			// Remove the certificate from the cache of the certificate manager
 			newCert, err := r.certManager.RotateCertificate(cert.GetCommonName())
 			if err != nil {
-				log.Error().Err(err).Msgf("Error rotating cert CN=%s", cert.GetCommonName())
+				log.Error().Err(err).Msgf("Error rotating cert SerialNumber=%s", cert.GetSerialNumber())
 				continue
 			}
-			log.Trace().Msgf("Rotated cert CN=%s", newCert.GetCommonName())
+			log.Trace().Msgf("Rotated cert SerialNumber=%s", newCert.GetSerialNumber())
 		}
 	}
 }

--- a/pkg/debugger/certificate.go
+++ b/pkg/debugger/certificate.go
@@ -23,7 +23,7 @@ func (ds DebugConfig) getCertHandler() http.Handler {
 			chain := cert.GetCertificateChain()
 			x509, err := certificate.DecodePEMCertificate(chain)
 			if err != nil {
-				log.Error().Err(err).Msgf("Error decoding PEM to x509 CN=%s", cert.GetCommonName())
+				log.Error().Err(err).Msgf("Error decoding PEM to x509 SerialNumber=%s", cert.GetSerialNumber())
 			}
 
 			_, _ = fmt.Fprintf(w, "---[ %d ]---\n", idx)

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -65,7 +65,7 @@ func (ds DebugConfig) getConfigDump(cn certificate.CommonName, w http.ResponseWr
 		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
 	}
 	w.Header().Set("Content-Type", "application/json")
-	envoyConfig := ds.getEnvoyConfig(pod, cn, "config_dump")
+	envoyConfig := ds.getEnvoyConfig(pod, "config_dump")
 	_, _ = fmt.Fprintf(w, "%s", envoyConfig)
 }
 
@@ -75,6 +75,6 @@ func (ds DebugConfig) getProxy(cn certificate.CommonName, w http.ResponseWriter)
 		log.Error().Err(err).Msgf("Error getting Pod from certificate with CN=%s", cn)
 	}
 	w.Header().Set("Content-Type", "application/json")
-	envoyConfig := ds.getEnvoyConfig(pod, cn, "certs")
+	envoyConfig := ds.getEnvoyConfig(pod, "certs")
 	_, _ = fmt.Fprintf(w, "%s", envoyConfig)
 }


### PR DESCRIPTION
This PR replaces logging of certificate's CN with certificate's SerialNumber.

This PR partially addresses the concerns outlined in https://github.com/openservicemesh/osm/issues/2311

This PR does not address all issues - this is first of a few.

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
