### PR TITLE
Change ValidateClient to return certificate SerialNumber for newly connected Envoy proxies

### DIFF
--- a/pkg/utils/mtls.go
+++ b/pkg/utils/mtls.go
@@ -40,29 +40,31 @@ func setupMutualTLS(insecure bool, serverName string, certPem []byte, keyPem []b
 }
 
 // ValidateClient ensures that the connected client is authorized to connect to the gRPC server.
-func ValidateClient(ctx context.Context, allowedCommonNames map[string]interface{}) (certificate.CommonName, error) {
+func ValidateClient(ctx context.Context, allowedCommonNames map[string]interface{}) (certificate.CommonName, certificate.SerialNumber, error) {
 	mtlsPeer, ok := peer.FromContext(ctx)
 	if !ok {
 		log.Error().Msg("[grpc][mTLS] No peer found")
-		return "", status.Error(codes.Unauthenticated, "no peer found")
+		return "", "", status.Error(codes.Unauthenticated, "no peer found")
 	}
 
 	tlsAuth, ok := mtlsPeer.AuthInfo.(credentials.TLSInfo)
 	if !ok {
 		log.Error().Msg("[grpc][mTLS] Unexpected peer transport credentials")
-		return "", status.Error(codes.Unauthenticated, "unexpected peer transport credentials")
+		return "", "", status.Error(codes.Unauthenticated, "unexpected peer transport credentials")
 	}
 
 	if len(tlsAuth.State.VerifiedChains) == 0 || len(tlsAuth.State.VerifiedChains[0]) == 0 {
 		log.Error().Msgf("[grpc][mTLS] Could not verify peer certificate")
-		return "", status.Error(codes.Unauthenticated, "could not verify peer certificate")
+		return "", "", status.Error(codes.Unauthenticated, "could not verify peer certificate")
 	}
 
 	// Check whether the subject common name is one that is allowed to connect.
 	cn := tlsAuth.State.VerifiedChains[0][0].Subject.CommonName
 	if _, ok := allowedCommonNames[cn]; len(allowedCommonNames) > 0 && !ok {
 		log.Error().Msgf("[grpc][mTLS] Subject common name %+v not allowed", cn)
-		return "", status.Error(codes.Unauthenticated, "disallowed subject common name")
+		return "", "", status.Error(codes.Unauthenticated, "disallowed subject common name")
 	}
-	return certificate.CommonName(cn), nil
+
+	serialNumber := tlsAuth.State.VerifiedChains[0][0].SerialNumber.String()
+	return certificate.CommonName(cn), certificate.SerialNumber(serialNumber), nil
 }

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -83,12 +83,14 @@ func TestValidateClient(t *testing.T) {
 	}
 
 	for _, vct := range validateClientTests {
-		result, err := ValidateClient(vct.ctx, vct.commonNames)
+		certCN, certSerialNumber, err := ValidateClient(vct.ctx, vct.commonNames)
 		if err != nil {
-			assert.Equal(result, certificate.CommonName(""))
+			assert.Equal(certCN, certificate.CommonName(""))
+			assert.Equal(certSerialNumber, certificate.SerialNumber(""))
 			assert.True(errors.Is(err, vct.expectedError))
 		} else {
-			assert.NotNil(result)
+			assert.NotNil(certCN)
+			assert.NotNil(certSerialNumber)
 			assert.Empty(vct.expectedError)
 		}
 	}


### PR DESCRIPTION
This PR changes the `ValidateClient()` function so that it returns not only the Envoy xDS certificate's CommonName, but also the certificate's SerialNumber, which will be used in log statements.

Also in this PR: removed logging of Pod IP and xDS certificate Subject CommonName