### PR TITLE
docs: landing page

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -2,7 +2,6 @@
 title: "Docs"
 description: "Open Service Mesh documentation and resources."
 type: docs
-aliases: ["/docs/"]
 ---
 
 ## Overview


### PR DESCRIPTION
Follow-up to #2328. This moves the `_index.htm` file to ensure the docs landing page exists at the site root.

Signed-off-by: flynnduism <dev@ronan.design>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [x]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
