### PR TITLE
fix(*): rm kubernetes service hostname resolution for root service in traffic split

### DIFF
--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -51,7 +51,8 @@ spec:
     name: bookstore-port
 
   selector:
-    app: $SVC
+    app: bookstore
+    version: $VERSION
 EOF
 
 echo -e "Deploy $SVC Deployment"

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -50,14 +50,16 @@ metadata:
   name: $SVC
   namespace: $BOOKSTORE_NAMESPACE
   labels:
-    app: $SVC
+    app: bookstore
+    version: $VERSION
 spec:
   ports:
   - port: 14001
     name: bookstore-port
 
   selector:
-    app: $SVC
+    app: bookstore
+    version: $VERSION
 EOF
 
 echo -e "Deploy $SVC Deployment"

--- a/demo/deploy-traffic-split.sh
+++ b/demo/deploy-traffic-split.sh
@@ -12,7 +12,7 @@ metadata:
   name: bookstore-split
   namespace: "$BOOKSTORE_NAMESPACE"
 spec:
-  service: bookstore
+  service: bookstore.bookstore
   backends:
 
   - service: bookstore-v1

--- a/docs/example/manifests/apps/bookstore-v1.yaml
+++ b/docs/example/manifests/apps/bookstore-v1.yaml
@@ -1,9 +1,3 @@
-# Deploy bookstore Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: bookstore
----
 # Deploy bookstore-v1 Service
 apiVersion: v1
 kind: Service
@@ -18,7 +12,8 @@ spec:
   - port: 14001
     name: bookstore-port
   selector:
-    app: bookstore-v1
+    app: bookstore
+    version: v1
 ---
 # Deploy bookstore-v1 Service Account
 apiVersion: v1
@@ -37,11 +32,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: bookstore-v1
+      app: bookstore
+      version: v1
   template:
     metadata:
       labels:
-        app: bookstore-v1
+        app: bookstore
+        version: v1
     spec:
       serviceAccountName: bookstore-v1
       containers:

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -6,13 +6,15 @@ metadata:
   name: bookstore-v2
   namespace: bookstore
   labels:
-    app: bookstore-v2
+    app: bookstore
+    version: v2
 spec:
   ports:
   - port: 14001
     name: bookstore-port
   selector:
-    app: bookstore-v2
+    app: bookstore
+    version: v2
 ---
 # Deploy bookstore-v2 Service Account
 apiVersion: v1

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -1,9 +1,3 @@
-# Deploy bookstore Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: bookstore
----
 # Deploy bookstore Service
 apiVersion: v1
 kind: Service

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"strings"
 
-	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/kubernetes"
@@ -29,26 +28,18 @@ func (mc *MeshCatalog) isTrafficSplitBackendService(svc service.MeshService) boo
 
 // getApexServicesForBackendService returns a list of services that serve as the apex service in a traffic split where the
 // given service is a backend
-func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.MeshService) []service.MeshService {
-	apexList := []service.MeshService{}
-	apexSet := mapset.NewSet()
+func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.MeshService) map[string]string {
+	nameApexServiceMap := map[string]string{}
 	for _, split := range mc.meshSpec.ListTrafficSplits() {
 		for _, backend := range split.Spec.Backends {
 			if backend.Service == targetService.Name && split.Namespace == targetService.Namespace {
-				apexSet.Add(service.MeshService{
-					Name:      split.Spec.Service,
-					Namespace: split.Namespace,
-				})
+				nameApexServiceMap[split.Name+"-"+split.Namespace] = split.Spec.Service
 				break
 			}
 		}
 	}
 
-	for v := range apexSet.Iter() {
-		apexList = append(apexList, v.(service.MeshService))
-	}
-
-	return apexList
+	return nameApexServiceMap
 }
 
 // GetServicesForServiceAccount returns a list of services corresponding to a service account

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -122,7 +122,7 @@ func MergeOutboundPolicies(original []*OutboundTrafficPolicy, latest ...*Outboun
 	for _, l := range latest {
 		foundHostnames := false
 		for _, or := range original {
-			if reflect.DeepEqual(or.Hostnames, l.Hostnames) {
+			if reflect.DeepEqual(or.Hostnames, l.Hostnames) || subset(or.Hostnames, l.Hostnames) {
 				foundHostnames = true
 				mergedRoutes := mergeRoutesWeightedClusters(or.Routes, l.Routes)
 				or.Routes = mergedRoutes

--- a/scripts/port-forward-bookstore-ui-v1.sh
+++ b/scripts/port-forward-bookstore-ui-v1.sh
@@ -16,6 +16,6 @@ if [ -z "$backend" ]; then
 fi
 
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8081}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore --selector version=v1 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv1_LOCAL_PORT":14001

--- a/scripts/port-forward-bookstore-ui-v2.sh
+++ b/scripts/port-forward-bookstore-ui-v2.sh
@@ -16,6 +16,6 @@ if [ -z "$backend" ]; then
 fi
 
 BOOKSTOREv2_LOCAL_PORT="${BOOKSTOREv2_LOCAL_PORT:-8082}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore --selector version=v2 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv2_LOCAL_PORT":14001

--- a/scripts/port-forward-bookstore.sh
+++ b/scripts/port-forward-bookstore.sh
@@ -10,6 +10,6 @@ if [ -z "$backend" ]; then
     exit 1
 fi
 
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector app="bookstore" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 15000:15000
 

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -41,6 +41,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 						Namespace: destNs,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
+						Labels:    map[string]string{"app": "server"},
 					})
 
 				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
@@ -61,6 +62,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 					Args:      []string{"while true; do sleep 30; done;"},
 					Image:     "songrgg/alpine-debug",
 					Ports:     []int{80},
+					Labels:    map[string]string{"app": "client"},
 				})
 
 				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -89,9 +89,9 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 					})
 
 				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = Td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				_, err = Td.CreateHTTPRouteGroup(destNs, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = Td.CreateTrafficTarget(destNs, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server

--- a/tests/e2e/e2e_controller_restart_test.go
+++ b/tests/e2e/e2e_controller_restart_test.go
@@ -73,9 +73,9 @@ func testHTTPTrafficWithControllerRestart() {
 			})
 
 		// Configs have to be put into a monitored NS
-		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		_, err = Td.CreateHTTPRouteGroup(destName, httpRG)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		_, err = Td.CreateTrafficTarget(destName, trafficTarget)
 		Expect(err).NotTo(HaveOccurred())
 
 		// All ready. Expect client to reach server

--- a/tests/e2e/e2e_controller_restart_test.go
+++ b/tests/e2e/e2e_controller_restart_test.go
@@ -43,6 +43,7 @@ func testHTTPTrafficWithControllerRestart() {
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				Labels:    map[string]string{"app": destName},
 			})
 
 		_, err := Td.CreateServiceAccount(destName, &svcAccDef)

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -54,11 +54,12 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				// Use a deployment with multiple replicaset at serverside
 				svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
-						Name:         "server",
-						Namespace:    destApp,
-						ReplicaCount: int32(replicaSetPerService),
-						Image:        "kennethreitz/httpbin",
-						Ports:        []int{80},
+						Name:           "server",
+						Namespace:      destApp,
+						ReplicaCount:   int32(replicaSetPerService),
+						Image:          "kennethreitz/httpbin",
+						Ports:          []int{80},
+						LabelSelectors: map[string]string{"app": "server"},
 					})
 
 				_, err := Td.CreateServiceAccount(destApp, &svcAccDef)
@@ -78,13 +79,14 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				for _, srcClient := range sourceNamespaces {
 					svcAccDef, deploymentDef, svcDef = Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							Name:         srcClient,
-							Namespace:    srcClient,
-							ReplicaCount: int32(replicaSetPerService),
-							Command:      []string{"/bin/bash", "-c", "--"},
-							Args:         []string{"while true; do sleep 30; done;"},
-							Image:        "songrgg/alpine-debug",
-							Ports:        []int{80}, // Can't deploy services with empty/no ports
+							Name:           srcClient,
+							Namespace:      srcClient,
+							ReplicaCount:   int32(replicaSetPerService),
+							Command:        []string{"/bin/bash", "-c", "--"},
+							Args:           []string{"while true; do sleep 30; done;"},
+							Image:          "songrgg/alpine-debug",
+							Ports:          []int{80}, // Can't deploy services with empty/no ports
+							LabelSelectors: map[string]string{"app": srcClient},
 						})
 					_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -119,9 +119,9 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 						})
 
 					// Configs have to be put into a monitored NS, and osm-system can't be by cli
-					_, err = Td.CreateHTTPRouteGroup(srcClient, httpRG)
+					_, err = Td.CreateHTTPRouteGroup(destApp, httpRG)
 					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+					_, err = Td.CreateTrafficTarget(destApp, trafficTarget)
 					Expect(err).NotTo(HaveOccurred())
 				}
 

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -40,6 +40,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 						Namespace: destNs,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
+						Labels:    map[string]string{"app": "server"},
 					})
 
 				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
@@ -87,9 +88,9 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 					})
 
 				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = Td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				_, err = Td.CreateHTTPRouteGroup(destNs, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = Td.CreateTrafficTarget(destNs, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -60,6 +60,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 					Args:      []string{"while true; do sleep 30; done;"},
 					Image:     "songrgg/alpine-debug",
 					Ports:     []int{80},
+					Labels:    map[string]string{"app": "client"},
 				})
 
 				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -46,11 +46,12 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 			// Get simple pod definitions for the HTTP server
 			svcAccDef, depDef, svcDef := Td.SimpleDeploymentApp(
 				SimpleDeploymentAppDef{
-					ReplicaCount: 1,
-					Name:         "server",
-					Namespace:    destNs,
-					Image:        "kennethreitz/httpbin",
-					Ports:        []int{80},
+					ReplicaCount:   1,
+					Name:           "server",
+					Namespace:      destNs,
+					Image:          "kennethreitz/httpbin",
+					Ports:          []int{80},
+					LabelSelectors: map[string]string{"app": "server"},
 				})
 
 			_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
@@ -65,13 +66,14 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 
 			// Get simple Pod definitions for the client
 			svcAccDef, depDef, svcDef = Td.SimpleDeploymentApp(SimpleDeploymentAppDef{
-				ReplicaCount: 1,
-				Name:         "client",
-				Namespace:    sourceNs,
-				Command:      []string{"/bin/bash", "-c", "--"},
-				Args:         []string{"while true; do sleep 30; done;"},
-				Image:        "songrgg/alpine-debug",
-				Ports:        []int{80},
+				ReplicaCount:   1,
+				Name:           "client",
+				Namespace:      sourceNs,
+				Command:        []string{"/bin/bash", "-c", "--"},
+				Args:           []string{"while true; do sleep 30; done;"},
+				Image:          "songrgg/alpine-debug",
+				Ports:          []int{80},
+				LabelSelectors: map[string]string{"app": "client"},
 			})
 
 			_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -87,9 +87,9 @@ func testMultipleServicePerPod() {
 			})
 
 		// Configs have to be put into a monitored NS
-		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		_, err = Td.CreateHTTPRouteGroup(destName, httpRG)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		_, err = Td.CreateTrafficTarget(destName, trafficTarget)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect client to reach HTTP server using the first service as FQDN

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -55,6 +55,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 				Namespace: destNs,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				Labels:    map[string]string{"app": "server"},
 			})
 
 		_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
@@ -74,6 +75,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 			Args:      []string{"while true; do sleep 30; done;"},
 			Image:     "songrgg/alpine-debug",
 			Ports:     []int{80},
+			Labels:    map[string]string{"app": "client"},
 		})
 
 		_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -57,6 +57,7 @@ func testTraffic(withSourceKubernetesService bool) {
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				Labels:    map[string]string{"app": destName},
 			})
 
 		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
@@ -147,6 +148,7 @@ func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {
 		Command:   []string{"sleep", "365d"},
 		Image:     "curlimages/curl",
 		Ports:     []int{80},
+		Labels:    map[string]string{"app": sourceName},
 	})
 
 	_, err := Td.CreateServiceAccount(sourceName, &svcAccDef)

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -87,9 +87,9 @@ func testTraffic(withSourceKubernetesService bool) {
 			})
 
 		// Configs have to be put into a monitored NS
-		_, err = Td.CreateHTTPRouteGroup(sourceName, httpRG)
+		_, err = Td.CreateHTTPRouteGroup(destName, httpRG)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = Td.CreateTrafficTarget(sourceName, trafficTarget)
+		_, err = Td.CreateTrafficTarget(destName, trafficTarget)
 		Expect(err).NotTo(HaveOccurred())
 
 		// All ready. Expect client to reach server
@@ -121,8 +121,8 @@ func testTraffic(withSourceKubernetesService bool) {
 		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s Kubernetes Service to a destination", sourceService)
 
 		By("Deleting SMI policies")
-		Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
-		Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
+		Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(destName).Delete(context.TODO(), trafficTarget.Name, metav1.DeleteOptions{})).To(Succeed())
+		Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(destName).Delete(context.TODO(), httpRG.Name, metav1.DeleteOptions{})).To(Succeed())
 
 		// Expect client not to reach server
 		cond = Td.WaitForRepeatedSuccess(func() bool {

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -168,8 +168,8 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 				Expect(cond).To(BeTrue())
 
 				By("Deleting SMI policies")
-				Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(sourceOne).Delete(context.TODO(), trafficTargetOne.Name, metav1.DeleteOptions{})).To(Succeed())
-				Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(sourceOne).Delete(context.TODO(), httpRGOne.Name, metav1.DeleteOptions{})).To(Succeed())
+				Expect(Td.SmiClients.AccessClient.AccessV1alpha3().TrafficTargets(destName).Delete(context.TODO(), trafficTargetOne.Name, metav1.DeleteOptions{})).To(Succeed())
+				Expect(Td.SmiClients.SpecClient.SpecsV1alpha4().HTTPRouteGroups(destName).Delete(context.TODO(), httpRGOne.Name, metav1.DeleteOptions{})).To(Succeed())
 
 				// Verify HTTP requests fail from allowed client to destination server after SMI policies are deleted
 				cond = Td.WaitForRepeatedSuccess(func() bool {
@@ -190,7 +190,7 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 
 // createPolicyForRoutePath creates an HTTPRouteGroup and TrafficTarget policy for the given source, destination and HTTP path regex
 func createPolicyForRoutePath(source string, destination string, pathRegex string) (smiSpecs.HTTPRouteGroup, smiAccess.TrafficTarget) {
-	routeGroupName := "test-route"
+	routeGroupName := source + "-" + destination
 	routeMatchName := "allowed-route"
 
 	routeGroup := smiSpecs.HTTPRouteGroup{

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -45,6 +45,7 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 						Namespace: destName,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
+						Labels:    map[string]string{"app": destName},
 					})
 				_, err := Td.CreateServiceAccount(destName, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -60,6 +61,7 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 					Command:   []string{"sleep", "365d"},
 					Image:     "curlimages/curl",
 					Ports:     []int{80},
+					Labels:    map[string]string{"app": sourceOne},
 				})
 				_, err = Td.CreateServiceAccount(sourceOne, &allowedSvcAccDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -73,6 +75,7 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 					Command:   []string{"sleep", "365d"},
 					Image:     "curlimages/curl",
 					Ports:     []int{80},
+					Labels:    map[string]string{"app": sourceTwo},
 				})
 				_, err = Td.CreateServiceAccount(sourceTwo, &deniedSvcAccDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -95,9 +98,9 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 				// Deploy policies to allow 'sourceOne' to access destination at HTTP path '/anything'
 				anythingPath := "/anything"
 				httpRGOne, trafficTargetOne := createPolicyForRoutePath(sourceOne, destName, anythingPath)
-				_, err = Td.CreateHTTPRouteGroup(sourceOne, httpRGOne)
+				_, err = Td.CreateHTTPRouteGroup(destName, httpRGOne)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(sourceOne, trafficTargetOne)
+				_, err = Td.CreateTrafficTarget(destName, trafficTargetOne)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Deploy policies to allow 'sourceTwo' to access destination at HTTP path '/foo'
@@ -105,9 +108,9 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 				// path '/anything' which is used to demonstrate RBAC per route.
 				fooPath := "/foo"
 				httpRGTwo, trafficTargetTwo := createPolicyForRoutePath(sourceTwo, destName, fooPath)
-				_, err = Td.CreateHTTPRouteGroup(sourceTwo, httpRGTwo)
+				_, err = Td.CreateHTTPRouteGroup(destName, httpRGTwo)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(sourceTwo, trafficTargetTwo)
+				_, err = Td.CreateTrafficTarget(destName, trafficTargetTwo)
 				Expect(err).NotTo(HaveOccurred())
 
 				// HTTP request from 'sourceOne': http://<address>/anything

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -61,6 +61,7 @@ func testTCPTraffic(permissiveMode bool) {
 				Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
 				Ports:       []int{destinationPort},
 				AppProtocol: AppProtocolTCP,
+				Labels:      map[string]string{"app": destName},
 			})
 
 		_, err := Td.CreateServiceAccount(destName, &svcAccDef)

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -54,6 +54,7 @@ func testTCPEgressTraffic() {
 				Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
 				Ports:       []int{destinationPort},
 				AppProtocol: AppProtocolTCP,
+				Labels:      map[string]string{"app": destName},
 			})
 
 		_, err := Td.CreateServiceAccount(destName, &svcAccDef)

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -68,11 +68,12 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 				for _, serverApp := range serverServices {
 					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							Name:         serverApp,
-							Namespace:    serverNamespace,
-							ReplicaCount: int32(serverReplicaSet),
-							Image:        "simonkowallik/httpbin",
-							Ports:        []int{80},
+							Name:           serverApp,
+							Namespace:      serverNamespace,
+							ReplicaCount:   int32(serverReplicaSet),
+							Image:          "simonkowallik/httpbin",
+							Ports:          []int{80},
+							LabelSelectors: map[string]string{"app": "test", "version": serverApp},
 						})
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -107,13 +108,14 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 				for _, clientApp := range clientServices {
 					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							Name:         clientApp,
-							Namespace:    clientApp,
-							ReplicaCount: int32(clientReplicaSet),
-							Command:      []string{"/bin/bash", "-c", "--"},
-							Args:         []string{"while true; do sleep 30; done;"},
-							Image:        "songrgg/alpine-debug",
-							Ports:        []int{80},
+							Name:           clientApp,
+							Namespace:      clientApp,
+							ReplicaCount:   int32(clientReplicaSet),
+							Command:        []string{"/bin/bash", "-c", "--"},
+							Args:           []string{"while true; do sleep 30; done;"},
+							Image:          "songrgg/alpine-debug",
+							Ports:          []int{80},
+							LabelSelectors: map[string]string{"app": "test", "version": clientApp},
 						})
 
 					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
@@ -159,6 +161,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 					Name:      trafficSplitName,
 					Namespace: serverNamespace,
 					Ports:     []int{80},
+					Labels:    map[string]string{"app": "test"},
 				})
 
 				// Creating trafficsplit service in K8s
@@ -169,7 +172,7 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 				trafficSplit := TrafficSplitDef{
 					Name:                    trafficSplitName,
 					Namespace:               serverNamespace,
-					TrafficSplitServiceName: trafficSplitName,
+					TrafficSplitServiceName: trafficSplitName + "." + serverNamespace,
 					Backends:                []TrafficSplitBackend{},
 				}
 				assignation := 100 / len(serverServices) // Spreading equitatively

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -149,9 +149,9 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 								DestinationSvcAccountName: dstServer,
 							})
 
-						_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
+						_, err := Td.CreateHTTPRouteGroup(serverNamespace, httpRG)
 						Expect(err).NotTo(HaveOccurred())
-						_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+						_, err = Td.CreateTrafficTarget(serverNamespace, trafficTarget)
 						Expect(err).NotTo(HaveOccurred())
 					}
 				}

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -142,6 +142,7 @@ type SimplePodAppDef struct {
 	Args        []string
 	Ports       []int
 	AppProtocol string
+	Labels      map[string]string
 }
 
 // SimplePodApp creates returns a set of k8s typed definitions for a pod-based k8s definition.
@@ -155,10 +156,8 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 
 	podDefinition := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: def.Name,
-			Labels: map[string]string{
-				"app": def.Name,
-			},
+			Name:   def.Name,
+			Labels: def.Labels,
 		},
 		Spec: corev1.PodSpec{
 			TerminationGracePeriodSeconds: new(int64), // 0
@@ -195,15 +194,11 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 
 	serviceDefinition := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: def.Name,
-			Labels: map[string]string{
-				"app": def.Name,
-			},
+			Name:   def.Name,
+			Labels: def.Labels,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"app": def.Name,
-			},
+			Selector: def.Labels,
 		},
 	}
 
@@ -260,13 +255,14 @@ func (td *OsmTestData) getKubernetesServerVersionNumber() ([]int, error) {
 
 // SimpleDeploymentAppDef defines some parametrization to create a deployment-based application from template
 type SimpleDeploymentAppDef struct {
-	Namespace    string
-	Name         string
-	Image        string
-	ReplicaCount int32
-	Command      []string
-	Args         []string
-	Ports        []int
+	Namespace      string
+	Name           string
+	Image          string
+	ReplicaCount   int32
+	Command        []string
+	Args           []string
+	Ports          []int
+	LabelSelectors map[string]string
 }
 
 // SimpleDeploymentApp creates returns a set of k8s typed definitions for a deployment-based k8s definition.
@@ -290,15 +286,11 @@ func (td *OsmTestData) SimpleDeploymentApp(def SimpleDeploymentAppDef) (corev1.S
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicaCountExplicitDeclaration,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": def.Name,
-				},
+				MatchLabels: def.LabelSelectors,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": def.Name,
-					},
+					Labels: def.LabelSelectors,
 				},
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: new(int64), // 0
@@ -334,14 +326,10 @@ func (td *OsmTestData) SimpleDeploymentApp(def SimpleDeploymentAppDef) (corev1.S
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      def.Name,
 			Namespace: def.Namespace,
-			Labels: map[string]string{
-				"app": def.Name,
-			},
+			Labels:    def.LabelSelectors,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"app": def.Name,
-			},
+			Selector: def.LabelSelectors,
 		},
 	}
 

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -94,11 +94,12 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 				for _, serverApp := range serverServices {
 					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							Name:         serverApp,
-							Namespace:    serverNamespace,
-							ReplicaCount: int32(serverReplicaSet),
-							Image:        "simonkowallik/httpbin",
-							Ports:        []int{80},
+							Name:           serverApp,
+							Namespace:      serverNamespace,
+							ReplicaCount:   int32(serverReplicaSet),
+							Image:          "simonkowallik/httpbin",
+							Ports:          []int{80},
+							LabelSelectors: map[string]string{"app": "test", "version": serverApp},
 						})
 
 					// Expose pod name as a header in server services' responses
@@ -130,13 +131,14 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 				for _, clientApp := range clientServices {
 					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							Name:         clientApp,
-							Namespace:    clientApp,
-							ReplicaCount: int32(clientReplicaSet),
-							Command:      []string{"/bin/bash", "-c", "--"},
-							Args:         []string{"while true; do sleep 30; done;"},
-							Image:        "songrgg/alpine-debug",
-							Ports:        []int{80},
+							Name:           clientApp,
+							Namespace:      clientApp,
+							ReplicaCount:   int32(clientReplicaSet),
+							Command:        []string{"/bin/bash", "-c", "--"},
+							Args:           []string{"while true; do sleep 30; done;"},
+							Image:          "songrgg/alpine-debug",
+							Ports:          []int{80},
+							LabelSelectors: map[string]string{"app": "test", "version": clientApp},
 						})
 
 					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
@@ -192,7 +194,7 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 				trafficSplit := TrafficSplitDef{
 					Name:                    TrafficSplitPrefix,
 					Namespace:               serverNamespace,
-					TrafficSplitServiceName: TrafficSplitPrefix,
+					TrafficSplitServiceName: TrafficSplitPrefix + "." + serverNamespace,
 					Backends:                []TrafficSplitBackend{},
 				}
 				assignment := 100 / len(serverServices) // Spread loadbalancing between backends


### PR DESCRIPTION
This PR is the result of an issue with the manual demo. Running the manual demo results in an error in osm controller logs when bookstore.bookstore is applied as the root service. Root service should be an FQDN according the SMI spec so bookstore.bookstore should work. However, the issue was that when calculating routes in routes.go for traffic splits, we were trying to get a full set of domains for the root service assuming it is a Kubernetes service without the namespace suffix. The PR takes out the logic to find the hostnames and simply creates a new outbound/inbound traffic policy where the domain is the root service. The traffic policy logic then merges this policy in with any other related policies, so if there is already a policy related to bookstore.bookstore, it will merge this split policy in with that so users can access bookstore.bookstore or bookstore.bookstore:14001 for example. In order for this to work properly, the root service must have a matching label selector to the pods that is splitting against. In other words, must be an overlap in label selectors between the root service and the backend services. There will create virtual hosts with proper domains for each Kubernetes service routing requests to Pods the way that Kubernetes does natively before traffic split is applied.


+ when traffic split routes are calculated, rm assumption
that the service is a kubernetes service
+ when traffic split routes are merged with inbound/outbound routes,
allow partial hostname match
+ If Kubernetes service is used as root service, the Kubernetes service must
have label selectors that match pods being served by backend services
+ update examples so that label selectors are used in the kubernetes native
way.
+ partially related to #2768

Signed-off-by: Michelle Noorali <minooral@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
