### PR TITLE
fix(scripts): add namespace to osm logs script

### DIFF
--- a/scripts/get-osm-namespace-logs.sh
+++ b/scripts/get-osm-namespace-logs.sh
@@ -27,14 +27,14 @@ for pod in $(echo "$res" |  jq '.items[] | .metadata.name' | sed 's/"//g') ; do
   for cont in $(echo "$res" | jq '.items[] | select(.metadata.name|contains("'"$pod"'")) | .spec.containers[].name' | sed 's/"//g') ; do
     # Logs for running instance
     echo "Checking $pod / $cont"
-    kubectl logs "$pod" -c "$cont" > "$logStorePath/running_${pod}_${cont}.log"
+    kubectl logs -n "$K8S_NAMESPACE" "$pod" -c "$cont" > "$logStorePath/running_${pod}_${cont}.log"
 
     # Check if there are logs of previous run (restart)
-    kubectl logs "$pod" -c "$cont" -p > /dev/null 2>&1 
+    kubectl logs -n "$K8S_NAMESPACE" "$pod" -c "$cont" -p > /dev/null 2>&1 
     foundPrevLogs=$?
     if [ $foundPrevLogs -eq 0 ]; then
       # There's logs, fetch
-      kubectl logs "$pod" -c "$cont" -p > "$logStorePath/previous_${cont}.log"
+      kubectl logs -n "$K8S_NAMESPACE" "$pod" -c "$cont" -p > "$logStorePath/previous_${cont}.log"
     fi
   done
 done


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the OSM namespace to each necessary `kubectl` command
in `scripts/get-osm-namespace-logs.sh`. Running the script previously
resulted in empty log files being created because the pods could not be
found without specifying the namespace.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No