### PR TITLE
tests(pkg/configurator): refactor to use stdlib + testify

### DIFF
--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -2,10 +2,10 @@ package configurator
 
 import (
 	"context"
+	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	tassert "github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,717 +16,262 @@ import (
 	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 )
 
-var _ = Describe("Test Envoy configuration creation", func() {
-	testErrorEnvoyLogLevel := "error"
-	//noling: goconst
-	defaultConfigMap := map[string]string{
-		PermissiveTrafficPolicyModeKey: "false",
-		egressKey:                      "true",
-		enableDebugServer:              "true",
-		prometheusScrapingKey:          "true",
-		tracingEnableKey:               "true",
-		useHTTPSIngressKey:             "true",
-		enablePrivilegedInitContainer:  "true",
-		envoyLogLevel:                  testErrorEnvoyLogLevel,
-		serviceCertValidityDurationKey: "24h",
+func TestGetConfigMapCacheKey(t *testing.T) {
+	c := Client{
+		osmConfigMapName: "mapName",
+		osmNamespace:     "namespaceName",
+	}
+	expected := "namespaceName/mapName"
+	actual := c.getConfigMapCacheKey()
+	tassert.Equal(t, expected, actual)
+}
+
+func TestCreateUpdateConfig(t *testing.T) {
+	t.Run("ConfigMap doesn't exist", func(t *testing.T) {
+		kubeClient := testclient.NewSimpleClientset()
+		stop := make(chan struct{})
+		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+		tassert.Equal(t, &osmConfig{}, cfg.(*Client).getConfigMap())
+	})
+
+	tests := []struct {
+		name                 string
+		initialConfigMapData map[string]string
+		checkCreate          func(*tassert.Assertions, Configurator)
+		updatedConfigMapData map[string]string
+		checkUpdate          func(*tassert.Assertions, Configurator)
+	}{
+		{
+			name: "default",
+			initialConfigMapData: map[string]string{
+				PermissiveTrafficPolicyModeKey: "false",
+				egressKey:                      "true",
+				enableDebugServer:              "true",
+				prometheusScrapingKey:          "true",
+				tracingEnableKey:               "true",
+				useHTTPSIngressKey:             "true",
+				enablePrivilegedInitContainer:  "true",
+				envoyLogLevel:                  "error",
+				serviceCertValidityDurationKey: "24h",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				expectedConfig := &osmConfig{
+					PermissiveTrafficPolicyMode:   false,
+					Egress:                        true,
+					EnableDebugServer:             true,
+					PrometheusScraping:            true,
+					TracingEnable:                 true,
+					UseHTTPSIngress:               true,
+					EnablePrivilegedInitContainer: true,
+					EnvoyLogLevel:                 "error",
+					ServiceCertValidityDuration:   "24h",
+				}
+				expectedConfigBytes, err := marshalConfigToJSON(expectedConfig)
+				assert.Nil(err)
+
+				configBytes, err := cfg.GetConfigMap()
+				assert.Nil(err)
+				assert.Equal(string(expectedConfigBytes), string(configBytes))
+			},
+		},
+		{
+			name: "IsPermissiveTrafficPolicyMode",
+			initialConfigMapData: map[string]string{
+				PermissiveTrafficPolicyModeKey: "true",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.IsPermissiveTrafficPolicyMode())
+			},
+			updatedConfigMapData: map[string]string{
+				PermissiveTrafficPolicyModeKey: "false",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.IsPermissiveTrafficPolicyMode())
+			},
+		},
+		{
+			name: "IsEgressEnabled",
+			initialConfigMapData: map[string]string{
+				egressKey: "true",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.IsEgressEnabled())
+			},
+			updatedConfigMapData: map[string]string{
+				egressKey: "false",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.IsEgressEnabled())
+			},
+		},
+		{
+			name: "IsDebugServerEnabled",
+			initialConfigMapData: map[string]string{
+				enableDebugServer: "true",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.IsDebugServerEnabled())
+			},
+			updatedConfigMapData: map[string]string{
+				enableDebugServer: "false",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.IsDebugServerEnabled())
+			},
+		},
+		{
+			name: "IsPrometheusScrapingEnabled",
+			initialConfigMapData: map[string]string{
+				prometheusScrapingKey: "true",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.IsPrometheusScrapingEnabled())
+			},
+			updatedConfigMapData: map[string]string{
+				prometheusScrapingKey: "false",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.IsPrometheusScrapingEnabled())
+			},
+		},
+		{
+			name: "IsTracingEnabled",
+			initialConfigMapData: map[string]string{
+				tracingEnableKey:   "true",
+				tracingAddressKey:  "myjaeger",
+				tracingPortKey:     "12121",
+				tracingEndpointKey: "/my/endpoint",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.IsTracingEnabled())
+				assert.Equal("myjaeger", cfg.GetTracingHost())
+				assert.Equal(uint32(12121), cfg.GetTracingPort())
+				assert.Equal("/my/endpoint", cfg.GetTracingEndpoint())
+			},
+			updatedConfigMapData: map[string]string{
+				tracingEnableKey:   "false",
+				tracingAddressKey:  "myjaeger",
+				tracingPortKey:     "12121",
+				tracingEndpointKey: "/my/endpoint",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.IsTracingEnabled())
+				assert.Equal(constants.DefaultTracingHost+".-test-osm-namespace-.svc.cluster.local", cfg.GetTracingHost())
+				assert.Equal(constants.DefaultTracingPort, cfg.GetTracingPort())
+				assert.Equal(constants.DefaultTracingEndpoint, cfg.GetTracingEndpoint())
+			},
+		},
+		{
+			name: "UseHTTPSIngress",
+			initialConfigMapData: map[string]string{
+				useHTTPSIngressKey: "true",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.UseHTTPSIngress())
+			},
+			updatedConfigMapData: map[string]string{
+				useHTTPSIngressKey: "false",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.UseHTTPSIngress())
+			},
+		},
+		{
+			name:                 "GetEnvoyLogLevel",
+			initialConfigMapData: map[string]string{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal("error", cfg.GetEnvoyLogLevel())
+			},
+			updatedConfigMapData: map[string]string{
+				envoyLogLevel: "info",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal("info", cfg.GetEnvoyLogLevel())
+			},
+		},
+		{
+			name: "GetServiceCertValidityDuration",
+			initialConfigMapData: map[string]string{
+				serviceCertValidityDurationKey: "5", // invalid, should default to 24h
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal(24*time.Hour, cfg.GetServiceCertValidityPeriod())
+			},
+			updatedConfigMapData: map[string]string{
+				serviceCertValidityDurationKey: "1h",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal(1*time.Hour, cfg.GetServiceCertValidityPeriod())
+			},
+		},
+		{
+			name:                 "GetOutboundIPRangeExclusionList",
+			initialConfigMapData: map[string]string{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Nil(cfg.GetOutboundIPRangeExclusionList())
+			},
+			updatedConfigMapData: map[string]string{
+				outboundIPRangeExclusionListKey: "1.1.1.1/32, 2.2.2.2/24",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal([]string{"1.1.1.1/32", "2.2.2.2/24"}, cfg.GetOutboundIPRangeExclusionList())
+			},
+		},
+		{
+			name: "IsPrivilegedInitContainer",
+			initialConfigMapData: map[string]string{
+				enablePrivilegedInitContainer: "true",
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.True(cfg.IsPrivilegedInitContainer())
+			},
+			updatedConfigMapData: map[string]string{
+				enablePrivilegedInitContainer: "false",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.False(cfg.IsPrivilegedInitContainer())
+			},
+		},
 	}
 
-	Context("create OSM configurator client", func() {
-		It("correctly creates a cache key", func() {
-			c := Client{
-				osmConfigMapName: "mapName",
-				osmNamespace:     "namespaceName",
-			}
-			expected := "namespaceName/mapName"
-			actual := c.getConfigMapCacheKey()
-			Expect(actual).To(Equal(expected))
-		})
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
 
-	Context("create OSM config with default values", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
+			kubeClient := testclient.NewSimpleClientset()
+			stop := make(chan struct{})
+			cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+			confChannel := events.GetPubSubInstance().Subscribe(announcements.ConfigMapAdded, announcements.ConfigMapUpdated)
+			defer events.GetPubSubInstance().Unsub(confChannel)
 
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("test GetConfigMap", func() {
 			configMap := v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,
 					Name:      osmConfigMapName,
 				},
-				Data: defaultConfigMap,
+				Data: test.initialConfigMapData,
 			}
 			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			assert.Nil(err)
 
+			log.Info().Msg("Waiting for create announcement")
 			<-confChannel
 
-			expectedConfig := &osmConfig{
-				PermissiveTrafficPolicyMode:   false,
-				Egress:                        true,
-				EnableDebugServer:             true,
-				PrometheusScraping:            true,
-				TracingEnable:                 true,
-				UseHTTPSIngress:               true,
-				EnablePrivilegedInitContainer: true,
-				EnvoyLogLevel:                 testErrorEnvoyLogLevel,
-				ServiceCertValidityDuration:   "24h",
+			test.checkCreate(assert, cfg)
+
+			if test.checkUpdate == nil {
+				return
 			}
-			expectedConfigBytes, err := marshalConfigToJSON(expectedConfig)
-			Expect(err).ToNot(HaveOccurred())
 
-			configBytes, err := cfg.GetConfigMap()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(configBytes)).To(Equal(string(expectedConfigBytes)))
-		})
-	})
-
-	Context("create OSM config for permissive_traffic_policy_mode", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that permissive_traffic_policy_mode is enabled", func() {
-			Expect(cfg.IsPermissiveTrafficPolicyMode()).To(BeFalse())
-			defaultConfigMap[PermissiveTrafficPolicyModeKey] = "true"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			configMap.Data = test.updatedConfigMapData
+			_, err = kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
+			assert.Nil(err)
 
 			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
+			log.Info().Msg("Waiting for update announcement")
 			<-confChannel
 
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsPermissiveTrafficPolicyMode()).To(BeTrue())
+			test.checkUpdate(assert, cfg)
 		})
-
-		It("correctly identifies that permissive_traffic_policy_mode is disabled", func() {
-			defaultConfigMap[PermissiveTrafficPolicyModeKey] = "false" //nolint: goconst
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsPermissiveTrafficPolicyMode()).To(BeFalse())
-		})
-	})
-
-	Context("create OSM config for egress", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that egress is enabled", func() {
-			Expect(cfg.IsEgressEnabled()).To(BeFalse())
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsEgressEnabled()).To(BeTrue())
-		})
-
-		It("correctly identifies that egress is disabled", func() {
-			defaultConfigMap[egressKey] = "false"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsEgressEnabled()).To(BeFalse())
-		})
-	})
-
-	Context("create OSM config for osm debug HTTP server", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that the debug server is enabled", func() {
-			Expect(cfg.IsDebugServerEnabled()).To(BeFalse())
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsDebugServerEnabled()).To(BeTrue())
-		})
-
-		It("correctly identifies that the debug server is disabled", func() {
-			defaultConfigMap[enableDebugServer] = "false"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsDebugServerEnabled()).To(BeFalse())
-		})
-	})
-
-	Context("create OSM config for Prometheus scraping", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that the config is enabled", func() {
-			Expect(cfg.IsPrometheusScrapingEnabled()).To(BeFalse())
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsPrometheusScrapingEnabled()).To(BeTrue())
-		})
-
-		It("correctly identifies that the config is disabled", func() {
-			defaultConfigMap[prometheusScrapingKey] = "false"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsPrometheusScrapingEnabled()).To(BeFalse())
-		})
-	})
-
-	Context("create OSM config for tracing", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that the config is enabled", func() {
-			defaultConfigMap[tracingAddressKey] = "myjaeger"
-			defaultConfigMap[tracingPortKey] = "12121"
-			defaultConfigMap[tracingEndpointKey] = "/my/endpoint"
-
-			Expect(cfg.IsTracingEnabled()).To(BeFalse())
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsTracingEnabled()).To(BeTrue())
-			Expect(cfg.GetTracingHost()).To(Equal("myjaeger"))
-			Expect(cfg.GetTracingPort()).To(Equal(uint32(12121)))
-			Expect(cfg.GetTracingEndpoint()).To(Equal("/my/endpoint"))
-		})
-
-		It("correctly identifies that the config is disabled", func() {
-			defaultConfigMap[tracingEnableKey] = "false"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsTracingEnabled()).To(BeFalse())
-			Expect(cfg.GetTracingHost()).To(Equal(constants.DefaultTracingHost + ".-test-osm-namespace-.svc.cluster.local"))
-			Expect(cfg.GetTracingPort()).To(Equal(constants.DefaultTracingPort))
-			Expect(cfg.GetTracingEndpoint()).To(Equal(constants.DefaultTracingEndpoint))
-		})
-	})
-
-	Context("create OSM config for useHTTPSIngress", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that useHTTPSIngress is enabled", func() {
-			Expect(cfg.UseHTTPSIngress()).To(BeFalse())
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.UseHTTPSIngress()).To(BeTrue())
-		})
-
-		It("correctly identifies that useHTTPSIngress is disabled", func() {
-			defaultConfigMap[useHTTPSIngressKey] = "false"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.UseHTTPSIngress()).To(BeFalse())
-		})
-	})
-
-	Context("create OSM config for the Envoy proxy log level", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		testInfoEnvoyLogLevel := "info"
-		testDebugEnvoyLogLevel := "debug"
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that the Envoy log level is error", func() {
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testErrorEnvoyLogLevel))
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testErrorEnvoyLogLevel))
-		})
-
-		It("correctly identifies that Envoy log level is info", func() {
-			defaultConfigMap[envoyLogLevel] = testInfoEnvoyLogLevel
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testInfoEnvoyLogLevel))
-		})
-
-		It("correctly identifies that Envoy log level is debug", func() {
-			defaultConfigMap[envoyLogLevel] = testDebugEnvoyLogLevel
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.GetEnvoyLogLevel()).To(Equal(testDebugEnvoyLogLevel))
-		})
-	})
-
-	Context("create OSM config service cert validity period", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly retrieves the default service cert validity duration when an invalid value is specified", func() {
-			defaultConfigMap[serviceCertValidityDurationKey] = "5" // no units, so invalid
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			<-confChannel
-
-			Expect(cfg.GetServiceCertValidityPeriod()).To(Equal(time.Duration(24 * time.Hour)))
-		})
-
-		It("correctly retrieves the service cert validity duration", func() {
-			defaultConfigMap[serviceCertValidityDurationKey] = "1h"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			<-confChannel
-
-			Expect(cfg.GetServiceCertValidityPeriod()).To(Equal(time.Duration(1 * time.Hour)))
-		})
-	})
-
-	Context("test outbound_ip_range_exclusion_list", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly returns an empty list when no exclusion list is specified", func() {
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOutboundIPRangeExclusionList()).To(BeNil())
-		})
-
-		It("correctly retrieves the IP ranges to exclude", func() {
-			defaultConfigMap[outboundIPRangeExclusionListKey] = "1.1.1.1/32, 2.2.2.2/24"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			<-confChannel
-
-			expected := []string{"1.1.1.1/32", "2.2.2.2/24"}
-			actual := cfg.GetOutboundIPRangeExclusionList()
-			Expect(actual).Should(HaveLen(len(expected)))
-			Expect(actual).Should(ConsistOf(expected))
-		})
-	})
-
-	Context("create OSM config for privilegedInitContainer", func() {
-		kubeClient := testclient.NewSimpleClientset()
-		stop := make(chan struct{})
-		cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
-		var confChannel chan interface{}
-
-		BeforeEach(func() {
-			confChannel = events.GetPubSubInstance().Subscribe(
-				announcements.ConfigMapAdded,
-				announcements.ConfigMapDeleted,
-				announcements.ConfigMapUpdated)
-		})
-
-		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(confChannel)
-		})
-
-		It("correctly identifies that privilegedInitContainer is enabled", func() {
-			Expect(cfg.IsPrivilegedInitContainer()).To(BeFalse())
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Create(context.TODO(), &configMap, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsPrivilegedInitContainer()).To(BeTrue())
-		})
-
-		It("correctly identifies that privilegedInitContainer is disabled", func() {
-			defaultConfigMap[enablePrivilegedInitContainer] = "false"
-			configMap := v1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: osmNamespace,
-					Name:      osmConfigMapName,
-				},
-				Data: defaultConfigMap,
-			}
-			_, err := kubeClient.CoreV1().ConfigMaps(osmNamespace).Update(context.TODO(), &configMap, metav1.UpdateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			// Wait for the config map change to propagate to the cache.
-			log.Info().Msg("Waiting for announcement")
-			<-confChannel
-
-			Expect(cfg.GetOSMNamespace()).To(Equal(osmNamespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cfg.IsPrivilegedInitContainer()).To(BeFalse())
-		})
-	})
-})
+	}
+}


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates the tests in pkg/configurator/methods_test.go to use
the standard Go testing library and testify.

Part of #1704

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No