### PR TITLE
docs: update version menu to show the correct release number

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -74,7 +74,7 @@ latexDashes = true
 
 # Add your release versions here
 [[params.versions]]
-  version = "v0.6.1"
+  version = "v0.7.0"
   url = "https://docs.openservicemesh.io"
 
 


### PR DESCRIPTION
Show correct release version no on docs site. Closes #2549.


---

> Documentation          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

> No
