### PR TITLE
test(trafficSplit): Add a test for service with zero weight in traffic split

### DIFF
--- a/pkg/catalog/routes_test.go
+++ b/pkg/catalog/routes_test.go
@@ -33,7 +33,7 @@ var expectedBookbuyerOutbound []*trafficpolicy.OutboundTrafficPolicy = []*traffi
 		Hostnames: tests.BookstoreV1Hostnames,
 		Routes: []*trafficpolicy.RouteWeightedClusters{
 			{
-				HTTPRouteMatch:   wildCardRouteMatch,
+				HTTPRouteMatch:   tests.WildCardRouteMatch,
 				WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 			},
 		},
@@ -43,7 +43,7 @@ var expectedBookbuyerOutbound []*trafficpolicy.OutboundTrafficPolicy = []*traffi
 		Hostnames: tests.BookstoreV2Hostnames,
 		Routes: []*trafficpolicy.RouteWeightedClusters{
 			{
-				HTTPRouteMatch:   wildCardRouteMatch,
+				HTTPRouteMatch:   tests.WildCardRouteMatch,
 				WeightedClusters: mapset.NewSet(tests.BookstoreV2DefaultWeightedCluster),
 			},
 		},
@@ -53,7 +53,7 @@ var expectedBookbuyerOutbound []*trafficpolicy.OutboundTrafficPolicy = []*traffi
 		Hostnames: tests.BookstoreApexHostnames,
 		Routes: []*trafficpolicy.RouteWeightedClusters{
 			{
-				HTTPRouteMatch:   wildCardRouteMatch,
+				HTTPRouteMatch:   tests.WildCardRouteMatch,
 				WeightedClusters: mapset.NewSet(tests.BookstoreApexDefaultWeightedCluster),
 			},
 		},
@@ -107,7 +107,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					Hostnames: tests.BookstoreV1Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 						},
 					},
@@ -117,7 +117,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					Hostnames: tests.BookstoreV2Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookstoreV2DefaultWeightedCluster),
 						},
 					},
@@ -127,7 +127,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 90},
 								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 10},
@@ -158,7 +158,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 90},
 								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 10},
@@ -205,7 +205,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 						},
 					},
@@ -224,7 +224,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookstoreV2DefaultWeightedCluster),
 						},
 					},
@@ -243,7 +243,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookbuyerDefaultWeightedCluster),
 						},
 					},
@@ -475,7 +475,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: tests.BookstoreApexNamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 90},
 								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 10},
@@ -501,7 +501,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 90},
 								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 10},
@@ -531,7 +531,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: tests.BookstoreApexNamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 90},
 								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 10},
@@ -544,7 +544,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: testSplit1NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "bar/bookstore-v1", Weight: 10},
 								service.WeightedCluster{ClusterName: "bar/bookstore-v2", Weight: 90},
@@ -570,7 +570,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: testSplit1NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "bar/bookstore-v1", Weight: 10},
 								service.WeightedCluster{ClusterName: "bar/bookstore-v2", Weight: 90},
@@ -600,7 +600,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: testSplit1NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "bar/bookstore-v1", Weight: 10},
 								service.WeightedCluster{ClusterName: "bar/bookstore-v2", Weight: 90},
@@ -613,7 +613,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					Hostnames: testSplit3NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch: wildCardRouteMatch,
+							HTTPRouteMatch: tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "baz/bookstore-v1", Weight: 10},
 								service.WeightedCluster{ClusterName: "baz/bookstore-v2", Weight: 90},
@@ -1278,7 +1278,7 @@ func TestBuildOutboundPolicies(t *testing.T) {
 			Hostnames: hostnames,
 			Routes: []*trafficpolicy.RouteWeightedClusters{
 				{
-					HTTPRouteMatch:   wildCardRouteMatch,
+					HTTPRouteMatch:   tests.WildCardRouteMatch,
 					WeightedClusters: mapset.NewSet(bookstoreWeightedCluster),
 				},
 			},
@@ -2014,7 +2014,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 					Rules: []*trafficpolicy.Rule{
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
-								HTTPRouteMatch:   wildCardRouteMatch,
+								HTTPRouteMatch:   tests.WildCardRouteMatch,
 								WeightedClusters: mapset.NewSet(tests.BookbuyerDefaultWeightedCluster),
 							},
 							AllowedServiceAccounts: mapset.NewSet(tests.BookbuyerServiceAccount, tests.BookstoreServiceAccount),
@@ -2249,7 +2249,7 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 					Rules: []*trafficpolicy.Rule{
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
-								HTTPRouteMatch: wildCardRouteMatch,
+								HTTPRouteMatch: tests.WildCardRouteMatch,
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{
 									ClusterName: "bookstore-ns/bookstore",
 									Weight:      100,
@@ -2331,7 +2331,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookstoreApexDefaultWeightedCluster),
 						},
 					},
@@ -2350,7 +2350,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 						},
 					},
@@ -2369,7 +2369,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   wildCardRouteMatch,
+							HTTPRouteMatch:   tests.WildCardRouteMatch,
 							WeightedClusters: mapset.NewSet(tests.BookbuyerDefaultWeightedCluster),
 						},
 					},

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -486,6 +486,12 @@ var (
 		SelectorKey:                      SelectorValue,
 		constants.EnvoyUniqueIDLabelName: ProxyUUID,
 	}
+
+	// WildCardRouteMatch is HTTPRouteMatch with wildcard path and method
+	WildCardRouteMatch trafficpolicy.HTTPRouteMatch = trafficpolicy.HTTPRouteMatch{
+		PathRegex: constants.RegexMatchAll,
+		Methods:   []string{constants.WildcardHTTPMethod},
+	}
 )
 
 // NewPodFixture creates a new Pod struct for testing.

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -1,0 +1,357 @@
+package scenarios
+
+import (
+	"fmt"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/golang/mock/gomock"
+	proto "github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/uuid"
+	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
+	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	tassert "github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/rds"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
+	"github.com/openservicemesh/osm/pkg/tests"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+func TestRDSRespose(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name                     string
+		downstreamSA             service.K8sServiceAccount
+		upstreamSA               service.K8sServiceAccount
+		upstreamServices         []service.MeshService
+		meshServices             []service.MeshService
+		trafficSpec              spec.HTTPRouteGroup
+		trafficSplit             split.TrafficSplit
+		expectedInboundPolicies  []*trafficpolicy.InboundTrafficPolicy
+		expectedOutboundPolicies []*trafficpolicy.OutboundTrafficPolicy
+	}{
+		{
+			name:             "Test RDS response with a traffic split having zero weight",
+			downstreamSA:     tests.BookbuyerServiceAccount,
+			upstreamSA:       tests.BookstoreServiceAccount,
+			upstreamServices: []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
+			meshServices:     []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService},
+			trafficSpec: spec.HTTPRouteGroup{
+				TypeMeta: v1.TypeMeta{
+					APIVersion: "specs.smi-spec.io/v1alpha4",
+					Kind:       "HTTPRouteGroup",
+				},
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: tests.Namespace,
+					Name:      tests.RouteGroupName,
+				},
+				Spec: spec.HTTPRouteGroupSpec{
+					Matches: []spec.HTTPMatch{
+						{
+							Name:      tests.BuyBooksMatchName,
+							PathRegex: tests.BookstoreBuyPath,
+							Methods:   []string{"GET"},
+							Headers: map[string]string{
+								"user-agent": tests.HTTPUserAgent,
+							},
+						},
+						{
+							Name:      tests.SellBooksMatchName,
+							PathRegex: tests.BookstoreSellPath,
+							Methods:   []string{"GET"},
+							Headers: map[string]string{
+								"user-agent": tests.HTTPUserAgent,
+							},
+						},
+					},
+				},
+			},
+			trafficSplit: split.TrafficSplit{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: tests.Namespace,
+				},
+				Spec: v1alpha2.TrafficSplitSpec{
+					Service: tests.BookstoreApexServiceName,
+					Backends: []v1alpha2.TrafficSplitBackend{
+						{
+							Service: tests.BookstoreV1ServiceName,
+							Weight:  0,
+						},
+						{
+							Service: tests.BookstoreV2ServiceName,
+							Weight:  100,
+						},
+					},
+				},
+			},
+			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "bookstore-v1.default",
+					Hostnames: []string{
+						"bookstore-v1",
+						"bookstore-v1.default",
+						"bookstore-v1.default.svc",
+						"bookstore-v1.default.svc.cluster",
+						"bookstore-v1.default.svc.cluster.local",
+						"bookstore-v1:8888",
+						"bookstore-v1.default:8888",
+						"bookstore-v1.default.svc:8888",
+						"bookstore-v1.default.svc.cluster:8888",
+						"bookstore-v1.default.svc.cluster.local:8888",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: tests.BookstoreBuyHTTPRoute,
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "default/bookstore-v1-local",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+								Name:      tests.BookbuyerServiceAccountName,
+								Namespace: tests.Namespace,
+							}),
+						},
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: tests.BookstoreSellHTTPRoute,
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "default/bookstore-v1-local",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+								Name:      tests.BookbuyerServiceAccountName,
+								Namespace: tests.Namespace,
+							}),
+						},
+					},
+				},
+				{
+					Name: tests.BookstoreApexServiceName,
+					Hostnames: []string{
+						"bookstore-apex",
+						"bookstore-apex.default",
+						"bookstore-apex.default.svc",
+						"bookstore-apex.default.svc.cluster",
+						"bookstore-apex.default.svc.cluster.local",
+						"bookstore-apex:8888",
+						"bookstore-apex.default:8888",
+						"bookstore-apex.default.svc:8888",
+						"bookstore-apex.default.svc.cluster:8888",
+						"bookstore-apex.default.svc.cluster.local:8888",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: tests.BookstoreBuyHTTPRoute,
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "default/bookstore-v1-local",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+								Name:      tests.BookbuyerServiceAccountName,
+								Namespace: tests.Namespace,
+							}),
+						},
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: tests.BookstoreSellHTTPRoute,
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "default/bookstore-v1-local",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+								Name:      tests.BookbuyerServiceAccountName,
+								Namespace: tests.Namespace,
+							}),
+						},
+					},
+				},
+			},
+			expectedOutboundPolicies: []*trafficpolicy.OutboundTrafficPolicy{
+				{
+					Name:      tests.BookstoreApexServiceName,
+					Hostnames: tests.BookstoreApexHostnames,
+					Routes: []*trafficpolicy.RouteWeightedClusters{
+						{
+							HTTPRouteMatch: tests.WildCardRouteMatch,
+							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 0},
+								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 100},
+							}),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockKubeController := k8s.NewMockController(mockCtrl)
+			mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
+			mockEndpointProvider := endpoint.NewMockProvider(mockCtrl)
+			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+			mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
+			kubeClient := testclient.NewSimpleClientset()
+			proxy, err := getBookstoreV1Proxy(kubeClient)
+			assert.Nil(err)
+
+			for _, meshSvc := range tc.meshServices {
+				k8sService := tests.NewServiceFixture(meshSvc.Name, meshSvc.Namespace, map[string]string{})
+				mockKubeController.EXPECT().GetService(meshSvc).Return(k8sService).AnyTimes()
+			}
+
+			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
+
+			mockMeshSpec.EXPECT().ListHTTPTrafficSpecs().Return([]*spec.HTTPRouteGroup{&tc.trafficSpec}).AnyTimes()
+			mockMeshSpec.EXPECT().ListTrafficSplits().Return([]*split.TrafficSplit{&tc.trafficSplit}).AnyTimes()
+			trafficTarget := tests.NewSMITrafficTarget(tc.downstreamSA.Name, tc.downstreamSA.Namespace, tc.upstreamSA.Name, tc.upstreamSA.Namespace)
+			mockMeshSpec.EXPECT().ListTrafficTargets().Return([]*access.TrafficTarget{&trafficTarget}).AnyTimes()
+
+			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
+
+			mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
+			mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(tc.expectedInboundPolicies).AnyTimes()
+			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
+			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()
+
+			actual, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+			assert.Nil(err)
+			assert.NotNil(actual)
+
+			// The RDS response will have two route configurations
+			// 1. RDS_Inbound
+			// 2. RDS_Outbound
+			routeConfig := &xds_route.RouteConfiguration{}
+			assert.Equal(2, len(actual.GetResources()))
+
+			// Check the inbound route configuration
+			unmarshallErr := proto.UnmarshalAny(actual.GetResources()[0], routeConfig)
+			if err != nil {
+				t.Fatal(unmarshallErr)
+			}
+
+			// The RDS_Inbound will have the following virtual hosts :
+			// inbound_virtual-host|bookstore-v1.default
+			// inbound_virtual-host|bookstore-apex
+			assert.Equal("RDS_Inbound", routeConfig.Name)
+			assert.Equal(2, len(routeConfig.VirtualHosts))
+
+			assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
+			assert.Equal(tests.BookstoreV1Hostnames, routeConfig.VirtualHosts[0].Domains)
+			assert.Equal(2, len(routeConfig.VirtualHosts[0].Routes))
+			assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
+			assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters().Clusters))
+			assert.Equal(routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
+			assert.Equal(tests.BookstoreSellHTTPRoute.PathRegex, routeConfig.VirtualHosts[0].Routes[1].GetMatch().GetSafeRegex().Regex)
+			assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes[1].GetRoute().GetWeightedClusters().Clusters))
+			assert.Equal(routeConfig.VirtualHosts[0].Routes[1].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
+
+			assert.Equal("inbound_virtual-host|bookstore-apex", routeConfig.VirtualHosts[1].Name)
+			assert.Equal(tests.BookstoreApexHostnames, routeConfig.VirtualHosts[1].Domains)
+			assert.Equal(2, len(routeConfig.VirtualHosts[1].Routes))
+			assert.Equal(tests.BookstoreBuyHTTPRoute.PathRegex, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
+			assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes[0].GetRoute().GetWeightedClusters().Clusters))
+			assert.Equal(routeConfig.VirtualHosts[1].Routes[0].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
+			assert.Equal(tests.BookstoreSellHTTPRoute.PathRegex, routeConfig.VirtualHosts[1].Routes[1].GetMatch().GetSafeRegex().Regex)
+			assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes[1].GetRoute().GetWeightedClusters().Clusters))
+			assert.Equal(routeConfig.VirtualHosts[1].Routes[1].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
+
+			// Check the outbound route configuration
+			unmarshallErr = proto.UnmarshalAny(actual.GetResources()[1], routeConfig)
+			if err != nil {
+				t.Fatal(unmarshallErr)
+			}
+
+			// The RDS_Outbound will have the following virtual hosts :
+			// outbound_virtual-host|bookstore-apex
+			assert.Equal("RDS_Outbound", routeConfig.Name)
+			assert.Equal(1, len(routeConfig.VirtualHosts))
+
+			assert.Equal("outbound_virtual-host|bookstore-apex", routeConfig.VirtualHosts[0].Name)
+			assert.Equal(tests.BookstoreApexHostnames, routeConfig.VirtualHosts[0].Domains)
+			assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes))
+			assert.Equal(tests.WildCardRouteMatch.PathRegex, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
+			assert.Equal(2, len(routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters().Clusters))
+			assert.Equal(routeConfig.VirtualHosts[0].Routes[0].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
+		})
+	}
+}
+
+func getBookstoreV1Proxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
+	// Create pod for bookbuyer
+	bookbuyerPodLabels := map[string]string{
+		tests.SelectorKey:                tests.BookbuyerService.Name,
+		constants.EnvoyUniqueIDLabelName: uuid.New().String(),
+	}
+	if _, err := tests.MakePod(kubeClient, tests.Namespace, tests.BookbuyerServiceName, tests.BookbuyerServiceAccountName, bookbuyerPodLabels); err != nil {
+		return nil, err
+	}
+
+	// Create pod for bookstore-v1
+	bookstoreV1PodLabels := map[string]string{
+		tests.SelectorKey:                tests.BookstoreV1ServiceName,
+		constants.EnvoyUniqueIDLabelName: tests.ProxyUUID,
+	}
+	if _, err := tests.MakePod(kubeClient, tests.Namespace, tests.BookstoreV1ServiceName, tests.BookstoreServiceAccountName, bookstoreV1PodLabels); err != nil {
+		return nil, err
+	}
+
+	// Create a pod for bookstore-v2
+	bookstoreV2PodLabels := map[string]string{
+		tests.SelectorKey:                tests.BookstoreV1ServiceName,
+		constants.EnvoyUniqueIDLabelName: uuid.New().String(),
+	}
+	if _, err := tests.MakePod(kubeClient, tests.Namespace, tests.BookstoreV2ServiceName, tests.BookstoreServiceAccountName, bookstoreV2PodLabels); err != nil {
+		return nil, err
+	}
+
+	// Create service for bookstore-v1 and bookstore-v2
+	for _, svcName := range []string{tests.BookstoreV1ServiceName, tests.BookstoreV2ServiceName} {
+		selectors := map[string]string{
+			tests.SelectorKey: svcName,
+		}
+		if _, err := tests.MakeService(kubeClient, svcName, selectors); err != nil {
+			return nil, err
+		}
+	}
+
+	// Create service for traffic split apex
+	for _, svcName := range []string{tests.BookstoreApexServiceName} {
+		selectors := map[string]string{
+			tests.SelectorKey: "bookstore",
+		}
+		if _, err := tests.MakeService(kubeClient, svcName, selectors); err != nil {
+			return nil, err
+		}
+	}
+
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookstoreServiceAccount, tests.Namespace))
+	certSerialNumber := certificate.SerialNumber("123456")
+	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	return proxy, nil
+}


### PR DESCRIPTION
**Description**:

A unit test has been added in tests/scenarios to validate a service
having zero weight in traffic split

Fixes #2424 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
