### PR TITLE
envoy/cds: set mandatory connect_timeout on synthetic cluster

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -79,7 +79,8 @@ func getSyntheticCluster(name string) *xds_cluster.Cluster {
 		ClusterDiscoveryType: &xds_cluster.Cluster_Type{
 			Type: xds_cluster.Cluster_STATIC,
 		},
-		LbPolicy: xds_cluster.Cluster_ROUND_ROBIN,
+		LbPolicy:       xds_cluster.Cluster_ROUND_ROBIN,
+		ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
 	}
 }
 

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -148,3 +148,14 @@ func TestGetLocalServiceCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSyntheticCluster(t *testing.T) {
+	assert := tassert.New(t)
+
+	actual := getSyntheticCluster("foo")
+	assert.NotNil(actual)
+	assert.Equal("foo", actual.Name)
+	assert.Equal(&xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STATIC}, actual.ClusterDiscoveryType)
+	assert.Equal(xds_cluster.Cluster_ROUND_ROBIN, actual.LbPolicy)
+	assert.Equal(ptypes.DurationProto(clusterConnectTimeout), actual.ConnectTimeout)
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
`connect_timeout` is mandatory for a cluster. Resolves
the error reported by Envoy when a synthetic cluster
is programmed.

```
{"level":"error","component":"envoy/ads","time":"2021-02-16T19:54:57Z","file":"stream.go:82","message":"[NACK] DiscoveryRequest error from Envoy with xDS Certificate SerialNumber=79974573966902936937525501793231715299 on Pod with UID=5871a4f2-69e2-4b52-9480-43e098480a98: code:13 message:\"Error adding/updating cluster(s) client-two/client-two.client-two.osm.synthetic-084dcde9-9d6a-4511-8a77-cd7bb5b8c3ae-local: Field 'connect_timeout' is missing in: name: \\\"client-two/client-two.client-two.osm.synthetic-084dcde9-9d6a-4511-8a77-cd7bb5b8c3ae-local\\\"\\ntype: STATIC\\n\" "}
```

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`