### PR TITLE
feat(metrics): Add source labels to WASM metrics

### DIFF
--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -17,7 +17,7 @@ const (
 	statPrefix = "http"
 )
 
-func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *xds_hcm.HttpConnectionManager {
+func getHTTPConnectionManager(routeName string, cfg configurator.Configurator, headers map[string]string) *xds_hcm.HttpConnectionManager {
 	connManager := &xds_hcm.HttpConnectionManager{
 		StatPrefix: statPrefix,
 		CodecType:  xds_hcm.HttpConnectionManager_AUTO,
@@ -62,8 +62,17 @@ func getHTTPConnectionManager(routeName string, cfg configurator.Configurator) *
 			return connManager
 		}
 
+		headerFilter, err := getAddHeadersFilter(headers)
+		if err != nil {
+			log.Error().Err(err).Msg("Could not get Lua filter definition")
+			return connManager
+		}
+
 		// wellknown.Router filter must be last
 		var filters []*xds_hcm.HttpFilter
+		if headerFilter != nil {
+			filters = append(filters, headerFilter)
+		}
 		if statsFilter != nil {
 			filters = append(filters, statsFilter)
 		}

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -38,7 +38,7 @@ func newIngressHTTPFilterChain(cfg configurator.Configurator, svc service.MeshSe
 		return nil
 	}
 
-	inboundConnManager := getHTTPConnectionManager(route.InboundRouteConfigName, cfg)
+	inboundConnManager := getHTTPConnectionManager(route.InboundRouteConfigName, cfg, nil)
 	marshalledInboundConnManager, err := ptypes.MarshalAny(inboundConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling inbound HttpConnectionManager object for proxy %s", svc)

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -84,7 +84,7 @@ func (lb *listenerBuilder) getInboundHTTPFilters(proxyService service.MeshServic
 	}
 
 	// Apply the HTTP Connection Manager Filter
-	inboundConnManager := getHTTPConnectionManager(route.InboundRouteConfigName, lb.cfg)
+	inboundConnManager := getHTTPConnectionManager(route.InboundRouteConfigName, lb.cfg, lb.statsHeaders)
 	marshalledInboundConnManager, err := ptypes.MarshalAny(inboundConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling inbound HttpConnectionManager for proxy  service %s", proxyService)
@@ -234,7 +234,7 @@ func (lb *listenerBuilder) getOutboundHTTPFilter() (*xds_listener.Filter, error)
 	var err error
 
 	marshalledFilter, err = ptypes.MarshalAny(
-		getHTTPConnectionManager(route.OutboundRouteConfigName, lb.cfg))
+		getHTTPConnectionManager(route.OutboundRouteConfigName, lb.cfg, lb.statsHeaders))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling HTTP connection manager object")
 		return nil, err

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -287,7 +287,7 @@ func TestGetOutboundFilterChainMatchForService(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
 
-	lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceAccount, mockConfigurator)
+	lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceAccount, mockConfigurator, nil)
 
 	testCases := []struct {
 		name        string

--- a/pkg/envoy/lds/types.go
+++ b/pkg/envoy/lds/types.go
@@ -14,7 +14,8 @@ var (
 
 // listenerBuilder is a type containing data to build the listener configurations
 type listenerBuilder struct {
-	svcAccount  service.K8sServiceAccount
-	meshCatalog catalog.MeshCataloger
-	cfg         configurator.Configurator
+	svcAccount   service.K8sServiceAccount
+	meshCatalog  catalog.MeshCataloger
+	cfg          configurator.Configurator
+	statsHeaders map[string]string
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -3,6 +3,7 @@ package envoy
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
@@ -52,6 +53,47 @@ type PodMetadata struct {
 // HasPodMetadata answers the question - has the Pod metadata been recorded for the given Envoy proxy
 func (p *Proxy) HasPodMetadata() bool {
 	return p.PodMetadata != nil
+}
+
+// StatsHeaders returns the headers required for SMI metrics
+func (p *Proxy) StatsHeaders() map[string]string {
+	unknown := "unknown"
+	podName := unknown
+	podNamespace := unknown
+	podControllerKind := unknown
+	podControllerName := unknown
+
+	if p.PodMetadata != nil {
+		if len(p.PodMetadata.Name) > 0 {
+			podName = p.PodMetadata.Name
+		}
+		if len(p.PodMetadata.Namespace) > 0 {
+			podNamespace = p.PodMetadata.Namespace
+		}
+		if len(p.PodMetadata.WorkloadKind) > 0 {
+			podControllerKind = p.PodMetadata.WorkloadKind
+		}
+		if len(p.PodMetadata.WorkloadName) > 0 {
+			podControllerName = p.PodMetadata.WorkloadName
+		}
+	}
+
+	// Assume ReplicaSets are controlled by a Deployment unless their names
+	// do not contain a hyphen. This aligns with the behavior of the
+	// Prometheus config in the OSM Helm chart.
+	if podControllerKind == "ReplicaSet" {
+		if hyp := strings.LastIndex(podControllerName, "-"); hyp >= 0 {
+			podControllerKind = "Deployment"
+			podControllerName = podControllerName[:hyp]
+		}
+	}
+
+	return map[string]string{
+		"osm-stats-pod":       podName,
+		"osm-stats-namespace": podNamespace,
+		"osm-stats-kind":      podControllerKind,
+		"osm-stats-name":      podControllerName,
+	}
 }
 
 // SetLastAppliedVersion records the version of the given Envoy proxy that was last acknowledged.

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -2,8 +2,10 @@ package envoy
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,3 +42,91 @@ var _ = Describe("Test proxy methods", func() {
 		})
 	})
 })
+
+func TestStatsHeaders(t *testing.T) {
+	const unknown = "unknown"
+	tests := []struct {
+		name     string
+		proxy    Proxy
+		expected map[string]string
+	}{
+		{
+			name: "nil metadata",
+			proxy: Proxy{
+				PodMetadata: nil,
+			},
+			expected: map[string]string{
+				"osm-stats-kind":      unknown,
+				"osm-stats-name":      unknown,
+				"osm-stats-namespace": unknown,
+				"osm-stats-pod":       unknown,
+			},
+		},
+		{
+			name: "empty metadata",
+			proxy: Proxy{
+				PodMetadata: &PodMetadata{},
+			},
+			expected: map[string]string{
+				"osm-stats-kind":      unknown,
+				"osm-stats-name":      unknown,
+				"osm-stats-namespace": unknown,
+				"osm-stats-pod":       unknown,
+			},
+		},
+		{
+			name: "full metadata",
+			proxy: Proxy{
+				PodMetadata: &PodMetadata{
+					Name:         "pod",
+					Namespace:    "ns",
+					WorkloadKind: "kind",
+					WorkloadName: "name",
+				},
+			},
+			expected: map[string]string{
+				"osm-stats-kind":      "kind",
+				"osm-stats-name":      "name",
+				"osm-stats-namespace": "ns",
+				"osm-stats-pod":       "pod",
+			},
+		},
+		{
+			name: "replicaset with expected name format",
+			proxy: Proxy{
+				PodMetadata: &PodMetadata{
+					WorkloadKind: "ReplicaSet",
+					WorkloadName: "some-name-randomchars",
+				},
+			},
+			expected: map[string]string{
+				"osm-stats-kind":      "Deployment",
+				"osm-stats-name":      "some-name",
+				"osm-stats-namespace": unknown,
+				"osm-stats-pod":       unknown,
+			},
+		},
+		{
+			name: "replicaset without expected name format",
+			proxy: Proxy{
+				PodMetadata: &PodMetadata{
+					WorkloadKind: "ReplicaSet",
+					WorkloadName: "name",
+				},
+			},
+			expected: map[string]string{
+				"osm-stats-kind":      "ReplicaSet",
+				"osm-stats-name":      "name",
+				"osm-stats-namespace": unknown,
+				"osm-stats-pod":       unknown,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.proxy.StatsHeaders()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a simple Lua HTTP filter to add the necessary source metadata
for SMI metrics to each request's headers which are read in the WASM
extension and used to tag the generated metrics.

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (#2546) ~~feat(metrics): Add stats.wasm to proxy config~~
6. (#2554) ~~feat(injector): Add name, workload name, workload kind to PodMetadata~~
7. (YOU ARE HERE) **feat(metrics): Add source labels to WASM metrics**
8. feat(metrics): Add dest labels to WASM metrics
9. feat(metrics): Add "unknown" for dest labels on local replies
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No