### PR TITLE
codecov: enable on pull action and ignore demo/test code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,8 +104,8 @@ jobs:
       - name: Test
         run: make go-test-coverage
       - name: Upload Coverage
-        if: ${{ success() && github.event_name == 'push' }}
-        run: bash <(curl -s https://codecov.io/bash)
+        if: ${{ success() }}
+        run: bash <(curl -s https://codecov.io/bash) -F unittests
 
   scenarios_tests:
     name: Test various Envoy + SMI configuration scenarios

--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -2,7 +2,8 @@
 
 set -aueo pipefail
 
-readarray -t modules < <(go list ./... | grep -v tests/e2e | grep -v tests/scenarios | grep -v tests/scale)
+readarray -t modules < <(go list ./... | grep -v tests/framework | grep -v tests/e2e | grep -v tests/scenarios | grep -v tests/scale | \
+   grep -v ci/ | grep -v demo/ | grep -v experimental/ | grep -v scripts/)
 
 go test -timeout 120s \
    -failfast \


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Enables codecov on pull actions till we have a way to generate
more meaningful coverage reports on a per PR basis. Currently
the diff does not show up correctly on the codecov dashboard.
Also ignores demo/test related files from coverage reporting.
Additionally, experimental autogenerated Go code is ignored.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`