### PR TITLE
metrics: set dynamic metric registration

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -153,7 +153,7 @@ func main() {
 	defer cancel()
 
 	// Start the default metrics store
-	metricsstore.DefaultMetricsStore.Start()
+	startMetricsStore()
 
 	// This component will be watching the OSM ConfigMap and will make it
 	// to the rest of the components.
@@ -247,6 +247,19 @@ func main() {
 
 	<-stop
 	log.Info().Msgf("Stopping osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
+}
+
+// Start the metric store, register the metrics OSM will expose
+func startMetricsStore() {
+	metricsstore.DefaultMetricsStore.Start(
+		metricsstore.DefaultMetricsStore.K8sAPIEventCounter,
+		metricsstore.DefaultMetricsStore.K8sMonitoredNamespaceCount,
+		metricsstore.DefaultMetricsStore.K8sMeshPodCount,
+		metricsstore.DefaultMetricsStore.ProxyConnectCount,
+		metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime,
+		metricsstore.DefaultMetricsStore.CertIssuedCount,
+		metricsstore.DefaultMetricsStore.CertIssuedTime,
+	)
 }
 
 // getHTTPHealthProbes returns the HTTP health probes served by OSM controller

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -127,7 +127,12 @@ func main() {
 	defer cancel()
 
 	// Start the default metrics store
-	metricsstore.DefaultMetricsStore.Start()
+	metricsstore.DefaultMetricsStore.Start(
+		metricsstore.DefaultMetricsStore.InjectorRqTime,
+		metricsstore.DefaultMetricsStore.InjectorSidecarCount,
+		metricsstore.DefaultMetricsStore.CertIssuedCount,
+		metricsstore.DefaultMetricsStore.CertIssuedTime,
+	)
 
 	// Initialize Configurator to watch osm-config ConfigMap
 	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -31,8 +31,8 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *v1beta1.AdmissionRe
 	}
 	elapsed := time.Since(startTime)
 
-	metricsstore.DefaultMetricsStore.CertXdsIssuedCount.Inc()
-	metricsstore.DefaultMetricsStore.CertXdsIssuedTime.
+	metricsstore.DefaultMetricsStore.CertIssuedCount.Inc()
+	metricsstore.DefaultMetricsStore.CertIssuedTime.
 		WithLabelValues().Observe(elapsed.Seconds())
 	originalHealthProbes := rewriteHealthProbes(pod)
 

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -49,11 +49,11 @@ type MetricsStore struct {
 	/*
 	 * Certificate metrics
 	 */
-	// CertXdsIssuedCount is the metric counter for the number of xds certificates issued
-	CertXdsIssuedCount prometheus.Counter
+	// CertIssuedCount is the metric counter for the number of certificates issued
+	CertIssuedCount prometheus.Counter
 
-	// CertXdsIssuedCounter the histogram to track the time to issue xds certificates
-	CertXdsIssuedTime *prometheus.HistogramVec
+	// CertXdsIssuedCounter the histogram to track the time to issue a certificates
+	CertIssuedTime *prometheus.HistogramVec
 
 	/*
 	 * MetricsStore internals should be defined below --------------
@@ -140,18 +140,18 @@ func init() {
 	/*
 	 * Certificate metrics
 	 */
-	defaultMetricsStore.CertXdsIssuedCount = prometheus.NewCounter(prometheus.CounterOpts{
+	defaultMetricsStore.CertIssuedCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metricsRootNamespace,
 		Subsystem: "cert",
-		Name:      "xds_issued_count",
+		Name:      "issued_count",
 		Help:      "represents the total number of XDS certificates issued to proxies",
 	})
 
-	defaultMetricsStore.CertXdsIssuedTime = prometheus.NewHistogramVec(
+	defaultMetricsStore.CertIssuedTime = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: metricsRootNamespace,
 			Subsystem: "cert",
-			Name:      "xds_issued_time",
+			Name:      "issued_time",
 			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90},
 			Help:      "Histogram to track time spent to issue xds certificate",
 		},
@@ -160,29 +160,15 @@ func init() {
 }
 
 // Start store
-func (ms *MetricsStore) Start() {
-	ms.registry.MustRegister(ms.K8sAPIEventCounter)
-	ms.registry.MustRegister(ms.K8sMonitoredNamespaceCount)
-	ms.registry.MustRegister(ms.K8sMeshPodCount)
-	ms.registry.MustRegister(ms.ProxyConnectCount)
-	ms.registry.MustRegister(ms.ProxyConfigUpdateTime)
-	ms.registry.MustRegister(ms.InjectorSidecarCount)
-	ms.registry.MustRegister(ms.InjectorRqTime)
-	ms.registry.MustRegister(ms.CertXdsIssuedCount)
-	ms.registry.MustRegister(ms.CertXdsIssuedTime)
+func (ms *MetricsStore) Start(cs ...prometheus.Collector) {
+	ms.registry.MustRegister(cs...)
 }
 
 // Stop store
-func (ms *MetricsStore) Stop() {
-	ms.registry.Unregister(ms.K8sAPIEventCounter)
-	ms.registry.Unregister(ms.K8sMonitoredNamespaceCount)
-	ms.registry.Unregister(ms.K8sMeshPodCount)
-	ms.registry.Unregister(ms.ProxyConnectCount)
-	ms.registry.Unregister(ms.ProxyConfigUpdateTime)
-	ms.registry.Unregister(ms.InjectorSidecarCount)
-	ms.registry.Unregister(ms.InjectorRqTime)
-	ms.registry.Unregister(ms.CertXdsIssuedCount)
-	ms.registry.Unregister(ms.CertXdsIssuedTime)
+func (ms *MetricsStore) Stop(cs ...prometheus.Collector) {
+	for _, c := range cs {
+		ms.registry.Unregister(c)
+	}
 }
 
 // Handler return the registry

--- a/pkg/metricsstore/metricsstore_test.go
+++ b/pkg/metricsstore/metricsstore_test.go
@@ -18,11 +18,17 @@ func TestMain(m *testing.M) {
 }
 
 func setup() {
-	DefaultMetricsStore.Start()
+	DefaultMetricsStore.Start(
+		DefaultMetricsStore.K8sAPIEventCounter,
+		DefaultMetricsStore.ProxyConnectCount,
+	)
 }
 
 func teardown() {
-	DefaultMetricsStore.Stop()
+	DefaultMetricsStore.Stop(
+		DefaultMetricsStore.K8sAPIEventCounter,
+		DefaultMetricsStore.ProxyConnectCount,
+	)
 }
 
 func TestK8sAPIEventCounter(t *testing.T) {


### PR DESCRIPTION
Initialization still happens for unrelated metrics to the componenets,
but this will at least prevent exposing unrelated metrics when scraping.

Additionally:
- `XdsCertCount/Times` have have had the `Xds` prefix stripped to be more generic for both Injector and OSM.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

**Affected area**:

- Metrics                [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No