### PR TITLE
docs: Rewrite the Manual demo doc

### DIFF
--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -6,6 +6,7 @@ aliases: ["OSM Manaual Demo"]
 weight: 2
 ---
 
+
 # OSM Manual Demo Guide
 
 The OSM Manual Install Demo Guide is a step by step set of instructions to quickly demo OSM's key features.


### PR DESCRIPTION
This PR rewrites the manual demo with the overall intent to make this specific to v0.8.0, and from here on provide versioned demo doc going forward with new releases.

Additionally in this PR:
  - removed references to bash scripts, brought these in as inline `kubectl` commands
  - removed links to external YAML files - these are now inline `bash` code with YAML heredocs
  - most importantly: the pod container images are pointing to specific versions of these apps
  - the doc points to a specific version of the OSM CLI and OSM Controller (v0.8.0)
