### PR TITLE
fix(cli): Add missing flags for upgrade

### DIFF
--- a/cmd/cli/mesh_upgrade_test.go
+++ b/cmd/cli/mesh_upgrade_test.go
@@ -85,6 +85,9 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	*u.enableEgress = true
 	u.envoyLogLevel = "trace"
 	u.tracingEndpoint = "/here"
+	u.outboundIPRangeExclusionList = []string{"0.0.0.0/0", "1.1.1.1/1"}
+	u.enablePrivilegedInitContainer = new(bool)
+	*u.enablePrivilegedInitContainer = true
 
 	err = u.run(config)
 	a.Nil(err)
@@ -107,6 +110,14 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	tracingEndpoint, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.tracing.endpoint")
 	a.Nil(err)
 	a.Equal("/here", tracingEndpoint)
+
+	outboundIPRangeExclusionList, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.outboundIPRangeExclusionList")
+	a.Nil(err)
+	a.Equal([]string{"0.0.0.0/0", "1.1.1.1/1"}, outboundIPRangeExclusionList)
+
+	enablePrivilegedInitContainer, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.enablePrivilegedInitContainer")
+	a.Nil(err)
+	a.True(enablePrivilegedInitContainer.(bool))
 
 	// Successive upgrades should keep the overridden values from the previous upgrade
 	u = defaultMeshUpgradeCmd()


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates the `osm mesh upgrade` command with two additional
flags mapping to fields recently added to the osm-config ConfigMap:

`--outbound-ip-range-exclusion-list`

`--enable-privileged-init-container`

Fixes #2651
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No