### PR TITLE
Fix check-go-version error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,23 +47,21 @@ MIN_REQUIRED_GO_VERSION_MAJOR = 1
 MIN_REQUIRED_GO_VERSION_MINOR = 15
 MIN_REQUIRED_GO_VERSION_PATCH = 7
 
-GO_VERSION_MESSAGE = Installed Go version is $(GO_VERSION_MAJOR).$(GO_VERSION_MINOR).$(GO_VERSION_PATCH). OSM requires Go version $(MIN_REQUIRED_GO_VERSION_MAJOR).$(MIN_REQUIRED_GO_VERSION_MINOR).$(MIN_REQUIRED_GO_VERSION_PATCH) or higher!
+GO_VERSION_MESSAGE = "Installed Go version is $(GO_VERSION_MAJOR).$(GO_VERSION_MINOR).$(GO_VERSION_PATCH).\n OSM requires Go version $(MIN_REQUIRED_GO_VERSION_MAJOR).$(MIN_REQUIRED_GO_VERSION_MINOR).$(MIN_REQUIRED_GO_VERSION_PATCH) or higher!\n\n"
 
 check-go-version: # Ensure the Go version used is what OSM requires
-	@echo -e "Installed Go version is $(GO_VERSION_MAJOR).$(GO_VERSION_MINOR).$(GO_VERSION_PATCH)."
-	@echo -e "OSM requires Go version $(MIN_REQUIRED_GO_VERSION_MAJOR).$(MIN_REQUIRED_GO_VERSION_MINOR).$(MIN_REQUIRED_GO_VERSION_PATCH) or higher!\n\n"
 	@if [ $(GO_VERSION_MAJOR) -gt $(MIN_REQUIRED_GO_VERSION_MAJOR) ]; then \
 		exit 0 ;\
 	elif [ $(GO_VERSION_MAJOR) -lt $(MIN_REQUIRED_GO_VERSION_MAJOR) ]; then \
-		echo '$(GO_VERSION_MESSAGE)';\
+		@echo -e '$(GO_VERSION_MESSAGE)';\
 		exit 1; \
 	elif [ $(GO_VERSION_MINOR) -gt $(MIN_REQUIRED_GO_VERSION_MINOR) ] ; then \
 		exit 0; \
 	elif [ $(GO_VERSION_MINOR) -lt $(MIN_REQUIRED_GO_VERSION_MINOR) ] ; then \
-		echo '$(GO_VERSION_MESSAGE)';\
+		@echo -e '$(GO_VERSION_MESSAGE)';\
 		exit 1; \
 	elif [ $(GO_VERSION_PATCH) -lt $(MIN_REQUIRED_GO_VERSION_PATCH) ] ; then \
-		echo '$(GO_VERSION_MESSAGE)';\
+		@echo -e '$(GO_VERSION_MESSAGE)';\
 		exit 1; \
 	fi
 


### PR DESCRIPTION
Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Remove buggy echo errors when go version checks out - `make check-go-version` is used in automated demo script(maybe in more places) to check go version is `>= 1.15.7` before building osm. This command prints error message even when go version check passes.

<!--


Please mark with X for applicable areas.

-->
**Affected area**:
- Other                  [x]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
