### PR TITLE
sds: Skip Secrets that cannot be marshaled

### DIFF
--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -77,6 +77,7 @@ func (s *sdsImpl) createDiscoveryResponse(request *xds_discovery.DiscoveryReques
 		marshalledSecret, err := ptypes.MarshalAny(envoyProto)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error marshaling Envoy secret %s for proxy with certificate SerialNumber=%s on Pod with UID=%s", envoyProto.Name, s.proxy.GetCertificateSerialNumber(), s.proxy.GetPodUID())
+			continue
 		}
 
 		resources = append(resources, marshalledSecret)


### PR DESCRIPTION
When we fail to marshal an xDS secret, we should not be sending the (most likely nil) struct to the respective Envoys.

Discovered this line while working on the following test PR: https://github.com/openservicemesh/osm/pull/2634