### PR TITLE
(tests): Fix labels and selectors while creating pods and services for various test scenarios

### DIFF
--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -45,19 +45,19 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 	certManager := tresor.NewFakeCertManager(mockConfigurator)
 
 	// Create a bookstoreV1 pod
-	bookstoreV1Pod := tests.NewPodTestFixtureWithOptions(tests.BookstoreV1Service.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName)
+	bookstoreV1Pod := tests.NewPodFixture(tests.BookstoreV1Service.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName, tests.PodLabels)
 	if _, err := kubeClient.CoreV1().Pods(tests.BookstoreV1Service.Namespace).Create(context.TODO(), &bookstoreV1Pod, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error creating new pod: %s", err.Error())
 	}
 
 	// Create a bookstoreV2 pod
-	bookstoreV2Pod := tests.NewPodTestFixtureWithOptions(tests.BookstoreV2Service.Namespace, tests.BookstoreV2Service.Name, tests.BookstoreServiceAccountName)
+	bookstoreV2Pod := tests.NewPodFixture(tests.BookstoreV2Service.Namespace, tests.BookstoreV2Service.Name, tests.BookstoreServiceAccountName, tests.PodLabels)
 	if _, err := kubeClient.CoreV1().Pods(tests.BookstoreV2Service.Namespace).Create(context.TODO(), &bookstoreV2Pod, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error creating new pod: %s", err.Error())
 	}
 
 	// Create a bookbuyer pod
-	bookbuyerPod := tests.NewPodTestFixtureWithOptions(tests.BookbuyerService.Namespace, tests.BookbuyerService.Name, tests.BookbuyerServiceAccountName)
+	bookbuyerPod := tests.NewPodFixture(tests.BookbuyerService.Namespace, tests.BookbuyerService.Name, tests.BookbuyerServiceAccountName, tests.PodLabels)
 	if _, err := kubeClient.CoreV1().Pods(tests.BookbuyerService.Namespace).Create(context.TODO(), &bookbuyerPod, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error creating new pod: %s", err.Error())
 	}

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -69,7 +69,7 @@ func newFakeMeshCatalog() *MeshCatalog {
 	certManager := tresor.NewFakeCertManager(cfg)
 
 	// Create a pod
-	pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName)
+	pod := tests.NewPodFixture(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 	if _, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{}); err != nil {
 		GinkgoT().Fatalf("Error creating new fake Mesh Catalog: %s", err.Error())
 	}

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 
 	Context("Test GetServicesFromEnvoyCertificate()", func() {
 		It("works as expected", func() {
-			pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName)
+			pod := tests.NewPodFixture(tests.Namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pod.Spec.ServiceAccountName).To(Equal(tests.BookstoreServiceAccountName))
@@ -106,9 +106,8 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			proxyUUID := uuid.New()
 			namespace := uuid.New().String()
 			podName := uuid.New().String()
-			newPod := tests.NewPodTestFixture(namespace, podName)
+			newPod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, tests.PodLabels)
 			newPod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
-			newPod.Labels[tests.SelectorKey] = tests.SelectorValue
 
 			_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -140,24 +139,29 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			someOtherEnvoyUID := uuid.New().String()
 			namespace := uuid.New().String()
 			mockKubeController := k8s.NewMockController(mockCtrl)
+			podlabels := map[string]string{
+				tests.SelectorKey:                tests.SelectorValue,
+				constants.EnvoyUniqueIDLabelName: proxyUUID.String(),
+			}
+			someOthePodLabels := map[string]string{
+				tests.SelectorKey:                tests.SelectorValue,
+				constants.EnvoyUniqueIDLabelName: someOtherEnvoyUID,
+			}
 
 			// Ensure correct presetup
 			pods, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(pods.Items)).To(Equal(0))
 
-			newPod0 := tests.NewPodTestFixture(namespace, fmt.Sprintf("pod-0-%s", uuid.New()))
-			newPod0.Labels[constants.EnvoyUniqueIDLabelName] = someOtherEnvoyUID
+			newPod0 := tests.NewPodFixture(namespace, fmt.Sprintf("pod-0-%s", uuid.New()), tests.BookstoreServiceAccountName, someOthePodLabels)
 			_, err = kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod0, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			newPod1 := tests.NewPodTestFixture(namespace, fmt.Sprintf("pod-1-%s", uuid.New()))
-			newPod1.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
+			newPod1 := tests.NewPodFixture(namespace, fmt.Sprintf("pod-1-%s", uuid.New()), tests.BookstoreServiceAccountName, podlabels)
 			_, err = kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod1, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			newPod2 := tests.NewPodTestFixture(namespace, fmt.Sprintf("pod-2-%s", uuid.New()))
-			newPod2.Labels[constants.EnvoyUniqueIDLabelName] = someOtherEnvoyUID
+			newPod2 := tests.NewPodFixture(namespace, fmt.Sprintf("pod-2-%s", uuid.New()), tests.BookstoreServiceAccountName, someOthePodLabels)
 			_, err = kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod2, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -186,7 +190,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			// Create a pod with the same certificateCN twice
 			for range []int{0, 1} {
 				podName := uuid.New().String()
-				newPod := tests.NewPodTestFixture(namespace, podName)
+				newPod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, tests.PodLabels)
 				newPod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
 
 				_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
@@ -212,9 +216,9 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			var pods []*v1.Pod
 			for range []int{0, 1} {
 				podName := uuid.New().String()
-				newPod := tests.NewPodTestFixture(namespace, podName)
+				tests.PodLabels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
+				newPod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, tests.PodLabels)
 				pods = append(pods, &newPod)
-				newPod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
 
 				_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -237,7 +241,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			mockKubeController := k8s.NewMockController(mockCtrl)
 
 			podName := uuid.New().String()
-			newPod := tests.NewPodTestFixture(namespace, podName)
+			newPod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, tests.PodLabels)
 			newPod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
 
 			_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
@@ -262,7 +266,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			mockKubeController := k8s.NewMockController(mockCtrl)
 
 			podName := uuid.New().String()
-			newPod := tests.NewPodTestFixture(namespace, podName)
+			newPod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, tests.PodLabels)
 			newPod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
 
 			_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod, metav1.CreateOptions{})
@@ -305,7 +309,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 				serviceNames = append(serviceNames, service.Name)
 			}
 
-			pod := tests.NewPodTestFixture(namespace, "pod-name")
+			pod := tests.NewPodFixture(namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			mockKubeController.EXPECT().ListServices().Return(services)
 			actualSvcs, err := listServicesForPod(&pod, mockKubeController)
 			Expect(err).ToNot(HaveOccurred())
@@ -326,7 +330,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			mockKubeController.EXPECT().ListServices().Return([]*v1.Service{service})
-			pod := tests.NewPodTestFixture(namespace, "pod-name")
+			pod := tests.NewPodFixture(namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			actualSvcs, err := listServicesForPod(&pod, mockKubeController)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(actualSvcs)).To(Equal(0))
@@ -350,7 +354,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			mockKubeController.EXPECT().ListServices().Return([]*v1.Service{service})
-			pod := tests.NewPodTestFixture(namespace, "pod-name")
+			pod := tests.NewPodFixture(namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			actualSvcs, err := listServicesForPod(&pod, mockKubeController)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(actualSvcs)).To(Equal(0))

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Test ADS response functions", func() {
 	mc := catalog.NewFakeMeshCatalog(kubeClient)
 
 	// Create a Pod
-	pod := tests.NewPodTestFixture(namespace, fmt.Sprintf("pod-0-%s", uuid.New()))
+	pod := tests.NewPodFixture(namespace, fmt.Sprintf("pod-0-%s", uuid.New()), tests.BookstoreServiceAccountName, tests.PodLabels)
 	pod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID
 	_, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 	It("should have created a pod", func() {

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -57,7 +57,7 @@ var _ = Describe("CDS Response", func() {
 
 			{
 				// Create a pod to match the CN
-				pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, podName, proxyServiceAccountName)
+				pod := tests.NewPodFixture(tests.Namespace, podName, proxyServiceAccountName, tests.PodLabels)
 				pod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String() // This is what links the Pod and the Certificate
 				_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -47,8 +47,8 @@ var _ = Describe("Test EDS response", func() {
 			{
 				// Create a pod to match the CN
 				podName := fmt.Sprintf("pod-0-%s", uuid.New())
+				pod := tests.NewPodFixture(tests.Namespace, podName, proxyServiceAccountName, tests.PodLabels)
 
-				pod := tests.NewPodTestFixtureWithOptions(tests.Namespace, podName, proxyServiceAccountName)
 				pod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String() // This is what links the Pod and the Certificate
 				_, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -55,8 +55,7 @@ var _ = Describe("Test all patch operations", func() {
 				nonInjectNamespaces: mapset.NewSet(),
 			}
 
-			pod := tests.NewPodTestFixture(namespace, podName)
-			pod.Labels = nil
+			pod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, nil)
 			pod.Annotations = nil
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("").Times(1)
 

--- a/pkg/kubernetes/event_handlers_test.go
+++ b/pkg/kubernetes/event_handlers_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Testing event handlers", func() {
 			podAddChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded)
 			defer events.GetPubSubInstance().Unsub(podAddChannel)
 
-			pod := tests.NewPodTestFixture(testNamespace, "pod-name")
+			pod := tests.NewPodFixture(testNamespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			eventTypes := EventTypes{
 				Add:    announcements.PodAdded,
 				Update: announcements.PodUpdated,
@@ -71,7 +71,7 @@ var _ = Describe("Testing event handlers", func() {
 	Context("create getNamespace", func() {
 		It("gets the namespace name", func() {
 			ns := uuid.New().String()
-			pod := tests.NewPodTestFixture(ns, uuid.New().String())
+			pod := tests.NewPodFixture(ns, uuid.New().String(), tests.BookstoreServiceAccountName, tests.PodLabels)
 			actual := getNamespace(&pod)
 			Expect(actual).To(Equal(ns))
 		})

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -430,35 +430,21 @@ var (
 		ClusterName: "default/bookstore-apex",
 		Weight:      100,
 	}
+
+	// PodLabels is a map of the default labels on pods
+	PodLabels = map[string]string{
+		SelectorKey:                      SelectorValue,
+		constants.EnvoyUniqueIDLabelName: ProxyUUID,
+	}
 )
 
-// NewPodTestFixture creates a new Pod struct for testing.
-func NewPodTestFixture(namespace string, podName string) corev1.Pod {
+// NewPodFixture creates a new Pod struct for testing.
+func NewPodFixture(namespace string, podName string, serviceAccountName string, labels map[string]string) corev1.Pod {
 	return corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      podName,
 			Namespace: namespace,
-			Labels: map[string]string{
-				SelectorKey:                      SelectorValue,
-				constants.EnvoyUniqueIDLabelName: ProxyUUID,
-			},
-		},
-		Spec: corev1.PodSpec{
-			ServiceAccountName: BookstoreServiceAccountName,
-		},
-	}
-}
-
-// NewPodTestFixtureWithOptions creates a new Pod struct with options for testing.
-func NewPodTestFixtureWithOptions(namespace string, podName string, serviceAccountName string) corev1.Pod {
-	return corev1.Pod{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-			Labels: map[string]string{
-				SelectorKey:                      SelectorValue,
-				constants.EnvoyUniqueIDLabelName: ProxyUUID,
-			},
+			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccountName,

--- a/pkg/tests/helpers.go
+++ b/pkg/tests/helpers.go
@@ -6,8 +6,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 // GetUnique gets a slice of strings and returns a slice with the unique strings
@@ -28,13 +26,7 @@ func GetUnique(slice []string) []string {
 }
 
 // MakeService creates a new service for a set of pods with matching selectors
-func MakeService(kubeClient kubernetes.Interface, svcName string) (*v1.Service, error) {
-	// These selectors must match the POD(s) created
-	selectors := map[string]string{
-		SelectorKey: SelectorValue,
-	}
-
-	// The serviceName must match the SMI
+func MakeService(kubeClient kubernetes.Interface, svcName string, selectors map[string]string) (*v1.Service, error) {
 	service := NewServiceFixture(svcName, Namespace, selectors)
 	createdService, err := kubeClient.CoreV1().Services(Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 	if err != nil {
@@ -44,11 +36,8 @@ func MakeService(kubeClient kubernetes.Interface, svcName string) (*v1.Service, 
 }
 
 // MakePod creates a pod
-func MakePod(kubeClient kubernetes.Interface, namespace, podName, serviceAccountName, proxyUUID string) (*v1.Pod, error) {
-	requestedPod := NewPodTestFixtureWithOptions(namespace, podName, serviceAccountName)
-
-	// The proxyUUID links the Pod and the Certificate created for it
-	requestedPod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID
+func MakePod(kubeClient kubernetes.Interface, namespace, podName, serviceAccountName string, labels map[string]string) (*v1.Pod, error) {
+	requestedPod := NewPodFixture(namespace, podName, serviceAccountName, labels)
 	createdPod, err := kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &requestedPod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description**:

This PR unifies the label/selector creation across all tests. 

For tests that involve getting the services from the proxy/cn it is necessary that the labels on the pods match the selectors on the services. This was being done incorrectly for a few tests, this PR mainly focuses on fixing that. In addition it also unifies the fixture creation by creating a single method  `NewPodFixture()`, that takes all the parameters required to create a pod ( namespace, pod name, service account and labels).  With this new method all previous methods have been deleted.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
