### PR TITLE
proxy: Add certificate SerialNumber as a parameter to the NewProxy() function and as a field to the Proxy{} struct

### DIFF
--- a/pkg/catalog/announcement_handlers_test.go
+++ b/pkg/catalog/announcement_handlers_test.go
@@ -29,10 +29,11 @@ var _ = Describe("Test Announcement Handlers", func() {
 		podUID = uuid.New().String()
 
 		envoyCN = "abcdefg"
+		certSerialNumber := certificate.SerialNumber("123456")
 		_, err := mc.certManager.IssueCertificate(envoyCN, 5*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
-		proxy = envoy.NewProxy(envoyCN, nil)
+		proxy = envoy.NewProxy(envoyCN, certSerialNumber, nil)
 		proxy.PodMetadata = &envoy.PodMetadata{
 			UID: podUID,
 		}

--- a/pkg/catalog/debugger_test.go
+++ b/pkg/catalog/debugger_test.go
@@ -12,8 +12,9 @@ import (
 
 var _ = Describe("Test catalog proxy register/unregister", func() {
 	mc := newFakeMeshCatalog()
-	cn := certificate.CommonName("foo")
-	proxy := envoy.NewProxy(cn, nil)
+	certCommonName := certificate.CommonName("foo")
+	certSerialNumber := certificate.SerialNumber("123456")
+	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 
 	Context("Test register/unregister proxies", func() {
 		It("no proxies expected, connected or disconnected", func() {
@@ -29,7 +30,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 
 		It("expect one proxy to connect", func() {
 			// mc.RegisterProxy(proxy)
-			mc.ExpectProxy(cn)
+			mc.ExpectProxy(certCommonName)
 
 			expectedProxies := mc.ListExpectedProxies()
 			Expect(len(expectedProxies)).To(Equal(1))
@@ -40,7 +41,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 			disconnectedProxies := mc.ListDisconnectedProxies()
 			Expect(len(disconnectedProxies)).To(Equal(0))
 
-			_, ok := expectedProxies[cn]
+			_, ok := expectedProxies[certCommonName]
 			Expect(ok).To(BeTrue())
 		})
 
@@ -56,7 +57,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 			disconnectedProxies := mc.ListDisconnectedProxies()
 			Expect(len(disconnectedProxies)).To(Equal(0))
 
-			_, ok := connectedProxies[cn]
+			_, ok := connectedProxies[certCommonName]
 			Expect(ok).To(BeTrue())
 		})
 
@@ -72,7 +73,7 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 			disconnectedProxies := mc.ListDisconnectedProxies()
 			Expect(len(disconnectedProxies)).To(Equal(1))
 
-			_, ok := disconnectedProxies[cn]
+			_, ok := disconnectedProxies[certCommonName]
 			Expect(ok).To(BeTrue())
 		})
 	})

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -18,7 +18,7 @@ func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
 
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
 func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
-	mc.connectedProxies.Store(proxy.XDSCertificateCommonName, connectedProxy{
+	mc.connectedProxies.Store(proxy.GetCertificateCommonName(), connectedProxy{
 		proxy:       proxy,
 		connectedAt: time.Now(),
 	})
@@ -33,9 +33,9 @@ func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
 
 // UnregisterProxy unregisters the given proxy from the catalog.
 func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	mc.connectedProxies.Delete(p.XDSCertificateCommonName)
+	mc.connectedProxies.Delete(p.GetCertificateCommonName())
 
-	mc.disconnectedProxies.Store(p.XDSCertificateCommonName, disconnectedProxy{
+	mc.disconnectedProxies.Store(p.GetCertificateCommonName(), disconnectedProxy{
 		lastSeen: time.Now(),
 	})
 

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -18,7 +18,7 @@ func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
 
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
 func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
-	mc.connectedProxies.Store(proxy.CommonName, connectedProxy{
+	mc.connectedProxies.Store(proxy.XDSCertificateCommonName, connectedProxy{
 		proxy:       proxy,
 		connectedAt: time.Now(),
 	})
@@ -33,9 +33,9 @@ func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
 
 // UnregisterProxy unregisters the given proxy from the catalog.
 func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	mc.connectedProxies.Delete(p.CommonName)
+	mc.connectedProxies.Delete(p.XDSCertificateCommonName)
 
-	mc.disconnectedProxies.Store(p.CommonName, disconnectedProxy{
+	mc.disconnectedProxies.Store(p.XDSCertificateCommonName, disconnectedProxy{
 		lastSeen: time.Now(),
 	})
 

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -49,7 +49,7 @@ func recordEnvoyPodMetadata(request *xds_discovery.DiscoveryRequest, proxy *envo
 			log.Error().Err(err).Msgf("Error parsing Envoy Node ID: %s", request.Node.Id)
 		} else {
 			log.Trace().Msgf("Recorded metadata for Envoy %s: podUID=%s, podNamespace=%s, serviceAccountName=%s, envoyNodeID=%s",
-				proxy.XDSCertificateCommonName, meta.UID, meta.Namespace, meta.ServiceAccount, meta.EnvoyNodeID)
+				proxy.GetCertificateCommonName(), meta.UID, meta.Namespace, meta.ServiceAccount, meta.EnvoyNodeID)
 			proxy.PodMetadata = meta
 
 			// We call RegisterProxy again on the MeshCatalog to update the index on pod metadata

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -49,7 +49,7 @@ func recordEnvoyPodMetadata(request *xds_discovery.DiscoveryRequest, proxy *envo
 			log.Error().Err(err).Msgf("Error parsing Envoy Node ID: %s", request.Node.Id)
 		} else {
 			log.Trace().Msgf("Recorded metadata for Envoy %s: podUID=%s, podNamespace=%s, serviceAccountName=%s, envoyNodeID=%s",
-				proxy.CommonName, meta.UID, meta.Namespace, meta.ServiceAccount, meta.EnvoyNodeID)
+				proxy.XDSCertificateCommonName, meta.UID, meta.Namespace, meta.ServiceAccount, meta.EnvoyNodeID)
 			proxy.PodMetadata = meta
 
 			// We call RegisterProxy again on the MeshCatalog to update the index on pod metadata

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -70,8 +70,9 @@ var _ = Describe("Test ADS response functions", func() {
 		GinkgoT().Fatalf("Error creating new Bookstire Apex service: %s", err.Error())
 	}
 
-	cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", proxyUUID, serviceAccountName, namespace))
-	proxy := envoy.NewProxy(cn, nil)
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", proxyUUID, serviceAccountName, namespace))
+	certSerialNumber := certificate.SerialNumber("123456")
+	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 
 	meshService := service.MeshService{
 		Namespace: "default",
@@ -107,9 +108,9 @@ var _ = Describe("Test ADS response functions", func() {
 	Context("Test sendAllResponses()", func() {
 
 		certManager := tresor.NewFakeCertManager(mockConfigurator)
-		cn := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), serviceAccountName, tests.Namespace))
+		certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), serviceAccountName, tests.Namespace))
 		certDuration := 1 * time.Hour
-		certPEM, _ := certManager.IssueCertificate(cn, certDuration)
+		certPEM, _ := certManager.IssueCertificate(certCommonName, certDuration)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 		server, actualResponses := tests.NewFakeXDSServer(cert, nil, nil)
 

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -30,7 +30,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	metricsstore.DefaultMetricsStore.ProxyConnectCount.Inc()
 
 	// This is the Envoy proxy that just connected to the control plane.
-	proxy := envoy.NewProxy(certCommonName, utils.GetIPFromContext(server.Context()))
+	proxy := envoy.NewProxy(certCommonName, certSerialNumber, utils.GetIPFromContext(server.Context()))
 	s.catalog.RegisterProxy(proxy)
 	defer s.catalog.UnregisterProxy(proxy)
 

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -78,7 +78,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	alreadyAdded := mapset.NewSet()
 	for _, cluster := range clusters {
 		if alreadyAdded.Contains(cluster.Name) {
-			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy for Service %s with CN=%s", cluster.Name, proxyServiceName, proxy.CommonName)
+			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy for Service %s with CN=%s", cluster.Name, proxyServiceName, proxy.XDSCertificateCommonName)
 			continue
 		}
 		alreadyAdded.Add(cluster.Name)

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -78,7 +78,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	alreadyAdded := mapset.NewSet()
 	for _, cluster := range clusters {
 		if alreadyAdded.Contains(cluster.Name) {
-			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy for Service %s with CN=%s", cluster.Name, proxyServiceName, proxy.XDSCertificateCommonName)
+			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy for Service %s with CN=%s", cluster.Name, proxyServiceName, proxy.GetCertificateCommonName())
 			continue
 		}
 		alreadyAdded.Add(cluster.Name)

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -52,7 +52,8 @@ var _ = Describe("CDS Response", func() {
 
 			// The format of the CN matters
 			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
-			proxy := envoy.NewProxy(xdsCertificate, nil)
+			certSerialNumber := certificate.SerialNumber("123456")
+			proxy := envoy.NewProxy(xdsCertificate, certSerialNumber, nil)
 
 			{
 				// Create a pod to match the CN

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -41,7 +41,8 @@ var _ = Describe("Test EDS response", func() {
 
 			// The format of the CN matters
 			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
-			proxy := envoy.NewProxy(xdsCertificate, nil)
+			certSerialNumber := certificate.SerialNumber("123456")
+			proxy := envoy.NewProxy(xdsCertificate, certSerialNumber, nil)
 
 			{
 				// Create a pod to match the CN
@@ -76,7 +77,8 @@ var _ = Describe("Test EDS response", func() {
 
 			// The format of the CN matters
 			xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, proxyServiceAccountName, tests.Namespace))
-			proxy := envoy.NewProxy(xdsCertificate, nil)
+			certSerialNumber := certificate.SerialNumber("123456")
+			proxy := envoy.NewProxy(xdsCertificate, certSerialNumber, nil)
 
 			// Don't create a pod/service for this proxy, this should result in an error when the
 			// service is being looked up based on the proxy's certificate

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -128,10 +128,15 @@ func (p Proxy) GetAnnouncementsChannel() chan announcements.Announcement {
 }
 
 // NewProxy creates a new instance of an Envoy proxy connected to the xDS servers.
-func NewProxy(cn certificate.CommonName, ip net.Addr) *Proxy {
+func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificate.SerialNumber, ip net.Addr) *Proxy {
 	return &Proxy{
-		CommonName: cn,
-		Addr:       ip,
+		CommonName:   certCommonName,
+		SerialNumber: certSerialNumber,
+
+		// PodUID will be set when the proxy is registered a second time during the xDS hand-shake
+		PodUID: "",
+
+		Addr: ip,
 
 		connectedAt: time.Now(),
 

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -13,10 +13,10 @@ import (
 // This should at some point have a 1:1 match to an Endpoint (which is a member of a meshed service).
 type Proxy struct {
 	// The Subject Common Name of the certificate used for Envoy to XDS communication.
-	XDSCertificateCommonName certificate.CommonName
+	xDSCertificateCommonName certificate.CommonName
 
 	// The Serial Number of the certificate used for Envoy to XDS communication.
-	XDSCertificateSerialNumber certificate.SerialNumber
+	xDSCertificateSerialNumber certificate.SerialNumber
 
 	PodUID string
 
@@ -107,12 +107,12 @@ func (p Proxy) GetPodUID() string {
 
 // GetCertificateCommonName returns the Subject Common Name from the mTLS certificate of the Envoy proxy connected to xDS.
 func (p Proxy) GetCertificateCommonName() certificate.CommonName {
-	return p.XDSCertificateCommonName
+	return p.xDSCertificateCommonName
 }
 
 // GetCertificateSerialNumber returns the Serial Number of the certificate for the connected Envoy proxy.
 func (p Proxy) GetCertificateSerialNumber() certificate.SerialNumber {
-	return p.XDSCertificateSerialNumber
+	return p.xDSCertificateSerialNumber
 }
 
 // GetConnectedAt returns the timestamp of when the given proxy connected to the control plane.
@@ -133,8 +133,8 @@ func (p Proxy) GetAnnouncementsChannel() chan announcements.Announcement {
 // NewProxy creates a new instance of an Envoy proxy connected to the xDS servers.
 func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificate.SerialNumber, ip net.Addr) *Proxy {
 	return &Proxy{
-		XDSCertificateCommonName:   certCommonName,
-		XDSCertificateSerialNumber: certSerialNumber,
+		xDSCertificateCommonName:   certCommonName,
+		xDSCertificateSerialNumber: certSerialNumber,
 
 		// PodUID will be set when the proxy is registered a second time during the xDS hand-shake
 		PodUID: "",

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -12,8 +12,11 @@ import (
 // Proxy is a representation of an Envoy proxy connected to the xDS server.
 // This should at some point have a 1:1 match to an Endpoint (which is a member of a meshed service).
 type Proxy struct {
-	certificate.CommonName
-	certificate.SerialNumber
+	// The Subject Common Name of the certificate used for Envoy to XDS communication.
+	XDSCertificateCommonName certificate.CommonName
+
+	// The Serial Number of the certificate used for Envoy to XDS communication.
+	XDSCertificateSerialNumber certificate.SerialNumber
 
 	PodUID string
 
@@ -104,12 +107,12 @@ func (p Proxy) GetPodUID() string {
 
 // GetCertificateCommonName returns the Subject Common Name from the mTLS certificate of the Envoy proxy connected to xDS.
 func (p Proxy) GetCertificateCommonName() certificate.CommonName {
-	return p.CommonName
+	return p.XDSCertificateCommonName
 }
 
 // GetCertificateSerialNumber returns the Serial Number of the certificate for the connected Envoy proxy.
 func (p Proxy) GetCertificateSerialNumber() certificate.SerialNumber {
-	return p.SerialNumber
+	return p.XDSCertificateSerialNumber
 }
 
 // GetConnectedAt returns the timestamp of when the given proxy connected to the control plane.
@@ -130,8 +133,8 @@ func (p Proxy) GetAnnouncementsChannel() chan announcements.Announcement {
 // NewProxy creates a new instance of an Envoy proxy connected to the xDS servers.
 func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificate.SerialNumber, ip net.Addr) *Proxy {
 	return &Proxy{
-		CommonName:   certCommonName,
-		SerialNumber: certSerialNumber,
+		XDSCertificateCommonName:   certCommonName,
+		XDSCertificateSerialNumber: certSerialNumber,
 
 		// PodUID will be set when the proxy is registered a second time during the xDS hand-shake
 		PodUID: "",

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -15,21 +15,21 @@ const (
 )
 
 var _ = Describe("Test proxy methods", func() {
-	cn := certificate.CommonName(fmt.Sprintf("UUID-of-proxy.%s.%s.one.two.three.co.uk", svc, ns))
-	// certSerialNumber := certificate.SerialNumber("123")
-	proxy := NewProxy(cn, nil)
+	certCommonName := certificate.CommonName(fmt.Sprintf("UUID-of-proxy.%s.%s.one.two.three.co.uk", svc, ns))
+	certSerialNumber := certificate.SerialNumber("123456")
+	proxy := NewProxy(certCommonName, certSerialNumber, nil)
 
 	Context("Testing proxy.GetCertificateCommonName()", func() {
 		It("should return DNS-1123 CN of the proxy", func() {
 			actualCN := proxy.GetCertificateCommonName()
-			Expect(actualCN).To(Equal(cn))
+			Expect(actualCN).To(Equal(certCommonName))
 		})
 	})
 
-	// Context("Testing proxy.GetCertificateSerialNumber()", func() {
-	// 	It("should return certificate serial number", func() {
-	// 		actualSerialNumber := proxy.GetCertificateSerialNumber()
-	//		Expect(actualSerialNumber).To(Equal(certSerialNumber))
-	//	})
-	//})
+	Context("Testing proxy.GetCertificateSerialNumber()", func() {
+		It("should return certificate serial number", func() {
+			actualSerialNumber := proxy.GetCertificateSerialNumber()
+			Expect(actualSerialNumber).To(Equal(certSerialNumber))
+		})
+	})
 })

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -132,10 +132,12 @@ func TestGetRootCert(t *testing.T) {
 				tc.prepare(&d)
 			}
 
+			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
+			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
 				proxyServices: []service.MeshService{tc.proxyService},
 				svcAccount:    tc.proxySvcAccount,
-				proxy:         envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
+				proxy:         envoy.NewProxy(certCommonName, certSerialNumber, nil),
 				certManager:   mockCertManager,
 
 				// these points to the dynamic mocks which gets updated for each test
@@ -345,10 +347,12 @@ func TestGetSDSSecrets(t *testing.T) {
 				tc.prepare(&d)
 			}
 
+			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
+			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
 				proxyServices: []service.MeshService{tc.proxyService},
 				svcAccount:    tc.proxySvcAccount,
-				proxy:         envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1")), nil),
+				proxy:         envoy.NewProxy(certCommonName, certSerialNumber, nil),
 				certManager:   mockCertManager,
 
 				// these points to the dynamic mocks which gets updated for each test

--- a/pkg/utils/mtls.go
+++ b/pkg/utils/mtls.go
@@ -65,6 +65,6 @@ func ValidateClient(ctx context.Context, allowedCommonNames map[string]interface
 		return "", "", status.Error(codes.Unauthenticated, "disallowed subject common name")
 	}
 
-	serialNumber := tlsAuth.State.VerifiedChains[0][0].SerialNumber.String()
-	return certificate.CommonName(cn), certificate.SerialNumber(serialNumber), nil
+	certificateSerialNumber := tlsAuth.State.VerifiedChains[0][0].SerialNumber.String()
+	return certificate.CommonName(cn), certificate.SerialNumber(certificateSerialNumber), nil
 }

--- a/tests/scenarios/helpers.go
+++ b/tests/scenarios/helpers.go
@@ -60,7 +60,9 @@ func getMeshCatalogAndProxy() (catalog.MeshCataloger, *envoy.Proxy, error) {
 		makeService(kubeClient, svcName)
 	}
 
-	proxy := envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace)), nil)
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+	certSerialNumber := certificate.SerialNumber("123456")
+	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 
 	return meshCatalog, proxy, nil
 }


### PR DESCRIPTION
This PR adds `SerialNumber` to the `NewProxy()` function in the `pkg/envoy` package.

With this change the `Proxy{}` struct is going to record not only the xDS certificate CommonName, but also the SerialNumber, and also the UID of the Pod the Envoy is fronting.

In a follow-up PR (https://github.com/openservicemesh/osm/pull/2333), the xDS certificate's `SerialNumber` is going to be used for all (most) log lines instead of the `CommonName`