### PR TITLE
tests: Ignore fakes when measuring unit test coverage

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -19,7 +19,7 @@ go test -timeout 120s \
    -covermode count "${modules[@]}" | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }
 
 # shellcheck disable=SC2002
-cat coverage.txt.with_generated_code | grep -v "_generated.go" > coverage.txt
+cat coverage.txt.with_generated_code | grep -v "_generated.go" | grep -v "fake.go" > coverage.txt
 
 # shellcheck disable=SC2002
 cat testoutput.txt | go run github.com/jstemmer/go-junit-report > report.xml


### PR DESCRIPTION
Ignore fakes when measuring unit test coverage.

---

This moves us (as of this commit) from `66.33%` to `66.75%` - so not much at all.