### PR TITLE
Move dispatcher and pubsub into new pkg/dispatcher package

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/debugger"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
 	"github.com/openservicemesh/osm/pkg/envoy/ads"
@@ -124,7 +125,7 @@ func main() {
 	}
 
 	featureflags.Initialize(optionalFeatures)
-	events.GetPubSubInstance() // Just to generate the interface, single routine context
+	dispatcher.GetPubSubInstance() // Just to generate the interface, single routine context
 
 	// Initialize kube config and client
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)

--- a/pkg/catalog/announcement_handlers_test.go
+++ b/pkg/catalog/announcement_handlers_test.go
@@ -3,20 +3,18 @@ package catalog
 import (
 	"time"
 
-	"github.com/google/uuid"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/google/uuid"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 )
 
 var _ = Describe("Test Announcement Handlers", func() {
@@ -59,11 +57,11 @@ var _ = Describe("Test Announcement Handlers", func() {
 
 			// Register to Update proxies event. We should see a schedule broadcast update
 			// requested by the handler when the certificate is released.
-			rcvBroadcastChannel := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
+			rcvBroadcastChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ScheduleProxyBroadcast)
 
 			// Publish a podDeleted event
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
-				AnnouncementType: announcements.PodDeleted,
+			dispatcher.GetPubSubInstance().Publish(dispatcher.PubSubMessage{
+				AnnouncementType: dispatcher.PodDeleted,
 				NewObj:           nil,
 				OldObj: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -99,8 +97,8 @@ var _ = Describe("Test Announcement Handlers", func() {
 			Expect(connectedProxies[0]).To(Equal(*proxy))
 
 			// Publish some event unrelated to podDeleted
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
-				AnnouncementType: announcements.IngressAdded,
+			dispatcher.GetPubSubInstance().Publish(dispatcher.PubSubMessage{
+				AnnouncementType: dispatcher.IngressAdded,
 				NewObj:           nil,
 				OldObj: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
@@ -12,7 +13,7 @@ import (
 )
 
 // NewMeshCatalog creates a new service catalog
-func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
+func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
 	log.Info().Msg("Create a new Service MeshCatalog.")
 	mc := MeshCatalog{
 		endpointsProviders: endpointsProviders,
@@ -31,7 +32,7 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 	// Run release certificate handler, which listens to podDelete events
 	mc.releaseCertificateHandler()
 
-	go mc.dispatcher()
+	go dispatcher.Start(stop)
 	return &mc
 }
 

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -35,7 +35,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 	meshSpec := smi.NewFakeMeshSpecClient()
 
-	stop := make(<-chan struct{})
+	stop := make(chan struct{})
 	endpointProviders := []endpoint.Provider{
 		kube.NewFakeProvider(),
 	}
@@ -88,7 +88,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 			return nil
 		}
 
-		var podRet []*v1.Pod = []*v1.Pod{}
+		var podRet []*v1.Pod
 		for idx := range vv.Items {
 			podRet = append(podRet, &vv.Items[idx])
 		}

--- a/pkg/certificate/mock_certificate_generated.go
+++ b/pkg/certificate/mock_certificate_generated.go
@@ -9,7 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	announcements "github.com/openservicemesh/osm/pkg/announcements"
+	dispatcher "github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 // MockCertificater is a mock of Certificater interface
@@ -143,10 +143,10 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GetAnnouncementsChannel mocks base method
-func (m *MockManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
+func (m *MockManager) GetAnnouncementsChannel() <-chan dispatcher.Announcement {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan announcements.Announcement)
+	ret0, _ := ret[0].(<-chan dispatcher.Announcement)
 	return ret0
 }
 

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -15,10 +15,10 @@ import (
 	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 // IssueCertificate implements certificate.Manager and returns a newly issued certificate.
@@ -89,7 +89,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	oldCert := cm.cache[cn]
 	cm.cache[cn] = newCert
 	cm.cacheLock.Unlock()
-	cm.announcements <- announcements.Announcement{}
+	cm.announcements <- dispatcher.Announcement{}
 
 	log.Debug().Msgf("Rotated certificate (old SerialNumber=%s) with new SerialNumber=%s; took %+v", oldCert.GetSerialNumber(), newCert.GetSerialNumber(), time.Since(start))
 
@@ -114,7 +114,7 @@ func (cm *CertManager) ListCertificates() ([]certificate.Certificater, error) {
 
 // GetAnnouncementsChannel returns a channel, which is used to announce when
 // changes have been made to the issued certificates.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
+func (cm *CertManager) GetAnnouncementsChannel() <-chan dispatcher.Announcement {
 	return cm.announcements
 }
 
@@ -244,7 +244,7 @@ func NewCertManager(
 	cm := &CertManager{
 		ca:            ca,
 		cache:         make(map[certificate.CommonName]certificate.Certificater),
-		announcements: make(chan announcements.Announcement),
+		announcements: make(chan dispatcher.Announcement),
 		namespace:     namespace,
 		client:        client.CertmanagerV1beta1().CertificateRequests(namespace),
 		issuerRef:     issuerRef,

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -9,10 +9,10 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1beta1"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1beta1"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -42,7 +42,7 @@ type CertManager struct {
 
 	// The channel announcing to the rest of the system when a certificate has
 	// changed.
-	announcements chan announcements.Announcement
+	announcements chan dispatcher.Announcement
 
 	// Control plane namespace where CertificateRequests are created.
 	namespace string

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -3,10 +3,10 @@ package tresor
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 const (
@@ -54,7 +54,7 @@ func NewCertManager(ca certificate.Certificater, certificatesOrganization string
 		ca: ca,
 
 		// Channel used to inform other components of cert changes (rotation etc.)
-		announcements: make(chan announcements.Announcement),
+		announcements: make(chan dispatcher.Announcement),
 
 		certificatesOrganization: certificatesOrganization,
 

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
@@ -152,7 +152,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	}
 
 	cm.cache.Store(cn, cert)
-	cm.announcements <- announcements.Announcement{}
+	cm.announcements <- dispatcher.Announcement{}
 
 	log.Debug().Msgf("Rotated certificate with new SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
 
@@ -175,6 +175,6 @@ func (cm *CertManager) GetRootCertificate() (certificate.Certificater, error) {
 }
 
 // GetAnnouncementsChannel implements certificate.Manager and returns the channel on which the certificate manager announces changes made to certificates.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
+func (cm *CertManager) GetAnnouncementsChannel() <-chan dispatcher.Announcement {
 	return cm.announcements
 }

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -3,9 +3,9 @@ package tresor
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 const (
@@ -23,7 +23,7 @@ func NewFakeCertManager(cfg configurator.Configurator) *CertManager {
 
 	return &CertManager{
 		ca:            ca.(*Certificate),
-		announcements: make(chan announcements.Announcement),
+		announcements: make(chan dispatcher.Announcement),
 		cfg:           cfg,
 	}
 }

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -35,7 +35,7 @@ type CertManager struct {
 	ca certificate.Certificater
 
 	// The channel announcing to the rest of the system when a certificate has changed
-	announcements chan announcements.Announcement
+	announcements chan dispatcher.Announcement
 
 	// Cache for all the certificates issued
 	// Types: map[certificate.CommonName]certificate.Certificater

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -6,12 +6,12 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -34,7 +34,7 @@ const (
 // NewCertManager implements certificate.Manager and wraps a Hashi Vault with methods to allow easy certificate issuance.
 func NewCertManager(vaultAddr, token string, role string, cfg configurator.Configurator) (*CertManager, error) {
 	c := &CertManager{
-		announcements: make(chan announcements.Announcement),
+		announcements: make(chan dispatcher.Announcement),
 		role:          vaultRole(role),
 		cfg:           cfg,
 	}
@@ -161,7 +161,7 @@ func (cm *CertManager) GetRootCertificate() (certificate.Certificater, error) {
 }
 
 // GetAnnouncementsChannel returns a channel used by the Hashi Vault instance to signal when a certificate has been changed.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
+func (cm *CertManager) GetAnnouncementsChannel() <-chan dispatcher.Announcement {
 	return cm.announcements
 }
 
@@ -175,7 +175,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	}
 
 	cm.cache.Store(cn, cert)
-	cm.announcements <- announcements.Announcement{}
+	cm.announcements <- dispatcher.Announcement{}
 
 	log.Trace().Msgf("Rotated certificate with new SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
 

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/hashicorp/vault/api"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 // CertManager implements certificate.Manager and contains a Hashi Vault client instance.
@@ -17,7 +17,7 @@ type CertManager struct {
 	ca certificate.Certificater
 
 	// The channel announcing to the rest of the system when a certificate has changed
-	announcements chan announcements.Announcement
+	announcements chan dispatcher.Announcement
 
 	// Cache for all the certificates issued
 	// Types: map[certificate.CommonName]certificate.Certificater

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -5,7 +5,7 @@ package certificate
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 const (
@@ -78,5 +78,5 @@ type Manager interface {
 	ReleaseCertificate(CommonName)
 
 	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the issued certificates.
-	GetAnnouncementsChannel() <-chan announcements.Announcement
+	GetAnnouncementsChannel() <-chan dispatcher.Announcement
 }

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -12,8 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 const (
@@ -30,11 +29,11 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 	cfg := newConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 	Expect(cfg).ToNot(BeNil())
 
-	confChannel := events.GetPubSubInstance().Subscribe(
-		announcements.ConfigMapAdded,
-		announcements.ConfigMapDeleted,
-		announcements.ConfigMapUpdated)
-	defer events.GetPubSubInstance().Unsub(confChannel)
+	confChannel := dispatcher.GetPubSubInstance().Subscribe(
+		dispatcher.ConfigMapAdded,
+		dispatcher.ConfigMapDeleted,
+		dispatcher.ConfigMapUpdated)
+	defer dispatcher.GetPubSubInstance().Unsub(confChannel)
 
 	configMap := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -11,8 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 )
 
 var _ = Describe("Test Envoy configuration creation", func() {
@@ -47,14 +46,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("test GetConfigMap", func() {
@@ -95,14 +94,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly identifies that permissive_traffic_policy_mode is enabled", func() {
@@ -158,14 +157,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly identifies that egress is enabled", func() {
@@ -220,14 +219,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly identifies that the debug server is enabled", func() {
@@ -259,14 +258,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 		var confChannel chan interface{}
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly identifies that the config is enabled", func() {
@@ -321,14 +320,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly identifies that the config is enabled", func() {
@@ -385,14 +384,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly identifies that the Envoy log level is error", func() {
@@ -468,14 +467,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly retrieves the default service cert validity duration when an invalid value is specified", func() {
@@ -520,14 +519,14 @@ var _ = Describe("Test Envoy configuration creation", func() {
 		var confChannel chan interface{}
 
 		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
+			confChannel = dispatcher.GetPubSubInstance().Subscribe(
+				dispatcher.ConfigMapAdded,
+				dispatcher.ConfigMapDeleted,
+				dispatcher.ConfigMapUpdated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
+			dispatcher.GetPubSubInstance().Unsub(confChannel)
 		})
 
 		It("correctly returns an empty list when no exclusion list is specified", func() {

--- a/pkg/debugger/debugger_config_listener.go
+++ b/pkg/debugger/debugger_config_listener.go
@@ -1,19 +1,18 @@
 package debugger
 
 import (
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/httpserver"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 )
 
 // StartDebugServerConfigListener registers a go routine to listen to configuration and configure debug server as needed
 func (d *DebugConfig) StartDebugServerConfigListener() {
 	// Subscribe to configuration updates
-	ch := events.GetPubSubInstance().Subscribe(
-		announcements.ConfigMapAdded,
-		announcements.ConfigMapDeleted,
-		announcements.ConfigMapUpdated)
+	ch := dispatcher.GetPubSubInstance().Subscribe(
+		dispatcher.ConfigMapAdded,
+		dispatcher.ConfigMapDeleted,
+		dispatcher.ConfigMapUpdated)
 
 	// This is the Debug server
 	httpDebugServer := httpserver.NewHTTPServer(constants.DebugPort)

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -1,46 +1,95 @@
-package catalog
+package dispatcher
 
 import (
 	"reflect"
 	"strings"
 	"time"
 
-	a "github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+	"github.com/openservicemesh/osm/pkg/logger"
 )
 
 const (
 	// maxBroadcastDeadlineTime is the max time we will delay a global proxy update
 	// if multiple events that would trigger it get coalesced over time.
 	maxBroadcastDeadlineTime = 15 * time.Second
+
 	// maxGraceDeadlineTime is the time we will wait for an additional global proxy update
 	// trigger if we just received one.
 	maxGraceDeadlineTime = 3 * time.Second
 )
 
+var log = logger.New("dispatcher")
+
+var (
+	// Broadcast is a group of AnnouncementTypes
+	Broadcast = []AnnouncementType{ScheduleProxyBroadcast} // Other modules requesting a global envoy update
+
+	// Endpoint is a group of AnnouncementTypes
+	Endpoint = []AnnouncementType{EndpointAdded, EndpointDeleted, EndpointUpdated} // endpoint
+
+	// Namespace is a group of AnnouncementTypes
+	Namespace = []AnnouncementType{NamespaceAdded, NamespaceDeleted, NamespaceUpdated} // namespace
+
+	// Pod is a group of AnnouncementTypes
+	Pod = []AnnouncementType{PodAdded, PodDeleted, PodUpdated} // pod
+
+	// RouteGroup is a group of AnnouncementTypes
+	RouteGroup = []AnnouncementType{RouteGroupAdded, RouteGroupDeleted, RouteGroupUpdated} // routegroup
+
+	// Service is a group of AnnouncementTypes
+	Service = []AnnouncementType{ServiceAdded, ServiceDeleted, ServiceUpdated} // service
+
+	// ServiceAccount is a group of AnnouncementTypes
+	ServiceAccount = []AnnouncementType{ServiceAccountAdded, ServiceAccountDeleted, ServiceAccountUpdated} // serviceaccount
+
+	// TrafficSplit is a group of AnnouncementTypes
+	TrafficSplit = []AnnouncementType{TrafficSplitAdded, TrafficSplitDeleted, TrafficSplitUpdated} // traffic split
+
+	// TrafficTarget is a group of AnnouncementTypes
+	TrafficTarget = []AnnouncementType{TrafficTargetAdded, TrafficTargetDeleted, TrafficTargetUpdated} // traffic target
+
+	// Ingress is a group of AnnouncementTypes
+	Ingress = []AnnouncementType{IngressAdded, IngressDeleted, IngressUpdated} // Ingress
+
+	// TCPRoute is a group of AnnouncementTypes
+	TCPRoute = []AnnouncementType{TCPRouteAdded, TCPRouteDeleted, TCPRouteUpdated} // TCProute
+)
+
+var allGroups = [][]AnnouncementType{
+	Broadcast,
+	Endpoint,
+	Namespace,
+	Pod,
+	RouteGroup,
+	Service,
+	ServiceAccount,
+	TrafficSplit,
+	TrafficTarget,
+	Ingress,
+	TCPRoute,
+}
+
+func flatten(groups ...[]AnnouncementType) []AnnouncementType {
+	var all []AnnouncementType
+	for _, group := range groups {
+		all = append(all, group...)
+	}
+	return all
+}
+
 // isDeltaUpdate assesses and returns if a pubsub message contains an actual delta in config
-func isDeltaUpdate(psubMsg events.PubSubMessage) bool {
+func isDeltaUpdate(psubMsg PubSubMessage) bool {
+	// TODO(draychev): "updated" needs to be a constant tied to the actual AnnouncementType
 	return !(strings.HasSuffix(psubMsg.AnnouncementType.String(), "updated") &&
 		reflect.DeepEqual(psubMsg.OldObj, psubMsg.NewObj))
 }
 
-func (mc *MeshCatalog) dispatcher() {
+// Start launches the dispatcher goroutine.
+func Start(stop chan struct{}) {
 	// This will be finely tuned in near future, we can instrument other modules
-	// to take ownership of certain events, and just notify dispatcher through
+	// to take ownership of certain events, and just notify Start through
 	// ScheduleBroadcastUpdate announcement type
-	subChannel := events.GetPubSubInstance().Subscribe(
-		a.ScheduleProxyBroadcast,                              // Other modules requesting a global envoy update
-		a.EndpointAdded, a.EndpointDeleted, a.EndpointUpdated, // endpoint
-		a.NamespaceAdded, a.NamespaceDeleted, a.NamespaceUpdated, // namespace
-		a.PodAdded, a.PodDeleted, a.PodUpdated, // pod
-		a.RouteGroupAdded, a.RouteGroupDeleted, a.RouteGroupUpdated, // routegroup
-		a.ServiceAdded, a.ServiceDeleted, a.ServiceUpdated, // service
-		a.ServiceAccountAdded, a.ServiceAccountDeleted, a.ServiceAccountUpdated, // serviceaccount
-		a.TrafficSplitAdded, a.TrafficSplitDeleted, a.TrafficSplitUpdated, // traffic split
-		a.TrafficTargetAdded, a.TrafficTargetDeleted, a.TrafficTargetUpdated, // traffic target
-		a.IngressAdded, a.IngressDeleted, a.IngressUpdated, // Ingress
-		a.TCPRouteAdded, a.TCPRouteDeleted, a.TCPRouteUpdated, // TCProute
-	)
+	subChannel := GetPubSubInstance().Subscribe(flatten(allGroups...)...)
 
 	// State and channels for event-coalescing
 	broadcastScheduled := false
@@ -63,10 +112,14 @@ func (mc *MeshCatalog) dispatcher() {
 
 	for {
 		select {
+		case <-stop:
+			log.Info().Msg("Dispatcher is quitting! (via stop channel)")
+			return
+
 		case message := <-subChannel:
 
 			// New message from pubsub
-			psubMessage, castOk := message.(events.PubSubMessage)
+			psubMessage, castOk := message.(PubSubMessage)
 			if !castOk {
 				log.Error().Msgf("Error casting PubSubMessage: %v", psubMessage)
 				continue
@@ -74,12 +127,12 @@ func (mc *MeshCatalog) dispatcher() {
 
 			// Identify if this is an actual delta, or just resync
 			delta := isDeltaUpdate(psubMessage)
-			log.Debug().Msgf("[Pubsub] %s - delta: %v", psubMessage.AnnouncementType.String(), delta)
+			log.Debug().Msgf("%s - delta: %v", psubMessage.AnnouncementType.String(), delta)
 
 			// Schedule an envoy broadcast update if we either:
 			// - detected a config delta
 			// - another module requested a broadcast through ScheduleProxyBroadcast
-			if delta || psubMessage.AnnouncementType == a.ScheduleProxyBroadcast {
+			if delta || psubMessage.AnnouncementType == ScheduleProxyBroadcast {
 				if !broadcastScheduled {
 					broadcastScheduled = true
 					chanMaxDeadline = time.After(maxBroadcastDeadlineTime)
@@ -96,8 +149,8 @@ func (mc *MeshCatalog) dispatcher() {
 		// A select-fallthrough doesn't exist, we are copying some code here
 		case <-chanMovingDeadline:
 			log.Debug().Msgf("[Moving deadline trigger] Broadcast envoy update")
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
-				AnnouncementType: a.ProxyBroadcast,
+			GetPubSubInstance().Publish(PubSubMessage{
+				AnnouncementType: ProxyBroadcast,
 			})
 
 			// broadcast done, reset timer channels
@@ -107,8 +160,8 @@ func (mc *MeshCatalog) dispatcher() {
 
 		case <-chanMaxDeadline:
 			log.Debug().Msgf("[Max deadline trigger] Broadcast envoy update")
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
-				AnnouncementType: a.ProxyBroadcast,
+			GetPubSubInstance().Publish(PubSubMessage{
+				AnnouncementType: ProxyBroadcast,
 			})
 
 			// broadcast done, reset timer channels

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -1,0 +1,38 @@
+package dispatcher
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test Dispatcher functions", func() {
+	defer GinkgoRecover()
+	Context("Test isDeltaUpdate()", func() {
+		It("returns false", func() {
+			message := PubSubMessage{
+				AnnouncementType: EndpointUpdated,
+				OldObj:           nil,
+				NewObj:           nil,
+			}
+			actual := isDeltaUpdate(message)
+			Expect(actual).To(BeFalse())
+		})
+	})
+
+	Context("Test flatten()", func() {
+		It("flattens the groups of announcement types", func() {
+			groups := [][]AnnouncementType{{TCPRouteAdded, TCPRouteDeleted}, {EndpointAdded, EndpointDeleted}}
+			expected := []AnnouncementType{TCPRouteAdded, TCPRouteDeleted, EndpointAdded, EndpointDeleted}
+			actual := flatten(groups...)
+			Expect(actual).To(Equal(expected))
+		})
+	})
+
+	Context("Test Start()", func() {
+		It("works", func() {
+			stop := make(chan struct{})
+			go func() { Start(stop) }()
+			close(stop)
+		})
+	})
+})

--- a/pkg/dispatcher/event_pubsub_test.go
+++ b/pkg/dispatcher/event_pubsub_test.go
@@ -1,4 +1,4 @@
-package events
+package dispatcher
 
 import (
 	"reflect"
@@ -7,8 +7,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
-
-	"github.com/openservicemesh/osm/pkg/announcements"
 )
 
 func TestPubSubEvents(t *testing.T) {
@@ -17,23 +15,23 @@ func TestPubSubEvents(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	testCases := []struct {
-		register      announcements.AnnouncementType
+		register      AnnouncementType
 		publish       PubSubMessage
 		expectMessage bool
 	}{
 		{
-			register: announcements.EndpointAdded,
+			register: EndpointAdded,
 			publish: PubSubMessage{
-				AnnouncementType: announcements.ConfigMapAdded,
+				AnnouncementType: ConfigMapAdded,
 				NewObj:           struct{}{},
 				OldObj:           nil,
 			},
 			expectMessage: false,
 		},
 		{
-			register: announcements.EndpointAdded,
+			register: EndpointAdded,
 			publish: PubSubMessage{
-				AnnouncementType: announcements.EndpointAdded,
+				AnnouncementType: EndpointAdded,
 				NewObj:           nil,
 				OldObj:           "randomString",
 			},
@@ -66,11 +64,11 @@ func TestPubSubClose(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	subChannel := GetPubSubInstance().Subscribe(announcements.EndpointUpdated)
+	subChannel := GetPubSubInstance().Subscribe(EndpointUpdated)
 
 	// publish something
 	GetPubSubInstance().Publish(PubSubMessage{
-		AnnouncementType: announcements.EndpointUpdated,
+		AnnouncementType: EndpointUpdated,
 	})
 
 	// make sure channel is drained and closed

--- a/pkg/dispatcher/pubsub.go
+++ b/pkg/dispatcher/pubsub.go
@@ -1,10 +1,6 @@
-package events
+package dispatcher
 
-import (
-	"github.com/cskr/pubsub"
-
-	"github.com/openservicemesh/osm/pkg/announcements"
-)
+import "github.com/cskr/pubsub"
 
 const (
 	// Default number of events a subscriber channel will buffer
@@ -22,7 +18,7 @@ type osmPubsub struct {
 }
 
 // Subscribe is the Subscribe implementation for PubSub
-func (c *osmPubsub) Subscribe(aTypes ...announcements.AnnouncementType) chan interface{} {
+func (c *osmPubsub) Subscribe(aTypes ...AnnouncementType) chan interface{} {
 	subTypes := []string{}
 	for _, v := range aTypes {
 		subTypes = append(subTypes, string(v))

--- a/pkg/dispatcher/suite_test.go
+++ b/pkg/dispatcher/suite_test.go
@@ -1,4 +1,4 @@
-package events
+package dispatcher
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestEvents(t *testing.T) {
+func TestCatalog(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Kubernetes events test suite")
+	RunSpecs(t, "Dispatcher Test Suite")
 }

--- a/pkg/dispatcher/types.go
+++ b/pkg/dispatcher/types.go
@@ -1,6 +1,27 @@
-// Package announcements provides the types and constants required to contextualize events received from the
+// Package dispatcher provides the types and constants required to contextualize events received from the
 // Kubernetes API server that are propagated internally within the control plane to trigger configuration changes.
-package announcements
+package dispatcher
+
+// PubSubMessage represents a common messages abstraction to pass through the PubSub interface
+type PubSubMessage struct {
+	AnnouncementType AnnouncementType
+	OldObj           interface{}
+	NewObj           interface{}
+}
+
+// PubSub is a simple interface to call for pubsub functionality in front of a pubsub implementation
+type PubSub interface {
+	// Subscribe returns a channel subscribed to the specific type/s of announcement/s passed by parameter
+	Subscribe(aTypes ...AnnouncementType) chan interface{}
+
+	// Publish publishes the message to all subscribers that have subscribed to <message.AnnouncementType> topic
+	Publish(message PubSubMessage)
+
+	// Unsub unsubscribes and closes the channel on pubsub backend
+	// Note this is a necessary step to ensure a channel can be
+	// garbage collected when it is freed.
+	Unsub(unsubChan chan interface{})
+}
 
 // AnnouncementType is used to record the type of announcement
 type AnnouncementType string

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -18,12 +18,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/utils"
@@ -307,14 +306,14 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	})
 
 	It("should return a service that matches the ServiceAccount associated with the Pod", func() {
-		podsAndServiceChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
-			announcements.PodDeleted,
-			announcements.PodUpdated,
-			announcements.ServiceAdded,
-			announcements.ServiceDeleted,
-			announcements.ServiceUpdated,
+		podsAndServiceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.PodAdded,
+			dispatcher.PodDeleted,
+			dispatcher.PodUpdated,
+			dispatcher.ServiceAdded,
+			dispatcher.ServiceDeleted,
+			dispatcher.ServiceUpdated,
 		)
-		defer events.GetPubSubInstance().Unsub(podsAndServiceChannel)
+		defer dispatcher.GetPubSubInstance().Unsub(podsAndServiceChannel)
 
 		// Create a Service
 		svc := &corev1.Service{
@@ -388,10 +387,10 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	})
 
 	It("should return an error when the Service selector doesn't match the pod", func() {
-		podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
-			announcements.PodDeleted,
-			announcements.PodUpdated)
-		defer events.GetPubSubInstance().Unsub(podsChannel)
+		podsChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.PodAdded,
+			dispatcher.PodDeleted,
+			dispatcher.PodUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(podsChannel)
 
 		// Create a Service
 		svc := &corev1.Service{
@@ -460,10 +459,10 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	})
 
 	It("should return an error when the service doesn't have a selector", func() {
-		podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
-			announcements.PodDeleted,
-			announcements.PodUpdated)
-		defer events.GetPubSubInstance().Unsub(podsChannel)
+		podsChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.PodAdded,
+			dispatcher.PodDeleted,
+			dispatcher.PodUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(podsChannel)
 
 		// Create a Service
 		svc := &corev1.Service{
@@ -531,14 +530,14 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		// This test is meant to ensure the
 		// service selector logic works as expected when multiple services
 		// have the same selector match.
-		podsAndServiceChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
-			announcements.PodDeleted,
-			announcements.PodUpdated,
-			announcements.ServiceAdded,
-			announcements.ServiceDeleted,
-			announcements.ServiceUpdated,
+		podsAndServiceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.PodAdded,
+			dispatcher.PodDeleted,
+			dispatcher.PodUpdated,
+			dispatcher.ServiceAdded,
+			dispatcher.ServiceDeleted,
+			dispatcher.ServiceUpdated,
 		)
-		defer events.GetPubSubInstance().Unsub(podsAndServiceChannel)
+		defer dispatcher.GetPubSubInstance().Unsub(podsAndServiceChannel)
 
 		// Create a Service
 		svc := &corev1.Service{

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -7,9 +7,8 @@ import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/pkg/errors"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
@@ -49,7 +48,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	go receive(requests, &server, proxy, quit, s.catalog)
 
 	// Register to Envoy global broadcast updates
-	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
+	broadcastUpdate := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ProxyBroadcast)
 
 	// Issues a send all response on a connecting envoy
 	// If this were to fail, it most likely just means we still have configuration being applied on flight,

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -8,8 +8,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -32,9 +32,9 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 	}
 
 	ingrEventTypes := k8s.EventTypes{
-		Add:    announcements.IngressAdded,
-		Update: announcements.IngressUpdated,
-		Delete: announcements.IngressDeleted,
+		Add:    dispatcher.IngressAdded,
+		Update: dispatcher.IngressUpdated,
+		Delete: dispatcher.IngressDeleted,
 	}
 	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", shouldObserve, ingrEventTypes))
 

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -70,9 +70,9 @@ func (c *Client) initNamespaceMonitor() {
 
 	// Add event handler to informer
 	nsEventTypes := EventTypes{
-		Add:    announcements.NamespaceAdded,
-		Update: announcements.NamespaceUpdated,
-		Delete: announcements.NamespaceDeleted,
+		Add:    dispatcher.NamespaceAdded,
+		Update: dispatcher.NamespaceUpdated,
+		Delete: dispatcher.NamespaceDeleted,
 	}
 	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), providerName, nil, nsEventTypes))
 }
@@ -89,9 +89,9 @@ func (c *Client) initServicesMonitor() {
 	c.informers[Services] = informerFactory.Core().V1().Services().Informer()
 
 	svcEventTypes := EventTypes{
-		Add:    announcements.ServiceAdded,
-		Update: announcements.ServiceUpdated,
-		Delete: announcements.ServiceDeleted,
+		Add:    dispatcher.ServiceAdded,
+		Update: dispatcher.ServiceUpdated,
+		Delete: dispatcher.ServiceDeleted,
 	}
 	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), providerName, c.shouldObserve, svcEventTypes))
 }
@@ -102,9 +102,9 @@ func (c *Client) initServiceAccountsMonitor() {
 	c.informers[ServiceAccounts] = informerFactory.Core().V1().ServiceAccounts().Informer()
 
 	svcEventTypes := EventTypes{
-		Add:    announcements.ServiceAccountAdded,
-		Update: announcements.ServiceAccountUpdated,
-		Delete: announcements.ServiceAccountDeleted,
+		Add:    dispatcher.ServiceAccountAdded,
+		Update: dispatcher.ServiceAccountUpdated,
+		Delete: dispatcher.ServiceAccountDeleted,
 	}
 	c.informers[ServiceAccounts].AddEventHandler(GetKubernetesEventHandlers((string)(ServiceAccounts), providerName, c.shouldObserve, svcEventTypes))
 }
@@ -114,9 +114,9 @@ func (c *Client) initPodMonitor() {
 	c.informers[Pods] = informerFactory.Core().V1().Pods().Informer()
 
 	podEventTypes := EventTypes{
-		Add:    announcements.PodAdded,
-		Update: announcements.PodUpdated,
-		Delete: announcements.PodDeleted,
+		Add:    dispatcher.PodAdded,
+		Update: dispatcher.PodUpdated,
+		Delete: dispatcher.PodDeleted,
 	}
 	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), providerName, c.shouldObserve, podEventTypes))
 }
@@ -126,9 +126,9 @@ func (c *Client) initEndpointMonitor() {
 	c.informers[Endpoints] = informerFactory.Core().V1().Endpoints().Informer()
 
 	eptEventTypes := EventTypes{
-		Add:    announcements.EndpointAdded,
-		Update: announcements.EndpointUpdated,
-		Delete: announcements.EndpointDeleted,
+		Add:    dispatcher.EndpointAdded,
+		Update: dispatcher.EndpointUpdated,
+		Delete: dispatcher.EndpointDeleted,
 	}
 	c.informers[Endpoints].AddEventHandler(GetKubernetesEventHandlers((string)(Endpoints), providerName, c.shouldObserve, eptEventTypes))
 }

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"time"
 
-	mapset "github.com/deckarep/golang-set"
-	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -139,10 +139,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should create and delete services, and be detected if NS is monitored", func() {
 			meshSvc := tests.BookbuyerService
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
-				announcements.ServiceDeleted,
-				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			serviceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ServiceAdded,
+				dispatcher.ServiceDeleted,
+				dispatcher.ServiceUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(serviceChannel)
 
 			// Create monitored namespace for this service
 			testNamespace := &corev1.Namespace{
@@ -188,10 +188,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should return a list of Services", func() {
 			// Define services to test with
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
-				announcements.ServiceDeleted,
-				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			serviceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ServiceAdded,
+				dispatcher.ServiceDeleted,
+				dispatcher.ServiceUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(serviceChannel)
 			testSvcs := []service.MeshService{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
@@ -255,10 +255,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should create and delete service accounts, and be detected if NS is monitored", func() {
 			k8sSvcAccount := tests.BookbuyerServiceAccount
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAccountAdded,
-				announcements.ServiceAccountDeleted,
-				announcements.ServiceAccountUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			serviceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ServiceAccountAdded,
+				dispatcher.ServiceAccountDeleted,
+				dispatcher.ServiceAccountUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(serviceChannel)
 
 			// Create monitored namespace for this service
 			testNamespace := &corev1.Namespace{
@@ -291,10 +291,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should return a list of service accounts", func() {
 			// Define services to test with
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAccountAdded,
-				announcements.ServiceAccountDeleted,
-				announcements.ServiceAccountUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			serviceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ServiceAccountAdded,
+				dispatcher.ServiceAccountDeleted,
+				dispatcher.ServiceAccountUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(serviceChannel)
 			testSvcAccounts := []service.K8sServiceAccount{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
@@ -362,14 +362,14 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			testSvcAccountName1 := "test-service-account-1"
 			testSvcAccountName2 := "test-service-account-2"
 
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
-				announcements.ServiceDeleted,
-				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
-			podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
-				announcements.PodDeleted,
-				announcements.PodUpdated)
-			defer events.GetPubSubInstance().Unsub(podsChannel)
+			serviceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ServiceAdded,
+				dispatcher.ServiceDeleted,
+				dispatcher.ServiceUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(serviceChannel)
+			podsChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.PodAdded,
+				dispatcher.PodDeleted,
+				dispatcher.PodUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(podsChannel)
 
 			// Create a namespace
 			testNamespace := &corev1.Namespace{
@@ -461,14 +461,14 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			testSvcAccountName1 := "test-service-account-1"
 			testSvcAccountName2 := "test-service-account-2"
 
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
-				announcements.ServiceDeleted,
-				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
-			podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
-				announcements.PodDeleted,
-				announcements.PodUpdated)
-			defer events.GetPubSubInstance().Unsub(podsChannel)
+			serviceChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.ServiceAdded,
+				dispatcher.ServiceDeleted,
+				dispatcher.ServiceUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(serviceChannel)
+			podsChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.PodAdded,
+				dispatcher.PodDeleted,
+				dispatcher.PodUpdated)
+			defer dispatcher.GetPubSubInstance().Unsub(podsChannel)
 
 			// Create a namespace
 			testNamespace := &corev1.Namespace{

--- a/pkg/kubernetes/event_handlers.go
+++ b/pkg/kubernetes/event_handlers.go
@@ -6,9 +6,8 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
-	a "github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
@@ -20,9 +19,9 @@ type observeFilter func(obj interface{}) bool
 
 // EventTypes is a struct helping pass the correct types to GetKubernetesEventHandlers
 type EventTypes struct {
-	Add    a.AnnouncementType
-	Update a.AnnouncementType
-	Delete a.AnnouncementType
+	Add    dispatcher.AnnouncementType
+	Update dispatcher.AnnouncementType
+	Delete dispatcher.AnnouncementType
 }
 
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
@@ -37,7 +36,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				logNotObservedNamespace(obj, eventTypes.Add, informerName, providerName)
 				return
 			}
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			dispatcher.GetPubSubInstance().Publish(dispatcher.PubSubMessage{
 				AnnouncementType: eventTypes.Add,
 				NewObj:           obj,
 				OldObj:           nil,
@@ -52,7 +51,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				logNotObservedNamespace(newObj, eventTypes.Update, informerName, providerName)
 				return
 			}
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			dispatcher.GetPubSubInstance().Publish(dispatcher.PubSubMessage{
 				AnnouncementType: eventTypes.Update,
 				NewObj:           oldObj,
 				OldObj:           newObj,
@@ -66,7 +65,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				logNotObservedNamespace(obj, eventTypes.Delete, informerName, providerName)
 				return
 			}
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			dispatcher.GetPubSubInstance().Publish(dispatcher.PubSubMessage{
 				AnnouncementType: eventTypes.Delete,
 				NewObj:           nil,
 				OldObj:           obj,
@@ -82,7 +81,7 @@ func getNamespace(obj interface{}) string {
 	return reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
 }
 
-func logNotObservedNamespace(obj interface{}, eventType a.AnnouncementType, informerName, providerName string) {
+func logNotObservedNamespace(obj interface{}, eventType dispatcher.AnnouncementType, informerName, providerName string) {
 	if emitLogs {
 		log.Debug().Msgf("Namespace %q is not observed by OSM; ignoring %s event; informer=%s; provider=%s", getNamespace(obj), eventType, informerName, providerName)
 	}

--- a/pkg/kubernetes/events/types.go
+++ b/pkg/kubernetes/events/types.go
@@ -2,14 +2,9 @@
 // publish events to the Kubernetes API server.
 package events
 
-import (
-	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/logger"
-)
+import "github.com/openservicemesh/osm/pkg/logger"
 
-var (
-	log = logger.New("kube-events")
-)
+var log = logger.New("kube-events")
 
 // Kubernetes Fatal Event reasons
 // Fatal events are prefixed with 'Fatal' to help the event recording framework to wait for fatal
@@ -27,24 +22,3 @@ const (
 	// CertificateIssuanceFailure signifies that a request to issue a certificate failed
 	CertificateIssuanceFailure = "FatalCertificateIssuanceFailure"
 )
-
-// PubSubMessage represents a common messages abstraction to pass through the PubSub interface
-type PubSubMessage struct {
-	AnnouncementType announcements.AnnouncementType
-	OldObj           interface{}
-	NewObj           interface{}
-}
-
-// PubSub is a simple interface to call for pubsub functionality in front of a pubsub implementation
-type PubSub interface {
-	// Subscribe returns a channel subscribed to the specific type/s of announcement/s passed by parameter
-	Subscribe(aTypes ...announcements.AnnouncementType) chan interface{}
-
-	// Publish publishes the message to all subscribers that have subscribed to <message.AnnouncementType> topic
-	Publish(message PubSubMessage)
-
-	// Unsub unsubscribes and closes the channel on pubsub backend
-	// Note this is a necessary step to ensure a channel can be
-	// garbage collected when it is freed.
-	Unsub(unsubChan chan interface{})
-}

--- a/pkg/kubernetes/metrics.go
+++ b/pkg/kubernetes/metrics.go
@@ -1,22 +1,22 @@
 package kubernetes
 
 import (
-	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
-func updateEventSpecificMetrics(eventType announcements.AnnouncementType) {
+func updateEventSpecificMetrics(eventType dispatcher.AnnouncementType) {
 	switch eventType {
-	case announcements.NamespaceAdded:
+	case dispatcher.NamespaceAdded:
 		metricsstore.DefaultMetricsStore.K8sMonitoredNamespaceCount.Inc()
 
-	case announcements.NamespaceDeleted:
+	case dispatcher.NamespaceDeleted:
 		metricsstore.DefaultMetricsStore.K8sMonitoredNamespaceCount.Dec()
 
-	case announcements.PodAdded:
+	case dispatcher.PodAdded:
 		metricsstore.DefaultMetricsStore.K8sMeshPodCount.Inc()
 
-	case announcements.PodDeleted:
+	case dispatcher.PodDeleted:
 		metricsstore.DefaultMetricsStore.K8sMeshPodCount.Dec()
 	}
 }

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -14,11 +13,13 @@ import (
 	smiTrafficSpecInformers "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/informers/externalversions"
 	smiTrafficSplitClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned"
 	smiTrafficSplitInformers "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/informers/externalversions"
+
+	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
-	a "github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -86,7 +87,7 @@ func (c *Client) run(stop <-chan struct{}) error {
 }
 
 // GetAnnouncementsChannel returns the announcement channel for the SMI client.
-func (c *Client) GetAnnouncementsChannel() <-chan a.Announcement {
+func (c *Client) GetAnnouncementsChannel() <-chan dispatcher.Announcement {
 	return c.announcements
 }
 
@@ -115,7 +116,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		informers:      &informerCollection,
 		caches:         &cacheCollection,
 		cacheSynced:    make(chan interface{}),
-		announcements:  make(chan a.Announcement),
+		announcements:  make(chan dispatcher.Announcement),
 		osmNamespace:   osmNamespace,
 		kubeController: kubeController,
 	}
@@ -126,30 +127,30 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 	}
 
 	splitEventTypes := k8s.EventTypes{
-		Add:    a.TrafficSplitAdded,
-		Update: a.TrafficSplitUpdated,
-		Delete: a.TrafficSplitDeleted,
+		Add:    dispatcher.TrafficSplitAdded,
+		Update: dispatcher.TrafficSplitUpdated,
+		Delete: dispatcher.TrafficSplitDeleted,
 	}
 	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", shouldObserve, splitEventTypes))
 
 	routeGroupEventTypes := k8s.EventTypes{
-		Add:    a.RouteGroupAdded,
-		Update: a.RouteGroupUpdated,
-		Delete: a.RouteGroupDeleted,
+		Add:    dispatcher.RouteGroupAdded,
+		Update: dispatcher.RouteGroupUpdated,
+		Delete: dispatcher.RouteGroupDeleted,
 	}
 	informerCollection.HTTPRouteGroup.AddEventHandler(k8s.GetKubernetesEventHandlers("HTTPRouteGroup", "SMI", shouldObserve, routeGroupEventTypes))
 
 	tcpRouteEventTypes := k8s.EventTypes{
-		Add:    a.TCPRouteAdded,
-		Update: a.TCPRouteUpdated,
-		Delete: a.TCPRouteDeleted,
+		Add:    dispatcher.TCPRouteAdded,
+		Update: dispatcher.TCPRouteUpdated,
+		Delete: dispatcher.TCPRouteDeleted,
 	}
 	informerCollection.TCPRoute.AddEventHandler(k8s.GetKubernetesEventHandlers("TCPRoute", "SMI", shouldObserve, tcpRouteEventTypes))
 
 	trafficTargetEventTypes := k8s.EventTypes{
-		Add:    a.TrafficTargetAdded,
-		Update: a.TrafficTargetUpdated,
-		Delete: a.TrafficTargetDeleted,
+		Add:    dispatcher.TrafficTargetAdded,
+		Update: dispatcher.TrafficTargetUpdated,
+		Delete: dispatcher.TrafficTargetDeleted,
 	}
 	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", shouldObserve, trafficTargetEventTypes))
 

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -15,10 +16,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -93,10 +93,10 @@ var _ = Describe("When listing TrafficSplit", func() {
 	})
 
 	It("should return a list of traffic split resources", func() {
-		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
-			announcements.TrafficSplitDeleted,
-			announcements.TrafficSplitUpdated)
-		defer events.GetPubSubInstance().Unsub(tsChannel)
+		tsChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.TrafficSplitAdded,
+			dispatcher.TrafficSplitDeleted,
+			dispatcher.TrafficSplitUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(tsChannel)
 
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
@@ -144,10 +144,10 @@ var _ = Describe("When listing TrafficSplit services", func() {
 	})
 
 	It("should return a list of weighted services corresponding to the traffic split backends", func() {
-		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
-			announcements.TrafficSplitDeleted,
-			announcements.TrafficSplitUpdated)
-		defer events.GetPubSubInstance().Unsub(tsChannel)
+		tsChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.TrafficSplitAdded,
+			dispatcher.TrafficSplitDeleted,
+			dispatcher.TrafficSplitUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(tsChannel)
 
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
@@ -199,10 +199,10 @@ var _ = Describe("When listing ServiceAccounts", func() {
 	})
 
 	It("should return a list of service accounts specified in TrafficTarget resources", func() {
-		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
-			announcements.TrafficTargetDeleted,
-			announcements.TrafficTargetUpdated)
-		defer events.GetPubSubInstance().Unsub(ttChannel)
+		ttChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.TrafficTargetAdded,
+			dispatcher.TrafficTargetDeleted,
+			dispatcher.TrafficTargetUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(ttChannel)
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
@@ -259,10 +259,10 @@ var _ = Describe("When listing TrafficTargets", func() {
 	})
 
 	It("Returns a list of TrafficTarget resources", func() {
-		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
-			announcements.TrafficTargetDeleted,
-			announcements.TrafficTargetUpdated)
-		defer events.GetPubSubInstance().Unsub(ttChannel)
+		ttChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.TrafficTargetAdded,
+			dispatcher.TrafficTargetDeleted,
+			dispatcher.TrafficTargetUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(ttChannel)
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
@@ -322,10 +322,10 @@ var _ = Describe("When listing ListHTTPTrafficSpecs", func() {
 	})
 
 	It("should return a list of ListHTTPTrafficSpecs resources", func() {
-		rgChannel := events.GetPubSubInstance().Subscribe(announcements.RouteGroupAdded,
-			announcements.RouteGroupDeleted,
-			announcements.RouteGroupUpdated)
-		defer events.GetPubSubInstance().Unsub(rgChannel)
+		rgChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.RouteGroupAdded,
+			dispatcher.RouteGroupDeleted,
+			dispatcher.RouteGroupUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(rgChannel)
 
 		routeSpec := &smiSpecs.HTTPRouteGroup{
 			TypeMeta: metav1.TypeMeta{
@@ -392,10 +392,10 @@ var _ = Describe("When listing TCP routes", func() {
 	})
 
 	It("should return a list of TCPRoute resources", func() {
-		trChannel := events.GetPubSubInstance().Subscribe(announcements.TCPRouteAdded,
-			announcements.TCPRouteDeleted,
-			announcements.TCPRouteUpdated)
-		defer events.GetPubSubInstance().Unsub(trChannel)
+		trChannel := dispatcher.GetPubSubInstance().Subscribe(dispatcher.TCPRouteAdded,
+			dispatcher.TCPRouteDeleted,
+			dispatcher.TCPRouteUpdated)
+		defer dispatcher.GetPubSubInstance().Unsub(trChannel)
 		routeSpec := &smiSpecs.TCPRoute{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha4",

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -5,7 +5,7 @@ import (
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -71,6 +71,6 @@ func (f fakeMeshSpec) ListTrafficTargets() []*access.TrafficTarget {
 }
 
 // GetAnnouncementsChannel returns the channel on which SMI makes announcements for the fake Mesh Spec.
-func (f fakeMeshSpec) GetAnnouncementsChannel() <-chan announcements.Announcement {
-	return make(chan announcements.Announcement)
+func (f fakeMeshSpec) GetAnnouncementsChannel() <-chan dispatcher.Announcement {
+	return make(chan dispatcher.Announcement)
 }

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/dispatcher"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -41,7 +41,7 @@ type Client struct {
 	cacheSynced    chan interface{}
 	providerIdent  string
 	informers      *informerCollection
-	announcements  chan announcements.Announcement
+	announcements  chan dispatcher.Announcement
 	osmNamespace   string
 	kubeController k8s.Controller
 }


### PR DESCRIPTION
This PR **moves** code (functions, constants, types) into a new 'pkg/dispatcher'.

In this PR:

  - Move  `pkg/catalog/dispatcher.go` → `pkg/dispatcher/dispatcher.go`
  - Also move ` pkg/kubernetes/events/event_pubsub.go` → `pkg/dispatcher/pubsub.go`
  - Move `pkg/announcements/types.go` → `pkg/dispatcher/types.go`

With that - pubsub, dispatcher, and announcements are all moved into a single place - `pkg/dispatcher`