### PR TITLE
fix(pkg/*): Fix service selector match logic

### DIFF
--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -169,6 +169,10 @@ func listServicesForPod(pod *v1.Pod, kubeController k8s.Controller) ([]v1.Servic
 			continue
 		}
 		svcRawSelector := svc.Spec.Selector
+		// service has no selectors, we do not need to match against the pod label
+		if len(svcRawSelector) == 0 {
+			continue
+		}
 		selector := labels.Set(svcRawSelector).AsSelector()
 		if selector.Matches(labels.Set(pod.Labels)) {
 			serviceList = append(serviceList, *svc)

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -190,6 +190,10 @@ func (c *Client) getServicesByLabels(podLabels map[string]string, namespace stri
 		}
 
 		svcRawSelector := svc.Spec.Selector
+		// service has no selectors, we do not need to match against the pod label
+		if len(svcRawSelector) == 0 {
+			continue
+		}
 		selector := labels.Set(svcRawSelector).AsSelector()
 		if selector.Matches(labels.Set(podLabels)) {
 			finalList = append(finalList, *svc)

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -279,6 +279,10 @@ func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]servic
 	for _, pod := range pods {
 		svcRawSelector := k8sSvc.Spec.Selector
 		selector := labels.Set(svcRawSelector).AsSelector()
+		// service has no selectors, we do not need to match against the pod label
+		if len(svcRawSelector) == 0 {
+			continue
+		}
 		if selector.Matches(labels.Set(pod.Labels)) {
 			podSvcAccount := service.K8sServiceAccount{
 				Name:      pod.Spec.ServiceAccountName,


### PR DESCRIPTION
**Description**:

This PR fixes a bug in how service selectors are matched against pod
labels. If there were no selectors for a service it was considered as a
match. With the changes in this PR services without selectors are not
considered for a match.

*Note*: This will break the current implementation of routes v2 (a feature under test), but I will tackle this  with issue #2545 

Fixes #2578

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
