### PR TITLE
fix(ci): skip codecov update on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Test
         run: make go-test-coverage
       - name: Upload Coverage
-        if: ${{ success() }}
+        if: ${{ success() && github.event_name == 'push' }}
         run: bash <(curl -s https://codecov.io/bash)
 
   scenarios_tests:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change only updates codecov on GitHub "push" events (to the main
branch) so transient PR branch coverage stats aren't stored in codecov.

Resolves #2413 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No