### PR TITLE
envoy/lds: support for outbound TCP traffic splitting

### DIFF
--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -345,6 +345,53 @@ func (lb *listenerBuilder) getOutboundTCPFilter(upstream service.MeshService) (*
 		StatPrefix:       fmt.Sprintf("%s:%s", outboundMeshTCPFilterChainPrefix, upstream),
 		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: upstream.String()},
 	}
+
+	var weightedClusters []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight
+	apexServices := mapset.NewSet()
+
+	for _, split := range lb.meshCatalog.GetSMISpec().ListTrafficSplits() {
+		// Split policy must be in the same namespace as the upstream service
+		if split.Namespace != upstream.Namespace {
+			continue
+		}
+		rootServiceName := kubernetes.GetServiceFromHostname(split.Spec.Service)
+		if rootServiceName != upstream.Name {
+			// This split policy does not correspond to the upstream service
+			continue
+		}
+
+		if apexServices.Contains(split.Spec.Service) {
+			log.Error().Msgf("Skipping traffic split policy %s/%s as there is already a corresponding policy for apex service %s", split.Namespace, split.Name, split.Spec.Service)
+			continue
+		}
+
+		for _, backend := range split.Spec.Backends {
+			if backend.Weight == 0 {
+				// Skip backends with a weight of 0
+				log.Warn().Msgf("Skipping backend %s that has a weight of 0 in traffic split policy %s/%s", backend.Service, split.Namespace, split.Name)
+				continue
+			}
+			backendCluster := &xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
+				Name:   fmt.Sprintf("%s/%s", split.Namespace, backend.Service), // cluster <namespace>/<service>
+				Weight: uint32(backend.Weight),
+			}
+			weightedClusters = append(weightedClusters, backendCluster)
+		}
+		apexServices.Add(split.Spec.Service)
+	}
+
+	if len(weightedClusters) == 0 {
+		// No weighted clusters implies a traffic split does not exist for this upstream, proxy it as is
+		tcpProxy.ClusterSpecifier = &xds_tcp_proxy.TcpProxy_Cluster{Cluster: upstream.String()}
+	} else {
+		// Weighted clusters found for this upstream, proxy traffic meant for this upstream to its weighted clusters
+		tcpProxy.ClusterSpecifier = &xds_tcp_proxy.TcpProxy_WeightedClusters{
+			WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
+				Clusters: weightedClusters,
+			},
+		}
+	}
+
 	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling TcpProxy object needed by outbound TCP filter for upstream service %s", upstream)

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -13,13 +13,16 @@ import (
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
+	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -425,21 +428,199 @@ func TestGetOutboundFilterChainMatchForService(t *testing.T) {
 
 func TestGetOutboundTCPFilter(t *testing.T) {
 	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
 	type testCase struct {
 		name                   string
 		upstream               service.MeshService
+		trafficSplits          []*smiSplit.TrafficSplit
 		expectedTCPProxyConfig *xds_tcp_proxy.TcpProxy
 		expectError            bool
 	}
 
 	testCases := []testCase{
 		{
-			name:     "simple TCP filter",
-			upstream: service.MeshService{Name: "foo", Namespace: "bar"},
+			name:          "TCP filter for upstream without any traffic split policies",
+			upstream:      service.MeshService{Name: "foo", Namespace: "bar"},
+			trafficSplits: nil,
 			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
 				StatPrefix:       "outbound-mesh-tcp-filter-chain:bar/foo",
 				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: "bar/foo"},
+			},
+			expectError: false,
+		},
+		{
+			name:     "TCP filter for upstream with matching traffic split policy",
+			upstream: service.MeshService{Name: "foo", Namespace: "bar"},
+			trafficSplits: []*smiSplit.TrafficSplit{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Spec: smiSplit.TrafficSplitSpec{
+						Service: "foo.bar.svc.cluster.local",
+						Backends: []smiSplit.TrafficSplitBackend{
+							{
+								Service: "foo-v1",
+								Weight:  10,
+							},
+							{
+								Service: "foo-v2",
+								Weight:  90,
+							},
+						},
+					},
+				},
+			},
+			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
+				StatPrefix: "outbound-mesh-tcp-filter-chain:bar/foo",
+				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_WeightedClusters{
+					WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
+						Clusters: []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
+							{
+								Name:   "bar/foo-v1",
+								Weight: 10,
+							},
+							{
+								Name:   "bar/foo-v2",
+								Weight: 90,
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:     "TCP filter for upstream without matching traffic split policy",
+			upstream: service.MeshService{Name: "foo", Namespace: "bar"},
+			trafficSplits: []*smiSplit.TrafficSplit{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Spec: smiSplit.TrafficSplitSpec{
+						Service: "not-upstream.bar.svc.cluster.local", // Root service is not the upstream the filter is being built for
+						Backends: []smiSplit.TrafficSplitBackend{
+							{
+								Service: "foo-v1",
+								Weight:  10,
+							},
+							{
+								Service: "foo-v2",
+								Weight:  90,
+							},
+						},
+					},
+				},
+			},
+			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
+				StatPrefix:       "outbound-mesh-tcp-filter-chain:bar/foo",
+				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: "bar/foo"},
+			},
+			expectError: false,
+		},
+		{
+			name:     "TCP filter for upstream with multiple matching policies, pick first",
+			upstream: service.MeshService{Name: "foo", Namespace: "bar"},
+			trafficSplits: []*smiSplit.TrafficSplit{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Spec: smiSplit.TrafficSplitSpec{
+						Service: "foo.bar.svc.cluster.local",
+						Backends: []smiSplit.TrafficSplitBackend{
+							{
+								Service: "foo-v1",
+								Weight:  10,
+							},
+							{
+								Service: "foo-v2",
+								Weight:  90,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Spec: smiSplit.TrafficSplitSpec{
+						Service: "foo.bar.svc.cluster.local",
+						Backends: []smiSplit.TrafficSplitBackend{
+							{
+								Service: "foo-v3",
+								Weight:  10,
+							},
+							{
+								Service: "foo-v4",
+								Weight:  90,
+							},
+						},
+					},
+				},
+			},
+			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
+				StatPrefix: "outbound-mesh-tcp-filter-chain:bar/foo",
+				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_WeightedClusters{
+					WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
+						Clusters: []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
+							{
+								Name:   "bar/foo-v1",
+								Weight: 10,
+							},
+							{
+								Name:   "bar/foo-v2",
+								Weight: 90,
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:     "TCP filter for upstream with matching traffic split policy including a backend with 0 weight",
+			upstream: service.MeshService{Name: "foo", Namespace: "bar"},
+			trafficSplits: []*smiSplit.TrafficSplit{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+					Spec: smiSplit.TrafficSplitSpec{
+						Service: "foo.bar.svc.cluster.local",
+						Backends: []smiSplit.TrafficSplitBackend{
+							{
+								Service: "foo-v1",
+								Weight:  100,
+							},
+							{
+								Service: "foo-v2",
+								Weight:  0,
+							},
+						},
+					},
+				},
+			},
+			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
+				StatPrefix: "outbound-mesh-tcp-filter-chain:bar/foo",
+				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_WeightedClusters{
+					WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
+						Clusters: []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
+							{
+								Name:   "bar/foo-v1",
+								Weight: 100,
+							},
+						},
+					},
+				},
 			},
 			expectError: false,
 		},
@@ -447,7 +628,15 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			lb := &listenerBuilder{} // will be used for TCP traffic splitting
+			mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
+			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+			mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
+
+			mockCatalog.EXPECT().GetSMISpec().Return(mockMeshSpec).AnyTimes()
+
+			mockMeshSpec.EXPECT().ListTrafficSplits().Return(tc.trafficSplits).Times(1)
+
+			lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceAccount, mockConfigurator, nil)
 			filter, err := lb.getOutboundTCPFilter(tc.upstream)
 
 			assert.Equal(tc.expectError, err != nil)

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -21,279 +21,321 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 		Bucket: 1,
 	},
 	func() {
-		Context("ClientServerTrafficSplit", func() {
-			const (
-				// to name the header we will use to identify the server that replies
-				HTTPHeaderName = "podname"
-			)
-			clientAppBaseName := "client"
-			serverNamespace := "server"
-			trafficSplitName := "traffic-split"
+		Context("HTTP traffic splitting with SMI", func() {
+			testTrafficSplit(AppProtocolHTTP)
+		})
 
-			// Scale number of client services/pods here
-			numberOfClientServices := 2
-			clientReplicaSet := 5
-
-			// Scale number of server services/pods here
-			numberOfServerServices := 5
-			serverReplicaSet := 2
-
-			clientServices := []string{}
-			serverServices := []string{}
-			allNamespaces := []string{}
-
-			for i := 0; i < numberOfClientServices; i++ {
-				clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
-			}
-
-			for i := 0; i < numberOfServerServices; i++ {
-				serverServices = append(serverServices, fmt.Sprintf("%s%d", serverNamespace, i))
-			}
-
-			allNamespaces = append(allNamespaces, clientServices...)
-			allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
-
-			// Used across the test to wait for concurrent steps to finish
-			var wg sync.WaitGroup
-
-			It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
-				// Install OSM
-				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
-
-				// Create NSs
-				Expect(Td.CreateMultipleNs(allNamespaces...)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
-
-				// Create server apps
-				for _, serverApp := range serverServices {
-					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
-						SimpleDeploymentAppDef{
-							Name:         serverApp,
-							Namespace:    serverNamespace,
-							ReplicaCount: int32(serverReplicaSet),
-							Image:        "simonkowallik/httpbin",
-							Ports:        []int{80},
-						})
-
-					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
-					// This httpbin fork will pick certain env variable formats and reply the values as headers.
-					// We will expose pod name as one of these env variables, and will use it
-					// to identify the pod that replies to the request, and validate the test
-					deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
-						{
-							Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
-							ValueFrom: &v1.EnvVarSource{
-								FieldRef: &v1.ObjectFieldSelector{
-									FieldPath: "metadata.name",
-								},
-							},
-						},
-					}
-
-					_, err := Td.CreateServiceAccount(serverNamespace, &svcAccDef)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateService(serverNamespace, svcDef)
-					Expect(err).NotTo(HaveOccurred())
-				}
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
-				}()
-
-				// Client apps
-				for _, clientApp := range clientServices {
-					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
-						SimpleDeploymentAppDef{
-							Name:         clientApp,
-							Namespace:    clientApp,
-							ReplicaCount: int32(clientReplicaSet),
-							Command:      []string{"/bin/bash", "-c", "--"},
-							Args:         []string{"while true; do sleep 30; done;"},
-							Image:        "songrgg/alpine-debug",
-							Ports:        []int{80},
-						})
-
-					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateDeployment(clientApp, deploymentDef)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateService(clientApp, svcDef)
-					Expect(err).NotTo(HaveOccurred())
-
-					wg.Add(1)
-					go func(app string) {
-						defer wg.Done()
-						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
-					}(clientApp)
-				}
-
-				wg.Wait()
-
-				// Put allow traffic target rules
-				for _, srcClient := range clientServices {
-					for _, dstServer := range serverServices {
-						httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-							SimpleAllowPolicy{
-								RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
-								TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
-
-								SourceNamespace:      srcClient,
-								SourceSVCAccountName: srcClient,
-
-								DestinationNamespace:      serverNamespace,
-								DestinationSvcAccountName: dstServer,
-							})
-
-						_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
-						Expect(err).NotTo(HaveOccurred())
-						_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
-						Expect(err).NotTo(HaveOccurred())
-					}
-				}
-
-				// Create traffic split service. Use simple Pod to create a simple service definition
-				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
-					Name:      trafficSplitName,
-					Namespace: serverNamespace,
-					Ports:     []int{80},
-				})
-
-				// Creating trafficsplit service in K8s
-				_, err := Td.CreateService(serverNamespace, trafficSplitService)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Create Traffic split with all server processes as backends
-				trafficSplit := TrafficSplitDef{
-					Name:                    trafficSplitName,
-					Namespace:               serverNamespace,
-					TrafficSplitServiceName: trafficSplitName,
-					Backends:                []TrafficSplitBackend{},
-				}
-				assignation := 100 / len(serverServices) // Spreading equitatively
-				for _, dstServer := range serverServices {
-					trafficSplit.Backends = append(trafficSplit.Backends,
-						TrafficSplitBackend{
-							Name:   dstServer,
-							Weight: assignation,
-						},
-					)
-				}
-				// Get the Traffic split structures
-				tSplit, err := Td.CreateSimpleTrafficSplit(trafficSplit)
-				Expect(err).To(BeNil())
-
-				// Push them in K8s
-				_, err = Td.CreateTrafficSplit(serverNamespace, tSplit)
-				Expect(err).To(BeNil())
-
-				By("Issuing http requests from clients to the traffic split FQDN")
-
-				// Test traffic
-				// Create Multiple HTTP request structure
-				requests := HTTPMultipleRequest{
-					Sources: []HTTPRequestDef{},
-				}
-				for _, ns := range clientServices {
-					pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
-					Expect(err).To(BeNil())
-
-					for _, pod := range pods.Items {
-						requests.Sources = append(requests.Sources, HTTPRequestDef{
-							SourceNs:        ns,
-							SourcePod:       pod.Name,
-							SourceContainer: ns, // container_name == NS for this test
-
-							// Targeting the trafficsplit FQDN
-							Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
-						})
-					}
-				}
-
-				var results HTTPMultipleResults
-				var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
-				success := Td.WaitForRepeatedSuccess(func() bool {
-					curlSuccess := true
-
-					// Get results
-					results = Td.MultipleHTTPRequest(&requests)
-
-					// Print results
-					Td.PrettyPrintHTTPResults(&results)
-
-					// Verify REST status code results
-					for _, ns := range results {
-						for _, podResult := range ns {
-							if podResult.Err != nil || podResult.StatusCode != 200 {
-								curlSuccess = false
-							} else {
-								// We should see pod header populated
-								dstPod, ok := podResult.Headers[HTTPHeaderName]
-								if ok {
-									// Store and mark that we have seen a response for this server pod
-									serversSeen[dstPod] = true
-								}
-							}
-						}
-					}
-					Td.T.Logf("Unique servers replied %d/%d",
-						len(serversSeen), numberOfServerServices*serverReplicaSet)
-
-					// Success conditions:
-					// - All clients have been answered consecutively 5 successful HTTP requests
-					// - We have seen all servers from the traffic split reply at least once
-					return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
-				}, 5, 150*time.Second)
-
-				Expect(success).To(BeTrue())
-
-				By("Issuing http requests from clients to the allowed individual service backends")
-
-				// Test now against the individual services, observe they should still be reachable
-				requests = HTTPMultipleRequest{
-					Sources: []HTTPRequestDef{},
-				}
-				for _, clientNs := range clientServices {
-					pods, err := Td.Client.CoreV1().Pods(clientNs).List(context.Background(), metav1.ListOptions{})
-					Expect(err).To(BeNil())
-					// For each client pod
-					for _, pod := range pods.Items {
-						// reach each service
-						for _, svcNs := range serverServices {
-							requests.Sources = append(requests.Sources, HTTPRequestDef{
-								SourceNs:        pod.Namespace,
-								SourcePod:       pod.Name,
-								SourceContainer: pod.Namespace, // We generally code it like so for test purposes
-
-								// direct traffic target against the specific server service in the server namespace
-								Destination: fmt.Sprintf("%s.%s", svcNs, serverNamespace),
-							})
-						}
-					}
-				}
-
-				results = HTTPMultipleResults{}
-				success = Td.WaitForRepeatedSuccess(func() bool {
-					// Get results
-					results = Td.MultipleHTTPRequest(&requests)
-
-					// Print results
-					Td.PrettyPrintHTTPResults(&results)
-
-					// Verify REST status code results
-					for _, ns := range results {
-						for _, podResult := range ns {
-							if podResult.Err != nil || podResult.StatusCode != 200 {
-								return false
-							}
-						}
-					}
-					return true
-				}, 2, 150*time.Second)
-
-				Expect(success).To(BeTrue())
-			})
+		Context("TCP traffic splitting with SMI", func() {
+			testTrafficSplit(AppProtocolTCP)
 		})
 	})
+
+func testTrafficSplit(appProtocol string) {
+	const (
+		// to name the header we will use to identify the server that replies
+		HTTPHeaderName = "podname"
+
+		serverPort = 80
+	)
+
+	clientAppBaseName := "client"
+	serverNamespace := "server"
+	trafficSplitName := "traffic-split"
+
+	// Scale number of client services/pods here
+	numberOfClientServices := 2
+	clientReplicaSet := 5
+
+	// Scale number of server services/pods here
+	numberOfServerServices := 5
+	serverReplicaSet := 2
+
+	clientServices := []string{}
+	serverServices := []string{}
+	allNamespaces := []string{}
+
+	for i := 0; i < numberOfClientServices; i++ {
+		clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
+	}
+
+	for i := 0; i < numberOfServerServices; i++ {
+		serverServices = append(serverServices, fmt.Sprintf("%s%d", serverNamespace, i))
+	}
+
+	allNamespaces = append(allNamespaces, clientServices...)
+	allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
+
+	// Used across the test to wait for concurrent steps to finish
+	var wg sync.WaitGroup
+
+	It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+
+		// Create NSs
+		Expect(Td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+		Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+
+		// Create server apps
+		for _, serverApp := range serverServices {
+			svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+				SimpleDeploymentAppDef{
+					Name:         serverApp,
+					Namespace:    serverNamespace,
+					ReplicaCount: int32(serverReplicaSet),
+					Image:        "simonkowallik/httpbin",
+					Ports:        []int{serverPort},
+					AppProtocol:  appProtocol,
+				})
+
+			// Expose an env variable such as XHTTPBIN_X_POD_NAME:
+			// This httpbin fork will pick certain env variable formats and reply the values as headers.
+			// We will expose pod name as one of these env variables, and will use it
+			// to identify the pod that replies to the request, and validate the test
+			deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+				{
+					Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
+					ValueFrom: &v1.EnvVarSource{
+						FieldRef: &v1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+			}
+
+			_, err := Td.CreateServiceAccount(serverNamespace, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateService(serverNamespace, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+		}()
+
+		// Client apps
+		for _, clientApp := range clientServices {
+			svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+				SimpleDeploymentAppDef{
+					Name:         clientApp,
+					Namespace:    clientApp,
+					ReplicaCount: int32(clientReplicaSet),
+					Command:      []string{"/bin/bash", "-c", "--"},
+					Args:         []string{"while true; do sleep 30; done;"},
+					Image:        "songrgg/alpine-debug",
+					Ports:        []int{80},
+				})
+
+			_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateDeployment(clientApp, deploymentDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateService(clientApp, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			wg.Add(1)
+			go func(app string) {
+				defer wg.Done()
+				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+			}(clientApp)
+		}
+
+		wg.Wait()
+
+		// Put allow traffic target rules
+		for _, srcClient := range clientServices {
+			for _, dstServer := range serverServices {
+				switch appProtocol {
+				// HTTP traffic
+				case AppProtocolHTTP:
+					httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+						SimpleAllowPolicy{
+							RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
+							TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+
+							SourceNamespace:      srcClient,
+							SourceSVCAccountName: srcClient,
+
+							DestinationNamespace:      serverNamespace,
+							DestinationSvcAccountName: dstServer,
+						})
+
+					_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+					Expect(err).NotTo(HaveOccurred())
+
+				// TCP traffic
+				case AppProtocolTCP:
+					tcpRoute, trafficTarget := Td.CreateSimpleTCPAllowPolicy(
+						SimpleAllowPolicy{
+							RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
+							TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+
+							SourceNamespace:      srcClient,
+							SourceSVCAccountName: srcClient,
+
+							DestinationNamespace:      serverNamespace,
+							DestinationSvcAccountName: dstServer,
+						},
+						serverPort,
+					)
+
+					// Configs have to be put into a monitored NS
+					_, err := Td.CreateTCPRoute(srcClient, tcpRoute)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+					Expect(err).NotTo(HaveOccurred())
+
+				default:
+					Td.T.Fatalf("Unsupported appProtocol %s for test, must be one of [http, tcp]", appProtocol)
+				}
+			}
+		}
+
+		// Create traffic split service. Use simple Pod to create a simple service definition
+		_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
+			Name:        trafficSplitName,
+			Namespace:   serverNamespace,
+			Ports:       []int{80},
+			AppProtocol: appProtocol,
+		})
+
+		// Creating trafficsplit service in K8s
+		_, err := Td.CreateService(serverNamespace, trafficSplitService)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create Traffic split with all server processes as backends
+		trafficSplit := TrafficSplitDef{
+			Name:                    trafficSplitName,
+			Namespace:               serverNamespace,
+			TrafficSplitServiceName: trafficSplitName,
+			Backends:                []TrafficSplitBackend{},
+		}
+		assignation := 100 / len(serverServices) // Spreading equitatively
+		for _, dstServer := range serverServices {
+			trafficSplit.Backends = append(trafficSplit.Backends,
+				TrafficSplitBackend{
+					Name:   dstServer,
+					Weight: assignation,
+				},
+			)
+		}
+		// Get the Traffic split structures
+		tSplit, err := Td.CreateSimpleTrafficSplit(trafficSplit)
+		Expect(err).To(BeNil())
+
+		// Push them in K8s
+		_, err = Td.CreateTrafficSplit(serverNamespace, tSplit)
+		Expect(err).To(BeNil())
+
+		By("Issuing http requests from clients to the traffic split FQDN")
+
+		// Test traffic
+		// Create Multiple HTTP request structure
+		requests := HTTPMultipleRequest{
+			Sources: []HTTPRequestDef{},
+		}
+		for _, ns := range clientServices {
+			pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+			Expect(err).To(BeNil())
+
+			for _, pod := range pods.Items {
+				requests.Sources = append(requests.Sources, HTTPRequestDef{
+					SourceNs:        ns,
+					SourcePod:       pod.Name,
+					SourceContainer: ns, // container_name == NS for this test
+
+					// Targeting the trafficsplit FQDN
+					Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
+				})
+			}
+		}
+
+		var results HTTPMultipleResults
+		var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+		success := Td.WaitForRepeatedSuccess(func() bool {
+			curlSuccess := true
+
+			// Get results
+			results = Td.MultipleHTTPRequest(&requests)
+
+			// Print results
+			Td.PrettyPrintHTTPResults(&results)
+
+			// Verify REST status code results
+			for _, ns := range results {
+				for _, podResult := range ns {
+					if podResult.Err != nil || podResult.StatusCode != 200 {
+						curlSuccess = false
+					} else {
+						// We should see pod header populated
+						dstPod, ok := podResult.Headers[HTTPHeaderName]
+						if ok {
+							// Store and mark that we have seen a response for this server pod
+							serversSeen[dstPod] = true
+						}
+					}
+				}
+			}
+			Td.T.Logf("Unique servers replied %d/%d",
+				len(serversSeen), numberOfServerServices*serverReplicaSet)
+
+			// Success conditions:
+			// - All clients have been answered consecutively 5 successful HTTP requests
+			// - We have seen all servers from the traffic split reply at least once
+			return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
+		}, 5, 150*time.Second)
+
+		Expect(success).To(BeTrue())
+
+		By("Issuing http requests from clients to the allowed individual service backends")
+
+		// Test now against the individual services, observe they should still be reachable
+		requests = HTTPMultipleRequest{
+			Sources: []HTTPRequestDef{},
+		}
+		for _, clientNs := range clientServices {
+			pods, err := Td.Client.CoreV1().Pods(clientNs).List(context.Background(), metav1.ListOptions{})
+			Expect(err).To(BeNil())
+			// For each client pod
+			for _, pod := range pods.Items {
+				// reach each service
+				for _, svcNs := range serverServices {
+					requests.Sources = append(requests.Sources, HTTPRequestDef{
+						SourceNs:        pod.Namespace,
+						SourcePod:       pod.Name,
+						SourceContainer: pod.Namespace, // We generally code it like so for test purposes
+
+						// direct traffic target against the specific server service in the server namespace
+						Destination: fmt.Sprintf("%s.%s", svcNs, serverNamespace),
+					})
+				}
+			}
+		}
+
+		results = HTTPMultipleResults{}
+		success = Td.WaitForRepeatedSuccess(func() bool {
+			// Get results
+			results = Td.MultipleHTTPRequest(&requests)
+
+			// Print results
+			Td.PrettyPrintHTTPResults(&results)
+
+			// Verify REST status code results
+			for _, ns := range results {
+				for _, podResult := range ns {
+					if podResult.Err != nil || podResult.StatusCode != 200 {
+						return false
+					}
+				}
+			}
+			return true
+		}, 2, 150*time.Second)
+
+		Expect(success).To(BeTrue())
+	})
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds support to split outbound TCP traffic based on SMI
traffic split. Existing e2e test for traffic split has
been extended for TCP.

Also replicates the appProtocol logic in SimplePodApp
to the SimpleDeploymentApp definition and method.
The test is mostly unchanged, except for creating
TCP routes instead of HTTP and fixing indentation.

Resolves #2666

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [X]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`