### PR TITLE
fix links to work on both github and the website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,7 +52,7 @@ Note that the full path can also specify the release (as branchname), as the str
 
 Relative links between markdown pages within the site should be simpler, except [it's hard](https://github.com/openservicemesh/osm/issues/2453#issuecomment-776236289) to create links that work on both Github.com and docs.openservicemesh.io. Github paths require file extensions (`/filename.md`), whereas Hugo needs just the slug (`/filename`). 
 
-To ensure the relative link works in both destinations, the best approach is to write the url with the `.md` extension (for Github) and then to add an `aliases` redirect for the path with the extension. 
+To ensure the relative link works in both destinations, the best approach is to write the url with the `.md` extension (for Github) and then to add an `aliases` redirect for the path with the extension. (The path without the extension will work on the website by default.)
 
 Example - linking foo.md (1) to bar.md (2):
 
@@ -62,7 +62,7 @@ Example - linking foo.md (1) to bar.md (2):
 title: "Foo.md"
 description: "Foo"
 type: docs
-aliases: ["foo"]
+aliases: ["foo.md"]
 ---
 
 Here's a link to [Bar](./bar.md).
@@ -74,7 +74,7 @@ Here's a link to [Bar](./bar.md).
 title: "Bar.md"
 description: "Bar"
 type: docs
-aliases: ["bar"]
+aliases: ["bar.md"]
 ---
 
 This is Bar. Go back to [Foo](./foo.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,7 +62,7 @@ Example - linking foo.md (1) to bar.md (2):
 title: "Foo.md"
 description: "Foo"
 type: docs
-aliases: ["foo.md"]
+aliases: ["foo"]
 ---
 
 Here's a link to [Bar](./bar.md).
@@ -74,7 +74,7 @@ Here's a link to [Bar](./bar.md).
 title: "Bar.md"
 description: "Bar"
 type: docs
-aliases: ["bar.md"]
+aliases: ["bar"]
 ---
 
 This is Bar. Go back to [Foo](./foo.md).

--- a/docs/content/docs/patterns/observability/_index.md
+++ b/docs/content/docs/patterns/observability/_index.md
@@ -10,6 +10,6 @@ aliases: ["observability"]
 OSM's observability stack includes Prometheus for metrics collection, Grafana for metrics visualization, Jaeger for tracing and Fluent Bit for log forwarding to a user-defined endpoint. These are disabled by default but may be enabled during OSM installation with flags `--deploy-prometheus`, `--deploy-grafana`, `--deploy-jaeger` and `--enable-fluentbit`.
 
 ## Table of Contents
-- [Metrics - Prometheus and Grafana](./metrics.md)
+- [Metrics - Prometheus and Grafana](/docs/tasks_usage/metrics.md)
 - [Tracing - Jaeger](./tracing.md)
-- [Log forwarding - Fluent Bit](./logs.md)
+- [Log forwarding - Fluent Bit](/docs/tasks_usage/logs.md)

--- a/docs/content/docs/patterns/observability/tracing.md
+++ b/docs/content/docs/patterns/observability/tracing.md
@@ -2,7 +2,7 @@
 title: "Tracing"
 description: "Tracing"
 type: docs
-aliases: ["tracing"]
+aliases: ["tracing.md"]
 ---
 
 # Tracing

--- a/docs/content/docs/patterns/observability/tracing.md
+++ b/docs/content/docs/patterns/observability/tracing.md
@@ -2,6 +2,7 @@
 title: "Tracing"
 description: "Tracing"
 type: docs
+aliases: ["tracing"]
 ---
 
 # Tracing

--- a/docs/content/docs/tasks_usage/logs.md
+++ b/docs/content/docs/tasks_usage/logs.md
@@ -2,7 +2,7 @@
 title: "Logs"
 description: "Logs"
 type: docs
-aliases: ["logs"]
+aliases: ["logs.md"]
 ---
 
 # Logs

--- a/docs/content/docs/tasks_usage/logs.md
+++ b/docs/content/docs/tasks_usage/logs.md
@@ -2,6 +2,7 @@
 title: "Logs"
 description: "Logs"
 type: docs
+aliases: ["logs"]
 ---
 
 # Logs

--- a/docs/content/docs/tasks_usage/metrics.md
+++ b/docs/content/docs/tasks_usage/metrics.md
@@ -2,6 +2,7 @@
 title: "Metrics"
 description: "Metrics"
 type: docs
+aliases: ["metrics"]
 ---
 
 

--- a/docs/content/docs/tasks_usage/metrics.md
+++ b/docs/content/docs/tasks_usage/metrics.md
@@ -2,7 +2,7 @@
 title: "Metrics"
 description: "Metrics"
 type: docs
-aliases: ["metrics"]
+aliases: ["metrics.md"]
 ---
 
 


### PR DESCRIPTION
It seems that aliases are the correct way to achieve links that work on both github and the website. This PR will serve as a test for the website build (to see if this is correct).

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>
