### PR TITLE
injector: Idiomatic logging of error messages with log.Error().Err(err)

### DIFF
--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -25,7 +25,7 @@ func (mc *MeshCatalog) GetResolvableServiceEndpoints(svc service.MeshService) ([
 	for _, provider := range mc.endpointsProviders {
 		ep, err := provider.GetResolvableEndpointsForService(svc)
 		if err != nil {
-			log.Trace().Msgf("[%s] Error getting endpoints for %s : %v", provider.GetID(), svc, err)
+			log.Error().Err(err).Msgf("[%s] Error getting endpoints for Service %s", provider.GetID(), svc)
 			continue
 		}
 		if len(ep) == 0 {

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -18,17 +18,18 @@ const (
 func (mc *MeshCatalog) GetServicesForServiceAccount(sa service.K8sServiceAccount) ([]service.MeshService, error) {
 	var services []service.MeshService
 	for _, provider := range mc.endpointsProviders {
-		if providerServices, err := provider.GetServicesForServiceAccount(sa); err != nil {
-			log.Warn().Msgf("Error getting K8s Services linked to Service Account %s from provider %s: %s", provider.GetID(), sa, err)
-		} else {
-			var svcs []string
-			for _, svc := range providerServices {
-				svcs = append(svcs, svc.String())
-			}
-
-			log.Trace().Msgf("Found K8s Services %s linked to Service Account %s from endpoint provider %s", strings.Join(svcs, ","), sa, provider.GetID())
-			services = append(services, providerServices...)
+		providerServices, err := provider.GetServicesForServiceAccount(sa)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error getting K8s Services linked to Service Account %s from provider %s", sa, provider.GetID())
+			continue
 		}
+		var svcs []string
+		for _, svc := range providerServices {
+			svcs = append(svcs, svc.String())
+		}
+
+		log.Trace().Msgf("Found K8s Services %s linked to Service Account %s from endpoint provider %s", strings.Join(svcs, ","), sa, provider.GetID())
+		services = append(services, providerServices...)
 	}
 
 	if len(services) == 0 {

--- a/pkg/configurator/validating_webhook.go
+++ b/pkg/configurator/validating_webhook.go
@@ -85,7 +85,7 @@ func NewValidatingWebhook(kubeClient kubernetes.Interface, certManager certifica
 	cn := certificate.CommonName(fmt.Sprintf("%s.%s.svc", validatorServiceName, osmNamespace))
 	cert, err := certManager.IssueCertificate(cn, constants.XDSCertificateValidityPeriod)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error issuing certificate for the validating webhook: %+v", err)
+		log.Error().Err(err).Msgf("Error issuing certificate for the validating webhook")
 		return err
 	}
 
@@ -101,7 +101,7 @@ func NewValidatingWebhook(kubeClient kubernetes.Interface, certManager certifica
 
 	// Update the ValidatingWebhookConfig with the OSM CA bundle
 	if err = updateValidatingWebhookCABundle(cert, webhookConfigName, whc.kubeClient); err != nil {
-		log.Error().Err(err).Msgf("Error configuring ValidatingWebhookConfiguration %s: %+v", webhookConfigName, err)
+		log.Error().Err(err).Msgf("Error configuring ValidatingWebhookConfiguration %s", webhookConfigName)
 		return err
 	}
 	return nil
@@ -131,7 +131,7 @@ func (whc *webhookConfig) runValidatingWebhook(stop <-chan struct{}) {
 		// Generate a key pair from your pem-encoded cert and key ([]byte).
 		cert, err := tls.X509KeyPair(whc.cert.GetCertificateChain(), whc.cert.GetPrivateKey())
 		if err != nil {
-			log.Error().Err(err).Msgf("Error parsing webhook certificate: %+v", err)
+			log.Error().Err(err).Msg("Error parsing webhook certificate")
 			return
 		}
 
@@ -140,7 +140,7 @@ func (whc *webhookConfig) runValidatingWebhook(stop <-chan struct{}) {
 			Certificates: []tls.Certificate{cert},
 		}
 		if err := server.ListenAndServeTLS("", ""); err != nil {
-			log.Error().Err(err).Msgf("Validating webhook HTTP server failed to start: %+v", err)
+			log.Error().Err(err).Msg("Validating webhook HTTP server failed to start")
 			return
 		}
 	}()

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -40,7 +40,7 @@ func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *
 
 		tracing, err := GetTracingConfig(cfg)
 		if err != nil {
-			log.Error().Err(err).Msgf("Error getting tracing config %s", err)
+			log.Error().Err(err).Msg("Error getting tracing config")
 			return connManager
 		}
 

--- a/pkg/envoy/lds/tracing.go
+++ b/pkg/envoy/lds/tracing.go
@@ -19,7 +19,7 @@ func GetTracingConfig(cfg configurator.Configurator) (*xds_hcm.HttpConnectionMan
 
 	zipkinConfMarshalled, err := ptypes.MarshalAny(zipkinTracingConf)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error marshalling zipkinConf config %s", err)
+		log.Error().Err(err).Msgf("Error marshalling Zipkin config")
 		return nil, err
 	}
 

--- a/pkg/reconciler/mutatingwebhook/reconcile.go
+++ b/pkg/reconciler/mutatingwebhook/reconcile.go
@@ -63,11 +63,11 @@ func (r *MutatingWebhookConfigurationReconciler) Reconcile(req ctrl.Request) (ct
 		}
 
 		if err := r.Update(ctx, instance); err != nil {
-			log.Error().Err(err).Msgf("Error updating mutatingwebhookconfiguration %s: %s", req.Name, err)
+			log.Error().Err(err).Msgf("Error updating MutatingWebhookConfiguration %s", req.Name)
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
-		log.Trace().Msgf("Successfully updated mutatingwebhookconfiguration CA bundle for : %s ", req.Name)
+		log.Debug().Msgf("Successfully updated CA Bundle for MutatingWebhookConfiguration %s ", req.Name)
 
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
This PR rewrites log statements that attempt to log an `err` message using `log.Error().Msgf(err)` to using `log.Error().Err(err).Msgf()`

This is another PR following the 1st in the series: https://github.com/openservicemesh/osm/pull/2348

In this PR - used the opportunity to remove a level of indentation using `continue` when there's an error.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
