### PR TITLE
Skip http_ingress_test if not kind cluster

### DIFF
--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -27,6 +27,11 @@ var _ = OSMDescribe("HTTP ingress",
 		const destNs = "server"
 
 		It("allows HTTP ingress traffic", func() {
+
+			if Td.InstType != KindCluster {
+				Skip("test requires Kind Cluster")
+			}
+
 			// Install OSM
 			installOpts := Td.GetOSMInstallOpts()
 			Expect(Td.InstallOSM(installOpts)).To(Succeed())


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--


-->
**Description**: The http_ingress_test sends a request to localhost, which is not compatible for non-kind clusters. Thus, I added a condition to skip this for other install types. 


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [X]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No
