### PR TITLE
Revert "envoy: wait indefinitely on TLS secrets"

### DIFF
--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -2,11 +2,9 @@ package envoy
 
 import (
 	"testing"
-	"time"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	tassert "github.com/stretchr/testify/assert"
 
@@ -136,8 +134,7 @@ var _ = Describe("Test Envoy tools", func() {
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
 							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+							ResourceApiVersion: core.ApiVersion_V3,
 						},
 					}},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
@@ -150,8 +147,7 @@ var _ = Describe("Test Envoy tools", func() {
 								ConfigSourceSpecifier: &core.ConfigSource_Ads{
 									Ads: &core.AggregatedConfigSource{},
 								},
-								ResourceApiVersion:  core.ApiVersion_V3,
-								InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+								ResourceApiVersion: core.ApiVersion_V3,
 							},
 						},
 					},
@@ -199,8 +195,7 @@ var _ = Describe("Test Envoy tools", func() {
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
 							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+							ResourceApiVersion: core.ApiVersion_V3,
 						},
 					}},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
@@ -210,8 +205,7 @@ var _ = Describe("Test Envoy tools", func() {
 								ConfigSourceSpecifier: &core.ConfigSource_Ads{
 									Ads: &core.AggregatedConfigSource{},
 								},
-								ResourceApiVersion:  core.ApiVersion_V3,
-								InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+								ResourceApiVersion: core.ApiVersion_V3,
 							},
 						},
 					},
@@ -257,25 +251,13 @@ var _ = Describe("Test Envoy tools", func() {
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name: "service-cert:default/bookbuyer",
-					SdsConfig: &core.ConfigSource{
-						ConfigSourceSpecifier: &core.ConfigSource_Ads{
-							Ads: &core.AggregatedConfigSource{},
-						},
-						ResourceApiVersion:  core.ApiVersion_V3,
-						InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-					},
+					Name:      "service-cert:default/bookbuyer",
+					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name: "root-cert-for-mtls-outbound:default/bookstore-v1",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_Ads{
-								Ads: &core.AggregatedConfigSource{},
-							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-						},
+						Name:      "root-cert-for-mtls-outbound:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,
@@ -299,25 +281,13 @@ var _ = Describe("Test Envoy tools", func() {
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name: "service-cert:default/bookstore-v1",
-					SdsConfig: &core.ConfigSource{
-						ConfigSourceSpecifier: &core.ConfigSource_Ads{
-							Ads: &core.AggregatedConfigSource{},
-						},
-						ResourceApiVersion:  core.ApiVersion_V3,
-						InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-					},
+					Name:      "service-cert:default/bookstore-v1",
+					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name: "root-cert-for-mtls-inbound:default/bookstore-v1",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_Ads{
-								Ads: &core.AggregatedConfigSource{},
-							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-						},
+						Name:      "root-cert-for-mtls-inbound:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,
@@ -341,25 +311,13 @@ var _ = Describe("Test Envoy tools", func() {
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name: "service-cert:default/bookstore-v1",
-					SdsConfig: &core.ConfigSource{
-						ConfigSourceSpecifier: &core.ConfigSource_Ads{
-							Ads: &core.AggregatedConfigSource{},
-						},
-						ResourceApiVersion:  core.ApiVersion_V3,
-						InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-					},
+					Name:      "service-cert:default/bookstore-v1",
+					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name: "root-cert-https:default/bookstore-v1",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_Ads{
-								Ads: &core.AggregatedConfigSource{},
-							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-						},
+						Name:      "root-cert-https:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This reverts commit 96faee85a81bd766e58243b41e9fb854dcc8ac48.
The original commit causes issues with the existing SDS logic
in a way that degrades performance. We will revisit this when
we introduce XDS snapshot cache.

Related to #2749

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`