### PR TITLE
injector: restrict envoy admin access to localhost

### DIFF
--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -21,7 +21,7 @@ func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Config
 			"access_log_path": "/dev/stdout",
 			"address": map[string]interface{}{
 				"socket_address": map[string]string{
-					"address":    "0.0.0.0",
+					"address":    constants.LocalhostIPAddress,
 					"port_value": strconv.Itoa(config.EnvoyAdminPort),
 				},
 			},

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -2,7 +2,7 @@ admin:
   access_log_path: /dev/stdout
   address:
     socket_address:
-      address: 0.0.0.0
+      address: 127.0.0.1
       port_value: "15000"
 dynamic_resources:
   ads_config:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The Envoy admin interface allows to perform destructive
operations as well as exposes sensitive information.
Access to the portal should be restricted to within
the localhost.
More info can be found at
https://www.envoyproxy.io/docs/envoy/latest/operations/admin

Port forwarding to the proxy pod to access the admin portal
over localhost will work as expected.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`