### PR TITLE
injector: Small correction to a log message

### DIFF
--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -265,7 +265,7 @@ func (wh *mutatingWebhook) isNamespaceInjectable(namespace string) bool {
 // The function returns an error when it is unable to determine whether to perform sidecar injection.
 func (wh *mutatingWebhook) mustInject(pod *corev1.Pod, namespace string) (bool, error) {
 	if !wh.isNamespaceInjectable(namespace) {
-		log.Warn().Msgf("Request is for pod with UUID %s in namespace %s; Injection in namespace %s is not permitted", namespace, pod.Name, namespace)
+		log.Warn().Msgf("Mutation request is for pod with UID %s; Injection in Namespace %s is not permitted", pod.ObjectMeta.UID, namespace)
 		return false, nil
 	}
 


### PR DESCRIPTION
This PR fixes a bug in the positioning of the string template and corrects the Pod UID; also simplifies the message.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>


---


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
