### PR TITLE
feat(metrics): Add dest labels to WASM metrics

### DIFF
--- a/pkg/envoy/rds/new_response.go
+++ b/pkg/envoy/rds/new_response.go
@@ -52,7 +52,7 @@ func newResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 		inboundTrafficPolicies = trafficpolicy.MergeInboundPolicies(true, inboundTrafficPolicies, ingressInboundPolicies...)
 	}
 
-	routeConfiguration := route.BuildRouteConfiguration(inboundTrafficPolicies, outboundTrafficPolicies)
+	routeConfiguration := route.BuildRouteConfiguration(inboundTrafficPolicies, outboundTrafficPolicies, proxy)
 	resp := &xds_discovery.DiscoveryResponse{
 		TypeUrl: string(envoy.TypeRDS),
 	}

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -91,8 +91,9 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, discoveryR
 		return nil, err
 	}
 
-	route.UpdateRouteConfiguration(outboundAggregatedRoutesByHostnames, outboundRouteConfig, route.OutboundRoute)
-	route.UpdateRouteConfiguration(inboundAggregatedRoutesByHostnames, inboundRouteConfig, route.InboundRoute)
+	route.UpdateRouteConfiguration(outboundAggregatedRoutesByHostnames, outboundRouteConfig, route.OutboundRoute, proxy)
+	route.UpdateRouteConfiguration(inboundAggregatedRoutesByHostnames, inboundRouteConfig, route.InboundRoute, proxy)
+
 	routeConfiguration = append(routeConfiguration, outboundRouteConfig)
 	routeConfiguration = append(routeConfiguration, inboundRouteConfig)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change configures RDS to add the destination metadata necessary for
SMI metrics to each response's headers. The headers are then read by the
WASM extension and used to tag the generated statistics. This change has
been integrated with both routes v2 and the existing routes
implementation.

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (#2546) ~~feat(metrics): Add stats.wasm to proxy config~~
6. (#2554) ~~feat(injector): Add name, workload name, workload kind to PodMetadata~~
7. (#2571) ~~feat(metrics): Add source labels to WASM metrics~~
8. (YOU ARE HERE) **feat(metrics): Add dest labels to WASM metrics**
9. feat(metrics): Add "unknown" for dest labels on local replies
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No