### PR TITLE
ingress: update api group to networking.k8s.io

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -6,7 +6,7 @@ rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
     verbs: ["list", "get", "watch"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["networking.k8s.io"]
     resources: ["ingresses"]
     verbs: ["list", "get", "watch"]
   - apiGroups: ["batch"]

--- a/demo/ingress/deploy-ingress-agic.sh
+++ b/demo/ingress/deploy-ingress-agic.sh
@@ -19,7 +19,7 @@ INGRESS_HOSTNAME="${INGRESS_HOSTNAME:-bookstore.osm.contoso.com}"
 
 echo "Create Bookstore Ingress Resource"
 kubectl apply -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: bookstore-v1

--- a/demo/ingress/deploy-ingress-nginx-with-host.sh
+++ b/demo/ingress/deploy-ingress-nginx-with-host.sh
@@ -14,7 +14,7 @@ source .env
 
 echo "Create Bookstore Ingress Resource"
 kubectl apply -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: bookstore-v1

--- a/demo/ingress/deploy-ingress-nginx.sh
+++ b/demo/ingress/deploy-ingress-nginx.sh
@@ -15,7 +15,7 @@ source .env
 
 echo "Create Bookstore Ingress Resource"
 kubectl apply -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: bookstore-v1

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -47,10 +46,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 	certManager := tresor.NewFakeCertManager(cfg)
 
-	announcementsCh := make(chan announcements.Announcement)
-
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(nil, nil).AnyTimes()
-	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsCh).AnyTimes()
 
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -94,9 +93,6 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 		tests.BookstoreApexService.Namespace,
 	})
 
-	announcementsChan := make(chan announcements.Announcement)
-
-	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsChan).AnyTimes()
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(getFakeIngresses(), nil).AnyTimes()
 
 	// #1683 tracks potential improvements to the following dynamic mocks

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -11,12 +11,11 @@ import (
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -107,9 +106,6 @@ func newFakeMeshCatalog() *MeshCatalog {
 		GinkgoT().Fatalf("Error creating new Bookstore Apex service", err.Error())
 	}
 
-	announcementsChan := make(chan announcements.Announcement)
-
-	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsChan).AnyTimes()
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(getFakeIngresses(), nil).AnyTimes()
 
 	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
@@ -154,8 +150,8 @@ func newFakeMeshCatalog() *MeshCatalog {
 		mockIngressMonitor, stop, cfg, endpointProviders...)
 }
 
-func getFakeIngresses() []*extensionsV1beta.Ingress {
-	return []*extensionsV1beta.Ingress{
+func getFakeIngresses() []*networkingV1beta1.Ingress {
+	return []*networkingV1beta1.Ingress{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "ingress-1",
@@ -164,23 +160,23 @@ func getFakeIngresses() []*extensionsV1beta.Ingress {
 					constants.OSMKubeResourceMonitorAnnotation: "enabled",
 				},
 			},
-			Spec: extensionsV1beta.IngressSpec{
-				Backend: &extensionsV1beta.IngressBackend{
+			Spec: networkingV1beta1.IngressSpec{
+				Backend: &networkingV1beta1.IngressBackend{
 					ServiceName: fakeIngressService,
 					ServicePort: intstr.IntOrString{
 						Type:   intstr.Int,
 						IntVal: fakeIngressPort,
 					},
 				},
-				Rules: []extensionsV1beta.IngressRule{
+				Rules: []networkingV1beta1.IngressRule{
 					{
 						Host: "fake1.com",
-						IngressRuleValue: extensionsV1beta.IngressRuleValue{
-							HTTP: &extensionsV1beta.HTTPIngressRuleValue{
-								Paths: []extensionsV1beta.HTTPIngressPath{
+						IngressRuleValue: networkingV1beta1.IngressRuleValue{
+							HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+								Paths: []networkingV1beta1.HTTPIngressPath{
 									{
 										Path: "/fake1-path1",
-										Backend: extensionsV1beta.IngressBackend{
+										Backend: networkingV1beta1.IngressBackend{
 											ServiceName: fakeIngressService,
 											ServicePort: intstr.IntOrString{
 												Type:   intstr.Int,
@@ -190,7 +186,7 @@ func getFakeIngresses() []*extensionsV1beta.Ingress {
 									},
 									{
 										Path: "/fake1-path2",
-										Backend: extensionsV1beta.IngressBackend{
+										Backend: networkingV1beta1.IngressBackend{
 											ServiceName: fakeIngressService,
 											ServicePort: intstr.IntOrString{
 												Type:   intstr.Int,
@@ -214,23 +210,23 @@ func getFakeIngresses() []*extensionsV1beta.Ingress {
 					constants.OSMKubeResourceMonitorAnnotation: "enabled",
 				},
 			},
-			Spec: extensionsV1beta.IngressSpec{
-				Backend: &extensionsV1beta.IngressBackend{
+			Spec: networkingV1beta1.IngressSpec{
+				Backend: &networkingV1beta1.IngressBackend{
 					ServiceName: fakeIngressService,
 					ServicePort: intstr.IntOrString{
 						Type:   intstr.Int,
 						IntVal: fakeIngressPort,
 					},
 				},
-				Rules: []extensionsV1beta.IngressRule{
+				Rules: []networkingV1beta1.IngressRule{
 					{
 						Host: "fake2.com",
-						IngressRuleValue: extensionsV1beta.IngressRuleValue{
-							HTTP: &extensionsV1beta.HTTPIngressRuleValue{
-								Paths: []extensionsV1beta.HTTPIngressPath{
+						IngressRuleValue: networkingV1beta1.IngressRuleValue{
+							HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+								Paths: []networkingV1beta1.HTTPIngressPath{
 									{
 										Path: "/fake2-path1",
-										Backend: extensionsV1beta.IngressBackend{
+										Backend: networkingV1beta1.IngressBackend{
 											ServiceName: fakeIngressService,
 											ServicePort: intstr.IntOrString{
 												Type:   intstr.Int,
@@ -244,12 +240,12 @@ func getFakeIngresses() []*extensionsV1beta.Ingress {
 					},
 					{
 						Host: "fake1.com",
-						IngressRuleValue: extensionsV1beta.IngressRuleValue{
-							HTTP: &extensionsV1beta.HTTPIngressRuleValue{
-								Paths: []extensionsV1beta.HTTPIngressPath{
+						IngressRuleValue: networkingV1beta1.IngressRuleValue{
+							HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+								Paths: []networkingV1beta1.HTTPIngressPath{
 									{
 										Path: "/fake1-path3",
-										Backend: extensionsV1beta.IngressBackend{
+										Backend: networkingV1beta1.IngressBackend{
 											ServiceName: fakeIngressService,
 											ServicePort: intstr.IntOrString{
 												Type:   intstr.Int,

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -190,8 +189,6 @@ var _ = Describe("RDS Response", func() {
 
 	certManager := tresor.NewFakeCertManager(cfg)
 
-	announcementsCh := make(chan announcements.Announcement)
-
 	// Create Bookstore-v1 Service
 	selector := map[string]string{tests.SelectorKey: tests.SelectorValue}
 	svc := tests.NewServiceFixture(tests.BookstoreV1Service.Name, tests.BookstoreV1Service.Namespace, selector)
@@ -218,7 +215,6 @@ var _ = Describe("RDS Response", func() {
 	}
 
 	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(nil, nil).AnyTimes()
-	mockIngressMonitor.EXPECT().GetAnnouncementsChannel().Return(announcementsCh).AnyTimes()
 
 	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
 	listExpectedNs := tests.GetUnique([]string{

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -3,7 +3,7 @@ package ingress
 import (
 	"reflect"
 
-	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -17,7 +17,7 @@ import (
 // NewIngressClient implements ingress.Monitor and creates the Kubernetes client to monitor Ingress resources.
 func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{}, cfg configurator.Configurator) (Monitor, error) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
-	informer := informerFactory.Extensions().V1beta1().Ingresses().Informer()
+	informer := informerFactory.Networking().V1beta1().Ingresses().Informer()
 
 	client := Client{
 		informer:       informer,
@@ -68,10 +68,10 @@ func (c *Client) run(stop <-chan struct{}) error {
 }
 
 // GetIngressResources returns the ingress resources whose backends correspond to the service
-func (c Client) GetIngressResources(meshService service.MeshService) ([]*extensionsV1beta.Ingress, error) {
-	var ingressResources []*extensionsV1beta.Ingress
+func (c Client) GetIngressResources(meshService service.MeshService) ([]*networkingV1beta1.Ingress, error) {
+	var ingressResources []*networkingV1beta1.Ingress
 	for _, ingressInterface := range c.cache.List() {
-		ingress, ok := ingressInterface.(*extensionsV1beta.Ingress)
+		ingress, ok := ingressInterface.(*networkingV1beta1.Ingress)
 		if !ok {
 			log.Error().Msg("Failed type assertion for Ingress in ingress cache")
 			continue

--- a/pkg/ingress/mock_client_generated.go
+++ b/pkg/ingress/mock_client_generated.go
@@ -8,9 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	"github.com/openservicemesh/osm/pkg/announcements"
 	service "github.com/openservicemesh/osm/pkg/service"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	v1beta1 "k8s.io/api/networking/v1beta1"
 )
 
 // MockMonitor is a mock of Monitor interface
@@ -34,20 +33,6 @@ func NewMockMonitor(ctrl *gomock.Controller) *MockMonitor {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMonitor) EXPECT() *MockMonitorMockRecorder {
 	return m.recorder
-}
-
-// GetAnnouncementsChannel mocks base method
-func (m *MockMonitor) GetAnnouncementsChannel() <-chan announcements.Announcement {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan announcements.Announcement)
-	return ret0
-}
-
-// GetAnnouncementsChannel indicates an expected call of GetAnnouncementsChannel
-func (mr *MockMonitorMockRecorder) GetAnnouncementsChannel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnouncementsChannel", reflect.TypeOf((*MockMonitor)(nil).GetAnnouncementsChannel))
 }
 
 // GetIngressResources mocks base method

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -2,7 +2,7 @@
 package ingress
 
 import (
-	extensionsV1beta "k8s.io/api/extensions/v1beta1"
+	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
@@ -25,5 +25,5 @@ type Client struct {
 // Monitor is the client interface for K8s Ingress resource
 type Monitor interface {
 	// GetIngressResources returns the ingress resources whose backends correspond to the service
-	GetIngressResources(service.MeshService) ([]*extensionsV1beta.Ingress, error)
+	GetIngressResources(service.MeshService) ([]*networkingV1beta1.Ingress, error)
 }

--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -10,7 +10,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	helmcli "helm.sh/helm/v3/pkg/cli"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -117,7 +117,7 @@ var _ = OSMDescribe("HTTP ingress",
 					},
 				},
 			}
-			_, err = Td.Client.ExtensionsV1beta1().Ingresses(destNs).Create(context.Background(), ing, metav1.CreateOptions{})
+			_, err = Td.Client.NetworkingV1beta1().Ingresses(destNs).Create(context.Background(), ing, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			// All ready. Expect client to reach server


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the API group for the ingress resource to
`networking.k8s.io`, which has been available since
k8s 1.14. The `extensions` API group will be
deprecated in k8s v1.22. Newer versions of some
ingress controllers also warn about using a much
older api version, which makes issues harder to
debug.

Also updates the docs, and tests that were incorrectly
using older mock versions.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`