### PR TITLE
ref(*): update scripts to handle multiple replicas

### DIFF
--- a/experimental/routes_refactor/demo/scripts/port-forward-bookbuyer-envoy.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookbuyer-envoy.sh
@@ -4,6 +4,6 @@
 source .env
 
 BOOKBUYER_LOCAL_PORT="${BOOKBUYER_LOCAL_PORT:-8080}"
-POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" 15000:15000

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookbuyer-ui.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookbuyer-ui.sh
@@ -8,6 +8,6 @@
 source .env
 
 BOOKBUYER_LOCAL_PORT="${BOOKBUYER_LOCAL_PORT:-8080}"
-POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" "$BOOKBUYER_LOCAL_PORT":80

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookstore-ui-v1.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookstore-ui-v1.sh
@@ -8,6 +8,6 @@
 source .env
 
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8081}"
-POD="$(kubectl get pods --selector app=bookstore --selector version=v1 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore --selector version=v1 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv1_LOCAL_PORT":80

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookstore-ui-v2.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookstore-ui-v2.sh
@@ -8,6 +8,6 @@
 source .env
 
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8082}"
-POD="$(kubectl get pods --selector app=bookstore --selector version=v2 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore --selector version=v2 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv1_LOCAL_PORT":80

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookstore-v1-envoy.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookstore-v1-envoy.sh
@@ -4,6 +4,6 @@
 source .env
 
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8081}"
-POD="$(kubectl get pods --selector app=bookstore --selector version=v1 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore --selector version=v1 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 15001:15000

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookstore-v2-envoy.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookstore-v2-envoy.sh
@@ -4,6 +4,6 @@
 source .env
 
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8082}"
-POD="$(kubectl get pods --selector app=bookstore --selector version=v2 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore --selector version=v2 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' |awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 15002:15000

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookthief-envoy.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookthief-envoy.sh
@@ -4,6 +4,6 @@
 source .env
 
 BOOKTHIEF_LOCAL_PORT="${BOOKTHIEF_LOCAL_PORT:-8083}"
-POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" 15003:15000

--- a/experimental/routes_refactor/demo/scripts/port-forward-bookthief-ui.sh
+++ b/experimental/routes_refactor/demo/scripts/port-forward-bookthief-ui.sh
@@ -8,6 +8,6 @@
 source .env
 
 BOOKTHIEF_LOCAL_PORT="${BOOKTHIEF_LOCAL_PORT:-8083}"
-POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" "$BOOKTHIEF_LOCAL_PORT":80

--- a/scripts/port-forward-bookbuyer-ui.sh
+++ b/scripts/port-forward-bookbuyer-ui.sh
@@ -8,6 +8,6 @@
 source .env
 
 BOOKBUYER_LOCAL_PORT="${BOOKBUYER_LOCAL_PORT:-8080}"
-POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers  | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" "$BOOKBUYER_LOCAL_PORT":80

--- a/scripts/port-forward-bookbuyer.sh
+++ b/scripts/port-forward-bookbuyer.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1091
 source .env
 
-POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookbuyer -n "$BOOKBUYER_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKBUYER_NAMESPACE" 15000:15000
 

--- a/scripts/port-forward-bookstore-ui-v1.sh
+++ b/scripts/port-forward-bookstore-ui-v1.sh
@@ -16,6 +16,6 @@ if [ -z "$backend" ]; then
 fi
 
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8081}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv1_LOCAL_PORT":80

--- a/scripts/port-forward-bookstore-ui-v2.sh
+++ b/scripts/port-forward-bookstore-ui-v2.sh
@@ -16,6 +16,6 @@ if [ -z "$backend" ]; then
 fi
 
 BOOKSTOREv2_LOCAL_PORT="${BOOKSTOREv2_LOCAL_PORT:-8082}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv2_LOCAL_PORT":80

--- a/scripts/port-forward-bookstore-ui.sh
+++ b/scripts/port-forward-bookstore-ui.sh
@@ -16,6 +16,6 @@ if [ -z "$backend" ]; then
 fi
 
 BOOKSTORE_LOCAL_PORT="${BOOKSTORE_LOCAL_PORT:-8084}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTORE_LOCAL_PORT":80

--- a/scripts/port-forward-bookstore.sh
+++ b/scripts/port-forward-bookstore.sh
@@ -10,6 +10,6 @@ if [ -z "$backend" ]; then
     exit 1
 fi
 
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 15000:15000
 

--- a/scripts/port-forward-bookthief-ui.sh
+++ b/scripts/port-forward-bookthief-ui.sh
@@ -8,6 +8,6 @@
 source .env
 
 BOOKTHIEF_LOCAL_PORT="${BOOKTHIEF_LOCAL_PORT:-8083}"
-POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" "$BOOKTHIEF_LOCAL_PORT":80

--- a/scripts/port-forward-bookthief.sh
+++ b/scripts/port-forward-bookthief.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1091
 source .env
 
-POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=bookthief -n "$BOOKTHIEF_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKTHIEF_NAMESPACE" 15000:15000
 

--- a/scripts/port-forward-grafana.sh
+++ b/scripts/port-forward-grafana.sh
@@ -2,6 +2,6 @@
 # shellcheck disable=SC1091
 source .env
 
-POD="$(kubectl get pods --selector app="osm-grafana" -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app="osm-grafana" -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$K8S_NAMESPACE" 3000:3000

--- a/scripts/port-forward-jaeger.sh
+++ b/scripts/port-forward-jaeger.sh
@@ -5,6 +5,6 @@ set -aueo pipefail
 
 source .env
 
-OSM_POD=$(kubectl get pods -n "$K8S_NAMESPACE" --no-headers  --selector app=jaeger | awk '{print $1}')
+OSM_POD=$(kubectl get pods -n "$K8S_NAMESPACE" --no-headers  --selector app=jaeger | awk 'NR==1{print $1}')
 
 kubectl port-forward -n "$K8S_NAMESPACE" "$OSM_POD"  16686:16686

--- a/scripts/port-forward-osm-debug.sh
+++ b/scripts/port-forward-osm-debug.sh
@@ -5,6 +5,6 @@ set -aueo pipefail
 
 source .env
 
-OSM_POD=$(kubectl get pods -n "$K8S_NAMESPACE" --no-headers  --selector app=osm-controller | awk '{print $1}')
+OSM_POD=$(kubectl get pods -n "$K8S_NAMESPACE" --no-headers  --selector app=osm-controller | awk 'NR==1{print $1}')
 
 kubectl port-forward -n "$K8S_NAMESPACE" "$OSM_POD"  9092:9092

--- a/scripts/port-forward-osm-metrics.sh
+++ b/scripts/port-forward-osm-metrics.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1091
 source .env
 
-POD="$(kubectl get pods --selector app=osm-controller -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app=osm-controller -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$K8S_NAMESPACE" 9091:9091
 

--- a/scripts/port-forward-prometheus.sh
+++ b/scripts/port-forward-prometheus.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1091
 source .env
 
-POD="$(kubectl get pods --selector app="osm-prometheus" -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk '{print $1}')"
+POD="$(kubectl get pods --selector app="osm-prometheus" -n "$K8S_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$K8S_NAMESPACE" 7070:7070
 


### PR DESCRIPTION
This PR updates the kubectl get pod lines in our port forward scripts to handle scenarios where there are multiple replicas of the application pods running. It specifically adds `NR==1` which is an awk command that stands for number of lines returned. The lines in the scripts now return the first pod matching the conditions specified.



**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
