### PR TITLE
tests(pkg/kube): Add portforward tests

### DIFF
--- a/pkg/kubernetes/portforward_test.go
+++ b/pkg/kubernetes/portforward_test.go
@@ -1,0 +1,104 @@
+package kubernetes
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+type fakeDialer struct {
+	conn    httpstream.Connection
+	dialErr error
+}
+
+func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+	return d.conn, "", d.dialErr
+}
+
+type noopConnection struct{}
+
+func (*noopConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	return nil, nil
+}
+func (*noopConnection) CloseChan() <-chan bool       { return nil }
+func (*noopConnection) Close() error                 { return nil }
+func (*noopConnection) SetIdleTimeout(time.Duration) {}
+
+func TestPortForwardSuccess(t *testing.T) {
+	dialer := &fakeDialer{
+		conn: &noopConnection{},
+	}
+
+	pf, err := NewPortForwarder(dialer, ":80")
+	if err != nil {
+		t.Fatal("error creating PortForwarder:", err)
+	}
+
+	err = pf.Start(func(*PortForwarder) error {
+		return nil
+	})
+	if err != nil {
+		t.Error("error running port forward:", err)
+	}
+	pf.Stop()
+}
+
+func TestPortForwardInvalidPortSpec(t *testing.T) {
+	portSpec := ""
+	pf, err := NewPortForwarder(nil, "")
+	if err == nil {
+		t.Errorf("Expected error for port spec %q, got none", portSpec)
+	}
+	if pf != nil {
+		t.Errorf("Expected PortForwarder to be nil, got %+v", pf)
+	}
+}
+
+func TestPortForwardDialError(t *testing.T) {
+	dialer := &fakeDialer{
+		dialErr: errors.New("some error"),
+	}
+	pf, err := NewPortForwarder(dialer, ":80")
+	if err != nil {
+		t.Fatal("error creating PortForwarder:", err)
+	}
+
+	err = pf.Start(func(*PortForwarder) error {
+		t.Error("Expected PortForwarder not to become ready but it did")
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("Expected running port forward to fail but it succeeded")
+	}
+	if !strings.Contains(err.Error(), dialer.dialErr.Error()) {
+		t.Errorf("Expected error matching %q, got %q", dialer.dialErr, err)
+	}
+}
+
+func TestPortForwardStoppedBySignal(t *testing.T) {
+	dialer := &fakeDialer{
+		conn: &noopConnection{},
+	}
+
+	pf, err := NewPortForwarder(dialer, ":80")
+	if err != nil {
+		t.Fatal("error creating PortForwarder:", err)
+	}
+
+	err = pf.Start(func(*PortForwarder) error {
+		return nil
+	})
+	if err != nil {
+		t.Error("error running port forward:", err)
+	}
+
+	// No Stop() needed when responding to SIGINT
+	pf.sigChan <- os.Interrupt
+	<-pf.Done()
+}

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -143,6 +143,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 
 			prometheus, err := Td.GetOSMPrometheusHandle()
 			Expect(err).NotTo(HaveOccurred())
+			defer prometheus.Stop()
 
 			dstPods, err := Td.Client.CoreV1().Pods(destNs).List(context.Background(), metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -368,7 +368,11 @@ func (td *OsmTestData) SimpleDeploymentApp(def SimpleDeploymentAppDef) (corev1.S
 
 // GetGrafanaPodHandle generic func to forward a grafana pod and returns a handler pointing to the locally forwarded resource
 func (td *OsmTestData) GetGrafanaPodHandle(ns string, grafanaPodName string, port uint16) (*Grafana, error) {
-	portForwarder, err := k8s.NewPortForwarder(td.RestConfig, td.Client, grafanaPodName, ns, port, port)
+	dialer, err := k8s.DialerToPod(td.RestConfig, td.Client, grafanaPodName, ns)
+	if err != nil {
+		return nil, err
+	}
+	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", port, port))
 	if err != nil {
 		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
 	}
@@ -392,7 +396,11 @@ func (td *OsmTestData) GetGrafanaPodHandle(ns string, grafanaPodName string, por
 
 // GetPrometheusPodHandle generic func to forward a prometheus pod and returns a handler pointing to the locally forwarded resource
 func (td *OsmTestData) GetPrometheusPodHandle(ns string, prometheusPodName string, port uint16) (*Prometheus, error) {
-	portForwarder, err := k8s.NewPortForwarder(td.RestConfig, td.Client, prometheusPodName, ns, port, port)
+	dialer, err := k8s.DialerToPod(td.RestConfig, td.Client, prometheusPodName, ns)
+	if err != nil {
+		return nil, err
+	}
+	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", port, port))
 	if err != nil {
 		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
 	}


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change primarily adds tests for the `PortForwarder` wrapper in
pkg/kubernetes/portforward.go, enabled by some light refactoring. The
only changes outside the `PortForwarder` implementation and tests are
for compatibility, no functional changes.

Fixes #2691
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No