### PR TITLE
docs/install: push additional images with latest_main tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,3 +273,7 @@ jobs:
         env:
           CTR_TAG: ${{ github.sha }}
         run: make docker-push
+      - name: Push images with latest_main tag
+        env:
+          CTR_TAG: latest_main
+        run: make docker-push

--- a/docs/content/docs/install/_index.md
+++ b/docs/content/docs/install/_index.md
@@ -19,17 +19,31 @@ Unpack the `osm` binary and add it to `$PATH` to get started.
 
 ### From Source (Linux, MacOS)
 
-Building OSM from source requires more steps but is the best way to test the latest changes and useful in a development environment.
+Building OSM CLI from source requires more steps but is the best way to test the latest changes and useful in a development environment.
 
 You must have a working [Go](https://golang.org/doc/install) environment.
 
 ```console
 $ git clone git@github.com:openservicemesh/osm.git
 $ cd osm
+```
+
+When OSM CLI is built from source, it might not be compatible with the default control plane images derived from the latest released version. In such cases, use the `latest_main` image tag to specify that the CLI should use the latest control plane images built from the `main` branch. It is recommended to build the OSM CLI binary from the latest commit on the `main` branch while using the `latest_main` image tag for compatibility reasons.
+
+```console
+# upstream points to git@github.com:openservicemesh/osm.git
+$ git fetch upstream && git rebease upstream/main
+
+# Compile OSM CLI
 $ make build-osm
 ```
 
 `make build-osm` will fetch any required dependencies, compile `osm` and place it in `bin/osm`. Add `bin/osm` to `$PATH` so you can easily use `osm`.
+
+```console
+# Install OSM using the latest image tag from main
+$ osm install --osm-image-tag latest_main
+```
 
 ## Install OSM
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
In addition to images pushed to the container registry
using the Git commit SHA on push events to the `main`
branch, this change pushes images with the `latest_main`
tag so that OSM cli built from latest source can use
the `latest_main` image tag. This simplifies the install
experience when using cli built from source. Previously
this would most likely fail due to version mismatches
between the cli built from source and the default
image versions (pointing to the previous release)
embedded in the cli.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`