### PR TITLE
workerpool: introduce workerpool concept and unit tests

### DIFF
--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -1,0 +1,125 @@
+package workerpool
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+const (
+	// Size of the job queue per worker
+	maxJobPerWorker = 4096
+)
+
+var (
+	log = logger.New("workerpool")
+)
+
+// worker context for a worker routine
+type worker struct {
+	id            int
+	jobs          chan Job        // Job queue
+	stop          chan struct{}   // Stop channel
+	wg            *sync.WaitGroup // Pointer to WorkerPool wg
+	jobsProcessed uint64          // Jobs processed by this worker
+}
+
+// WorkerPool object representation
+type WorkerPool struct {
+	wg            sync.WaitGroup // Sync group, to stop workers if needed
+	workerContext []*worker      // Worker contexts
+	nWorkers      uint64         // Number of workers. Uint64 for easier mod hash later
+	rRobinCounter uint64         // Used only by the round robin api. Modified atomically on API.
+}
+
+// Job is a runnable interface to queue jobs on a WorkerPool
+type Job interface {
+	JobName() string // Returns name for a job
+	Hash() uint64    // Returns a uint64 hash for a job.
+	Run()            // Executes the job
+}
+
+// NewWorkerPool creates a new work group.
+// If nWorkers is 0, will poll goMaxProcs to get the number of routines to spawn.
+// Reminder: routines are never pinned to system threads, it's up to the go scheduler to decide
+// when and where these will be scheduled.
+func NewWorkerPool(nWorkers int) *WorkerPool {
+	if nWorkers == 0 {
+		// read GOMAXPROCS, -1 to avoid changing it
+		nWorkers = runtime.GOMAXPROCS(-1)
+	}
+
+	log.Info().Msgf("New worker pool setting up %d workers", nWorkers)
+
+	var workPool WorkerPool
+	for i := 0; i < nWorkers; i++ {
+		workPool.workerContext = append(workPool.workerContext,
+			&worker{
+				id:            i,
+				jobs:          make(chan Job, maxJobPerWorker),
+				stop:          make(chan struct{}, 1),
+				wg:            &workPool.wg,
+				jobsProcessed: 0,
+			},
+		)
+		workPool.wg.Add(1)
+		workPool.nWorkers++
+
+		go (workPool.workerContext[i]).work()
+	}
+
+	return &workPool
+}
+
+// AddJob posts the job on a worker queue
+// Uses Hash underneath to choose worker to post the job to
+func (wp *WorkerPool) AddJob(jobs Job) {
+	wp.workerContext[jobs.Hash()%wp.nWorkers].jobs <- jobs
+}
+
+// AddJobRoundRobin adds a job in round robin to the queues
+// Concurrent calls to AddJobRoundRobin are thread safe and fair
+// between each other
+func (wp *WorkerPool) AddJobRoundRobin(jobs Job) {
+	added := atomic.AddUint64(&wp.rRobinCounter, 1)
+	wp.workerContext[added%wp.nWorkers].jobs <- jobs
+}
+
+// GetWorkerNumber get number of queues/workers
+func (wp *WorkerPool) GetWorkerNumber() int {
+	return int(wp.nWorkers)
+}
+
+// Stop stops the workerpool
+func (wp *WorkerPool) Stop() {
+	for _, worker := range wp.workerContext {
+		worker.stop <- struct{}{}
+	}
+	wp.wg.Wait()
+}
+
+func (workContext *worker) work() {
+	defer workContext.wg.Done()
+
+	log.Info().Msgf("Worker %d running", workContext.id)
+	for {
+		select {
+		case j := <-workContext.jobs:
+			t := time.Now()
+			log.Debug().Msgf("work[%d]: Starting %v", workContext.id, j.JobName())
+
+			// Run current job
+			j.Run()
+
+			log.Debug().Msgf("work[%d][%s] : took %v", workContext.id, j.JobName(), time.Since(t))
+			workContext.jobsProcessed++
+
+		case <-workContext.stop:
+			log.Debug().Msgf("work[%d]: Stopped", workContext.id)
+			return
+		}
+	}
+}

--- a/pkg/workerpool/workerpool_test.go
+++ b/pkg/workerpool/workerpool_test.go
@@ -1,0 +1,102 @@
+package workerpool
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewWorkerPool(t *testing.T) {
+	assert := assert.New(t)
+	wp := NewWorkerPool(0)
+
+	assert.Equal(wp.GetWorkerNumber(), runtime.GOMAXPROCS(-1))
+	wp.Stop()
+
+	wp = NewWorkerPool(25)
+	assert.Equal(wp.GetWorkerNumber(), 25)
+	wp.Stop()
+}
+
+// Sample test job below for testing
+type testJob struct {
+	jobDone chan struct{}
+	hash    uint64
+}
+
+func (tj *testJob) Run() {
+	// Just signal back we are done
+	tj.jobDone <- struct{}{}
+}
+
+func (tj *testJob) JobName() string {
+	return "testJob"
+}
+
+func (tj *testJob) Hash() uint64 {
+	return tj.hash
+}
+
+// Uses AddJob, which relies on job hash for queue assignment
+func TestAddJob(t *testing.T) {
+	assert := assert.New(t)
+
+	njobs := 10 // also worker routines
+	wp := NewWorkerPool(njobs)
+	joblist := make([]testJob, njobs)
+
+	// Create and add jobs
+	for i := 0; i < njobs; i++ {
+		joblist[i] = testJob{
+			jobDone: make(chan struct{}, 1),
+			hash:    uint64(i),
+		}
+
+		wp.AddJob(&joblist[i])
+	}
+
+	// Verifiy all jobs ran through the workers
+	for i := 0; i < njobs; i++ {
+		<-joblist[i].jobDone
+	}
+
+	wp.Stop()
+
+	// Verify all the workers processed 1 job (as expected by the static hash)
+	for i := 0; i < njobs; i++ {
+		assert.Equal(uint64(1), wp.workerContext[i].jobsProcessed)
+	}
+}
+
+// Uses AddJobRoundRobin, which relies on round robin for queue assignment
+func TestAddJobRoundRobin(t *testing.T) {
+	assert := assert.New(t)
+
+	njobs := 10 // also worker routines
+	wp := NewWorkerPool(njobs)
+	joblist := make([]testJob, njobs)
+
+	// Create and add jobs
+	for i := 0; i < njobs; i++ {
+		joblist[i] = testJob{
+			jobDone: make(chan struct{}, 1),
+			hash:    uint64(i),
+		}
+
+		wp.AddJobRoundRobin(&joblist[i])
+	}
+
+	// Verifiy all jobs ran through the workers
+	for i := 0; i < njobs; i++ {
+		<-joblist[i].jobDone
+	}
+
+	wp.Stop()
+
+	// Verify all the workers processed 1 job (round-robbined)
+	assert.Equal(uint64(njobs), wp.rRobinCounter)
+	for i := 0; i < njobs; i++ {
+		assert.Equal(uint64(1), wp.workerContext[i].jobsProcessed)
+	}
+}


### PR DESCRIPTION
Workerpool is an implementation of the thread-pool paradigm
in Go. The benefits of it in Go however, can be quite different
from any other language able to schedule themselves on system threads.

By using a workpool model, the main focus and intention is to limit the
number of goroutines that can do busy-work and get scheduled concurrently
at any point in time.

Too many goroutines being scheduled at the same time will cause other
goroutines (maybe more critical ones) to be scheduled less often, thus
incurring in resource starvation on those and potentially triggering other
issues.

By being able to queue up work, we should be able to run a more deterministic
runtime (despite Go's nature, this we will not be able to help), less dependant
on the scheduler and more accurate in terms of time, as now the number of routines
doing busy work can be made constant at the expense of serialization, as opposed to
having O(N) routines attempting to run at the same time.


- New Functionality      [x]
- Performance            [x]


- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No