### PR TITLE
ref(docs): rm ns yaml from manual demo manifests

### DIFF
--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -1,9 +1,3 @@
-# Deploy bookbuyer Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: bookbuyer
----
 # Deploy bookbuyer Service Account
 apiVersion: v1
 kind: ServiceAccount

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -1,9 +1,3 @@
-# Deploy bookstore Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: bookstore
----
 # Deploy bookstore Service
 apiVersion: v1
 kind: Service

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -1,9 +1,3 @@
-# Deploy bookthief Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: bookthief
----
 # Deploy bookthief ServiceAccount
 apiVersion: v1
 kind: ServiceAccount

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -1,9 +1,3 @@
-# Deploy bookwarehouse Namespace
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: bookwarehouse
----
 # Deploy bookwarehouse Service Account
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
gets rid of kubectl error on commandline.
redundant action since namespace was already created during
previous manual demo steps

resolves #2836

Signed-off-by: Michelle Noorali <minooral@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
