### PR TITLE
tests(metricsstore): Refactor to improve coverage

### DIFF
--- a/pkg/metricsstore/metricsstore_test.go
+++ b/pkg/metricsstore/metricsstore_test.go
@@ -4,18 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
 )
-
-func TestMain(m *testing.M) {
-	setup()
-	code := m.Run()
-	teardown()
-	os.Exit(code)
-}
 
 func setup() {
 	DefaultMetricsStore.Start(
@@ -31,13 +23,48 @@ func teardown() {
 	)
 }
 
-func TestK8sAPIEventCounter(t *testing.T) {
-	assert := tassert.New(t)
+func TestMetricsStore(t *testing.T) {
+	setup()
+	defer teardown()
 
-	apiEventCount := 3
+	t.Run("K8sAPIEventCounter", func(t *testing.T) {
+		assert := tassert.New(t)
 
-	for i := 1; i <= apiEventCount; i++ {
-		DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues("add", "foo").Inc()
+		apiEventCount := 3
+
+		for i := 1; i <= apiEventCount; i++ {
+			DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues("add", "foo").Inc()
+
+			handler := DefaultMetricsStore.Handler()
+
+			req, err := http.NewRequest("GET", "/metrics", nil)
+			assert.Nil(err)
+
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(http.StatusOK, rr.Code)
+
+			expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count represents the number of events received from the Kubernetes API Server
+# TYPE osm_k8s_api_event_count counter
+osm_k8s_api_event_count{namespace="foo",type="add"} %d
+`, i /* api event count */)
+			assert.Contains(rr.Body.String(), expectedResp)
+		}
+	})
+
+	t.Run("ProxyConnectCount", func(t *testing.T) {
+		assert := tassert.New(t)
+
+		proxiesConnected := 5
+		proxiesDisconnected := 2
+
+		for i := 1; i <= proxiesConnected; i++ {
+			DefaultMetricsStore.ProxyConnectCount.Inc()
+		}
+		for i := 1; i <= proxiesDisconnected; i++ {
+			DefaultMetricsStore.ProxyConnectCount.Dec()
+		}
 
 		handler := DefaultMetricsStore.Handler()
 
@@ -49,40 +76,10 @@ func TestK8sAPIEventCounter(t *testing.T) {
 
 		assert.Equal(http.StatusOK, rr.Code)
 
-		expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count represents the number of events received from the Kubernetes API Server
-# TYPE osm_k8s_api_event_count counter
-osm_k8s_api_event_count{namespace="foo",type="add"} %d
-`, i /* api event count */)
-		assert.Contains(rr.Body.String(), expectedResp)
-	}
-}
-
-func TestProxyConnectCount(t *testing.T) {
-	assert := tassert.New(t)
-
-	proxiesConnected := 5
-	proxiesDisconnected := 2
-
-	for i := 1; i <= proxiesConnected; i++ {
-		DefaultMetricsStore.ProxyConnectCount.Inc()
-	}
-	for i := 1; i <= proxiesDisconnected; i++ {
-		DefaultMetricsStore.ProxyConnectCount.Dec()
-	}
-
-	handler := DefaultMetricsStore.Handler()
-
-	req, err := http.NewRequest("GET", "/metrics", nil)
-	assert.Nil(err)
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	assert.Equal(http.StatusOK, rr.Code)
-
-	expectedResp := fmt.Sprintf(`# HELP osm_proxy_connect_count represents the number of proxies connected to OSM controller
+		expectedResp := fmt.Sprintf(`# HELP osm_proxy_connect_count represents the number of proxies connected to OSM controller
 # TYPE osm_proxy_connect_count gauge
 osm_proxy_connect_count %d
 `, proxiesConnected-proxiesDisconnected)
-	assert.Contains(rr.Body.String(), expectedResp)
+		assert.Contains(rr.Body.String(), expectedResp)
+	})
 }


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change restructures the tests in pkg/metricsstore so that the call
to `(*MetricsStore).Stop()` is moved from `TestMain` to an individual
test function to be counted for coverage. No functional changes.

Fixes #2689
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No