### PR TITLE
service: Simplify stringer method for K8sServiceAccount

### DIFF
--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,9 +1,7 @@
 // Package service models an instance of a service managed by OSM controller and utility routines associated with it.
 package service
 
-import (
-	"strings"
-)
+import "fmt"
 
 const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
@@ -28,7 +26,7 @@ type K8sServiceAccount struct {
 
 // String returns the string representation of the service account object
 func (sa K8sServiceAccount) String() string {
-	return strings.Join([]string{sa.Namespace, namespaceNameSeparator, sa.Name}, "")
+	return fmt.Sprintf("%s%s%s", sa.Namespace, namespaceNameSeparator, sa.Name)
 }
 
 // IsEmpty returns true if the given service account object is empty

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test pkg/service functions", func() {
+	defer GinkgoRecover()
+
+	Context("Test K8sServiceAccount struct methods", func() {
+		namespace := uuid.New().String()
+		serviceAccountName := uuid.New().String()
+		sa := K8sServiceAccount{
+			Namespace: namespace,
+			Name:      serviceAccountName,
+		}
+
+		It("implements stringer interface correctly", func() {
+			Expect(sa.String()).To(Equal(fmt.Sprintf("%s/%s", namespace, serviceAccountName)))
+		})
+
+		It("implements IsEmpty correctly", func() {
+			Expect(sa.IsEmpty()).To(BeFalse())
+			Expect(K8sServiceAccount{}.IsEmpty()).To(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
This PR is a tiny simplification to the `String()` method of the `service.K8sServiceAccount` struct & adds a test for it.