### PR TITLE
configurator/test: fix bug due to test pollution

### DIFF
--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -247,10 +247,7 @@ func TestCheckDefaultFields(t *testing.T) {
 
 func TestValidateFields(t *testing.T) {
 	assert := tassert.New(t)
-	resp := &v1beta1.AdmissionResponse{
-		Allowed: true,
-		Result:  &metav1.Status{Reason: ""},
-	}
+
 	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: whc.osmNamespace,
@@ -319,6 +316,10 @@ func TestValidateFields(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			resp := &v1beta1.AdmissionResponse{
+				Allowed: true,
+				Result:  &metav1.Status{Reason: ""},
+			}
 			res := whc.validateFields(tc.configMap, resp)
 			assert.Contains(tc.expRes.Result.Status, res.Result.Status)
 			assert.Equal(tc.expRes.Allowed, res.Allowed)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
A variable that should be scoped to the given
test case in the table of tests was scoped
to the function, causing new tests being added
to the table to fail. Currently this test only
passes because of the way existing tests in the
table are ordered.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`