### PR TITLE
catalog: fix misleading error log

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -309,65 +309,6 @@ func TestListTrafficPoliciesForTrafficSplits(t *testing.T) {
 	}
 }
 
-func TestIsValidTrafficTarget(t *testing.T) {
-	assert := tassert.New(t)
-
-	getTrafficTarget := func(rules []access.TrafficTargetRule) *access.TrafficTarget {
-		return &access.TrafficTarget{
-			TypeMeta: v1.TypeMeta{
-				APIVersion: "access.smi-spec.io/v1alpha3",
-				Kind:       "TrafficTarget",
-			},
-			ObjectMeta: v1.ObjectMeta{
-				Name:      "target",
-				Namespace: "default",
-			},
-			Spec: access.TrafficTargetSpec{
-				Destination: access.IdentityBindingSubject{
-					Kind:      "Name",
-					Name:      "dest-id",
-					Namespace: "default",
-				},
-				Sources: []access.IdentityBindingSubject{{
-					Kind:      "Name",
-					Name:      "source-id",
-					Namespace: "default",
-				}},
-				Rules: rules,
-			},
-		}
-	}
-
-	testCases := []struct {
-		name     string
-		input    *access.TrafficTarget
-		expected bool
-	}{
-		{
-			name:     "is valid",
-			input:    &tests.TrafficTarget,
-			expected: true,
-		},
-		{
-			name:     "is not valid because TrafficTarget.Spec.Rules is nil",
-			input:    getTrafficTarget(nil),
-			expected: false,
-		},
-		{
-			name:     "is not valid because TrafficTarget.Spec.Rules is not nil but is empty",
-			input:    getTrafficTarget([]access.TrafficTargetRule{}),
-			expected: false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing isValidTrafficTarget when input %s ", tc.name), func(t *testing.T) {
-			actual := isValidTrafficTarget(tc.input)
-			assert.Equal(tc.expected, actual)
-		})
-	}
-}
-
 func TestRoutesFromRules(t *testing.T) {
 	assert := tassert.New(t)
 	mc := MeshCatalog{meshSpec: smi.NewFakeMeshSpecClient()}

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -12,8 +12,14 @@ import (
 )
 
 const (
+	// serviceAccountKind is the kind specified for the destination and sources in an SMI TrafficTarget policy
 	serviceAccountKind = "ServiceAccount"
-	tcpRouteKind       = "TCPRoute"
+
+	// tcpRouteKind is the kind specified for the TCP route rules in an SMI Traffictarget policy
+	tcpRouteKind = "TCPRoute"
+
+	// httpRouteGroupKind is the kind specified for the HTTP route rules in an SMI Traffictarget policy
+	httpRouteGroupKind = "HTTPRouteGroup"
 )
 
 // ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given upstream service account
@@ -183,4 +189,24 @@ func (mc *MeshCatalog) getTCPRouteMatchesFromTrafficTarget(trafficTarget smiAcce
 	}
 
 	return matches, nil
+}
+
+// isValidTrafficTarget checks if the given SMI TrafficTarget object is valid
+func isValidTrafficTarget(t *smiAccess.TrafficTarget) bool {
+	return t != nil && t.Spec.Rules != nil && len(t.Spec.Rules) > 0 && hasValidRulesKind(t.Spec.Rules)
+}
+
+// hasValidRulesKind checks if the given SMI TrafficTarget object has valid kind for rules
+func hasValidRulesKind(rules []smiAccess.TrafficTargetRule) bool {
+	for _, rule := range rules {
+		switch rule.Kind {
+		case httpRouteGroupKind, tcpRouteKind:
+			// valid Kind for rules
+
+		default:
+			log.Error().Msgf("Invalid Kind for rule %s in TrafficTarget policy %s", rule.Name, rule.Kind)
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
While building traffic policies for HTTP routes, if
the code encounters TCP route policies it logs an
error that the Kind for the rule is invalid. This
is misleading because the Kind is valid but just
simply be ignored while building HTTP traffic policies.
This change removes this misleading log and adds
extra validations for the TrafficTarget object before
it is consumed for policy building.

Also extends the helper to check for a valid
traffic target to examine the rules kind.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`