### PR TITLE
smi/traffic-access: update to v1alpha3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OSM is an open source project that is [**not** covered by the Microsoft Azure su
 
 |   Specification Component    |         Supported Release          |          Comments          |
 | :---------------------------- | :--------------------------------: |  :--------------------------------: |
-| Traffic Access Control  |  [v1alpha2](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha2/traffic-access.md)  | |
+| Traffic Access Control  |  [v1alpha3](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha3/traffic-access.md)  | |
 | Traffic Specs  |  [v1alpha4](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-specs/v1alpha4/traffic-specs.md)  | |
 | Traffic Split  |  [v1alpha2](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha2/traffic-split.md) | |
 | Traffic Metrics  | [v1alpha1](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-metrics/v1alpha1/traffic-metrics.md) | 🚧 **In Progress** [#379](https://github.com/openservicemesh/osm/issues/379) 🚧 |
@@ -136,5 +136,5 @@ This software is covered under the MIT license. You can read the license [here](
 
 [1]: https://en.wikipedia.org/wiki/Service_mesh
 [2]: https://github.com/servicemeshinterface/smi-spec/blob/master/SPEC_LATEST_STABLE.md
-[3]: https://github.com/servicemeshinterface/smi-spec/blob/v0.5.0/apis/traffic-split/v1alpha2/traffic-split.md
-[4]: https://github.com/servicemeshinterface/smi-spec/blob/v0.5.0/apis/traffic-access/v1alpha2/traffic-access.md
+[3]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha2/traffic-split.md
+[4]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha3/traffic-access.md

--- a/charts/osm/crds/access.yaml
+++ b/charts/osm/crds/access.yaml
@@ -1,5 +1,4 @@
 ---
-# TrafficTarget v1alpha2
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -13,11 +12,14 @@ spec:
       - tt
     plural: traffictargets
     singular: traffictarget
-  version: v1alpha2
+  version: v1alpha3
   versions:
-    - name: v1alpha2
+    - name: v1alpha3
       served: true
       storage: true
+    - name: v1alpha2
+      served: false
+      storage: false
     - name: v1alpha1
       served: false
       storage: false
@@ -27,6 +29,8 @@ spec:
         spec:
           required:
             - destination
+            - rules
+            - sources
           properties:
             destination:
               description: The destination of this traffic target.
@@ -44,9 +48,6 @@ spec:
                 namespace:
                   description: Namespace of the destination.
                   type: string
-                port:
-                  description: Port number of the destination.
-                  type: number
             rules:
               description: Specifications of this traffic target.
               type: array
@@ -62,6 +63,7 @@ spec:
                     enum:
                       - HTTPRouteGroup
                       - TCPRoute
+                      - UDPRoute
                   name:
                     description: Name of this spec.
                     type: string

--- a/cmd/cli/trafficpolicy_check.go
+++ b/cmd/cli/trafficpolicy_check.go
@@ -124,7 +124,7 @@ func (cmd *trafficPolicyCheckCmd) checkTrafficPolicy(srcPod, dstPod *corev1.Pod)
 
 	// SMI traffic policy mode
 	fmt.Fprintf(cmd.out, "[+] SMI traffic policy mode enabled for mesh operated by osm-controller running in %s namespace\n\n", osmNamespace)
-	trafficTargets, err := cmd.smiAccessClient.AccessV1alpha2().TrafficTargets(dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
+	trafficTargets, err := cmd.smiAccessClient.AccessV1alpha3().TrafficTargets(dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return errors.Errorf("Error listing SMI TrafficTarget policies: %s", err)
 	}

--- a/cmd/cli/trafficpolicy_check_test.go
+++ b/cmd/cli/trafficpolicy_check_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"testing"
 
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	fakeAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned/fake"
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -168,7 +168,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			},
 			smiAccess.TrafficTarget{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "access.smi-spec.io/v1alpha2",
+					APIVersion: "access.smi-spec.io/v1alpha3",
 					Kind:       "TrafficTarget",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -224,7 +224,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			},
 			smiAccess.TrafficTarget{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "access.smi-spec.io/v1alpha2",
+					APIVersion: "access.smi-spec.io/v1alpha3",
 					Kind:       "TrafficTarget",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -281,7 +281,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			},
 			smiAccess.TrafficTarget{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: "access.smi-spec.io/v1alpha2",
+					APIVersion: "access.smi-spec.io/v1alpha3",
 					Kind:       "TrafficTarget",
 				},
 				ObjectMeta: metav1.ObjectMeta{
@@ -353,7 +353,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			assert.Nil(err)
 
 			// create the traffic target
-			_, err = fakeAccessClient.AccessV1alpha2().TrafficTargets(tc.trafficTarget.Namespace).Create(context.TODO(), &tc.trafficTarget, metav1.CreateOptions{})
+			_, err = fakeAccessClient.AccessV1alpha3().TrafficTargets(tc.trafficTarget.Namespace).Create(context.TODO(), &tc.trafficTarget, metav1.CreateOptions{})
 			assert.Nil(err)
 
 			err = cmd.checkTrafficPolicy(&tc.srcPod, &tc.dstPod)
@@ -365,7 +365,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			assert.Nil(err)
 
 			// delete the TrafficTarget for the next test case
-			err = fakeAccessClient.AccessV1alpha2().TrafficTargets(tc.trafficTarget.Namespace).Delete(context.TODO(), tc.trafficTarget.Name, metav1.DeleteOptions{})
+			err = fakeAccessClient.AccessV1alpha3().TrafficTargets(tc.trafficTarget.Namespace).Delete(context.TODO(), tc.trafficTarget.Name, metav1.DeleteOptions{})
 			assert.Nil(err)
 		})
 	}

--- a/demo/deploy-traffic-target-with-same-sa.sh
+++ b/demo/deploy-traffic-target-with-same-sa.sh
@@ -7,7 +7,7 @@ source .env
 
 kubectl apply -f - <<EOF
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookbuyer-access-bookstore
   namespace: "$BOOKSTORE_NAMESPACE"
@@ -40,7 +40,7 @@ spec:
 ---
 
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-access-bookwarehouse
   namespace: "$BOOKWAREHOUSE_NAMESPACE"

--- a/demo/deploy-traffic-target.sh
+++ b/demo/deploy-traffic-target.sh
@@ -7,7 +7,7 @@ source .env
 
 kubectl apply -f - <<EOF
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookbuyer-access-bookstore-v1
   namespace: "$BOOKSTORE_NAMESPACE"
@@ -41,7 +41,7 @@ spec:
 ---
 
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookbuyer-access-bookstore-v2
   namespace: "$BOOKSTORE_NAMESPACE"
@@ -74,7 +74,7 @@ spec:
 ---
 
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-access-bookwarehouse
   namespace: "$BOOKWAREHOUSE_NAMESPACE"

--- a/docs/example/README.md
+++ b/docs/example/README.md
@@ -121,7 +121,7 @@ Currently the Bookthief application has not been authorized to participate in th
 Current TrafficTarget spec with commented `Bookthief` kind:
 ```
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v1
   namespace: bookstore
@@ -148,7 +148,7 @@ spec:
  Updated TrafficTarget spec with uncommented `Bookthief` kind:
  ```
  kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v1
   namespace: bookstore

--- a/docs/example/manifests/access/traffic-access.yaml
+++ b/docs/example/manifests/access/traffic-access.yaml
@@ -1,5 +1,5 @@
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v1
   namespace: bookstore

--- a/docs/example/manifests/bookstore-v2/bookstore-v2.yaml
+++ b/docs/example/manifests/bookstore-v2/bookstore-v2.yaml
@@ -54,7 +54,7 @@ spec:
               value: bookstore-v2
 ---
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v2
   namespace: bookstore

--- a/docs/example/manifests/bookstore-v2/traffic-access-v2.yaml
+++ b/docs/example/manifests/bookstore-v2/traffic-access-v2.yaml
@@ -1,5 +1,5 @@
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v2
   namespace: bookstore

--- a/experimental/routes_refactor/demo/manifests/traffic-access.yaml
+++ b/experimental/routes_refactor/demo/manifests/traffic-access.yaml
@@ -1,5 +1,5 @@
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v1
   namespace: bookstore
@@ -39,7 +39,7 @@ spec:
     - GET
 ---
 kind: TrafficTarget
-apiVersion: access.smi-spec.io/v1alpha2
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
   name: bookstore-v2
   namespace: bookstore

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -3,7 +3,7 @@ package catalog
 import (
 	"time"
 
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
@@ -60,7 +60,7 @@ func (mc *MeshCatalog) ListDisconnectedProxies() map[certificate.CommonName]time
 }
 
 // ListSMIPolicies returns all policies OSM is aware of.
-func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget) {
+func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget) {
 	trafficSplits := mc.meshSpec.ListTrafficSplits()
 	splitServices := mc.meshSpec.ListTrafficSplitServices()
 	serviceAccounts := mc.meshSpec.ListServiceAccounts()

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	specs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -130,7 +130,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(testParams.permissiveMode).AnyTimes()
 
-	mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*target.TrafficTarget{&tests.TrafficTarget}).AnyTimes()
+	mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*access.TrafficTarget{&tests.TrafficTarget}).AnyTimes()
 	mockMeshSpec.EXPECT().ListHTTPTrafficSpecs().Return([]*specs.HTTPRouteGroup{&tests.HTTPRouteGroup}).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, mockMeshSpec, certManager,

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -14,9 +14,9 @@ import (
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface
@@ -292,14 +292,14 @@ func (mr *MockMeshCatalogerMockRecorder) ListMonitoredNamespaces() *gomock.Call 
 }
 
 // ListSMIPolicies mocks base method
-func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha20.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha2.TrafficTarget) {
+func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSMIPolicies")
-	ret0, _ := ret[0].([]*v1alpha20.TrafficSplit)
+	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
 	ret1, _ := ret[1].([]service.WeightedService)
 	ret2, _ := ret[2].([]service.K8sServiceAccount)
 	ret3, _ := ret[3].([]*v1alpha4.HTTPRouteGroup)
-	ret4, _ := ret[4].([]*v1alpha2.TrafficTarget)
+	ret4, _ := ret[4].([]*v1alpha3.TrafficTarget)
 	return ret0, ret1, ret2, ret3, ret4
 }
 

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -7,7 +7,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -411,7 +411,7 @@ func getDefaultWeightedClusterForService(meshService service.MeshService) servic
 }
 
 // listTrafficTargetPermutations creates a list of TrafficTargets for each source and destination pair.
-func (mc *MeshCatalog) listTrafficTargetPermutations(trafficTarget target.TrafficTarget, src target.IdentityBindingSubject, dest target.IdentityBindingSubject) ([]trafficpolicy.TrafficTarget, error) {
+func (mc *MeshCatalog) listTrafficTargetPermutations(trafficTarget access.TrafficTarget, src access.IdentityBindingSubject, dest access.IdentityBindingSubject) ([]trafficpolicy.TrafficTarget, error) {
 	sourceServiceAccount := service.K8sServiceAccount{
 		Namespace: src.Namespace,
 		Name:      src.Name,
@@ -451,7 +451,7 @@ func (mc *MeshCatalog) listTrafficTargetPermutations(trafficTarget target.Traffi
 
 // routesFromRules takes a set of traffic target rules and the namespace of the traffic target and returns a list of
 //	http route matches (trafficpolicy.HTTPRouteMatch)
-func (mc *MeshCatalog) routesFromRules(rules []target.TrafficTargetRule, trafficTargetNamespace string) ([]trafficpolicy.HTTPRouteMatch, error) {
+func (mc *MeshCatalog) routesFromRules(rules []access.TrafficTargetRule, trafficTargetNamespace string) ([]trafficpolicy.HTTPRouteMatch, error) {
 	routes := []trafficpolicy.HTTPRouteMatch{}
 
 	specMatchRoute, err := mc.getHTTPPathsPerRoute() // returns map[traffic_spec_name]map[match_name]trafficpolicy.HTTPRoute
@@ -529,7 +529,7 @@ func (mc *MeshCatalog) listMeshServices() []service.MeshService {
 	return services
 }
 
-func (mc *MeshCatalog) getDestinationServicesFromTrafficTarget(t *target.TrafficTarget) ([]service.MeshService, error) {
+func (mc *MeshCatalog) getDestinationServicesFromTrafficTarget(t *access.TrafficTarget) ([]service.MeshService, error) {
 	sa := service.K8sServiceAccount{
 		Name:      t.Spec.Destination.Name,
 		Namespace: t.Spec.Destination.Namespace,
@@ -541,7 +541,7 @@ func (mc *MeshCatalog) getDestinationServicesFromTrafficTarget(t *target.Traffic
 	return destServices, nil
 }
 
-func (mc *MeshCatalog) buildInboundPolicies(t *target.TrafficTarget) []*trafficpolicy.InboundTrafficPolicy {
+func (mc *MeshCatalog) buildInboundPolicies(t *access.TrafficTarget) []*trafficpolicy.InboundTrafficPolicy {
 	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
 
 	// fetch services running workloads with destination service account
@@ -582,7 +582,7 @@ func (mc *MeshCatalog) buildInboundPolicies(t *target.TrafficTarget) []*trafficp
 	return inboundPolicies
 }
 
-func (mc *MeshCatalog) buildOutboundPolicies(source service.K8sServiceAccount, t *target.TrafficTarget) []*trafficpolicy.OutboundTrafficPolicy {
+func (mc *MeshCatalog) buildOutboundPolicies(source service.K8sServiceAccount, t *access.TrafficTarget) []*trafficpolicy.OutboundTrafficPolicy {
 	outPolicies := []*trafficpolicy.OutboundTrafficPolicy{}
 
 	// fetch services running workloads with destination service account
@@ -641,7 +641,7 @@ func (mc *MeshCatalog) listPoliciesFromTrafficTargets(sa service.K8sServiceAccou
 	return inboundPolicies, outboundPolicies, nil
 }
 
-func isValidTrafficTarget(t *target.TrafficTarget) bool {
+func isValidTrafficTarget(t *access.TrafficTarget) bool {
 	return t.Spec.Rules != nil && len(t.Spec.Rules) > 0
 }
 

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -7,7 +7,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	specs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
@@ -27,23 +27,23 @@ import (
 func TestIsValidTrafficTarget(t *testing.T) {
 	assert := tassert.New(t)
 
-	getTrafficTarget := func(rules []target.TrafficTargetRule) *target.TrafficTarget {
-		return &target.TrafficTarget{
+	getTrafficTarget := func(rules []access.TrafficTargetRule) *access.TrafficTarget {
+		return &access.TrafficTarget{
 			TypeMeta: v1.TypeMeta{
-				APIVersion: "access.smi-spec.io/v1alpha2",
+				APIVersion: "access.smi-spec.io/v1alpha3",
 				Kind:       "TrafficTarget",
 			},
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "target",
 				Namespace: "default",
 			},
-			Spec: target.TrafficTargetSpec{
-				Destination: target.IdentityBindingSubject{
+			Spec: access.TrafficTargetSpec{
+				Destination: access.IdentityBindingSubject{
 					Kind:      "Name",
 					Name:      "dest-id",
 					Namespace: "default",
 				},
-				Sources: []target.IdentityBindingSubject{{
+				Sources: []access.IdentityBindingSubject{{
 					Kind:      "Name",
 					Name:      "source-id",
 					Namespace: "default",
@@ -55,7 +55,7 @@ func TestIsValidTrafficTarget(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		input    *target.TrafficTarget
+		input    *access.TrafficTarget
 		expected bool
 	}{
 		{
@@ -70,7 +70,7 @@ func TestIsValidTrafficTarget(t *testing.T) {
 		},
 		{
 			name:     "is not valid because TrafficTarget.Spec.Rules is not nil but is empty",
-			input:    getTrafficTarget([]target.TrafficTargetRule{}),
+			input:    getTrafficTarget([]access.TrafficTargetRule{}),
 			expected: false,
 		},
 	}
@@ -200,13 +200,13 @@ func TestRoutesFromRules(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		rules          []target.TrafficTargetRule
+		rules          []access.TrafficTargetRule
 		namespace      string
 		expectedRoutes []trafficpolicy.HTTPRouteMatch
 	}{
 		{
 			name: "http route group and match name exist",
-			rules: []target.TrafficTargetRule{
+			rules: []access.TrafficTargetRule{
 				{
 					Kind:    "HTTPRouteGroup",
 					Name:    tests.RouteGroupName,
@@ -218,7 +218,7 @@ func TestRoutesFromRules(t *testing.T) {
 		},
 		{
 			name: "http route group and match name do not exist",
-			rules: []target.TrafficTargetRule{
+			rules: []access.TrafficTargetRule{
 				{
 					Kind:    "HTTPRouteGroup",
 					Name:    "DoesNotExist",
@@ -767,7 +767,7 @@ func TestBuildOutboundPolicies(t *testing.T) {
 
 	trafficSpec := spec.HTTPRouteGroup{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "specs.smi-spec.io/v1alpha2",
+			APIVersion: "specs.smi-spec.io/v1alpha4",
 			Kind:       "HTTPRouteGroup",
 		},
 		ObjectMeta: v1.ObjectMeta{
@@ -865,7 +865,7 @@ func TestBuildInboundPoliciesDiffNamespaces(t *testing.T) {
 
 	trafficSpec := spec.HTTPRouteGroup{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "specs.smi-spec.io/v1alpha2",
+			APIVersion: "specs.smi-spec.io/v1alpha4",
 			Kind:       "HTTPRouteGroup",
 		},
 		ObjectMeta: v1.ObjectMeta{
@@ -976,7 +976,7 @@ func TestBuildInboundPoliciesSameNamespace(t *testing.T) {
 
 	trafficSpec := spec.HTTPRouteGroup{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "specs.smi-spec.io/v1alpha2",
+			APIVersion: "specs.smi-spec.io/v1alpha4",
 			Kind:       "HTTPRouteGroup",
 		},
 		ObjectMeta: v1.ObjectMeta{
@@ -1220,22 +1220,22 @@ func TestGetDestinationServicesFromTrafficTarget(t *testing.T) {
 	mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
 	mockKubeController.EXPECT().GetService(destMeshService).Return(destK8sService).AnyTimes()
 
-	trafficTarget := &target.TrafficTarget{
+	trafficTarget := &access.TrafficTarget{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "access.smi-spec.io/v1alpha2",
+			APIVersion: "access.smi-spec.io/v1alpha3",
 			Kind:       "TrafficTarget",
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "target",
 			Namespace: "bookstore-ns",
 		},
-		Spec: target.TrafficTargetSpec{
-			Destination: target.IdentityBindingSubject{
+		Spec: access.TrafficTargetSpec{
+			Destination: access.IdentityBindingSubject{
 				Kind:      "Name",
 				Name:      "bookstore",
 				Namespace: "bookstore-ns",
 			},
-			Sources: []target.IdentityBindingSubject{{
+			Sources: []access.IdentityBindingSubject{{
 				Kind:      "Name",
 				Name:      "bookbuyer",
 				Namespace: "default",

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	mapset "github.com/deckarep/golang-set"
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +39,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			[]*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -62,7 +61,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 				},
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -108,7 +107,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			[]*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -149,7 +148,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			[]*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -219,7 +218,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			[]*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -241,7 +240,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 				},
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -291,7 +290,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			[]*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -332,7 +331,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			[]*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -421,7 +420,7 @@ func TestTrafficTargetIdentityToSvcAccount(t *testing.T) {
 
 func TestTrafficTargetIdentitiesToSvcAccounts(t *testing.T) {
 	assert := tassert.New(t)
-	input := []target.IdentityBindingSubject{
+	input := []smiAccess.IdentityBindingSubject{
 		{
 			Kind:      "ServiceAccount",
 			Name:      "example1",
@@ -469,7 +468,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			trafficTargets: []*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -540,7 +539,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			trafficTargets: []*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -632,7 +631,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			trafficTargets: []*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -664,7 +663,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 				},
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{
@@ -797,7 +796,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			trafficTargets: []*smiAccess.TrafficTarget{
 				{
 					TypeMeta: metav1.TypeMeta{
-						APIVersion: "access.smi-spec.io/v1alpha2",
+						APIVersion: "access.smi-spec.io/v1alpha3",
 						Kind:       "TrafficTarget",
 					},
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	"k8s.io/client-go/kubernetes"
@@ -78,7 +78,7 @@ type MeshCataloger interface {
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
 	// ListSMIPolicies lists SMI policies.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 
 	// ListEndpointsForService returns the list of individual instance endpoint backing a service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)

--- a/pkg/debugger/mock_debugger.go
+++ b/pkg/debugger/mock_debugger.go
@@ -10,7 +10,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
@@ -17,7 +17,7 @@ type policies struct {
 	WeightedServices []service.WeightedService   `json:"weighted_services"`
 	ServiceAccounts  []service.K8sServiceAccount `json:"service_accounts"`
 	RouteGroups      []*spec.HTTPRouteGroup      `json:"route_groups"`
-	TrafficTargets   []*target.TrafficTarget     `json:"traffic_targets"`
+	TrafficTargets   []*access.TrafficTarget     `json:"traffic_targets"`
 }
 
 func (ds DebugConfig) getOSMConfigHandler() http.Handler {

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	tassert "github.com/stretchr/testify/assert"
@@ -44,7 +44,7 @@ func TestGetSMIPolicies(t *testing.T) {
 		[]*spec.HTTPRouteGroup{
 			&tests.HTTPRouteGroup,
 		},
-		[]*target.TrafficTarget{
+		[]*access.TrafficTarget{
 			&tests.TrafficTarget,
 		},
 	)
@@ -53,6 +53,6 @@ func TestGetSMIPolicies(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 	smiPoliciesHandler.ServeHTTP(responseRecorder, nil)
 	actualResponseBody := responseRecorder.Body.String()
-	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"weighted_services":[{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v1"},"weight:omitempty":90,"root_service:omitempty":"bookstore-apex"},{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v2"},"weight:omitempty":10,"root_service:omitempty":"bookstore-apex"}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha2","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha2","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"Name","name":"bookstore","namespace":"default"},"sources":[{"kind":"Name","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
+	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"weighted_services":[{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v1"},"weight:omitempty":90,"root_service:omitempty":"bookstore-apex"},{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v2"},"weight:omitempty":10,"root_service:omitempty":"bookstore-apex"}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha4","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha3","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"Name","name":"bookstore","namespace":"default"},"sources":[{"kind":"Name","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
 	assert.Equal(actualResponseBody, expectedResponseBody, "Actual value did not match expectations:\n%s", actualResponseBody)
 }

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -3,7 +3,7 @@ package debugger
 import (
 	"time"
 
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	"k8s.io/client-go/kubernetes"
@@ -48,7 +48,7 @@ type MeshCatalogDebugger interface {
 	ListDisconnectedProxies() map[certificate.CommonName]time.Time
 
 	// ListSMIPolicies lists the SMI policies detected by OSM.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 
 	// ListMonitoredNamespaces lists the namespaces that the control plan knows about.
 	ListMonitoredNamespaces() []string

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	smiAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
@@ -114,7 +114,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		TrafficSplit:   smiTrafficSplitInformerFactory.Split().V1alpha2().TrafficSplits().Informer(),
 		HTTPRouteGroup: smiTrafficSpecInformerFactory.Specs().V1alpha4().HTTPRouteGroups().Informer(),
 		TCPRoute:       smiTrafficSpecInformerFactory.Specs().V1alpha4().TCPRoutes().Informer(),
-		TrafficTarget:  smiTrafficTargetInformerFactory.Access().V1alpha2().TrafficTargets().Informer(),
+		TrafficTarget:  smiTrafficTargetInformerFactory.Access().V1alpha3().TrafficTargets().Informer(),
 	}
 
 	cacheCollection := CacheCollection{

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -5,7 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	testTrafficTargetClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned/fake"
@@ -213,7 +213,7 @@ var _ = Describe("When listing ServiceAccounts", func() {
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "access.smi-spec.io/v1alpha2",
+				APIVersion: "access.smi-spec.io/v1alpha3",
 				Kind:       "TrafficTarget",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -239,7 +239,7 @@ var _ = Describe("When listing ServiceAccounts", func() {
 			},
 		}
 
-		_, err := fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Create(context.TODO(), trafficTarget, metav1.CreateOptions{})
+		_, err := fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha3().TrafficTargets(testNamespaceName).Create(context.TODO(), trafficTarget, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		<-ttChannel
 
@@ -248,7 +248,7 @@ var _ = Describe("When listing ServiceAccounts", func() {
 		numExpectedSvcAccounts := len(trafficTarget.Spec.Sources) + 1 // 1 for the destination ServiceAccount
 		Expect(len(svcAccounts)).To(Equal(numExpectedSvcAccounts))
 
-		err = fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})
+		err = fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha3().TrafficTargets(testNamespaceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		<-ttChannel
 	})
@@ -273,7 +273,7 @@ var _ = Describe("When listing TrafficTargets", func() {
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "access.smi-spec.io/v1alpha2",
+				APIVersion: "access.smi-spec.io/v1alpha3",
 				Kind:       "TrafficTarget",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -299,14 +299,14 @@ var _ = Describe("When listing TrafficTargets", func() {
 			},
 		}
 
-		_, err := fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Create(context.TODO(), trafficTarget, metav1.CreateOptions{})
+		_, err := fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha3().TrafficTargets(testNamespaceName).Create(context.TODO(), trafficTarget, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		<-ttChannel
 
 		targets := meshSpec.ListTrafficTargets()
 		Expect(len(targets)).To(Equal(1))
 
-		err = fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha2().TrafficTargets(testNamespaceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})
+		err = fakeClientSet.smiTrafficTargetClientSet.AccessV1alpha3().TrafficTargets(testNamespaceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		<-ttChannel
 	})
@@ -405,7 +405,7 @@ var _ = Describe("When listing TCP routes", func() {
 		defer events.GetPubSubInstance().Unsub(trChannel)
 		routeSpec := &smiSpecs.TCPRoute{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "specs.smi-spec.io/v1alpha2",
+				APIVersion: "specs.smi-spec.io/v1alpha4",
 				Kind:       "TCPRoute",
 			},
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -1,7 +1,7 @@
 package smi
 
 import (
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
@@ -15,7 +15,7 @@ type fakeMeshSpec struct {
 	trafficSplits    []*split.TrafficSplit
 	httpRouteGroups  []*spec.HTTPRouteGroup
 	tcpRoutes        []*spec.TCPRoute
-	trafficTargets   []*target.TrafficTarget
+	trafficTargets   []*access.TrafficTarget
 	backpressures    []*backpressure.Backpressure
 	weightedServices []service.WeightedService
 	serviceAccounts  []service.K8sServiceAccount
@@ -27,7 +27,7 @@ func NewFakeMeshSpecClient() MeshSpec {
 		trafficSplits:    []*split.TrafficSplit{&tests.TrafficSplit},
 		httpRouteGroups:  []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 		tcpRoutes:        []*spec.TCPRoute{&tests.TCPRoute},
-		trafficTargets:   []*target.TrafficTarget{&tests.TrafficTarget},
+		trafficTargets:   []*access.TrafficTarget{&tests.TrafficTarget},
 		weightedServices: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService},
 		serviceAccounts: []service.K8sServiceAccount{
 			tests.BookstoreServiceAccount,
@@ -69,7 +69,7 @@ func (f fakeMeshSpec) GetTCPRoute(_ string) *spec.TCPRoute {
 }
 
 // ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.
-func (f fakeMeshSpec) ListTrafficTargets() []*target.TrafficTarget {
+func (f fakeMeshSpec) ListTrafficTargets() []*access.TrafficTarget {
 	return f.trafficTargets
 }
 

--- a/pkg/smi/mock_meshspec.go
+++ b/pkg/smi/mock_meshspec.go
@@ -10,9 +10,9 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/openservicemesh/osm/experimental/pkg/apis/policy/v1alpha1"
 	service "github.com/openservicemesh/osm/pkg/service"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 )
 
 // MockMeshSpec is a mock of MeshSpec interface
@@ -123,10 +123,10 @@ func (mr *MockMeshSpecMockRecorder) ListTrafficSplitServices() *gomock.Call {
 }
 
 // ListTrafficSplits mocks base method
-func (m *MockMeshSpec) ListTrafficSplits() []*v1alpha20.TrafficSplit {
+func (m *MockMeshSpec) ListTrafficSplits() []*v1alpha2.TrafficSplit {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTrafficSplits")
-	ret0, _ := ret[0].([]*v1alpha20.TrafficSplit)
+	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
 	return ret0
 }
 
@@ -137,10 +137,10 @@ func (mr *MockMeshSpecMockRecorder) ListTrafficSplits() *gomock.Call {
 }
 
 // ListTrafficTargets mocks base method
-func (m *MockMeshSpec) ListTrafficTargets() []*v1alpha2.TrafficTarget {
+func (m *MockMeshSpec) ListTrafficTargets() []*v1alpha3.TrafficTarget {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTrafficTargets")
-	ret0, _ := ret[0].([]*v1alpha2.TrafficTarget)
+	ret0, _ := ret[0].([]*v1alpha3.TrafficTarget)
 	return ret0
 }
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -1,7 +1,7 @@
 package smi
 
 import (
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
@@ -68,7 +68,7 @@ type MeshSpec interface {
 	GetTCPRoute(string) *spec.TCPRoute
 
 	// ListTrafficTargets lists SMI TrafficTarget resources
-	ListTrafficTargets() []*target.TrafficTarget
+	ListTrafficTargets() []*access.TrafficTarget
 
 	// GetBackpressurePolicy fetches the Backpressure policy for the MeshService
 	GetBackpressurePolicy(service.MeshService) *backpressure.Backpressure

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 
-	target "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
@@ -285,27 +285,27 @@ var (
 	}
 
 	// TrafficTarget is a traffic target SMI object.
-	TrafficTarget = target.TrafficTarget{
+	TrafficTarget = access.TrafficTarget{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "access.smi-spec.io/v1alpha2",
+			APIVersion: "access.smi-spec.io/v1alpha3",
 			Kind:       "TrafficTarget",
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      TrafficTargetName,
 			Namespace: "default",
 		},
-		Spec: target.TrafficTargetSpec{
-			Destination: target.IdentityBindingSubject{
+		Spec: access.TrafficTargetSpec{
+			Destination: access.IdentityBindingSubject{
 				Kind:      "Name",
 				Name:      BookstoreServiceAccountName,
 				Namespace: "default",
 			},
-			Sources: []target.IdentityBindingSubject{{
+			Sources: []access.IdentityBindingSubject{{
 				Kind:      "Name",
 				Name:      BookbuyerServiceAccountName,
 				Namespace: "default",
 			}},
-			Rules: []target.TrafficTargetRule{{
+			Rules: []access.TrafficTargetRule{{
 				Kind:    "HTTPRouteGroup",
 				Name:    RouteGroupName,
 				Matches: []string{BuyBooksMatchName, SellBooksMatchName},
@@ -356,7 +356,7 @@ var (
 	// HTTPRouteGroup is the HTTP route group SMI object.
 	HTTPRouteGroup = spec.HTTPRouteGroup{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "specs.smi-spec.io/v1alpha2",
+			APIVersion: "specs.smi-spec.io/v1alpha4",
 			Kind:       "HTTPRouteGroup",
 		},
 		ObjectMeta: v1.ObjectMeta{
@@ -395,7 +395,7 @@ var (
 	// TCPRoute is a TCPRoute SMI resource
 	TCPRoute = spec.TCPRoute{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "specs.smi-spec.io/v1alpha2",
+			APIVersion: "specs.smi-spec.io/v1alpha4",
 			Kind:       "TCPRoute",
 		},
 		ObjectMeta: v1.ObjectMeta{
@@ -497,28 +497,28 @@ func NewMeshServiceFixture(serviceName, namespace string) service.MeshService {
 }
 
 // NewSMITrafficTarget creates a new SMI Traffic Target
-func NewSMITrafficTarget(sourceName, sourceNamespace, destName, destNamespace string) target.TrafficTarget {
-	return target.TrafficTarget{
+func NewSMITrafficTarget(sourceName, sourceNamespace, destName, destNamespace string) access.TrafficTarget {
+	return access.TrafficTarget{
 		TypeMeta: v1.TypeMeta{
-			APIVersion: "access.smi-spec.io/v1alpha2",
+			APIVersion: "access.smi-spec.io/v1alpha3",
 			Kind:       "TrafficTarget",
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      destName,
 			Namespace: destNamespace,
 		},
-		Spec: target.TrafficTargetSpec{
-			Destination: target.IdentityBindingSubject{
+		Spec: access.TrafficTargetSpec{
+			Destination: access.IdentityBindingSubject{
 				Kind:      "ServiceAccount",
 				Name:      destName,
 				Namespace: destNamespace,
 			},
-			Sources: []target.IdentityBindingSubject{{
+			Sources: []access.IdentityBindingSubject{{
 				Kind:      "ServiceAccount",
 				Name:      sourceName,
 				Namespace: sourceNamespace,
 			}},
-			Rules: []target.TrafficTargetRule{{
+			Rules: []access.TrafficTargetRule{{
 				Kind:    "HTTPRouteGroup",
 				Name:    RouteGroupName,
 				Matches: []string{BuyBooksMatchName, SellBooksMatchName},

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -116,7 +116,7 @@ func testTraffic(withSourceKubernetesService bool) {
 			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s Kubernetes Service to a destination", sourceService)
 
 			By("Deleting SMI policies")
-			Expect(Td.SmiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+			Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
 			Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
 
 			// Expect client not to reach server

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -141,7 +141,7 @@ func testTCPTraffic(permissiveMode bool) {
 
 			if !permissiveMode {
 				By("Deleting SMI policies")
-				Expect(Td.SmiClients.AccessClient.AccessV1alpha2().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
+				Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
 				Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().TCPRoutes(sourceName).Delete(context.TODO(), trafficRouteName, metav1.DeleteOptions{})).To(Succeed())
 
 				// Expect client not to reach server

--- a/tests/framework/common_smi.go
+++ b/tests/framework/common_smi.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha2"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	smiTrafficAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
@@ -64,7 +64,7 @@ func (td *OsmTestData) CreateTCPRoute(ns string, route smiSpecs.TCPRoute) (*smiS
 
 // CreateTrafficTarget Creates an SMI TrafficTarget
 func (td *OsmTestData) CreateTrafficTarget(ns string, tar smiAccess.TrafficTarget) (*smiAccess.TrafficTarget, error) {
-	tt, err := td.SmiClients.AccessClient.AccessV1alpha2().TrafficTargets(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
+	tt, err := td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create TrafficTarget")
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
v1alpha3 of SMI traffic access is the latest. It
deprecates the `port` field (unused in OSM)
and adds constraints on the source, destination and rules
field in the `TraffciTarget` spec.

Also renames the import aliases to be based on pkg path
and updates older traffic specs api references.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [X]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`