### PR TITLE
constants: rename HTTP server port constant for clarity

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -251,7 +251,7 @@ func main() {
 	}
 
 	// Initialize OSM's http service server
-	httpServer := httpserver.NewHTTPServer(constants.OSMServicePort)
+	httpServer := httpserver.NewHTTPServer(constants.OSMHTTPServerPort)
 
 	// Health/Liveness probes
 	funcProbes := []health.Probes{xdsServer}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -60,8 +60,8 @@ const (
 	// InjectorWebhookPort is the port on which the sidecar injection webhook listens
 	InjectorWebhookPort = 9090
 
-	// OSMServicePort is the port on which OSM exposes HTTP paths for metrics and probes
-	OSMServicePort = 9091
+	// OSMHTTPServerPort is the port on which osm-controller serves HTTP requests for metrics, health probes etc.
+	OSMHTTPServerPort = 9091
 
 	//DebugPort is the port on which OSM exposes its debug server
 	DebugPort = 9092


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
`OSMServicePort` is ambiguous because osm-controller exposes
multiple ports for the `osm-controller` service: ADS server,
webhook, debug server etc.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`