### PR TITLE
Update memory limits for OSM

### DIFF
--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -20,7 +20,7 @@ OpenServiceMesh:
     resource:
       limits:
         cpu: "1.5"
-        memory: "256M"
+        memory: "512M"
       requests:
         cpu: "0.5"
         memory: "32M"


### PR DESCRIPTION
(Tentative)

256 falls a bit short in memory to support up to 200 pods.
Updating max limits 512, to at least be able to support acknowledge
current limits with current defaults, without having K8s prune it due
to OOM.

![image](https://user-images.githubusercontent.com/5503924/106944685-c1c95400-66db-11eb-9889-875dddbff0ac.png)

- Performance            [X]

Please answer the following questions with yes/no.
No
- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
