### PR TITLE
pkg/configurator: Demote Error to a Warning; Clarification

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -254,7 +254,7 @@ func (c *Client) getConfigMap() *osmConfig {
 	}
 
 	if !exists {
-		log.Error().Msgf("ConfigMap %s does not exist in cache", configMapCacheKey)
+		log.Warn().Msgf("ConfigMap %s does not exist. Default config values will be used.", configMapCacheKey)
 		return &osmConfig{}
 	}
 	configMap := item.(*v1.ConfigMap)


### PR DESCRIPTION
This Error should be a Warning. It is acceptable for the OSM ConfigMap to not exist - we have default values.

Message: 
```
6:04PM ERR ConfigMap osm-system/osm-config does not exist in cache component=configurator file=client.go:257
```