### PR TITLE
docs: use relative paths for internal links

### DIFF
--- a/docs/content/docs/troubleshooting/traffic/egress.md
+++ b/docs/content/docs/troubleshooting/traffic/egress.md
@@ -33,10 +33,10 @@ Errors will be logged with the `level` key in the log message set to `error`:
 
 ### 3. Confirm the Envoy configuration
 
-Confirm the Envoy proxy configuration on the client has a default egress filter chain on the outbound listener. Refer to the [sample configurations](https://github.com/openservicemesh/osm/blob/main/docs/content/docs/tasks_usage/traffic_management/egress.md#envoy-configurations) to verify that the client is configured to have outbound access to external destinations.
+Confirm the Envoy proxy configuration on the client has a default egress filter chain on the outbound listener. Refer to the [sample configurations](../../../tasks_usage/traffic_management/egress#envoy-configurations) to verify that the client is configured to have outbound access to external destinations.
 
 ## When the setting needs to be persisted across upgrades
 
 While the `osm-config` ConfigMap can be directly updated using the `kubectl patch` command, to persist configuration changes across upgrades, it is recommended to always use `osm mesh upgrade` CLI command to update the mesh configuration.
 
-Refer to the [configuring egress](https://github.com/openservicemesh/osm/blob/main/docs/content/docs/tasks_usage/traffic_management/egress.md#configuring-egress) section to enable or disable egress.
+Refer to the [configuring egress](../../../tasks_usage/traffic_management/egress#configuring-egress) section to enable or disable egress.

--- a/docs/content/docs/troubleshooting/traffic/permissive_traffic_policy_mode.md
+++ b/docs/content/docs/troubleshooting/traffic/permissive_traffic_policy_mode.md
@@ -33,10 +33,10 @@ Errors will be logged with the `level` key in the log message set to `error`:
 
 ### 3. Confirm the Envoy configuration
 
-Confirm the Envoy proxy configuration on the client and server pods are allowing the client to access the server. Refer to the [sample configurations](https://github.com/openservicemesh/osm/blob/main/docs/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md#envoy-configurations) to verify that the client has valid routes programmed to access the server.
+Confirm the Envoy proxy configuration on the client and server pods are allowing the client to access the server. Refer to the [sample configurations](../../../tasks_usage/traffic_management/permissive_traffic_policy_mode#envoy-configurations) to verify that the client has valid routes programmed to access the server.
 
 ## When the setting needs to be persisted across upgrades
 
 While the `osm-config` ConfigMap can be directly updated using the `kubectl patch` command, to persist configuration changes across upgrades, it is recommended to always use `osm mesh upgrade` CLI command to update the mesh configuration.
 
-Refer to the [configuring permissive traffic policy mode](https://github.com/openservicemesh/osm/blob/main/docs/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md#configuring-permissive-traffic-policy-mode) section to enable or disable permissive traffic policy mode.
+Refer to the [configuring permissive traffic policy mode](../../../tasks_usage/traffic_management/permissive_traffic_policy_mode#configuring-permissive-traffic-policy-mode) section to enable or disable permissive traffic policy mode.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Internal links (links within `docs/content/docs`) should
use relative paths so there are navigable within the website.
Before this change, browsing the doc on the website would
redirect to the github page.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`