### PR TITLE
feat(e2e): print pod statuses when ready/running check times out

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1082,6 +1082,16 @@ func (td *OsmTestData) WaitForPodsRunningReady(ns string, timeout time.Duration,
 		time.Sleep(time.Second)
 	}
 
+	pods, err := td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to list pods")
+	}
+	td.T.Log("Pod Statuses in namespace", ns)
+	for _, pod := range pods.Items {
+		status, _ := json.MarshalIndent(pod.Status, "", "  ")
+		td.T.Logf("Pod %s:\n%s", pod.Name, status)
+	}
+
 	return fmt.Errorf("Not all pods were Running & Ready in NS %s after %v", ns, timeout)
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds additional log statements to the
`WaitForPodsRunningReady()` helper when the check times out that print
the pod names and statuses.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No