### PR TITLE
envoy/ads: add unit test for helper

### DIFF
--- a/pkg/envoy/ads/stream_test.go
+++ b/pkg/envoy/ads/stream_test.go
@@ -1,0 +1,53 @@
+package ads
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+func TestIsCNForProxy(t *testing.T) {
+	assert := tassert.New(t)
+
+	type testCase struct {
+		name     string
+		cn       certificate.CommonName
+		proxy    *envoy.Proxy
+		expected bool
+	}
+
+	certSerialNumber := certificate.SerialNumber("123456")
+
+	testCases := []testCase{
+		{
+			name:     "workload CN belongs to proxy",
+			cn:       certificate.CommonName("svc-acc.namespace.cluster.local"),
+			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.svc-acc.namespace", uuid.New())), certSerialNumber, nil),
+			expected: true,
+		},
+		{
+			name:     "workload CN does not belong to proxy",
+			cn:       certificate.CommonName("svc-acc.namespace.cluster.local"),
+			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.svc-acc-foo.namespace", uuid.New())), certSerialNumber, nil),
+			expected: false,
+		},
+		{
+			name:     "not a workload CN",
+			cn:       certificate.CommonName("some-cn.type"),
+			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.svc-acc-foo.namespace", uuid.New())), certSerialNumber, nil),
+			expected: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			actual := isCNforProxy(tc.proxy, tc.cn)
+			assert.Equal(tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Change 9a7904c6 missed committing the unit test
since the new test was an untracked file. Adds
the test that was supposed to be a part of 9a7904c6.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`