### PR TITLE
charts/osm: update README and remove trailing whitespace

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -1,62 +1,116 @@
-# osm
+# Open Service Mesh Helm Chart
 
 ![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
 
-A Helm chart to install the OSM control plane on Kubernetes
+A Helm chart to install the [OSM](https://github.com/openservicemesh/osm) control plane on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes v1.15+
+
+## Get Repo Info
+
+```console
+helm repo add osm https://openservicemesh.github.io/osm
+helm repo update
+```
+
+## Install Chart
+
+```console
+helm install [RELEASE_NAME] osm/osm
+```
+
+The command deploys `osm-controller` on the Kubernetes cluster in the default configuration.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+helm show values osm/osm
+```
+
+The following table lists the configurable parameters of the osm chart and their default values.
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| OpenServiceMesh.caBundleSecretName | string | `"osm-ca-bundle"` |  |
-| OpenServiceMesh.certificateManager | string | `"tresor"` |  |
-| OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager"` |  |
-| OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` |  |
-| OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` |  |
-| OpenServiceMesh.controllerLogLevel | string | `"trace"` |  |
-| OpenServiceMesh.deployGrafana | bool | `false` |  |
-| OpenServiceMesh.deployJaeger | bool | `false` |  |
-| OpenServiceMesh.deployPrometheus | bool | `false` |  |
-| OpenServiceMesh.enableBackpressureExperimental | bool | `false` |  |
-| OpenServiceMesh.enableDebugServer | bool | `false` |  |
-| OpenServiceMesh.enableEgress | bool | `false` |  |
-| OpenServiceMesh.enableFluentbit | bool | `false` |  |
-| OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` |  |
-| OpenServiceMesh.enablePrometheusScraping | bool | `true` |  |
-| OpenServiceMesh.enforceSingleMesh | bool | `false` |  |
-| OpenServiceMesh.envoyLogLevel | string | `"error"` |  |
-| OpenServiceMesh.fluentBit.enableProxySupport | bool | `false` |  |
-| OpenServiceMesh.fluentBit.httpProxy | string | `""` |  |
-| OpenServiceMesh.fluentBit.httpsProxy | string | `""` |  |
-| OpenServiceMesh.fluentBit.logLevel | string | `"error"` |  |
-| OpenServiceMesh.fluentBit.name | string | `"fluentbit-logger"` |  |
-| OpenServiceMesh.fluentBit.outputPlugin | string | `"stdout"` |  |
-| OpenServiceMesh.fluentBit.primaryKey | string | `""` |  |
-| OpenServiceMesh.fluentBit.pullPolicy | string | `"IfNotPresent"` |  |
-| OpenServiceMesh.fluentBit.registry | string | `"fluent"` |  |
-| OpenServiceMesh.fluentBit.tag | string | `"1.6.4"` |  |
-| OpenServiceMesh.fluentBit.workspaceId | string | `""` |  |
-| OpenServiceMesh.grafana.enableRemoteRendering | bool | `false` |  |
-| OpenServiceMesh.grafana.port | int | `3000` |  |
-| OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` |  |
-| OpenServiceMesh.image.registry | string | `"openservicemesh"` |  |
-| OpenServiceMesh.image.tag | string | `"v0.6.1"` |  |
-| OpenServiceMesh.imagePullSecrets | list | `[]` |  |
-| OpenServiceMesh.meshName | string | `"osm"` |  |
-| OpenServiceMesh.osmNamespace | string | `""` |  |
-| OpenServiceMesh.prometheus.port | int | `7070` |  |
-| OpenServiceMesh.prometheus.retention.time | string | `"15d"` |  |
-| OpenServiceMesh.replicaCount | int | `1` |  |
-| OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` |  |
-| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.0"` |  |
-| OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` |  |
-| OpenServiceMesh.tracing.enable | bool | `true` |  |
-| OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` |  |
-| OpenServiceMesh.tracing.port | int | `9411` |  |
-| OpenServiceMesh.useHTTPSIngress | bool | `false` |  |
-| OpenServiceMesh.vault.host | string | `nil` |  |
-| OpenServiceMesh.vault.protocol | string | `"http"` |  |
-| OpenServiceMesh.vault.role | string | `"openservicemesh"` |  |
-| OpenServiceMesh.vault.token | string | `nil` |  |
-| OpenServiceMesh.webhookConfigNamePrefix | string | `"osm-webhook"` |  |
+| OpenServiceMesh.caBundleSecretName | string | `"osm-ca-bundle"` | The Kubernetes secret to store `ca.crt` |
+| OpenServiceMesh.certificateManager | string | `"tresor"` | The Certificate manager type: `tresor`, `vault` or `cert-manager` |
+| OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager"` | cert-manager issuer group |
+| OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` | cert-manager issuer kind |
+| OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` | cert-manager issuer namecert-manager issuer name |
+| OpenServiceMesh.controllerLogLevel | string | `"trace"` | Controller log verbosity |
+| OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana |
+| OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger in the OSM namespace |
+| OpenServiceMesh.deployPrometheus | bool | `false` | Deploy Prometheus |
+| OpenServiceMesh.enableBackpressureExperimental | bool | `false` | Enable experimental backpressure feature |
+| OpenServiceMesh.enableDebugServer | bool | `false` | Enable the debug HTTP server |
+| OpenServiceMesh.enableEgress | bool | `false` | Enable egress in the mesh |
+| OpenServiceMesh.enableFluentbit | bool | `false` | Enable Fluentbit sidecar deployment |
+| OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` | Enable permissive traffic policy mode |
+| OpenServiceMesh.enablePrometheusScraping | bool | `true` | Enable Prometheus metrics scraping on sidecar proxies |
+| OpenServiceMesh.enableRoutesV2Experimental | bool | `false` | Enable experimental routes feature |
+| OpenServiceMesh.enforceSingleMesh | bool | `false` | Enforce only deploying one mesh in the cluster |
+| OpenServiceMesh.envoyLogLevel | string | `"error"` | Envoy log level is used to specify the level of logs collected from envoy |
+| OpenServiceMesh.fluentBit.enableProxySupport | bool | `false` | Enable proxy support for FluentBit |
+| OpenServiceMesh.fluentBit.httpProxy | string | `""` | HTTP Proxy url for FluentBit |
+| OpenServiceMesh.fluentBit.httpsProxy | string | `""` | HTTPS Proxy url for FluentBit |
+| OpenServiceMesh.fluentBit.logLevel | string | `"error"` | Log level for FluentBit |
+| OpenServiceMesh.fluentBit.name | string | `"fluentbit-logger"` | luentBit Sidecar container name |
+| OpenServiceMesh.fluentBit.outputPlugin | string | `"stdout"` | FluentBit Output Plugin, can be `stdout` or `azure` |
+| OpenServiceMesh.fluentBit.primaryKey | string | `""` | PrimaryKey for FluentBit output plugin to Azure LogAnalytics |
+| OpenServiceMesh.fluentBit.pullPolicy | string | `"IfNotPresent"` | PullPolicy for FluentBit sidecar container |
+| OpenServiceMesh.fluentBit.registry | string | `"fluent"` | Registry for FluentBit sidecar container |
+| OpenServiceMesh.fluentBit.tag | string | `"1.6.4"` | FluentBit sidecar image tag |
+| OpenServiceMesh.fluentBit.workspaceId | string | `""` | WorkspaceId for FluentBit output plugin to Azure LogAnalytics |
+| OpenServiceMesh.grafana.enableRemoteRendering | bool | `false` | Enable Remote Rendering in Grafana |
+| OpenServiceMesh.grafana.port | int | `3000` | Grafana port |
+| OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` | `osm-controller` pod PullPolicy |
+| OpenServiceMesh.image.registry | string | `"openservicemesh"` | `osm-controller` image registry |
+| OpenServiceMesh.image.tag | string | `"v0.6.1"` | `osm-controller` image tag |
+| OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
+| OpenServiceMesh.meshName | string | `"osm"` | Name for the new control plane instance |
+| OpenServiceMesh.osmNamespace | string | `""` | Optional parameter. If not specified, the release namespace is used to deploy the osm components. |
+| OpenServiceMesh.prometheus.port | int | `7070` | Prometheus port |
+| OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus retention time |
+| OpenServiceMesh.replicaCount | int | `1` | `osm-controller` replicas |
+| OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Sets the service certificatevalidity duration |
+| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.0"` | Envoy sidecar image |
+| OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` | Tracing destination cluster (must contain the namespace) |
+| OpenServiceMesh.tracing.enable | bool | `true` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster |
+| OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Destination's API or collector endpoint where the spans will be sent to |
+| OpenServiceMesh.tracing.port | int | `9411` | Destination port for the listener |
+| OpenServiceMesh.useHTTPSIngress | bool | `false` | Enables HTTPS ingress on the mesh |
+| OpenServiceMesh.vault.host | string | `nil` | Hashicorp Vault host/service - where Vault is installed |
+| OpenServiceMesh.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
+| OpenServiceMesh.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
+| OpenServiceMesh.vault.token | string | `nil` | token that should be used to connect to Vault |
+| OpenServiceMesh.webhookConfigNamePrefix | string | `"osm-webhook"` | Validating- and MutatingWebhookConfiguration name |
 
+<!-- markdownlint-enable MD013 MD034 -->
+<!-- markdownlint-restore -->

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 OpenServiceMesh:
-  # -- `osm-controller` replicas 
+  # -- `osm-controller` replicas
   replicaCount: 1
   image:
     # -- `osm-controller` image registry
@@ -12,95 +12,95 @@ OpenServiceMesh:
     pullPolicy: IfNotPresent
     # -- `osm-controller` image tag
     tag: v0.6.1
-  # -- `osm-controller` image pull secret   
+  # -- `osm-controller` image pull secret
   imagePullSecrets: []
-  # -- Envoy sidecar image  
+  # -- Envoy sidecar image
   sidecarImage: envoyproxy/envoy-alpine:v1.17.0
   prometheus:
-    # -- Prometheus port  
+    # -- Prometheus port
     port: 7070
     retention:
       # -- Prometheus retention time
       time: 15d
-  # -- The Certificate manager type: `tresor`, `vault` or `cert-manager` 
+  # -- The Certificate manager type: `tresor`, `vault` or `cert-manager`
   certificateManager: tresor
   vault:
-    # --  Hashicorp Vault host/service - where Vault is installed 
+    # --  Hashicorp Vault host/service - where Vault is installed
     host:
     # -- protocol to use to connect to Vault
     protocol: http
     # -- token that should be used to connect to Vault
     token:
-    # -- Vault role to be used by Open Service Mesh   
+    # -- Vault role to be used by Open Service Mesh
     role: openservicemesh
   certmanager:
-    # --  cert-manager issuer namecert-manager issuer name 
+    # --  cert-manager issuer namecert-manager issuer name
     issuerName: osm-ca
-    # -- cert-manager issuer kind 
+    # -- cert-manager issuer kind
     issuerKind: Issuer
     # -- cert-manager issuer group
     issuerGroup: cert-manager
-  # -- Sets the service certificatevalidity duration 
+  # -- Sets the service certificatevalidity duration
   serviceCertValidityDuration: 24h
   # -- The Kubernetes secret to store `ca.crt`
   caBundleSecretName: osm-ca-bundle
   grafana:
-    # -- Grafana port 
+    # -- Grafana port
     port: 3000
-    # -- Enable Remote Rendering in Grafana  
+    # -- Enable Remote Rendering in Grafana
     enableRemoteRendering: false
-  # -- Enable the debug HTTP server    
+  # -- Enable the debug HTTP server
   enableDebugServer: false
-  # -- Enable permissive traffic policy mode  
+  # -- Enable permissive traffic policy mode
   enablePermissiveTrafficPolicy: false
-  # -- Enable experimental backpressure feature 
+  # -- Enable experimental backpressure feature
   enableBackpressureExperimental: false
-   # -- Enable experimental routes feature 
+   # -- Enable experimental routes feature
   enableRoutesV2Experimental: false
-  # -- Enable egress in the mesh 
+  # -- Enable egress in the mesh
   enableEgress: false
   # -- Deploy Prometheus
   deployPrometheus: false
-  # -- Enable Prometheus metrics scraping on sidecar proxies  
+  # -- Enable Prometheus metrics scraping on sidecar proxies
   enablePrometheusScraping: true
   # -- Deploy Grafana
   deployGrafana: false
-  # -- Enable Fluentbit sidecar deployment 
+  # -- Enable Fluentbit sidecar deployment
   enableFluentbit: false
   fluentBit:
     # -- luentBit Sidecar container name
     name: fluentbit-logger
-    # -- Registry for FluentBit sidecar container 
+    # -- Registry for FluentBit sidecar container
     registry: fluent
     # -- FluentBit sidecar image tag
     tag: 1.6.4
-    # -- PullPolicy for FluentBit sidecar container  
+    # -- PullPolicy for FluentBit sidecar container
     pullPolicy: IfNotPresent
-    # -- Log level for FluentBit  
+    # -- Log level for FluentBit
     logLevel: error
-    # -- FluentBit Output Plugin, can be `stdout` or `azure` 
+    # -- FluentBit Output Plugin, can be `stdout` or `azure`
     outputPlugin: stdout
     # -- WorkspaceId for FluentBit output plugin to Azure LogAnalytics
     workspaceId: ""
-    # -- PrimaryKey for FluentBit output plugin to Azure LogAnalytics  
+    # -- PrimaryKey for FluentBit output plugin to Azure LogAnalytics
     primaryKey: ""
     # -- Enable proxy support for FluentBit
     enableProxySupport: false
-    # -- HTTP Proxy url for FluentBit  
+    # -- HTTP Proxy url for FluentBit
     httpProxy: ""
-    # -- HTTPS Proxy url for FluentBit  
+    # -- HTTPS Proxy url for FluentBit
     httpsProxy: ""
   # -- Name for the new control plane instance
   meshName: osm
-  # -- Enables HTTPS ingress on the mesh   
+  # -- Enables HTTPS ingress on the mesh
   useHTTPSIngress: false
-  # -- Envoy log level is used to specify the level of logs collected from envoy 
+  # -- Envoy log level is used to specify the level of logs collected from envoy
   envoyLogLevel: error
-  # -- Controller log verbosity 
+  # -- Controller log verbosity
   controllerLogLevel: trace
-  # -- Enforce only deploying one mesh in the cluster     
+  # -- Enforce only deploying one mesh in the cluster
   enforceSingleMesh: false
-  # -- Validating- and MutatingWebhookConfiguration name            
+  # -- Validating- and MutatingWebhookConfiguration name
   webhookConfigNamePrefix: osm-webhook
 
   # -- Optional parameter. If not specified, the release namespace is used to deploy the osm components.
@@ -114,14 +114,14 @@ OpenServiceMesh:
   # backends (https://github.com/openservicemesh/osm/issues/1596)
   tracing:
 
-    # -- Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster      
+    # -- Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster
     enable: true
 
-    # -- Tracing destination cluster (must contain the namespace) 
+    # -- Tracing destination cluster (must contain the namespace)
     address: "jaeger.osm-system.svc.cluster.local"
 
-    # -- Destination port for the listener   
+    # -- Destination port for the listener
     port: 9411
 
-    # -- Destination's API or collector endpoint where the spans will be sent to  
+    # -- Destination's API or collector endpoint where the spans will be sent to
     endpoint: "/api/v2/spans"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates to using the autogenerated README from `make chart-readme`
and removes trailing whitespace in `values.yaml`.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`