### PR TITLE
ads: Do not log Envoy's XDS Certificate CN; log cert's SerialNumber instead

### DIFF
--- a/pkg/catalog/announcement_handlers_test.go
+++ b/pkg/catalog/announcement_handlers_test.go
@@ -3,10 +3,11 @@ package catalog
 import (
 	"time"
 
+	"github.com/google/uuid"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,13 +28,10 @@ var _ = Describe("Test Announcement Handlers", func() {
 	BeforeEach(func() {
 		mc = NewFakeMeshCatalog(testclient.NewSimpleClientset())
 		podUID = uuid.New().String()
-
-		envoyCN = "abcdefg"
-		certSerialNumber := certificate.SerialNumber("123456")
 		_, err := mc.certManager.IssueCertificate(envoyCN, 5*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
-		proxy = envoy.NewProxy(envoyCN, certSerialNumber, nil)
+		proxy = envoy.NewProxy(envoyCN, "-cert-serial-number-", nil)
 		proxy.PodMetadata = &envoy.PodMetadata{
 			UID: podUID,
 		}

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -33,7 +33,7 @@ func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
 		// Create a PodUID to Cert Serial Number so we can easily look-up the SerialNumber of the cert issued to a proxy for a given Pod.
 		mc.podUIDToCertificateSerialNumber.Store(podUID, proxy.GetCertificateSerialNumber())
 	}
-	log.Trace().Msgf("Registered new proxy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+	log.Debug().Msgf("Registered new proxy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
@@ -44,5 +44,5 @@ func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
 		lastSeen: time.Now(),
 	})
 
-	log.Trace().Msgf("Unregistered proxy with certificate SerialNumber=%v on Pod with UID=%s", p.GetCertificateSerialNumber(), p.GetPodUID())
+	log.Debug().Msgf("Unregistered proxy with certificate SerialNumber=%v on Pod with UID=%s", p.GetCertificateSerialNumber(), p.GetPodUID())
 }

--- a/pkg/catalog/proxy.go
+++ b/pkg/catalog/proxy.go
@@ -26,9 +26,14 @@ func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
 	// If this proxy object is on a Kubernetes Pod - it will have an UID
 	if proxy.HasPodMetadata() {
 		podUID := types.UID(proxy.PodMetadata.UID)
+
+		// Create a PodUID to Certificate CN map so we can easily determine the CN from the PodUID
 		mc.podUIDToCN.Store(podUID, proxy.GetCertificateCommonName())
+
+		// Create a PodUID to Cert Serial Number so we can easily look-up the SerialNumber of the cert issued to a proxy for a given Pod.
+		mc.podUIDToCertificateSerialNumber.Store(podUID, proxy.GetCertificateSerialNumber())
 	}
-	log.Info().Msgf("Registered new proxy: CN=%v, ip=%v", proxy.GetCertificateCommonName(), proxy.GetIP())
+	log.Trace().Msgf("Registered new proxy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
@@ -39,5 +44,5 @@ func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
 		lastSeen: time.Now(),
 	})
 
-	log.Info().Msgf("Unregistered proxy: CN=%v, ip=%v", p.GetCertificateCommonName(), p.GetIP())
+	log.Trace().Msgf("Unregistered proxy with certificate SerialNumber=%v on Pod with UID=%s", p.GetCertificateSerialNumber(), p.GetPodUID())
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -47,8 +47,11 @@ type MeshCatalog struct {
 	// lookups
 	kubeController k8s.Controller
 
-	// Maintain a mapping of pod UID to CN of the Envoy on that pod
+	// Maintain a mapping of pod UID to CN of the Envoy on the given pod
 	podUIDToCN sync.Map
+
+	// Maintain a mapping of pod UID to certificate SerialNumber of the Envoy on the given pod
+	podUIDToCertificateSerialNumber sync.Map
 }
 
 // MeshCataloger is the mechanism by which the Service Mesh controller discovers all Envoy proxies connected to the catalog.

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -36,7 +36,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 		return nil, err
 	}
 
-	log.Trace().Msgf("It took %+v to issue certificate with SerialNumber=%s", time.Since(start), cert.GetSerialNumber())
+	log.Debug().Msgf("It took %+v to issue certificate with SerialNumber=%s", time.Since(start), cert.GetSerialNumber())
 
 	return cert, nil
 }
@@ -91,7 +91,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	cm.cacheLock.Unlock()
 	cm.announcements <- announcements.Announcement{}
 
-	log.Info().Msgf("Rotated certificate (old SerialNumber=%s) with new SerialNumber=%s; took %+v", oldCert.GetSerialNumber(), newCert.GetSerialNumber(), time.Since(start))
+	log.Debug().Msgf("Rotated certificate (old SerialNumber=%s) with new SerialNumber=%s; took %+v", oldCert.GetSerialNumber(), newCert.GetSerialNumber(), time.Since(start))
 
 	return newCert, nil
 }

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -200,7 +200,7 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 		return nil, err
 	}
 
-	log.Trace().Msgf("Created CertificateRequest %s/%s for CN=%s", cm.namespace, cr.Name, cn)
+	log.Debug().Msgf("Created CertificateRequest %s/%s for CN=%s", cm.namespace, cr.Name, cn)
 
 	// TODO: add timeout option instead of 60s hard coded.
 	cr, err = cm.waitForCertificateReady(cr.Name, time.Second*60)

--- a/pkg/debugger/envoy.go
+++ b/pkg/debugger/envoy.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (ds DebugConfig) getEnvoyConfig(pod *v1.Pod, url string) string {
-	log.Info().Msgf("Getting Envoy config for Pod with UID=%s", pod.ObjectMeta.UID)
+	log.Info().Msgf("Getting Envoy config on Pod with UID=%s", pod.ObjectMeta.UID)
 
 	minPort := 16000
 	maxPort := 18000
@@ -40,7 +40,7 @@ func (ds DebugConfig) getEnvoyConfig(pod *v1.Pod, url string) string {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Error().Msgf("Error getting Envoy config for Pod with UID=%s; HTTP Error %d", pod.ObjectMeta.UID, resp.StatusCode)
+		log.Error().Msgf("Error getting Envoy config on Pod with UID=%s; HTTP Error %d", pod.ObjectMeta.UID, resp.StatusCode)
 		portFwdRequest.Stop <- struct{}{}
 		return fmt.Sprintf("Error: %s", err)
 	}

--- a/pkg/debugger/envoy.go
+++ b/pkg/debugger/envoy.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (ds DebugConfig) getEnvoyConfig(pod *v1.Pod, url string) string {
-	log.Info().Msgf("Getting Envoy config on Pod with UID=%s", pod.ObjectMeta.UID)
+	log.Debug().Msgf("Getting Envoy config on Pod with UID=%s", pod.ObjectMeta.UID)
 
 	minPort := 16000
 	maxPort := 18000

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -31,14 +31,10 @@ func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery
 				// Set the Pod metadata on the given proxy only once. This could arrive with the first few XDS requests.
 				recordEnvoyPodMetadata(request, proxy, catalog)
 			}
-			nodeID := ""
-			if request.Node != nil {
-				nodeID = request.Node.Id
-			}
-			log.Trace().Msgf("[grpc] Received DiscoveryRequest from Envoy with CN %s; Node ID: %s", proxy.GetCertificateCommonName(), nodeID)
+			log.Trace().Msgf("[grpc] Received DiscoveryRequest from Envoy with certificate SerialNumber %s", proxy.GetCertificateSerialNumber())
 			requests <- *request
 		} else {
-			log.Warn().Msgf("[grpc] Unknown resource: %+v", request)
+			log.Warn().Msgf("[grpc] Received a request for an unknown TypeURL: %+v", request.TypeUrl)
 		}
 	}
 }
@@ -50,10 +46,12 @@ func recordEnvoyPodMetadata(request *xds_discovery.DiscoveryRequest, proxy *envo
 		} else {
 			log.Trace().Msgf("Recorded metadata for Envoy %s: podUID=%s, podNamespace=%s, serviceAccountName=%s, envoyNodeID=%s",
 				proxy.GetCertificateCommonName(), meta.UID, meta.Namespace, meta.ServiceAccount, meta.EnvoyNodeID)
+
+			// Set the Pod Metadata, which will be used in the RegisterProxy() invocation below!
 			proxy.PodMetadata = meta
 
-			// We call RegisterProxy again on the MeshCatalog to update the index on pod metadata
-			catalog.RegisterProxy(proxy)
+			// We call RegisterProxy again, for a second time, on the MeshCatalog to update the index on pod metadata
+			catalog.RegisterProxy(proxy) // Second of Two invocations. First one was on establishing the gRPC stream.
 		}
 	}
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -25,16 +25,16 @@ func (s *Server) sendTypeResponse(tURI envoy.TypeURI,
 	xdsShortName := envoy.XDSShortURINames[tURI]
 	defer xdsPathTimeTrack(time.Now(), xdsShortName, proxy.GetCertificateCommonName().String(), &success)
 
-	log.Trace().Msgf("[%s] Creating response for proxy with CN=%s", xdsShortName, proxy.GetCertificateCommonName())
+	log.Trace().Msgf("[%s] Creating response for proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 
 	discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, req, cfg)
 	if err != nil {
-		log.Error().Err(err).Msgf("[%s] Failed to create response for proxy with CN=%s", xdsShortName, proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("[%s] Failed to create response for proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return err
 	}
 
 	if err := (*server).Send(discoveryResponse); err != nil {
-		log.Error().Err(err).Msgf("[%s] Error sending to proxy with CN=%s", xdsShortName, proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("[%s] Error sending to proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return err
 	}
 
@@ -43,7 +43,7 @@ func (s *Server) sendTypeResponse(tURI envoy.TypeURI,
 }
 
 func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, cfg configurator.Configurator) {
-	log.Trace().Msgf("A change announcement triggered *DS update for proxy with CN=%s", proxy.GetCertificateCommonName())
+	log.Trace().Msgf("A change announcement triggered *DS update for proxy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 
 	// Tracks the success of this full update of all its XDS paths. If a single XDS response path fails for this full update,
 	// the full updated will be considered as failed for metric purposes (success = false)
@@ -79,7 +79,7 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.Aggr
 func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCataloger) *xds_discovery.DiscoveryRequest {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with CN=%q", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil
 	}
 	// Github Issue #1575
@@ -87,7 +87,7 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 
 	proxyIdentity, err := catalog.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with CN=%q", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil
 	}
 

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -78,13 +78,13 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	alreadyAdded := mapset.NewSet()
 	for _, cluster := range clusters {
 		if alreadyAdded.Contains(cluster.Name) {
-			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy with XDS Certificate SerialNumber=%s on on Pod with UID=%s", cluster.Name, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy with XDS Certificate SerialNumber=%s on Pod with UID=%s", cluster.Name, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 			continue
 		}
 		alreadyAdded.Add(cluster.Name)
 		marshalledClusters, err := ptypes.MarshalAny(cluster)
 		if err != nil {
-			log.Error().Err(err).Msgf("Failed to marshal cluster %s for Envoy with XDS Certificate SerialNumber=%s on on Pod with UID=%s", cluster.Name, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+			log.Error().Err(err).Msgf("Failed to marshal cluster %s for Envoy with XDS Certificate SerialNumber=%s on Pod with UID=%s", cluster.Name, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 			return nil, err
 		}
 		resp.Resources = append(resp.Resources, marshalledClusters)

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -19,7 +19,7 @@ import (
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, _ configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with CN=%q", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err
 	}
 	// Github Issue #1575
@@ -27,7 +27,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	proxyIdentity, err := catalog.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with CN=%q", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err
 	}
 

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -20,7 +20,7 @@ import (
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with CN=%q", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err
 	}
 	// Github Issue #1575
@@ -28,7 +28,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	svcAccount, err := catalog.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error retrieving ServiceAccount for proxy %s", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error retrieving ServiceAccount for Envoy with certificate with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err
 	}
 

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -18,8 +18,6 @@ type Proxy struct {
 	// The Serial Number of the certificate used for Envoy to XDS communication.
 	xDSCertificateSerialNumber certificate.SerialNumber
 
-	PodUID string
-
 	net.Addr
 	announcements chan announcements.Announcement
 
@@ -97,12 +95,15 @@ func (p *Proxy) SetNewNonce(typeURI TypeURI) string {
 
 // String returns the CommonName of the proxy.
 func (p Proxy) String() string {
-	return string(p.GetCertificateCommonName())
+	return p.GetPodUID()
 }
 
 // GetPodUID returns the UID of the pod, which the connected Envoy proxy is fronting.
 func (p Proxy) GetPodUID() string {
-	return p.PodUID
+	if p.PodMetadata == nil {
+		return ""
+	}
+	return p.PodMetadata.UID
 }
 
 // GetCertificateCommonName returns the Subject Common Name from the mTLS certificate of the Envoy proxy connected to xDS.
@@ -135,9 +136,6 @@ func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificat
 	return &Proxy{
 		xDSCertificateCommonName:   certCommonName,
 		xDSCertificateSerialNumber: certSerialNumber,
-
-		// PodUID will be set when the proxy is registered a second time during the xDS hand-shake
-		PodUID: "",
 
 		Addr: ip,
 

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -3,6 +3,8 @@ package envoy
 import (
 	"fmt"
 
+	"github.com/google/uuid"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -17,19 +19,24 @@ const (
 var _ = Describe("Test proxy methods", func() {
 	certCommonName := certificate.CommonName(fmt.Sprintf("UUID-of-proxy.%s.%s.one.two.three.co.uk", svc, ns))
 	certSerialNumber := certificate.SerialNumber("123456")
+	podUID := uuid.New().String()
 	proxy := NewProxy(certCommonName, certSerialNumber, nil)
 
-	Context("Testing proxy.GetCertificateCommonName()", func() {
-		It("should return DNS-1123 CN of the proxy", func() {
-			actualCN := proxy.GetCertificateCommonName()
-			Expect(actualCN).To(Equal(certCommonName))
+	Context("test GetPodUID() with empty Pod Metadata field", func() {
+		It("returns correct values", func() {
+			Expect(proxy.GetPodUID()).To(Equal(""))
 		})
 	})
 
-	Context("Testing proxy.GetCertificateSerialNumber()", func() {
-		It("should return certificate serial number", func() {
-			actualSerialNumber := proxy.GetCertificateSerialNumber()
-			Expect(actualSerialNumber).To(Equal(certSerialNumber))
+	Context("test correctness proxy object creation", func() {
+		It("returns correct values", func() {
+			Expect(proxy.GetCertificateCommonName()).To(Equal(certCommonName))
+			Expect(proxy.GetCertificateSerialNumber()).To(Equal(certSerialNumber))
+
+			proxy.PodMetadata = &PodMetadata{
+				UID: podUID,
+			}
+			Expect(proxy.GetPodUID()).To(Equal(podUID))
 		})
 	})
 })

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -21,7 +21,7 @@ import (
 func NewResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, _ configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
 	svcList, err := catalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with CN=%q", proxy.GetCertificateCommonName())
+		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err
 	}
 	// Github Issue #1575


### PR DESCRIPTION
This PR removes XDS Certificate CommonName from log messages and uses XDS Certificate's SerialNumber.

---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
