### PR TITLE
test: verify service port's appProtocol precedence over name

### DIFF
--- a/docs/content/docs/design/service_app_protocol.md
+++ b/docs/content/docs/design/service_app_protocol.md
@@ -12,7 +12,7 @@ This document proposes to leverage the newly introduced `AppProtocol` field to d
 
 The `AppProtocol` can be specified by default in Kubernetes server versions >= v1.19. In older versions where this field cannot be set, the application protocol for a service port can be indicated by prefixing the protocol name as a part of the port name. If the application protocol cannot be derived,  OSM controller will use `http` as the default application protocol for a port.
 
-
+*Note that for port field in the service spec, the `AppProtocol` field takes precedence over the `Name` field if both are specified.
 ## Example
 
 Consider the following SMI traffic access and traffic specs policies:

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -246,6 +246,32 @@ func TestGetPortToProtocolMappingForResolvableService(t *testing.T) {
 
 		{
 			// Test case 3
+			name: "service with appProtocol and named port specified",
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svc.Name,
+					Namespace: svc.Namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name: "http-port1",
+							TargetPort: intstr.IntOrString{
+								Type:   intstr.String,
+								IntVal: 8080,
+							},
+							AppProtocol: &appProtocolTCP, // takes precedence over 'Name'
+							Port:        80,
+						},
+					},
+				},
+			},
+			expectedPortToProtocolMap: map[uint32]string{80: "tcp"},
+			expectError:               false,
+		},
+
+		{
+			// Test case 4
 			name:                      "service doesn't exist",
 			service:                   nil,
 			expectedPortToProtocolMap: nil,

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -211,6 +211,12 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 							Port:     120,
 							Protocol: v1.ProtocolTCP,
 						},
+						{
+							Name:        "http-prefix",
+							Port:        130,
+							Protocol:    v1.ProtocolTCP,
+							AppProtocol: &appProtoTCP, // AppProtocol takes precedence over Name
+						},
 					},
 				},
 			},
@@ -219,7 +225,7 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 		portToProtocolMap, err := provider.GetTargetPortToProtocolMappingForService(tests.BookbuyerService)
 		Expect(err).To(BeNil())
 
-		expectedPortToProtocolMap := map[uint32]string{70: "tcp", 80: "http", 90: "http", 100: "tcp", 110: "grpc", 120: "http"}
+		expectedPortToProtocolMap := map[uint32]string{70: "tcp", 80: "http", 90: "http", 100: "tcp", 110: "grpc", 120: "http", 130: "tcp"}
 		Expect(portToProtocolMap).To(Equal(expectedPortToProtocolMap))
 	})
 })


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds tests to verify that the port's `appProtocol` field takes
precedence over the `name` field if both are specified.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`