### PR TITLE
Change e2e log level to info

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -105,7 +105,7 @@ var (
 	// default deploy Fluentbit
 	defaultDeployFluentbit = false
 	// default envoy loglevel
-	defaultEnvoyLogLevel = "debug"
+	defaultEnvoyLogLevel = "info"
 	// Test folder base default value
 	testFolderBase = "/tmp"
 )


### PR DESCRIPTION
Rule out if debug log level is actually affecting
the already slow gh kind CI environment.

If we observe same failures, this will be instantly rolled back.

- CI System              [X]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No