### PR TITLE
fix(*): rm filterTrafficSplit logic as it is no longer needed

### DIFF
--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based
@@ -31,10 +30,6 @@ func (mc *MeshCatalog) GetServicesFromEnvoyCertificate(cn certificate.CommonName
 	if len(services) == 0 {
 		return nil, nil
 	}
-
-	// Remove services that have been split into other services.
-	// Filters out services referenced in TrafficSplit.spec.service
-	services = mc.filterTrafficSplitServices(services)
 
 	meshServices := kubernetesServicesToMeshServices(services)
 
@@ -60,34 +55,6 @@ func listServiceNames(meshServices []service.MeshService) (serviceNames []string
 		serviceNames = append(serviceNames, fmt.Sprintf("%s/%s", meshService.Namespace, meshService.Name))
 	}
 	return serviceNames
-}
-
-// filterTrafficSplitServices takes a list of services and removes from it the ones
-// that have been split via an SMI TrafficSplit.
-func (mc *MeshCatalog) filterTrafficSplitServices(services []v1.Service) []v1.Service {
-	excludeTheseServices := make(map[service.MeshService]interface{})
-	for _, trafficSplit := range mc.meshSpec.ListTrafficSplits() {
-		svc := service.MeshService{
-			Namespace: trafficSplit.Namespace,
-			Name:      trafficSplit.Spec.Service,
-		}
-		excludeTheseServices[svc] = nil
-	}
-
-	log.Debug().Msgf("Filtered out apex services (no pods can belong to these): %+v", excludeTheseServices)
-
-	// These are the services except ones that are a root of a TrafficSplit policy
-	var filteredServices []v1.Service
-
-	for i, svc := range services {
-		nsSvc := utils.K8sSvcToMeshSvc(&services[i])
-		if _, shouldSkip := excludeTheseServices[nsSvc]; shouldSkip {
-			continue
-		}
-		filteredServices = append(filteredServices, svc)
-	}
-
-	return filteredServices
 }
 
 // GetPodFromCertificate returns the Kubernetes Pod object for a given certificate.

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -382,39 +382,6 @@ var _ = Describe("Test XDS certificate tooling", func() {
 		})
 	})
 
-	Context("Test filterTrafficSplitServices()", func() {
-		It("returns services except these to be traffic split", func() {
-
-			services := []v1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "foo",
-						Name:      "A",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: tests.TrafficSplit.Namespace,
-						Name:      tests.TrafficSplit.Spec.Service,
-					},
-				},
-			}
-
-			expected := []v1.Service{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "foo",
-						Name:      "A",
-					},
-				},
-			}
-
-			actual := mc.filterTrafficSplitServices(services)
-
-			Expect(actual).To(Equal(expected))
-		})
-	})
-
 	Context("Test kubernetesServicesToMeshServices()", func() {
 		It("converts a list of Kubernetes Services to a list of OSM Mesh Services", func() {
 

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -1,0 +1,323 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Test traffic split where root service is same as backend service",
+	OSMDescribeInfo{
+		Tier:   1,
+		Bucket: 2,
+	},
+	func() {
+		Context("HTTP traffic splitting with SMI", func() {
+			testRecursiveTrafficSplit(AppProtocolHTTP)
+		})
+
+		Context("TCP traffic splitting with SMI", func() {
+			testRecursiveTrafficSplit(AppProtocolTCP)
+		})
+	})
+
+func testRecursiveTrafficSplit(appProtocol string) {
+	defer GinkgoRecover()
+	const (
+		// to name the header we will use to identify the server that replies
+		HTTPHeaderName = "podname"
+
+		serverPort = 80
+	)
+
+	clientAppBaseName := "client"
+	serverNamespace := "server-namespace"
+	trafficSplitName := "server"
+
+	// Scale number of client services/pods here
+	numberOfClientServices := 1
+	clientReplicaSet := 1
+
+	// Scale number of server services/pods here
+	numberOfServerServices := 1
+	serverReplicaSet := 1
+
+	clientServices := []string{}
+	serverServices := []string{trafficSplitName}
+	allNamespaces := []string{}
+
+	for i := 0; i < numberOfClientServices; i++ {
+		clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))
+	}
+
+	allNamespaces = append(allNamespaces, clientServices...)
+	allNamespaces = append(allNamespaces, serverNamespace) // 1 namespace for all server services (for the trafficsplit)
+
+	// Used across the test to wait for concurrent steps to finish
+	var wg sync.WaitGroup
+
+	It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+
+		// Create NSs
+		Expect(Td.CreateMultipleNs(allNamespaces...)).To(Succeed())
+		Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
+
+		// Create server app
+		svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+			SimpleDeploymentAppDef{
+				Name:         trafficSplitName,
+				Namespace:    serverNamespace,
+				ReplicaCount: int32(serverReplicaSet),
+				Image:        "simonkowallik/httpbin",
+				Ports:        []int{serverPort},
+				AppProtocol:  appProtocol,
+			})
+
+		// Expose an env variable such as XHTTPBIN_X_POD_NAME:
+		// This httpbin fork will pick certain env variable formats and reply the values as headers.
+		// We will expose pod name as one of these env variables, and will use it
+		// to identify the pod that replies to the request, and validate the test
+		deploymentDef.Spec.Template.Spec.Containers[0].Env = []v1.EnvVar{
+			{
+				Name: fmt.Sprintf("XHTTPBIN_%s", HTTPHeaderName),
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						FieldPath: "metadata.name",
+					},
+				},
+			},
+		}
+
+		_, err := Td.CreateServiceAccount(serverNamespace, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateService(serverNamespace, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+		}()
+
+		// Client apps
+		for _, clientApp := range clientServices {
+			svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+				SimpleDeploymentAppDef{
+					Name:         clientApp,
+					Namespace:    clientApp,
+					ReplicaCount: int32(clientReplicaSet),
+					Command:      []string{"/bin/bash", "-c", "--"},
+					Args:         []string{"while true; do sleep 30; done;"},
+					Image:        "songrgg/alpine-debug",
+					Ports:        []int{80},
+				})
+
+			_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateDeployment(clientApp, deploymentDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateService(clientApp, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			wg.Add(1)
+			go func(app string) {
+				defer wg.Done()
+				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+			}(clientApp)
+		}
+
+		wg.Wait()
+
+		// Create Traffic split with single service with the same name as backend
+		trafficSplit := TrafficSplitDef{
+			Name:                    trafficSplitName,
+			Namespace:               serverNamespace,
+			TrafficSplitServiceName: trafficSplitName,
+			Backends: []TrafficSplitBackend{
+				{
+					Name:   trafficSplitName,
+					Weight: 100,
+				},
+			},
+		}
+
+		// Get the Traffic split structures
+		tSplit, err := Td.CreateSimpleTrafficSplit(trafficSplit)
+		Expect(err).To(BeNil())
+
+		// Push them in K8s
+		_, err = Td.CreateTrafficSplit(serverNamespace, tSplit)
+		Expect(err).To(BeNil())
+
+		// Put allow traffic target rules
+		for _, srcClient := range clientServices {
+			for _, dstServer := range serverServices {
+				switch appProtocol {
+				// HTTP traffic
+				case AppProtocolHTTP:
+					httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+						SimpleAllowPolicy{
+							RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
+							TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+
+							SourceNamespace:      srcClient,
+							SourceSVCAccountName: srcClient,
+
+							DestinationNamespace:      serverNamespace,
+							DestinationSvcAccountName: dstServer,
+						})
+
+					// Configs have to be put into same NS as server/destination
+					_, err := Td.CreateHTTPRouteGroup(srcClient, httpRG)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+					Expect(err).NotTo(HaveOccurred())
+
+				// TCP traffic
+				case AppProtocolTCP:
+					tcpRoute, trafficTarget := Td.CreateSimpleTCPAllowPolicy(
+						SimpleAllowPolicy{
+							RouteGroupName:    fmt.Sprintf("%s-%s", srcClient, dstServer),
+							TrafficTargetName: fmt.Sprintf("%s-%s", srcClient, dstServer),
+
+							SourceNamespace:      srcClient,
+							SourceSVCAccountName: srcClient,
+
+							DestinationNamespace:      serverNamespace,
+							DestinationSvcAccountName: dstServer,
+						},
+						serverPort,
+					)
+
+					// Configs have to be put into same NS as server/destination
+					_, err := Td.CreateTCPRoute(srcClient, tcpRoute)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = Td.CreateTrafficTarget(srcClient, trafficTarget)
+					Expect(err).NotTo(HaveOccurred())
+
+				default:
+					Td.T.Fatalf("Unsupported appProtocol %s for test, must be one of [http, tcp]", appProtocol)
+				}
+			}
+		}
+
+		By("Issuing http requests from clients to the traffic split FQDN")
+
+		// Test traffic
+		// Create Multiple HTTP request structure
+		requests := HTTPMultipleRequest{
+			Sources: []HTTPRequestDef{},
+		}
+		for _, ns := range clientServices {
+			pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+			Expect(err).To(BeNil())
+
+			for _, pod := range pods.Items {
+				requests.Sources = append(requests.Sources, HTTPRequestDef{
+					SourceNs:        ns,
+					SourcePod:       pod.Name,
+					SourceContainer: ns, // container_name == NS for this test
+
+					// Targeting the trafficsplit FQDN
+					Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
+				})
+			}
+		}
+
+		var results HTTPMultipleResults
+		var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+		success := Td.WaitForRepeatedSuccess(func() bool {
+			curlSuccess := true
+
+			// Get results
+			results = Td.MultipleHTTPRequest(&requests)
+
+			// Print results
+			Td.PrettyPrintHTTPResults(&results)
+
+			// Verify REST status code results
+			for _, ns := range results {
+				for _, podResult := range ns {
+					if podResult.Err != nil || podResult.StatusCode != 200 {
+						curlSuccess = false
+					} else {
+						// We should see pod header populated
+						dstPod, ok := podResult.Headers[HTTPHeaderName]
+						if ok {
+							// Store and mark that we have seen a response for this server pod
+							serversSeen[dstPod] = true
+						}
+					}
+				}
+			}
+			Td.T.Logf("Unique servers replied %d/%d",
+				len(serversSeen), numberOfServerServices*serverReplicaSet)
+
+			// Success conditions:
+			// - All clients have been answered consecutively 5 successful HTTP requests
+			// - We have seen all servers from the traffic split reply at least once
+			return curlSuccess && (len(serversSeen) == numberOfServerServices*serverReplicaSet)
+		}, 5, 150*time.Second)
+
+		Expect(success).To(BeTrue())
+
+		By("Issuing http requests from clients to the allowed individual service backends")
+
+		// Test now against the individual services, observe they should still be reachable
+		requests = HTTPMultipleRequest{
+			Sources: []HTTPRequestDef{},
+		}
+		for _, clientNs := range clientServices {
+			pods, err := Td.Client.CoreV1().Pods(clientNs).List(context.Background(), metav1.ListOptions{})
+			Expect(err).To(BeNil())
+			// For each client pod
+			for _, pod := range pods.Items {
+				// reach each service
+				for _, svcNs := range serverServices {
+					requests.Sources = append(requests.Sources, HTTPRequestDef{
+						SourceNs:        pod.Namespace,
+						SourcePod:       pod.Name,
+						SourceContainer: pod.Namespace, // We generally code it like so for test purposes
+
+						// direct traffic target against the specific server service in the server namespace
+						Destination: fmt.Sprintf("%s.%s", svcNs, serverNamespace),
+					})
+				}
+			}
+		}
+
+		results = HTTPMultipleResults{}
+		success = Td.WaitForRepeatedSuccess(func() bool {
+			// Get results
+			results = Td.MultipleHTTPRequest(&requests)
+
+			// Print results
+			Td.PrettyPrintHTTPResults(&results)
+
+			// Verify REST status code results
+			for _, ns := range results {
+				for _, podResult := range ns {
+					if podResult.Err != nil || podResult.StatusCode != 200 {
+						return false
+					}
+				}
+			}
+			return true
+		}, 2, 150*time.Second)
+
+		Expect(success).To(BeTrue())
+	})
+}


### PR DESCRIPTION
Keeping this prevents us from referencing just a service name
without the namespace suffic as the traffic split root service

Signed-off-by: Michelle Noorali <minooral@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
