### PR TITLE
pkg/ticker: reintroduce ticker concept

### DIFF
--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -13,6 +13,12 @@ const (
 	// ScheduleProxyBroadcast is used by other modules to request the dispatcher to schedule a global proxy broadcast
 	ScheduleProxyBroadcast AnnouncementType = "schedule-proxy-broadcast"
 
+	// TickerStart starts Ticker to trigger time-based proxy updates
+	TickerStart AnnouncementType = "ticker-start"
+
+	// TickerStop stops Ticker to stop time-based proxy updates
+	TickerStop AnnouncementType = "ticker-stop"
+
 	// ProxyBroadcast is used to notify all Proxy streams that they need to trigger an update
 	ProxyBroadcast AnnouncementType = "proxy-broadcast"
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/smi"
+	"github.com/openservicemesh/osm/pkg/ticker"
 )
 
 // NewMeshCatalog creates a new service catalog
@@ -32,6 +33,8 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 	mc.releaseCertificateHandler()
 
 	go mc.dispatcher()
+	ticker.InitTicker()
+
 	return &mc
 }
 

--- a/pkg/ticker/ticker.go
+++ b/pkg/ticker/ticker.go
@@ -1,0 +1,67 @@
+package ticker
+
+import (
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var (
+	log = logger.New("ticker")
+)
+
+// InitTicker initializes a global ticker that is configured via
+// pubsub, and triggers global proxy updates also through pubsub.
+// Upon this function return, the ticker is guaranteed to be started
+// and ready to receive new events.
+func InitTicker() {
+	doneInit := make(chan struct{})
+	go ticker(doneInit)
+	<-doneInit
+}
+
+func ticker(ready chan struct{}) {
+	ticker := make(<-chan time.Time)
+	tickStart := events.GetPubSubInstance().Subscribe(
+		announcements.TickerStart)
+	tickStop := events.GetPubSubInstance().Subscribe(
+		announcements.TickerStop)
+
+	// Notify the calling function we are ready to receive events
+	// Necessary as starting the ticker could loose events by the
+	// caller if the caller intends to immedaitely start it
+	close(ready)
+
+	for {
+		select {
+		case msg := <-tickStart:
+			psubMsg, ok := msg.(events.PubSubMessage)
+			if !ok {
+				log.Error().Msgf("Could not cast to pubsub msg %v", msg)
+				continue
+			}
+
+			// Cast new object to duration value
+			tickerDuration, ok := psubMsg.NewObj.(time.Duration)
+			if !ok {
+				log.Error().Msgf("Failed to cast ticker duration %v", psubMsg)
+				continue
+			}
+
+			log.Info().Msgf("Ticker Starting with duration of %s", tickerDuration)
+			ticker = time.NewTicker(tickerDuration).C
+		case <-tickStop:
+			log.Info().Msgf("Ticker Stopping")
+			ticker = make(<-chan time.Time)
+		case <-ticker:
+			log.Info().Msgf("Ticker requesting broadcast proxy update")
+			events.GetPubSubInstance().Publish(
+				events.PubSubMessage{
+					AnnouncementType: announcements.ScheduleProxyBroadcast,
+				},
+			)
+		}
+	}
+}

--- a/pkg/ticker/ticker_test.go
+++ b/pkg/ticker/ticker_test.go
@@ -1,0 +1,59 @@
+package ticker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+)
+
+func TestTicker(t *testing.T) {
+	assert := assert.New(t)
+
+	broadcastEvents := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
+	broadcastsReceived := 0
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-broadcastEvents:
+				broadcastsReceived++
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	// Start the ticker routine
+	InitTicker()
+
+	// Start ticker, tick at 100ms rate
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.TickerStart,
+		NewObj:           time.Duration(100 * time.Millisecond),
+	})
+
+	// broadcast events should increase in the next few seconds
+	assert.Eventually(func() bool {
+		return broadcastsReceived > 0
+	}, 3*time.Second, 500*time.Millisecond)
+
+	// Stop the ticker
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.TickerStop,
+	})
+
+	// Should stop increasing
+	assert.Eventually(func() bool {
+		firstRead := broadcastsReceived
+		time.Sleep(1 * time.Second)
+		secondRead := broadcastsReceived
+
+		return firstRead == secondRead
+	}, 6*time.Second, 2*time.Second)
+
+	close(stop)
+}


### PR DESCRIPTION
New package contains a ticker implementation that is fully
interacted through pubsub (this will allow us to decouple
from whichever way we want to configure it with, configmap,
pflag, debugServer endpoint, etc.)

It starts turned off by default and is run after dispatcher
starts. Next commit will introduce configurability.

Signed-off-by: edu <eduser25@gmail.com>

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No