### PR TITLE
docs(envoy): Document ports used by envoy

### DIFF
--- a/docs/content/docs/application_requirements.md
+++ b/docs/content/docs/application_requirements.md
@@ -8,3 +8,12 @@ type: docs
 
 ## Application UIDs
 Do not run applications with the user ID (UID) value of **1500**. This is **reserved** for the Envoy proxy sidecar container injected into pods by OSM's sidecar injector.
+
+## Ports
+Do not use the following ports as they are used by the Envoy sidecar.
+| Port  | Description |
+| ------| ----------- |
+| 15000 | Envoy Admin Port |
+| 15001 | Envoy Outbound Listener Port |
+| 15003 | Envoy Inbound Listener Port |
+| 15010 | Envoy Prometheus Inbound Listener Port |

--- a/pkg/injector/health_probes.go
+++ b/pkg/injector/health_probes.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	// TODO(draychev): Dynamically generate init/init-iptables.sh from these constants: https://github.com/openservicemesh/osm/issues/2243
 	livenessProbePort  = int32(15901)
 	readinessProbePort = int32(15902)
 	startupProbePort   = int32(15903)


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Documents ports used by Envoy so that customers know not to use them for their applications.

Closes #2106 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
