### PR TITLE
feat(metrics): clean up WASM metrics in Prometheus config

### DIFF
--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -111,6 +111,104 @@ data:
           regex: ^ReplicaSet;(.*)-[^-]+$
           target_label: source_workload_name    
 
+      - job_name: 'smi-metrics'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target_label: __address__
+        metric_relabel_configs:
+        - source_labels: [__name__]
+          regex: 'envoy_.*osm_request_(total|duration_ms_(bucket|count|sum))'
+          action: keep
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_(\d{3})_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: response_code
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_(.*)_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: source_namespace
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_(.*)_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: source_kind
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_(.*)_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: source_name
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_(.*)_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: source_pod
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_(.*)_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: destination_namespace
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_(.*)_destination_name_.*_destination_pod_.*_osm_request_total
+          target_label: destination_kind
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_(.*)_destination_pod_.*_osm_request_total
+          target_label: destination_name
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_(.*)_osm_request_total
+          target_label: destination_pod
+        - source_labels: [__name__]
+          action: replace
+          regex: .*(osm_request_total)
+          target_label: __name__
+
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_(.*)_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: source_namespace
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_(.*)_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: source_kind
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_.*_source_name_(.*)_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: source_name
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_(.*)_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: source_pod
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_(.*)_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: destination_namespace
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_(.*)_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: destination_kind
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_(.*)_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          target_label: destination_name
+        - source_labels: [__name__]
+          action: replace
+          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_(.*)_osm_request_duration_ms_(bucket|sum|count)
+          target_label: destination_pod
+        - source_labels: [__name__]
+          action: replace
+          regex: .*(osm_request_duration_ms_(bucket|sum|count))
+          target_label: __name__
+
       - job_name: 'kubernetes-cadvisor'
         scheme: https
         tls_config:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The proxy-wasm SDK doesn't directly tag the metrics it generates.
Instead, it encodes the tags in the metric name. This change modifies
the Prometheus config to modify the metrics and move the encoded tags to
actual Prometheus tags.

One limitation to note is that because Prometheus doesn't allow '-' or
'.' in metric names, proxy-wasm converts all instances of either to '_'.
This means a metric on a pod named 'abc-123' will have a pod name tag of
'abc_123' and will collide with the metrics on a pod named 'abc.123'.
This limitation has been documented in docs/content/docs/patterns/wasm.md.

For example,

    envoy_response_code_200_source_namespace_bookbuyer_source_kind_Deployment_source_name_bookbuyer_source_pod_bookbuyer_74ff55c5b_kcb8q_destination_namespace_bookstore_destination_kind_Deployment_destination_name_bookstore_v1_destination_pod_bookstore_v1_74ff55c5b_kcb8q_osm_request_total{}

is transformed into

    osm_request_total{response_code="200", source_namespace="bookbuyer", source_kind="Deployment", source_name="bookbuyer", source_pod="bookbuyer_74ff55c5b_kcb8q", destination_namespace="bookstore", destination_kind="Deployment", destination_name="bookstore_v1", destination_pod="bookstore_v1_74ff55c5b_kcb8q"}

---

This PR is part of several which together extend Envoy to generate custom 
metrics needed to implement the SMI metrics spec (#984).
Here is a map of the PRs as they're currently planned:

1. (#2479) ~~ref(injector): pass pod object to getEnvoySidecarContainerSpec~~
2. (#2488) ~~feat(metrics): add WASM metrics source~~
3. (#2503) ~~docs(metrics): Add docs for WASM stats~~
4. (#2517) ~~feat(metrics): Add WASM feature flag~~
5. (#2546) ~~feat(metrics): Add stats.wasm to proxy config~~
6. (#2554) ~~feat(injector): Add name, workload name, workload kind to PodMetadata~~
7. (#2571) ~~feat(metrics): Add source labels to WASM metrics~~
8. (#2574) ~~feat(metrics): Add dest labels to WASM metrics~~
9. (#2587) ~~feat(metrics): Add "unknown" for dest labels on local replies~~
10. (YOU ARE HERE) **feat(metrics): clean up WASM metrics in Prometheus config**
11. feat(metrics): add flag to enable WASM metrics
12. tests(e2e): add WASM metrics test

The remaining changes can be found here: https://github.com/openservicemesh/osm/compare/main...nojnhuh:wasm-metrics

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No