### PR TITLE
injector: allow outbound IP range exclusions

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -50,6 +50,9 @@ const (
 
 	// serviceCertValidityDurationKey is the key name used to specify the validity duration of service certificates in the ConfigMap
 	serviceCertValidityDurationKey = "service_cert_validity_duration"
+
+	// outboundIPRangeExclusionListKey is the key name used to specify the ip ranges to exclude from outbound sidecar interception
+	outboundIPRangeExclusionListKey = "outbound_ip_range_exclusion_list"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -213,6 +216,9 @@ type osmConfig struct {
 	// It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix.
 	// Ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
 	ServiceCertValidityDuration string `yaml:"service_cert_validity_duration"`
+
+	// OutboundIPRangeExclusionList is the list of outbound IP ranges to exclude from sidecar interception
+	OutboundIPRangeExclusionList string `yaml:"outbound_ip_range_exclusion_list"`
 }
 
 func (c *Client) run(stop <-chan struct{}) {
@@ -264,6 +270,7 @@ func parseOSMConfigMap(configMap *v1.ConfigMap) *osmConfig {
 	osmConfigMap.TracingEnable, _ = GetBoolValueForKey(configMap, tracingEnableKey)
 	osmConfigMap.EnvoyLogLevel, _ = GetStringValueForKey(configMap, envoyLogLevel)
 	osmConfigMap.ServiceCertValidityDuration, _ = GetStringValueForKey(configMap, serviceCertValidityDurationKey)
+	osmConfigMap.OutboundIPRangeExclusionList, _ = GetStringValueForKey(configMap, outboundIPRangeExclusionListKey)
 
 	if osmConfigMap.TracingEnable {
 		osmConfigMap.TracingAddress, _ = GetStringValueForKey(configMap, tracingAddressKey)

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -51,17 +51,18 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 
 		It("Tag matches const key for all fields of OSM ConfigMap struct", func() {
 			fieldNameTag := map[string]string{
-				"PermissiveTrafficPolicyMode": PermissiveTrafficPolicyModeKey,
-				"Egress":                      egressKey,
-				"EnableDebugServer":           enableDebugServer,
-				"PrometheusScraping":          prometheusScrapingKey,
-				"TracingEnable":               tracingEnableKey,
-				"TracingAddress":              tracingAddressKey,
-				"TracingPort":                 tracingPortKey,
-				"TracingEndpoint":             tracingEndpointKey,
-				"UseHTTPSIngress":             useHTTPSIngressKey,
-				"EnvoyLogLevel":               envoyLogLevel,
-				"ServiceCertValidityDuration": serviceCertValidityDurationKey,
+				"PermissiveTrafficPolicyMode":  PermissiveTrafficPolicyModeKey,
+				"Egress":                       egressKey,
+				"EnableDebugServer":            enableDebugServer,
+				"PrometheusScraping":           prometheusScrapingKey,
+				"TracingEnable":                tracingEnableKey,
+				"TracingAddress":               tracingAddressKey,
+				"TracingPort":                  tracingPortKey,
+				"TracingEndpoint":              tracingEndpointKey,
+				"UseHTTPSIngress":              useHTTPSIngressKey,
+				"EnvoyLogLevel":                envoyLogLevel,
+				"ServiceCertValidityDuration":  serviceCertValidityDurationKey,
+				"OutboundIPRangeExclusionList": outboundIPRangeExclusionListKey,
 			}
 			t := reflect.TypeOf(osmConfig{})
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -3,6 +3,7 @@ package configurator
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -113,4 +114,19 @@ func (c *Client) GetServiceCertValidityPeriod() time.Duration {
 	}
 
 	return validityDuration
+}
+
+// GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
+func (c *Client) GetOutboundIPRangeExclusionList() []string {
+	ipRangesStr := c.getConfigMap().OutboundIPRangeExclusionList
+	if ipRangesStr == "" {
+		return nil
+	}
+
+	exclusionList := strings.Split(ipRangesStr, ",")
+	for i := range exclusionList {
+		exclusionList[i] = strings.TrimSpace(exclusionList[i])
+	}
+
+	return exclusionList
 }

--- a/pkg/configurator/mock_client.go
+++ b/pkg/configurator/mock_client.go
@@ -5,10 +5,10 @@
 package configurator
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	announcements "github.com/openservicemesh/osm/pkg/announcements"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockConfigurator is a mock of Configurator interface
@@ -75,6 +75,20 @@ func (m *MockConfigurator) GetOSMNamespace() string {
 func (mr *MockConfiguratorMockRecorder) GetOSMNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOSMNamespace", reflect.TypeOf((*MockConfigurator)(nil).GetOSMNamespace))
+}
+
+// GetOutboundIPRangeExclusionList mocks base method
+func (m *MockConfigurator) GetOutboundIPRangeExclusionList() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOutboundIPRangeExclusionList")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetOutboundIPRangeExclusionList indicates an expected call of GetOutboundIPRangeExclusionList
+func (mr *MockConfiguratorMockRecorder) GetOutboundIPRangeExclusionList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundIPRangeExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundIPRangeExclusionList))
 }
 
 // GetServiceCertValidityPeriod mocks base method
@@ -201,24 +215,6 @@ func (m *MockConfigurator) IsTracingEnabled() bool {
 func (mr *MockConfiguratorMockRecorder) IsTracingEnabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTracingEnabled", reflect.TypeOf((*MockConfigurator)(nil).IsTracingEnabled))
-}
-
-// Subscribe mocks base method
-func (m *MockConfigurator) Subscribe(arg0 ...announcements.AnnouncementType) chan interface{} {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{}
-	for _, a := range arg0 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Subscribe", varargs...)
-	ret0, _ := ret[0].(chan interface{})
-	return ret0
-}
-
-// Subscribe indicates an expected call of Subscribe
-func (mr *MockConfiguratorMockRecorder) Subscribe(arg0 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockConfigurator)(nil).Subscribe), arg0...)
 }
 
 // UseHTTPSIngress mocks base method

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -61,4 +61,7 @@ type Configurator interface {
 
 	// GetServiceCertValidityPeriod returns the validity duration for service certificates
 	GetServiceCertValidityPeriod() time.Duration
+
+	// GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
+	GetOutboundIPRangeExclusionList() []string
 }

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -1,65 +1,14 @@
 package injector
 
 import (
-	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-// iptablesInitCommands is the list of iptables commands that need to be run in the given order
-// to set up iptable redirection for inbound and outbound traffic via the sidecar proxy.
-var iptablesInitCommands = []string{
-	// Create a new chain for redirecting outbound traffic to PROXY_PORT
-	"iptables -t nat -N PROXY_REDIRECT",
-	fmt.Sprintf("iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port %d", constants.EnvoyOutboundListenerPort),
-
-	// Traffic to the Proxy Admin port flows to the Proxy -- not redirected
-	fmt.Sprintf("iptables -t nat -A PROXY_REDIRECT -p tcp --dport %d -j ACCEPT", constants.EnvoyAdminPort),
-
-	// Create a new chain for redirecting inbound traffic to PROXY_INBOUND_PORT
-	"iptables -t nat -N PROXY_IN_REDIRECT",
-	fmt.Sprintf("iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port %d", constants.EnvoyInboundListenerPort),
-
-	// Create a new chain to redirect inbound traffic to Envoy
-	"iptables -t nat -N PROXY_INBOUND",
-	"iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND",
-
-	// Skip inbound stats query redirection
-	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", constants.EnvoyPrometheusInboundListenerPort),
-
-	// Skip inbound health probes; These ports will be explicitly handled by listeners configured on the
-	// Envoy proxy IF any health probes have been configured in the Pod Spec.
-	// TODO(draychev): Do not add these if no health probes have been defined (https://github.com/openservicemesh/osm/issues/2243)
-	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", livenessProbePort),
-	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", readinessProbePort),
-	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", startupProbePort),
-
-	// Redirect remaining inbound traffic to PROXY_INBOUND_PORT
-	"iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT",
-
-	// Create a new chain to redirect outbound traffic to Envoy
-	"iptables -t nat -N PROXY_OUTPUT",
-
-	// For all TCP traffic, jump to PROXY_OUTPUT chain from OUTPUT chain
-	"iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT",
-
-	// TODO(shashank): Redirect app back calls to itself using PROXY_UID
-
-	// Don't redirect Envoy traffic back to itself for non-loopback traffic
-	fmt.Sprintf("iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner %d -j RETURN", constants.EnvoyUID),
-
-	// Skip localhost traffic
-	"iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN",
-
-	// Redirect remaining outbound traffic to Envoy
-	"iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT",
-}
-
-func getInitContainerSpec(containerName, containerImage string) corev1.Container {
-	iptablesInitCommands := strings.Join(iptablesInitCommands, " && ")
+func getInitContainerSpec(containerName string, containerImage string, outboundIPRangeExclusionList []string) corev1.Container {
+	iptablesInitCommandsList := generateIptablesCommands(outboundIPRangeExclusionList)
+	iptablesInitCommand := strings.Join(iptablesInitCommandsList, " && ")
 
 	return corev1.Container{
 		Name:  containerName,
@@ -74,7 +23,7 @@ func getInitContainerSpec(containerName, containerImage string) corev1.Container
 		Command: []string{"/bin/sh"},
 		Args: []string{
 			"-c",
-			iptablesInitCommands,
+			iptablesInitCommand,
 		},
 	}
 }

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -1,22 +1,36 @@
 package injector
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"fmt"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Test volume functions", func() {
-	Context("Test getInitContainerSpec", func() {
-		It("creates volume spec", func() {
-			actual := getInitContainerSpec("-container-name-", "-init-container-image-")
-			expected := v1.Container{
+func TestGetInitContainerSpec(t *testing.T) {
+	assert := tassert.New(t)
+
+	containerName := "-container-name-"
+	containerImage := "-init-container-image-"
+
+	testCases := []struct {
+		name                         string
+		outboundIPRangeExclusionList []string
+
+		expectedSpec v1.Container
+	}{
+		{
+			name:                         "init container without outbound exclusion list",
+			outboundIPRangeExclusionList: nil,
+
+			expectedSpec: v1.Container{
 				Name:    "-container-name-",
 				Image:   "-init-container-image-",
 				Command: []string{"/bin/sh"},
 				Args: []string{
 					"-c",
-					"iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -N PROXY_INBOUND && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1337 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT",
+					"iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1337 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT",
 				},
 				WorkingDir: "",
 				Resources:  v1.ResourceRequirements{},
@@ -31,8 +45,42 @@ var _ = Describe("Test volume functions", func() {
 				Stdin:     false,
 				StdinOnce: false,
 				TTY:       false,
-			}
-			Expect(actual).To(Equal(expected))
+			},
+		},
+
+		{
+			name:                         "init container with outbound exclusion list",
+			outboundIPRangeExclusionList: []string{"1.1.1.1/32", "10.0.0.10/24"},
+
+			expectedSpec: v1.Container{
+				Name:    "-container-name-",
+				Image:   "-init-container-image-",
+				Command: []string{"/bin/sh"},
+				Args: []string{
+					"-c",
+					"iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1337 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT && iptables -t nat -I PROXY_OUTPUT -d 1.1.1.1/32 -j RETURN && iptables -t nat -I PROXY_OUTPUT -d 10.0.0.10/24 -j RETURN",
+				},
+				WorkingDir: "",
+				Resources:  v1.ResourceRequirements{},
+				SecurityContext: &v1.SecurityContext{
+					Capabilities: &v1.Capabilities{
+						Add: []v1.Capability{
+							"NET_ADMIN",
+						},
+					},
+					Privileged: nil,
+				},
+				Stdin:     false,
+				StdinOnce: false,
+				TTY:       false,
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			actual := getInitContainerSpec(containerName, containerImage, tc.outboundIPRangeExclusionList)
+			assert.Equal(tc.expectedSpec, actual)
 		})
-	})
-})
+	}
+}

--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -1,0 +1,91 @@
+package injector
+
+import (
+	"fmt"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+// iptablesRedirectionChains is the list of iptables chains created for traffic redirection via the proxy sidecar
+var iptablesRedirectionChains = []string{
+	// Chain to intercept inbound traffic
+	"iptables -t nat -N PROXY_INBOUND",
+
+	// Chain to redirect inbound traffic to the proxy
+	"iptables -t nat -N PROXY_IN_REDIRECT",
+
+	// Chain to intercept outbound traffic
+	"iptables -t nat -N PROXY_OUTPUT",
+
+	// Chain to redirect outbound traffic to the proxy
+	"iptables -t nat -N PROXY_REDIRECT",
+}
+
+// iptablesOutboundStaticRules is the list of iptables rules related to outbound traffic interception and redirection
+var iptablesOutboundStaticRules = []string{
+	// Redirects outbound TCP traffic hitting PROXY_REDIRECT chain to Envoy's outbound listener port
+	fmt.Sprintf("iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port %d", constants.EnvoyOutboundListenerPort),
+
+	// Traffic to the Proxy Admin port flows to the Proxy -- not redirected
+	fmt.Sprintf("iptables -t nat -A PROXY_REDIRECT -p tcp --dport %d -j ACCEPT", constants.EnvoyAdminPort),
+
+	// For outbound TCP traffic jump from OUTPUT chain to PROXY_OUTPUT chain
+	"iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT",
+
+	// TODO(#1266): Redirect app back calls to itself using PROXY_UID
+
+	// Don't redirect Envoy traffic back to itself for non-loopback traffic
+	fmt.Sprintf("iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner %d -j RETURN", constants.EnvoyUID),
+
+	// Skip localhost traffic, doesn't need to be routed via the proxy
+	"iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN",
+
+	// Redirect remaining outbound traffic to Envoy
+	"iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT",
+}
+
+// iptablesInboundStaticRules is the list of iptables rules related to inbound traffic interception and redirection
+var iptablesInboundStaticRules = []string{
+	// Redirects inbound TCP traffic hitting the PROXY_IN_REDIRECT chain to Envoy's inbound listener port
+	fmt.Sprintf("iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port %d", constants.EnvoyInboundListenerPort),
+
+	// For inbound traffic jump from PREROUTING chain to PROXY_INBOUND chain
+	"iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND",
+
+	// Skip metrics query traffic being directed to Envoy's inbound prometheus listener port
+	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", constants.EnvoyPrometheusInboundListenerPort),
+
+	// Skip inbound health probes; These ports will be explicitly handled by listeners configured on the
+	// Envoy proxy IF any health probes have been configured in the Pod Spec.
+	// TODO(draychev): Do not add these if no health probes have been defined (https://github.com/openservicemesh/osm/issues/2243)
+	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", livenessProbePort),
+	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", readinessProbePort),
+	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", startupProbePort),
+
+	// Redirect remaining inbound traffic to Envoy
+	"iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT",
+}
+
+// generateIptablesCommands generates a list of iptables commands to set up sidecar interception and redirection
+func generateIptablesCommands(outboundIPRangeExclusionList []string) []string {
+	var cmd []string
+
+	// 1. Create redirection chains
+	cmd = append(cmd, iptablesRedirectionChains...)
+
+	// 2. Create outbound rules
+	cmd = append(cmd, iptablesOutboundStaticRules...)
+
+	// 3. Create inbound rules
+	cmd = append(cmd, iptablesInboundStaticRules...)
+
+	// 4. Create dynamic outbound exclusion rules
+	for _, cidr := range outboundIPRangeExclusionList {
+		// *Note: it is important to use the insert option '-I' instead of the append option '-A' to ensure the exclusion
+		// rules take precedence over the static redirection rules. Iptables rules are evaluated in order.
+		rule := fmt.Sprintf("iptables -t nat -I PROXY_OUTPUT -d %s -j RETURN", cidr)
+		cmd = append(cmd, rule)
+	}
+
+	return cmd
+}

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -48,7 +48,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 	pod.Spec.Volumes = append(pod.Spec.Volumes, getVolumeSpec(envoyBootstrapConfigName)...)
 
 	// Add the Init Container
-	initContainer := getInitContainerSpec(constants.InitContainerName, wh.config.InitContainerImage)
+	initContainer := getInitContainerSpec(constants.InitContainerName, wh.config.InitContainerImage, wh.configurator.GetOutboundIPRangeExclusionList())
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
 	// envoyNodeID and envoyClusterID are required for Envoy proxy to start.

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Test all patch operations", func() {
 			pod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, nil)
 			pod.Annotations = nil
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("").Times(1)
+			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
 
 			req := &v1beta1.AdmissionRequest{Namespace: namespace}
 			jsonPatches, err := wh.createPatch(&pod, req, proxyUUID)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds capability in `injector` to configure global outbound
IP range exclusion list via the osm-config ConfigMap. This
is required in managed environments where certain outbound
traffic (ex. access to node's metadata service, retrieve
AAD access tokens for pods in AKS etc.) needs to bypass the
proxy.

It also updates iptables rules generation for better readability.

A subsequent change will expose configuring this option via
osm cli, document this option, and add validation webhook checks
when ready to use.

Part of #2344

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`