### PR TITLE
Turn off tracing by default

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -107,7 +107,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Sets the service certificatevalidity duration |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.0"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` | Tracing destination cluster (must contain the namespace) |
-| OpenServiceMesh.tracing.enable | bool | `true` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster |
+| OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Destination's API or collector endpoint where the spans will be sent to |
 | OpenServiceMesh.tracing.port | int | `9411` | Destination port for the listener |
 | OpenServiceMesh.useHTTPSIngress | bool | `false` | Enables HTTPS ingress on the mesh |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -123,7 +123,7 @@ OpenServiceMesh:
   tracing:
 
     # -- Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster
-    enable: true
+    enable: false
 
     # -- Tracing destination cluster (must contain the namespace)
     address: "jaeger.osm-system.svc.cluster.local"


### PR DESCRIPTION
Jaeger was turned off by default but tracing was left on, which
causes envoys to report connection errors to the Jaeger cluster.

Turning it as off, to follow Jaeger's current defaults.

Signed-off-by: Eduard Serra <eduser25@gmail.com>


**Affected area**:

- Metrics                [X]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No