### PR TITLE
chore(routesv2): Remove unused struct from `trafficpolicy` package

### DIFF
--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -139,7 +139,6 @@ func buildOutboundRoutes(outRoutes []*trafficpolicy.RouteWeightedClusters) []*xd
 	var routes []*xds_route.Route
 	for _, outRoute := range outRoutes {
 		emptyHeaders := map[string]string{}
-		// TODO: When implementing trafficsplit v1alpha4, buildRoute here should take in path, method, headers from trafficpolicy.HTTPRouteMatch
 		routes = append(routes, buildRoute(constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), OutboundRoute))
 	}
 	return routes

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -4,7 +4,6 @@ package tests
 import (
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net"
 
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
@@ -210,75 +209,6 @@ var (
 	Endpoint = endpoint.Endpoint{
 		IP:   net.ParseIP(ServiceIP),
 		Port: endpoint.Port(ServicePort),
-	}
-
-	// BookstoreV1TrafficPolicy is a traffic policy SMI object.
-	BookstoreV1TrafficPolicy = trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v1", TrafficTargetName),
-		Destination: BookstoreV1Service,
-		Source:      BookbuyerService,
-		HTTPRouteMatches: []trafficpolicy.HTTPRouteMatch{
-			{
-				PathRegex: BookstoreBuyPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
-			{
-				PathRegex: BookstoreSellPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
-		},
-	}
-
-	// BookstoreV2TrafficPolicy is a traffic policy SMI object.
-	BookstoreV2TrafficPolicy = trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-v2", BookstoreV2TrafficTargetName),
-		Destination: BookstoreV2Service,
-		Source:      BookbuyerService,
-		HTTPRouteMatches: []trafficpolicy.HTTPRouteMatch{
-			{
-				PathRegex: BookstoreBuyPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
-			{
-				PathRegex: BookstoreSellPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
-		},
-	}
-
-	// BookstoreApexTrafficPolicy is a traffic policy SMI object.
-	BookstoreApexTrafficPolicy = trafficpolicy.TrafficTarget{
-		Name:        fmt.Sprintf("%s:default/bookbuyer->default/bookstore-apex", TrafficTargetName),
-		Destination: BookstoreApexService,
-		Source:      BookbuyerService,
-		HTTPRouteMatches: []trafficpolicy.HTTPRouteMatch{
-			{
-				PathRegex: BookstoreBuyPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
-			{
-				PathRegex: BookstoreSellPath,
-				Methods:   []string{"GET"},
-				Headers: map[string]string{
-					"user-agent": HTTPUserAgent,
-				},
-			},
-		},
 	}
 
 	// TrafficSplit is a traffic split SMI object.

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -6,7 +6,6 @@ import (
 	set "github.com/deckarep/golang-set"
 
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // TrafficSpecName is the namespaced name of the SMI TrafficSpec
@@ -27,19 +26,10 @@ type TCPRouteMatch struct {
 	Ports []int `json:"ports:omitempty"`
 }
 
-// TrafficTarget is a struct to represent a traffic policy between a source and destination along with its routes
-type TrafficTarget struct {
-	Name             string              `json:"name:omitempty"`
-	Destination      service.MeshService `json:"destination:omitempty"`
-	Source           service.MeshService `json:"source:omitempty"`
-	HTTPRouteMatches []HTTPRouteMatch    `json:"http_route_matches:omitempty"`
-}
-
 // RouteWeightedClusters is a struct of an HTTPRoute, associated weighted clusters and the domains
 type RouteWeightedClusters struct {
 	HTTPRouteMatch   HTTPRouteMatch `json:"http_route_match:omitempty"`
 	WeightedClusters set.Set        `json:"weighted_clusters:omitempty"`
-	Hostnames        set.Set        `json:"hostnames:omitempty"` // TODO remove hostnames as part of #2034
 }
 
 // InboundTrafficPolicy is a struct that associates incoming traffic on a set of Hostnames with a list of Rules


### PR DESCRIPTION
**Description**: 

Removal of unused structs from the `trafficpolicy` package post migration
to routesv2. No functional changes

Fixes #2397

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
