### PR TITLE
ref(pkg): update NewRouteWeightedClusters method

### DIFF
--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -31,7 +31,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]
 	for _, ingress := range ingresses {
 		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == svc.Name {
 			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
-			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(wildCardRouteMatch, ingressWeightedCluster), wildcardServiceAccount)
+			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(wildCardRouteMatch, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
 			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
 		}
 
@@ -50,7 +50,7 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]
 				if ingressPath.Path != "" {
 					routePolicy.PathRegex = ingressPath.Path
 				}
-				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(routePolicy, ingressWeightedCluster), wildcardServiceAccount)
+				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(routePolicy, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
 			}
 
 			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -10,10 +10,16 @@ import (
 )
 
 // NewRouteWeightedCluster takes a route and weighted cluster and returns a *RouteWeightedCluster
-func NewRouteWeightedCluster(route HTTPRouteMatch, weightedCluster service.WeightedCluster) *RouteWeightedClusters {
+func NewRouteWeightedCluster(route HTTPRouteMatch, weightedClusters []service.WeightedCluster) *RouteWeightedClusters {
+
+	weightedClusterSet := set.NewSet()
+	for _, wc := range weightedClusters {
+		weightedClusterSet.Add(wc)
+	}
+
 	return &RouteWeightedClusters{
 		HTTPRouteMatch:   route,
-		WeightedClusters: set.NewSet(weightedCluster),
+		WeightedClusters: weightedClusterSet,
 	}
 }
 

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -11,7 +11,6 @@ import (
 
 // NewRouteWeightedCluster takes a route and weighted cluster and returns a *RouteWeightedCluster
 func NewRouteWeightedCluster(route HTTPRouteMatch, weightedClusters []service.WeightedCluster) *RouteWeightedClusters {
-
 	weightedClusterSet := set.NewSet()
 	for _, wc := range weightedClusters {
 		weightedClusterSet.Add(wc)

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -685,10 +685,27 @@ func TestNewInboundTrafficPolicy(t *testing.T) {
 
 func TestNewRouteWeightedCluster(t *testing.T) {
 	assert := tassert.New(t)
-	expected := &RouteWeightedClusters{HTTPRouteMatch: testHTTPRouteMatch, WeightedClusters: set.NewSet(testWeightedCluster)}
 
-	actual := NewRouteWeightedCluster(testHTTPRouteMatch, testWeightedCluster)
-	assert.Equal(expected, actual)
+	testCases := []struct {
+		name             string
+		route            HTTPRouteMatch
+		weightedClusters []service.WeightedCluster
+		expected         *RouteWeightedClusters
+	}{
+		{
+			name:             "single weighted cluster in set",
+			route:            testHTTPRouteMatch,
+			weightedClusters: []service.WeightedCluster{testWeightedCluster},
+			expected:         &RouteWeightedClusters{HTTPRouteMatch: testHTTPRouteMatch, WeightedClusters: set.NewSet(testWeightedCluster)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := NewRouteWeightedCluster(tc.route, tc.weightedClusters)
+			assert.Equal(tc.expected, actual)
+		})
+	}
 }
 
 func TestNewOutboundPolicy(t *testing.T) {


### PR DESCRIPTION
+ now accepts a slice of service.WeightedCluster
+ easier to create RouteWeightedCluster now where there
is more than one backend/weighted cluster
+ prep for #2368

Signed-off-by: Michelle Noorali <minooral@microsoft.com>


Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
