### PR TITLE
feat(ingress): Add support for ingress resources in routes v2

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -343,8 +343,12 @@ type MeshCataloger interface {
 	//GetWeightedClusterForService returns the weighted cluster for a service
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)
 
-	// GetIngressRoutesPerHost returns the HTTP route matches per host associated with an ingress service
-	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRouteMatch, error)
+  // GetIngressRoutesPerHost returns the HTTP route matches per host associated with an ingress service
+  // TODO : remove as a part of routes refactor cleanup (#2397)
+  GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRouteMatch, error)
+  
+  // GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
+  GetIngressPoliciesForService(service.MeshService, service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error)
 }
 ```
 

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -1,12 +1,15 @@
 package catalog
 
 import (
+	"fmt"
+
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 // GetIngressRoutesPerHost returns route matches per host as defined in observed ingress k8s resources.
+// TODO : Remove as a part of routes refactor cleanup (#2397)
 func (mc *MeshCatalog) GetIngressRoutesPerHost(service service.MeshService) (map[string][]trafficpolicy.HTTPRouteMatch, error) {
 	domainRoutesMap := make(map[string][]trafficpolicy.HTTPRouteMatch)
 	ingresses, err := mc.ingressMonitor.GetIngressResources(service)
@@ -49,4 +52,50 @@ func (mc *MeshCatalog) GetIngressRoutesPerHost(service service.MeshService) (map
 	log.Trace().Msgf("Created routes per host for service %s: %+v", service, domainRoutesMap)
 
 	return domainRoutesMap, nil
+}
+
+// GetIngressPoliciesForService returns a list of inbound traffic policies for a service as defined in observed ingress k8s resources.
+func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService, sa service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error) {
+	inboundIngressPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	ingresses, err := mc.ingressMonitor.GetIngressResources(svc)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to get ingress resources for service %s", svc)
+		return inboundIngressPolicies, err
+	}
+	if len(ingresses) == 0 {
+		log.Trace().Msgf("No ingress resources found for service %s", svc)
+		return inboundIngressPolicies, err
+	}
+
+	ingressWeightedCluster := getDefaultWeightedClusterForService(svc)
+
+	for _, ingress := range ingresses {
+		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == svc.Name {
+			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s-%s-%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
+			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(wildCardRouteMatch, ingressWeightedCluster), sa)
+			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
+		}
+
+		for _, rule := range ingress.Spec.Rules {
+			domain := rule.Host
+			if domain == "" {
+				domain = constants.WildcardHTTPMethod
+			}
+			ingressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s-%s-%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, domain), []string{domain})
+
+			for _, ingressPath := range rule.HTTP.Paths {
+				if ingressPath.Backend.ServiceName != svc.Name {
+					continue
+				}
+				routePolicy := wildCardRouteMatch
+				if routePolicy.PathRegex != "" {
+					routePolicy.PathRegex = ingressPath.Path
+				}
+				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(routePolicy, ingressWeightedCluster), sa)
+			}
+
+			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)
+		}
+	}
+	return inboundIngressPolicies, nil
 }

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -69,6 +69,21 @@ func (mr *MockMeshCatalogerMockRecorder) GetIngressRoutesPerHost(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressRoutesPerHost", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressRoutesPerHost), arg0)
 }
 
+// GetIngressPoliciesForService mocks base method
+func (m *MockMeshCataloger) GetIngressPoliciesForService(arg0 service.MeshService, arg1 service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIngressPoliciesForService", arg0, arg1)
+	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIngressPoliciesForService indicates an expected call of GetIngressPoliciesForService
+func (mr *MockMeshCatalogerMockRecorder) GetIngressPoliciesForService(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressPoliciesForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressPoliciesForService), arg0, arg1)
+}
+
 // GetPortToProtocolMappingForService mocks base method
 func (m *MockMeshCataloger) GetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -594,7 +594,7 @@ func (mc *MeshCatalog) listPoliciesFromTrafficTargets(sa service.K8sServiceAccou
 		}
 
 		if t.Spec.Destination.Name == sa.Name { // found inbound
-			inboundPolicies = trafficpolicy.MergeInboundPolicies(inboundPolicies, mc.buildInboundPolicies(t)...)
+			inboundPolicies = trafficpolicy.MergeInboundPolicies(false, inboundPolicies, mc.buildInboundPolicies(t)...)
 		}
 
 		for _, source := range t.Spec.Sources {

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -114,7 +114,11 @@ type MeshCataloger interface {
 	GetWeightedClusterForService(service service.MeshService) (service.WeightedCluster, error)
 
 	// GetIngressRoutesPerHost returns the HTTP route matches per host associated with an ingress service
+	// TODO : remove as a part of routes refactor (#2397)
 	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRouteMatch, error)
+
+	// GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
+	GetIngressPoliciesForService(service.MeshService, service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error)
 
 	// ListMonitoredNamespaces lists namespaces monitored by the control plane
 	ListMonitoredNamespaces() []string

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -64,8 +64,9 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	// --- INGRESS -------------------
 	// Apply an ingress filter chain if there are any ingress routes
+	// TODO : Replace with GetIngressPoliciesForService as a part of routes refactor cleanup (#2397)
 	if ingressRoutesPerHost, err := meshCatalog.GetIngressRoutesPerHost(proxyServiceName); err != nil {
-		log.Error().Err(err).Msgf("Error getting ingress routes per host for service %s", proxyServiceName)
+		log.Error().Err(err).Msgf("Error getting ingress for service %s", proxyServiceName)
 	} else {
 		thereAreIngressRoutes := len(ingressRoutesPerHost) > 0
 

--- a/pkg/envoy/rds/ingress.go
+++ b/pkg/envoy/rds/ingress.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
+// TODO : remove as a part of routes refactor cleanup (#2397)
 func updateRoutesForIngress(svc service.MeshService, catalog catalog.MeshCataloger, routesPerHost map[string]map[string]trafficpolicy.RouteWeightedClusters) error {
 	ingressRoutesPerHost, err := catalog.GetIngressRoutesPerHost(svc)
 	if err != nil {

--- a/pkg/envoy/rds/new_response_test.go
+++ b/pkg/envoy/rds/new_response_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -40,20 +42,57 @@ func TestNewResponse(t *testing.T) {
 						HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
 						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 					},
-					AllowedServiceAccounts: set.NewSet(tests.BookbuyerServiceAccount),
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
 				},
 				{
 					Route: trafficpolicy.RouteWeightedClusters{
 						HTTPRouteMatch:   tests.BookstoreSellHTTPRoute,
 						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 					},
-					AllowedServiceAccounts: set.NewSet(tests.BookbuyerServiceAccount),
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+				},
+			},
+		},
+	}
+
+	testIngressInbound := []*trafficpolicy.InboundTrafficPolicy{
+		{
+			Name:      "bookstore-v1-default-bookstore-v1.default.svc.cluster.local",
+			Hostnames: []string{"bookstore-v1.default.svc.cluster.local"},
+			Rules: []*trafficpolicy.Rule{
+				{
+					Route: trafficpolicy.RouteWeightedClusters{
+						HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+							PathRegex: tests.BookstoreBuyPath,
+							Methods:   []string{constants.WildcardHTTPMethod},
+						},
+						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+					},
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+				},
+			},
+		},
+		{
+			Name:      "bookstore-v1-default-*",
+			Hostnames: []string{"*"},
+			Rules: []*trafficpolicy.Rule{
+				{
+					Route: trafficpolicy.RouteWeightedClusters{
+						HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+							PathRegex: tests.BookstoreBuyPath,
+							Methods:   []string{constants.WildcardHTTPMethod},
+						},
+						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+					},
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
 				},
 			},
 		},
 	}
 
 	mockCatalog.EXPECT().ListTrafficPoliciesForServiceAccount(gomock.Any()).Return(testInbound, nil, nil).AnyTimes()
+	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
+	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 
 	actual, err := newResponse(mockCatalog, testProxy)
 	assert.Nil(err)
@@ -64,6 +103,17 @@ func TestNewResponse(t *testing.T) {
 		t.Fatal(unmarshallErr)
 	}
 	assert.Equal("RDS_Inbound", routeConfig.Name)
-	assert.Equal(1, len(routeConfig.VirtualHosts))
+	assert.Equal(2, len(routeConfig.VirtualHosts))
+
 	assert.Equal("inbound_virtualHost|bookstore-v1-default", routeConfig.VirtualHosts[0].Name)
+	assert.Equal(tests.BookstoreV1Hostnames, routeConfig.VirtualHosts[0].Domains)
+	assert.Equal(3, len(routeConfig.VirtualHosts[0].Routes))
+	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
+	assert.Equal(tests.BookstoreSellHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[1].GetMatch().GetSafeRegex().Regex)
+	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[2].GetMatch().GetSafeRegex().Regex)
+
+	assert.Equal("inbound_virtualHost|bookstore-v1-default-*", routeConfig.VirtualHosts[1].Name)
+	assert.Equal([]string{"*"}, routeConfig.VirtualHosts[1].Domains)
+	assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes))
+	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
 }


### PR DESCRIPTION
**Description**:

This change enables use of ingress resources in osm for the routes v2 and fixes #2367 

Unit tests have also been added as a part of this PR to test that the ingress resources and inbound routes are being built correctly for different scenarios. 

This change has been tested with an Nginx Ingress Controller based on the documentation provided here : https://github.com/openservicemesh/osm/blob/main/docs/content/docs/patterns/ingress.md#using-nginx-ingress-controller

When an ingress resource with the host specified the envoy config is as follows : 

Ingress resource :  (https://github.com/openservicemesh/osm/blob/main/demo/ingress/deploy-ingress-nginx-with-host.sh) 
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: bookstore-v1
  namespace: bookstore
  annotations:
    kubernetes.io/ingress.class: nginx
spec:
  rules:
  - host: bookstore-v1.bookstore.svc.cluster.local
    http:
      paths:
      - path: /books-bought
        backend:
          serviceName: bookstore-v1
          servicePort: 80
```

Envoy config on bookstore-v1 : 
```
"dynamic_route_configs": [
    {
     "version_info": "13",
     "route_config": {
      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name": "RDS_Inbound",
      "virtual_hosts": [
       {
        "name": "inbound_virtualHost|bookstore-v1-bookstore",
        "domains": [
         "bookstore-v1",
         "bookstore-v1.bookstore",
         "bookstore-v1.bookstore.svc",
         "bookstore-v1.bookstore.svc.cluster",
         "bookstore-v1.bookstore.svc.cluster.local",
         "bookstore-v1:80",
         "bookstore-v1.bookstore:80",
         "bookstore-v1.bookstore.svc:80",
         "bookstore-v1.bookstore.svc.cluster:80",
         "bookstore-v1.bookstore.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": "GET"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*a-book.*new"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         },
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": "GET"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": "/books-bought"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         },
         { // ingress route
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": "/books-bought"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": false
     },
     "last_updated": "2021-02-01T21:12:55.902Z"
    }
   ]
``` 

For an ingress resource without a host, the envoy config looks like : 

Ingress resource :  (https://github.com/openservicemesh/osm/blob/main/demo/ingress/deploy-ingress-nginx.sh) 
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: bookstore-v1
  namespace: $BOOKSTORE_NAMESPACE
  annotations:
    kubernetes.io/ingress.class: nginx
spec:
  rules:
  - http:
      paths:
      - path: /books-bought
        backend:
          serviceName: bookstore-v1
          servicePort: 80
```

Envoy config on bookstore-v1 : 
```
"dynamic_route_configs": [
    {
     "version_info": "14",
     "route_config": {
      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name": "RDS_Inbound",
      "virtual_hosts": [
       {
        "name": "inbound_virtualHost|bookstore-v1-bookstore",
        "domains": [
         "bookstore-v1",
         "bookstore-v1.bookstore",
         "bookstore-v1.bookstore.svc",
         "bookstore-v1.bookstore.svc.cluster",
         "bookstore-v1.bookstore.svc.cluster.local",
         "bookstore-v1:80",
         "bookstore-v1.bookstore:80",
         "bookstore-v1.bookstore.svc:80",
         "bookstore-v1.bookstore.svc.cluster:80",
         "bookstore-v1.bookstore.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": "GET"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*a-book.*new"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         },
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": "GET"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": "/books-bought"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       { // ingress route 
        "name": "inbound_virtualHost|bookstore-v1-bookstore-*",
        "domains": [
         "*"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": "/books-bought"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": false
     },
     "last_updated": "2021-02-01T21:15:49.610Z"
    }
   ]
```

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no` 
