### PR TITLE
envoy: Test Proxy{} methods

### DIFF
--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -36,6 +36,10 @@ type Proxy struct {
 	PodMetadata *PodMetadata
 }
 
+func (p Proxy) String() string {
+	return fmt.Sprintf("Proxy on Pod with UID=%s", p.GetPodUID())
+}
+
 // PodMetadata is a struct holding information on the Pod on which a given Envoy proxy is installed
 // This struct is initialized *eventually*, when the metadata arrives via xDS.
 type PodMetadata struct {
@@ -159,11 +163,6 @@ func (p Proxy) GetCertificateSerialNumber() certificate.SerialNumber {
 // GetConnectedAt returns the timestamp of when the given proxy connected to the control plane.
 func (p Proxy) GetConnectedAt() time.Time {
 	return p.connectedAt
-}
-
-// GetIP returns the IP address of the Envoy proxy connected to xDS.
-func (p Proxy) GetIP() net.Addr {
-	return p.Addr
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the given Envoy proxy.

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -30,15 +30,89 @@ var _ = Describe("Test proxy methods", func() {
 		})
 	})
 
+	Context("test GetLastAppliedVersion()", func() {
+		It("returns correct values", func() {
+			actual := proxy.GetLastAppliedVersion(TypeCDS)
+			Expect(actual).To(Equal(uint64(0)))
+
+			proxy.SetLastAppliedVersion(TypeCDS, uint64(345))
+
+			actual = proxy.GetLastAppliedVersion(TypeCDS)
+			Expect(actual).To(Equal(uint64(345)))
+		})
+	})
+
+	Context("test GetLastSentNonce()", func() {
+		It("returns correct values", func() {
+			proxy.SetNewNonce(TypeCDS)
+
+			firstNonce := proxy.GetLastSentNonce(TypeCDS)
+			Expect(firstNonce).ToNot(Equal(uint64(0)))
+
+			proxy.SetNewNonce(TypeCDS)
+
+			secondNonce := proxy.GetLastSentNonce(TypeCDS)
+			Expect(secondNonce).ToNot(Equal(firstNonce))
+		})
+	})
+
+	Context("test GetLastSentVersion()", func() {
+		It("returns correct values", func() {
+			actual := proxy.GetLastSentVersion(TypeCDS)
+			Expect(actual).To(Equal(uint64(0)))
+
+			newVersion := uint64(132)
+			proxy.SetLastSentVersion(TypeCDS, newVersion)
+
+			actual = proxy.GetLastSentVersion(TypeCDS)
+			Expect(actual).To(Equal(newVersion))
+
+			proxy.IncrementLastSentVersion(TypeCDS)
+			actual = proxy.GetLastSentVersion(TypeCDS)
+			Expect(actual).To(Equal(newVersion + 1))
+		})
+	})
+
+	Context("test GetConnectedAt()", func() {
+		It("returns correct values", func() {
+			actual := proxy.GetConnectedAt()
+			Expect(actual).ToNot(Equal(uint64(0)))
+		})
+	})
+
+	Context("test HasPodMetadata()", func() {
+		It("returns correct values", func() {
+			actual := proxy.HasPodMetadata()
+			Expect(actual).To(BeFalse())
+		})
+	})
+
+	Context("test StatsHeaders()", func() {
+		It("returns correct values", func() {
+			actual := proxy.StatsHeaders()
+			expected := map[string]string{
+				"osm-stats-namespace": "unknown",
+				"osm-stats-kind":      "unknown",
+				"osm-stats-name":      "unknown",
+				"osm-stats-pod":       "unknown",
+			}
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
 	Context("test correctness proxy object creation", func() {
 		It("returns correct values", func() {
 			Expect(proxy.GetCertificateCommonName()).To(Equal(certCommonName))
 			Expect(proxy.GetCertificateSerialNumber()).To(Equal(certSerialNumber))
+			Expect(proxy.HasPodMetadata()).To(BeFalse())
 
 			proxy.PodMetadata = &PodMetadata{
 				UID: podUID,
 			}
+
+			Expect(proxy.HasPodMetadata()).To(BeTrue())
 			Expect(proxy.GetPodUID()).To(Equal(podUID))
+			Expect(proxy.String()).To(Equal(fmt.Sprintf("Proxy on Pod with UID=%s", podUID)))
 		})
 	})
 })


### PR DESCRIPTION
This PR adds test for the methods of `Proxy{}` struct in `pkg/envoy`.