### PR TITLE
ads: change `handle()` returns from ADS path from DiscoveryResponses to unmarshalled

### DIFF
--- a/pkg/envoy/ads/errors.go
+++ b/pkg/envoy/ads/errors.go
@@ -5,5 +5,4 @@ import (
 )
 
 var errUnknownTypeURL = errors.New("unknown TypeUrl")
-var errCreatingResponse = errors.New("creating response")
 var errGrpcClosed = errors.New("grpc closed")

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -26,7 +27,7 @@ const ServerType = "ADS"
 func NewADSServer(meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamespace string, cfg configurator.Configurator, certManager certificate.Manager) *Server {
 	server := Server{
 		catalog: meshCatalog,
-		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) (*xds_discovery.DiscoveryResponse, error){
+		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error){
 			envoy.TypeEDS: eds.NewResponse,
 			envoy.TypeCDS: cds.NewResponse,
 			envoy.TypeRDS: rds.NewResponse,

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -21,7 +22,7 @@ var (
 // Server implements the Envoy xDS Aggregate Discovery Services
 type Server struct {
 	catalog        catalog.MeshCataloger
-	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) (*xds_discovery.DiscoveryResponse, error)
+	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error)
 	xdsLog         map[certificate.CommonName]map[envoy.TypeURI][]time.Time
 	xdsMapLogMutex sync.Mutex
 	osmNamespace   string

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -4,7 +4,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/ptypes"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -13,7 +13,7 @@ import (
 )
 
 // NewResponse creates a new Cluster Discovery Response.
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
@@ -68,11 +68,8 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		clusters = append(clusters, getTracingCluster(cfg))
 	}
 
-	resp := &xds_discovery.DiscoveryResponse{
-		TypeUrl: string(envoy.TypeCDS),
-	}
-
 	alreadyAdded := mapset.NewSet()
+	var resources []types.Resource
 	for _, cluster := range clusters {
 		if alreadyAdded.Contains(cluster.Name) {
 			log.Error().Msgf("Found duplicate clusters with name %s; Duplicate will not be sent to Envoy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
@@ -80,14 +77,8 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 			continue
 		}
 		alreadyAdded.Add(cluster.Name)
-		marshalledClusters, err := ptypes.MarshalAny(cluster)
-		if err != nil {
-			log.Error().Err(err).Msgf("Failed to marshal cluster %s for Envoy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
-				cluster.Name, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-			return nil, err
-		}
-		resp.Resources = append(resp.Resources, marshalledClusters)
+		resources = append(resources, cluster)
 	}
 
-	return resp, nil
+	return resources, nil
 }

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -64,13 +64,12 @@ func TestNewResponse(t *testing.T) {
 	// 4. Tracing cluster
 	// 5. Passthrough cluster for egress
 	numExpectedClusters := 6 // source and destination clusters
-	assert.Equal(numExpectedClusters, len((*resp).Resources))
+	assert.Equal(numExpectedClusters, len(resp))
 	actualClusters := []*xds_cluster.Cluster{}
-	for _, resource := range (*resp).Resources {
-		cl := xds_cluster.Cluster{}
-		err = ptypes.UnmarshalAny(resource, &cl)
-		require.Nil(err)
-		actualClusters = append(actualClusters, &cl)
+	for idx := range resp {
+		cl, ok := resp[idx].(*xds_cluster.Cluster)
+		require.True(ok)
+		actualClusters = append(actualClusters, cl)
 	}
 	expectedLocalCluster := &xds_cluster.Cluster{
 		TransportSocketMatches: nil,

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -2,8 +2,7 @@ package eds
 
 import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/any"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -14,7 +13,7 @@ import (
 )
 
 // NewResponse creates a new Endpoint Discovery Response.
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, _ configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, _ configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
 	proxyIdentity, err := catalog.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up proxy identity for proxy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
@@ -27,22 +26,13 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		return nil, err
 	}
 
-	var protos []*any.Any
+	var resources []types.Resource
 	for svc, endpoints := range allowedEndpoints {
 		loadAssignment := newClusterLoadAssignment(svc, endpoints)
-		proto, err := ptypes.MarshalAny(loadAssignment)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error marshalling EDS payload for proxy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-			continue
-		}
-		protos = append(protos, proto)
+		resources = append(resources, loadAssignment)
 	}
 
-	resp := &xds_discovery.DiscoveryResponse{
-		Resources: protos,
-		TypeUrl:   string(envoy.TypeEDS),
-	}
-	return resp, nil
+	return resources, nil
 }
 
 // getEndpointsForProxy returns only those service endpoints that belong to the allowed outbound service accounts for the proxy

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -8,7 +8,6 @@ import (
 
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	tassert "github.com/stretchr/testify/assert"
@@ -72,21 +71,20 @@ func TestEndpointConfiguration(t *testing.T) {
 	assert.NotNil(meshCatalog)
 	assert.NotNil(proxy)
 
-	actual, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
+	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
 	assert.Nil(err)
-	assert.NotNil(actual)
+	assert.NotNil(resources)
 
 	// There are 3 endpoints configured based on the configuration:
 	// 1. Bookstore
 	// 2. Bookstore-v1
 	// 3. Bookstore-v2
-	assert.Len(actual.Resources, 3)
+	assert.Len(resources, 3)
 
-	loadAssignment := xds_endpoint.ClusterLoadAssignment{}
+	loadAssignment, ok := resources[0].(*xds_endpoint.ClusterLoadAssignment)
 
 	// validating an endpoint
-	err = ptypes.UnmarshalAny(actual.Resources[0], &loadAssignment)
-	assert.Nil(err)
+	assert.True(ok)
 	assert.Len(loadAssignment.Endpoints, 1)
 }
 

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -2,7 +2,7 @@ package rds
 
 import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/ptypes"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -13,7 +13,7 @@ import (
 )
 
 // NewResponse creates a new Route Discovery Response.
-func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
 	var inboundTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
 	var outboundTrafficPolicies []*trafficpolicy.OutboundTrafficPolicy
 
@@ -45,17 +45,10 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_dis
 	}
 
 	routeConfiguration := route.BuildRouteConfiguration(inboundTrafficPolicies, outboundTrafficPolicies, proxy)
-	resp := &xds_discovery.DiscoveryResponse{
-		TypeUrl: string(envoy.TypeRDS),
-	}
+	resp := []types.Resource{}
 
 	for _, config := range routeConfiguration {
-		marshalledRouteConfig, err := ptypes.MarshalAny(config)
-		if err != nil {
-			log.Error().Err(err).Msgf("Failed to marshal route config for proxy")
-			return nil, err
-		}
-		resp.Resources = append(resp.Resources, marshalledRouteConfig)
+		resp = append(resp, config)
 	}
 
 	return resp, nil

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -5,7 +5,7 @@ import (
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
-	"github.com/golang/protobuf/ptypes"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -16,7 +16,7 @@ import (
 )
 
 // NewResponse creates a new Secrets Discovery Response.
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, certManager certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, certManager certificate.Manager) ([]types.Resource, error) {
 	log.Info().Msgf("Composing SDS Discovery Response for Envoy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 
 	// OSM currently relies on kubernetes ServiceAccount for service identity
@@ -33,9 +33,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request 
 		svcAccount:  svcAccount,
 	}
 
-	discoveryResponse := &xds_discovery.DiscoveryResponse{
-		TypeUrl: string(envoy.TypeSDS),
-	}
+	resp := []types.Resource{}
 
 	// The DiscoveryRequest contains the requested certs
 	requestedCerts := request.ResourceNames
@@ -54,15 +52,10 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request 
 	// 2. Create SDS secret resources based on the requested certs in the DiscoveryRequest
 	// request.ResourceNames is expected to be a list of either "service-cert:namespace/service" or "root-cert:namespace/service"
 	for _, envoyProto := range s.getSDSSecrets(cert, requestedCerts, proxy) {
-		marshalledSecret, err := ptypes.MarshalAny(envoyProto)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error marshaling Envoy secret %s for proxy with certificate SerialNumber=%s on Pod with UID=%s", envoyProto.Name, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-		}
-
-		discoveryResponse.Resources = append(discoveryResponse.Resources, marshalledSecret)
+		resp = append(resp, envoyProto)
 	}
 
-	return discoveryResponse, nil
+	return resp, nil
 }
 
 func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []string, proxy *envoy.Proxy) (certs []*xds_auth.Secret) {

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/mock/gomock"
@@ -66,11 +67,12 @@ func TestNewResponse(t *testing.T) {
 	assert.Nil(actualSDSResponse)
 
 	// ----- Test with an properly configured proxy
-	actualSDSResponse, err = NewResponse(meshCatalog, goodProxy, request, cfg, certManager)
+	resources, err := NewResponse(meshCatalog, goodProxy, request, cfg, certManager)
 	assert.Equal(err, nil, fmt.Sprintf("Error evaluating sds.NewResponse(): %s", err))
-	assert.NotNil(actualSDSResponse)
-	assert.Equal(len(actualSDSResponse.Resources), 3)
-	assert.Equal(actualSDSResponse.TypeUrl, "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret")
+	assert.NotNil(resources)
+	assert.Equal(len(resources), 3)
+	_, ok := resources[0].(*xds_auth.Secret)
+	assert.True(ok)
 }
 
 func TestGetRootCert(t *testing.T) {

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -8,7 +8,6 @@ import (
 
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	"github.com/onsi/ginkgo"
@@ -48,19 +47,17 @@ var _ = Describe(``+
 			// ---[  Get the config from rds.NewResponse()  ]-------
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			actual, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
 			It("did not return an error", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).ToNot(BeNil())
-				Expect(len(actual.Resources)).To(Equal(1))
+				Expect(resources).ToNot(BeNil())
+				Expect(len(resources)).To(Equal(1))
 			})
 
 			// ---[  Prepare the config for testing  ]-------
-			routeCfg := xds_route.RouteConfiguration{}
-
-			err = ptypes.UnmarshalAny(actual.Resources[0], &routeCfg)
+			routeCfg, ok := resources[0].(*xds_route.RouteConfiguration)
 			It("returns a response that can be unmarshalled into an xds RouteConfiguration struct", func() {
-				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
 				Expect(routeCfg.Name).To(Equal("RDS_Outbound"))
 			})
 

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -7,7 +7,6 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/mock/gomock"
-	proto "github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
@@ -238,21 +237,18 @@ func TestRDSRespose(t *testing.T) {
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()
 
-			actual, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
 			assert.Nil(err)
-			assert.NotNil(actual)
+			assert.NotNil(resources)
 
 			// The RDS response will have two route configurations
 			// 1. RDS_Inbound
 			// 2. RDS_Outbound
-			routeConfig := &xds_route.RouteConfiguration{}
-			assert.Equal(2, len(actual.GetResources()))
+			assert.Equal(2, len(resources))
 
 			// Check the inbound route configuration
-			unmarshallErr := proto.UnmarshalAny(actual.GetResources()[0], routeConfig)
-			if err != nil {
-				t.Fatal(unmarshallErr)
-			}
+			routeConfig, ok := resources[0].(*xds_route.RouteConfiguration)
+			assert.True(ok)
 
 			// The RDS_Inbound will have the following virtual hosts :
 			// inbound_virtual-host|bookstore-v1.default
@@ -281,10 +277,8 @@ func TestRDSRespose(t *testing.T) {
 			assert.Equal(routeConfig.VirtualHosts[1].Routes[1].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
 
 			// Check the outbound route configuration
-			unmarshallErr = proto.UnmarshalAny(actual.GetResources()[1], routeConfig)
-			if err != nil {
-				t.Fatal(unmarshallErr)
-			}
+			routeConfig, ok = resources[1].(*xds_route.RouteConfiguration)
+			assert.True(ok)
 
 			// The RDS_Outbound will have the following virtual hosts :
 			// outbound_virtual-host|bookstore-apex


### PR DESCRIPTION
We plan to integrate some consistency checks for xDS,
for that we will need to keep track of the latest resources sent
to an envoy and store them latest values sent to the envoys.

This commit starts by avoiding marshalling at the `Response`
paths and return `types.Resources`, which are generic interfaces
for xDS resources.

Some code has been refactored around `sendAllResponse`,
the now called `sendResponse` allows sending one or multiple TypeURIs
in a generic way, and can be used by either the "Global update" path,
"DiscoveryRequest" path, and even the "SDS cert rotated" path.

Ie., for a full update:
```
err := s.sendResponse(mapset.NewSetWith(
                        envoy.TypeCDS,
                        envoy.TypeEDS,
                        envoy.TypeLDS,
                        envoy.TypeRDS,
                        envoy.TypeSDS),
                      proxy, &server, nil, config)
```

Signed-off-by: edu <eduser25@gmail.com>


**Affected area**:

- New Functionality      [x]
- Other                  [x]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No