### PR TITLE
doc: Adding minimal Nginx and AGIC ingress controller docs

### DIFF
--- a/docs/content/docs/tasks_usage/ingress/agic.md
+++ b/docs/content/docs/tasks_usage/ingress/agic.md
@@ -1,0 +1,107 @@
+---
+title: "Using Azure Application Gateway Ingress Controller with OSM"
+description: "This document provides step by step instructions on installing and integrationg Azure Application Gateway Ingress Controller with Open Service Mesh."
+type: docs
+aliases: ["AGIC"]
+weight: 2
+release: 0.8.0
+---
+
+The [Azure Application Gateway Ingress Controller (AGIC)](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview)
+is a Kubernetes controller for the Azure Application Gateway.
+AGIC works with in tandem with
+[Azure Application Gateway](https://docs.microsoft.com/en-us/azure/application-gateway/overview)
+to provide ingress for Kubernetes clusters on Azure.
+AGIC is installed on the cluster. The App Gateway is outside of the Kubernetes cluster
+and exposed to the Internet via a public IP address.
+AGIC continuously monitors the Kubernetes cluster for changes.
+Any updates of services and pods are reflected in Azure Application Gateway's configuration.
+App Gateway's backend pools are updated with the latest available Endpoints (Pod IP)
+addresses from the Kubernetes cluster.
+
+Excellent and thorough documentation is already [avalible on AGIC's website](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-overview).
+
+The example below uses OSM's `bookstore` app to illustrate exposing a Kubernetes service to the Internet:
+
+2. Create bookstore service:
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore
+  labels:
+    app: bookstore
+spec:
+  selector:
+    app: bookstore
+  ports:
+  - port: 14001
+EOF
+```
+
+3. Create bookstore pod:
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bookstore
+  labels:
+    app: bookstore
+spec:
+  containers:
+  - name: bookstore
+    image: openservicemesh/bookstore:v0.8.0
+    ports:
+      - containerPort: 14001
+    command: ["/bookstore"]
+    args: ["--port", "14001"]
+EOF
+```
+
+4. Expose the bookstore service to the Internet:
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bookstore-ingress
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+
+spec:
+
+  rules:
+    - host: bookstore.contoso.com
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: bookstore
+            servicePort: 14001
+
+  backend:
+    serviceName: bookstore
+    servicePort: 14001
+EOF
+```
+
+5. Test your service via the public IP address of App Gateway:
+
+If you have DNS setup already:
+```bash
+curl http://bookstore.contoso.com/
+```
+
+Alternatively - get the public IP address of Azure Application Gateway (1.2.3.4 for instance):
+```bash
+curl -H 'Host: bookstore.contoso.com' http://1.2.3.4/
+```
+
+# Troubleshooting
+  - [AGIC Troubleshooting Documentation](https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-troubleshoot)
+  - [Additional troubleshooting tools are available on AGIC's GitHub repo](https://github.com/Azure/application-gateway-kubernetes-ingress/blob/master/docs/troubleshootings/troubleshooting-installing-a-simple-application.md)

--- a/docs/content/docs/tasks_usage/ingress/nginx.md
+++ b/docs/content/docs/tasks_usage/ingress/nginx.md
@@ -1,0 +1,122 @@
+---
+title: "Using Nginx Ingress Controller with OSM"
+description: "This document provides step by step instructions on installing and integrationg Nginx Ingress Controller with Open Service Mesh."
+type: docs
+aliases: ["Nginx"]
+weight: 2
+release: 0.8.0
+---
+
+Nginx is a popular layer 7 reverse proxy and load balancer. Nginx Ingress Controller is the Kubernetes component, which continuously configures Nginx to expose Kubernetes Services to the Internet and other external to the cluster networks.
+
+Excellent documentation is already [avalible on the Nginx website](https://docs.nginx.com/nginx-ingress-controller/installation/installation-with-helm/#adding-the-helm-repository). The following 2 shell commands will use Helm to install Nginx:
+
+```bash
+helm repo add nginx-stable https://helm.nginx.com/stable
+helm repo update
+helm install nginx-stable/nginx-ingress --generate-name
+```
+
+View the newly installed ingress controller pod:
+```bash
+kubectl get pods | grep nginx
+```
+
+The example below uses OSM's `bookstore` app to illustrate exposing a Kubernetes service to the Internet:
+
+1. Create bookstore service:
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore
+  labels:
+    app: bookstore
+spec:
+  selector:
+    app: bookstore
+  ports:
+  - port: 14001
+EOF
+```
+
+2. Create bookstore pod:
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bookstore
+  labels:
+    app: bookstore
+spec:
+  serviceAccountName: bookstore
+  containers:
+  - name: bookstore
+    image: openservicemesh/bookstore:v0.8.0
+    ports:
+      - containerPort: 14001
+    command: ["/bookstore"]
+    args: ["--port", "14001"]
+EOF
+```
+
+3. Expose the bookstore service to the Internet:
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bookstore-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+
+spec:
+
+  rules:
+    - host: bookstore.contoso.com
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: bookstore
+            servicePort: 14001
+
+  backend:
+    serviceName: bookstore
+    servicePort: 14001
+EOF
+```
+
+4. View Nginx logs:
+```bash
+POD=$(kubectl get pods | grep 'nginx-ingress' | awk '{print $1}')
+
+kubectl logs $POD -f
+```
+
+5. View Nginx Services:
+```bash
+kubectl get services
+```
+
+```
+NAME                                     TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)                      AGE
+nginx-ingress-1616041155-nginx-ingress   LoadBalancer   10.0.120.194   1.2.3.4        80:32237/TCP,443:31563/TCP   23m
+```
+
+6. Test your service via the external IP address:
+
+If you have DNS setup already:
+```bash
+curl http://bookstore.contoso.com/
+```
+
+Alternatively:
+```bash
+curl -H 'Host: bookstore.contoso.com' http://1.2.3.4/
+```


### PR DESCRIPTION
This PR adds minimal documentation on how to add Nginx or Application Gateway Ingress controllers to an OSM service mesh.

ref https://github.com/openservicemesh/osm/issues/2871 https://github.com/openservicemesh/osm/issues/2868 https://github.com/openservicemesh/osm/issues/2827