### PR TITLE
charts/osm: change default controller log level to info

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -64,7 +64,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager"` | cert-manager issuer group |
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` | cert-manager issuer kind |
 | OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` | cert-manager issuer namecert-manager issuer name |
-| OpenServiceMesh.controllerLogLevel | string | `"trace"` | Controller log verbosity |
+| OpenServiceMesh.controllerLogLevel | string | `"info"` | Controller log verbosity |
 | OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana |
 | OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger in the OSM namespace |
 | OpenServiceMesh.deployPrometheus | bool | `false` | Deploy Prometheus |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -105,7 +105,7 @@ OpenServiceMesh:
   # -- Envoy log level is used to specify the level of logs collected from envoy
   envoyLogLevel: error
   # -- Controller log verbosity
-  controllerLogLevel: trace
+  controllerLogLevel: info
   # -- Enforce only deploying one mesh in the cluster
   enforceSingleMesh: false
   # -- Validating- and MutatingWebhookConfiguration name


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Changes the default controller log level from trace
to info. It was set to trace for local development
purpose.

It can be changed as follows:
```
osm install --set="OpenServiceMesh.controllerLogLevel=trace"
```

```
./demo/run-osm-demo.sh --set="OpenServiceMesh.controllerLogLevel=trace"
```

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`