### PR TITLE
fix(e2e): fix HTTP ingress test when OSM is installed outside osm-system

### DIFF
--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -10,6 +10,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	helmcli "helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/kube"
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -55,6 +56,7 @@ var _ = OSMDescribe("HTTP ingress",
 			// Install nginx ingress controller
 			helm := &action.Configuration{}
 			Expect(helm.Init(Td.Env.RESTClientGetter(), Td.OsmNamespace, "secret", Td.T.Logf)).To(Succeed())
+			helm.KubeClient.(*kube.Client).Namespace = Td.OsmNamespace
 			install := action.NewInstall(helm)
 			install.RepoURL = "https://kubernetes.github.io/ingress-nginx"
 			install.Namespace = Td.OsmNamespace


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The nginx ingress controller installation was failing because Helm was
running hooks in the "osm-system" namespace, defaulted from OSM's
`*cli.EnvSettings`, even though the install was intended for a different
namespace. The hooks would fail because the "osm-system" namespace
doesn't exist when OSM is installed in a different namespace. This
change forces Helm's kube client to run in the context of the release's
namespace.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No