### PR TITLE
pkg/identity: Increase test coverage

### DIFF
--- a/pkg/identity/kubernetes_test.go
+++ b/pkg/identity/kubernetes_test.go
@@ -35,4 +35,6 @@ func TestGetKubernetesServiceIdentity(t *testing.T) {
 			assert.Equal(si, tc.expectedServiceIdentity)
 		})
 	}
+
+	assert.Equal(ServiceIdentity("foo").String(), "foo")
 }


### PR DESCRIPTION
Increasing test coverage of `./pkg/identity`
```
$ go test -cover ./pkg/identity/...
ok      github.com/openservicemesh/osm/pkg/identity     (cached)        coverage: 100.0% of statements
```