### PR TITLE
feat(*): support SMI traffic split v1alpha4

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -145,7 +145,7 @@ spec:
 
 ---
 
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-traffic-split
@@ -190,7 +190,7 @@ This certificate's Common Name leverages the DNS-1123 standard with the followin
 ### (E) Policy
 The policy component referenced in the diagram above (E) is any [SMI Spec resource](https://github.com/deislabs/smi-spec#service-mesh-interface) referencing the [service (C)](#c-service). For instance, `TrafficSplit`, referencing a services `bookstore`, and `bookstore-v1`:
 ```yaml
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-traffic-split

--- a/README.md
+++ b/README.md
@@ -138,5 +138,5 @@ This software is covered under the Apache 2.0 license. You can read the license 
 
 [1]: https://en.wikipedia.org/wiki/Service_mesh
 [2]: https://github.com/servicemeshinterface/smi-spec/blob/master/SPEC_LATEST_STABLE.md
-[3]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha2/traffic-split.md
+[3]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha4/traffic-split.md
 [4]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha3/traffic-access.md

--- a/charts/osm/crds/split.yaml
+++ b/charts/osm/crds/split.yaml
@@ -20,7 +20,6 @@ metadata:
   name: trafficsplits.split.smi-spec.io
 spec:
   group: split.smi-spec.io
-  version: v1alpha2
   scope: Namespaced
   names:
     kind: TrafficSplit
@@ -29,10 +28,20 @@ spec:
     - ts
     plural: trafficsplits
     singular: trafficsplit
+  version: v1alpha4
   versions:
-  - name: v1alpha2
-    served: true
-    storage: true
+    - name: v1alpha4
+      served: true
+      storage: true
+    - name: v1alpha3
+      served: false
+      storage: false
+    - name: v1alpha2
+      served: false
+      storage: false
+    - name: v1alpha1
+      served: false
+      storage: false
   additionalPrinterColumns:
   - name: Service
     type: string
@@ -50,6 +59,21 @@ spec:
             service:
               description: The apex service of this split.
               type: string
+            matches:
+              description: The HTTP route groups that this traffic split should match.
+              type: array
+              items:
+                type: object
+                required: ['kind', 'name']
+                properties:
+                  kind:
+                    description: Kind of the matching group.
+                    type: string
+                    enum:
+                      - HTTPRouteGroup
+                  name:
+                    description: Name of the matching group.
+                    type: string
             backends:
               description: The backend services of this split.
               type: array

--- a/demo/deploy-traffic-split.sh
+++ b/demo/deploy-traffic-split.sh
@@ -6,7 +6,7 @@ set -aueo pipefail
 source .env
 
 kubectl apply -f - <<EOF
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-split
@@ -14,11 +14,8 @@ metadata:
 spec:
   service: bookstore
   backends:
-
   - service: bookstore-v1
     weight: 50
   - service: bookstore-v2
     weight: 50
-
-
 EOF

--- a/docs/content/docs/design_concepts/components_desc.md
+++ b/docs/content/docs/design_concepts/components_desc.md
@@ -79,7 +79,7 @@ spec:
     app: bookstore
 
 ---
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-traffic-split
@@ -131,7 +131,7 @@ This certificate's Common Name leverages the DNS-1123 standard with the followin
 The policy component referenced in the diagram above (E) is any [SMI Spec resource](https://github.com/deislabs/smi-spec#service-mesh-interface) referencing the [service (C)](#c-service). For instance, `TrafficSplit`, referencing a services `bookstore`, and `bookstore-v1`:
 
 ```yaml
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-traffic-split

--- a/docs/content/docs/getting_started/_index.md
+++ b/docs/content/docs/getting_started/_index.md
@@ -21,7 +21,7 @@ OSM runs an Envoy based control plane on Kubernetes, can be configured with SMI 
 
 ## Features
 
-1. Easily and transparently configure [traffic shifting](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha2/traffic-split.md) for deployments
+1. Easily and transparently configure [traffic shifting](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha4/traffic-split.md) for deployments
 1. Secure service to service communication by [enabling mTLS](https://github.com/openservicemesh/osm/blob/main/docs/patterns/certificates.md)
 1. Define and execute fine grained [access control](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha3/traffic-access.md) policies for services
 1. [Observability](https://github.com/openservicemesh/osm/blob/main/docs/patterns/observability/README.md) and insights into application metrics for debugging and monitoring services
@@ -42,5 +42,5 @@ OSM is under active development and is NOT ready for production workloads.
 | :---------------------- | :-----------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------: |
 | Traffic Access Control  |  [v1alpha3](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha3/traffic-access.md)  |                                                                                 |
 | Traffic Specs           |   [v1alpha4](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-specs/v1alpha4/traffic-specs.md)   |                                                                                 |
-| Traffic Split           |   [v1alpha2](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha2/traffic-split.md)   |                                                                                 |
+| Traffic Split           |   [v1alpha4](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha4/traffic-split.md)   |                                                                                 |
 | Traffic Metrics         | [v1alpha1](https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-metrics/v1alpha1/traffic-metrics.md) | 🚧 **In Progress** [#379](https://github.com/openservicemesh/osm/issues/379) 🚧 |

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -395,4 +395,4 @@ For more details about uninstalling OSM, see the [uninstallation guide](../unins
 
 [1]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-access/v1alpha2/traffic-access.md
 [2]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-specs/v1alpha4/traffic-specs.md
-[3]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha2/traffic-split.md
+[3]: https://github.com/servicemeshinterface/smi-spec/blob/v0.6.0/apis/traffic-split/v1alpha4/traffic-split.md

--- a/docs/content/docs/troubleshooting/upgrade.md
+++ b/docs/content/docs/troubleshooting/upgrade.md
@@ -11,7 +11,7 @@ If the [upgrade CRD guide](../upgrade_guide.md##crd-upgrades) was not followed, 
 
 The OSM controller will then crash with errors similar to this:
 ```
-reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to list *v1alpha2.TrafficTarget: the server could not find the requested resource (get traffictargets.access.smi-spec.io)
+reflector.go:178] pkg/mod/k8s.io/client-go@v0.18.6/tools/cache/reflector.go:125: Failed to list *v1alpha4.TrafficTarget: the server could not find the requested resource (get traffictargets.access.smi-spec.io)
 ```
 To resolve these errors:
 1. Checkout the correct release branch of the [repo](https://github.com/openservicemesh/osm) and run the following commands from the root. 

--- a/docs/example/manifests/split/traffic-split-50-50.yaml
+++ b/docs/example/manifests/split/traffic-split-50-50.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-split

--- a/docs/example/manifests/split/traffic-split-v1.yaml
+++ b/docs/example/manifests/split/traffic-split-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-split

--- a/docs/example/manifests/split/traffic-split-v2.yaml
+++ b/docs/example/manifests/split/traffic-split-v2.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha2
+apiVersion: split.smi-spec.io/v1alpha4
 kind: TrafficSplit
 metadata:
   name: bookstore-split

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -5,7 +5,7 @@ import (
 
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	specs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -16,7 +16,7 @@ import (
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	v1alpha40 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface
@@ -290,10 +290,10 @@ func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interf
 }
 
 // ListSMIPolicies mocks base method
-func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
+func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha40.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSMIPolicies")
-	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
+	ret0, _ := ret[0].([]*v1alpha40.TrafficSplit)
 	ret1, _ := ret[1].([]service.K8sServiceAccount)
 	ret2, _ := ret[2].([]*v1alpha4.HTTPRouteGroup)
 	ret3, _ := ret[3].([]*v1alpha3.TrafficTarget)

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -7,8 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -377,9 +376,9 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: tests.Namespace,
 		},
-		Spec: v1alpha2.TrafficSplitSpec{
+		Spec: split.TrafficSplitSpec{
 			Service: tests.BookstoreApexServiceName + "." + tests.Namespace,
-			Backends: []v1alpha2.TrafficSplitBackend{
+			Backends: []split.TrafficSplitBackend{
 				{
 					Service: tests.BookstoreV1ServiceName,
 					Weight:  tests.Weight90,

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"

--- a/pkg/debugger/mock_debugger_generated.go
+++ b/pkg/debugger/mock_debugger_generated.go
@@ -14,7 +14,7 @@ import (
 	service "github.com/openservicemesh/osm/pkg/service"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	v1alpha40 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 )
 
 // MockCertificateManagerDebugger is a mock of CertificateManagerDebugger interface
@@ -134,10 +134,10 @@ func (mr *MockMeshCatalogDebuggerMockRecorder) ListMonitoredNamespaces() *gomock
 }
 
 // ListSMIPolicies mocks base method
-func (m *MockMeshCatalogDebugger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
+func (m *MockMeshCatalogDebugger) ListSMIPolicies() ([]*v1alpha40.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSMIPolicies")
-	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
+	ret0, _ := ret[0].([]*v1alpha40.TrafficSplit)
 	ret1, _ := ret[1].([]service.K8sServiceAccount)
 	ret2, _ := ret[2].([]*v1alpha4.HTTPRouteGroup)
 	ret3, _ := ret[3].([]*v1alpha3.TrafficTarget)

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -7,7 +7,7 @@ import (
 
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 
 	"github.com/openservicemesh/osm/pkg/service"
 )

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -49,6 +49,6 @@ func TestGetSMIPolicies(t *testing.T) {
 	responseRecorder := httptest.NewRecorder()
 	smiPoliciesHandler.ServeHTTP(responseRecorder, nil)
 	actualResponseBody := responseRecorder.Body.String()
-	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{}}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha4","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha3","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"ServiceAccount","name":"bookstore","namespace":"default"},"sources":[{"kind":"ServiceAccount","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
+	expectedResponseBody := `{"traffic_splits":[{"metadata":{"name":"bar","namespace":"foo","creationTimestamp":null},"spec":{"service":"","backends":null}}],"service_accounts":[{"Namespace":"default","Name":"bookbuyer"}],"route_groups":[{"kind":"HTTPRouteGroup","apiVersion":"specs.smi-spec.io/v1alpha4","metadata":{"name":"bookstore-service-routes","namespace":"default","creationTimestamp":null},"spec":{"matches":[{"name":"buy-books","methods":["GET"],"pathRegex":"/buy","headers":[{"user-agent":"test-UA"}]},{"name":"sell-books","methods":["GET"],"pathRegex":"/sell","headers":[{"user-agent":"test-UA"}]},{"name":"allow-everything-on-header","headers":[{"user-agent":"test-UA"}]}]}}],"traffic_targets":[{"kind":"TrafficTarget","apiVersion":"access.smi-spec.io/v1alpha3","metadata":{"name":"bookbuyer-access-bookstore","namespace":"default","creationTimestamp":null},"spec":{"destination":{"kind":"ServiceAccount","name":"bookstore","namespace":"default"},"sources":[{"kind":"ServiceAccount","name":"bookbuyer","namespace":"default"}],"rules":[{"kind":"HTTPRouteGroup","name":"bookstore-service-routes","matches":["buy-books","sell-books"]}]}}]}`
 	assert.Equal(expectedResponseBody, actualResponseBody, "Actual value did not match expectations:\n%s", actualResponseBody)
 }

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -6,7 +6,7 @@ import (
 
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -13,7 +13,7 @@ import (
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
-	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	smiAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
 	smiAccessInformers "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/informers/externalversions"
 	smiTrafficSpecClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/clientset/versioned"
@@ -97,7 +97,7 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 	smiTrafficTargetInformerFactory := smiAccessInformers.NewSharedInformerFactory(smiAccessClient, k8s.DefaultKubeEventResyncInterval)
 
 	informerCollection := informerCollection{
-		TrafficSplit:   smiTrafficSplitInformerFactory.Split().V1alpha2().TrafficSplits().Informer(),
+		TrafficSplit:   smiTrafficSplitInformerFactory.Split().V1alpha4().TrafficSplits().Informer(),
 		HTTPRouteGroup: smiTrafficSpecInformerFactory.Specs().V1alpha4().HTTPRouteGroups().Informer(),
 		TCPRoute:       smiTrafficSpecInformerFactory.Specs().V1alpha4().TCPRoutes().Informer(),
 		TrafficTarget:  smiTrafficTargetInformerFactory.Access().V1alpha3().TrafficTargets().Informer(),

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	testTrafficTargetClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned/fake"
 	testTrafficSpecClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/clientset/versioned/fake"
 	testTrafficSplitClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned/fake"
@@ -118,7 +118,7 @@ var _ = Describe("When listing TrafficSplit", func() {
 			},
 		}
 
-		_, err := fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha2().TrafficSplits(testNamespaceName).Create(context.TODO(), split, metav1.CreateOptions{})
+		_, err := fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha4().TrafficSplits(testNamespaceName).Create(context.TODO(), split, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		<-tsChannel
 
@@ -126,7 +126,7 @@ var _ = Describe("When listing TrafficSplit", func() {
 		Expect(len(splits)).To(Equal(1))
 		Expect(split).To(Equal(splits[0]))
 
-		err = fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha2().TrafficSplits(testNamespaceName).Delete(context.TODO(), split.Name, metav1.DeleteOptions{})
+		err = fakeClientSet.smiTrafficSplitClientSet.SplitV1alpha4().TrafficSplits(testNamespaceName).Delete(context.TODO(), split.Name, metav1.DeleteOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		<-tsChannel
 	})

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -3,7 +3,7 @@ package smi
 import (
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/service"

--- a/pkg/smi/mock_meshspec_generated.go
+++ b/pkg/smi/mock_meshspec_generated.go
@@ -11,7 +11,7 @@ import (
 	service "github.com/openservicemesh/osm/pkg/service"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	v1alpha40 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 )
 
 // MockMeshSpec is a mock of MeshSpec interface
@@ -94,10 +94,10 @@ func (mr *MockMeshSpecMockRecorder) ListTCPTrafficSpecs() *gomock.Call {
 }
 
 // ListTrafficSplits mocks base method
-func (m *MockMeshSpec) ListTrafficSplits() []*v1alpha2.TrafficSplit {
+func (m *MockMeshSpec) ListTrafficSplits() []*v1alpha40.TrafficSplit {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTrafficSplits")
-	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
+	ret0, _ := ret[0].([]*v1alpha40.TrafficSplit)
 	return ret0
 }
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -5,7 +5,7 @@ package smi
 import (
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 
 	"k8s.io/client-go/tools/cache"
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -8,7 +8,7 @@ import (
 
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -209,13 +209,13 @@ var (
 	}
 
 	// TrafficSplit is a traffic split SMI object.
-	TrafficSplit = v1alpha2.TrafficSplit{
+	TrafficSplit = split.TrafficSplit{
 		ObjectMeta: v1.ObjectMeta{
 			Namespace: Namespace,
 		},
-		Spec: v1alpha2.TrafficSplitSpec{
+		Spec: split.TrafficSplitSpec{
 			Service: BookstoreApexServiceName,
-			Backends: []v1alpha2.TrafficSplitBackend{
+			Backends: []split.TrafficSplitBackend{
 				{
 					Service: BookstoreV1ServiceName,
 					Weight:  Weight90,

--- a/tests/framework/common_smi.go
+++ b/tests/framework/common_smi.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	smiTrafficAccessClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned"
 	smiTrafficSpecClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/clientset/versioned"
 	smiTrafficSplitClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned"
@@ -73,7 +73,7 @@ func (td *OsmTestData) CreateTrafficTarget(ns string, tar smiAccess.TrafficTarge
 
 // CreateTrafficSplit Creates an SMI TrafficSplit
 func (td *OsmTestData) CreateTrafficSplit(ns string, tar smiSplit.TrafficSplit) (*smiSplit.TrafficSplit, error) {
-	tt, err := td.SmiClients.SplitClient.SplitV1alpha2().TrafficSplits(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
+	tt, err := td.SmiClients.SplitClient.SplitV1alpha4().TrafficSplits(ns).Create(context.Background(), &tar, metav1.CreateOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create TrafficSplit")
 	}

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha4"
 	tassert "github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
**WIP**

+ updates OSM to support SMI Traffic Split v1alpha4
which includes HTTPRouteGroup support enabling scenarios
such as A/B testing and routing based on HTTP attributes

* resolves #2759
* resolves #2368

Signed-off-by: Michelle Noorali <minooral@microsoft.com>

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [X ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
