### PR TITLE
docs: Remove automated demo; Make manual demo main and only demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The OSM project builds on the ideas and implementations of many cloud native eco
     - [Prerequisites](#prerequisites)
     - [Get the OSM CLI](#get-the-osm-cli)
     - [Install OSM](#install-osm)
-- [Demos](#demos)
+- [Demonstration](#demonstration)
 - [Using OSM](#using-osm)
     - [OSM Usage Patterns](#osm-usage-patterns)
 - [Community](#community)
@@ -97,11 +97,9 @@ $ osm install
 
 See the [installation guide](docs/content/docs/install/_index.md) for more detailed options.
 
-## Demos
-We have provided two demos for you to experience OSM.
+## Demonstration
 
-- The [automated demo](demo/README.md) is a set of scripts anyone can run and shows how OSM can manage, secure and provide observability for microservice environments.
-- The [manual demo](docs/content/docs/install/manual_demo/_index.md) is a step-by-step walkthrough set of instruction of the automated demo.
+The OSM [Bookstore demo](docs/content/docs/install/manual_demo/_index.md) is a step-by-step walkthrough of how to install a bookbuyer and bookstore apps, and configure connectivity between these using SMI.
 
 ## Using OSM
 

--- a/docs/content/docs/dev_guide/_index.md
+++ b/docs/content/docs/dev_guide/_index.md
@@ -10,7 +10,7 @@ weight: 5
 Welcome to the Open Service Mesh development guide!
 Thank you for joining us on a journey to build an SMI-native lightweight service mesh. The first of our [core principles](https://github.com/openservicemesh/osm#core-principles) is to create a system, which is "simple to understand and contribute to." We hope that you would find the source code easy to understand. If not - we invite you to help us fulfill this principle. There is no PR too small!
 
-To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo/).
+To understand _what_ Open Service Mesh does - take it for a spin and kick the tires. Install it on your Kubernetes cluster by following [this guide](../install/manual_demo/_index.md).
 
 To get a deeper understanding of how OSM functions - take a look at the detailed [software design](../design_concepts).
 
@@ -263,7 +263,7 @@ For more information, please refer to [OSM's E2E Readme](https://github.com/open
 
 When we want to ensure that the entire system works correctly over time and
 transitions state as expected - we run
-[the demo included in the docs](https://github.com/openservicemesh/osm/blob/main/docs/example/README.md).
+[the demo included in the docs](https://github.com/openservicemesh/osm/blob/main/demo/README.md).
 This type of test is the slowest, but also most comprehensive. This test will ensure that your changes
 work with a real Kubernetes cluster, with real SMI policy, and real functions - no mocked or fake Go objects.
 


### PR DESCRIPTION
This PR removes the `automated demo`, which provides little value to new comers to this project. The automated demo is mainly needed for CI and development purposes.

The doc in `./demo/README.md` is still useful within the developer's guide, but not as a way to fully experience OSM.