### PR TITLE
xdslogs, fix race when multiple verticals write in xdslog map

### DIFF
--- a/pkg/envoy/ads/debugger.go
+++ b/pkg/envoy/ads/debugger.go
@@ -3,11 +3,25 @@ package ads
 import (
 	"time"
 
+	"github.com/jinzhu/copier"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 // GetXDSLog implements XDSDebugger interface and a log of the XDS responses sent to Envoy proxies.
-func (s Server) GetXDSLog() *map[certificate.CommonName]map[envoy.TypeURI][]time.Time {
-	return &s.xdsLog
+func (s *Server) GetXDSLog() *map[certificate.CommonName]map[envoy.TypeURI][]time.Time {
+	var logsCopy map[certificate.CommonName]map[envoy.TypeURI][]time.Time
+	var err error
+
+	s.withXdsLogMutex(func() {
+		// Making a copy to avoid debugger potential reads while writes are happening from XDS routines
+		err = copier.Copy(&logsCopy, &s.xdsLog)
+	})
+
+	if err != nil {
+		log.Err(err).Msgf("Failed to copy xdsLogMap")
+	}
+
+	return &logsCopy
 }

--- a/pkg/envoy/ads/profile.go
+++ b/pkg/envoy/ads/profile.go
@@ -4,7 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
+)
+
+const (
+	// MaxXdsLogsPerProxy keeps a higher bound of how many timestamps do we keep per proxy
+	MaxXdsLogsPerProxy = 20
 )
 
 func xdsPathTimeTrack(t time.Time, tURIStr string, commonNameStr string, success *bool) {
@@ -18,4 +25,24 @@ func xdsPathTimeTrack(t time.Time, tURIStr string, commonNameStr string, success
 	metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime.
 		WithLabelValues(tURIStr, fmt.Sprintf("%t", *success)).
 		Observe(elapsed.Seconds())
+}
+
+func (s *Server) trackXDSLog(cn certificate.CommonName, typeURL envoy.TypeURI) {
+	s.withXdsLogMutex(func() {
+		if _, ok := s.xdsLog[cn]; !ok {
+			s.xdsLog[cn] = make(map[envoy.TypeURI][]time.Time)
+		}
+
+		timeSlice, ok := s.xdsLog[cn][typeURL]
+		if !ok {
+			s.xdsLog[cn][typeURL] = []time.Time{time.Now()}
+			return
+		}
+
+		timeSlice = append(timeSlice, time.Now())
+		if len(timeSlice) > MaxXdsLogsPerProxy {
+			timeSlice = timeSlice[1:]
+		}
+		s.xdsLog[cn][typeURL] = timeSlice
+	})
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -131,11 +131,8 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *xds
 		return nil, errUnknownTypeURL
 	}
 
-	if s.enableDebug {
-		if _, ok := s.xdsLog[proxy.GetCertificateCommonName()]; !ok {
-			s.xdsLog[proxy.GetCertificateCommonName()] = make(map[envoy.TypeURI][]time.Time)
-		}
-		s.xdsLog[proxy.GetCertificateCommonName()][typeURL] = append(s.xdsLog[proxy.GetCertificateCommonName()][typeURL], time.Now())
+	if s.cfg.IsDebugServerEnabled() {
+		s.trackXDSLog(proxy.GetCertificateCommonName(), typeURL)
 	}
 
 	// request.Node is only available on the first Discovery Request; will be nil on the following

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Test ADS response functions", func() {
 		mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 		mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(certDuration).AnyTimes()
+		mockConfigurator.EXPECT().IsDebugServerEnabled().Return(true).AnyTimes()
 
 		It("returns Aggregated Discovery Service response", func() {
 			s := NewADSServer(mc, true, tests.Namespace, mockConfigurator, mockCertManager)

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -1,6 +1,7 @@
 package ads
 
 import (
+	"sync"
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -18,12 +19,12 @@ var (
 
 // Server implements the Envoy xDS Aggregate Discovery Services
 type Server struct {
-	catalog      catalog.MeshCataloger
-	xdsHandlers  map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) (*xds_discovery.DiscoveryResponse, error)
-	xdsLog       map[certificate.CommonName]map[envoy.TypeURI][]time.Time
-	enableDebug  bool
-	osmNamespace string
-	cfg          configurator.Configurator
-	certManager  certificate.Manager
-	ready        bool
+	catalog        catalog.MeshCataloger
+	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) (*xds_discovery.DiscoveryResponse, error)
+	xdsLog         map[certificate.CommonName]map[envoy.TypeURI][]time.Time
+	xdsMapLogMutex sync.Mutex
+	osmNamespace   string
+	cfg            configurator.Configurator
+	certManager    certificate.Manager
+	ready          bool
 }


### PR DESCRIPTION
There is a race when multiple envoys are connecting at the same time, where
multiple writes can happen on the xdslog map.
Although rare, it's easy to hit with a beefier setup with more pods, or specially
when OSM restarts (since all pods will attempt to connect mostly at the same time).

- For now this is gated with a simple mutex. If this introduces unwanted penalties
we could discuss dropping all this in-memory logging and have regular logging do
the job instead.
- Also limited the number of logs we can store at a time per proxy (before
 had no upper limit)
- A copy of the map is now handed to debugger, to avoid read/write concurrent
accesses on the map.

Fixes #2441

Signed-off-by: Eduard Serra <eduser25@gmail.com>

**Affected area**:

- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No