### PR TITLE
tests/e2e: move upgrade test to bucket 4 to balance time

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -40,7 +40,6 @@ Independent of tiers, tests are also organized into buckets. Each bucket runs in
 | e2e_trafficsplit_same_sa_test.go | 1 | 4
 | e2e_pod_client_server_test.go | 1 | 4
 | e2e_helm_install_test.go | 2 | 1
-| e2e_upgrade_test.go | 2 | 1
 | e2e_controller_restart_test.go | 2 | 1
 | e2e_hashivault_test.go| 2 | 2
 | e2e_certmanager_test.go | 2 | 2
@@ -51,6 +50,7 @@ Independent of tiers, tests are also organized into buckets. Each bucket runs in
 | e2e_debug_server_test.go | 2 | 4
 | e2e_fluentbit_deployment_test.go | 2 | 4
 | e2e_fluentbit_output_test.go | 2 | 4
+| e2e_upgrade_test.go | 2 | 4
 
 **Note**: These tiers and buckets and which tests fall into each are likely to change as the test suite grows.
 

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 var _ = OSMDescribe("Upgrade from latest",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 4,
 	},
 	func() {
 		const ns = "upgrade-test"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Moves the upgrade test to bucket 4 from bucket 1, so the
tests times per bucket are more equalized pre-checkin.
Currently bucket 1 takes the longest and bucket 4 the
shortest in the pre-checkin CI.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`