### PR TITLE
feat(metrics): Add stats.wasm to proxy config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ _dist/
 creds.json
 screenlog.*
 demo/bin/
+*.wasm
 
 ## Ignore test coverage files
 coverage.json

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/route"
+	"github.com/openservicemesh/osm/pkg/featureflags"
 )
 
 // Tests TestGetFilterForService checks that a proper filter type is properly returned
@@ -111,6 +112,46 @@ var _ = Describe("Test getHTTPConnectionManager", func() {
 			var nilHcmTrace *xds_hcm.HttpConnectionManager_Tracing = nil
 
 			Expect(connManager.Tracing).To(Equal(nilHcmTrace))
+		})
+
+		It("Returns no stats config when WASM is disabled", func() {
+			mockConfigurator.EXPECT().IsTracingEnabled().AnyTimes()
+			oldWASMflag := featureflags.Features.WASMStats
+			featureflags.Features.WASMStats = false
+
+			oldStatsWASMBytes := statsWASMBytes
+			statsWASMBytes = "some bytes"
+
+			connManager := getHTTPConnectionManager(route.InboundRouteConfigName, mockConfigurator)
+
+			Expect(connManager.HttpFilters).To(HaveLen(2))
+			Expect(connManager.HttpFilters[0].GetName()).To(Equal(wellknown.HTTPRoleBasedAccessControl))
+			Expect(connManager.HttpFilters[1].GetName()).To(Equal(wellknown.Router))
+			Expect(connManager.LocalReplyConfig).To(BeNil())
+
+			// reset global state
+			statsWASMBytes = oldStatsWASMBytes
+			featureflags.Features.WASMStats = oldWASMflag
+		})
+
+		It("Returns proper stats config when WASM is enabled", func() {
+			mockConfigurator.EXPECT().IsTracingEnabled().AnyTimes()
+			oldWASMflag := featureflags.Features.WASMStats
+			featureflags.Features.WASMStats = true
+
+			oldStatsWASMBytes := statsWASMBytes
+			statsWASMBytes = "some bytes"
+
+			connManager := getHTTPConnectionManager(route.InboundRouteConfigName, mockConfigurator)
+
+			Expect(connManager.GetHttpFilters()).To(HaveLen(3))
+			Expect(connManager.GetHttpFilters()[0].GetName()).To(Equal("envoy.filters.http.wasm"))
+			Expect(connManager.GetHttpFilters()[1].GetName()).To(Equal(wellknown.HTTPRoleBasedAccessControl))
+			Expect(connManager.GetHttpFilters()[2].GetName()).To(Equal(wellknown.Router))
+
+			// reset global state
+			statsWASMBytes = oldStatsWASMBytes
+			featureflags.Features.WASMStats = oldWASMflag
 		})
 	})
 })

--- a/pkg/envoy/lds/wasm.go
+++ b/pkg/envoy/lds/wasm.go
@@ -1,0 +1,61 @@
+package lds
+
+import (
+	"encoding/base64"
+	"io/ioutil"
+	"strings"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xds_wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
+	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	xds_wasm_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
+
+	"github.com/golang/protobuf/ptypes"
+)
+
+var statsWASMBytes string
+
+func init() {
+	b64 := base64.NewDecoder(base64.StdEncoding, strings.NewReader(statsWASMBytes))
+	b, _ := ioutil.ReadAll(b64)
+	statsWASMBytes = string(b)
+}
+
+func getStatsWASMFilter() (*xds_hcm.HttpFilter, error) {
+	if len(statsWASMBytes) == 0 {
+		return nil, nil
+	}
+	wasmPlug := &xds_wasm.Wasm{
+		Config: &xds_wasm_ext.PluginConfig{
+			Name: "stats",
+			Vm: &xds_wasm_ext.PluginConfig_VmConfig{
+				VmConfig: &xds_wasm_ext.VmConfig{
+					Runtime: "envoy.wasm.runtime.v8",
+					Code: &envoy_config_core_v3.AsyncDataSource{
+						Specifier: &envoy_config_core_v3.AsyncDataSource_Local{
+							Local: &envoy_config_core_v3.DataSource{
+								Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+									InlineBytes: []byte(statsWASMBytes),
+								},
+							},
+						},
+					},
+					AllowPrecompiled: true,
+				},
+			},
+		},
+	}
+
+	wasmAny, err := ptypes.MarshalAny(wasmPlug)
+	if err != nil {
+		log.Error().Err(err).Msg("Error marshalling WasmService object")
+		return nil, err
+	}
+
+	return &xds_hcm.HttpFilter{
+		Name: "envoy.filters.http.wasm",
+		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
+			TypedConfig: wasmAny,
+		},
+	}, nil
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change propagates the stats.wasm module to each sidecar proxy's
config. stats.wasm is built and embedded in the osm-controller binary
and configured inline via LDS.

Follow-up from #2531

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (YOU ARE HERE) **feat(metrics): Add stats.wasm to proxy config**
6. feat(injector): Add name, workload name, workload kind to PodMetadata
7. feat(metrics): Add source labels to WASM metrics
8. feat(metrics): Add dest labels to WASM metrics
9. feat(metrics): Add "unknown" for dest labels on local replies
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No