### PR TITLE
docs(metrics): Add docs for WASM stats

### DIFF
--- a/docs/content/docs/development_guide.md
+++ b/docs/content/docs/development_guide.md
@@ -59,6 +59,7 @@ as a birds-eye view of where the different components are located.
     - `smi/` - SMI client, informer, caches and tools
     - `tests/` - test fixtures and other functions to make unit testing easier
     - `trafficpolicy/` - SMI related types
+  - `wasm/` - Source for a WebAssembly-based Envoy extension
 </details>
 
 The Open Service Mesh controller is written in Go.

--- a/docs/developer/wasm.md
+++ b/docs/developer/wasm.md
@@ -1,0 +1,13 @@
+# WebAssembly Envoy Extensions
+
+OSM includes a [WebAssembly extension](/wasm/stats.cc) to Envoy. It extends Envoy's statistics to enable [SMI metrics](https://github.com/servicemeshinterface/smi-metrics) and is built using the [proxy-wasm-cpp-sdk](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk).
+
+## Build
+Building the WASM module requires only Docker as a pre-requisite and can be invoked as `make bin/osm-controller/stats.wasm` directly, or automatically as part of `make docker-build-osm-controller`.
+
+## How it Works
+Each proxy is configured by xDS to add HTTP headers prefixed with `osm-` with the metadata required for the [metrics' labels](/docs/content/docs/patterns/observability.md#custom-metrics) to each request and response, like workload name, namespace, etc. Because of the [order in which Envoy processes HTTP filters](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_filters#filter-ordering), response headers to add are configured by the router filter via RDS while request headers to add are configured via a Lua extension so that both sets of headers are made available to the WASM extension.
+
+Each proxy only knows about its own metadata, so metadata about the downstream proxy is read from request headers while metadata about the upstream proxy is read from response headers.
+
+Request durations represent the time between when stream context is created and ended/reset on the downstream proxy.


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds documentation regarding the WASM-based Envoy extension
used to implement SMI metrics. User-facing docs have been added with
what metrics are generated and known gaps. Developer documentation
includes how to build the extension and a high-level description of how
it works.

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (YOU ARE HERE) **docs(metrics): Add docs for WASM stats**
4. feat(metrics): Add WASM feature flag
5. feat(metrics): Add stats.wasm to workload pods
6. feat(injector): Add name, workload name, workload kind to PodMetadata
7. feat(metrics): Add source labels to WASM metrics
8. feat(metrics): Add dest labels to WASM metrics
9. feat(metrics): Add "unknown" for dest labels on local replies
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The full set of changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No