### PR TITLE
ref(routesv2): Build inbound routes in routes v2 using proxy service

### DIFF
--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -323,13 +323,12 @@ func (mr *MockMeshCatalogerMockRecorder) ListMonitoredNamespaces() *gomock.Call 
 }
 
 // ListPoliciesForPermissiveMode mocks base method
-func (m *MockMeshCataloger) ListPoliciesForPermissiveMode(arg0 []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error) {
+func (m *MockMeshCataloger) ListPoliciesForPermissiveMode(arg0 []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPoliciesForPermissiveMode", arg0)
 	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
 	ret1, _ := ret[1].([]*trafficpolicy.OutboundTrafficPolicy)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	return ret0, ret1
 }
 
 // ListPoliciesForPermissiveMode indicates an expected call of ListPoliciesForPermissiveMode
@@ -386,20 +385,32 @@ func (mr *MockMeshCatalogerMockRecorder) ListTrafficPolicies(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListTrafficPolicies), arg0)
 }
 
-// ListTrafficPoliciesForServiceAccount mocks base method
-func (m *MockMeshCataloger) ListTrafficPoliciesForServiceAccount(arg0 service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error) {
+// ListOutboundTrafficPolicies mocks base method
+func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTrafficPoliciesForServiceAccount", arg0)
-	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
-	ret1, _ := ret[1].([]*trafficpolicy.OutboundTrafficPolicy)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "ListOutboundTrafficPolicies", arg0)
+	ret0, _ := ret[0].([]*trafficpolicy.OutboundTrafficPolicy)
+	return ret0
 }
 
-// ListTrafficPoliciesForServiceAccount indicates an expected call of ListTrafficPoliciesForServiceAccount
-func (mr *MockMeshCatalogerMockRecorder) ListTrafficPoliciesForServiceAccount(arg0 interface{}) *gomock.Call {
+// ListOutboundTrafficPolicies indicates an expected call of ListOutboundTrafficPolicies
+func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficPoliciesForServiceAccount", reflect.TypeOf((*MockMeshCataloger)(nil).ListTrafficPoliciesForServiceAccount), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundTrafficPolicies), arg0)
+}
+
+// ListInboundTrafficPolicies mocks base method
+func (m *MockMeshCataloger) ListInboundTrafficPolicies(arg0 service.K8sServiceAccount, arg1 []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInboundTrafficPolicies", arg0, arg1)
+	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
+	return ret0
+}
+
+// ListInboundTrafficPolicies indicates an expected call of ListInboundTrafficPolicies
+func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficPolicies(arg0 interface{}, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListInboundTrafficPolicies), arg0, arg1)
 }
 
 // RegisterProxy mocks base method

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -66,11 +66,14 @@ type MeshCataloger interface {
 	// ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
 	ListTrafficPolicies(service.MeshService) ([]trafficpolicy.TrafficTarget, error)
 
-	// ListTrafficPoliciesForServiceAccount returns all inbound and outbound traffic policies related to the given service account
-	ListTrafficPoliciesForServiceAccount(service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error)
+	// ListTrafficPoliciesForServiceAccount returns all inbound traffic policies related to the given service account and inbound services
+	ListInboundTrafficPolicies(service.K8sServiceAccount, []service.MeshService) []*trafficpolicy.InboundTrafficPolicy
+
+	// ListTrafficPoliciesForServiceAccount returns all outbound traffic policies related to the given service account
+	ListOutboundTrafficPolicies(service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy
 
 	// ListPoliciesForPermissiveMode returns all inbound and outbound traffic policies related to the given services
-	ListPoliciesForPermissiveMode(services []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy, error)
+	ListPoliciesForPermissiveMode(services []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy)
 
 	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
 	ListAllowedInboundServices(service.MeshService) ([]service.MeshService, error)

--- a/pkg/envoy/rds/new_response.go
+++ b/pkg/envoy/rds/new_response.go
@@ -31,15 +31,11 @@ func newResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 
 	if cfg.IsPermissiveTrafficPolicyMode() {
 		// Build traffic policies from service discovery for permissive mode
-		inboundTrafficPolicies, outboundTrafficPolicies, err = catalog.ListPoliciesForPermissiveMode(services)
+		inboundTrafficPolicies, outboundTrafficPolicies = catalog.ListPoliciesForPermissiveMode(services)
 	} else {
 		// Build traffic policies from SMI Traffic Target and Traffic Split
-		inboundTrafficPolicies, outboundTrafficPolicies, err = catalog.ListTrafficPoliciesForServiceAccount(proxyIdentity)
-	}
-
-	if err != nil {
-		log.Error().Err(err).Msgf("Error listing policies for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
-		return nil, err
+		inboundTrafficPolicies = catalog.ListInboundTrafficPolicies(proxyIdentity, services)
+		outboundTrafficPolicies = catalog.ListOutboundTrafficPolicies(proxyIdentity)
 	}
 
 	// Get Ingress inbound policies for the proxy

--- a/pkg/envoy/rds/new_response_test.go
+++ b/pkg/envoy/rds/new_response_test.go
@@ -34,6 +34,8 @@ func TestNewResponse(t *testing.T) {
 	certSerialNumber := certificate.SerialNumber("123456")
 	testProxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 
+	testOutbound := []*trafficpolicy.OutboundTrafficPolicy{}
+
 	testInbound := []*trafficpolicy.InboundTrafficPolicy{
 		{
 			Name:      "bookstore-v1.default",
@@ -92,7 +94,8 @@ func TestNewResponse(t *testing.T) {
 		},
 	}
 
-	mockCatalog.EXPECT().ListTrafficPoliciesForServiceAccount(gomock.Any()).Return(testInbound, nil, nil).AnyTimes()
+	mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(testInbound).AnyTimes()
+	mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(testOutbound).AnyTimes()
 	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
 	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 
@@ -215,7 +218,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	}
 
 	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
-	mockCatalog.EXPECT().ListPoliciesForPermissiveMode(gomock.Any()).Return(testPermissiveInbound, testOutbound, nil).AnyTimes()
+	mockCatalog.EXPECT().ListPoliciesForPermissiveMode(gomock.Any()).Return(testPermissiveInbound, testOutbound).AnyTimes()
 	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()


### PR DESCRIPTION
**Description**:

This PR refactors routes v2 to build inbound routes based on the proxy's
services rather than its service account. This is necessary so that only
routes and clusters for the proxy's service are only programmed.

To make this change the routes v2 api that build both inbound and
outbound routes together is split into two separate api's.

Fixes #2591

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
