### PR TITLE
configurator: remove optional tracing config keys from required list

### DIFF
--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -10,8 +10,8 @@ data:
   enable_debug_server: {{ .Values.OpenServiceMesh.enableDebugServer | quote }}
   prometheus_scraping: {{ .Values.OpenServiceMesh.enablePrometheusScraping | quote }}
 
-{{- if .Values.OpenServiceMesh.tracing.enable }}
   tracing_enable: {{ .Values.OpenServiceMesh.tracing.enable | quote }}
+{{- if .Values.OpenServiceMesh.tracing.enable }}
   tracing_address: {{ .Values.OpenServiceMesh.tracing.address | quote }}
   tracing_port: {{ .Values.OpenServiceMesh.tracing.port | quote }}
   tracing_endpoint: {{ .Values.OpenServiceMesh.tracing.endpoint | quote }}

--- a/docs/content/docs/osm_config_map.md
+++ b/docs/content/docs/osm_config_map.md
@@ -18,7 +18,7 @@ OSM deploys a configMap `osm-config` as a part of its control plane (in the same
 | envoy_log_level | OpenServiceMesh.envoyLogLevel | string | trace, debug, info, warning, warn, error, critical, off | `"error"` | Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh. |
 | prometheus_scraping | OpenServiceMesh.enablePrometheusScraping | bool | true, false | `"true"` | Enables Prometheus metrics scraping on sidecar proxies. |
 | service_cert_validity_duration | OpenServiceMesh.serviceCertValidityDuration | string | 24h, 1h30m (any time duration) | `"24h"` | Sets the service certificatevalidity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix. |
-| tracing_enable | OpenServiceMesh.tracing.enable | bool | true, false | `"true"` | Enables Jaeger tracing for the mesh. |
+| tracing_enable | OpenServiceMesh.tracing.enable | bool | true, false | `"false"` | Enables Jaeger tracing for the mesh. |
 | tracing_address | OpenServiceMesh.tracing.address | string | jaeger.mesh-namespace.svc.cluster.local | `jaeger.osm-system.svc.cluster.local` | Address of the Jaeger deployment, if tracing is enabled. |
 | tracing_endpoint | OpenServiceMesh.tracing.endpoint | string | /api/v2/spans | /api/v2/spans | Endpoint for tracing data, if tracing enabled. |
 | tracing_port| OpenServiceMesh.tracing.port | int | any non-zero integer value | `"9411"` | Port on which tracing is enabled. |

--- a/pkg/configurator/validating_webhook.go
+++ b/pkg/configurator/validating_webhook.go
@@ -36,7 +36,7 @@ var (
 	ValidEnvoyLogLevels = []string{"trace", "debug", "info", "warning", "warn", "error", "critical", "off"}
 
 	// defaultFields are the default fields in osm-config
-	defaultFields = []string{"egress", "enable_debug_server", "permissive_traffic_policy_mode", "prometheus_scraping", "tracing_enable", "use_https_ingress", "envoy_log_level", "service_cert_validity_duration", "tracing_address", "tracing_port", "tracing_endpoint"}
+	defaultFields = []string{"egress", "enable_debug_server", "permissive_traffic_policy_mode", "prometheus_scraping", "use_https_ingress", "envoy_log_level", "service_cert_validity_duration", "tracing_enable"}
 )
 
 const (


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The ConfigMap keys related to tracing are optional and not
required. Update the validating webhook to not expect them
by default.

This fixes the CI breakage introduced from ea1d39ad.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`