### PR TITLE
fix(pkg/catalog): resolve root service hostnames

### DIFF
--- a/pkg/catalog/routes.go
+++ b/pkg/catalog/routes.go
@@ -61,8 +61,8 @@ func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespa
 	apexServices := mapset.NewSet()
 	for _, split := range mc.meshSpec.ListTrafficSplits() {
 		svc := service.MeshService{
-			Name:      split.Spec.Service,
-			Namespace: split.ObjectMeta.Namespace,
+			Name:      kubernetes.GetServiceFromHostname(split.Spec.Service),
+			Namespace: split.Namespace,
 		}
 
 		hostnames, err := mc.getServiceHostnames(svc, svc.Namespace == sourceNamespace)

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -35,10 +35,11 @@ func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.Me
 	for _, split := range mc.meshSpec.ListTrafficSplits() {
 		for _, backend := range split.Spec.Backends {
 			if backend.Service == targetService.Name && split.Namespace == targetService.Namespace {
-				apexSet.Add(service.MeshService{
-					Name:      split.Spec.Service,
+				meshService := service.MeshService{
+					Name:      kubernetes.GetServiceFromHostname(split.Spec.Service),
 					Namespace: split.Namespace,
-				})
+				}
+				apexSet.Add(meshService)
 				break
 			}
 		}


### PR DESCRIPTION
fix(pkg/catalog): resolve root service hostnames

the routes v2 logic was assuming that the root service was
a kubernetes service with no namespace suffix. So specifying
"bookstore.bookstore" as the root service didn't work.
There is more work to be done here to make sure that we follow
the SMI spec which states that a root service should be an
fqdn but for the time being, this fix allows us to run the manual
demo successfully.

Followup: #2797 

Signed-off-by: Michelle Noorali <minooral@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
