### PR TITLE
ads: Adding a comment to a log line to remind us of the importance of logging ADS request/responses carefully

### DIFF
--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -154,6 +154,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *xds
 	response.Nonce = proxy.SetNewNonce(typeURL)
 	response.VersionInfo = strconv.FormatUint(proxy.IncrementLastSentVersion(typeURL), 10)
 
+	// NOTE: Never log entire 'response' - will contain secrets!
 	log.Trace().Msgf("Constructed %s response: VersionInfo=%s", response.TypeUrl, response.VersionInfo)
 
 	return response, nil


### PR DESCRIPTION
Adding a comment to a log line to remind us of the importance of logging ADS request/responses carefully

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>

---


- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
