### PR TITLE
tests/e2e: add more buckets and reorganize test bucketing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        bucket: [1, 2]
+        bucket: [1, 2, 3, 4]
     env:
       CTR_TAG: ${{ github.sha }}
       CTR_REGISTRY: "localhost:5000" # unused for kind, but currently required in framework

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -24,6 +24,33 @@ Tests are organized by top-level `Describe` blocks into tiers based on priority.
 
 Independent of tiers, tests are also organized into buckets. Each bucket runs in parallel, and individual tests in the bucket run sequentially.
 
+### Test organization
+
+| Test  | Tier | Bucket |
+|--|--|--|
+| e2e_smi_traffic_target_test.go | 1 | 1
+| e2e_trafficsplit_test.go | 1 | 1
+| e2e_permissive_test.go | 1 | 1
+| e2e_deployment_client_server_test.go | 1 | 2
+| e2e_tcp_client_server_test.go | 1 | 2
+| e2e_grpc_client_server_test.go | 1 | 2
+| e2e_http_ingress_test.go | 1 | 3
+| e2e_egress_test.go | 1 | 3
+| e2e_tcp_egress_test.go | 1 | 3
+| e2e_trafficsplit_same_sa_test.go | 1 | 4
+| e2e_pod_client_server_test.go | 1 | 4
+| e2e_helm_install_test.go | 2 | 1
+| e2e_upgrade_test.go | 2 | 1
+| e2e_controller_restart_test.go | 2 | 1
+| e2e_hashivault_test.go| 2 | 2
+| e2e_certmanager_test.go | 2 | 2
+| e2e_ip_exclusion_test.go | 2 | 3
+| e2e_multiple_services_per_pod_test.go | 2 | 3
+| e2e_metrics_test.go | 2 | 4
+| e2e_debug_server_test.go | 2 | 4
+| e2e_fluentbit_test.go | 2 | 4
+| e2e_fluentbit_out_test.go | 2 | 4
+
 **Note**: These tiers and buckets and which tests fall into each are likely to change as the test suite grows.
 
 To help organize the tests, a custom `Describe` block named `OSMDescribe` is provided which accepts an additional struct parameter which contains fields for test metadata like tier and bucket. `OSMDescribe` will construct a well-formatted name including the test metadata which can be used in CI to run tests accordingly. Ginkgo's original `Describe` should not be used directly at the top-level and `OSMDescribe` should be used instead.
@@ -121,16 +148,16 @@ will anyway be destroyed.
 ```
 Plus, `go test` and `Ginkgo` specific flags, of course.
 
-#### Running individual tests: 
+#### Running individual tests:
 
-The `ginkgo.focus` flag can be used to run individual tests. The flag should specify the "Context" of the test they wish to run, which can be found in the `.go` file for that test. For instance, if you want to run the `e2e_tcp_client_server_test` with SMI policies, you should run: 
+The `ginkgo.focus` flag can be used to run individual tests. The flag should specify the "Context" of the test they wish to run, which can be found in the `.go` file for that test. For instance, if you want to run the `e2e_tcp_client_server_test` with SMI policies, you should run:
 
 ```console
 go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.focus="\bSimpleClientServer TCP with SMI policies\b"
 ```
 
-#### Setting test timeout: 
+#### Setting test timeout:
 
-The `test.timeout` flag sets a total time limit for all the tests that you are running. If you run the e2es without specifying any timeout limit, the tests will terminate after 10 minutes. To run the tests without any time limit, you should set `test.timeout 0`. 
+The `test.timeout` flag sets a total time limit for all the tests that you are running. If you run the e2es without specifying any timeout limit, the tests will terminate after 10 minutes. To run the tests without any time limit, you should set `test.timeout 0`.
 
-To set a specific time limit, a unit must be specified along with a number. For instance, if you want to set the limit to 90 seconds (say for just testing one e2e), you should say `test.timeout 90s`. If you want the tests to run for 60 minutes, you should say `test.timeout 60m`. 
+To set a specific time limit, a unit must be specified along with a number. For instance, if you want to set the limit to 90 seconds (say for just testing one e2e), you should say `test.timeout 90s`. If you want the tests to run for 60 minutes, you should say `test.timeout 60m`.

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -14,7 +14,7 @@ import (
 var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 4,
 	},
 	func() {
 		Context("DebugServer", func() {

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -17,7 +17,7 @@ import (
 var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 2,
 	},
 	func() {
 		Context("DeploymentsClientServer", func() {

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("HTTP and HTTPS Egress",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 3,
 	},
 	func() {
 		Context("Egress", func() {

--- a/tests/e2e/e2e_fluentbit_test.go
+++ b/tests/e2e/e2e_fluentbit_test.go
@@ -16,7 +16,7 @@ import (
 var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 4,
 	},
 	func() {
 		Context("Fluentbit", func() {

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 2,
 	},
 	func() {
 		Context("HashivaultSimpleClientServer", func() {

--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -20,7 +20,7 @@ import (
 var _ = OSMDescribe("HTTP ingress",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 3,
 	},
 	func() {
 		const destNs = "server"

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("Tests traffic via IP range exclusion",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 3,
 	},
 	func() {
 		Context("Test IP range exclusion", func() {

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -17,7 +17,7 @@ import (
 var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 	OSMDescribeInfo{
 		Tier:   2, // experimental feature
-		Bucket: 1,
+		Bucket: 4,
 	},
 	func() {
 		const sourceNs = "clientns"

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("Test access via multiple services matching the same pod",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 3,
 	},
 	func() {
 		Context("Multiple services matching same pod", func() {

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -14,7 +14,7 @@ import (
 var _ = OSMDescribe("Permissive Traffic Policy Mode",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 1,
 	},
 	func() {
 		Context("Permissive mode HTTP test with a Kubernetes Service for the Source", func() {

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -18,7 +18,7 @@ import (
 var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 4,
 	},
 	func() {
 		Context("Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP", func() {

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -19,7 +19,7 @@ import (
 var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 1,
 	},
 	func() {
 		Context("SMI TrafficTarget", func() {

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -17,7 +17,7 @@ import (
 var _ = OSMDescribe("Test TCP traffic from 1 pod client -> 1 pod server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 2,
 	},
 	func() {
 		Context("SimpleClientServer TCP with SMI policies", func() {

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -14,7 +14,7 @@ import (
 var _ = OSMDescribe("Test TCP traffic from 1 pod client -> egress server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 3,
 	},
 	func() {
 		Context("SimpleClientServer egress TCP", func() {

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -18,7 +18,7 @@ import (
 var _ = OSMDescribe("Test TrafficSplit where each backend shares the same ServiceAccount",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 4,
 	},
 	func() {
 		Context("ClientServerTrafficSplitSameSA", func() {

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -18,7 +18,7 @@ import (
 var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 1,
 	},
 	func() {
 		Context("ClientServerTrafficSplit", func() {

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -22,7 +22,7 @@ import (
 var _ = OSMDescribe("Upgrade from latest",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 1,
 	},
 	func() {
 		const ns = "upgrade-test"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds 2 more buckets to parallelize e2e tests and reorganizes
them roughly based on their areas.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`