### PR TITLE
docs/tasks_usage: alias docs to render correctly on website

### DIFF
--- a/docs/content/docs/tasks_usage/traffic_management/egress.md
+++ b/docs/content/docs/tasks_usage/traffic_management/egress.md
@@ -2,9 +2,10 @@
 title: "Egress"
 description: "Enable access to the Internet and services external to the service mesh."
 type: docs
+aliases: ["egress.md"]
 ---
 
-## Allowing access to the Internet and out-of-mesh services (egress)
+# Allowing access to the Internet and out-of-mesh services (egress)
 
 This document describes the steps required to enable access to the Internet and services external to the service mesh, sometimes referred to as `egress` traffic.
 

--- a/docs/content/docs/tasks_usage/traffic_management/ingress.md
+++ b/docs/content/docs/tasks_usage/traffic_management/ingress.md
@@ -2,6 +2,7 @@
 title: "Ingress"
 description: "How to expose HTTP and HTTPS routes outside the cluster to services within the cluster using Kubernetes Ingress"
 type: docs
+aliases: ["ingress.md"]
 ---
 
 # Exposing services outside the cluster using Ingress


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Internal links to docs (links within docs/content/docs) needs
to have an alias so they are navigable directly on the website.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`