### PR TITLE
Makefile: add target to check chart readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,15 @@ jobs:
       - name: go mod tidy
         run: make go-mod-tidy
 
+  charts:
+    name: Chart checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: chart checks
+        run: make chart-checks
+
   build:
     name: Go build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ clean-osm:
 chart-readme:
 	go run github.com/norwoodj/helm-docs/cmd/helm-docs -c charts -t charts/osm/README.md.gotmpl
 
+.PHONY: chart-checks
+chart-checks: chart-readme
+	@git diff --exit-code charts/osm/README.md || { echo "----- Please commit the changes made by 'make chart-readme' -----"; exit 1; }
+
 .PHONY: go-checks
 go-checks: go-lint go-fmt go-mod-tidy
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a make target to check if the chart readme is up to date, 
and a github action to ensure the readme for the chart is updated 
together with the chart.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`