### PR TITLE
pkg/envoy: Enable some logs at info

### DIFF
--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -84,6 +84,7 @@ func (mc *MeshCatalog) dispatcher() {
 					broadcastScheduled = true
 					chanMaxDeadline = time.After(maxBroadcastDeadlineTime)
 					chanMovingDeadline = time.After(maxGraceDeadlineTime)
+					log.Info().Msg("Broadcast scheduled by config changes")
 				} else {
 					// If a broadcast is already scheduled, just reset the moving deadline
 					chanMovingDeadline = time.After(maxGraceDeadlineTime)
@@ -95,7 +96,7 @@ func (mc *MeshCatalog) dispatcher() {
 
 		// A select-fallthrough doesn't exist, we are copying some code here
 		case <-chanMovingDeadline:
-			log.Debug().Msgf("[Moving deadline trigger] Broadcast envoy update")
+			log.Info().Msgf("Moving deadline trigger - Broadcast envoy update")
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
@@ -106,7 +107,7 @@ func (mc *MeshCatalog) dispatcher() {
 			chanMaxDeadline = make(<-chan time.Time)
 
 		case <-chanMaxDeadline:
-			log.Debug().Msgf("[Max deadline trigger] Broadcast envoy update")
+			log.Info().Msgf("Max deadline trigger - Broadcast envoy update")
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})

--- a/pkg/envoy/ads/profile.go
+++ b/pkg/envoy/ads/profile.go
@@ -7,6 +7,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
+
+	"github.com/rs/zerolog"
 )
 
 const (
@@ -14,12 +16,12 @@ const (
 	MaxXdsLogsPerProxy = 20
 )
 
-func xdsPathTimeTrack(t time.Time, tURIStr string, commonNameStr string, success *bool) {
+func xdsPathTimeTrack(t time.Time, log *zerolog.Event, tURIStr string, proxyXdsCertSerialNum string, success *bool) {
 	elapsed := time.Since(t)
 
-	log.Debug().Msgf("[%s] proxy %s took %s",
+	log.Msgf("[%s] processing for Proxy Serial=%s took %s",
 		tURIStr,
-		commonNameStr,
+		proxyXdsCertSerialNum,
 		elapsed)
 
 	metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime.

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -23,7 +23,7 @@ func (s *Server) sendTypeResponse(tURI envoy.TypeURI,
 	// Tracks the success of this TypeURI response operation; accounts also for receipt on envoy server side
 	success := false
 	xdsShortName := envoy.XDSShortURINames[tURI]
-	defer xdsPathTimeTrack(time.Now(), xdsShortName, proxy.GetCertificateCommonName().String(), &success)
+	defer xdsPathTimeTrack(time.Now(), log.Debug(), xdsShortName, proxy.GetCertificateSerialNumber().String(), &success)
 
 	log.Trace().Msgf("[%s] Creating response for proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 
@@ -48,7 +48,7 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.Aggr
 	// Tracks the success of this full update of all its XDS paths. If a single XDS response path fails for this full update,
 	// the full updated will be considered as failed for metric purposes (success = false)
 	success := true
-	defer xdsPathTimeTrack(time.Now(), ADSUpdateStr, proxy.GetCertificateCommonName().String(), &success)
+	defer xdsPathTimeTrack(time.Now(), log.Info(), ADSUpdateStr, proxy.GetCertificateSerialNumber().String(), &success)
 
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -150,8 +150,9 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 				log.Debug().Msgf("Received discovery request with Nonce=%s from Envoy on Pod with UID=%s; matches=%t; proxy last Nonce=%s",
 					discoveryRequest.ResponseNonce, proxy.GetPodUID(), discoveryRequest.ResponseNonce == lastNonce, lastNonce)
 			}
-			log.Debug().Msgf("Received discovery request <%s> for resources (%v) from Envoy on Pod with UID=<%s> with Nonce=%s",
-				discoveryRequest.TypeUrl, discoveryRequest.ResourceNames, proxy.GetPodUID(), discoveryRequest.ResponseNonce)
+			xdsShortName := envoy.XDSShortURINames[typeURL]
+			log.Info().Msgf("Discovery request <%s> for resources (%v) from Envoy UID=<%s> with Nonce=%s",
+				xdsShortName, discoveryRequest.ResourceNames, proxy.GetPodUID(), discoveryRequest.ResponseNonce)
 
 			err := s.sendTypeResponse(typeURL, proxy, &server, &discoveryRequest, s.cfg)
 			if err != nil {
@@ -160,7 +161,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			}
 
 		case <-broadcastUpdate:
-			log.Debug().Msgf("Broadcast update received for Envoy with xDS Certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+			log.Info().Msgf("Broadcast wake for Proxy SerialNumber=%s UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 			s.sendAllResponses(proxy, &server, s.cfg)
 		}
 	}


### PR DESCRIPTION
Enables info logging for high level events, that should give sufficient
insight to understand what was the control plane up to at a specific point
in time while not drowning the logging facility.


- Dispatcher top level events
  - Scheduling proxy broadcast, firing proxy broadcast
- ADS
  - End of ADS update (includes time full config took, ONLY full ADS, not per xds path)
 - Stream.go
   - Discovery request wake (important, as individual paths will not log)
   - Broadcast update wake


Signed-off-by: Eduard Serra <eduser25@gmail.com>

- Control Plane          [x]
- Logging                   [x]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No