### PR TITLE
Fix typo on Prometheus enablement flag

### DIFF
--- a/docs/patterns/observability/README.md
+++ b/docs/patterns/observability/README.md
@@ -1,6 +1,6 @@
 # Observability
 
-OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--deploy-grafana`, `--deploy-grafana` and `--enable-fluentbit`.
+OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--deploy-prometheus`, `--deploy-grafana` and `--enable-fluentbit`.
 
 ## Table of Contents
 - [Metrics - Prometheus and Grafana](/docs/patterns/observability/metrics.md)


### PR DESCRIPTION
**Description**: Just fixes up a typo in one of the docs pages.

**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]

- Does this change contain code from or inspired by another project? **No.** If so, did you notify the maintainers and provide attribution? **N/A**
