### PR TITLE
ref(pkg/catalog/*) : Remove references to GetHostnamesForUpstreamService

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -337,7 +337,8 @@ type MeshCataloger interface {
 	// GetServicesForServiceAccount returns a list of services corresponding to a service account
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
-	// GetResolvableHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
+  // GetResolvableHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
+  // TODO : remove as a part of routes refactor (#2397)
 	GetResolvableHostnamesForUpstreamService(downstream, upstream service.MeshService) ([]string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -84,6 +84,7 @@ func (mr *MockMeshCatalogerMockRecorder) GetPortToProtocolMappingForService(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortToProtocolMappingForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetPortToProtocolMappingForService), arg0)
 }
 
+// TODO : remove as a part of routes refactor (#2397)
 // GetResolvableHostnamesForUpstreamService mocks base method
 func (m *MockMeshCataloger) GetResolvableHostnamesForUpstreamService(arg0, arg1 service.MeshService) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -93,6 +94,7 @@ func (m *MockMeshCataloger) GetResolvableHostnamesForUpstreamService(arg0, arg1 
 	return ret0, ret1
 }
 
+// TODO : remove as a part of routes refactor (#2397)
 // GetResolvableHostnamesForUpstreamService indicates an expected call of GetResolvableHostnamesForUpstreamService
 func (mr *MockMeshCatalogerMockRecorder) GetResolvableHostnamesForUpstreamService(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -175,6 +175,7 @@ func (mc *MeshCatalog) GetWeightedClusterForService(svc service.MeshService) (se
 // GetResolvableHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
 // The hostname is the FQDN for the service, and can include ports as well.
 // Ex. bookstore.default, bookstore.default:80, bookstore.default.svc, bookstore.default.svc:80 etc.
+// TODO : remove as a part of routes refactor (#2397)
 func (mc *MeshCatalog) GetResolvableHostnamesForUpstreamService(downstream, upstream service.MeshService) ([]string, error) {
 	sameNamespace := downstream.Namespace == upstream.Namespace
 	var svcHostnames []string
@@ -472,22 +473,6 @@ func (mc *MeshCatalog) routesFromRules(rules []access.TrafficTargetRule, traffic
 	}
 
 	return routes, nil
-}
-
-// GetHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
-// The hostname is the FQDN for the service, and can include ports as well.
-// Ex. bookstore.default, bookstore.default:80, bookstore.default.svc, bookstore.default.svc:80 etc.
-// TODO: replace GetResolvableHostnamesForUpstreamService with this func once routes refactor is complete (#issue)
-func (mc *MeshCatalog) GetHostnamesForUpstreamService(downstream, upstream service.MeshService) ([]string, error) {
-	sameNamespace := downstream.Namespace == upstream.Namespace
-	// The hostnames for this service are the Kubernetes service DNS names
-	hostnames, err := mc.getServiceHostnames(upstream, sameNamespace)
-	if err != nil {
-		log.Error().Err(err).Msgf("Error getting service hostnames for upstream service %s", upstream)
-		return nil, err
-	}
-
-	return hostnames, nil
 }
 
 // listMeshServices returns all services in the mesh

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -83,75 +83,6 @@ func TestIsValidTrafficTarget(t *testing.T) {
 	}
 }
 
-func TestGetHostnamesForUpstreamService(t *testing.T) {
-	assert := tassert.New(t)
-
-	mc := newFakeMeshCatalogForRoutes(t, testParams{})
-
-	testCases := []struct {
-		name              string
-		upstream          service.MeshService
-		downstream        service.MeshService
-		expectedHostnames []string
-		expectedErr       bool
-	}{
-		{
-			name:     "When upstream and downstream are  in same namespace",
-			upstream: tests.BookstoreV1Service,
-			downstream: service.MeshService{
-				Namespace: "default",
-				Name:      "foo",
-			},
-			expectedHostnames: tests.BookstoreV1Hostnames,
-			expectedErr:       false,
-		},
-		{
-			name:     "When upstream and downstream are not in same namespace",
-			upstream: tests.BookstoreV1Service,
-			downstream: service.MeshService{
-				Namespace: "bar",
-				Name:      "foo",
-			},
-			expectedHostnames: []string{
-				"bookstore-v1.default",
-				"bookstore-v1.default.svc",
-				"bookstore-v1.default.svc.cluster",
-				"bookstore-v1.default.svc.cluster.local",
-				"bookstore-v1.default:8888",
-				"bookstore-v1.default.svc:8888",
-				"bookstore-v1.default.svc.cluster:8888",
-				"bookstore-v1.default.svc.cluster.local:8888",
-			},
-			expectedErr: false,
-		},
-		{
-			name: "When upstream service does not exist",
-			upstream: service.MeshService{
-				Namespace: "bar",
-				Name:      "DoesNotExist",
-			},
-			downstream: service.MeshService{
-				Namespace: "bar",
-				Name:      "foo",
-			},
-			expectedHostnames: nil,
-			expectedErr:       true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing hostnames when %s svc reaches %s svc", tc.downstream, tc.upstream), func(t *testing.T) {
-			actual, err := mc.GetHostnamesForUpstreamService(tc.downstream, tc.upstream)
-			if tc.expectedErr == false {
-				assert.Nil(err)
-			} else {
-				assert.NotNil(err)
-			}
-			assert.Equal(actual, tc.expectedHostnames, tc.name)
-		})
-	}
-}
-
 func TestRoutesFromRules(t *testing.T) {
 	assert := tassert.New(t)
 	mc := MeshCatalog{meshSpec: smi.NewFakeMeshSpecClient()}
@@ -513,6 +444,7 @@ func TestGetDefaultWeightedClusterForService(t *testing.T) {
 	assert.Equal(actual, expected)
 }
 
+// TODO : remove as a part of routes refactor (#2397)
 func TestGetResolvableHostnamesForUpstreamService(t *testing.T) {
 	assert := tassert.New(t)
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -108,6 +108,7 @@ type MeshCataloger interface {
 	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
 
 	// GetResolvableHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
+	// TODO : remove as a part of routes refactor (#2397)
 	GetResolvableHostnamesForUpstreamService(downstream, upstream service.MeshService) ([]string, error)
 
 	//GetWeightedClusterForService returns the weighted cluster for a service


### PR DESCRIPTION
**Description**:

Removing references to methods `GetHostnamesForUpstreamService` which is not being used. Also added TODO's to remove `GetResolvableHostnamesForUpstreamService` once we cut over to routes v2.

Fixes  #2048 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X}


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no` 
