### PR TITLE
docs(demo): fix broken link and clarify statement

### DIFF
--- a/docs/content/docs/dev_guide/_index.md
+++ b/docs/content/docs/dev_guide/_index.md
@@ -10,7 +10,7 @@ weight: 5
 Welcome to the Open Service Mesh development guide!
 Thank you for joining us on a journey to build an SMI-native lightweight service mesh. The first of our [core principles](https://github.com/openservicemesh/osm#core-principles) is to create a system, which is "simple to understand and contribute to." We hope that you would find the source code easy to understand. If not - we invite you to help us fulfill this principle. There is no PR too small!
 
-To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo).
+To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo/).
 
 To get a deeper understanding of how OSM functions - take a look at the detailed [software design](../design_concepts/_index.md).
 

--- a/docs/content/docs/dev_guide/_index.md
+++ b/docs/content/docs/dev_guide/_index.md
@@ -12,7 +12,7 @@ Thank you for joining us on a journey to build an SMI-native lightweight service
 
 To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo/).
 
-To get a deeper understanding of how OSM functions - take a look at the detailed [software design](../design_concepts/_index.md).
+To get a deeper understanding of how OSM functions - take a look at the detailed [software design](../design_concepts).
 
 When you are ready to jump in - [fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) and then [clone it](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) on your workstation.
 

--- a/docs/content/docs/dev_guide/_index.md
+++ b/docs/content/docs/dev_guide/_index.md
@@ -10,7 +10,7 @@ weight: 5
 Welcome to the Open Service Mesh development guide!
 Thank you for joining us on a journey to build an SMI-native lightweight service mesh. The first of our [core principles](https://github.com/openservicemesh/osm#core-principles) is to create a system, which is "simple to understand and contribute to." We hope that you would find the source code easy to understand. If not - we invite you to help us fulfill this principle. There is no PR too small!
 
-To understand _what_ Open Service Mesh does - take it for a spin and kick the tires. Install it on your Kubernetes cluster by following [this guide](./install/manual_demo/_index.md).
+To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo/_index.md).
 
 To get a deeper understanding of how OSM functions - take a look at the detailed [software design](../design_concepts/_index.md).
 

--- a/docs/content/docs/dev_guide/_index.md
+++ b/docs/content/docs/dev_guide/_index.md
@@ -10,7 +10,7 @@ weight: 5
 Welcome to the Open Service Mesh development guide!
 Thank you for joining us on a journey to build an SMI-native lightweight service mesh. The first of our [core principles](https://github.com/openservicemesh/osm#core-principles) is to create a system, which is "simple to understand and contribute to." We hope that you would find the source code easy to understand. If not - we invite you to help us fulfill this principle. There is no PR too small!
 
-To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo/_index.md).
+To understand _what_ Open Service Mesh does - take it for a spin and kick the tires by following [this manual demo guide](../install/manual_demo).
 
 To get a deeper understanding of how OSM functions - take a look at the detailed [software design](../design_concepts/_index.md).
 


### PR DESCRIPTION
Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Fixes link and statement to clarify that it points to manual demo docs, not install docs.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [x]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [x]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
