### PR TITLE
test(routesv2): add e2e tests for routes v2

### DIFF
--- a/tests/e2e/e2e_routesv2_permissive_test.go
+++ b/tests/e2e/e2e_routesv2_permissive_test.go
@@ -1,0 +1,115 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+// TODO : remove as a part of routes refactor (#2397). Routes v2 will become the default and this test will no longer be needed
+var _ = OSMDescribe("Routes V2 Permissive Traffic Policy Mode",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 1,
+	},
+	func() {
+		Context("PermissiveModeRoutesV2", func() {
+			const sourceNs = "client"
+			const destNs = "server"
+			var ns []string = []string{sourceNs, destNs}
+
+			It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
+				// Install OSM
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnablePermissiveMode = true
+				installOpts.EnableRoutesV2Experimental = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+				// Create Test NS
+				for _, n := range ns {
+					Expect(Td.CreateNs(n, nil)).To(Succeed())
+					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+				}
+
+				// Get simple pod definitions for the HTTP server
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      "server",
+						Namespace: destNs,
+						Image:     "kennethreitz/httpbin",
+						Ports:     []int{80},
+					})
+
+				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				dstPod, err := Td.CreatePod(destNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(destNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
+
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+					Name:      "client",
+					Namespace: sourceNs,
+					Command:   []string{"/bin/bash", "-c", "--"},
+					Args:      []string{"while true; do sleep 30; done;"},
+					Image:     "songrgg/alpine-debug",
+					Ports:     []int{80},
+				})
+
+				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := Td.CreatePod(sourceNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(sourceNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
+
+				req := HTTPRequestDef{
+					SourceNs:        srcPod.Namespace,
+					SourcePod:       srcPod.Name,
+					SourceContainer: "client",
+
+					Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+				}
+
+				By("Ensuring traffic is allowed when permissive mode is enabled")
+
+				cond := Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(req)
+
+					if result.Err != nil || result.StatusCode != 200 {
+						Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+						return false
+					}
+					Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+					return true
+				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+				Expect(cond).To(BeTrue())
+
+				By("Ensuring traffic is not allowed when permissive mode is disabled")
+
+				Expect(Td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
+
+				cond = Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(req)
+
+					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+						Td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
+						return false
+					}
+					Td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
+					return true
+				}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+				Expect(cond).To(BeTrue())
+			})
+		})
+	})

--- a/tests/e2e/e2e_routesv2_pod_client_server_test.go
+++ b/tests/e2e/e2e_routesv2_pod_client_server_test.go
@@ -1,0 +1,144 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+// TODO : remove as a part of routes refactor (#2397). Routes v2 will become the default and this test will no longer be needed
+var _ = OSMDescribe("RoutesV2 Test HTTP traffic from 1 pod client -> 1 pod server",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 2,
+	},
+	func() {
+		Context("RoutesV2SimpleClientServer", func() {
+			const sourceName = "client"
+			const destName = "server"
+			var ns = []string{sourceName, destName}
+
+			It("Tests HTTP traffic for client pod -> server pod", func() {
+				// Install OSM
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnableRoutesV2Experimental = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+				// Create Test NS
+				for _, n := range ns {
+					Expect(Td.CreateNs(n, nil)).To(Succeed())
+					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+				}
+
+				// Get simple pod definitions for the HTTP server
+				svcAccDef, podDef, svcDef := Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      destName,
+						Namespace: destName,
+						Image:     "kennethreitz/httpbin",
+						Ports:     []int{80},
+					})
+
+				_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreatePod(destName, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				dstSvc, err := Td.CreateService(destName, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect it to be up and running in it's receiver namespace
+				Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+				// Get simple Pod definitions for the client
+				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+					Name:      sourceName,
+					Namespace: sourceName,
+					Command:   []string{"sleep", "365d"},
+					Image:     "curlimages/curl",
+					Ports:     []int{80},
+				})
+
+				_, err = Td.CreateServiceAccount(sourceName, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				srcPod, err := Td.CreatePod(sourceName, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(sourceName, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Expect it to be up and running in it's receiver namespace
+				Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+
+				By("Creating SMI policies")
+				// Deploy allow rule client->server
+				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+					SimpleAllowPolicy{
+						RouteGroupName:    "routes",
+						TrafficTargetName: "test-target",
+
+						SourceNamespace:      sourceName,
+						SourceSVCAccountName: sourceName,
+
+						DestinationNamespace:      destName,
+						DestinationSvcAccountName: destName,
+					})
+
+				// Configs have to be put into a monitored NS
+				_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+				Expect(err).NotTo(HaveOccurred())
+
+				// All ready. Expect client to reach server
+				clientToServer := HTTPRequestDef{
+					SourceNs:        sourceName,
+					SourcePod:       srcPod.Name,
+					SourceContainer: sourceName,
+
+					Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+				}
+
+				srcToDestStr := fmt.Sprintf("%s -> %s",
+					fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+					clientToServer.Destination)
+
+				cond := Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(clientToServer)
+
+					if result.Err != nil || result.StatusCode != 200 {
+						Td.T.Logf("> (%s) HTTP Req failed %d %v",
+							srcToDestStr, result.StatusCode, result.Err)
+						return false
+					}
+					Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+					return true
+				}, 5, 90*time.Second)
+				Expect(cond).To(BeTrue())
+
+				By("Deleting SMI policies")
+				Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+				Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
+
+				// Expect client not to reach server
+				cond = Td.WaitForRepeatedSuccess(func() bool {
+					result := Td.HTTPRequest(clientToServer)
+
+					// Curl exit code 7 == Conn refused
+					if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+						Td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
+						return false
+					}
+					Td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
+					return true
+				}, 5, 150*time.Second)
+				Expect(cond).To(BeTrue())
+			})
+		})
+	})

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -330,6 +330,9 @@ type InstallOSMOpts struct {
 	EnvoyLogLevel        string
 	EnableDebugServer    bool
 
+	// TODO : remove as a part of routes refactor (#2397)
+	EnableRoutesV2Experimental bool
+
 	SetOverrides []string
 }
 
@@ -478,6 +481,8 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		"--enable-permissive-traffic-policy="+strconv.FormatBool(instOpts.EnablePermissiveMode),
 		"--enable-debug-server="+strconv.FormatBool(instOpts.EnableDebugServer),
 		"--envoy-log-level="+instOpts.EnvoyLogLevel,
+		// TODO : remove as a part of routes refactor (#2397)
+		"--enable-routes-v2-experimental="+strconv.FormatBool(instOpts.EnableRoutesV2Experimental),
 	)
 
 	switch instOpts.CertManager {


### PR DESCRIPTION
**Description**:

This PR adds two e2e tests. The first test is to validate that permissive mode works with routesv2 and the second is to validate traffic target scenario with routes v2. These are temporary tests and will be deprecated once we cut over and make routesv2 the default in osm
 
Part of #2391 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no` 
