### PR TITLE
chore(pkg/*): Improve virtual host naming syntax

### DIFF
--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -71,7 +71,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService, sa 
 
 	for _, ingress := range ingresses {
 		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == svc.Name {
-			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s-%s-%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
+			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s.%s|%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
 			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(wildCardRouteMatch, ingressWeightedCluster), sa)
 			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
 		}
@@ -81,7 +81,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService, sa 
 			if domain == "" {
 				domain = constants.WildcardHTTPMethod
 			}
-			ingressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s-%s-%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, domain), []string{domain})
+			ingressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s.%s|%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, domain), []string{domain})
 
 			for _, ingressPath := range rule.HTTP.Paths {
 				if ingressPath.Backend.ServiceName != svc.Name {

--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -673,7 +673,7 @@ func isValidTrafficTarget(t *access.TrafficTarget) bool {
 func buildPolicyName(svc service.MeshService, sameNamespace bool) string {
 	name := svc.Name
 	if !sameNamespace {
-		return name + "-" + svc.Namespace
+		return name + "." + svc.Namespace
 	}
 	return name
 }

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -701,7 +701,7 @@ func TestBuildOutboundPolicies(t *testing.T) {
 	}
 	expected := []*trafficpolicy.OutboundTrafficPolicy{
 		{
-			Name:      destMeshService.Name + "-" + destMeshService.Namespace,
+			Name:      destMeshService.Name + "." + destMeshService.Namespace,
 			Hostnames: hostnames,
 			Routes: []*trafficpolicy.RouteWeightedClusters{
 				{
@@ -802,7 +802,7 @@ func TestBuildInboundPoliciesDiffNamespaces(t *testing.T) {
 	}
 	expectedPolicies := []*trafficpolicy.InboundTrafficPolicy{
 		{
-			Name:      "bookstore-bookstore-ns",
+			Name:      "bookstore.bookstore-ns",
 			Hostnames: expectedHostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -913,7 +913,7 @@ func TestBuildInboundPoliciesSameNamespace(t *testing.T) {
 	}
 	expectedPolicies := []*trafficpolicy.InboundTrafficPolicy{
 		{
-			Name:      "bookstore-default",
+			Name:      "bookstore.default",
 			Hostnames: expectedHostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -962,7 +962,7 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 			name: "inbound traffic policies for permissive mode",
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore-bookstore-ns",
+					Name: "bookstore.bookstore-ns",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.bookstore-ns",
@@ -1049,7 +1049,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 			services:        map[string]string{"bookstore-v1": "default", "bookstore-apex": "default", "bookbuyer": "default"},
 			expectedOutboundPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name: "bookstore-apex-default",
+					Name: "bookstore-apex.default",
 					Hostnames: []string{
 						"bookstore-apex.default",
 						"bookstore-apex.default.svc",
@@ -1068,7 +1068,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookstore-v1-default",
+					Name: "bookstore-v1.default",
 					Hostnames: []string{
 						"bookstore-v1.default",
 						"bookstore-v1.default.svc",
@@ -1161,7 +1161,7 @@ func TestListPoliciesFromTrafficTargets(t *testing.T) {
 
 	expectedBookstoreInbound := []*trafficpolicy.InboundTrafficPolicy{
 		{
-			Name:      "bookstore-v1-default",
+			Name:      "bookstore-v1.default",
 			Hostnames: tests.BookstoreV1Hostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -1181,7 +1181,7 @@ func TestListPoliciesFromTrafficTargets(t *testing.T) {
 			},
 		},
 		{
-			Name:      "bookstore-v2-default",
+			Name:      "bookstore-v2.default",
 			Hostnames: tests.BookstoreV2Hostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -1201,7 +1201,7 @@ func TestListPoliciesFromTrafficTargets(t *testing.T) {
 			},
 		},
 		{
-			Name:      "bookstore-apex-default",
+			Name:      "bookstore-apex.default",
 			Hostnames: tests.BookstoreApexHostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -1277,7 +1277,7 @@ func TestListPoliciesForPermissiveMode(t *testing.T) {
 
 	expectedBookbuyerOutbound := []*trafficpolicy.OutboundTrafficPolicy{
 		{
-			Name: "bookstore-v1-default",
+			Name: "bookstore-v1.default",
 			Hostnames: []string{
 				"bookstore-v1.default",
 				"bookstore-v1.default.svc",
@@ -1296,7 +1296,7 @@ func TestListPoliciesForPermissiveMode(t *testing.T) {
 			},
 		},
 		{
-			Name: "bookstore-v2-default",
+			Name: "bookstore-v2.default",
 			Hostnames: []string{
 				"bookstore-v2.default",
 				"bookstore-v2.default.svc",
@@ -1318,7 +1318,7 @@ func TestListPoliciesForPermissiveMode(t *testing.T) {
 
 	expectedBookbuyerInbound := []*trafficpolicy.InboundTrafficPolicy{
 		{
-			Name: "bookbuyer-default",
+			Name: "bookbuyer.default",
 			Hostnames: []string{
 				"bookbuyer",
 				"bookbuyer.default",
@@ -1450,7 +1450,7 @@ func TestBuildPolicyName(t *testing.T) {
 			name:          "different namespace",
 			svc:           svc,
 			sameNamespace: false,
-			expectedName:  "foo-default",
+			expectedName:  "foo.default",
 		},
 	}
 

--- a/pkg/envoy/rds/new_response_test.go
+++ b/pkg/envoy/rds/new_response_test.go
@@ -36,7 +36,7 @@ func TestNewResponse(t *testing.T) {
 
 	testInbound := []*trafficpolicy.InboundTrafficPolicy{
 		{
-			Name:      "bookstore-v1-default",
+			Name:      "bookstore-v1.default",
 			Hostnames: tests.BookstoreV1Hostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -75,7 +75,7 @@ func TestNewResponse(t *testing.T) {
 			},
 		},
 		{
-			Name:      "bookstore-v1-default-*",
+			Name:      "bookstore-v1.default|*",
 			Hostnames: []string{"*"},
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -109,14 +109,14 @@ func TestNewResponse(t *testing.T) {
 	assert.Equal("RDS_Inbound", routeConfig.Name)
 	assert.Equal(2, len(routeConfig.VirtualHosts))
 
-	assert.Equal("inbound_virtualHost|bookstore-v1-default", routeConfig.VirtualHosts[0].Name)
+	assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
 	assert.Equal(tests.BookstoreV1Hostnames, routeConfig.VirtualHosts[0].Domains)
 	assert.Equal(3, len(routeConfig.VirtualHosts[0].Routes))
 	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
 	assert.Equal(tests.BookstoreSellHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[1].GetMatch().GetSafeRegex().Regex)
 	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[2].GetMatch().GetSafeRegex().Regex)
 
-	assert.Equal("inbound_virtualHost|bookstore-v1-default-*", routeConfig.VirtualHosts[1].Name)
+	assert.Equal("inbound_virtual-host|bookstore-v1.default|*", routeConfig.VirtualHosts[1].Name)
 	assert.Equal([]string{"*"}, routeConfig.VirtualHosts[1].Domains)
 	assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes))
 	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
@@ -137,7 +137,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 
 	testPermissiveInbound := []*trafficpolicy.InboundTrafficPolicy{
 		{
-			Name:      "bookstore-v1-default",
+			Name:      "bookstore-v1.default",
 			Hostnames: tests.BookstoreV1Hostnames,
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -156,7 +156,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 
 	testOutbound := []*trafficpolicy.OutboundTrafficPolicy{
 		{
-			Name: "bookbuyer-default",
+			Name: "bookbuyer.default",
 			Hostnames: []string{
 				"bookbuyer.default",
 				"bookbuyer.default.svc",
@@ -197,7 +197,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 			},
 		},
 		{
-			Name:      "bookstore-v1-default-*",
+			Name:      "bookstore-v1.default|*",
 			Hostnames: []string{"*"},
 			Rules: []*trafficpolicy.Rule{
 				{
@@ -231,13 +231,13 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	assert.Equal("RDS_Inbound", routeConfig.Name)
 	assert.Equal(2, len(routeConfig.VirtualHosts))
 
-	assert.Equal("inbound_virtualHost|bookstore-v1-default", routeConfig.VirtualHosts[0].Name)
+	assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
 	assert.Equal(tests.BookstoreV1Hostnames, routeConfig.VirtualHosts[0].Domains)
 	assert.Equal(2, len(routeConfig.VirtualHosts[0].Routes))
 	assert.Equal(constants.RegexMatchAll, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
 	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[1].GetMatch().GetSafeRegex().Regex)
 
-	assert.Equal("inbound_virtualHost|bookstore-v1-default-*", routeConfig.VirtualHosts[1].Name)
+	assert.Equal("inbound_virtual-host|bookstore-v1.default|*", routeConfig.VirtualHosts[1].Name)
 	assert.Equal([]string{"*"}, routeConfig.VirtualHosts[1].Domains)
 	assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes))
 	assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
@@ -250,7 +250,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	assert.Equal("RDS_Outbound", routeConfig.Name)
 	assert.Equal(1, len(routeConfig.VirtualHosts))
 
-	assert.Equal("outbound_virtualHost|bookbuyer-default", routeConfig.VirtualHosts[0].Name)
+	assert.Equal("outbound_virtual-host|bookbuyer.default", routeConfig.VirtualHosts[0].Name)
 	assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes))
 	assert.Equal(constants.RegexMatchAll, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
 }

--- a/pkg/envoy/route/config.go
+++ b/pkg/envoy/route/config.go
@@ -35,10 +35,10 @@ const (
 	OutboundRouteConfigName = "RDS_Outbound"
 
 	// inboundVirtualHost is the name of the virtual host on the inbound route configuration
-	inboundVirtualHost = "inbound_virtualHost"
+	inboundVirtualHost = "inbound_virtual-host"
 
 	// outboundVirtualHost is the name of the virtual host on the outbound route configuration
-	outboundVirtualHost = "outbound_virtualHost"
+	outboundVirtualHost = "outbound_virtual-host"
 
 	// MethodHeaderKey is the key of the header for HTTP methods
 	MethodHeaderKey = ":method"

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -101,14 +101,14 @@ func TestBuildVirtualHostStub(t *testing.T) {
 			namePrefix:   inboundVirtualHost,
 			host:         "host",
 			domains:      []string{"domain1", "domain2"},
-			expectedName: "inbound_virtualHost|host",
+			expectedName: "inbound_virtual-host|host",
 		},
 		{
 			name:         "outbound virtual host",
 			namePrefix:   outboundVirtualHost,
 			host:         "host",
 			domains:      []string{"domain1", "domain2"},
-			expectedName: "outbound_virtualHost|host",
+			expectedName: "outbound_virtual-host|host",
 		},
 	}
 

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -59,9 +59,9 @@ var _ = Describe(``+
 			})
 
 			const (
-				apexName = "outbound_virtualHost|bookstore-apex"
-				v1Name   = "outbound_virtualHost|bookstore-v1"
-				v2Name   = "outbound_virtualHost|bookstore-v2"
+				apexName = "outbound_virtual-host|bookstore-apex"
+				v1Name   = "outbound_virtual-host|bookstore-v1"
+				v2Name   = "outbound_virtual-host|bookstore-v2"
 			)
 			expectedVHostNames := []string{apexName, v1Name, v2Name}
 


### PR DESCRIPTION
**Description**:

The virtual_host naming is changed to the following syntax: `inbound-virtual-host|<svc-name>.<namespace>`

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
