### PR TITLE
certificate/rotation: correctly rotate certs

### DIFF
--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -134,6 +134,9 @@ const (
 
 	// IngressUpdated is the type of announcement emitted when we observe an update to a Kubernetes Ingress
 	IngressUpdated AnnouncementType = "ingress-updated"
+
+	// CertificateRotated is the type of announcement emitted when a certificate is rotated by the certificate provider
+	CertificateRotated AnnouncementType = "certificate-rotated"
 )
 
 // Announcement is a struct for messages between various components of OSM signaling a need for a change in Envoy proxy configuration

--- a/pkg/certificate/mock_certificate_generated.go
+++ b/pkg/certificate/mock_certificate_generated.go
@@ -9,7 +9,6 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	announcements "github.com/openservicemesh/osm/pkg/announcements"
 )
 
 // MockCertificater is a mock of Certificater interface
@@ -140,20 +139,6 @@ func NewMockManager(ctrl *gomock.Controller) *MockManager {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
-}
-
-// GetAnnouncementsChannel mocks base method
-func (m *MockManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAnnouncementsChannel")
-	ret0, _ := ret[0].(<-chan announcements.Announcement)
-	return ret0
-}
-
-// GetAnnouncementsChannel indicates an expected call of GetAnnouncementsChannel
-func (mr *MockManagerMockRecorder) GetAnnouncementsChannel() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnnouncementsChannel", reflect.TypeOf((*MockManager)(nil).GetAnnouncementsChannel))
 }
 
 // GetCertificate mocks base method

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -93,8 +93,8 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 
 	events.GetPubSubInstance().Publish(events.PubSubMessage{
 		AnnouncementType: announcements.CertificateRotated,
-		NewObj:           cn,
-		OldObj:           cn,
+		NewObj:           newCert,
+		OldObj:           oldCert,
 	})
 
 	log.Debug().Msgf("Rotated certificate (old SerialNumber=%s) with new SerialNumber=%s; took %+v", oldCert.GetSerialNumber(), newCert.GetSerialNumber(), time.Since(start))

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 )
 
 // IssueCertificate implements certificate.Manager and returns a newly issued certificate.
@@ -89,7 +90,12 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	oldCert := cm.cache[cn]
 	cm.cache[cn] = newCert
 	cm.cacheLock.Unlock()
-	cm.announcements <- announcements.Announcement{}
+
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.CertificateRotated,
+		NewObj:           cn,
+		OldObj:           cn,
+	})
 
 	log.Debug().Msgf("Rotated certificate (old SerialNumber=%s) with new SerialNumber=%s; took %+v", oldCert.GetSerialNumber(), newCert.GetSerialNumber(), time.Since(start))
 
@@ -110,12 +116,6 @@ func (cm *CertManager) ListCertificates() ([]certificate.Certificater, error) {
 	}
 	cm.cacheLock.RUnlock()
 	return certs, nil
-}
-
-// GetAnnouncementsChannel returns a channel, which is used to announce when
-// changes have been made to the issued certificates.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
-	return cm.announcements
 }
 
 // certificaterFromCertificateRequest will construct a certificate.Certificater
@@ -242,14 +242,13 @@ func NewCertManager(
 	informerFactory.Start(make(chan struct{}))
 
 	cm := &CertManager{
-		ca:            ca,
-		cache:         make(map[certificate.CommonName]certificate.Certificater),
-		announcements: make(chan announcements.Announcement),
-		namespace:     namespace,
-		client:        client.CertmanagerV1beta1().CertificateRequests(namespace),
-		issuerRef:     issuerRef,
-		crLister:      crLister,
-		cfg:           cfg,
+		ca:        ca,
+		cache:     make(map[certificate.CommonName]certificate.Certificater),
+		namespace: namespace,
+		client:    client.CertmanagerV1beta1().CertificateRequests(namespace),
+		issuerRef: issuerRef,
+		crLister:  crLister,
+		cfg:       cfg,
 	}
 
 	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -9,7 +9,6 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1beta1"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1beta1"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -39,10 +38,6 @@ type CertManager struct {
 	// certificate.Certificaters
 	cache     map[certificate.CommonName]certificate.Certificater
 	cacheLock sync.RWMutex
-
-	// The channel announcing to the rest of the system when a certificate has
-	// changed.
-	announcements chan announcements.Announcement
 
 	// Control plane namespace where CertificateRequests are created.
 	namespace string

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -3,7 +3,6 @@ package tresor
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -52,9 +51,6 @@ func NewCertManager(ca certificate.Certificater, certificatesOrganization string
 	certManager := CertManager{
 		// The root certificate signing all newly issued certificates
 		ca: ca,
-
-		// Channel used to inform other components of cert changes (rotation etc.)
-		announcements: make(chan announcements.Announcement),
 
 		certificatesOrganization: certificatesOrganization,
 

--- a/pkg/certificate/providers/tresor/fake.go
+++ b/pkg/certificate/providers/tresor/fake.go
@@ -3,7 +3,6 @@ package tresor
 import (
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
@@ -22,9 +21,8 @@ func NewFakeCertManager(cfg configurator.Configurator) *CertManager {
 	}
 
 	return &CertManager{
-		ca:            ca.(*Certificate),
-		announcements: make(chan announcements.Announcement),
-		cfg:           cfg,
+		ca:  ca.(*Certificate),
+		cfg: cfg,
 	}
 }
 

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -33,9 +32,6 @@ var (
 type CertManager struct {
 	// The Certificate Authority root certificate to be used by this certificate manager
 	ca certificate.Certificater
-
-	// The channel announcing to the rest of the system when a certificate has changed
-	announcements chan announcements.Announcement
 
 	// Cache for all the certificates issued
 	// Types: map[certificate.CommonName]certificate.Certificater

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/rotor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -34,9 +35,8 @@ const (
 // NewCertManager implements certificate.Manager and wraps a Hashi Vault with methods to allow easy certificate issuance.
 func NewCertManager(vaultAddr, token string, role string, cfg configurator.Configurator) (*CertManager, error) {
 	c := &CertManager{
-		announcements: make(chan announcements.Announcement),
-		role:          vaultRole(role),
-		cfg:           cfg,
+		role: vaultRole(role),
+		cfg:  cfg,
 	}
 	config := api.DefaultConfig()
 	config.Address = vaultAddr
@@ -160,11 +160,6 @@ func (cm *CertManager) GetRootCertificate() (certificate.Certificater, error) {
 	return cm.ca, nil
 }
 
-// GetAnnouncementsChannel returns a channel used by the Hashi Vault instance to signal when a certificate has been changed.
-func (cm *CertManager) GetAnnouncementsChannel() <-chan announcements.Announcement {
-	return cm.announcements
-}
-
 // RotateCertificate implements certificate.Manager and rotates an existing certificate.
 func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
 	start := time.Now()
@@ -175,7 +170,12 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	}
 
 	cm.cache.Store(cn, cert)
-	cm.announcements <- announcements.Announcement{}
+
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.CertificateRotated,
+		NewObj:           cn,
+		OldObj:           cn,
+	})
 
 	log.Trace().Msgf("Rotated certificate with new SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
 

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -164,22 +164,27 @@ func (cm *CertManager) GetRootCertificate() (certificate.Certificater, error) {
 func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
 	start := time.Now()
 
-	cert, err := cm.issue(cn, cm.cfg.GetServiceCertValidityPeriod())
-	if err != nil {
-		return cert, err
+	oldCert, ok := cm.cache.Load(cn)
+	if !ok {
+		return nil, errors.Errorf("Old certificate does not exist for CN=%s", cn)
 	}
 
-	cm.cache.Store(cn, cert)
+	newCert, err := cm.issue(cn, cm.cfg.GetServiceCertValidityPeriod())
+	if err != nil {
+		return nil, err
+	}
+
+	cm.cache.Store(cn, newCert)
 
 	events.GetPubSubInstance().Publish(events.PubSubMessage{
 		AnnouncementType: announcements.CertificateRotated,
-		NewObj:           cn,
-		OldObj:           cn,
+		NewObj:           newCert,
+		OldObj:           oldCert.(certificate.Certificater),
 	})
 
-	log.Trace().Msgf("Rotated certificate with new SerialNumber=%s took %+v", cert.GetSerialNumber(), time.Since(start))
+	log.Debug().Msgf("Rotated certificate (old SerialNumber=%s) with new SerialNumber=%s took %+v", oldCert.(certificate.Certificater).GetSerialNumber(), newCert.GetSerialNumber(), time.Since(start))
 
-	return cert, nil
+	return newCert, nil
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/vault/api"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
@@ -15,9 +14,6 @@ import (
 type CertManager struct {
 	// The Certificate Authority root certificate to be used by this certificate manager
 	ca certificate.Certificater
-
-	// The channel announcing to the rest of the system when a certificate has changed
-	announcements chan announcements.Announcement
 
 	// Cache for all the certificates issued
 	// Types: map[certificate.CommonName]certificate.Certificater

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -4,8 +4,6 @@ package certificate
 
 import (
 	"time"
-
-	"github.com/openservicemesh/osm/pkg/announcements"
 )
 
 const (
@@ -76,7 +74,4 @@ type Manager interface {
 	// ReleaseCertificate informs the underlying certificate issuer that the given cert will no longer be needed.
 	// This method could be called when a given payload is terminated. Calling this should remove certs from cache and free memory if possible.
 	ReleaseCertificate(CommonName)
-
-	// GetAnnouncementsChannel returns a channel, which is used to announce when changes have been made to the issued certificates.
-	GetAnnouncementsChannel() <-chan announcements.Announcement
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -73,6 +73,16 @@ func (s *Server) sendAllResponses(proxy *envoy.Proxy, server *xds_discovery.Aggr
 	}
 }
 
+// sendSDSResponse sends an SDS response to the given proxy containing all associated secrets
+func (s *Server) sendSDSResponse(proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, cfg configurator.Configurator) {
+	request := makeRequestForAllSecrets(proxy, s.catalog)
+
+	if err := s.sendTypeResponse(envoy.TypeSDS, proxy, server, request, cfg); err != nil {
+		log.Error().Err(err).Msgf("Failed to create and send %s update to Proxy %s",
+			envoy.TypeSDS, proxy.GetCertificateCommonName())
+	}
+}
+
 // makeRequestForAllSecrets constructs an SDS request AS IF an Envoy proxy sent it.
 // This request will result in the rest of the system creating an SDS response with the certificates
 // required by this proxy. The proxy itself did not ask for these. We know it needs them - so we send them.

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -56,7 +56,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	// Register to Envoy global broadcast updates
 	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
 
-	// Register for ceriticate rotation updates
+	// Register for certificate rotation updates
 	certAnnouncement := events.GetPubSubInstance().Subscribe(announcements.CertificateRotated)
 
 	// Issues a send all response on a connecting envoy

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -173,8 +173,8 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			s.sendAllResponses(proxy, &server, s.cfg)
 
 		case certUpdateMsg := <-certAnnouncement:
-			cn := certUpdateMsg.(events.PubSubMessage).NewObj.(certificate.CommonName)
-			if isCNforProxy(proxy, cn) {
+			certificate := certUpdateMsg.(events.PubSubMessage).NewObj.(certificate.Certificater)
+			if isCNforProxy(proxy, certificate.GetCommonName()) {
 				// The CN whose corresponding certificate was updated (rotated) by the certificate provider is associated
 				// with this proxy, so update the secrets corresponding to this certificate via SDS.
 				log.Debug().Msgf("Certificate has been updated for proxy with SerialNumber=%s, UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -3,14 +3,19 @@ package ads
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
@@ -50,6 +55,9 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 
 	// Register to Envoy global broadcast updates
 	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
+
+	// Register for ceriticate rotation updates
+	certAnnouncement := events.GetPubSubInstance().Subscribe(announcements.CertificateRotated)
 
 	// Issues a send all response on a connecting envoy
 	// If this were to fail, it most likely just means we still have configuration being applied on flight,
@@ -163,6 +171,36 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 		case <-broadcastUpdate:
 			log.Info().Msgf("Broadcast wake for Proxy SerialNumber=%s UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 			s.sendAllResponses(proxy, &server, s.cfg)
+
+		case certUpdateMsg := <-certAnnouncement:
+			cn := certUpdateMsg.(events.PubSubMessage).NewObj.(certificate.CommonName)
+			if isCNforProxy(proxy, cn) {
+				// The CN whose corresponding certificate was updated (rotated) by the certificate provider is associated
+				// with this proxy, so update the secrets corresponding to this certificate via SDS.
+				log.Debug().Msgf("Certificate has been updated for proxy with SerialNumber=%s, UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+				s.sendSDSResponse(proxy, &server, s.cfg)
+			}
 		}
 	}
+}
+
+// isCNforProxy returns true if the given CN for the workload certificate matches the given proxy's identity.
+// Proxy identity corresponds to the k8s service account, while the workload certificate is of the form
+// <svc-account>.<namespace>.<trust-domain>.
+func isCNforProxy(proxy *envoy.Proxy, cn certificate.CommonName) bool {
+	proxyIdentity, err := catalog.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
+	if err != nil {
+		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with SerialNumber=%s on Pod with UID=%s",
+			proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+		return false
+	}
+
+	// Workload certificate CN is of the form <svc-account>.<namespace>.<trust-domain>
+	chunks := strings.Split(cn.String(), constants.DomainDelimiter)
+	if len(chunks) < 3 {
+		return false
+	}
+
+	identityForCN := service.K8sServiceAccount{Name: chunks[0], Namespace: chunks[1]}
+	return identityForCN == proxyIdentity
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Certificates are not being rotated as expected
because the channel on which they are making
announcements is no longer used and had been
dropped in favor of the pub-sub messaging infra.

This change fixes cert rotation as follows:
1. Uses the pub-sub model to publish cert rotation
   events when a cert corresponding to a given CN
   is rotated.
2. Updates the certificates stored in Envoy for those
   proxies whose identity matches the CN being rotated.

Verified that updated certs are correctly pushed to
proxies with this change.

Resolves #2786

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`