### PR TITLE
tests(pkg/cli): verify Namespace() error path

### DIFF
--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -64,3 +64,16 @@ func TestNew(t *testing.T) {
 		})
 	}
 }
+
+func TestNamespaceErr(t *testing.T) {
+	env := New()
+
+	// Tell kube to load config from a file that doesn't exist. The exact error
+	// doesn't matter, this was just the simplest way to force an error to
+	// occur. Users of this package are not able to do this, but the resulting
+	// behavior is the same as if any other error had occurred.
+	kConfigPath := "This doesn't even look like a valid path name"
+	env.config.KubeConfig = &kConfigPath
+
+	tassert.Equal(t, env.Namespace(), "default")
+}


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a test to pkg/cli to verify that
`(*EnvSettings).Namespace()` behaves as expected when an error occurs.
I added additional details in a comment in the test.

Fixes #2722

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No