### PR TITLE
docs(release): add patch release instructions

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,7 +2,7 @@ name: Release Helm Chart
 on:
   push:
     tags:
-      - "chart/*"
+      - "v*"
 
 jobs:
   release:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds details about how to cut a patch release to the release
guide. It also consolidates the instructions for cutting CLI/image
releases and chart releases, since those will be done in sync and it
simplifies the steps.

Fixes #2058
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No