### PR TITLE
pkg/smi,kubernetes: unexport package scoped types

### DIFF
--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -24,7 +24,7 @@ func NewKubernetesController(kubeClient kubernetes.Interface, meshName string, s
 	client := Client{
 		kubeClient:  kubeClient,
 		meshName:    meshName,
-		informers:   InformerCollection{},
+		informers:   informerCollection{},
 		cacheSynced: make(chan interface{}),
 	}
 
@@ -74,7 +74,7 @@ func (c *Client) initNamespaceMonitor() {
 		Update: announcements.NamespaceUpdated,
 		Delete: announcements.NamespaceDeleted,
 	}
-	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), ProviderName, nil, nsEventTypes))
+	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), providerName, nil, nsEventTypes))
 }
 
 // Function to filter K8s meta Objects by OSM's isMonitoredNamespace
@@ -93,7 +93,7 @@ func (c *Client) initServicesMonitor() {
 		Update: announcements.ServiceUpdated,
 		Delete: announcements.ServiceDeleted,
 	}
-	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), ProviderName, c.shouldObserve, svcEventTypes))
+	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), providerName, c.shouldObserve, svcEventTypes))
 }
 
 // Initializes Service Account monitoring
@@ -106,7 +106,7 @@ func (c *Client) initServiceAccountsMonitor() {
 		Update: announcements.ServiceAccountUpdated,
 		Delete: announcements.ServiceAccountDeleted,
 	}
-	c.informers[ServiceAccounts].AddEventHandler(GetKubernetesEventHandlers((string)(ServiceAccounts), ProviderName, c.shouldObserve, svcEventTypes))
+	c.informers[ServiceAccounts].AddEventHandler(GetKubernetesEventHandlers((string)(ServiceAccounts), providerName, c.shouldObserve, svcEventTypes))
 }
 
 func (c *Client) initPodMonitor() {
@@ -118,7 +118,7 @@ func (c *Client) initPodMonitor() {
 		Update: announcements.PodUpdated,
 		Delete: announcements.PodDeleted,
 	}
-	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), ProviderName, c.shouldObserve, podEventTypes))
+	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), providerName, c.shouldObserve, podEventTypes))
 }
 
 func (c *Client) initEndpointMonitor() {
@@ -130,7 +130,7 @@ func (c *Client) initEndpointMonitor() {
 		Update: announcements.EndpointUpdated,
 		Delete: announcements.EndpointDeleted,
 	}
-	c.informers[Endpoints].AddEventHandler(GetKubernetesEventHandlers((string)(Endpoints), ProviderName, c.shouldObserve, eptEventTypes))
+	c.informers[Endpoints].AddEventHandler(GetKubernetesEventHandlers((string)(Endpoints), providerName, c.shouldObserve, eptEventTypes))
 }
 
 func (c *Client) run(stop <-chan struct{}) error {

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -39,8 +39,8 @@ const (
 	// DefaultKubeEventResyncInterval is the default resync interval for k8s events
 	DefaultKubeEventResyncInterval = 5 * time.Minute
 
-	// ProviderName is used for provider logging
-	ProviderName = "Kubernetes"
+	// providerName is the name of the Kubernetes event provider
+	providerName = "Kubernetes"
 )
 
 // InformerKey stores the different Informers we keep for K8s resources
@@ -59,14 +59,14 @@ const (
 	ServiceAccounts InformerKey = "ServiceAccounts"
 )
 
-// InformerCollection is the type holding the collection of informers we keep
-type InformerCollection map[InformerKey]cache.SharedIndexInformer
+// informerCollection is the type holding the collection of informers we keep
+type informerCollection map[InformerKey]cache.SharedIndexInformer
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
 	meshName    string
 	kubeClient  kubernetes.Interface
-	informers   InformerCollection
+	informers   informerCollection
 	cacheSynced chan interface{}
 }
 

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -96,14 +96,14 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 	smiTrafficSpecInformerFactory := smiTrafficSpecInformers.NewSharedInformerFactory(smiTrafficSpecClient, k8s.DefaultKubeEventResyncInterval)
 	smiTrafficTargetInformerFactory := smiAccessInformers.NewSharedInformerFactory(smiAccessClient, k8s.DefaultKubeEventResyncInterval)
 
-	informerCollection := InformerCollection{
+	informerCollection := informerCollection{
 		TrafficSplit:   smiTrafficSplitInformerFactory.Split().V1alpha2().TrafficSplits().Informer(),
 		HTTPRouteGroup: smiTrafficSpecInformerFactory.Specs().V1alpha4().HTTPRouteGroups().Informer(),
 		TCPRoute:       smiTrafficSpecInformerFactory.Specs().V1alpha4().TCPRoutes().Informer(),
 		TrafficTarget:  smiTrafficTargetInformerFactory.Access().V1alpha3().TrafficTargets().Informer(),
 	}
 
-	cacheCollection := CacheCollection{
+	cacheCollection := cacheCollection{
 		TrafficSplit:   informerCollection.TrafficSplit.GetStore(),
 		HTTPRouteGroup: informerCollection.HTTPRouteGroup.GetStore(),
 		TCPRoute:       informerCollection.TCPRoute.GetStore(),

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -19,16 +19,16 @@ var (
 	log = logger.New("mesh-spec")
 )
 
-// InformerCollection is a struct of the Kubernetes informers used in OSM
-type InformerCollection struct {
+// informerCollection is a struct of the Kubernetes informers used for SMI resources
+type informerCollection struct {
 	TrafficSplit   cache.SharedIndexInformer
 	HTTPRouteGroup cache.SharedIndexInformer
 	TCPRoute       cache.SharedIndexInformer
 	TrafficTarget  cache.SharedIndexInformer
 }
 
-// CacheCollection is a struct of the Kubernetes caches used in OSM
-type CacheCollection struct {
+// cacheCollection is a struct of the Kubernetes caches used for SMI resources
+type cacheCollection struct {
 	TrafficSplit   cache.Store
 	HTTPRouteGroup cache.Store
 	TCPRoute       cache.Store
@@ -37,10 +37,10 @@ type CacheCollection struct {
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
-	caches         *CacheCollection
+	caches         *cacheCollection
 	cacheSynced    chan interface{}
 	providerIdent  string
-	informers      *InformerCollection
+	informers      *informerCollection
 	announcements  chan announcements.Announcement
 	osmNamespace   string
 	kubeController k8s.Controller


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Makes a few exported types and variables that are
package scoped to be scoped within the package.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`