### PR TITLE
metricstore: remove high cardinality labels from metrics osm metrics

### DIFF
--- a/pkg/envoy/ads/profile.go
+++ b/pkg/envoy/ads/profile.go
@@ -16,6 +16,6 @@ func xdsPathTimeTrack(t time.Time, tURIStr string, commonNameStr string, success
 		elapsed)
 
 	metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime.
-		WithLabelValues(commonNameStr, tURIStr, fmt.Sprintf("%t", *success)).
+		WithLabelValues(tURIStr, fmt.Sprintf("%t", *success)).
 		Observe(elapsed.Seconds())
 }

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -33,7 +33,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 
 	metricsstore.DefaultMetricsStore.CertXdsIssuedCount.Inc()
 	metricsstore.DefaultMetricsStore.CertXdsIssuedTime.
-		WithLabelValues(cn.String()).Observe(elapsed.Seconds())
+		WithLabelValues().Observe(elapsed.Seconds())
 	originalHealthProbes := rewriteHealthProbes(pod)
 
 	wh.meshCatalog.ExpectProxy(cn)

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -110,7 +110,6 @@ func init() {
 			Help:      "Histogram to track time spent for proxy configuration",
 		},
 		[]string{
-			"proxy_cn",      // proxy_cn is the common name of the proxy
 			"resource_type", // identifies a typeURI resource
 			"success",       // further labels if the operation succeeded or not
 		})
@@ -155,9 +154,7 @@ func init() {
 			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90},
 			Help:      "Histogram to track time spent to issue xds certificate",
 		},
-		[]string{
-			"common_name", // common_name is the common name of the certificate
-		})
+		[]string{})
 	defaultMetricsStore.registry = prometheus.NewRegistry()
 }
 


### PR DESCRIPTION
They are causing serious memory outages on Prometheus at a larger number
of pods. Storing is linear (0.5Mb/pod), but once the metrics are queried,
Prometheus spikes in memory footprint really hard on these.

Disabling for the time being, we will reintroduce them with config switches
for 0.8, for setups that either can or want to handle the extra resource consumption: 
https://github.com/openservicemesh/osm/issues/2408

**Affected area**:

- Metrics                [X]
- Performance            [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No