### PR TITLE
charts/osm: make IP range exclusion configurable

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -96,6 +96,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.meshName | string | `"osm"` | Name for the new control plane instance |
 | OpenServiceMesh.osmNamespace | string | `""` | Optional parameter. If not specified, the release namespace is used to deploy the osm components. |
+| OpenServiceMesh.outboundIPRangeExclusionList | list | `[]` | Optional parameter to specify a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
 | OpenServiceMesh.prometheus.port | int | `7070` | Prometheus port |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus retention time |
 | OpenServiceMesh.replicaCount | int | `1` | `osm-controller` replicas |

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -19,3 +19,7 @@ data:
 
   use_https_ingress: {{ .Values.OpenServiceMesh.useHTTPSIngress | default "false" | quote }}
   service_cert_validity_duration: {{ .Values.OpenServiceMesh.serviceCertValidityDuration | quote }}
+
+{{- if .Values.OpenServiceMesh.outboundIPRangeExclusionList }}
+  outbound_ip_range_exclusion_list: {{ join "," .Values.OpenServiceMesh.outboundIPRangeExclusionList | quote }}
+{{- end}}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -125,3 +125,7 @@ OpenServiceMesh:
 
     # -- Destination's API or collector endpoint where the spans will be sent to
     endpoint: "/api/v2/spans"
+
+  # -- Optional parameter to specify a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy.
+  # If specified, must be a list of IP ranges of the form a.b.c.d/x.
+  outboundIPRangeExclusionList: []

--- a/docs/content/docs/osm_config_map.md
+++ b/docs/content/docs/osm_config_map.md
@@ -23,3 +23,4 @@ OSM deploys a configMap `osm-config` as a part of its control plane (in the same
 | tracing_endpoint | OpenServiceMesh.tracing.endpoint | string | /api/v2/spans | /api/v2/spans | Endpoint for tracing data, if tracing enabled. |
 | tracing_port| OpenServiceMesh.tracing.port | int | any non-zero integer value | `"9411"` | Port on which tracing is enabled. |
 | use_https_ingress | OpenServiceMesh.useHTTPSIngress | bool | true, false | `"false"`| Enables HTTPS ingress on the mesh. |
+| outbound_ip_range_exclusion_list | OpenServiceMesh.outboundIPRangeExclusionList | string | comma separated list of IP ranges of the form a.b.c.d/x | `-`| Global list of IP address ranges to exclude from outbound traffic interception by the sidecar proxy. |


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
osm-config configMap allows specifying the outbound IP
ranges to exclude from sidecar interception. Allow
users to set this at install time.

This can be set via the Helm chart directly or by
using the `--set` option with the osm install command.
```
osm install \
  --set="OpenServiceMesh.outboundIPRangeExclusionList={1.1.1.1/32,2.2.2.2/24}"
```

Part of #2344

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`