### PR TITLE
injector: Idiomatic logging of error messages with log.Error().Err(err)

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -131,7 +131,7 @@ func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(identity service.K
 					Namespace: t.Spec.Destination.Namespace,
 				})
 				if err != nil {
-					log.Error().Msgf("No Services found matching Service Account %s in Namespace %s", t.Spec.Destination.Name, t.Namespace)
+					log.Error().Err(err).Msgf("No Services found matching Service Account %s in Namespace %s", t.Spec.Destination.Name, t.Namespace)
 					break
 				}
 				for _, destService := range destServices {
@@ -487,7 +487,7 @@ func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sService
 	for _, sa := range saList {
 		services, err := mc.GetServicesForServiceAccount(sa)
 		if err != nil {
-			log.Error().Msgf("Error getting services linked to Service Account %s: %v", sa, err)
+			log.Error().Err(err).Msgf("Error getting services linked to Service Account %s", sa)
 			continue
 		} else {
 			for _, s := range services {
@@ -547,14 +547,14 @@ func (mc *MeshCatalog) buildInboundPolicies(t *access.TrafficTarget) []*trafficp
 	// fetch services running workloads with destination service account
 	destServices, err := mc.getDestinationServicesFromTrafficTarget(t)
 	if err != nil {
-		log.Error().Msgf("Error resolving destination from traffic target %s (%s): %v", t.Name, t.Namespace, err)
+		log.Error().Err(err).Msgf("Error resolving destination from traffic target %s (%s)", t.Name, t.Namespace)
 		return inboundPolicies
 	}
 
 	// fetch all routes referenced in traffic target
 	routeMatches, err := mc.routesFromRules(t.Spec.Rules, t.Namespace)
 	if err != nil {
-		log.Error().Msgf("Error finding route matches from TrafficTarget %s in namespace %s: %v", t.Name, t.Namespace, err)
+		log.Error().Err(err).Msgf("Error finding route matches from TrafficTarget %s in namespace %s", t.Name, t.Namespace)
 		return inboundPolicies
 	}
 
@@ -588,7 +588,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(source service.K8sServiceAccount, t
 	// fetch services running workloads with destination service account
 	destServices, err := mc.getDestinationServicesFromTrafficTarget(t)
 	if err != nil {
-		log.Error().Msgf("Error resolving destination from traffic target %s (%s): %v", t.Name, t.Namespace, err)
+		log.Error().Err(err).Msgf("Error resolving destination from traffic target %s (%s)", t.Name, t.Namespace)
 		return outPolicies
 	}
 

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -16,13 +16,13 @@ var (
 func readTimeout(req *http.Request) (time.Duration, error) {
 	durationValue, found := req.URL.Query()[webhookMutateTimeoutKey]
 	if !found || len(durationValue) != 1 {
-		log.Error().Msgf("Webhook timeout value not found in request")
+		log.Error().Msg("Webhook timeout value not found in request")
 		return defaultK8sTimeout, errParseWebhookTimeout
 	}
 
 	val, err := time.ParseDuration(durationValue[0])
 	if err != nil {
-		log.Error().Msgf("Error parsing timeout value as duration: %v", err)
+		log.Error().Err(err).Msg("Error parsing timeout value as duration")
 		return defaultK8sTimeout, errParseWebhookTimeout
 	}
 	return val, nil

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -114,7 +114,7 @@ func (wh *mutatingWebhook) run(stop <-chan struct{}) {
 		// Generate a key pair from your pem-encoded cert and key ([]byte).
 		cert, err := tls.X509KeyPair(wh.cert.GetCertificateChain(), wh.cert.GetPrivateKey())
 		if err != nil {
-			log.Error().Err(err).Msgf("Error parsing webhook certificate: %+v", err)
+			log.Error().Err(err).Msg("Error parsing webhook certificate")
 			return
 		}
 
@@ -124,7 +124,7 @@ func (wh *mutatingWebhook) run(stop <-chan struct{}) {
 		}
 
 		if err := server.ListenAndServeTLS("", ""); err != nil {
-			log.Error().Err(err).Msgf("Sidecar-injection webhook HTTP server failed to start: %+v", err)
+			log.Error().Err(err).Msg("Sidecar injection webhook HTTP server failed to start")
 			return
 		}
 	}()
@@ -143,7 +143,7 @@ func (wh *mutatingWebhook) run(stop <-chan struct{}) {
 func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write([]byte("Health OK")); err != nil {
-		log.Error().Err(err).Msgf("Error writing bytes for mutating webhook health check handler")
+		log.Error().Err(err).Msg("Error writing bytes for mutating webhook health check handler")
 	}
 }
 
@@ -168,7 +168,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	// Read timeout from request url
 	reqTimeout, err := readTimeout(req)
 	if err != nil {
-		log.Error().Msgf("Could not read timeout from request url: %v", err)
+		log.Error().Err(err).Msg("Could not read timeout from request url")
 	}
 	// Execute at return of this handler
 	defer webhookTimeTrack(time.Now(), reqTimeout, &success)


### PR DESCRIPTION
This PR rewrites log statements that attempt to log an `err` message using `log.Error().Msgf(err)` to using `log.Error().Err(err).Msgf()`

---



<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
