### PR TITLE
sds: Remove unused services list from SDS struct

### DIFF
--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -33,7 +33,6 @@ func TestGetRootCert(t *testing.T) {
 	type testCase struct {
 		name            string
 		sdsCert         envoy.SDSCert
-		proxyService    service.MeshService
 		proxySvcAccount service.K8sServiceAccount
 		prepare         func(d *dynamicMock)
 
@@ -50,7 +49,6 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-1/service-1",
 				CertType: envoy.RootCertTypeForMTLSInbound,
 			},
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -76,7 +74,6 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-2/service-2",
 				CertType: envoy.RootCertTypeForMTLSOutbound,
 			},
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -102,7 +99,6 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-2/service-2",
 				CertType: envoy.RootCertTypeForMTLSOutbound,
 			},
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -207,7 +203,6 @@ func TestGetSDSSecrets(t *testing.T) {
 
 	type testCase struct {
 		name            string
-		proxyService    service.MeshService
 		proxySvcAccount service.K8sServiceAccount
 		prepare         func(d *dynamicMock)
 
@@ -229,7 +224,6 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 1: root-cert-for-mtls-inbound requested -------------------------------
 		{
 			name:            "test root-cert-for-mtls-inbound cert type request",
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -254,7 +248,6 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 2: root-cert-for-mtls-outbound requested -------------------------------
 		{
 			name:            "test root-cert-for-mtls-outbound cert type request",
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -280,7 +273,6 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 3: root-cert-for-https requested -------------------------------
 		{
 			name:            "test root-cert-https cert type request",
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -300,7 +292,6 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 4: service-cert requested -------------------------------
 		{
 			name:            "test root-cert-https cert type request",
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -320,7 +311,6 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 5: invalid cert type requested -------------------------------
 		{
 			name:            "test root-cert-https cert type request",
-			proxyService:    service.MeshService{Name: "service-1", Namespace: "ns-1"},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: nil,

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -137,10 +137,9 @@ func TestGetRootCert(t *testing.T) {
 			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
 			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
-				proxyServices: []service.MeshService{tc.proxyService},
-				svcAccount:    tc.proxySvcAccount,
-				proxy:         envoy.NewProxy(certCommonName, certSerialNumber, nil),
-				certManager:   mockCertManager,
+				svcAccount:  tc.proxySvcAccount,
+				proxy:       envoy.NewProxy(certCommonName, certSerialNumber, nil),
+				certManager: mockCertManager,
 
 				// these points to the dynamic mocks which gets updated for each test
 				meshCatalog: d.mockCatalog,
@@ -356,10 +355,9 @@ func TestGetSDSSecrets(t *testing.T) {
 			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
 			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
-				proxyServices: []service.MeshService{tc.proxyService},
-				svcAccount:    tc.proxySvcAccount,
-				proxy:         envoy.NewProxy(certCommonName, certSerialNumber, nil),
-				certManager:   mockCertManager,
+				svcAccount:  tc.proxySvcAccount,
+				proxy:       envoy.NewProxy(certCommonName, certSerialNumber, nil),
+				certManager: mockCertManager,
 
 				// these points to the dynamic mocks which gets updated for each test
 				meshCatalog: d.mockCatalog,

--- a/pkg/envoy/sds/types.go
+++ b/pkg/envoy/sds/types.go
@@ -16,10 +16,9 @@ var (
 
 // sdsImpl is the type that implements the internal functionality of SDS
 type sdsImpl struct {
-	proxy         *envoy.Proxy
-	proxyServices []service.MeshService
-	svcAccount    service.K8sServiceAccount
-	meshCatalog   catalog.MeshCataloger
-	cfg           configurator.Configurator
-	certManager   certificate.Manager
+	proxy       *envoy.Proxy
+	svcAccount  service.K8sServiceAccount
+	meshCatalog catalog.MeshCataloger
+	cfg         configurator.Configurator
+	certManager certificate.Manager
 }


### PR DESCRIPTION
This PR cleans up SDS:
 - removes  `proxyServices` from the `sdsImpl` struct
 - removes the use of `GetServicesFromEnvoyCertificate()`, which is no longer needed.