### PR TITLE
feat(pkg/catalog): build outbound traffic split policies

### DIFF
--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -171,6 +171,18 @@ var (
 		"bookstore-apex.default.svc.cluster.local:8888",
 	}
 
+	// BookstoreApexNamespacedHostnames are the namespaced hostnames for the bookstore-apex service
+	BookstoreApexNamespacedHostnames = []string{
+		"bookstore-apex.default",
+		"bookstore-apex.default.svc",
+		"bookstore-apex.default.svc.cluster",
+		"bookstore-apex.default.svc.cluster.local",
+		"bookstore-apex.default:8888",
+		"bookstore-apex.default.svc:8888",
+		"bookstore-apex.default.svc.cluster:8888",
+		"bookstore-apex.default.svc.cluster.local:8888",
+	}
+
 	// BookstoreBuyHTTPRoute is an HTTP route to buy books
 	BookstoreBuyHTTPRoute = trafficpolicy.HTTPRouteMatch{
 		PathRegex: BookstoreBuyPath,


### PR DESCRIPTION
* Adds function for building outbound traffic split policies
* Part of #2400 

Signed-off-by: Michelle Noorali <minooral@microsoft.com>



Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
