### PR TITLE
chore(pkg/catalog/*) : Add a function to create ingress policy name

### DIFF
--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -71,7 +71,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService, sa 
 
 	for _, ingress := range ingresses {
 		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == svc.Name {
-			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s.%s|%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
+			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
 			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(wildCardRouteMatch, ingressWeightedCluster), sa)
 			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
 		}
@@ -81,7 +81,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService, sa 
 			if domain == "" {
 				domain = constants.WildcardHTTPMethod
 			}
-			ingressPolicy := trafficpolicy.NewInboundTrafficPolicy(fmt.Sprintf("%s.%s|%s", ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, domain), []string{domain})
+			ingressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, domain), []string{domain})
 
 			for _, ingressPath := range rule.HTTP.Paths {
 				if ingressPath.Backend.ServiceName != svc.Name {
@@ -98,4 +98,9 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService, sa 
 		}
 	}
 	return inboundIngressPolicies, nil
+}
+
+func buildIngressPolicyName(name, namespace, host string) string {
+	policyName := fmt.Sprintf("%s.%s|%s", name, namespace, host)
+	return policyName
 }

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -341,3 +341,33 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildIngressPolicyName(t *testing.T) {
+	assert := tassert.New(t)
+	testCases := []struct {
+		name         string
+		namespace    string
+		host         string
+		expectedName string
+	}{
+		{
+			name:         "bookbuyer",
+			namespace:    "default",
+			host:         "*",
+			expectedName: "bookbuyer.default|*",
+		},
+		{
+			name:         "bookbuyer",
+			namespace:    "bookbuyer-ns",
+			host:         "foobar.com",
+			expectedName: "bookbuyer.bookbuyer-ns|foobar.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := buildIngressPolicyName(tc.name, tc.namespace, tc.host)
+			assert.Equal(tc.expectedName, actual)
+		})
+	}
+}


### PR DESCRIPTION
**Description**:

Creating a function to build the ingress policy name rather than building it in-line

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
