### PR TITLE
feat(metrics): Add "unknown" for dest labels on local replies

### DIFF
--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -1,6 +1,8 @@
 package lds
 
 import (
+	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
@@ -77,6 +79,31 @@ func getHTTPConnectionManager(routeName string, cfg configurator.Configurator, h
 			filters = append(filters, statsFilter)
 		}
 		connManager.HttpFilters = append(filters, connManager.HttpFilters...)
+
+		// When Envoy responds to an outgoing HTTP request with a local reply,
+		// destination_* tags for WASM metrics are missing. This configures
+		// Envoy's local replies to add the same headers that are expected from
+		// HTTP responses with the "unknown" value hardcoded because we don't
+		// know the intended destination of the request.
+		var localReplyHeaders []*envoy_config_core_v3.HeaderValueOption
+		for k := range headers {
+			localReplyHeaders = append(localReplyHeaders, &envoy_config_core_v3.HeaderValueOption{
+				Header: &envoy_config_core_v3.HeaderValue{
+					Key:   k,
+					Value: "unknown",
+				},
+			})
+		}
+		connManager.LocalReplyConfig = &xds_hcm.LocalReplyConfig{
+			Mappers: []*xds_hcm.ResponseMapper{
+				{
+					Filter: &envoy_config_accesslog_v3.AccessLogFilter{
+						FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_NotHealthCheckFilter{},
+					},
+					HeadersToAdd: localReplyHeaders,
+				},
+			},
+		}
 	}
 
 	return connManager

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -150,6 +150,8 @@ var _ = Describe("Test getHTTPConnectionManager", func() {
 			Expect(connManager.GetHttpFilters()[2].GetName()).To(Equal(wellknown.HTTPRoleBasedAccessControl))
 			Expect(connManager.GetHttpFilters()[3].GetName()).To(Equal(wellknown.Router))
 
+			Expect(connManager.GetLocalReplyConfig().GetMappers()[0].HeadersToAdd[0].Header.Value).To(Equal("unknown"))
+
 			// reset global state
 			statsWASMBytes = oldStatsWASMBytes
 			featureflags.Features.WASMStats = oldWASMflag


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Because `destination_*` tags are generated at the request's destination,
requests that invoke a local response from Envoy have no `destination_*`
values. This change modifies Envoy to add the expected header keys with
the value "unknown" to stay consistent with the behavior for requests
that don't invoke a local reply.


---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (#2546) ~~feat(metrics): Add stats.wasm to proxy config~~
6. (#2554) ~~feat(injector): Add name, workload name, workload kind to PodMetadata~~
7. (#2571) ~~feat(metrics): Add source labels to WASM metrics~~
8. (#2574) ~~feat(metrics): Add dest labels to WASM metrics~~
9. (YOU ARE HERE) **feat(metrics): Add "unknown" for dest labels on local replies**
10. feat(metrics): clean up WASM metrics in Prometheus config
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No