### PR TITLE
catalog/ingress: make tests comprehensive and correct check

### DIFF
--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -92,8 +92,6 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 		tests.BookstoreApexService.Namespace,
 	})
 
-	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(getFakeIngresses(), nil).AnyTimes()
-
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {
 		// play pretend this call queries a controller cache

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -8,12 +8,13 @@ import (
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
+// Ingress does not depend on k8s service accounts, program a wildcard (empty struct) to indicate
+// to RDS that an inbound traffic policy for ingress should not enforce service account based RBAC policies.
+var wildcardServiceAccount = service.K8sServiceAccount{}
+
 // GetIngressPoliciesForService returns a list of inbound traffic policies for a service as defined in observed ingress k8s resources.
 func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
 	inboundIngressPolicies := []*trafficpolicy.InboundTrafficPolicy{}
-	// Ingress does not depend on k8s service accounts, program a wildcard (empty struct) to indicate
-	// to RDS that an inbound traffic policy for ingress should not enforce service account based RBAC policies.
-	wildcardServiceAccount := service.K8sServiceAccount{}
 
 	ingresses, err := mc.ingressMonitor.GetIngressResources(svc)
 	if err != nil {
@@ -46,7 +47,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]
 					continue
 				}
 				routePolicy := wildCardRouteMatch
-				if routePolicy.PathRegex != "" {
+				if ingressPath.Path != "" {
 					routePolicy.PathRegex = ingressPath.Path
 				}
 				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(routePolicy, ingressWeightedCluster), wildcardServiceAccount)

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -1,311 +1,507 @@
 package catalog
 
 import (
-	"context"
+	"fmt"
 	"testing"
 
-	. "github.com/onsi/ginkgo"
-
+	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	testclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
-	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/endpoint"
-	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
 	"github.com/openservicemesh/osm/pkg/ingress"
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/smi"
-	"github.com/openservicemesh/osm/pkg/tests"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 var (
-	fakeIngressService         = "fake-service"
-	fakeIngressNamespace       = "ingress-ns"
-	fakeIngressPort      int32 = 80
-
-	// fakeIngressPaths is a mapping of the fake ingress resource domains to its paths
-	fakeIngressPaths = map[string][]string{
-		"fake1.com": {"/fake1-path1", "/fake1-path2", "/fake1-path3"},
-		"fake2.com": {"/fake2-path1"},
-		"*":         {".*"},
-	}
+	fakeIngressPort int32 = 80
 )
-
-func newFakeMeshCatalog() *MeshCatalog {
-	defer GinkgoRecover()
-
-	var (
-		mockCtrl           *gomock.Controller
-		mockKubeController *k8s.MockController
-		mockIngressMonitor *ingress.MockMonitor
-	)
-
-	mockCtrl = gomock.NewController(GinkgoT())
-	mockKubeController = k8s.NewMockController(mockCtrl)
-	mockIngressMonitor = ingress.NewMockMonitor(mockCtrl)
-
-	meshSpec := smi.NewFakeMeshSpecClient()
-
-	osmNamespace := "-test-osm-namespace-"
-	osmConfigMapName := "-test-osm-config-map-"
-
-	stop := make(chan struct{})
-	endpointProviders := []endpoint.Provider{
-		kube.NewFakeProvider(),
-	}
-	kubeClient := testclient.NewSimpleClientset()
-
-	cfg := configurator.NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-
-	certManager := tresor.NewFakeCertManager(cfg)
-
-	// Create a Bookstore-v1 pod
-	pod := tests.NewPodFixture(tests.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName, tests.PodLabels)
-	if _, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{}); err != nil {
-		GinkgoT().Fatalf("Error creating new fake Mesh Catalog: %s", err.Error())
-	}
-
-	// Create a Bookstore-v2 pod
-	pod = tests.NewPodFixture(tests.Namespace, tests.BookstoreV2Service.Name, tests.BookstoreV2ServiceAccountName, tests.PodLabels)
-	if _, err := kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{}); err != nil {
-		GinkgoT().Fatalf("Error creating new fake Mesh Catalog: %s", err.Error())
-	}
-
-	// Create Bookstore-v1 Service
-	selector := map[string]string{tests.SelectorKey: tests.SelectorValue}
-	svc := tests.NewServiceFixture(tests.BookstoreV1Service.Name, tests.BookstoreV1Service.Namespace, selector)
-	if _, err := kubeClient.CoreV1().Services(tests.BookstoreV1Service.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
-		GinkgoT().Fatalf("Error creating new Bookstore service: %s", err.Error())
-	}
-
-	// Create Bookstore-v2 Service
-	svc = tests.NewServiceFixture(tests.BookstoreV2Service.Name, tests.BookstoreV2Service.Namespace, selector)
-	if _, err := kubeClient.CoreV1().Services(tests.BookstoreV2Service.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
-		GinkgoT().Fatalf("Error creating new Bookstore service: %s", err.Error())
-	}
-
-	// Create Bookbuyer Service
-	svc = tests.NewServiceFixture(tests.BookbuyerService.Name, tests.BookbuyerService.Namespace, nil)
-	if _, err := kubeClient.CoreV1().Services(tests.BookbuyerService.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
-		GinkgoT().Fatalf("Error creating new Bookbuyer service: %s", err.Error())
-	}
-
-	// Create Bookstore apex Service
-	svc = tests.NewServiceFixture(tests.BookstoreApexService.Name, tests.BookstoreApexService.Namespace, nil)
-	if _, err := kubeClient.CoreV1().Services(tests.BookstoreApexService.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{}); err != nil {
-		GinkgoT().Fatalf("Error creating new Bookstore Apex service", err.Error())
-	}
-
-	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(getFakeIngresses(), nil).AnyTimes()
-
-	// Monitored namespaces is made a set to make sure we don't repeat namespaces on mock
-	listExpectedNs := tests.GetUnique([]string{
-		tests.BookstoreV1Service.Namespace,
-		tests.BookbuyerService.Namespace,
-		tests.BookstoreApexService.Namespace,
-	})
-
-	// #1683 tracks potential improvements to the following dynamic mocks
-	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {
-		// play pretend this call queries a controller cache
-		var services []*corev1.Service
-
-		for _, ns := range listExpectedNs {
-			// simulate lookup on controller cache
-			svcList, _ := kubeClient.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
-			for serviceIdx := range svcList.Items {
-				services = append(services, &svcList.Items[serviceIdx])
-			}
-		}
-
-		return services
-	}).AnyTimes()
-	mockKubeController.EXPECT().GetService(gomock.Any()).DoAndReturn(func(msh service.MeshService) *corev1.Service {
-		// simulate lookup on controller cache
-		vv, err := kubeClient.CoreV1().Services(msh.Namespace).Get(context.TODO(), msh.Name, metav1.GetOptions{})
-
-		if err != nil {
-			return nil
-		}
-
-		return vv
-	}).AnyTimes()
-	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV1Service.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().ListMonitoredNamespaces().Return(listExpectedNs, nil).AnyTimes()
-
-	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
-		mockIngressMonitor, stop, cfg, endpointProviders...)
-}
-
-func getFakeIngresses() []*networkingV1beta1.Ingress {
-	return []*networkingV1beta1.Ingress{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ingress-1",
-				Namespace: fakeIngressNamespace,
-				Annotations: map[string]string{
-					constants.OSMKubeResourceMonitorAnnotation: "enabled",
-				},
-			},
-			Spec: networkingV1beta1.IngressSpec{
-				Backend: &networkingV1beta1.IngressBackend{
-					ServiceName: fakeIngressService,
-					ServicePort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: fakeIngressPort,
-					},
-				},
-				Rules: []networkingV1beta1.IngressRule{
-					{
-						Host: "fake1.com",
-						IngressRuleValue: networkingV1beta1.IngressRuleValue{
-							HTTP: &networkingV1beta1.HTTPIngressRuleValue{
-								Paths: []networkingV1beta1.HTTPIngressPath{
-									{
-										Path: "/fake1-path1",
-										Backend: networkingV1beta1.IngressBackend{
-											ServiceName: fakeIngressService,
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: fakeIngressPort,
-											},
-										},
-									},
-									{
-										Path: "/fake1-path2",
-										Backend: networkingV1beta1.IngressBackend{
-											ServiceName: fakeIngressService,
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: fakeIngressPort,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ingress-2",
-				Namespace: fakeIngressNamespace,
-				Annotations: map[string]string{
-					constants.OSMKubeResourceMonitorAnnotation: "enabled",
-				},
-			},
-			Spec: networkingV1beta1.IngressSpec{
-				Backend: &networkingV1beta1.IngressBackend{
-					ServiceName: fakeIngressService,
-					ServicePort: intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: fakeIngressPort,
-					},
-				},
-				Rules: []networkingV1beta1.IngressRule{
-					{
-						Host: "fake2.com",
-						IngressRuleValue: networkingV1beta1.IngressRuleValue{
-							HTTP: &networkingV1beta1.HTTPIngressRuleValue{
-								Paths: []networkingV1beta1.HTTPIngressPath{
-									{
-										Path: "/fake2-path1",
-										Backend: networkingV1beta1.IngressBackend{
-											ServiceName: fakeIngressService,
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: fakeIngressPort,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Host: "fake1.com",
-						IngressRuleValue: networkingV1beta1.IngressRuleValue{
-							HTTP: &networkingV1beta1.HTTPIngressRuleValue{
-								Paths: []networkingV1beta1.HTTPIngressPath{
-									{
-										Path: "/fake1-path3",
-										Backend: networkingV1beta1.IngressBackend{
-											ServiceName: fakeIngressService,
-											ServicePort: intstr.IntOrString{
-												Type:   intstr.Int,
-												IntVal: fakeIngressPort,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func pathContains(allowed []string, path string) bool {
-	for _, p := range allowed {
-		if path == p {
-			return true
-		}
-	}
-	return false
-}
 
 func TestGetIngressPoliciesForService(t *testing.T) {
 	assert := tassert.New(t)
-	mc := newFakeMeshCatalog()
-	fakeService := service.MeshService{
-		Namespace: fakeIngressNamespace,
-		Name:      fakeIngressService,
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockIngressMonitor := ingress.NewMockMonitor(mockCtrl)
+	meshCatalog := &MeshCatalog{
+		ingressMonitor: mockIngressMonitor,
 	}
 
-	inboundIngressPolicies, err := mc.GetIngressPoliciesForService(fakeService)
-	assert.Empty(err)
+	type testCase struct {
+		name                    string
+		svc                     service.MeshService
+		ingresses               []*networkingV1beta1.Ingress
+		expectedTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
+		excpectError            bool
+	}
 
-	// The number of ingress inbound policies is the number of unique hosts across the ingress resources :
-	// 1. Hostnames: {"*"}
-	// 2. Hostnames: {"fake1.com"}
-	// 2. Hostnames: {"fake2.com"}
-	assert.Equal(len(inboundIngressPolicies), len(fakeIngressPaths))
+	testCases := []testCase{
+		{
+			name: "Ingress rule with multiple rules and no default backend",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake1-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake2-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake1-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake2-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Ingress rule with multiple rules and a default backend",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Backend: &networkingV1beta1.IngressBackend{
+							ServiceName: "foo",
+							ServicePort: intstr.IntOrString{
+								Type:   intstr.Int,
+								IntVal: fakeIngressPort,
+							},
+						},
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake1-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake2-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|*",
+					Hostnames: []string{
+						"*",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: wildCardRouteMatch,
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake1-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake2-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Multiple ingresses matching different hosts",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake1-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-2",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake2-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake1-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-2.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake2-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Multiple ingresses matching same hosts with different rules",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake1-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-2",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path: "/fake1-path2",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake1-path1",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									PathRegex: "/fake1-path2",
+									Methods:   []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+	}
 
-	for i := 0; i < len(inboundIngressPolicies); i++ {
-		for _, rule := range inboundIngressPolicies[i].Rules {
-			// For each ingress path, all HTTP methods are allowed, which is a regex match all of '*'
-			assert.Len(rule.Route.HTTPRouteMatch.Methods, 1)
-			assert.Equal(rule.Route.HTTPRouteMatch.Methods[0], constants.WildcardHTTPMethod)
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockIngressMonitor.EXPECT().GetIngressResources(tc.svc).Return(tc.ingresses, nil).Times(1)
 
-			//  rule.Route constains the path specified in the ingress resource rule. Since the same service
-			// could be a backend for multiple ingress resources, we don't know which ingress resource
-			// this path corresponds to. In order to not make assumptions
-			// on the implementation of 'GetIngressPoliciesForServices()', we relax the check here
-			// to match on any of the ingress paths corresponding to the host.
-			assert.True(pathContains(fakeIngressPaths[inboundIngressPolicies[i].Hostnames[0]], rule.Route.HTTPRouteMatch.PathRegex))
+			actualPolicies, err := meshCatalog.GetIngressPoliciesForService(tc.svc)
 
-			// Allowed service accounts should be wildcarded with an empty service account for ingress rules
-			assert.NotNil(rule.AllowedServiceAccounts)
-			assert.Equal(1, rule.AllowedServiceAccounts.Cardinality()) // single wildcard service account
-			allowedSvcAccounts := rule.AllowedServiceAccounts.Pop().(service.K8sServiceAccount)
-			assert.True((allowedSvcAccounts.IsEmpty()))
-		}
+			assert.Equal(tc.excpectError, err != nil)
+			assert.ElementsMatch(tc.expectedTrafficPolicies, actualPolicies)
+		})
 	}
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Makes the tests comprehensive to exactly match all expected
policies from ingress. The previous version of this test
was not thorough in verifying ingress -> policy translation.
Also voids the need for fake ingresses and fixes a logic
in the code related to path matching. Additionally, the
fake catalog helper is moved to fake.go.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`