### PR TITLE
ref(pkg/catalog) : Use the same catalog APIs to build inbound and outbound traffic policies for SMI and permissive mode

### DIFF
--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -349,21 +349,6 @@ func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundTrafficPolicies), arg0)
 }
 
-// ListPoliciesForPermissiveMode mocks base method
-func (m *MockMeshCataloger) ListPoliciesForPermissiveMode(arg0 []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPoliciesForPermissiveMode", arg0)
-	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
-	ret1, _ := ret[1].([]*trafficpolicy.OutboundTrafficPolicy)
-	return ret0, ret1
-}
-
-// ListPoliciesForPermissiveMode indicates an expected call of ListPoliciesForPermissiveMode
-func (mr *MockMeshCatalogerMockRecorder) ListPoliciesForPermissiveMode(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesForPermissiveMode", reflect.TypeOf((*MockMeshCataloger)(nil).ListPoliciesForPermissiveMode), arg0)
-}
-
 // ListSMIPolicies mocks base method
 func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -66,14 +66,11 @@ type MeshCataloger interface {
 	// ListTrafficPolicies returns all the traffic policies for a given service that Envoy proxy should be aware of.
 	ListTrafficPolicies(service.MeshService) ([]trafficpolicy.TrafficTarget, error)
 
-	// ListTrafficPoliciesForServiceAccount returns all inbound traffic policies related to the given service account and inbound services
+	// ListInboundTrafficPolicies returns all inbound traffic policies related to the given service account and upstream services
 	ListInboundTrafficPolicies(service.K8sServiceAccount, []service.MeshService) []*trafficpolicy.InboundTrafficPolicy
 
-	// ListTrafficPoliciesForServiceAccount returns all outbound traffic policies related to the given service account
+	// ListOutboundTrafficPolicies returns all outbound traffic policies related to the given service account
 	ListOutboundTrafficPolicies(service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy
-
-	// ListPoliciesForPermissiveMode returns all inbound and outbound traffic policies related to the given services
-	ListPoliciesForPermissiveMode(services []service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, []*trafficpolicy.OutboundTrafficPolicy)
 
 	// ListAllowedInboundServices lists the inbound services allowed to connect to the given service.
 	ListAllowedInboundServices(service.MeshService) ([]service.MeshService, error)

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -29,14 +29,10 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_dis
 		return nil, err
 	}
 
-	if cfg.IsPermissiveTrafficPolicyMode() {
-		// Build traffic policies from service discovery for permissive mode
-		inboundTrafficPolicies, outboundTrafficPolicies = cataloger.ListPoliciesForPermissiveMode(services)
-	} else {
-		// Build traffic policies from SMI Traffic Target and Traffic Split
-		inboundTrafficPolicies = cataloger.ListInboundTrafficPolicies(proxyIdentity, services)
-		outboundTrafficPolicies = cataloger.ListOutboundTrafficPolicies(proxyIdentity)
-	}
+	// Build traffic policies from  either SMI Traffic Target and Traffic Split or service discovery
+	// depending on whether permissive mode is enabled or not
+	inboundTrafficPolicies = cataloger.ListInboundTrafficPolicies(proxyIdentity, services)
+	outboundTrafficPolicies = cataloger.ListOutboundTrafficPolicies(proxyIdentity)
 
 	// Get Ingress inbound policies for the proxy
 	for _, svc := range services {

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -157,7 +157,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 		},
 	}
 
-	testOutbound := []*trafficpolicy.OutboundTrafficPolicy{
+	testPermissiveOutbound := []*trafficpolicy.OutboundTrafficPolicy{
 		{
 			Name: "bookbuyer.default",
 			Hostnames: []string{
@@ -218,7 +218,8 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	}
 
 	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
-	mockCatalog.EXPECT().ListPoliciesForPermissiveMode(gomock.Any()).Return(testPermissiveInbound, testOutbound).AnyTimes()
+	mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(testPermissiveInbound).AnyTimes()
+	mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(testPermissiveOutbound).AnyTimes()
 	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()


### PR DESCRIPTION
**Description**:

The PR gets rid of the `ListPoliciesForPermissiveMode` API and includes
the permissive mode logic within the `ListInboundTrafficPolicies` and `ListOutboundTrafficPolicies`
API's respectively.

Unit tests have also been updated as a part of this PR.

Fixes #2598

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
