### PR TITLE
fix(e2e): wait for automatic vault installation

### DIFF
--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -26,7 +26,6 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 				installOpts := Td.GetOSMInstallOpts()
 				installOpts.CertManager = "vault"
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
-				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 3 /* vault, controller, injector */)).To(Succeed())
 
 				// Create Test NS
 				for _, n := range ns {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -512,6 +512,10 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 			"--vault-protocol="+instOpts.VaultProtocol,
 			"--vault-role="+instOpts.VaultRole,
 		)
+		// Wait for the vault pod
+		if err := td.WaitForPodsRunningReady(instOpts.ControlPlaneNS, 60*time.Second, 1); err != nil {
+			return errors.Wrap(err, "failed waiting for vault pod to become ready")
+		}
 	case "cert-manager":
 		if err := td.installCertManager(instOpts); err != nil {
 			return err


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The HashiCorp Vault e2e test fails occasionally because of the new pod
restart check because the osm-controller sometimes comes up before the
Vault pod is ready, so it fails and restarts and the rest of the test
succeeds. This change waits for the Vault pod to become ready before
installing OSM.

Fixes #2670
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No