### PR TITLE
tests(e2e): disable upgrade test

### DIFF
--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 var _ = OSMDescribe("Upgrade from latest",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 0, // Disabled in CI pending https://github.com/openservicemesh/osm/issues/2675
 	},
 	func() {
 		const ns = "upgrade-test"


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The upgrade e2e test is currently failing consistently in CI but not
locally for me. I suspect the kind cluster spun up for CI doesn't have
sufficient CPU to handle spinning up the new control plane before
tearing down the old one. This is causing CI to run longer than
necessary while we don't have a fix. Issue #2675 is tracking this.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No