### PR TITLE
pkg/envoy: Remove announcement channel from Proxy{}

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -162,10 +162,6 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 		case <-broadcastUpdate:
 			log.Debug().Msgf("Broadcast update received for Envoy with xDS Certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 			s.sendAllResponses(proxy, &server, s.cfg)
-
-		case <-proxy.GetAnnouncementsChannel():
-			log.Debug().Msgf("Individual update for Envoy with xDS Certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-			s.sendAllResponses(proxy, &server, s.cfg)
 		}
 	}
 }

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
@@ -20,7 +19,6 @@ type Proxy struct {
 	xDSCertificateSerialNumber certificate.SerialNumber
 
 	net.Addr
-	announcements chan announcements.Announcement
 
 	// The time this Proxy connected to the OSM control plane
 	connectedAt time.Time
@@ -166,11 +164,6 @@ func (p Proxy) GetIP() net.Addr {
 	return p.Addr
 }
 
-// GetAnnouncementsChannel returns the announcement channel for the given Envoy proxy.
-func (p Proxy) GetAnnouncementsChannel() chan announcements.Announcement {
-	return p.announcements
-}
-
 // NewProxy creates a new instance of an Envoy proxy connected to the xDS servers.
 func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificate.SerialNumber, ip net.Addr) *Proxy {
 	return &Proxy{
@@ -181,7 +174,6 @@ func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificat
 
 		connectedAt: time.Now(),
 
-		announcements:      make(chan announcements.Announcement),
 		lastNonce:          make(map[TypeURI]string),
 		lastSentVersion:    make(map[TypeURI]uint64),
 		lastAppliedVersion: make(map[TypeURI]uint64),


### PR DESCRIPTION
This PR removes the unused `announcements` channel from the `Proxy{}` struct