### PR TITLE
fix(pkg/envoy/cds): fix local clusters

### DIFF
--- a/pkg/envoy/cds/new_response.go
+++ b/pkg/envoy/cds/new_response.go
@@ -7,17 +7,13 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/featureflags"
 )
 
-// NewResponse creates a new Cluster Discovery Response.
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
-	if featureflags.IsRoutesV2Enabled() {
-		return newResponse(meshCatalog, proxy, cfg)
-	}
+// newResponse creates a new Cluster Discovery Response.
+func newResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, cfg configurator.Configurator) (*xds_discovery.DiscoveryResponse, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
@@ -50,15 +46,21 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		clusters = append(clusters, cluster)
 	}
 
-	// Create a local cluster for the service.
-	// The local cluster will be used for incoming traffic.
-	localClusterName := envoy.GetLocalClusterNameForService(proxyServiceName)
-	localCluster, err := getLocalServiceCluster(meshCatalog, proxyServiceName, localClusterName)
+	services, err := meshCatalog.GetServicesForServiceAccount(proxyIdentity)
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
-		return nil, err
+		log.Error().Err(err).Msgf("Error looking up Services for ServiceAccount %v to build local clusters", proxyIdentity)
 	}
-	clusters = append(clusters, localCluster)
+	for _, service := range services {
+		// Create a local cluster for the service.
+		// The local cluster will be used for incoming traffic.
+		localClusterName := envoy.GetLocalClusterNameForService(service)
+		localCluster, err := getLocalServiceCluster(meshCatalog, service, localClusterName)
+		if err != nil {
+			log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
+			return nil, err
+		}
+		clusters = append(clusters, localCluster)
+	}
 
 	// Add an outbound passthrough cluster for egress
 	if cfg.IsEgressEnabled() {


### PR DESCRIPTION
* builds local clusters for all services that point
to pods with specified service account
* fixes bug where you see traffic only going to one version
of bookstore. This was happening because we were building a local
cluster for one service related to service account when there are
multiple services related to the service account

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
