### PR TITLE
sds: Remove unused field from SDS struct; No need to use GetServicesFromEnvoyCertificate()

### DIFF
--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -135,10 +135,9 @@ func TestGetRootCert(t *testing.T) {
 			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
 			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
-				proxyServices: []service.MeshService{tc.proxyService},
-				svcAccount:    tc.proxySvcAccount,
-				proxy:         envoy.NewProxy(certCommonName, certSerialNumber, nil),
-				certManager:   mockCertManager,
+				svcAccount:  tc.proxySvcAccount,
+				proxy:       envoy.NewProxy(certCommonName, certSerialNumber, nil),
+				certManager: mockCertManager,
 
 				// these points to the dynamic mocks which gets updated for each test
 				meshCatalog: d.mockCatalog,
@@ -350,10 +349,9 @@ func TestGetSDSSecrets(t *testing.T) {
 			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
 			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
-				proxyServices: []service.MeshService{tc.proxyService},
-				svcAccount:    tc.proxySvcAccount,
-				proxy:         envoy.NewProxy(certCommonName, certSerialNumber, nil),
-				certManager:   mockCertManager,
+
+				proxy:       envoy.NewProxy(certCommonName, certSerialNumber, nil),
+				certManager: mockCertManager,
 
 				// these points to the dynamic mocks which gets updated for each test
 				meshCatalog: d.mockCatalog,

--- a/pkg/envoy/sds/types.go
+++ b/pkg/envoy/sds/types.go
@@ -16,10 +16,9 @@ var (
 
 // sdsImpl is the type that implements the internal functionality of SDS
 type sdsImpl struct {
-	proxy         *envoy.Proxy
-	proxyServices []service.MeshService
-	svcAccount    service.K8sServiceAccount
-	meshCatalog   catalog.MeshCataloger
-	cfg           configurator.Configurator
-	certManager   certificate.Manager
+	proxy       *envoy.Proxy
+	svcAccount  service.K8sServiceAccount
+	meshCatalog catalog.MeshCataloger
+	cfg         configurator.Configurator
+	certManager certificate.Manager
 }


### PR DESCRIPTION
This PR cleans up SDS:
 - removes  `proxyServices` from the `sdsImpl` struct
 - removes the use of `GetServicesFromEnvoyCertificate()`, which is no longer needed.