### PR TITLE
ingress/rbac: allow any downstream principal to access the service

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -349,7 +349,7 @@ type MeshCataloger interface {
   GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRouteMatch, error)
 
   // GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
-  GetIngressPoliciesForService(service.MeshService, service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error)
+  GetIngressPoliciesForService(service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error)
 }
 ```
 

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -5,6 +5,8 @@
 package catalog
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
@@ -15,7 +17,6 @@ import (
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	reflect "reflect"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface
@@ -54,18 +55,18 @@ func (mr *MockMeshCatalogerMockRecorder) ExpectProxy(arg0 interface{}) *gomock.C
 }
 
 // GetIngressPoliciesForService mocks base method
-func (m *MockMeshCataloger) GetIngressPoliciesForService(arg0 service.MeshService, arg1 service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error) {
+func (m *MockMeshCataloger) GetIngressPoliciesForService(arg0 service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIngressPoliciesForService", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetIngressPoliciesForService", arg0)
 	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetIngressPoliciesForService indicates an expected call of GetIngressPoliciesForService
-func (mr *MockMeshCatalogerMockRecorder) GetIngressPoliciesForService(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMeshCatalogerMockRecorder) GetIngressPoliciesForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressPoliciesForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressPoliciesForService), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressPoliciesForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressPoliciesForService), arg0)
 }
 
 // GetIngressRoutesPerHost mocks base method
@@ -98,7 +99,6 @@ func (mr *MockMeshCatalogerMockRecorder) GetPortToProtocolMappingForService(arg0
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortToProtocolMappingForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetPortToProtocolMappingForService), arg0)
 }
 
-// TODO : remove as a part of routes refactor (#2397)
 // GetResolvableHostnamesForUpstreamService mocks base method
 func (m *MockMeshCataloger) GetResolvableHostnamesForUpstreamService(arg0, arg1 service.MeshService) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -108,7 +108,6 @@ func (m *MockMeshCataloger) GetResolvableHostnamesForUpstreamService(arg0, arg1 
 	return ret0, ret1
 }
 
-// TODO : remove as a part of routes refactor (#2397)
 // GetResolvableHostnamesForUpstreamService indicates an expected call of GetResolvableHostnamesForUpstreamService
 func (mr *MockMeshCatalogerMockRecorder) GetResolvableHostnamesForUpstreamService(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
@@ -204,6 +203,21 @@ func (mr *MockMeshCatalogerMockRecorder) GetWeightedClusterForService(arg0 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWeightedClusterForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetWeightedClusterForService), arg0)
 }
 
+// ListAllowedEndpointsForService mocks base method
+func (m *MockMeshCataloger) ListAllowedEndpointsForService(arg0 service.K8sServiceAccount, arg1 service.MeshService) ([]endpoint.Endpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllowedEndpointsForService", arg0, arg1)
+	ret0, _ := ret[0].([]endpoint.Endpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllowedEndpointsForService indicates an expected call of ListAllowedEndpointsForService
+func (mr *MockMeshCatalogerMockRecorder) ListAllowedEndpointsForService(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedEndpointsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedEndpointsForService), arg0, arg1)
+}
+
 // ListAllowedInboundServiceAccounts mocks base method
 func (m *MockMeshCataloger) ListAllowedInboundServiceAccounts(arg0 service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
@@ -278,6 +292,20 @@ func (mr *MockMeshCatalogerMockRecorder) ListEndpointsForService(arg0 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEndpointsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListEndpointsForService), arg0)
 }
 
+// ListInboundTrafficPolicies mocks base method
+func (m *MockMeshCataloger) ListInboundTrafficPolicies(arg0 service.K8sServiceAccount, arg1 []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInboundTrafficPolicies", arg0, arg1)
+	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
+	return ret0
+}
+
+// ListInboundTrafficPolicies indicates an expected call of ListInboundTrafficPolicies
+func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficPolicies(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListInboundTrafficPolicies), arg0, arg1)
+}
+
 // ListInboundTrafficTargetsWithRoutes mocks base method
 func (m *MockMeshCataloger) ListInboundTrafficTargetsWithRoutes(arg0 service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
 	m.ctrl.T.Helper()
@@ -285,21 +313,6 @@ func (m *MockMeshCataloger) ListInboundTrafficTargetsWithRoutes(arg0 service.K8s
 	ret0, _ := ret[0].([]trafficpolicy.TrafficTargetWithRoutes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
-}
-
-// ListAllowedEndpointsForService mocks base method
-func (m *MockMeshCataloger) ListAllowedEndpointsForService(arg0 service.K8sServiceAccount, arg1 service.MeshService) ([]endpoint.Endpoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedEndpointsForService", arg0, arg1)
-	ret0, _ := ret[0].([]endpoint.Endpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAllowedEndpointsForService indicates an expected call of ListAllowedEndpointsForService
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedEndpointsForService(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedEndpointsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedEndpointsForService), arg0, arg1)
 }
 
 // ListInboundTrafficTargetsWithRoutes indicates an expected call of ListInboundTrafficTargetsWithRoutes
@@ -320,6 +333,20 @@ func (m *MockMeshCataloger) ListMonitoredNamespaces() []string {
 func (mr *MockMeshCatalogerMockRecorder) ListMonitoredNamespaces() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMonitoredNamespaces", reflect.TypeOf((*MockMeshCataloger)(nil).ListMonitoredNamespaces))
+}
+
+// ListOutboundTrafficPolicies mocks base method
+func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOutboundTrafficPolicies", arg0)
+	ret0, _ := ret[0].([]*trafficpolicy.OutboundTrafficPolicy)
+	return ret0
+}
+
+// ListOutboundTrafficPolicies indicates an expected call of ListOutboundTrafficPolicies
+func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundTrafficPolicies), arg0)
 }
 
 // ListPoliciesForPermissiveMode mocks base method
@@ -383,34 +410,6 @@ func (m *MockMeshCataloger) ListTrafficPolicies(arg0 service.MeshService) ([]tra
 func (mr *MockMeshCatalogerMockRecorder) ListTrafficPolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListTrafficPolicies), arg0)
-}
-
-// ListOutboundTrafficPolicies mocks base method
-func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOutboundTrafficPolicies", arg0)
-	ret0, _ := ret[0].([]*trafficpolicy.OutboundTrafficPolicy)
-	return ret0
-}
-
-// ListOutboundTrafficPolicies indicates an expected call of ListOutboundTrafficPolicies
-func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundTrafficPolicies), arg0)
-}
-
-// ListInboundTrafficPolicies mocks base method
-func (m *MockMeshCataloger) ListInboundTrafficPolicies(arg0 service.K8sServiceAccount, arg1 []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListInboundTrafficPolicies", arg0, arg1)
-	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
-	return ret0
-}
-
-// ListInboundTrafficPolicies indicates an expected call of ListInboundTrafficPolicies
-func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficPolicies(arg0 interface{}, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListInboundTrafficPolicies), arg0, arg1)
 }
 
 // RegisterProxy mocks base method

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -132,7 +132,7 @@ type MeshCataloger interface {
 	GetIngressRoutesPerHost(service.MeshService) (map[string][]trafficpolicy.HTTPRouteMatch, error)
 
 	// GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
-	GetIngressPoliciesForService(service.MeshService, service.K8sServiceAccount) ([]*trafficpolicy.InboundTrafficPolicy, error)
+	GetIngressPoliciesForService(service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error)
 
 	// ListMonitoredNamespaces lists namespaces monitored by the control plane
 	ListMonitoredNamespaces() []string

--- a/pkg/envoy/rds/new_response.go
+++ b/pkg/envoy/rds/new_response.go
@@ -40,7 +40,7 @@ func newResponse(catalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_disco
 
 	// Get Ingress inbound policies for the proxy
 	for _, svc := range services {
-		ingressInboundPolicies, err := catalog.GetIngressPoliciesForService(svc, proxyIdentity)
+		ingressInboundPolicies, err := catalog.GetIngressPoliciesForService(svc)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error looking up ingress policies for service=%s", svc.String())
 			return nil, err

--- a/pkg/envoy/rds/new_response_test.go
+++ b/pkg/envoy/rds/new_response_test.go
@@ -96,7 +96,7 @@ func TestNewResponse(t *testing.T) {
 
 	mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(testInbound).AnyTimes()
 	mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(testOutbound).AnyTimes()
-	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
+	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
 	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
@@ -219,7 +219,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 
 	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 	mockCatalog.EXPECT().ListPoliciesForPermissiveMode(gomock.Any()).Return(testPermissiveInbound, testOutbound).AnyTimes()
-	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any(), gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
+	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()
 

--- a/pkg/envoy/route/rbac_test.go
+++ b/pkg/envoy/route/rbac_test.go
@@ -27,7 +27,7 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 		expectError        bool
 	}{
 		{
-			name: "valid trafficpolicy rule",
+			name: "valid trafficpolicy rule with restricted downstream identities",
 			rule: &trafficpolicy.Rule{
 				Route: trafficpolicy.RouteWeightedClusters{
 					HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
@@ -57,6 +57,31 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 								},
 							},
 						},
+					},
+				},
+				Permissions: []*xds_rbac.Permission{
+					{
+						Rule: &xds_rbac.Permission_Any{Any: true},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid trafficpolicy rule which allows all downstream identities",
+			rule: &trafficpolicy.Rule{
+				Route: trafficpolicy.RouteWeightedClusters{
+					HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
+					WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+				},
+				AllowedServiceAccounts: set.NewSetFromSlice([]interface{}{
+					service.K8sServiceAccount{}, // setting an empty service account will result in all downstreams being allowed
+				}),
+			},
+			expectedRBACPolicy: &xds_rbac.Policy{
+				Principals: []*xds_rbac.Principal{
+					{
+						Identifier: &xds_rbac.Principal_Any{Any: true},
 					},
 				},
 				Permissions: []*xds_rbac.Permission{

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -32,8 +32,14 @@ type K8sServiceAccount struct {
 	Name      string
 }
 
+// String returns the string representation of the service account object
 func (sa K8sServiceAccount) String() string {
 	return strings.Join([]string{sa.Namespace, namespaceNameSeparator, sa.Name}, "")
+}
+
+// IsEmpty returns true if the given service account object is empty
+func (sa K8sServiceAccount) IsEmpty() bool {
+	return (K8sServiceAccount{}) == sa
 }
 
 // GetSyntheticService creates a MeshService for the given K8s Service Account,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Since ingress policies are not based on service accounts, traffic
policy routes derived from ingress rules should not enforce RBAC
policies based on the downstream's service account.
This change adds support to wildcard the allowed service accounts
for an ingress route so that the corresponding RBAC policy
can create a rule that allows any downstream principal.

This is required for ingress to work with routesV2 and RBAC
per route policies.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`