### PR TITLE
feat(injector): Add name, workload name, workload kind to PodMetadata

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -39,11 +39,14 @@ type Proxy struct {
 // This struct is initialized *eventually*, when the metadata arrives via xDS.
 type PodMetadata struct {
 	UID            string
+	Name           string
 	Namespace      string
 	IP             string
 	ServiceAccount string
 	Cluster        string
 	EnvoyNodeID    string
+	WorkloadKind   string
+	WorkloadName   string
 }
 
 // HasPodMetadata answers the question - has the Pod metadata been recorded for the given Envoy proxy

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -343,15 +343,15 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetEnvoyServiceNodeID()", func() {
 		It("", func() {
-			actual := GetEnvoyServiceNodeID("-nodeID-")
-			expected := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-"
+			actual := GetEnvoyServiceNodeID("-nodeID-", "-workload-kind-", "-workload-name-")
+			expected := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-/$(POD_NAME)/-workload-kind-/-workload-name-"
 			Expect(actual).To(Equal(expected))
 		})
 	})
 
 	Context("Test ParseEnvoyServiceNodeID()", func() {
 		It("", func() {
-			serviceNodeID := GetEnvoyServiceNodeID("-nodeID-")
+			serviceNodeID := GetEnvoyServiceNodeID("-nodeID-", "-workload-kind-", "-workload-name-")
 			meta, err := ParseEnvoyServiceNodeID(serviceNodeID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(meta.UID).To(Equal("$(POD_UID)"))
@@ -359,6 +359,23 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(meta.IP).To(Equal("$(POD_IP)"))
 			Expect(meta.ServiceAccount).To(Equal("$(SERVICE_ACCOUNT)"))
 			Expect(meta.EnvoyNodeID).To(Equal("-nodeID-"))
+			Expect(meta.Name).To(Equal("$(POD_NAME)"))
+			Expect(meta.WorkloadKind).To(Equal("-workload-kind-"))
+			Expect(meta.WorkloadName).To(Equal("-workload-name-"))
+		})
+
+		It("handles when not all fields are defined", func() {
+			serviceNodeID := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-"
+			meta, err := ParseEnvoyServiceNodeID(serviceNodeID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(meta.UID).To(Equal("$(POD_UID)"))
+			Expect(meta.Namespace).To(Equal("$(POD_NAMESPACE)"))
+			Expect(meta.IP).To(Equal("$(POD_IP)"))
+			Expect(meta.ServiceAccount).To(Equal("$(SERVICE_ACCOUNT)"))
+			Expect(meta.EnvoyNodeID).To(Equal("-nodeID-"))
+			Expect(meta.Name).To(Equal(""))
+			Expect(meta.WorkloadKind).To(Equal(""))
+			Expect(meta.WorkloadName).To(Equal(""))
 		})
 	})
 })


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the pod name and controlling workload name and kind to
the `PodMetadata` tracked with each proxy. These fields are needed to
implement SMI metrics.

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (#2546) ~~feat(metrics): Add stats.wasm to proxy config~~
6. (YOU ARE HERE) **feat(injector): Add name, workload name, workload kind to PodMetadata**
7. feat(metrics): Add source labels to WASM metrics
8. feat(metrics): Add dest labels to WASM metrics
9. feat(metrics): Add "unknown" for dest labels on local replies
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No