### PR TITLE
fix(release): remove merge commit lines from generated changelog

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -18,7 +18,7 @@ tags=$(git -c 'versionsort.suffix=-alpha,-beta,-rc' tag -l --sort=version:refnam
 ! [[ "$tag" =~ -(alpha|beta|rc) ]] && tags=$(grep -Eve '-(alpha|beta|rc)' <<< "$tags")
 prev=$(tail -2 <<< "$tags" | head -1)
 
-changelog=$(git log "$prev".."$tag" --format="* %s %H (%aN)")
+changelog=$(git log "$prev".."$tag" --no-merges --format="* %s %H (%aN)")
 
 # Determine if any CRDs were updated between tags
 # CRD upgrades require manually deleting prior CRDs before upgrading Helm chart


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Now that we're adding merge commits, the generated changelog includes lots of "Merged pull request..." messages which are just noise. This change adds `--no-merges` to the `git log` command used in the release notes script to automatically filter those messages out.

I already edited v0.7.0-rc.1 to remove the merge commit messages from the changelog.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No