### PR TITLE
test(pkg/kubernetes): Add test for GetAppProtocolFromPortName()

### DIFF
--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -101,3 +101,41 @@ func TestGetServiceFromHostname(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAppProtocolFromPortName(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name             string
+		portName         string
+		expectedProtocal string
+	}{
+		{
+			name:             "tcp protocol",
+			portName:         "tcp-port-test",
+			expectedProtocal: "tcp",
+		},
+		{
+			name:             "http protocol",
+			portName:         "http-port-test",
+			expectedProtocal: "http",
+		},
+		{
+			name:             "grpc protocol",
+			portName:         "grpc-port-test",
+			expectedProtocal: "grpc",
+		},
+		{
+			name:             "default protocol",
+			portName:         "port-test",
+			expectedProtocal: "http",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := GetAppProtocolFromPortName(tc.portName)
+			assert.Equal(tc.expectedProtocal, actual)
+		})
+	}
+}


### PR DESCRIPTION
**Description**:

 Add test for GetAppProtocolFromPortName()

Fixes: #2694 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
