### PR TITLE
feat(metrics): Add stats.wasm to workload pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,13 @@ docker-build-init:
 docker-build-osm-controller: build-osm-controller
 	docker build -t $(CTR_REGISTRY)/osm-controller:$(CTR_TAG) -f dockerfiles/Dockerfile.osm-controller bin/osm-controller
 
-docker-build-osm-injector: build-osm-injector
+docker-build-osm-injector: build-osm-injector bin/osm-injector/stats.wasm
 	docker build -t $(CTR_REGISTRY)/osm-injector:$(CTR_TAG) -f dockerfiles/Dockerfile.osm-injector bin/osm-injector
+
+bin/osm-injector/stats.wasm: wasm/stats.cc wasm/Makefile
+	docker run -v $(PWD)/wasm:/work -w /work openservicemesh/proxy-wasm-cpp-sdk:956f0d500c380cc1656a2d861b7ee12c2515a664 /build_wasm.sh
+	@mkdir -p bin/osm-injector/
+	@mv wasm/stats.wasm bin/osm-injector
 
 .PHONY: docker-build
 docker-build: $(DOCKER_DEMO_TARGETS) docker-build-init docker-build-osm-controller docker-build-osm-injector

--- a/dockerfiles/Dockerfile.osm-injector
+++ b/dockerfiles/Dockerfile.osm-injector
@@ -1,2 +1,2 @@
 FROM gcr.io/distroless/static
-COPY osm-injector /
+COPY osm-injector stats.wasm /

--- a/docs/content/docs/uninstallation_guide.md
+++ b/docs/content/docs/uninstallation_guide.md
@@ -36,6 +36,7 @@ The following sections detail which Kubernetes resources are cleaned up and whic
 1. Existing Envoy sidecar containers
     - Redeploy application pods to delete sidecars
 1. Envoy bootstrap config secrets (stored in the application namespace)
+1. If WebAssembly stats were enabled, a ConfigMap named `envoy-stats-wasm` in each application namespace
 1. Namespace annotations, including but not limited to `openservicemesh.io/monitored-by`
 1. Custom resource definitions ([CRDs](https://github.com/openservicemesh/osm/tree/main/charts/osm/crds))
 1. Vault resources provided by the user

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -137,6 +137,13 @@ const (
 
 	// OSMConfigMap is the name of the OSM ConfigMap
 	OSMConfigMap = "osm-config"
+
+	// StatsWASMLocation is the directory on each pod containing the stats WASM module
+	StatsWASMLocation = "/var/wasm"
+
+	// StatsWASMFilename is the filename of the Envoy stats WASM module. It
+	// resides inside StatsWASMLocation on each pod.
+	StatsWASMFilename = "stats.wasm"
 )
 
 // Annotations used by the controller

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -1,20 +1,63 @@
 package lds
 
 import (
+	"path/filepath"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xds_wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	xds_wasm_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/featureflags"
 )
 
 const (
 	statPrefix = "http"
 )
+
+func getStatsWASMFilter() (*xds_hcm.HttpFilter, error) {
+	wasm := &xds_wasm.Wasm{
+		Config: &xds_wasm_ext.PluginConfig{
+			Name: "stats",
+			Vm: &xds_wasm_ext.PluginConfig_VmConfig{
+				VmConfig: &xds_wasm_ext.VmConfig{
+					Runtime: "envoy.wasm.runtime.v8",
+					Code: &envoy_config_core_v3.AsyncDataSource{
+						Specifier: &envoy_config_core_v3.AsyncDataSource_Local{
+							Local: &envoy_config_core_v3.DataSource{
+								Specifier: &envoy_config_core_v3.DataSource_Filename{
+									Filename: filepath.Join(constants.StatsWASMLocation, constants.StatsWASMFilename),
+								},
+							},
+						},
+					},
+					AllowPrecompiled: true,
+				},
+			},
+		},
+	}
+
+	wasmAny, err := ptypes.MarshalAny(wasm)
+	if err != nil {
+		log.Error().Err(err).Msg("Error marshalling WasmService object")
+		return nil, err
+	}
+
+	return &xds_hcm.HttpFilter{
+		Name: "envoy.filters.http.wasm",
+		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
+			TypedConfig: wasmAny,
+		},
+	}, nil
+}
 
 func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *xds_hcm.HttpConnectionManager {
 	connManager := &xds_hcm.HttpConnectionManager{
@@ -45,6 +88,19 @@ func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *
 		}
 
 		connManager.Tracing = tracing
+	}
+
+	if featureflags.IsWASMStatsEnabled() {
+		statsFilter, err := getStatsWASMFilter()
+		if err != nil {
+			log.Error().Err(err).Msg("failed to get stats WASM filter")
+			return connManager
+		}
+
+		// wellknown.Router filter must be last
+		var filters []*xds_hcm.HttpFilter
+		filters = append(filters, statsFilter)
+		connManager.HttpFilters = append(filters, connManager.HttpFilters...)
 	}
 
 	return connManager

--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -1,16 +1,10 @@
 package lds
 
 import (
-	"path/filepath"
-
-	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	xds_wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	xds_wasm_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -22,42 +16,6 @@ import (
 const (
 	statPrefix = "http"
 )
-
-func getStatsWASMFilter() (*xds_hcm.HttpFilter, error) {
-	wasm := &xds_wasm.Wasm{
-		Config: &xds_wasm_ext.PluginConfig{
-			Name: "stats",
-			Vm: &xds_wasm_ext.PluginConfig_VmConfig{
-				VmConfig: &xds_wasm_ext.VmConfig{
-					Runtime: "envoy.wasm.runtime.v8",
-					Code: &envoy_config_core_v3.AsyncDataSource{
-						Specifier: &envoy_config_core_v3.AsyncDataSource_Local{
-							Local: &envoy_config_core_v3.DataSource{
-								Specifier: &envoy_config_core_v3.DataSource_Filename{
-									Filename: filepath.Join(constants.StatsWASMLocation, constants.StatsWASMFilename),
-								},
-							},
-						},
-					},
-					AllowPrecompiled: true,
-				},
-			},
-		},
-	}
-
-	wasmAny, err := ptypes.MarshalAny(wasm)
-	if err != nil {
-		log.Error().Err(err).Msg("Error marshalling WasmService object")
-		return nil, err
-	}
-
-	return &xds_hcm.HttpFilter{
-		Name: "envoy.filters.http.wasm",
-		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
-			TypedConfig: wasmAny,
-		},
-	}, nil
-}
 
 func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *xds_hcm.HttpConnectionManager {
 	connManager := &xds_hcm.HttpConnectionManager{

--- a/pkg/envoy/lds/wasm.go
+++ b/pkg/envoy/lds/wasm.go
@@ -1,0 +1,50 @@
+package lds
+
+import (
+	"path/filepath"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xds_wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	xds_wasm_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func getStatsWASMFilter() (*xds_hcm.HttpFilter, error) {
+	wasm := &xds_wasm.Wasm{
+		Config: &xds_wasm_ext.PluginConfig{
+			Name: "stats",
+			Vm: &xds_wasm_ext.PluginConfig_VmConfig{
+				VmConfig: &xds_wasm_ext.VmConfig{
+					Runtime: "envoy.wasm.runtime.v8",
+					Code: &envoy_config_core_v3.AsyncDataSource{
+						Specifier: &envoy_config_core_v3.AsyncDataSource_Local{
+							Local: &envoy_config_core_v3.DataSource{
+								Specifier: &envoy_config_core_v3.DataSource_Filename{
+									Filename: filepath.Join(constants.StatsWASMLocation, constants.StatsWASMFilename),
+								},
+							},
+						},
+					},
+					AllowPrecompiled: true,
+				},
+			},
+		},
+	}
+
+	wasmAny, err := ptypes.MarshalAny(wasm)
+	if err != nil {
+		log.Error().Err(err).Msg("Error marshalling WasmService object")
+		return nil, err
+	}
+
+	return &xds_hcm.HttpFilter{
+		Name: "envoy.filters.http.wasm",
+		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
+			TypedConfig: wasmAny,
+		},
+	}, nil
+}

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	envoyBootstrapConfigVolume = "envoy-bootstrap-config-volume"
+	statsWASMConfigMapName     = "envoy-stats-wasm"
 )
 
 var log = logger.New("sidecar-injector")
@@ -25,6 +26,7 @@ type mutatingWebhook struct {
 	osmNamespace   string
 	cert           certificate.Certificater
 	configurator   configurator.Configurator
+	statsWASM      []byte
 
 	nonInjectNamespaces mapset.Set
 }

--- a/pkg/injector/volumes.go
+++ b/pkg/injector/volumes.go
@@ -2,11 +2,13 @@ package injector
 
 import (
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/featureflags"
 )
 
 // getVolumeSpec returns a list of volumes to add to the POD
 func getVolumeSpec(envoyBootstrapConfigName string) []corev1.Volume {
-	return []corev1.Volume{
+	volumes := []corev1.Volume{
 		{
 			Name: envoyBootstrapConfigVolume,
 			VolumeSource: corev1.VolumeSource{
@@ -16,4 +18,19 @@ func getVolumeSpec(envoyBootstrapConfigName string) []corev1.Volume {
 			},
 		},
 	}
+
+	if featureflags.IsWASMStatsEnabled() {
+		volumes = append(volumes, corev1.Volume{
+			Name: envoyStatsWASMVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: statsWASMConfigMapName,
+					},
+				},
+			},
+		})
+	}
+
+	return volumes
 }

--- a/pkg/injector/volumes_test.go
+++ b/pkg/injector/volumes_test.go
@@ -5,6 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/featureflags"
 )
 
 var _ = Describe("Test volume functions", func() {
@@ -20,6 +22,17 @@ var _ = Describe("Test volume functions", func() {
 				},
 			}}
 			Expect(actual).To(Equal(expected))
+		})
+
+		It("creates a WASM volume when WASM is enabled", func() {
+			oldWASMflag := featureflags.IsWASMStatsEnabled()
+			featureflags.Features.WASMStats = true
+
+			actual := getVolumeSpec("-envoy-config-")
+			Expect(actual).To(HaveLen(2))
+			Expect(actual[1].Name).To(Equal(envoyStatsWASMVolumeName))
+
+			featureflags.Features.WASMStats = oldWASMflag
 		})
 	})
 })

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -55,7 +55,7 @@ const (
 )
 
 // NewMutatingWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
-func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certManager certificate.Manager, kubeController k8s.Controller, meshName, osmNamespace, webhookConfigName string, stop <-chan struct{}, cfg configurator.Configurator) error {
+func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certManager certificate.Manager, kubeController k8s.Controller, meshName, osmNamespace, webhookConfigName string, stop <-chan struct{}, cfg configurator.Configurator, statsWASM []byte) error {
 	// This is a certificate issued for the webhook handler
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned with the MutatingWebhookConfiguration
@@ -74,6 +74,7 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 		osmNamespace:   osmNamespace,
 		cert:           webhookHandlerCert,
 		configurator:   cfg,
+		statsWASM:      statsWASM,
 
 		// Envoy sidecars should never be injected in these namespaces
 		nonInjectNamespaces: mapset.NewSetFromSlice([]interface{}{

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -503,7 +503,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		cfg := configurator.NewMockConfigurator(mockController)
 		certManager := tresor.NewFakeCertManager(cfg)
 
-		actualErr := NewMutatingWebhook(injectorConfig, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, stop, cfg)
+		actualErr := NewMutatingWebhook(injectorConfig, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, stop, cfg, nil)
 		expectedErrorMessage := "Error configuring MutatingWebhookConfiguration -webhook-name-: mutatingwebhookconfigurations.admissionregistration.k8s.io \"-webhook-name-\" not found"
 		Expect(actualErr.Error()).To(Equal(expectedErrorMessage))
 	})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change propagates the stats.wasm module to each workload pod in a
mesh and configures each proxy to load it when the feature flag is
enabled.

At a high-level:
- stats.wasm is made available to the osm-injector binary.
- The mutating webhook creates a ConfigMap in the workload namespace
with the stats.wasm module and adds the ConfigMap as a volume to each
injected pod and mounts it in the sidecar container.
- Each proxy is configured to load the WASM from the local file system.

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (YOU ARE HERE) **feat(metrics): Add stats.wasm to workload pods**
6. feat(injector): Add name, workload name, workload kind to PodMetadata
7. feat(metrics): Add source labels to WASM metrics
8. feat(metrics): Add dest labels to WASM metrics
9. feat(metrics): Add "unknown" for dest labels on local replies
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No