### PR TITLE
cmd/osm-controller: fix bug in flag parsing

### DIFF
--- a/cmd/osm-controller/certificates_test.go
+++ b/cmd/osm-controller/certificates_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, osmCertificateManagerKind, ns,
+			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, providers.Kind(certProviderKind), ns,
 				secretName, tresorOptions, vaultOptions, certManagerOptions)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -76,7 +76,7 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, osmCertificateManagerKind, ns,
+			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, providers.Kind(certProviderKind), ns,
 				secretName, tresorOptions, vaultOptions, certManagerOptions)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -91,7 +91,7 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, osmCertificateManagerKind, ns,
+			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, providers.Kind(certProviderKind), ns,
 				secretName, tresorOptions, vaultOptions, certManagerOptions)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -122,7 +122,7 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, osmCertificateManagerKind, ns,
+			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, providers.Kind(certProviderKind), ns,
 				secretName, tresorOptions, vaultOptions, certManagerOptions)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -151,7 +151,7 @@ var _ = Describe("Test CMD tools", func() {
 			ns := uuid.New().String()
 			secretName := uuid.New().String()
 
-			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, osmCertificateManagerKind, ns,
+			certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, nil, nil, providers.Kind(certProviderKind), ns,
 				secretName, tresorOptions, vaultOptions, certManagerOptions)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/cmd/osm-controller/validate.go
+++ b/cmd/osm-controller/validate.go
@@ -40,7 +40,7 @@ func validateCLIParams() error {
 }
 
 func validateCertificateManagerOptions() error {
-	switch osmCertificateManagerKind {
+	switch providers.Kind(certProviderKind) {
 	case providers.TresorKind:
 		return providers.ValidateTresorOptions(tresorOptions)
 
@@ -51,7 +51,7 @@ func validateCertificateManagerOptions() error {
 		return providers.ValidateCertManagerOptions(certManagerOptions)
 
 	default:
-		return errors.Errorf("Invalid certificate manager kind %s. Please specify a valid certificate manager, one of: [%v] \n",
-			osmCertificateManagerKind, providers.ValidCertificateProviders)
+		return errors.Errorf("Invalid certificate manager kind %s. Please specify a valid certificate manager, one of: [%v]",
+			certProviderKind, providers.ValidCertificateProviders)
 	}
 }

--- a/cmd/osm-controller/validate_test.go
+++ b/cmd/osm-controller/validate_test.go
@@ -13,8 +13,8 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 		testCaBundleSecretName = "test-secret"
 	)
 
-	Context("tresor osmCertificateManagerKind is passed in", func() {
-		osmCertificateManagerKind = providers.TresorKind
+	Context("tresor certProviderKind is passed in", func() {
+		certProviderKind = providers.TresorKind.String()
 
 		err := validateCertificateManagerOptions()
 
@@ -22,8 +22,8 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 			Expect(err).To(BeNil())
 		})
 	})
-	Context("vault osmCertificateManagerKind is passed in and vaultToken is not empty", func() {
-		osmCertificateManagerKind = providers.VaultKind
+	Context("vault certProviderKind is passed in and vaultToken is not empty", func() {
+		certProviderKind = providers.VaultKind.String()
 		vaultOptions.VaultToken = "anythinghere"
 
 		err := validateCertificateManagerOptions()
@@ -32,8 +32,8 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 			Expect(err).To(BeNil())
 		})
 	})
-	Context("vault osmCertificateManagerKind is passed in but vaultToken is empty", func() {
-		osmCertificateManagerKind = providers.VaultKind
+	Context("vault certProviderKind is passed in but vaultToken is empty", func() {
+		certProviderKind = providers.VaultKind.String()
 		vaultOptions.VaultToken = ""
 
 		err := validateCertificateManagerOptions()
@@ -43,8 +43,8 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 
 		})
 	})
-	Context("cert-manager osmCertificateManagerKind is passed in with valid caBundleSecretName and certmanagerIssuerName", func() {
-		osmCertificateManagerKind = providers.CertManagerKind
+	Context("cert-manager certProviderKind is passed in with valid caBundleSecretName and certmanagerIssuerName", func() {
+		certProviderKind = providers.CertManagerKind.String()
 		caBundleSecretName = testCaBundleSecretName
 		certManagerOptions.IssuerName = "test-issuer"
 
@@ -54,8 +54,8 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 			Expect(err).To(BeNil())
 		})
 	})
-	Context("cert-manager osmCertificateManagerKind is passed in with caBundleSecretName but no certmanagerIssureName", func() {
-		osmCertificateManagerKind = providers.CertManagerKind
+	Context("cert-manager certProviderKind is passed in with caBundleSecretName but no certmanagerIssureName", func() {
+		certProviderKind = providers.CertManagerKind.String()
 		caBundleSecretName = testCaBundleSecretName
 		certManagerOptions.IssuerName = ""
 
@@ -65,8 +65,8 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Context("cert-manager osmCertificateManagerKind is passed in without caBundleSecretName but no certmanagerIssureName", func() {
-		osmCertificateManagerKind = providers.CertManagerKind
+	Context("cert-manager certProviderKind is passed in without caBundleSecretName but no certmanagerIssureName", func() {
+		certProviderKind = providers.CertManagerKind.String()
 		caBundleSecretName = ""
 		certManagerOptions.IssuerName = ""
 
@@ -78,7 +78,7 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 	})
 
 	Context("invalid kind is passed in", func() {
-		osmCertificateManagerKind = "invalidkind"
+		certProviderKind = "invalidkind"
 
 		err := validateCertificateManagerOptions()
 
@@ -99,7 +99,7 @@ var _ = Describe("Test validateCLIParams", func() {
 	)
 
 	Context("none of the necessary CLI params are empty", func() {
-		osmCertificateManagerKind = providers.TresorKind
+		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
 		injectorConfig = injector.Config{
@@ -116,7 +116,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		})
 	})
 	Context("mesh name is empty", func() {
-		osmCertificateManagerKind = providers.TresorKind
+		certProviderKind = providers.TresorKind.String()
 		meshName = ""
 		osmNamespace = testOsmNamespace
 		injectorConfig = injector.Config{
@@ -132,7 +132,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		})
 	})
 	Context("osmNamespace is empty", func() {
-		osmCertificateManagerKind = providers.TresorKind
+		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = ""
 		injectorConfig = injector.Config{
@@ -148,7 +148,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		})
 	})
 	Context("InitContainerImage on injectorConfig is empty", func() {
-		osmCertificateManagerKind = providers.TresorKind
+		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
 		injectorConfig = injector.Config{
@@ -164,7 +164,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		})
 	})
 	Context("SidecarImage on injectorConfig is empty", func() {
-		osmCertificateManagerKind = providers.TresorKind
+		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
 		injectorConfig = injector.Config{
@@ -180,7 +180,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		})
 	})
 	Context("webhookConfigName is empty", func() {
-		osmCertificateManagerKind = providers.TresorKind
+		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
 		injectorConfig = injector.Config{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The value for a flag can only be used after `flags.Parse()`
is invoked. Since the cert provider kind is an enum and
can't be set directly via the call to `flags.Parse()`, parse
the provider kind as a string and set it to `providers.Kind`
only when necessary.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`