### PR TITLE
gRPC: allow specifying gRPC as appProtocol for service ports

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -3,6 +3,7 @@ package lds
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -27,6 +28,7 @@ const (
 	outboundMeshTCPFilterChainPrefix  = "outbound-mesh-tcp-filter-chain"
 	httpAppProtocol                   = "http"
 	tcpAppProtocol                    = "tcp"
+	gRPCAppProtocol                   = "grpc"
 )
 
 func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshService) []*xds_listener.FilterChain {
@@ -40,8 +42,8 @@ func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshS
 
 	// Create protocol specific inbound filter chains per port to handle different ports serving different protocols
 	for port, appProtocol := range protocolToPortMap {
-		switch appProtocol {
-		case httpAppProtocol:
+		switch strings.ToLower(appProtocol) {
+		case httpAppProtocol, gRPCAppProtocol:
 			// Filter chain for HTTP port
 			filterChainForPort, err := lb.getInboundMeshHTTPFilterChain(proxyService, port)
 			if err != nil {
@@ -401,8 +403,8 @@ func (lb *listenerBuilder) getOutboundFilterChainPerUpstream() []*xds_listener.F
 
 		// Create protocol specific inbound filter chains per port to handle different ports serving different protocols
 		for port, appProtocol := range protocolToPortMap {
-			switch appProtocol {
-			case httpAppProtocol:
+			switch strings.ToLower(appProtocol) {
+			case httpAppProtocol, gRPCAppProtocol:
 				// Construct HTTP filter chain
 				if httpFilterChain, err := lb.getOutboundHTTPFilterChainForService(upstream, port); err != nil {
 					log.Error().Err(err).Msgf("Error constructing outbound HTTP filter chain for upstream service %s on proxy with identity %s", upstream, lb.svcAccount)

--- a/tests/e2e/e2e_grpc_client_server_test.go
+++ b/tests/e2e/e2e_grpc_client_server_test.go
@@ -1,0 +1,160 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+const grpcbinInsecurePort = 9000
+
+var _ = OSMDescribe("Test gRPC traffic from 1 pod client -> 1 pod server",
+	OSMDescribeInfo{
+		Tier:   1,
+		Bucket: 2,
+	},
+	func() {
+		Context("gRPC client server with SMI policies", func() {
+			testGRPCTraffic()
+		})
+	})
+
+func testGRPCTraffic() {
+	{
+		const sourceName = "client"
+		const destName = "server"
+		var ns = []string{sourceName, destName}
+
+		It("Tests gRPC traffic for client pod -> server pod", func() {
+			// Install OSM
+			Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+
+			// Create Test NS
+			for _, n := range ns {
+				Expect(Td.CreateNs(n, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+			}
+
+			// Get simple pod definitions for the gRPC server
+			svcAccDef, podDef, svcDef := Td.SimplePodApp(
+				SimplePodAppDef{
+					Name:        destName,
+					Namespace:   destName,
+					Image:       "moul/grpcbin",
+					Ports:       []int{9000},
+					AppProtocol: "grpc",
+				})
+
+			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreatePod(destName, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			dstSvc, err := Td.CreateService(destName, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+			srcPod := setupGRPCClient(sourceName)
+
+			trafficTargetName := "test-target"
+			trafficRouteName := "routes"
+
+			By("Creating SMI policies")
+			// Deploy allow rule client->server
+			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+				SimpleAllowPolicy{
+					RouteGroupName:    trafficRouteName,
+					TrafficTargetName: trafficTargetName,
+
+					SourceNamespace:      sourceName,
+					SourceSVCAccountName: sourceName,
+
+					DestinationNamespace:      destName,
+					DestinationSvcAccountName: destName,
+				})
+
+			// Configs have to be put into a monitored NS
+			_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+			Expect(err).NotTo(HaveOccurred())
+
+			// All ready. Expect client to reach server
+			clientToServer := GRPCRequestDef{
+				SourceNs:        sourceName,
+				SourcePod:       srcPod.Name,
+				SourceContainer: sourceName,
+
+				Destination: fmt.Sprintf("%s.%s:%d", dstSvc.Name, dstSvc.Namespace, grpcbinInsecurePort),
+
+				JSONRequest: "{\"greeting\": \"client\"}",
+				Symbol:      "hello.HelloService/SayHello",
+			}
+
+			srcToDestStr := fmt.Sprintf("%s/%s -> %s",
+				clientToServer.SourceNs, clientToServer.SourcePod, clientToServer.Destination)
+
+			cond := Td.WaitForRepeatedSuccess(func() bool {
+				result := Td.GRPCRequest(clientToServer)
+
+				if result.Err != nil {
+					Td.T.Logf("> (%s) gRPC req failed, response: %s, err: %s",
+						srcToDestStr, result.Response, result.Err)
+					return false
+				}
+
+				Td.T.Logf("> (%s) gRPC req succeeded, response: %s", srcToDestStr, result.Response)
+				return true
+			}, 5, 90*time.Second)
+
+			Expect(cond).To(BeTrue(), "Failed testing gRPC traffic for: %s", srcToDestStr)
+
+			By("Deleting SMI policies")
+			Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
+			Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), trafficRouteName, metav1.DeleteOptions{})).To(Succeed())
+
+			// Expect client not to reach server
+			cond = Td.WaitForRepeatedSuccess(func() bool {
+				result := Td.GRPCRequest(clientToServer)
+
+				if result.Err == nil {
+					Td.T.Logf("> (%s) gRPC req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
+					return false
+				}
+				Td.T.Logf("> (%s) gRPC req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
+				return true
+			}, 5, 150*time.Second)
+			Expect(cond).To(BeTrue())
+		})
+	}
+}
+
+func setupGRPCClient(sourceName string) *corev1.Pod {
+	// Get simple Pod definitions for the client
+	svcAccDef, podDef, _ := Td.SimplePodApp(SimplePodAppDef{
+		Name:      sourceName,
+		Namespace: sourceName,
+		Command:   []string{"sleep", "365d"},
+		Image:     "networld/grpcurl",
+	})
+
+	_, err := Td.CreateServiceAccount(sourceName, &svcAccDef)
+	Expect(err).NotTo(HaveOccurred())
+
+	srcPod, err := Td.CreatePod(sourceName, podDef)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Expect it to be up and running in it's receiver namespace
+	Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+
+	return srcPod
+}


### PR DESCRIPTION
OSM supports gRPC traffic since gRPC uses HTTP2 as the transport.
gRPC traffic is supported as long as a gRPC client uses plaintext
request origination and lets OSM upgrade it to TLS.

This change allows specifying `grpc` as an application protocol
so that it can leverage HTTP based routing. 

An e2e test has been added where a gRPC client 
[grpcurl](https://github.com/fullstorydev/grpcurl) makes gRPC requests to the [grpcbin](https://github.com/moul/grpcbin) service.

Part of #2353

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

Sample output from test:
```
STEP: Creating SMI policies
...
> (client/client -> server.server:9000) gRPC req succeeded, response: {
  "reply": "hello client"
}
> (client/client -> server.server:9000) gRPC req succeeded, response: {
  "reply": "hello client"
}
...
...
STEP: Deleting SMI policies
STEP: [WaitForRepeatedSuccess] waiting 2m30s for 5 iterations to succeed
..
> (client/client -> server.server:9000) gRPC req failed correctly, response: , err: Remote exec err: command terminated with exit code 1 | stderr:  | cmd: [/grpcurl -d {"greeting": "client"} -plaintext server.server:9000 hello.HelloService/SayHello]
> (client/client -> server.server:9000) gRPC req failed correctly, response: , err: Remote exec err: command terminated with exit code 1 | stderr:  | cmd: [/grpcurl -d {"greeting": "client"} -plaintext server.server:9000 hello.HelloService/SayHello]
```
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`