### PR TITLE
charts/osm: update envoy to 1.17.1

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -105,7 +105,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus retention time |
 | OpenServiceMesh.replicaCount | int | `1` | `osm-controller` replicas |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Sets the service certificatevalidity duration |
-| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.0"` | Envoy sidecar image |
+| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.1"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` | Tracing destination cluster (must contain the namespace) |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Destination's API or collector endpoint where the spans will be sent to |

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -173,7 +173,7 @@
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
                     "examples": [
-                        "envoyproxy/envoy-alpine:v1.17.0"
+                        "envoyproxy/envoy-alpine:v1.17.1"
                     ]
                 },
                 "certificateManager": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -15,7 +15,7 @@ OpenServiceMesh:
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
   # -- Envoy sidecar image
-  sidecarImage: envoyproxy/envoy-alpine:v1.17.0
+  sidecarImage: envoyproxy/envoy-alpine:v1.17.1
   osmcontroller:
     resource:
       limits:
@@ -144,6 +144,6 @@ OpenServiceMesh:
       requests:
         cpu: "0.3"
         memory: "64M"
-  
+
   # -- Run init container in privileged mode
   enablePrivilegedInitContainer: false


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
A zero day vulnerability was found in v1.17.0
related to JWT filters. Although OSM does not
use JWT filters, updating the default image
is beneficial from a security compliance
perspective and allows downstream projects
that have forked the repo to use upstream
charts as is.

Refer to the following announcement for more info:
https://groups.google.com/g/envoy-security-announce/c/Hp16L27L00Q

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [X]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`