### PR TITLE
Require Go version 1.15.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ E2E_FLAGS_DEFAULT := -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGIS
 # Installed Go version
 # This is the version of Go going to be used to compile this project.
 # It will be compared with the minimum requirements for OSM.
-GO_VERSION_MAJOR = $(shell go version | grep -Po 'go\K(\d+)')
-GO_VERSION_MINOR = $(shell go version | grep -Po 'go\d+\.\K(\d+)')
-GO_VERSION_PATCH = $(shell go version | grep -Po 'go\d+\.\d+\.\K(\d+)')
+GO_VERSION_MAJOR = $(shell go version | sed -E 's/.*go([[:digit:]]+)\..*/\1/')
+GO_VERSION_MINOR = $(shell go version | sed -E 's/.*go[[:digit:]]+\.([[:digit:]]+)\..*/\1/')
+GO_VERSION_PATCH = $(shell go version | sed -E 's/.*go[[:digit:]]+\.[[:digit:]]+\.([[:digit:]]+)[[:space:]].*/\1/')
 
 # Required Go version
 # These variables set the minimum required version of Go for this project.

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ build-osm-controller: check-go-version clean-osm-controller wasm/stats.wasm
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-controller/osm-controller -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -X github.com/openservicemesh/osm/pkg/envoy/lds.statsWASMBytes=$$(base64 < wasm/stats.wasm | tr -d \\n) -s -w" ./cmd/osm-controller
 
 .PHONY: build-osm-injector
-build-osm-injector: clean-osm-injector
+build-osm-injector: check-go-version clean-osm-injector
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-injector/osm-injector -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w" ./cmd/osm-injector
 
 .PHONY: build-osm

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -1,6 +1,9 @@
 // Package main implements the main entrypoint for osm-controller and utility routines to
 // bootstrap the various internal components of osm-controller.
 // osm-controller is the core control plane componenent in OSM responsible for progamming sidecar proxies.
+
+// +build go1.15
+
 package main
 
 import (

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -1,9 +1,6 @@
 // Package main implements the main entrypoint for osm-controller and utility routines to
 // bootstrap the various internal components of osm-controller.
 // osm-controller is the core control plane componenent in OSM responsible for progamming sidecar proxies.
-
-// +build go1.15
-
 package main
 
 import (

--- a/demo/README.md
+++ b/demo/README.md
@@ -3,7 +3,7 @@
 ## System Requirements
 - MacOS, Linux or WSL2 on Windows
 - GCC
-- Go version 1.15 or higher
+- Go version [1.15.7 or higher](https://github.com/openservicemesh/osm/issues/2363)
 - Kubectl version 1.15 or higher
 - Docker CLI
    - on a Debian based GNU/Linux system: `sudo apt-get install docker`


### PR DESCRIPTION
This PR adds the `check-go-version` Makefile target, which ensures that the version of Go used to build OSM meets some minimal requirement. The requirement is hard-coded in the Makefile as well.

Fixes https://github.com/openservicemesh/osm/issues/2363

Example:
```bash
$ make build

You are building OSM with Go version 1.15.2. OSM requires Go version 1.15.7 or higher!
Makefile:40: recipe for target 'check-go-version' failed
make: *** [check-go-version] Error 1
```