### PR TITLE
test(pkg/envoy): ParseEnvoyServiceNodeID with less than 5 chunks in the NodeID string

### DIFF
--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -396,5 +396,12 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(meta.WorkloadKind).To(Equal(""))
 			Expect(meta.WorkloadName).To(Equal(""))
 		})
+
+		It("should error when there are less than 5 chunks in the serviceNodeID string", func() {
+			// this 'serviceNodeID' will yield 2 chunks
+			serviceNodeID := "$(POD_UID)/$(POD_NAMESPACE)"
+			_, err := ParseEnvoyServiceNodeID(serviceNodeID)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
Fixes #2713 
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
adds a test for `ParseEnvoyServiceNodeID` in pkg/envoy/xdsutil_test.go
which checks whether it handles when `serviceNodeID` yields less than
5 chunks on splitting

Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [x]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
no