### PR TITLE
ads: Curate log messages when Envoys connect to xDS control plane

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -93,11 +93,6 @@ func (p *Proxy) SetNewNonce(typeURI TypeURI) string {
 	return p.lastNonce[typeURI]
 }
 
-// String returns the CommonName of the proxy.
-func (p Proxy) String() string {
-	return p.GetPodUID()
-}
-
 // GetPodUID returns the UID of the pod, which the connected Envoy proxy is fronting.
 func (p Proxy) GetPodUID() string {
 	if p.PodMetadata == nil {


### PR DESCRIPTION
This PR ensures that log messages emitted by `ads/stream.go` abide by the heuristic we established - we will log the Envoy xDS Certificate SerialNumber and not the Subject CommonName.

---

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
