### PR TITLE
debugger: disable printing expected proxy list

### DIFF
--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -34,7 +34,8 @@ func (ds DebugConfig) getProxies() http.Handler {
 			ds.getProxy(certificate.CommonName(specificProxy[0]), w)
 		} else {
 			printProxies(w, listConnected(), "Connected")
-			printProxies(w, ds.meshCatalogDebugger.ListExpectedProxies(), "Expected")
+			// TODO(#2481): Print expected proxies once #2481 is addressed
+			//printProxies(w, ds.meshCatalogDebugger.ListExpectedProxies(), "Expected")
 			printProxies(w, ds.meshCatalogDebugger.ListDisconnectedProxies(), "Disconnected")
 		}
 	})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change is a temporary workaround till issue #2481 is
addressed. As a part of #1939, `injector` will be taken
out of `osm-controller`, after which we will no longer
get the list of expected proxies.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`