### PR TITLE
tests(pkg/cli): add test for EnvVars()

### DIFF
--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -52,6 +52,16 @@ func TestNew(t *testing.T) {
 			flags := pflag.NewFlagSet("test-new", pflag.ContinueOnError)
 
 			for k, v := range test.envVars {
+				oldv, found := os.LookupEnv(k)
+				defer func(k string, oldv string, found bool) {
+					var err error
+					if found {
+						err = os.Setenv(k, oldv)
+					} else {
+						err = os.Unsetenv(k)
+					}
+					assert.Nil(err)
+				}(k, oldv, found)
 				err := os.Setenv(k, v)
 				assert.Nil(err)
 			}
@@ -76,4 +86,9 @@ func TestNamespaceErr(t *testing.T) {
 	env.config.KubeConfig = &kConfigPath
 
 	tassert.Equal(t, env.Namespace(), "default")
+}
+
+func TestEnvVars(t *testing.T) {
+	env := New()
+	tassert.Equal(t, map[string]string{"OSM_NAMESPACE": "osm-system"}, env.EnvVars())
 }


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a test in pkg/cli for the `(*EnvSettings).EnvVars()`
function. It also adds a change in the tests for `New()` to undo any
environment variable changes so the new test runs the same both in
isolation and in the context of the other tests.

Fixes #2721
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No