### PR TITLE
test(*): Update test fixtures to have multiple traffic targets

### DIFF
--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -130,7 +130,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(testParams.permissiveMode).AnyTimes()
 
-	mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*access.TrafficTarget{&tests.TrafficTarget}).AnyTimes()
+	mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget}).AnyTimes()
 	mockMeshSpec.EXPECT().ListHTTPTrafficSpecs().Return([]*specs.HTTPRouteGroup{&tests.HTTPRouteGroup}).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, mockMeshSpec, certManager,

--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -845,7 +845,6 @@ func TestListTrafficTargetPermutations(t *testing.T) {
 
 	expected := []string{
 		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreV1Service),
-		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreV2Service),
 		utils.GetTrafficTargetName(tests.TrafficTargetName, tests.BookbuyerService, tests.BookstoreApexService),
 	}
 	assert.ElementsMatch(actualTargetNames, expected)
@@ -1551,26 +1550,6 @@ func TestListPoliciesFromTrafficTargets(t *testing.T) {
 					Route: trafficpolicy.RouteWeightedClusters{
 						HTTPRouteMatch:   tests.BookstoreSellHTTPRoute,
 						WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
-					},
-					AllowedServiceAccounts: mapset.NewSet(tests.BookbuyerServiceAccount),
-				},
-			},
-		},
-		{
-			Name:      "bookstore-v2.default",
-			Hostnames: tests.BookstoreV2Hostnames,
-			Rules: []*trafficpolicy.Rule{
-				{
-					Route: trafficpolicy.RouteWeightedClusters{
-						HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
-						WeightedClusters: mapset.NewSet(tests.BookstoreV2DefaultWeightedCluster),
-					},
-					AllowedServiceAccounts: mapset.NewSet(tests.BookbuyerServiceAccount),
-				},
-				{
-					Route: trafficpolicy.RouteWeightedClusters{
-						HTTPRouteMatch:   tests.BookstoreSellHTTPRoute,
-						WeightedClusters: mapset.NewSet(tests.BookstoreV2DefaultWeightedCluster),
 					},
 					AllowedServiceAccounts: mapset.NewSet(tests.BookbuyerServiceAccount),
 				},

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -20,8 +20,9 @@ func NewFakeProvider() endpoint.Provider {
 			tests.BookstoreApexService.String(): {tests.Endpoint},
 		},
 		services: map[service.K8sServiceAccount][]service.MeshService{
-			tests.BookstoreServiceAccount: {tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
-			tests.BookbuyerServiceAccount: {tests.BookbuyerService},
+			tests.BookstoreServiceAccount:   {tests.BookstoreV1Service, tests.BookstoreApexService},
+			tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
+			tests.BookbuyerServiceAccount:   {tests.BookbuyerService},
 		},
 	}
 }

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -27,7 +27,7 @@ func NewFakeMeshSpecClient() MeshSpec {
 		trafficSplits:    []*split.TrafficSplit{&tests.TrafficSplit},
 		httpRouteGroups:  []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 		tcpRoutes:        []*spec.TCPRoute{&tests.TCPRoute},
-		trafficTargets:   []*access.TrafficTarget{&tests.TrafficTarget},
+		trafficTargets:   []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
 		weightedServices: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService},
 		serviceAccounts: []service.K8sServiceAccount{
 			tests.BookstoreServiceAccount,

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -51,6 +51,8 @@ const (
 	BookstoreServiceAccountName = "bookstore"
 	// BookbuyerServiceAccountName is the name of the bookbuyer service account
 	BookbuyerServiceAccountName = "bookbuyer"
+	// BookstoreV2ServiceAccountName is the name of the bookstore-v2 service account
+	BookstoreV2ServiceAccountName = "bookstore-v2"
 
 	// TrafficTargetName is the name of the traffic target SMI object.
 	TrafficTargetName = "bookbuyer-access-bookstore"
@@ -325,6 +327,35 @@ var (
 		},
 	}
 
+	// BookstoreV2TrafficTarget is a traffic target SMI object for bookstore-v2.
+	BookstoreV2TrafficTarget = access.TrafficTarget{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "access.smi-spec.io/v1alpha3",
+			Kind:       "TrafficTarget",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      TrafficTargetName,
+			Namespace: "default",
+		},
+		Spec: access.TrafficTargetSpec{
+			Destination: access.IdentityBindingSubject{
+				Kind:      "Name",
+				Name:      BookstoreV2ServiceAccountName,
+				Namespace: "default",
+			},
+			Sources: []access.IdentityBindingSubject{{
+				Kind:      "Name",
+				Name:      BookbuyerServiceAccountName,
+				Namespace: "default",
+			}},
+			Rules: []access.TrafficTargetRule{{
+				Kind:    "HTTPRouteGroup",
+				Name:    RouteGroupName,
+				Matches: []string{BuyBooksMatchName, SellBooksMatchName},
+			}},
+		},
+	}
+
 	// RoutePolicyMap is a map of a key to a route policy SMI object.
 	RoutePolicyMap = map[trafficpolicy.TrafficSpecName]map[trafficpolicy.TrafficSpecMatchName]trafficpolicy.HTTPRouteMatch{
 		trafficpolicy.TrafficSpecName(fmt.Sprintf("HTTPRouteGroup/%s/%s", Namespace, RouteGroupName)): {
@@ -337,6 +368,12 @@ var (
 	BookstoreServiceAccount = service.K8sServiceAccount{
 		Namespace: Namespace,
 		Name:      BookstoreServiceAccountName,
+	}
+
+	// BookstoreV2ServiceAccount is a namespaced service account.
+	BookstoreV2ServiceAccount = service.K8sServiceAccount{
+		Namespace: Namespace,
+		Name:      BookstoreV2ServiceAccountName,
 	}
 
 	// BookbuyerServiceAccount is a namespaced bookbuyer account.


### PR DESCRIPTION
**Description**:

This PR updates the the test fixtures so that bookstore-v1 and bookstor-v2 belong to different service accounts. Corresponding tests have also been updated

Signed-off-by: Sneha Chhabria <snchh@microsoft.com> 

Part of #1658 

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
