### PR TITLE
Fix skip statement in upgrade e2e test

### DIFF
--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -27,7 +27,7 @@ var _ = OSMDescribe("Upgrade from latest",
 
 		It("Tests upgrading the control plane", func() {
 			if Td.InstType == NoInstall {
-				Td.T.Skip("test requires fresh OSM install")
+				Skip("test requires fresh OSM install")
 			}
 
 			if _, err := exec.LookPath("kubectl"); err != nil {


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixed the "skip" step in e2e_upgrade_test.go, as I noticed this test was not being skipped in the osm-azure CI even when the installType was set to NoInstall. 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
