### PR TITLE
Fix race on webhook certificate creation

### DIFF
--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -178,7 +178,7 @@ func main() {
 	}
 
 	// Initialize the reconciler for the injector's MutatingWebhookConfiguration
-	if err := createReconciler(certManager); err != nil {
+	if err := createReconciler(kubeClient); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller manager to reconcile sidecar injector webhook config")
 	}
 

--- a/cmd/osm-injector/reconcile.go
+++ b/cmd/osm-injector/reconcile.go
@@ -3,14 +3,14 @@ package main
 import (
 	"fmt"
 
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/reconciler"
 )
 
 // createReconciler sets up k8s controller manager to reconcile osm-injector's mutatingwehbookconfiguration
-func createReconciler(certManager certificate.Manager) error {
+func createReconciler(kubeClient *kubernetes.Clientset) error {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: "0", /* disables controller manager metrics serving */
@@ -24,10 +24,10 @@ func createReconciler(certManager certificate.Manager) error {
 	// Add a reconciler for osm-injector's mutatingwehbookconfiguration
 	if err = (&reconciler.MutatingWebhookConfigurationReconciler{
 		Client:       mgr.GetClient(),
+		KubeClient:   kubeClient,
 		Scheme:       mgr.GetScheme(),
 		OsmWebhook:   fmt.Sprintf("osm-webhook-%s", meshName),
 		OsmNamespace: osmNamespace,
-		CertManager:  certManager,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error().Err(err).Msg("Error creating controller to reconcile MutatingWebhookConfiguration")
 		return err

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,6 +85,9 @@ const (
 	// XDSCertificateValidityPeriod is the TTL of the certificates used for Envoy to xDS communication.
 	XDSCertificateValidityPeriod = 87600 * time.Hour // a decade
 
+	// WebhookCertificateSecretName is the default value for webhook secret name
+	WebhookCertificateSecretName = "mutating-webhook-cert-secret"
+
 	// RegexMatchAll is a regex pattern match for all
 	RegexMatchAll = ".*"
 


### PR DESCRIPTION
There was a race when creating webhook certificate, would prevent
multiple injectors to receive webhook calls.

This PR synchronizes the certificate creation for multiple instances
through secrets API.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

**Affected area**:


- Control Plane          [X]
- Certificate Management [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No