### PR TITLE
fix(.github/workflows): Wrap env variables in double quotes when using in JSON

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -26,10 +26,10 @@ jobs:
         issueTime=$(date +%s)
         expireTime=$(date -d "$expireTime + 600 seconds" +%s)
         header=$(echo '{ "alg": "RS256", "typ": "JWT" }' | jq -r '(. | @base64)')
-        payload=$(echo '{"iss": '"$ID"',"iat": '$issueTime' ,"exp": '$expireTime'}'| jq -r '(. | @base64)'| sed s/\+/-/ | sed -E s/=+$//)
-        echo "$PK" > key.pem
-        signature=$(echo -n "$header.$payload" | openssl dgst -sha256 -binary -sign key.pem | openssl enc -base64 | tr -d '\n=' | tr -- '+/' '-_')
-        tokenURL=$(curl -i -s -X GET -H "Authorization: Bearer $header.$payload.$signature" -H "Accept: application/vnd.github.v3+json" https://api.github.com/app/installations | grep -m1 'access_tokens_url' | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//')
+        payload=$(echo '{"iss": "'"$ID"'","iat": '$issueTime' ,"exp": '$expireTime'}'| jq -r '(. | @base64)'| sed s/\+/-/ | sed -E s/=+$//)
+        echo "$PK" > key
+        signature=$(echo -n "$header.$payload" | openssl dgst -sha256 -binary -sign key | openssl enc -base64 | tr -d '\n=' | tr -- '+/' '-_')
+        tokenURL=$(curl -i -s -X GET -H "Authorization: Bearer $header.$payload.$signature" -H "Accept: application/vnd.github.v3+json" https://api.github.com/app/installations | grep -A5 openservicemesh | grep 'access_tokens_url' | awk '{print $2}' | sed -e 's/^"//' -e 's/",$//')
         token=$(curl -i -s -X POST -H "Authorization: Bearer $header.$payload.$signature" -H "Accept: application/vnd.github.v3+json" "$tokenURL" | grep 'token'| awk '{print $2}' | sed -e 's/^"//' -e 's/",$//')
         echo "GITHUB_TOKEN=$token" >> "$GITHUB_ENV"
     - name: automerge


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Added double quotes because not interpolating ID because ENV variable is not wrapped in double quotes.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
