### PR TITLE
Allow named service ports to specify application protocol

### DIFF
--- a/docs/content/docs/design/service_app_protocol.md
+++ b/docs/content/docs/design/service_app_protocol.md
@@ -10,7 +10,7 @@ Kubernetes services expose one or more ports. A port exposed by an application r
 
 This document proposes to leverage the newly introduced `AppProtocol` field to determine the application protocol for a service’s port in OSM. The application protocol on the port will be used to infer the protocol of the inbound traffic received on that port by the upstream proxy. Based on the protocol detected, appropriate filer chains will be configured on the upstream proxy to apply protocol specific filters to handle protocol specific policies.
 
-The minimum Kubernetes version must be v1.19 for features that require the `AppProtocol` to be specified for the service ports. If the Kubernetes version is lower than v1.19 or if the `AppProtocol` field is not set on the service's ports, OSM controller will log error events where applicable.
+The `AppProtocol` can be specified by default in Kubernetes server versions >= v1.19. In older versions where this field cannot be set, the application protocol for a service port can be indicated by prefixing the protocol name as a part of the port name. If the application protocol cannot be derived,  OSM controller will use `http` as the default application protocol for a port.
 
 
 ## Example
@@ -87,4 +87,19 @@ spec:
   - port: 8080
     name: some-port
     appProtocol: tcp
+```
+
+If the cluster is using an older Kubernetes version where `appProtocol` cannot be specified in the Service spec, the application protocol can be indicated by prefixing the port name with the protocol as follows:
+
+```yaml
+kind: Service
+metadata:
+  name: service-3
+  namespace: default
+spec:
+  ports:
+  - port: 80
+    name: http-someport # prefix 'http-' indicates http application protocol
+  - port: 90
+    name: tcp-someport # prefix 'tcp-' indicates tcp application protocol
 ```

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golangci/golangci-lint v1.32.2
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
+	github.com/hashicorp/go-version v1.1.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/jetstack/cert-manager v0.16.1
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -6,12 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
-)
-
-const (
-	// defaultAppProtocol is the default application protocol for a port if unspecified
-	defaultAppProtocol = "http"
 )
 
 // GetServicesForServiceAccount returns a list of services corresponding to a service account
@@ -85,9 +81,11 @@ func (mc *MeshCatalog) GetPortToProtocolMappingForService(svc service.MeshServic
 	}
 
 	for _, portSpec := range k8sSvc.Spec.Ports {
-		appProtocol := defaultAppProtocol
+		var appProtocol string
 		if portSpec.AppProtocol != nil {
 			appProtocol = *portSpec.AppProtocol
+		} else {
+			appProtocol = kubernetes.GetAppProtocolFromPortName(portSpec.Name)
 		}
 		portToProtocolMap[uint32(portSpec.Port)] = appProtocol
 	}

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -15,11 +15,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-const (
-	// defaultAppProtocol is the default application protocol for a port if unspecified
-	defaultAppProtocol = "http"
-)
-
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
 func NewProvider(kubeClient kubernetes.Interface, kubeController k8s.Controller, providerIdent string, cfg configurator.Configurator) (endpoint.Provider, error) {
 	client := Client{
@@ -140,9 +135,12 @@ func (c Client) GetTargetPortToProtocolMappingForService(svc service.MeshService
 	// to worry about different application protocols being set.
 	for _, endpointSet := range endpoints.Subsets {
 		for _, port := range endpointSet.Ports {
-			appProtocol := defaultAppProtocol
+			var appProtocol string
 			if port.AppProtocol != nil {
 				appProtocol = *port.AppProtocol
+			} else {
+				appProtocol = k8s.GetAppProtocolFromPortName(port.Name)
+				log.Debug().Msgf("endpoint port name: %s, appProtocol: %s", port.Name, appProtocol)
 			}
 
 			portToProtocolMap[uint32(port.Port)] = appProtocol

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -180,16 +180,36 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 					},
 					Ports: []v1.EndpointPort{
 						{
-							Name:        "port",
-							Port:        88,
+							Name:        "port1", // appProtocol specified
+							Port:        70,
 							Protocol:    v1.ProtocolTCP,
 							AppProtocol: &appProtoTCP,
 						},
 						{
-							Name:        "port",
+							Name:        "port2", // appProtocol specified
 							Port:        80,
 							Protocol:    v1.ProtocolTCP,
 							AppProtocol: &appProtoHTTP,
+						},
+						{
+							Name:     "http-port3", // appProtocol derived from port name
+							Port:     90,
+							Protocol: v1.ProtocolTCP,
+						},
+						{
+							Name:     "tcp-port4", // appProtocol derived from port name
+							Port:     100,
+							Protocol: v1.ProtocolTCP,
+						},
+						{
+							Name:     "grpc-port5", // appProtocol derived from port name
+							Port:     110,
+							Protocol: v1.ProtocolTCP,
+						},
+						{
+							Name:     "no-protocol-prefix", // appProtocol defaults to http
+							Port:     120,
+							Protocol: v1.ProtocolTCP,
 						},
 					},
 				},
@@ -199,7 +219,7 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 		portToProtocolMap, err := provider.GetTargetPortToProtocolMappingForService(tests.BookbuyerService)
 		Expect(err).To(BeNil())
 
-		expectedPortToProtocolMap := map[uint32]string{88: appProtoTCP, 80: appProtoHTTP}
+		expectedPortToProtocolMap := map[uint32]string{70: "tcp", 80: "http", 90: "http", 100: "tcp", 110: "grpc", 120: "http"}
 		Expect(portToProtocolMap).To(Equal(expectedPortToProtocolMap))
 	})
 })

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -48,7 +48,7 @@ func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAc
 }
 
 func (f fakeClient) GetTargetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
-	return map[uint32]string{uint32(tests.Endpoint.Port): defaultAppProtocol}, nil
+	return map[uint32]string{uint32(tests.Endpoint.Port): "http"}, nil
 }
 
 // GetID returns the unique identifier of the EndpointsProvider.

--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	clusterDomain = "cluster.local"
+	clusterDomain      = "cluster.local"
+	defaultAppProtocol = "http"
 )
 
 // GetHostnamesForService returns a list of hostnames over which the service can be accessed within the local cluster.
@@ -56,4 +57,23 @@ func GetServiceFromHostname(host string) string {
 	// For services that are not namespaced the service name contains the port as well
 	// Ex. service:port
 	return strings.Split(service, ":")[0]
+}
+
+// GetAppProtocolFromPortName returns the port's application protocol from its name, 'defaultAppProtocol' if not specified.
+func GetAppProtocolFromPortName(portName string) string {
+	portName = strings.ToLower(portName)
+
+	switch {
+	case strings.HasPrefix(portName, "http-"):
+		return "http"
+
+	case strings.HasPrefix(portName, "tcp-"):
+		return "tcp"
+
+	case strings.HasPrefix(portName, "grpc-"):
+		return "grpc"
+
+	default:
+		return defaultAppProtocol
+	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently the application protocol for a port (http, tcp etc.)
is determined by specifying the `appProtocol` field on the service's
port spec. The app protocol is required to correctly configure protocol
specific filtering and routing. Since the appProtocol field is only
enabled by default in kubernetes version >= 1.19, clusters using an
older version cannot leverage features such as TCP, gRPC etc.

This change provides a workaround by allowing to specify the app
protocol for a service port by prefixing the protocol name in the
port. The e2e test suite has been updated to be backward compatible
with older k8s API versions by leveraging named service ports in
k8s < 1.19.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`