### PR TITLE
test: pkg/service ClusterName.String() method

### DIFF
--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -29,4 +29,13 @@ var _ = Describe("Test pkg/service functions", func() {
 			Expect(K8sServiceAccount{}.IsEmpty()).To(BeTrue())
 		})
 	})
+
+	Context("Test ClusterName String method", func() {
+		clusterNameStr := uuid.New().String()
+		cn := ClusterName(clusterNameStr)
+
+		It("implements stringer correctly", func() {
+			Expect(cn.String()).To(Equal(clusterNameStr))
+		})
+	})
 })


### PR DESCRIPTION
Fixes: #2687 

**Description:**
this change adds a test for the `ClusterName.String()` method in
pkg/service/types.go

Signed-off-by: DelusionalOptimist <rudrakshpareek3601@gmail.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
  no
