### PR TITLE
envoy/ads: Augment log messages with context

### DIFF
--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -20,10 +20,10 @@ func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery
 		request, recvErr := (*server).Recv()
 		if recvErr != nil {
 			if status.Code(recvErr) == codes.Canceled || recvErr == io.EOF {
-				log.Error().Msgf("[grpc] Connection terminated: %+v", recvErr)
+				log.Debug().Err(recvErr).Msgf("[grpc] Connection terminated")
 				return
 			}
-			log.Error().Msgf("[grpc] Connection terminated with error: %+v", recvErr)
+			log.Error().Err(recvErr).Msgf("[grpc] Connection error")
 			return
 		}
 		if request.TypeUrl != "" {

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -63,7 +63,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			return nil
 
 		case <-quit:
-			log.Info().Msg("Stream closed!")
+			log.Debug().Msgf("gRPC stream with Envoy on Pod with UID=%s closed!", proxy.GetPodUID())
 			metricsstore.DefaultMetricsStore.ProxyConnectCount.Dec()
 			return nil
 


### PR DESCRIPTION
This PR tweaks a few ADS messages to add more context.

Changing log.Error to log.Debug for when a gRPC is cancelled.