### PR TITLE
tests/e2e: remove redundant scoping within function

### DIFF
--- a/tests/e2e/e2e_controller_restart_test.go
+++ b/tests/e2e/e2e_controller_restart_test.go
@@ -22,106 +22,104 @@ var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server before 
 	})
 
 func testHTTPTrafficWithControllerRestart() {
-	{
-		const sourceName = "client"
-		const destName = "server"
-		var ns = []string{sourceName, destName}
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
 
-		It("Tests HTTP traffic for client pod -> server pod", func() {
-			// Install OSM
-			Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+	It("Tests HTTP traffic for client pod -> server pod", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Get simple pod definitions for the HTTP server
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      destName,
+				Namespace: destName,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		srcPod := setupSource(sourceName, false /* no service for client */)
+
+		By("Creating SMI policies")
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    "routes",
+				TrafficTargetName: "test-target",
+
+				SourceNamespace:      sourceName,
+				SourceSVCAccountName: sourceName,
+
+				DestinationNamespace:      destName,
+				DestinationSvcAccountName: destName,
+			})
+
+		// Configs have to be put into a monitored NS
+		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:      destName,
-					Namespace: destName,
-					Image:     "kennethreitz/httpbin",
-					Ports:     []int{80},
-				})
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination service %s", srcPod.Name, dstSvc.Name)
 
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+		// Restart osm-controller
+		By("Restarting OSM controller")
+		Expect(Td.RestartOSMController(Td.GetOSMInstallOpts())).To(Succeed())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		// Expect client to reach server
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
 
-			srcPod := setupSource(sourceName, false /* no service for client */)
-
-			By("Creating SMI policies")
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    "routes",
-					TrafficTargetName: "test-target",
-
-					SourceNamespace:      sourceName,
-					SourceSVCAccountName: sourceName,
-
-					DestinationNamespace:      destName,
-					DestinationSvcAccountName: destName,
-				})
-
-			// Configs have to be put into a monitored NS
-			_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// All ready. Expect client to reach server
-			clientToServer := HTTPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
-
-			srcToDestStr := fmt.Sprintf("%s -> %s",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToServer.Destination)
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToServer)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 5, 90*time.Second)
-
-			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination service %s", srcPod.Name, dstSvc.Name)
-
-			// Restart osm-controller
-			By("Restarting OSM controller")
-			Expect(Td.RestartOSMController(Td.GetOSMInstallOpts())).To(Succeed())
-
-			// Expect client to reach server
-			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToServer)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 20, 40*time.Second)
-			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination service %s after osm-controller restart", srcPod.Name, dstSvc.Name)
-		})
-	}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 20, 40*time.Second)
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination service %s after osm-controller restart", srcPod.Name, dstSvc.Name)
+	})
 }

--- a/tests/e2e/e2e_grpc_insecure_origination_test.go
+++ b/tests/e2e/e2e_grpc_insecure_origination_test.go
@@ -31,115 +31,113 @@ var _ = OSMDescribe("gRPC insecure traffic origination for client pod -> server 
 	})
 
 func testGRPCTraffic() {
-	{
-		const sourceName = "client"
-		const destName = "server"
-		var ns = []string{sourceName, destName}
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
 
-		It("Tests insecure gRPC traffic origination for client pod -> server pod using HTTP routes", func() {
-			// Install OSM
-			Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+	It("Tests insecure gRPC traffic origination for client pod -> server pod using HTTP routes", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Get simple pod definitions for the gRPC server
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:        destName,
+				Namespace:   destName,
+				Image:       "moul/grpcbin",
+				Ports:       []int{grpcbinInsecurePort},
+				AppProtocol: "grpc",
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		srcPod := setupGRPCClient(sourceName)
+
+		trafficTargetName := "test-target" //nolint: goconst
+		trafficRouteName := "routes"       //nolint: goconst
+
+		By("Creating SMI policies")
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    trafficRouteName,
+				TrafficTargetName: trafficTargetName,
+
+				SourceNamespace:      sourceName,
+				SourceSVCAccountName: sourceName,
+
+				DestinationNamespace:      destName,
+				DestinationSvcAccountName: destName,
+			})
+
+		// Configs have to be put into a monitored NS
+		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		// All ready. Expect client to reach server
+		clientToServer := GRPCRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s:%d", dstSvc.Name, dstSvc.Namespace, grpcbinInsecurePort),
+
+			JSONRequest: "{\"greeting\": \"client\"}",
+			Symbol:      "hello.HelloService/SayHello",
+			UseTLS:      false, // insecure gRPC, service mesh will upgrade connection to mTLS
+		}
+
+		srcToDestStr := fmt.Sprintf("%s/%s -> %s",
+			clientToServer.SourceNs, clientToServer.SourcePod, clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.GRPCRequest(clientToServer)
+
+			if result.Err != nil {
+				Td.T.Logf("> (%s) gRPC req failed, response: %s, err: %s",
+					srcToDestStr, result.Response, result.Err)
+				return false
 			}
 
-			// Get simple pod definitions for the gRPC server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:        destName,
-					Namespace:   destName,
-					Image:       "moul/grpcbin",
-					Ports:       []int{grpcbinInsecurePort},
-					AppProtocol: "grpc",
-				})
+			Td.T.Logf("> (%s) gRPC req succeeded, response: %s", srcToDestStr, result.Response)
+			return true
+		}, 5, 90*time.Second)
 
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+		Expect(cond).To(BeTrue(), "Failed testing gRPC traffic for: %s", srcToDestStr)
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		By("Deleting SMI policies")
+		Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
+		Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), trafficRouteName, metav1.DeleteOptions{})).To(Succeed())
 
-			srcPod := setupGRPCClient(sourceName)
+		// Expect client not to reach server
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.GRPCRequest(clientToServer)
 
-			trafficTargetName := "test-target" //nolint: goconst
-			trafficRouteName := "routes"       //nolint: goconst
-
-			By("Creating SMI policies")
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    trafficRouteName,
-					TrafficTargetName: trafficTargetName,
-
-					SourceNamespace:      sourceName,
-					SourceSVCAccountName: sourceName,
-
-					DestinationNamespace:      destName,
-					DestinationSvcAccountName: destName,
-				})
-
-			// Configs have to be put into a monitored NS
-			_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// All ready. Expect client to reach server
-			clientToServer := GRPCRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s:%d", dstSvc.Name, dstSvc.Namespace, grpcbinInsecurePort),
-
-				JSONRequest: "{\"greeting\": \"client\"}",
-				Symbol:      "hello.HelloService/SayHello",
-				UseTLS:      false, // insecure gRPC, service mesh will upgrade connection to mTLS
+			if result.Err == nil {
+				Td.T.Logf("> (%s) gRPC req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
+				return false
 			}
-
-			srcToDestStr := fmt.Sprintf("%s/%s -> %s",
-				clientToServer.SourceNs, clientToServer.SourcePod, clientToServer.Destination)
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.GRPCRequest(clientToServer)
-
-				if result.Err != nil {
-					Td.T.Logf("> (%s) gRPC req failed, response: %s, err: %s",
-						srcToDestStr, result.Response, result.Err)
-					return false
-				}
-
-				Td.T.Logf("> (%s) gRPC req succeeded, response: %s", srcToDestStr, result.Response)
-				return true
-			}, 5, 90*time.Second)
-
-			Expect(cond).To(BeTrue(), "Failed testing gRPC traffic for: %s", srcToDestStr)
-
-			By("Deleting SMI policies")
-			Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
-			Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), trafficRouteName, metav1.DeleteOptions{})).To(Succeed())
-
-			// Expect client not to reach server
-			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.GRPCRequest(clientToServer)
-
-				if result.Err == nil {
-					Td.T.Logf("> (%s) gRPC req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
-					return false
-				}
-				Td.T.Logf("> (%s) gRPC req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
-				return true
-			}, 5, 150*time.Second)
-			Expect(cond).To(BeTrue())
-		})
-	}
+			Td.T.Logf("> (%s) gRPC req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
+			return true
+		}, 5, 150*time.Second)
+		Expect(cond).To(BeTrue())
+	})
 }
 
 func setupGRPCClient(sourceName string) *corev1.Pod {

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -22,76 +22,74 @@ var _ = OSMDescribe("Tests traffic via IP range exclusion",
 	})
 
 func testIPExclusion() {
-	{
-		const sourceName = "client"
-		const destName = "server"
-		var ns = []string{sourceName, destName}
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
 
-		It("Tests HTTP traffic to external server via IP exclusion", func() {
-			// Install OSM
-			installOpts := Td.GetOSMInstallOpts()
-			installOpts.EnablePermissiveMode = false // explicitly set to false to demonstrate IP exclusion
-			Expect(Td.InstallOSM(installOpts)).To(Succeed())
+	It("Tests HTTP traffic to external server via IP exclusion", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = false // explicitly set to false to demonstrate IP exclusion
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+		}
+		// Only add source namespace to the mesh, destination is simulating an external cluster
+		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
+
+		// Set up the destination HTTP server. It is not part of the mesh
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      destName,
+				Namespace: destName,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		// The destination IP will be programmed as an IP exclusion
+		destinationIPRange := fmt.Sprintf("%s/32", dstSvc.Spec.ClusterIP)
+		Expect(Td.UpdateOSMConfig("outbound_ip_range_exclusion_list", destinationIPRange))
+
+		srcPod := setupSource(sourceName, false)
+
+		By("Using IP range exclusion to access destination")
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
-			// Only add source namespace to the mesh, destination is simulating an external cluster
-			Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
 
-			// Set up the destination HTTP server. It is not part of the mesh
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:      destName,
-					Namespace: destName,
-					Image:     "kennethreitz/httpbin",
-					Ports:     []int{80},
-				})
-
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
-
-			// The destination IP will be programmed as an IP exclusion
-			destinationIPRange := fmt.Sprintf("%s/32", dstSvc.Spec.ClusterIP)
-			Expect(Td.UpdateOSMConfig("outbound_ip_range_exclusion_list", destinationIPRange))
-
-			srcPod := setupSource(sourceName, false)
-
-			By("Using IP range exclusion to access destination")
-			// All ready. Expect client to reach server
-			clientToServer := HTTPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
-			}
-
-			srcToDestStr := fmt.Sprintf("%s -> %s",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToServer.Destination)
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToServer)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 5, 90*time.Second)
-
-			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination %s", srcPod.Name, destinationIPRange)
-		})
-	}
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination %s", srcPod.Name, destinationIPRange)
+	})
 }

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -29,121 +29,119 @@ var _ = OSMDescribe("Test access via multiple services matching the same pod",
 // 1. 'client' pod -> service 'server' -> 'server' pod
 // 2. 'client' pod -> service 'server-second' -> 'server' pod
 func testMultipleServicePerPod() {
-	{
-		const sourceName = "client"
-		const destName = "server"
-		var ns = []string{sourceName, destName}
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
 
-		It("Tests traffic to multiple services matching the same pod", func() {
-			// Install OSM
-			Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+	It("Tests traffic to multiple services matching the same pod", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Create an HTTP server that clients will send requests to
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      destName,
+				Namespace: destName,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		firstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a 2nd service, which has the same label selectors as the first service created above.
+		// This will be used to verify that multiple services having label selectors matching the
+		// same pod can work as expected.
+		secondSvcDef := svcDef
+		secondSvcDef.Name = fmt.Sprintf("%s-second", svcDef.Name)
+		secondSvc, err := Td.CreateService(destName, secondSvcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		srcPod := setupSource(sourceName, false /* no service for client */)
+
+		By("Creating SMI policies")
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    "routes",
+				TrafficTargetName: "test-target",
+
+				SourceNamespace:      sourceName,
+				SourceSVCAccountName: sourceName,
+
+				DestinationNamespace:      destName,
+				DestinationSvcAccountName: destName,
+			})
+
+		// Configs have to be put into a monitored NS
+		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect client to reach HTTP server using the first service as FQDN
+		clientToFirstService := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s", firstSvc.Name, firstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToFirstService.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToFirstService)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic: %s", srcToDestStr)
 
-			// Create an HTTP server that clients will send requests to
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:      destName,
-					Namespace: destName,
-					Image:     "kennethreitz/httpbin",
-					Ports:     []int{80},
-				})
+		// Expect client to reach HTTP server using the second service as FQDN
+		clientToSecondService := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
 
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			firstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+			Destination: fmt.Sprintf("%s.%s", secondSvc.Name, secondSvc.Namespace),
+		}
 
-			// Create a 2nd service, which has the same label selectors as the first service created above.
-			// This will be used to verify that multiple services having label selectors matching the
-			// same pod can work as expected.
-			secondSvcDef := svcDef
-			secondSvcDef.Name = fmt.Sprintf("%s-second", svcDef.Name)
-			secondSvc, err := Td.CreateService(destName, secondSvcDef)
-			Expect(err).NotTo(HaveOccurred())
+		srcToDestStr = fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToSecondService.Destination)
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToSecondService)
 
-			srcPod := setupSource(sourceName, false /* no service for client */)
-
-			By("Creating SMI policies")
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    "routes",
-					TrafficTargetName: "test-target",
-
-					SourceNamespace:      sourceName,
-					SourceSVCAccountName: sourceName,
-
-					DestinationNamespace:      destName,
-					DestinationSvcAccountName: destName,
-				})
-
-			// Configs have to be put into a monitored NS
-			_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Expect client to reach HTTP server using the first service as FQDN
-			clientToFirstService := HTTPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s", firstSvc.Name, firstSvc.Namespace),
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
-
-			srcToDestStr := fmt.Sprintf("%s -> %s",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToFirstService.Destination)
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToFirstService)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 5, 90*time.Second)
-			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic: %s", srcToDestStr)
-
-			// Expect client to reach HTTP server using the second service as FQDN
-			clientToSecondService := HTTPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s", secondSvc.Name, secondSvc.Namespace),
-			}
-
-			srcToDestStr = fmt.Sprintf("%s -> %s",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToSecondService.Destination)
-
-			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToSecondService)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 5, 90*time.Second)
-			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic: %s", srcToDestStr)
-		})
-	}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic: %s", srcToDestStr)
+	})
 }

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -32,100 +32,98 @@ var _ = OSMDescribe("Permissive Traffic Policy Mode",
 	})
 
 func testPermissiveMode(withSourceKubernetesService bool) {
-	{
-		const sourceNs = "client"
-		const destNs = "server"
-		var ns []string = []string{sourceNs, destNs}
+	const sourceNs = "client"
+	const destNs = "server"
+	var ns []string = []string{sourceNs, destNs}
 
-		It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
-			// Install OSM
-			installOpts := Td.GetOSMInstallOpts()
-			installOpts.EnablePermissiveMode = true
-			Expect(Td.InstallOSM(installOpts)).To(Succeed())
+	It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = true
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
-			}
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:      "server",
-					Namespace: destNs,
-					Image:     "kennethreitz/httpbin",
-					Ports:     []int{80},
-				})
-
-			_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstPod, err := Td.CreatePod(destNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreateService(destNs, svcDef)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
-
-			// Get simple Pod definitions for the client
-			svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
-				Name:      "client",
-				Namespace: sourceNs,
-				Command:   []string{"/bin/bash", "-c", "--"},
-				Args:      []string{"while true; do sleep 30; done;"},
-				Image:     "songrgg/alpine-debug",
+		// Get simple pod definitions for the HTTP server
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      "server",
+				Namespace: destNs,
+				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
 			})
 
-			_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			srcPod, err := Td.CreatePod(sourceNs, podDef)
-			Expect(err).NotTo(HaveOccurred())
+		_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstPod, err := Td.CreatePod(destNs, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateService(destNs, svcDef)
+		Expect(err).NotTo(HaveOccurred())
 
-			if withSourceKubernetesService {
-				_, err = Td.CreateService(sourceNs, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-			}
+		Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
 
-			Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
-
-			req := HTTPRequestDef{
-				SourceNs:        srcPod.Namespace,
-				SourcePod:       srcPod.Name,
-				SourceContainer: "client",
-
-				Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
-			}
-
-			By("Ensuring traffic is allowed when permissive mode is enabled")
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(req)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
-				return true
-			}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
-			Expect(cond).To(BeTrue())
-
-			By("Ensuring traffic is not allowed when permissive mode is disabled")
-
-			Expect(Td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
-
-			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(req)
-
-				if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-					Td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
-				return true
-			}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
-			Expect(cond).To(BeTrue())
+		// Get simple Pod definitions for the client
+		svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+			Name:      "client",
+			Namespace: sourceNs,
+			Command:   []string{"/bin/bash", "-c", "--"},
+			Args:      []string{"while true; do sleep 30; done;"},
+			Image:     "songrgg/alpine-debug",
+			Ports:     []int{80},
 		})
-	}
+
+		_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		srcPod, err := Td.CreatePod(sourceNs, podDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		if withSourceKubernetesService {
+			_, err = Td.CreateService(sourceNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
+
+		req := HTTPRequestDef{
+			SourceNs:        srcPod.Namespace,
+			SourcePod:       srcPod.Name,
+			SourceContainer: "client",
+
+			Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+		}
+
+		By("Ensuring traffic is allowed when permissive mode is enabled")
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(req)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> REST req failed (status: %d) %v", result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+			return true
+		}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+		Expect(cond).To(BeTrue())
+
+		By("Ensuring traffic is not allowed when permissive mode is disabled")
+
+		Expect(Td.UpdateOSMConfig("permissive_traffic_policy_mode", "false"))
+
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(req)
+
+			if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+				Td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
+			return true
+		}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+		Expect(cond).To(BeTrue())
+	})
 }

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -36,109 +36,107 @@ var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 	})
 
 func testTraffic(withSourceKubernetesService bool) {
-	{
-		const sourceName = "client"
-		const destName = "server"
-		var ns = []string{sourceName, destName}
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
 
-		It("Tests HTTP traffic for client pod -> server pod", func() {
-			// Install OSM
-			Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+	It("Tests HTTP traffic for client pod -> server pod", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Get simple pod definitions for the HTTP server
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      destName,
+				Namespace: destName,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		srcPod := setupSource(sourceName, withSourceKubernetesService)
+
+		By("Creating SMI policies")
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    "routes",
+				TrafficTargetName: "test-target",
+
+				SourceNamespace:      sourceName,
+				SourceSVCAccountName: sourceName,
+
+				DestinationNamespace:      destName,
+				DestinationSvcAccountName: destName,
+			})
+
+		// Configs have to be put into a monitored NS
+		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
 
-			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:      destName,
-					Namespace: destName,
-					Image:     "kennethreitz/httpbin",
-					Ports:     []int{80},
-				})
+		sourceService := map[bool]string{true: "with", false: "without"}[withSourceKubernetesService]
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s Kubernetes Service to a destination", sourceService)
 
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+		By("Deleting SMI policies")
+		Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+		Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		// Expect client not to reach server
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
 
-			srcPod := setupSource(sourceName, withSourceKubernetesService)
-
-			By("Creating SMI policies")
-			// Deploy allow rule client->server
-			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-				SimpleAllowPolicy{
-					RouteGroupName:    "routes",
-					TrafficTargetName: "test-target",
-
-					SourceNamespace:      sourceName,
-					SourceSVCAccountName: sourceName,
-
-					DestinationNamespace:      destName,
-					DestinationSvcAccountName: destName,
-				})
-
-			// Configs have to be put into a monitored NS
-			_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
-			Expect(err).NotTo(HaveOccurred())
-
-			// All ready. Expect client to reach server
-			clientToServer := HTTPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
-
-				Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+			// Curl exit code 7 == Conn refused
+			if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+				Td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
+				return false
 			}
-
-			srcToDestStr := fmt.Sprintf("%s -> %s",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToServer.Destination)
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToServer)
-
-				if result.Err != nil || result.StatusCode != 200 {
-					Td.T.Logf("> (%s) HTTP Req failed %d %v",
-						srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
-				return true
-			}, 5, 90*time.Second)
-
-			sourceService := map[bool]string{true: "with", false: "without"}[withSourceKubernetesService]
-			Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s Kubernetes Service to a destination", sourceService)
-
-			By("Deleting SMI policies")
-			Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
-			Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
-
-			// Expect client not to reach server
-			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.HTTPRequest(clientToServer)
-
-				// Curl exit code 7 == Conn refused
-				if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
-					Td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
-					return false
-				}
-				Td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
-				return true
-			}, 5, 150*time.Second)
-			Expect(cond).To(BeTrue())
-		})
-	}
+			Td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
+			return true
+		}, 5, 150*time.Second)
+		Expect(cond).To(BeTrue())
+	})
 }
 
 func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -30,133 +30,131 @@ var _ = OSMDescribe("Test TCP traffic from 1 pod client -> 1 pod server",
 	})
 
 func testTCPTraffic(permissiveMode bool) {
-	{
-		const sourceName = "client"
-		const destName = "server"
-		var ns = []string{sourceName, destName}
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
 
-		It("Tests TCP traffic for client pod -> server pod", func() {
-			// Install OSM
-			installOpts := Td.GetOSMInstallOpts()
-			installOpts.EnablePermissiveMode = permissiveMode
-			Expect(Td.InstallOSM(installOpts)).To(Succeed())
+	It("Tests TCP traffic for client pod -> server pod", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = permissiveMode
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-			// Load TCP server image
-			Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
+		// Load TCP server image
+		Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
 
-			// Create Test NS
-			for _, n := range ns {
-				Expect(Td.CreateNs(n, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		destinationPort := 80
+
+		// Get simple pod definitions for the TCP server
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:        destName,
+				Namespace:   destName,
+				Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag),
+				Command:     []string{"/tcp-echo-server"},
+				Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
+				Ports:       []int{destinationPort},
+				AppProtocol: AppProtocolTCP,
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
+
+		srcPod := setupSource(sourceName, false /* no kubernetes service for the client */)
+
+		trafficTargetName := "test-target"
+		trafficRouteName := "routes"
+
+		if !permissiveMode {
+			By("Creating SMI policies")
+			// Deploy allow rule client->server
+			tcpRoute, trafficTarget := Td.CreateSimpleTCPAllowPolicy(
+				SimpleAllowPolicy{
+					RouteGroupName:    trafficRouteName,
+					TrafficTargetName: trafficTargetName,
+
+					SourceNamespace:      sourceName,
+					SourceSVCAccountName: sourceName,
+
+					DestinationNamespace:      destName,
+					DestinationSvcAccountName: destName,
+				},
+				destinationPort,
+			)
+
+			// Configs have to be put into a monitored NS
+			_, err = Td.CreateTCPRoute(sourceName, tcpRoute)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// All ready. Expect client to reach server
+		requestMsg := "test request"
+		clientToServer := TCPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			DestinationHost: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+			DestinationPort: destinationPort,
+			Message:         requestMsg,
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s:%d",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.DestinationHost, clientToServer.DestinationPort)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.TCPRequest(clientToServer)
+
+			if result.Err != nil {
+				Td.T.Logf("> (%s) TCP Req failed, response: %s, err: %s",
+					srcToDestStr, result.Response, result.Err)
+				return false
 			}
 
-			destinationPort := 80
-
-			// Get simple pod definitions for the TCP server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:        destName,
-					Namespace:   destName,
-					Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag),
-					Command:     []string{"/tcp-echo-server"},
-					Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
-					Ports:       []int{destinationPort},
-					AppProtocol: AppProtocolTCP,
-				})
-
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
-
-			srcPod := setupSource(sourceName, false /* no kubernetes service for the client */)
-
-			trafficTargetName := "test-target"
-			trafficRouteName := "routes"
-
-			if !permissiveMode {
-				By("Creating SMI policies")
-				// Deploy allow rule client->server
-				tcpRoute, trafficTarget := Td.CreateSimpleTCPAllowPolicy(
-					SimpleAllowPolicy{
-						RouteGroupName:    trafficRouteName,
-						TrafficTargetName: trafficTargetName,
-
-						SourceNamespace:      sourceName,
-						SourceSVCAccountName: sourceName,
-
-						DestinationNamespace:      destName,
-						DestinationSvcAccountName: destName,
-					},
-					destinationPort,
-				)
-
-				// Configs have to be put into a monitored NS
-				_, err = Td.CreateTCPRoute(sourceName, tcpRoute)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
-				Expect(err).NotTo(HaveOccurred())
+			// Ensure the echo response contains request message
+			if !strings.Contains(result.Response, requestMsg) {
+				Td.T.Logf("> (%s) Unexpected response: %s.\n Response expected to contain: %s", srcToDestStr, result.Response, requestMsg)
+				return false
 			}
+			Td.T.Logf("> (%s) TCP Req succeeded, response: %s", srcToDestStr, result.Response)
+			return true
+		}, 5, 90*time.Second)
 
-			// All ready. Expect client to reach server
-			requestMsg := "test request"
-			clientToServer := TCPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
+		Expect(cond).To(BeTrue(), "Failed testing TCP traffic from %s", srcToDestStr)
 
-				DestinationHost: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
-				DestinationPort: destinationPort,
-				Message:         requestMsg,
-			}
+		if !permissiveMode {
+			By("Deleting SMI policies")
+			Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
+			Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().TCPRoutes(sourceName).Delete(context.TODO(), trafficRouteName, metav1.DeleteOptions{})).To(Succeed())
 
-			srcToDestStr := fmt.Sprintf("%s -> %s:%d",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToServer.DestinationHost, clientToServer.DestinationPort)
-
-			cond := Td.WaitForRepeatedSuccess(func() bool {
+			// Expect client not to reach server
+			cond = Td.WaitForRepeatedSuccess(func() bool {
 				result := Td.TCPRequest(clientToServer)
 
-				if result.Err != nil {
-					Td.T.Logf("> (%s) TCP Req failed, response: %s, err: %s",
-						srcToDestStr, result.Response, result.Err)
+				if result.Err == nil {
+					Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
 					return false
 				}
-
-				// Ensure the echo response contains request message
-				if !strings.Contains(result.Response, requestMsg) {
-					Td.T.Logf("> (%s) Unexpected response: %s.\n Response expected to contain: %s", srcToDestStr, result.Response, requestMsg)
-					return false
-				}
-				Td.T.Logf("> (%s) TCP Req succeeded, response: %s", srcToDestStr, result.Response)
+				Td.T.Logf("> (%s) TCP Req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
 				return true
-			}, 5, 90*time.Second)
-
-			Expect(cond).To(BeTrue(), "Failed testing TCP traffic from %s", srcToDestStr)
-
-			if !permissiveMode {
-				By("Deleting SMI policies")
-				Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTargetName, metav1.DeleteOptions{})).To(Succeed())
-				Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().TCPRoutes(sourceName).Delete(context.TODO(), trafficRouteName, metav1.DeleteOptions{})).To(Succeed())
-
-				// Expect client not to reach server
-				cond = Td.WaitForRepeatedSuccess(func() bool {
-					result := Td.TCPRequest(clientToServer)
-
-					if result.Err == nil {
-						Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
-						return false
-					}
-					Td.T.Logf("> (%s) TCP Req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
-					return true
-				}, 5, 150*time.Second)
-				Expect(cond).To(BeTrue())
-			}
-		})
-	}
+			}, 5, 150*time.Second)
+			Expect(cond).To(BeTrue())
+		}
+	})
 }

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -23,103 +23,101 @@ var _ = OSMDescribe("Test TCP traffic from 1 pod client -> egress server",
 	})
 
 func testTCPEgressTraffic() {
-	{
-		const sourceName = "client"
-		const destName = "egress-server"
+	const sourceName = "client"
+	const destName = "egress-server"
 
-		It("Tests TCP traffic for client pod -> server pod", func() {
-			// Install OSM
-			installOpts := Td.GetOSMInstallOpts()
-			installOpts.EgressEnabled = true
-			Expect(Td.InstallOSM(installOpts)).To(Succeed())
+	It("Tests TCP traffic for client pod -> server pod", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EgressEnabled = true
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-			// Load TCP server image
-			Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
+		// Load TCP server image
+		Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
 
-			// Create client ns and add it to the mesh
-			Expect(Td.CreateNs(sourceName, nil)).To(Succeed())
-			Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
+		// Create client ns and add it to the mesh
+		Expect(Td.CreateNs(sourceName, nil)).To(Succeed())
+		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
 
-			// Create external ns for server not part of the mesh
-			Expect(Td.CreateNs(destName, nil)).To(Succeed())
+		// Create external ns for server not part of the mesh
+		Expect(Td.CreateNs(destName, nil)).To(Succeed())
 
-			destinationPort := 80
+		destinationPort := 80
 
-			// Get simple pod definitions for the TCP server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
-				SimplePodAppDef{
-					Name:        destName,
-					Namespace:   destName,
-					Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag),
-					Command:     []string{"/tcp-echo-server"},
-					Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
-					Ports:       []int{destinationPort},
-					AppProtocol: AppProtocolTCP,
-				})
+		// Get simple pod definitions for the TCP server
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:        destName,
+				Namespace:   destName,
+				Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag),
+				Command:     []string{"/tcp-echo-server"},
+				Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
+				Ports:       []int{destinationPort},
+				AppProtocol: AppProtocolTCP,
+			})
 
-			_, err := Td.CreateServiceAccount(destName, &svcAccDef)
-			Expect(err).NotTo(HaveOccurred())
-			_, err = Td.CreatePod(destName, podDef)
-			Expect(err).NotTo(HaveOccurred())
-			dstSvc, err := Td.CreateService(destName, svcDef)
-			Expect(err).NotTo(HaveOccurred())
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
 
-			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
 
-			srcPod := setupSource(sourceName, false /* no kubernetes service for the client */)
+		srcPod := setupSource(sourceName, false /* no kubernetes service for the client */)
 
-			// All ready. Expect client to reach server
-			requestMsg := "test request"
-			clientToServer := TCPRequestDef{
-				SourceNs:        sourceName,
-				SourcePod:       srcPod.Name,
-				SourceContainer: sourceName,
+		// All ready. Expect client to reach server
+		requestMsg := "test request"
+		clientToServer := TCPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
 
-				DestinationHost: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
-				DestinationPort: destinationPort,
-				Message:         requestMsg,
+			DestinationHost: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+			DestinationPort: destinationPort,
+			Message:         requestMsg,
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s:%d",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.DestinationHost, clientToServer.DestinationPort)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.TCPRequest(clientToServer)
+
+			if result.Err != nil {
+				Td.T.Logf("> (%s) TCP Req failed, response: %s, err: %s",
+					srcToDestStr, result.Response, result.Err)
+				return false
 			}
 
-			srcToDestStr := fmt.Sprintf("%s -> %s:%d",
-				fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
-				clientToServer.DestinationHost, clientToServer.DestinationPort)
+			// Ensure the echo response contains request message
+			if !strings.Contains(result.Response, requestMsg) {
+				Td.T.Logf("> (%s) Unexpected response: %s.\n Response expected to contain: %s", result.Response, requestMsg)
+				return false
+			}
+			Td.T.Logf("> (%s) TCP Req succeeded, response: %s", srcToDestStr, result.Response)
+			return true
+		}, 5, 90*time.Second)
 
-			cond := Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.TCPRequest(clientToServer)
+		Expect(cond).To(BeTrue(), "Failed testing TCP traffic from %s", srcToDestStr)
 
-				if result.Err != nil {
-					Td.T.Logf("> (%s) TCP Req failed, response: %s, err: %s",
-						srcToDestStr, result.Response, result.Err)
-					return false
-				}
+		By("Disabling egress")
+		Expect(Td.UpdateOSMConfig("egress", "false")).To(Succeed())
 
-				// Ensure the echo response contains request message
-				if !strings.Contains(result.Response, requestMsg) {
-					Td.T.Logf("> (%s) Unexpected response: %s.\n Response expected to contain: %s", result.Response, requestMsg)
-					return false
-				}
-				Td.T.Logf("> (%s) TCP Req succeeded, response: %s", srcToDestStr, result.Response)
-				return true
-			}, 5, 90*time.Second)
+		// Expect client not to reach server
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.TCPRequest(clientToServer)
 
-			Expect(cond).To(BeTrue(), "Failed testing TCP traffic from %s", srcToDestStr)
-
-			By("Disabling egress")
-			Expect(Td.UpdateOSMConfig("egress", "false")).To(Succeed())
-
-			// Expect client not to reach server
-			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.TCPRequest(clientToServer)
-
-				if result.Err == nil {
-					Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
-					return false
-				}
-				Td.T.Logf("> (%s) TCP Req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
-				return true
-			}, 5, 150*time.Second)
-			Expect(cond).To(BeTrue())
-		})
-	}
+			if result.Err == nil {
+				Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
+				return false
+			}
+			Td.T.Logf("> (%s) TCP Req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
+			return true
+		}, 5, 150*time.Second)
+		Expect(cond).To(BeTrue())
+	})
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change removes the extra scoping of the whole
function in tests, which is redundant and doesn't
serve any purpose. 
No functional changes have been made to the tests.

It changes:
```
func() {
   {
       ...
   }
}
```
to
```
func() {
  ...
}
```

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`