### PR TITLE
fix(e2e): reduce CPU needed for upgrade test

### DIFF
--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 var _ = OSMDescribe("Upgrade from latest",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 0, // Disabled in CI pending https://github.com/openservicemesh/osm/issues/2675
+		Bucket: 1,
 	},
 	func() {
 		const ns = "upgrade-test"
@@ -59,6 +59,24 @@ var _ = OSMDescribe("Upgrade from latest",
 				"OpenServiceMesh": map[string]interface{}{
 					"deployPrometheus": true,
 					"deployJaeger":     false,
+
+					// Reduce CPU so CI (capped at 2 CPU) can handle standing
+					// up the new control plane before tearing the old one
+					// down.
+					"osmcontroller": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"requests": map[string]interface{}{
+								"cpu": "0.3",
+							},
+						},
+					},
+					"injector": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"requests": map[string]interface{}{
+								"cpu": "0.1",
+							},
+						},
+					},
 				},
 			}
 			chartPath, err := i.LocateChart("osm", helmEnv)


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change reduces the CPU requests for the osm-controller and
osm-injector pods so that the kind cluster in CI can handle standing up
the new control plane before tearing the old one down.

Fixes #2675
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No