### PR TITLE
ref(injector): pass pod object to getEnvoySidecarContainerSpec

### DIFF
--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -1,6 +1,7 @@
 package injector
 
 import (
+	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -15,9 +16,14 @@ const (
 	envoyProxyConfigPath     = "/etc/envoy"
 )
 
-func getEnvoySidecarContainerSpec(containerName, envoyImage, nodeID, clusterID string, cfg configurator.Configurator, originalHealthProbes healthProbes) corev1.Container {
+func getEnvoySidecarContainerSpec(pod *corev1.Pod, envoyImage string, cfg configurator.Configurator, originalHealthProbes healthProbes) corev1.Container {
+	// nodeID and clusterID are required for Envoy proxy to start.
+	nodeID := pod.Spec.ServiceAccountName
+	// cluster ID will be used as an identifier to the tracing sink
+	clusterID := fmt.Sprintf("%s.%s", pod.Spec.ServiceAccountName, pod.Namespace)
+
 	return corev1.Container{
-		Name:            containerName,
+		Name:            constants.EnvoyContainerName,
 		Image:           envoyImage,
 		ImagePullPolicy: corev1.PullAlways,
 		SecurityContext: &corev1.SecurityContext{

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -51,14 +51,8 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 	initContainer := getInitContainerSpec(constants.InitContainerName, wh.config.InitContainerImage, wh.configurator.GetOutboundIPRangeExclusionList())
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
-	// envoyNodeID and envoyClusterID are required for Envoy proxy to start.
-	envoyNodeID := pod.Spec.ServiceAccountName
-
-	// envoyCluster ID will be used as an identifier to the tracing sink
-	envoyClusterID := fmt.Sprintf("%s.%s", pod.Spec.ServiceAccountName, namespace)
-
 	// Add the Envoy sidecar
-	sidecar := getEnvoySidecarContainerSpec(constants.EnvoyContainerName, wh.config.SidecarImage, envoyNodeID, envoyClusterID, wh.configurator, originalHealthProbes)
+	sidecar := getEnvoySidecarContainerSpec(pod, wh.config.SidecarImage, wh.configurator, originalHealthProbes)
 	pod.Spec.Containers = append(pod.Spec.Containers, sidecar)
 
 	enableMetrics, err := wh.isMetricsEnabled(namespace)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change refactors `getEnvoySidecarContainerSpec` to accept the pod
object as an argument so its other fields do not have to be passed as
additional arguments explicitly. In particular, the pod's owner
references will be read to keep track of which workload it is a part of,
which is needed to implement SMI metrics.

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

* (YOU ARE HERE) **ref(injector): pass pod object to getEnvoySidecarContainerSpec**
* feat(metrics): add WASM metrics source
* docs(metrics): Add docs for WASM stats
* feat(metrics): Add WASM feature flag
* feat(metrics): Add stats.wasm to workload pods
* feat(injector): Add name, workload name, workload kind to PodMetadata
* feat(metrics): Add source labels to WASM metrics
* feat(metrics): Add dest labels to WASM metrics
* feat(metrics): Add "unknown" for dest labels on local replies
* feat(metrics): clean up WASM metrics in Prometheus config
* feat(metrics): add flag to enable WASM metrics
* tests(e2e): add WASM metrics test

The full set of changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No