### PR TITLE
charts/osm: remove osm-config ConfigMap validation for CREATE

### DIFF
--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -23,7 +23,6 @@ webhooks:
       apiVersions:
         - v1
       operations:
-        - CREATE
         - UPDATE
       resources:
         - configmaps


### PR DESCRIPTION
This PR cherry-picks 4df9e3b6 to release-v0.8.
----------------

There is a race condition between osm-config ConfigMap creation
and osm config validator webhook. It has been observed sometimes
where the validating webhook config is deployed *before*
osm-config-validator service is ready. When this happens,
creation of osm-config ConfigMap fails because the validating
webhook is not ready.

Since creation of osm-config ConfigMap is handled by the install
workflow (cli or Helm) internally, it is safe to remove interception
of CREATE osm-config webhook requests and only validate mutations
(UPDATE) to the osm-config ConfigMap.

Error seen:
```
Failed calling webhook, failing closed osm-config-webhook.k8s.io: \
    failed calling webhook "osm-config-webhook.k8s.io": \
    Post "https://osm-config-validator.osm-system.svc:9093/ \
    validate-webhook?timeout=30s": service "osm-config-validator" not found
```

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
