### PR TITLE
pkg/*: deprecate older API to list traffic splits

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -312,7 +312,7 @@ type MeshCataloger interface {
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
 	// ListSMIPolicies lists SMI policies.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
 
 	// ListEndpointsForService returns the list of provider endpoints corresponding to a service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
@@ -445,9 +445,6 @@ type MeshSpec interface {
 	// ListTrafficSplits lists SMI TrafficSplit resources
 	ListTrafficSplits() []*split.TrafficSplit
 
-	// ListTrafficSplitServices lists WeightedServices for the services specified in TrafficSplit SMI resources
-	ListTrafficSplitServices() []service.WeightedService
-
 	// ListServiceAccounts lists ServiceAccount resources specified in SMI TrafficTarget resources
 	ListServiceAccounts() []service.K8sServiceAccount
 
@@ -566,14 +563,6 @@ The following types are referenced in the interfaces proposed in this document:
       ```go
       // ClusterName is a type for a service name
       type ClusterName string
-      ```
-  -  WeightedService
-      ```go
-      //WeightedService is a struct of a service name and its weight
-      type WeightedService struct {
-	   ServiceName MeshService `json:"service_name:omitempty"`
-	   Weight      int               `json:"weight:omitempty"`
-      }
       ```
 
   -  RoutePolicy

--- a/docs/content/docs/design_concepts/design_appendix.md
+++ b/docs/content/docs/design_concepts/design_appendix.md
@@ -45,15 +45,6 @@ The following types are referenced in the interfaces proposed in this document:
   // ClusterName is a type for a service name
   type ClusterName string
   ```
-- WeightedService
-
-  ```go
-  //WeightedService is a struct of a service name and its weight
-  type WeightedService struct {
-   ServiceName MeshService `json:"service_name:omitempty"`
-   Weight      int               `json:"weight:omitempty"`
-  }
-  ```
 
 - RoutePolicy
 

--- a/docs/content/docs/design_concepts/interfaces.md
+++ b/docs/content/docs/design_concepts/interfaces.md
@@ -74,7 +74,7 @@ type MeshCataloger interface {
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
 	// ListSMIPolicies lists SMI policies.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)
 
 	// ListEndpointsForService returns the list of provider endpoints corresponding to a service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
@@ -212,9 +212,6 @@ The `MeshSpec` implementation **has no awareness** of:
 type MeshSpec interface {
 	// ListTrafficSplits lists SMI TrafficSplit resources
 	ListTrafficSplits() []*split.TrafficSplit
-
-	// ListTrafficSplitServices lists WeightedServices for the services specified in TrafficSplit SMI resources
-	ListTrafficSplitServices() []service.WeightedService
 
 	// ListServiceAccounts lists ServiceAccount resources specified in SMI TrafficTarget resources
 	ListServiceAccounts() []service.K8sServiceAccount

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -60,14 +60,13 @@ func (mc *MeshCatalog) ListDisconnectedProxies() map[certificate.CommonName]time
 }
 
 // ListSMIPolicies returns all policies OSM is aware of.
-func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget) {
+func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget) {
 	trafficSplits := mc.meshSpec.ListTrafficSplits()
-	splitServices := mc.meshSpec.ListTrafficSplitServices()
 	serviceAccounts := mc.meshSpec.ListServiceAccounts()
 	trafficSpecs := mc.meshSpec.ListHTTPTrafficSpecs()
 	trafficTargets := mc.meshSpec.ListTrafficTargets()
 
-	return trafficSplits, splitServices, serviceAccounts, trafficSpecs, trafficTargets
+	return trafficSplits, serviceAccounts, trafficSpecs, trafficTargets
 }
 
 // ListMonitoredNamespaces returns all namespaces that the mesh is monitoring.

--- a/pkg/catalog/debugger_test.go
+++ b/pkg/catalog/debugger_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -93,13 +92,9 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 
 	Context("Test ListSMIPolicies", func() {
 		It("lists available SMI Spec policies", func() {
-			trafficSplits, weightedServices, serviceAccounts, routeGroups, trafficTargets := mc.ListSMIPolicies()
+			trafficSplits, serviceAccounts, routeGroups, trafficTargets := mc.ListSMIPolicies()
 
 			Expect(trafficSplits[0].Spec.Service).To(Equal("bookstore-apex"))
-			Expect(weightedServices[0]).To(Equal(service.WeightedService{
-				Service:     tests.BookstoreV1Service,
-				Weight:      tests.Weight90,
-				RootService: "bookstore-apex"}))
 			Expect(serviceAccounts[0].String()).To(Equal("default/bookstore"))
 			Expect(routeGroups[0].Name).To(Equal("bookstore-service-routes"))
 			Expect(trafficTargets[0].Name).To(Equal(tests.TrafficTargetName))

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -290,15 +290,14 @@ func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interf
 }
 
 // ListSMIPolicies mocks base method
-func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
+func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSMIPolicies")
 	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
-	ret1, _ := ret[1].([]service.WeightedService)
-	ret2, _ := ret[2].([]service.K8sServiceAccount)
-	ret3, _ := ret[3].([]*v1alpha4.HTTPRouteGroup)
-	ret4, _ := ret[4].([]*v1alpha3.TrafficTarget)
-	return ret0, ret1, ret2, ret3, ret4
+	ret1, _ := ret[1].([]service.K8sServiceAccount)
+	ret2, _ := ret[2].([]*v1alpha4.HTTPRouteGroup)
+	ret3, _ := ret[3].([]*v1alpha3.TrafficTarget)
+	return ret0, ret1, ret2, ret3
 }
 
 // ListSMIPolicies indicates an expected call of ListSMIPolicies

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -82,7 +82,7 @@ type MeshCataloger interface {
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
 	// ListSMIPolicies lists SMI policies.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 
 	// ListEndpointsForService returns the list of individual instance endpoint backing a service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)

--- a/pkg/debugger/mock_debugger_generated.go
+++ b/pkg/debugger/mock_debugger_generated.go
@@ -134,15 +134,14 @@ func (mr *MockMeshCatalogDebuggerMockRecorder) ListMonitoredNamespaces() *gomock
 }
 
 // ListSMIPolicies mocks base method
-func (m *MockMeshCatalogDebugger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
+func (m *MockMeshCatalogDebugger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSMIPolicies")
 	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
-	ret1, _ := ret[1].([]service.WeightedService)
-	ret2, _ := ret[2].([]service.K8sServiceAccount)
-	ret3, _ := ret[3].([]*v1alpha4.HTTPRouteGroup)
-	ret4, _ := ret[4].([]*v1alpha3.TrafficTarget)
-	return ret0, ret1, ret2, ret3, ret4
+	ret1, _ := ret[1].([]service.K8sServiceAccount)
+	ret2, _ := ret[2].([]*v1alpha4.HTTPRouteGroup)
+	ret3, _ := ret[3].([]*v1alpha3.TrafficTarget)
+	return ret0, ret1, ret2, ret3
 }
 
 // ListSMIPolicies indicates an expected call of ListSMIPolicies

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -13,11 +13,10 @@ import (
 )
 
 type policies struct {
-	TrafficSplits    []*split.TrafficSplit       `json:"traffic_splits"`
-	WeightedServices []service.WeightedService   `json:"weighted_services"`
-	ServiceAccounts  []service.K8sServiceAccount `json:"service_accounts"`
-	RouteGroups      []*spec.HTTPRouteGroup      `json:"route_groups"`
-	TrafficTargets   []*access.TrafficTarget     `json:"traffic_targets"`
+	TrafficSplits   []*split.TrafficSplit       `json:"traffic_splits"`
+	ServiceAccounts []service.K8sServiceAccount `json:"service_accounts"`
+	RouteGroups     []*spec.HTTPRouteGroup      `json:"route_groups"`
+	TrafficTargets  []*access.TrafficTarget     `json:"traffic_targets"`
 }
 
 func (ds DebugConfig) getOSMConfigHandler() http.Handler {
@@ -34,7 +33,7 @@ func (ds DebugConfig) getOSMConfigHandler() http.Handler {
 func (ds DebugConfig) getSMIPoliciesHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var p policies
-		p.TrafficSplits, p.WeightedServices, p.ServiceAccounts, p.RouteGroups, p.TrafficTargets = ds.meshCatalogDebugger.ListSMIPolicies()
+		p.TrafficSplits, p.ServiceAccounts, p.RouteGroups, p.TrafficTargets = ds.meshCatalogDebugger.ListSMIPolicies()
 
 		jsonPolicies, err := json.Marshal(p)
 		if err != nil {

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -34,10 +34,6 @@ func TestGetSMIPolicies(t *testing.T) {
 					Name:      "bar",
 				}},
 		},
-		[]service.WeightedService{
-			tests.BookstoreV1WeightedService,
-			tests.BookstoreV2WeightedService,
-		},
 		[]service.K8sServiceAccount{
 			tests.BookbuyerServiceAccount,
 		},
@@ -53,6 +49,6 @@ func TestGetSMIPolicies(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 	smiPoliciesHandler.ServeHTTP(responseRecorder, nil)
 	actualResponseBody := responseRecorder.Body.String()
-	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"weighted_services":[{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v1"},"weight:omitempty":90,"root_service:omitempty":"bookstore-apex"},{"service_name:omitempty":{"Namespace":"default","Name":"bookstore-v2"},"weight:omitempty":10,"root_service:omitempty":"bookstore-apex"}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha4","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha3","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"ServiceAccount","name":"bookstore","namespace":"default"},"sources":[{"kind":"ServiceAccount","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
-	assert.Equal(actualResponseBody, expectedResponseBody, "Actual value did not match expectations:\n%s", actualResponseBody)
+	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha4","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha3","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"ServiceAccount","name":"bookstore","namespace":"default"},"sources":[{"kind":"ServiceAccount","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
+	assert.Equal(expectedResponseBody, actualResponseBody, "Actual value did not match expectations:\n%s", actualResponseBody)
 }

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -49,7 +49,7 @@ type MeshCatalogDebugger interface {
 	ListDisconnectedProxies() map[certificate.CommonName]time.Time
 
 	// ListSMIPolicies lists the SMI policies detected by OSM.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.WeightedService, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 
 	// ListMonitoredNamespaces lists the namespaces that the control plan knows about.
 	ListMonitoredNamespaces() []string

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -42,13 +42,6 @@ func (c ClusterName) String() string {
 	return string(c)
 }
 
-//WeightedService is a struct of a service name, its weight and its root service
-type WeightedService struct {
-	Service     MeshService `json:"service_name:omitempty"`
-	Weight      int         `json:"weight:omitempty"`
-	RootService string      `json:"root_service:omitempty"`
-}
-
 // WeightedCluster is a struct of a cluster and is weight that is backing a service
 type WeightedCluster struct {
 	ClusterName ClusterName `json:"cluster_name:omitempty"`

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -228,27 +228,6 @@ func (c *Client) ListTrafficTargets() []*smiAccess.TrafficTarget {
 	return trafficTargets
 }
 
-// ListTrafficSplitServices implements mesh.MeshSpec by returning the services observed from the given compute provider
-func (c *Client) ListTrafficSplitServices() []service.WeightedService {
-	var services []service.WeightedService
-	for _, splitIface := range c.caches.TrafficSplit.List() {
-		trafficSplit := splitIface.(*smiSplit.TrafficSplit)
-		rootService := trafficSplit.Spec.Service
-
-		for _, backend := range trafficSplit.Spec.Backends {
-			// The TrafficSplit SMI Spec does not allow providing a namespace for the backends,
-			// so we assume that the top level namespace for the TrafficSplit is the namespace
-			// the backends belong to.
-			meshService := service.MeshService{
-				Namespace: trafficSplit.Namespace,
-				Name:      backend.Service,
-			}
-			services = append(services, service.WeightedService{Service: meshService, Weight: backend.Weight, RootService: rootService})
-		}
-	}
-	return services
-}
-
 // ListServiceAccounts lists ServiceAccounts specified in SMI TrafficTarget resources
 func (c *Client) ListServiceAccounts() []service.K8sServiceAccount {
 	var serviceAccounts []service.K8sServiceAccount

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -11,22 +11,20 @@ import (
 )
 
 type fakeMeshSpec struct {
-	trafficSplits    []*split.TrafficSplit
-	httpRouteGroups  []*spec.HTTPRouteGroup
-	tcpRoutes        []*spec.TCPRoute
-	trafficTargets   []*access.TrafficTarget
-	weightedServices []service.WeightedService
-	serviceAccounts  []service.K8sServiceAccount
+	trafficSplits   []*split.TrafficSplit
+	httpRouteGroups []*spec.HTTPRouteGroup
+	tcpRoutes       []*spec.TCPRoute
+	trafficTargets  []*access.TrafficTarget
+	serviceAccounts []service.K8sServiceAccount
 }
 
 // NewFakeMeshSpecClient creates a fake Mesh Spec used for testing.
 func NewFakeMeshSpecClient() MeshSpec {
 	return fakeMeshSpec{
-		trafficSplits:    []*split.TrafficSplit{&tests.TrafficSplit},
-		httpRouteGroups:  []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
-		tcpRoutes:        []*spec.TCPRoute{&tests.TCPRoute},
-		trafficTargets:   []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
-		weightedServices: []service.WeightedService{tests.BookstoreV1WeightedService, tests.BookstoreV2WeightedService},
+		trafficSplits:   []*split.TrafficSplit{&tests.TrafficSplit},
+		httpRouteGroups: []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
+		tcpRoutes:       []*spec.TCPRoute{&tests.TCPRoute},
+		trafficTargets:  []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
 		serviceAccounts: []service.K8sServiceAccount{
 			tests.BookstoreServiceAccount,
 			tests.BookstoreV2ServiceAccount,
@@ -38,11 +36,6 @@ func NewFakeMeshSpecClient() MeshSpec {
 // ListTrafficSplits lists TrafficSplit SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListTrafficSplits() []*split.TrafficSplit {
 	return f.trafficSplits
-}
-
-// ListTrafficSplitServices fetches all services declared with SMI Spec for the fake Mesh Spec.
-func (f fakeMeshSpec) ListTrafficSplitServices() []service.WeightedService {
-	return f.weightedServices
 }
 
 // ListServiceAccounts fetches all service accounts declared with SMI Spec for the fake Mesh Spec.

--- a/pkg/smi/mock_meshspec_generated.go
+++ b/pkg/smi/mock_meshspec_generated.go
@@ -93,20 +93,6 @@ func (mr *MockMeshSpecMockRecorder) ListTCPTrafficSpecs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTCPTrafficSpecs", reflect.TypeOf((*MockMeshSpec)(nil).ListTCPTrafficSpecs))
 }
 
-// ListTrafficSplitServices mocks base method
-func (m *MockMeshSpec) ListTrafficSplitServices() []service.WeightedService {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTrafficSplitServices")
-	ret0, _ := ret[0].([]service.WeightedService)
-	return ret0
-}
-
-// ListTrafficSplitServices indicates an expected call of ListTrafficSplitServices
-func (mr *MockMeshSpecMockRecorder) ListTrafficSplitServices() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficSplitServices", reflect.TypeOf((*MockMeshSpec)(nil).ListTrafficSplitServices))
-}
-
 // ListTrafficSplits mocks base method
 func (m *MockMeshSpec) ListTrafficSplits() []*v1alpha2.TrafficSplit {
 	m.ctrl.T.Helper()

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -51,9 +51,6 @@ type MeshSpec interface {
 	// ListTrafficSplits lists SMI TrafficSplit resources
 	ListTrafficSplits() []*split.TrafficSplit
 
-	// ListTrafficSplitServices lists WeightedServices for the services specified in TrafficSplit SMI resources
-	ListTrafficSplitServices() []service.WeightedService
-
 	// ListServiceAccounts lists ServiceAccount resources specified in SMI TrafficTarget resources
 	ListServiceAccounts() []service.K8sServiceAccount
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -304,26 +304,6 @@ var (
 		Name:      BookbuyerServiceAccountName,
 	}
 
-	// BookstoreV1WeightedService is a service with a weight used for traffic split.
-	BookstoreV1WeightedService = service.WeightedService{
-		Service: service.MeshService{
-			Namespace: Namespace,
-			Name:      BookstoreV1ServiceName,
-		},
-		Weight:      Weight90,
-		RootService: BookstoreApexServiceName,
-	}
-
-	// BookstoreV2WeightedService is a service with a weight used for traffic split.
-	BookstoreV2WeightedService = service.WeightedService{
-		Service: service.MeshService{
-			Namespace: Namespace,
-			Name:      BookstoreV2ServiceName,
-		},
-		Weight:      Weight10,
-		RootService: BookstoreApexServiceName,
-	}
-
 	// HTTPRouteGroup is the HTTP route group SMI object.
 	HTTPRouteGroup = spec.HTTPRouteGroup{
 		TypeMeta: v1.TypeMeta{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The `ListTrafficSplitServices` api does not provide any additional
information compared to the `ListTrafficSplits` api. Use a single
api for consistency.
Since `ListTrafficSplits` lists the entire SMI traffic split resource,
this is sufficient enough in the debugger. The traffic split dump
in the debugger was previously duplicating traffic split resources
from two different apis.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`