### PR TITLE
fix(cds): return local cluster endpoints per  port

### DIFF
--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -1,7 +1,7 @@
 package cds
 
 import (
-	"net"
+	"errors"
 	"testing"
 
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -15,7 +15,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -77,15 +76,19 @@ func TestGetLocalServiceCluster(t *testing.T) {
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
 
 	testCases := []struct {
-		name                        string
-		endpoints                   []endpoint.Endpoint
-		expectedLocalityLbEndpoints []*xds_endpoint.LocalityLbEndpoints
-		expectedLbPolicy            xds_cluster.Cluster_LbPolicy
-		expectedProtocolSelection   xds_cluster.Cluster_ClusterProtocolSelection
+		name                             string
+		proxyService                     service.MeshService
+		portToProtocolMapping            map[uint32]string
+		expectedLocalityLbEndpoints      []*xds_endpoint.LocalityLbEndpoints
+		expectedLbPolicy                 xds_cluster.Cluster_LbPolicy
+		expectedProtocolSelection        xds_cluster.Cluster_ClusterProtocolSelection
+		expectedPortToProtocolMappingErr bool
+		expectedErr                      bool
 	}{
 		{
-			name:      "when service returns one endpoint",
-			endpoints: []endpoint.Endpoint{tests.Endpoint},
+			name:                  "when service returns a single port",
+			proxyService:          proxyService,
+			portToProtocolMapping: map[uint32]string{uint32(8080): "something"},
 			expectedLocalityLbEndpoints: []*xds_endpoint.LocalityLbEndpoints{
 				{
 					Locality: &xds_core.Locality{
@@ -94,7 +97,7 @@ func TestGetLocalServiceCluster(t *testing.T) {
 					LbEndpoints: []*xds_endpoint.LbEndpoint{{
 						HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
 							Endpoint: &xds_endpoint.Endpoint{
-								Address: envoy.GetAddress(constants.WildcardIPAddr, uint32(tests.ServicePort)),
+								Address: envoy.GetAddress(constants.WildcardIPAddr, uint32(8080)),
 							},
 						},
 						LoadBalancingWeight: &wrappers.UInt32Value{
@@ -103,48 +106,45 @@ func TestGetLocalServiceCluster(t *testing.T) {
 					}},
 				},
 			},
+			expectedPortToProtocolMappingErr: false,
+			expectedErr:                      false,
 		},
 		{
-			name: "when service returns two endpoints with same port",
-			endpoints: []endpoint.Endpoint{tests.Endpoint, {
-				IP:   net.ParseIP("1.2.3.4"),
-				Port: endpoint.Port(tests.ServicePort),
-			}},
-			expectedLocalityLbEndpoints: []*xds_endpoint.LocalityLbEndpoints{
-				{
-					Locality: &xds_core.Locality{
-						Zone: "zone",
-					},
-					LbEndpoints: []*xds_endpoint.LbEndpoint{{
-						HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
-							Endpoint: &xds_endpoint.Endpoint{
-								Address: envoy.GetAddress(constants.WildcardIPAddr, uint32(tests.ServicePort)),
-							},
-						},
-						LoadBalancingWeight: &wrappers.UInt32Value{
-							Value: constants.ClusterWeightAcceptAll, // Local cluster accepts all traffic
-						},
-					}},
-				},
-			},
+			name:                             "when err fetching ports",
+			proxyService:                     proxyService,
+			portToProtocolMapping:            map[uint32]string{},
+			expectedLocalityLbEndpoints:      []*xds_endpoint.LocalityLbEndpoints{},
+			expectedPortToProtocolMappingErr: true,
+			expectedErr:                      true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockCatalog.EXPECT().ListEndpointsForService(proxyService).Return(tc.endpoints, nil).Times(1)
-			cluster, err := getLocalServiceCluster(mockCatalog, proxyService, clusterName)
-			assert.Nil(err)
-			assert.Equal(clusterName, cluster.Name)
-			assert.Equal(clusterName, cluster.AltStatName)
-			assert.Equal(ptypes.DurationProto(clusterConnectTimeout), cluster.ConnectTimeout)
-			assert.Equal(xds_cluster.Cluster_ROUND_ROBIN, cluster.LbPolicy)
-			assert.Equal(&xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STRICT_DNS}, cluster.ClusterDiscoveryType)
-			assert.Equal(true, cluster.RespectDnsTtl)
-			assert.Equal(xds_cluster.Cluster_V4_ONLY, cluster.DnsLookupFamily)
-			assert.Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL, cluster.ProtocolSelection)
-			assert.Equal(len(tc.expectedLocalityLbEndpoints), len(cluster.LoadAssignment.Endpoints))
-			//assert.Equal(tc.expectedLocalityLbEndpoints, cluster.LoadAssignment.Endpoints)
+			if tc.expectedPortToProtocolMappingErr {
+				mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(tc.proxyService).Return(tc.portToProtocolMapping, errors.New("error")).Times(1)
+			} else {
+				mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(tc.proxyService).Return(tc.portToProtocolMapping, nil).Times(1)
+			}
+
+			cluster, err := getLocalServiceCluster(mockCatalog, tc.proxyService, clusterName)
+
+			if tc.expectedErr {
+				assert.NotNil(err)
+				assert.Nil(cluster)
+			} else {
+				assert.Nil(err)
+				assert.Equal(clusterName, cluster.Name)
+				assert.Equal(clusterName, cluster.AltStatName)
+				assert.Equal(ptypes.DurationProto(clusterConnectTimeout), cluster.ConnectTimeout)
+				assert.Equal(xds_cluster.Cluster_ROUND_ROBIN, cluster.LbPolicy)
+				assert.Equal(&xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STRICT_DNS}, cluster.ClusterDiscoveryType)
+				assert.Equal(true, cluster.RespectDnsTtl)
+				assert.Equal(xds_cluster.Cluster_V4_ONLY, cluster.DnsLookupFamily)
+				assert.Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL, cluster.ProtocolSelection)
+				assert.Equal(len(tc.expectedLocalityLbEndpoints), len(cluster.LoadAssignment.Endpoints))
+				assert.ElementsMatch(tc.expectedLocalityLbEndpoints, cluster.LoadAssignment.Endpoints)
+			}
 		})
 	}
 }

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -1,23 +1,30 @@
 package cds
 
 import (
+	"net"
 	"testing"
 
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-
+	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	tassert "github.com/stretchr/testify/assert"
 
+	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 func TestGetUpstreamServiceCluster(t *testing.T) {
 	assert := tassert.New(t)
 
-	mockCtrl := gomock.NewController(GinkgoT())
+	mockCtrl := gomock.NewController(t)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	downstreamSvc := tests.BookbuyerService
 	upstreamSvc := tests.BookstoreV1Service
@@ -53,6 +60,91 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 			assert.Equal(tc.expectedClusterType, remoteCluster.GetType())
 			assert.Equal(tc.expectedLbPolicy, remoteCluster.LbPolicy)
 			assert.Equal(tc.expectedProtocolSelection, remoteCluster.ProtocolSelection)
+		})
+	}
+}
+
+func TestGetLocalServiceCluster(t *testing.T) {
+	assert := tassert.New(t)
+
+	clusterName := "bookbuyer-local"
+	proxyService := service.MeshService{
+		Name:      "bookbuyer",
+		Namespace: "bookbuyer-ns",
+	}
+
+	mockCtrl := gomock.NewController(t)
+	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
+
+	testCases := []struct {
+		name                        string
+		endpoints                   []endpoint.Endpoint
+		expectedLocalityLbEndpoints []*xds_endpoint.LocalityLbEndpoints
+		expectedLbPolicy            xds_cluster.Cluster_LbPolicy
+		expectedProtocolSelection   xds_cluster.Cluster_ClusterProtocolSelection
+	}{
+		{
+			name:      "when service returns one endpoint",
+			endpoints: []endpoint.Endpoint{tests.Endpoint},
+			expectedLocalityLbEndpoints: []*xds_endpoint.LocalityLbEndpoints{
+				{
+					Locality: &xds_core.Locality{
+						Zone: "zone",
+					},
+					LbEndpoints: []*xds_endpoint.LbEndpoint{{
+						HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
+							Endpoint: &xds_endpoint.Endpoint{
+								Address: envoy.GetAddress(constants.WildcardIPAddr, uint32(tests.ServicePort)),
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: constants.ClusterWeightAcceptAll, // Local cluster accepts all traffic
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "when service returns two endpoints with same port",
+			endpoints: []endpoint.Endpoint{tests.Endpoint, {
+				IP:   net.ParseIP("1.2.3.4"),
+				Port: endpoint.Port(tests.ServicePort),
+			}},
+			expectedLocalityLbEndpoints: []*xds_endpoint.LocalityLbEndpoints{
+				{
+					Locality: &xds_core.Locality{
+						Zone: "zone",
+					},
+					LbEndpoints: []*xds_endpoint.LbEndpoint{{
+						HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
+							Endpoint: &xds_endpoint.Endpoint{
+								Address: envoy.GetAddress(constants.WildcardIPAddr, uint32(tests.ServicePort)),
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: constants.ClusterWeightAcceptAll, // Local cluster accepts all traffic
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCatalog.EXPECT().ListEndpointsForService(proxyService).Return(tc.endpoints, nil).Times(1)
+			cluster, err := getLocalServiceCluster(mockCatalog, proxyService, clusterName)
+			assert.Nil(err)
+			assert.Equal(clusterName, cluster.Name)
+			assert.Equal(clusterName, cluster.AltStatName)
+			assert.Equal(ptypes.DurationProto(clusterConnectTimeout), cluster.ConnectTimeout)
+			assert.Equal(xds_cluster.Cluster_ROUND_ROBIN, cluster.LbPolicy)
+			assert.Equal(&xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STRICT_DNS}, cluster.ClusterDiscoveryType)
+			assert.Equal(true, cluster.RespectDnsTtl)
+			assert.Equal(xds_cluster.Cluster_V4_ONLY, cluster.DnsLookupFamily)
+			assert.Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL, cluster.ProtocolSelection)
+			assert.Equal(len(tc.expectedLocalityLbEndpoints), len(cluster.LoadAssignment.Endpoints))
+			//assert.Equal(tc.expectedLocalityLbEndpoints, cluster.LoadAssignment.Endpoints)
 		})
 	}
 }

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -1,46 +1,58 @@
 package cds
 
 import (
+	"testing"
+
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
-var _ = Describe("Cluster configurations", func() {
-	var (
-		mockCtrl         *gomock.Controller
-		mockConfigurator *configurator.MockConfigurator
-	)
+func TestGetUpstreamServiceCluster(t *testing.T) {
+	assert := tassert.New(t)
 
-	mockCtrl = gomock.NewController(GinkgoT())
-	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
-
+	mockCtrl := gomock.NewController(GinkgoT())
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	downstreamSvc := tests.BookbuyerService
 	upstreamSvc := tests.BookstoreV1Service
-	Context("Test getUpstreamServiceCluster", func() {
-		It("Returns an EDS based cluster when permissive mode is disabled", func() {
-			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
 
+	testCases := []struct {
+		name                      string
+		permissiveMode            bool
+		expectedClusterType       xds_cluster.Cluster_DiscoveryType
+		expectedLbPolicy          xds_cluster.Cluster_LbPolicy
+		expectedProtocolSelection xds_cluster.Cluster_ClusterProtocolSelection
+	}{
+		{
+			name:                      "Returns an EDS based cluster when permissive mode is disabled",
+			permissiveMode:            false,
+			expectedClusterType:       xds_cluster.Cluster_EDS,
+			expectedLbPolicy:          xds_cluster.Cluster_ROUND_ROBIN,
+			expectedProtocolSelection: xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		},
+		{
+			name:                      "Returns an Original Destination based cluster when permissive mode is enabled",
+			permissiveMode:            true,
+			expectedClusterType:       xds_cluster.Cluster_ORIGINAL_DST,
+			expectedLbPolicy:          xds_cluster.Cluster_CLUSTER_PROVIDED,
+			expectedProtocolSelection: xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
 			remoteCluster, err := getUpstreamServiceCluster(upstreamSvc, downstreamSvc, mockConfigurator)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(remoteCluster.GetType()).To(Equal(xds_cluster.Cluster_EDS))
-			Expect(remoteCluster.LbPolicy).To(Equal(xds_cluster.Cluster_ROUND_ROBIN))
-			Expect(remoteCluster.ProtocolSelection).To(Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL))
+			assert.Nil(err)
+			assert.Equal(tc.expectedClusterType, remoteCluster.GetType())
+			assert.Equal(tc.expectedLbPolicy, remoteCluster.LbPolicy)
+			assert.Equal(tc.expectedProtocolSelection, remoteCluster.ProtocolSelection)
 		})
-
-		It("Returns an Original Destination based cluster when permissive mode is enabled", func() {
-			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).Times(1)
-
-			remoteCluster, err := getUpstreamServiceCluster(upstreamSvc, downstreamSvc, mockConfigurator)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(remoteCluster.GetType()).To(Equal(xds_cluster.Cluster_ORIGINAL_DST))
-			Expect(remoteCluster.LbPolicy).To(Equal(xds_cluster.Cluster_CLUSTER_PROVIDED))
-			Expect(remoteCluster.ProtocolSelection).To(Equal(xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL))
-		})
-	})
-})
+	}
+}

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -50,10 +50,15 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	// Create a local cluster for the service.
 	// The local cluster will be used for incoming traffic.
 	localClusterName := envoy.GetLocalClusterNameForService(proxyServiceName)
-	localCluster, err := getLocalServiceCluster(meshCatalog, proxyServiceName, localClusterName)
-	if err != nil {
-		log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
-		return nil, err
+	var localCluster *xds_cluster.Cluster
+	if proxyServiceName.IsSyntheticService() {
+		localCluster = getSyntheticCluster(localClusterName)
+	} else {
+		localCluster, err = getLocalServiceCluster(meshCatalog, proxyServiceName, localClusterName)
+		if err != nil {
+			log.Error().Err(err).Msgf("Failed to get local cluster config for proxy %s", proxyServiceName)
+			return nil, err
+		}
 	}
 	clusters = append(clusters, localCluster)
 

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -79,6 +79,12 @@ func (sa K8sServiceAccount) GetSyntheticService() MeshService {
 	}
 }
 
+// IsSyntheticService evaluates the given service name and returns a boolean to denote whether the name
+// looks like the name of a synthetic service or not
+func (ms MeshService) IsSyntheticService() bool {
+	return strings.Contains(ms.Name, ".osm.synthetic-")
+}
+
 // ClusterName is a type for a service name
 type ClusterName string
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The `getLocalServiceCluster` function was returning an xds cluster with endpoints based on Kubernetes service endpoints when it should have been building local cluster endpoints based on the port specified in the service spec. i.e. 0.0.0.0:<port>
As a result, there were 18 extra, duplicate  entries in the envoy local clusters that were being programmed per Kubernetes service endpoints (or Pod replicas)

This PR fixes the getLocalServiceCluster to return a local cluster with endpoints based on the Kubernetes ports rather than the Kubernetes Service endpoints. The tests in the clusters_test.go have been converted from gingko to use the go testing framework and tests for getLocalServiceCluster has been added.

To see the issue exposed in a test, please pull down this branch and checkout the commit sha 9f952062e652ba66d4fb2cc46cb663217bef5088 and run the tests. You can also check out that commit, run the demo, play with the replica count on bookbuyer and inspect the clusters in the envoy admin UI to see the duplicate entries.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [X ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
