### PR TITLE
chore(release): adds a PR template for releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -1,0 +1,21 @@
+<!--
+
+Use the checklist below to ensure your release PR is complete before marking it ready for review.
+
+-->
+
+- [ ] I have cherry-picked any changes [labelled](https://github.com/openservicemesh/osm/labels) `needs-cherry-pick-vX.Y.Z`
+- [ ] I have made all of the following version and patch updates:
+  1. Updated the container image tag in charts/osm/values.yaml
+  2. Updated the chart **and** app version in charts/osm/Chart.yaml
+  3. Updated the default osm-controller image tag in osm cli
+  4. Updated the image tags used in the demo manifests
+  5. Regenerated the Helm chart README.md
+
+- [ ] I have checked that the base branch for this PR is correct as defined by the release guide
+<!--
+  If this PR is for updating the release branch, ensure the base branch is `release-vX.Y`.
+  If this PR is for making changes on the main branch, ensure the base branch is `main`. 
+-->
+
+Is this a release candidate?

--- a/docs/content/docs/release_guide.md
+++ b/docs/content/docs/release_guide.md
@@ -54,7 +54,9 @@ Create a new commit on the new branch to update the hardcoded version informatio
 * The Helm chart [README.md](https://github.com/openservicemesh/osm/blob/main/charts/osm/README.md)
   - Necessary changes should be made automatically by running `make chart-readme`
 
-Once patches and version information have been updated on a new branch off of the release branch, create a pull request from the new branch to the release branch. Proceed to the next step once the pull request is approved and merged.
+Once patches and version information have been updated on a new branch off of the release branch, create a pull request from the new branch to the release branch. When creating your pull request, generate its description by adding `?expand=1&template=release_pull_request_template.md` to the PR URL or copy the raw template from [release_pull_request_template.md](https://raw.githubusercontent.com/openservicemesh/osm/main/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md).
+
+Proceed to the next step once the pull request is approved and merged.
 
 ## Create and push a Git tag
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Adds a PR template that can be used via URL or pasted into the PR description box. [GitHub does not currently provide a UI](https://github.community/t/multiple-pull-request-templates/1850) to toggle between PR templates as it does for issue templates, so a little manual toggling will have to do for now.

Resolves #2919 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
