### PR TITLE
tests/e2e: fix default expectations in Helm install test

### DIFF
--- a/tests/e2e/e2e_helm_install_test.go
+++ b/tests/e2e/e2e_helm_install_test.go
@@ -13,7 +13,7 @@ var _ = OSMDescribe("Test osm control plane installation with Helm",
 		Bucket: 1,
 	},
 	func() {
-		Context("Using default values", func() {
+		Context("Helm install using default values", func() {
 			It("installs osm control plane successfully", func() {
 				if Td.InstType == NoInstall {
 					Skip("Test is not going through InstallOSM, hence cannot be automatically skipped with NoInstall (#1908)")
@@ -34,10 +34,7 @@ var _ = OSMDescribe("Test osm control plane installation with Helm",
 				Expect(configmap.Data["envoy_log_level"]).Should(Equal("error"))
 				Expect(configmap.Data["enable_debug_server"]).Should(Equal("false"))
 				Expect(configmap.Data["prometheus_scraping"]).Should(Equal("true"))
-				Expect(configmap.Data["tracing_enable"]).Should(Equal("true"))
-				Expect(configmap.Data["tracing_address"]).Should(Equal("jaeger.osm-system.svc.cluster.local"))
-				Expect(configmap.Data["tracing_port"]).Should(Equal("9411"))
-				Expect(configmap.Data["tracing_endpoint"]).Should(Equal("/api/v2/spans"))
+				Expect(configmap.Data["tracing_enable"]).Should(Equal("false"))
 				Expect(configmap.Data["use_https_ingress"]).Should(Equal("false"))
 				Expect(configmap.Data["service_cert_validity_duration"]).Should(Equal("24h"))
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
After ea1d39ad and dcfe26eb, tracing defaults to false and
the tracing config is only set when tracing is enabled.
This change updates the Helm install test to reflect this.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`