### PR TITLE
ref(pkg/catalog/*): Remove reference to GetServicesForServiceAccounts

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -474,31 +474,6 @@ func (mc *MeshCatalog) routesFromRules(rules []access.TrafficTargetRule, traffic
 	return routes, nil
 }
 
-// GetServicesForServiceAccounts returns a list of services corresponding to a list service accounts
-//	TODO: Consider merging this function and mc.GetServicesForServiceAccount in future (#2038)
-func (mc *MeshCatalog) GetServicesForServiceAccounts(saList []service.K8sServiceAccount) []service.MeshService {
-	serviceMap := map[service.MeshService]bool{}
-
-	for _, sa := range saList {
-		services, err := mc.GetServicesForServiceAccount(sa)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error getting services linked to Service Account %s", sa)
-			continue
-		} else {
-			for _, s := range services {
-				serviceMap[s] = true
-			}
-		}
-	}
-
-	serviceList := []service.MeshService{}
-	for k := range serviceMap {
-		serviceList = append(serviceList, k)
-	}
-
-	return serviceList
-}
-
 // GetHostnamesForUpstreamService returns the hostnames over which an upstream service is accessible from a downstream service
 // The hostname is the FQDN for the service, and can include ports as well.
 // Ex. bookstore.default, bookstore.default:80, bookstore.default.svc, bookstore.default.svc:80 etc.

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -152,48 +152,6 @@ func TestGetHostnamesForUpstreamService(t *testing.T) {
 	}
 }
 
-func TestGetServicesForServiceAccounts(t *testing.T) {
-	assert := tassert.New(t)
-	mc := newFakeMeshCatalog()
-
-	testCases := []struct {
-		name     string
-		input    []service.K8sServiceAccount
-		expected []service.MeshService
-	}{
-		{
-			name:     "multiple service accounts and services",
-			input:    []service.K8sServiceAccount{tests.BookstoreServiceAccount, tests.BookbuyerServiceAccount},
-			expected: []service.MeshService{tests.BookbuyerService, tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
-		},
-		{
-			name:     "single service account and service",
-			input:    []service.K8sServiceAccount{tests.BookbuyerServiceAccount},
-			expected: []service.MeshService{tests.BookbuyerService},
-		},
-		{
-			name: "service account does not exist",
-			input: []service.K8sServiceAccount{{
-				Name:      "DoesNotExist",
-				Namespace: "default",
-			}},
-			expected: []service.MeshService{},
-		},
-		{
-			name:     "duplicate service accounts and services",
-			input:    []service.K8sServiceAccount{tests.BookbuyerServiceAccount, tests.BookbuyerServiceAccount},
-			expected: []service.MeshService{tests.BookbuyerService},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing GetServicesForServiceAccounts where %s", tc.name), func(t *testing.T) {
-			actual := mc.GetServicesForServiceAccounts(tc.input)
-			assert.ElementsMatch(tc.expected, actual)
-		})
-	}
-}
-
 func TestRoutesFromRules(t *testing.T) {
 	assert := tassert.New(t)
 	mc := MeshCatalog{meshSpec: smi.NewFakeMeshSpecClient()}


### PR DESCRIPTION
**Description**:

This PR removes references to GetServicesForServiceAccounts as it no longer used

Fixes #2038 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
