### PR TITLE
feat(permissive-mode): Add support for permissive mode in routes v2

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -470,7 +470,10 @@ type MeshSpec interface {
 	GetService(service.MeshService) *corev1.Service
 
 	// ListServices Lists Kubernets Service resources that are part of monitored namespaces
-	ListServices() []*corev1.Service
+    ListServices() []*corev1.Service
+  
+	// ListServiceAccounts Lists Kubernets Service Account resources that are part of monitored namespaces
+    ListServiceAccounts() []*corev1.ServiceAccounts
 
 	// ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -15,6 +15,9 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "namespaces", "pods", "services", "secrets", "configmaps"]
     verbs: ["list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["list", "get"]
 
   # Port forwarding is needed for the OSM pod to be able to connect
   # to participating Envoys and fetch their configuration.

--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -58,6 +58,17 @@ const (
 
 	// ---
 
+	// ServiceAccountAdded is the type of announcement emitted when we observe an addition of a Kubernetes Service Account
+	ServiceAccountAdded AnnouncementType = "serviceaccount-added"
+
+	// ServiceAccountDeleted the type of announcement emitted when we observe the deletion of a Kubernetes Service Account
+	ServiceAccountDeleted AnnouncementType = "serviceaccount-deleted"
+
+	// ServiceAccountUpdated is the type of announcement emitted when we observe an update to a Kubernetes Service
+	ServiceAccountUpdated AnnouncementType = "serviceaccount-updated"
+
+	// ---
+
 	// TrafficSplitAdded is the type of announcement emitted when we observe an addition of a Kubernetes TrafficSplit
 	TrafficSplitAdded AnnouncementType = "trafficsplit-added"
 

--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -35,6 +35,7 @@ func (mc *MeshCatalog) dispatcher() {
 		a.PodAdded, a.PodDeleted, a.PodUpdated, // pod
 		a.RouteGroupAdded, a.RouteGroupDeleted, a.RouteGroupUpdated, // routegroup
 		a.ServiceAdded, a.ServiceDeleted, a.ServiceUpdated, // service
+		a.ServiceAccountAdded, a.ServiceAccountDeleted, a.ServiceAccountUpdated, // serviceaccount
 		a.TrafficSplitAdded, a.TrafficSplitDeleted, a.TrafficSplitUpdated, // traffic split
 		a.TrafficTargetAdded, a.TrafficTargetDeleted, a.TrafficTargetUpdated, // traffic target
 		a.BackpressureAdded, a.BackpressureDeleted, a.BackpressureUpdated, // backpressure

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -65,6 +65,18 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 		return services
 	}).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccounts().DoAndReturn(func() []*corev1.ServiceAccount {
+		// play pretend this call queries a controller cache
+		var serviceAccounts []*corev1.ServiceAccount
+
+		// This assumes that catalog tests use monitored namespaces at all times
+		svcAccountList, _ := kubeClient.CoreV1().ServiceAccounts("").List(context.Background(), metav1.ListOptions{})
+		for idx := range svcAccountList.Items {
+			serviceAccounts = append(serviceAccounts, &svcAccountList.Items[idx])
+		}
+
+		return serviceAccounts
+	}).AnyTimes()
 	mockKubeController.EXPECT().GetService(gomock.Any()).DoAndReturn(func(msh service.MeshService) *v1.Service {
 		// play pretend this call queries a controller cache
 		vv, err := kubeClient.CoreV1().Services(msh.Namespace).Get(context.Background(), msh.Name, metav1.GetOptions{})

--- a/pkg/catalog/mock_catalog.go
+++ b/pkg/catalog/mock_catalog.go
@@ -372,6 +372,22 @@ func (mr *MockMeshCatalogerMockRecorder) ListTrafficPoliciesForServiceAccount(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficPoliciesForServiceAccount", reflect.TypeOf((*MockMeshCataloger)(nil).ListTrafficPoliciesForServiceAccount), arg0)
 }
 
+// ListPoliciesForPermissiveMode mocks base method
+func (m *MockMeshCataloger) ListPoliciesForPermissiveMode(arg0 []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPoliciesForPermissiveMode", arg0)
+	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
+	ret1, _ := ret[1].([]*trafficpolicy.OutboundTrafficPolicy)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListPoliciesForPermissiveMode indicates an expected call of ListPoliciesForPermissiveMode
+func (mr *MockMeshCatalogerMockRecorder) ListPoliciesForPermissiveMode(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesForPermissiveMode", reflect.TypeOf((*MockMeshCataloger)(nil).ListPoliciesForPermissiveMode), arg0)
+}
+
 // RegisterProxy mocks base method
 func (m *MockMeshCataloger) RegisterProxy(arg0 *envoy.Proxy) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -65,6 +65,9 @@ type MeshCataloger interface {
 	// ListTrafficPoliciesForServiceAccount returns all inbound and outbound traffic policies related to the given service account
 	ListTrafficPoliciesForServiceAccount(service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error)
 
+	// ListPoliciesForPermissiveMode returns all inbound and outbound traffic policies related to the given services
+	ListPoliciesForPermissiveMode(services []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error)
+
 	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
 	ListAllowedInboundServices(service.MeshService) ([]service.MeshService, error)
 

--- a/pkg/envoy/rds/new_response.go
+++ b/pkg/envoy/rds/new_response.go
@@ -6,28 +6,43 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	cat "github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
-func newResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy) (*xds_discovery.DiscoveryResponse, error) {
+func newResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+	var inboundTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
+	var outboundTrafficPolicies []*trafficpolicy.OutboundTrafficPolicy
+
 	proxyIdentity, err := cat.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up Service Account for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
 		return nil, err
 	}
-	inboundTrafficPolicies, outboundTrafficPolicies, err := catalog.ListTrafficPoliciesForServiceAccount(proxyIdentity)
-	if err != nil {
-		return nil, err
-	}
 
-	// Get Ingress inbound policies for the proxy
 	services, err := catalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up services for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
 		return nil, err
 	}
+
+	if cfg.IsPermissiveTrafficPolicyMode() {
+		// Build traffic policies from service discovery for permissive mode
+		inboundTrafficPolicies, outboundTrafficPolicies, err = catalog.ListPoliciesForPermissiveMode(services)
+	} else {
+		// Build traffic policies from SMI Traffic Target and Traffic Split
+		inboundTrafficPolicies, outboundTrafficPolicies, err = catalog.ListTrafficPoliciesForServiceAccount(proxyIdentity)
+	}
+
+	if err != nil {
+		log.Error().Err(err).Msgf("Error listing policies for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
+		return nil, err
+	}
+
+	// Get Ingress inbound policies for the proxy
 	for _, svc := range services {
 		ingressInboundPolicies, err := catalog.GetIngressPoliciesForService(svc, proxyIdentity)
 		if err != nil {

--- a/pkg/envoy/rds/new_response_test.go
+++ b/pkg/envoy/rds/new_response_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -26,6 +27,7 @@ func TestNewResponse(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
 	uuid := uuid.New().String()
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.one.two.three.co.uk", uuid, "some-service", "some-namespace"))
@@ -94,7 +96,9 @@ func TestNewResponse(t *testing.T) {
 	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
 	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 
-	actual, err := newResponse(mockCatalog, testProxy)
+	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
+
+	actual, err := newResponse(mockCatalog, testProxy, nil, mockConfigurator, nil)
 	assert.Nil(err)
 
 	routeConfig := &xds_route.RouteConfiguration{}
@@ -115,5 +119,138 @@ func TestNewResponse(t *testing.T) {
 	assert.Equal("inbound_virtualHost|bookstore-v1-default-*", routeConfig.VirtualHosts[1].Name)
 	assert.Equal([]string{"*"}, routeConfig.VirtualHosts[1].Domains)
 	assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes))
-	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
+	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
+}
+
+func TestNewResponseWithPermissiveMode(t *testing.T) {
+	assert := tassert.New(t)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+
+	uuid := uuid.New().String()
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.one.two.three.co.uk", uuid, "some-service", "some-namespace"))
+	certSerialNumber := certificate.SerialNumber("123456")
+	testProxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+
+	testPermissiveInbound := []*trafficpolicy.InboundTrafficPolicy{
+		{
+			Name:      "bookstore-v1-default",
+			Hostnames: tests.BookstoreV1Hostnames,
+			Rules: []*trafficpolicy.Rule{
+				{
+					Route: trafficpolicy.RouteWeightedClusters{
+						HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+							PathRegex: constants.RegexMatchAll,
+							Methods:   []string{constants.WildcardHTTPMethod},
+						},
+						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+					},
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+				},
+			},
+		},
+	}
+
+	testOutbound := []*trafficpolicy.OutboundTrafficPolicy{
+		{
+			Name: "bookbuyer-default",
+			Hostnames: []string{
+				"bookbuyer.default",
+				"bookbuyer.default.svc",
+				"bookbuyer.default.svc.cluster",
+				"bookbuyer.default.svc.cluster.local",
+				"bookbuyer.default:8888",
+				"bookbuyer.default.svc:8888",
+				"bookbuyer.default.svc.cluster:8888",
+				"bookbuyer.default.svc.cluster.local:8888",
+			},
+			Routes: []*trafficpolicy.RouteWeightedClusters{
+				{
+					HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+						PathRegex: constants.RegexMatchAll,
+						Methods:   []string{constants.WildcardHTTPMethod},
+					},
+					WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+				},
+			},
+		},
+	}
+
+	testIngressInbound := []*trafficpolicy.InboundTrafficPolicy{
+		{
+			Name:      "bookstore-v1-default-bookstore-v1.default.svc.cluster.local",
+			Hostnames: []string{"bookstore-v1.default.svc.cluster.local"},
+			Rules: []*trafficpolicy.Rule{
+				{
+					Route: trafficpolicy.RouteWeightedClusters{
+						HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+							PathRegex: tests.BookstoreBuyPath,
+							Methods:   []string{constants.WildcardHTTPMethod},
+						},
+						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+					},
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+				},
+			},
+		},
+		{
+			Name:      "bookstore-v1-default-*",
+			Hostnames: []string{"*"},
+			Rules: []*trafficpolicy.Rule{
+				{
+					Route: trafficpolicy.RouteWeightedClusters{
+						HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+							PathRegex: tests.BookstoreBuyPath,
+							Methods:   []string{constants.WildcardHTTPMethod},
+						},
+						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+					},
+					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+				},
+			},
+		},
+	}
+
+	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
+	mockCatalog.EXPECT().ListPoliciesForPermissiveMode(gomock.Any()).Return(testPermissiveInbound, testOutbound, nil).AnyTimes()
+	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
+
+	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()
+
+	actual, err := newResponse(mockCatalog, testProxy, nil, mockConfigurator, nil)
+	assert.Nil(err)
+
+	routeConfig := &xds_route.RouteConfiguration{}
+	unmarshallErr := proto.UnmarshalAny(actual.GetResources()[0], routeConfig)
+	if err != nil {
+		t.Fatal(unmarshallErr)
+	}
+	assert.Equal("RDS_Inbound", routeConfig.Name)
+	assert.Equal(2, len(routeConfig.VirtualHosts))
+
+	assert.Equal("inbound_virtualHost|bookstore-v1-default", routeConfig.VirtualHosts[0].Name)
+	assert.Equal(tests.BookstoreV1Hostnames, routeConfig.VirtualHosts[0].Domains)
+	assert.Equal(2, len(routeConfig.VirtualHosts[0].Routes))
+	assert.Equal(constants.RegexMatchAll, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
+	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[1].GetMatch().GetSafeRegex().Regex)
+
+	assert.Equal("inbound_virtualHost|bookstore-v1-default-*", routeConfig.VirtualHosts[1].Name)
+	assert.Equal([]string{"*"}, routeConfig.VirtualHosts[1].Domains)
+	assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes))
+	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
+
+	routeConfig = &xds_route.RouteConfiguration{}
+	unmarshallErr = proto.UnmarshalAny(actual.GetResources()[1], routeConfig)
+	if err != nil {
+		t.Fatal(unmarshallErr)
+	}
+	assert.Equal("RDS_Outbound", routeConfig.Name)
+	assert.Equal(1, len(routeConfig.VirtualHosts))
+
+	assert.Equal("outbound_virtualHost|bookbuyer-default", routeConfig.VirtualHosts[0].Name)
+	assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes))
+	assert.Equal(constants.RegexMatchAll, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
 }

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -19,9 +19,9 @@ import (
 )
 
 // NewResponse creates a new Route Discovery Response.
-func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, _ configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, discoveryRequest *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, certManager certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
 	if featureflags.IsRoutesV2Enabled() {
-		return newResponse(cataloger, proxy)
+		return newResponse(cataloger, proxy, discoveryRequest, cfg, certManager)
 	}
 
 	svcList, err := cataloger.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())

--- a/pkg/kubernetes/mock_controller.go
+++ b/pkg/kubernetes/mock_controller.go
@@ -148,3 +148,17 @@ func (mr *MockControllerMockRecorder) ListServices() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockController)(nil).ListServices))
 }
+
+// ListServiceAccounts mocks base method
+func (m *MockController) ListServiceAccounts() []*v1.ServiceAccount {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServiceAccounts")
+	ret0, _ := ret[0].([]*v1.ServiceAccount)
+	return ret0
+}
+
+// ListServiceAccounts indicates an expected call of ListServiceAccounts
+func (mr *MockControllerMockRecorder) ListServiceAccounts() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccounts", reflect.TypeOf((*MockController)(nil).ListServiceAccounts))
+}

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -53,6 +53,8 @@ const (
 	Pods InformerKey = "Pods"
 	// Endpoints lookup identifier
 	Endpoints InformerKey = "Endpoints"
+	// ServiceAccounts lookup identifier
+	ServiceAccounts InformerKey = "ServiceAccounts"
 )
 
 // InformerCollection is the type holding the collection of informers we keep
@@ -70,6 +72,9 @@ type Client struct {
 type Controller interface {
 	// ListServices returns a list of all (monitored-namespace filtered) services in the mesh
 	ListServices() []*corev1.Service
+
+	// ListServiceAccounts returns a list of all (monitored-namespace filtered) service accounts in the mesh
+	ListServiceAccounts() []*corev1.ServiceAccount
 
 	// Returns a corev1 Service representation if the MeshService exists in cache, otherwise nil
 	GetService(svc service.MeshService) *corev1.Service

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -431,6 +431,12 @@ var (
 		Weight:      100,
 	}
 
+	// BookbuyerDefaultWeightedCluster is a weighted cluster for bookbuyer
+	BookbuyerDefaultWeightedCluster = service.WeightedCluster{
+		ClusterName: "default/bookbuyer",
+		Weight:      100,
+	}
+
 	// PodLabels is a map of the default labels on pods
 	PodLabels = map[string]string{
 		SelectorKey:                      SelectorValue,
@@ -470,6 +476,16 @@ func NewServiceFixture(serviceName, namespace string, selectors map[string]strin
 				Port:     ServicePort,
 			}},
 			Selector: selectors,
+		},
+	}
+}
+
+// NewServiceAccountFixture creates a new Kubernetes service account
+func NewServiceAccountFixture(svcAccountName, namespace string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      svcAccountName,
+			Namespace: namespace,
 		},
 	}
 }

--- a/pkg/utils/serviceaccount.go
+++ b/pkg/utils/serviceaccount.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+// SvcAccountToK8sSvcAccount converts a Kubernetes service to a MeshService.
+func SvcAccountToK8sSvcAccount(svcAccount *corev1.ServiceAccount) service.K8sServiceAccount {
+	return service.K8sServiceAccount{
+		Namespace: svcAccount.Namespace,
+		Name:      svcAccount.Name,
+	}
+}

--- a/pkg/utils/serviceaccount_test.go
+++ b/pkg/utils/serviceaccount_test.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+func TestSvcAccountToK8sSvcAccount(t *testing.T) {
+	assert := tassert.New(t)
+
+	sa := tests.NewServiceAccountFixture(tests.BookbuyerServiceAccountName, tests.Namespace)
+	svcAccount := SvcAccountToK8sSvcAccount(sa)
+	expectedSvcAccount := service.K8sServiceAccount{
+		Name:      tests.BookbuyerServiceAccountName,
+		Namespace: tests.Namespace,
+	}
+
+	assert.Equal(svcAccount, expectedSvcAccount)
+}


### PR DESCRIPTION
**Description**:

This change supports permissive mode in routes v2. 

For allow all/permissive mode inbound and outbound policies for a given proxy  are built based on service discovery. Unit tests have been added to validate various scenarios. 

For a demo setup with bookbuyer, bookstore-v1, bookstore-v2 and bookthief in permissive mode the route configurations are as follows : 

1. Route configuration for bookbuyer : 
    ```
    "dynamic_route_configs": [
    {
     "version_info": "7",
     "route_config": {
      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name": "RDS_Outbound",
      "virtual_hosts": [
       {
        "name": "outbound_virtualHost|bookstore-v1-bookstore",
        "domains": [
         "bookstore-v1.bookstore",
         "bookstore-v1.bookstore.svc",
         "bookstore-v1.bookstore.svc.cluster",
         "bookstore-v1.bookstore.svc.cluster.local",
         "bookstore-v1.bookstore:80",
         "bookstore-v1.bookstore.svc:80",
         "bookstore-v1.bookstore.svc.cluster:80",
         "bookstore-v1.bookstore.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       {
        "name": "outbound_virtualHost|bookstore-v2-bookstore",
        "domains": [
         "bookstore-v2.bookstore",
         "bookstore-v2.bookstore.svc",
         "bookstore-v2.bookstore.svc.cluster",
         "bookstore-v2.bookstore.svc.cluster.local",
         "bookstore-v2.bookstore:80",
         "bookstore-v2.bookstore.svc:80",
         "bookstore-v2.bookstore.svc.cluster:80",
         "bookstore-v2.bookstore.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v2",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       {
        "name": "outbound_virtualHost|bookthief-bookthief",
        "domains": [
         "bookthief.bookthief",
         "bookthief.bookthief.svc",
         "bookthief.bookthief.svc.cluster",
         "bookthief.bookthief.svc.cluster.local",
         "bookthief.bookthief:9999",
         "bookthief.bookthief.svc:9999",
         "bookthief.bookthief.svc.cluster:9999",
         "bookthief.bookthief.svc.cluster.local:9999"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookthief/bookthief",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       {
        "name": "outbound_virtualHost|bookwarehouse-bookwarehouse",
        "domains": [
         "bookwarehouse.bookwarehouse",
         "bookwarehouse.bookwarehouse.svc",
         "bookwarehouse.bookwarehouse.svc.cluster",
         "bookwarehouse.bookwarehouse.svc.cluster.local",
         "bookwarehouse.bookwarehouse:80",
         "bookwarehouse.bookwarehouse.svc:80",
         "bookwarehouse.bookwarehouse.svc.cluster:80",
         "bookwarehouse.bookwarehouse.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookwarehouse/bookwarehouse",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": false
     },
     "last_updated": "2021-02-05T00:46:57.787Z"
    },
    {
     "version_info": "7",
     "route_config": {
      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name": "RDS_Inbound",
      "virtual_hosts": [
       {
        "name": "inbound_virtualHost|bookbuyer-bookbuyer",
        "domains": [
         "bookbuyer",
         "bookbuyer.bookbuyer",
         "bookbuyer.bookbuyer.svc",
         "bookbuyer.bookbuyer.svc.cluster",
         "bookbuyer.bookbuyer.svc.cluster.local",
         "bookbuyer:9999",
         "bookbuyer.bookbuyer:9999",
         "bookbuyer.bookbuyer.svc:9999",
         "bookbuyer.bookbuyer.svc.cluster:9999",
         "bookbuyer.bookbuyer.svc.cluster.local:9999"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookbuyer/bookbuyer-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": false
     },
     "last_updated": "2021-02-05T00:46:57.791Z"
    }
   ]
    ```
 2. Route configuration on bookstore-v1 : 

    ``` 
    "dynamic_route_configs": [
    {
     "version_info": "6",
     "route_config": {
      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name": "RDS_Inbound",
      "virtual_hosts": [
       {
        "name": "inbound_virtualHost|bookstore-v1-bookstore",
        "domains": [
         "bookstore-v1",
         "bookstore-v1.bookstore",
         "bookstore-v1.bookstore.svc",
         "bookstore-v1.bookstore.svc.cluster",
         "bookstore-v1.bookstore.svc.cluster.local",
         "bookstore-v1:80",
         "bookstore-v1.bookstore:80",
         "bookstore-v1.bookstore.svc:80",
         "bookstore-v1.bookstore.svc.cluster:80",
         "bookstore-v1.bookstore.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v1-local",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": false
     },
     "last_updated": "2021-02-05T00:46:57.783Z"
    },
    {
     "version_info": "6",
     "route_config": {
      "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
      "name": "RDS_Outbound",
      "virtual_hosts": [
       {
        "name": "outbound_virtualHost|bookbuyer-bookbuyer",
        "domains": [
         "bookbuyer.bookbuyer",
         "bookbuyer.bookbuyer.svc",
         "bookbuyer.bookbuyer.svc.cluster",
         "bookbuyer.bookbuyer.svc.cluster.local",
         "bookbuyer.bookbuyer:9999",
         "bookbuyer.bookbuyer.svc:9999",
         "bookbuyer.bookbuyer.svc.cluster:9999",
         "bookbuyer.bookbuyer.svc.cluster.local:9999"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookbuyer/bookbuyer",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       {
        "name": "outbound_virtualHost|bookstore-v2-bookstore",
        "domains": [
         "bookstore-v2.bookstore",
         "bookstore-v2.bookstore.svc",
         "bookstore-v2.bookstore.svc.cluster",
         "bookstore-v2.bookstore.svc.cluster.local",
         "bookstore-v2.bookstore:80",
         "bookstore-v2.bookstore.svc:80",
         "bookstore-v2.bookstore.svc.cluster:80",
         "bookstore-v2.bookstore.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookstore/bookstore-v2",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       {
        "name": "outbound_virtualHost|bookthief-bookthief",
        "domains": [
         "bookthief.bookthief",
         "bookthief.bookthief.svc",
         "bookthief.bookthief.svc.cluster",
         "bookthief.bookthief.svc.cluster.local",
         "bookthief.bookthief:9999",
         "bookthief.bookthief.svc:9999",
         "bookthief.bookthief.svc.cluster:9999",
         "bookthief.bookthief.svc.cluster.local:9999"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookthief/bookthief",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       },
       {
        "name": "outbound_virtualHost|bookwarehouse-bookwarehouse",
        "domains": [
         "bookwarehouse.bookwarehouse",
         "bookwarehouse.bookwarehouse.svc",
         "bookwarehouse.bookwarehouse.svc.cluster",
         "bookwarehouse.bookwarehouse.svc.cluster.local",
         "bookwarehouse.bookwarehouse:80",
         "bookwarehouse.bookwarehouse.svc:80",
         "bookwarehouse.bookwarehouse.svc.cluster:80",
         "bookwarehouse.bookwarehouse.svc.cluster.local:80"
        ],
        "routes": [
         {
          "match": {
           "headers": [
            {
             "name": ":method",
             "safe_regex_match": {
              "google_re2": {},
              "regex": ".*"
             }
            }
           ],
           "safe_regex": {
            "google_re2": {},
            "regex": ".*"
           }
          },
          "route": {
           "weighted_clusters": {
            "clusters": [
             {
              "name": "bookwarehouse/bookwarehouse",
              "weight": 100
             }
            ],
            "total_weight": 100
           }
          }
         }
        ]
       }
      ],
      "validate_clusters": false
     },
     "last_updated": "2021-02-05T00:46:57.773Z"
    }
   ]
    ```

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
