### PR TITLE
Fixed tag order in release-notes.sh

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 tag=$1
 
-tags=$(git -c 'versionsort.suffix=-alpha,-beta,-rc' tag -l --sort=version:refname | sed "/^$tag$/q" )
+tags=$(git tag | tr - \~ | sort -V | tr \~ - | sed "/^$tag$/q" )
 ! [[ "$tag" =~ -(alpha|beta|rc) ]] && tags=$(grep -Eve '-(alpha|beta|rc)' <<< "$tags")
 prev=$(tail -2 <<< "$tags" | head -1)
 


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: This PR fixes a bug with respect to the order of the tags and the $prev tag in the release-notes.script. Note: this original bug was not occurring for everybody so it may not be reproduceable. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? No
