### PR TITLE
docs(docs/content/docs): Add documentation for automerge 

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -75,20 +75,6 @@ pull_request_rules:
         # Choices are either merge base branch into PR (default) or rebase the PR against the base branch
         strict_method: rebase
 
-  - name: Automatic rebase for automerge label
-    conditions:
-      # True if the PR has the automerge label
-      - label=automerge
-      # True when the PR is not conflicting with the base branch
-      - -conflict
-      # True if the PR is not in draft state
-      - -draft
-    actions:
-      rebase:
-        # bot_account is the account the rebase will be done under
-        # if not specified Mergify will use any user in OSM that's logged into Mergify
-        bot_account: OSM-PR-bot
-
   - name: Automatic rebase for autorebase label
     conditions:
       # True if the PR has the autorebase label

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ git push -f
 
 ### Merging pull requests
 Pull requests by default must be merged by a core maintainer using the `Merge pull request` option.
+Maintainers can add the `automerge` or `autorebase` label to a pull request, additional details [here](docs/content/docs/automerge.md).
 
 Pull requests will be merged based on the following criteria:
 

--- a/docs/content/docs/automerge.md
+++ b/docs/content/docs/automerge.md
@@ -1,0 +1,27 @@
+---
+title: "Automerge Pull Requests"
+description: "How to use labels and commands to automerge/autorebase your pull request."
+type: docs
+---
+
+OSM uses [Mergify](https://docs.mergify.io/) to automatically merge (automerge) and automatically rebase (autorebase) pull requests.
+
+# Automerge
+A pull request will be automerged via a merge commit if it meets the following criteria:
+ - Has the `automerge` label
+ - Does not have the `wip` label
+ - Does not have the `do-not-merge/hold` label
+ - Successfully completed all checks
+ - Has at least 2 maintainer approvals
+ - Base branch is either main or a release branch
+If the pull request has an `automerge` label, the OSM-PR-bot will also autorebase the pull request if the PR branch goes out-of-date.
+> Note: Currently, pull requests that are paths-ignore cannot be merged automatically.
+
+# Autorebase
+A pull request will be autorebased only and not automerged if it has the `autorebase` label. The rebase action will be completed by OSM-PR-bot.
+
+# In Pull Request Comments
+Some Mergify commands can also be triggered via comments on the pull request.
+- `@Mergifyio refresh` will re-evaluate the rules
+- `@Mergifyio rebase` will rebase this PR on its base branch
+- `@Mergifyio backport <destination>` will [backport](https://docs.mergify.io/actions/backport.html) this PR on <destination> branch


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Add documentation for automerge and removed redundant rebase rule for `automerge` label and resolves #2945 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No