### PR TITLE
Cherry-picks 2 SDS related bug fixes to v0.8

### DIFF
--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -112,7 +112,24 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 		TypeUrl: string(envoy.TypeSDS),
 	}
 
-	// There is an SDS validation cert corresponding to each upstream service.
+	// Create an SDS service cert for each service associated with this proxy.
+	// This service cert is referenced in the per service inbound filter chain's DownstreamTlsContext
+	// that is a part the proxy's inbound listener.
+	proxyServices, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
+	if err != nil {
+		log.Error().Err(err).Msgf("Error getting services associated with Envoy with certificate SerialNumber=%s on Pod with UID=%s",
+			proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+		return nil
+	}
+	for _, proxySvc := range proxyServices {
+		proxySvcCert := envoy.SDSCert{
+			Name:     proxySvc.String(),
+			CertType: envoy.ServiceCertType,
+		}.String()
+		discoveryRequest.ResourceNames = append(discoveryRequest.ResourceNames, proxySvcCert)
+	}
+
+	// Create an SDS validation cert corresponding to each upstream service that this proxy can connect to.
 	// Each cert is used to validate the certificate presented by the corresponding upstream service.
 	upstreamServices := meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity)
 	for _, upstream := range upstreamServices {

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -42,7 +43,7 @@ var _ = Describe("Test ADS response functions", func() {
 	kubeClient := testclient.NewSimpleClientset()
 	namespace := tests.Namespace
 	proxyUUID := tests.ProxyUUID
-	serviceName := tests.BookstoreV1ServiceName
+	proxyService := service.MeshService{Name: tests.BookstoreV1ServiceName, Namespace: namespace}
 	proxySvcAccount := tests.BookstoreServiceAccount
 
 	labels := map[string]string{constants.EnvoyUniqueIDLabelName: tests.ProxyUUID}
@@ -56,7 +57,7 @@ var _ = Describe("Test ADS response functions", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	svc := tests.NewServiceFixture(serviceName, namespace, labels)
+	svc := tests.NewServiceFixture(proxyService.Name, namespace, labels)
 	_, err = kubeClient.CoreV1().Services(namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 	It("should have created a service", func() {
 		Expect(err).ToNot(HaveOccurred())
@@ -81,16 +82,24 @@ var _ = Describe("Test ADS response functions", func() {
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
 					envoy.SDSCert{
+						// Client certificate presented when this proxy is a downstream
 						Name:     proxySvcAccount.String(),
 						CertType: envoy.ServiceCertType,
 					}.String(),
 					envoy.SDSCert{
+						// Validation certificate for mTLS when this proxy is an upstream
 						Name:     proxySvcAccount.String(),
 						CertType: envoy.RootCertTypeForMTLSInbound,
 					}.String(),
 					envoy.SDSCert{
+						// Validation ceritificate for TLS when this proxy is an upstream
 						Name:     proxySvcAccount.String(),
 						CertType: envoy.RootCertTypeForHTTPS,
+					}.String(),
+					envoy.SDSCert{
+						// Server certificate presented when this proxy is an upstream
+						Name:     proxyService.String(),
+						CertType: envoy.ServiceCertType,
 					}.String(),
 				},
 			}
@@ -141,7 +150,13 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect((*actualResponses)[4].VersionInfo).To(Equal("1"))
 			Expect((*actualResponses)[4].TypeUrl).To(Equal(string(envoy.TypeSDS)))
 			log.Printf("%v", len((*actualResponses)[4].Resources))
-			Expect(len((*actualResponses)[4].Resources)).To(Equal(3))
+
+			// Expect 4 SDS certs:
+			// 1. client cert when this proxy is a downstream
+			// 2. mTLS validation cert when this proxy is an upstream
+			// 3. TLS validation cert when this proxy is an upstream
+			// 4. server cert when this proxy is an upstream
+			Expect(len((*actualResponses)[4].Resources)).To(Equal(4))
 
 			secretOne := xds_auth.Secret{}
 			firstSecret := (*actualResponses)[4].Resources[0]
@@ -165,6 +180,15 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(secretThree.Name).To(Equal(envoy.SDSCert{
 				Name:     proxySvcAccount.String(),
 				CertType: envoy.RootCertTypeForHTTPS,
+			}.String()))
+
+			secretFour := xds_auth.Secret{}
+			fourthSecret := (*actualResponses)[4].Resources[3]
+			err = ptypes.UnmarshalAny(fourthSecret, &secretFour)
+			Expect(err).To(BeNil())
+			Expect(secretFour.Name).To(Equal(envoy.SDSCert{
+				Name:     proxyService.String(),
+				CertType: envoy.ServiceCertType,
 			}.String()))
 		})
 	})
@@ -200,7 +224,13 @@ var _ = Describe("Test ADS response functions", func() {
 
 			Expect(sdsResponse.VersionInfo).To(Equal("2")) // 2 because first update was by the previous test for the proxy
 			Expect(sdsResponse.TypeUrl).To(Equal(string(envoy.TypeSDS)))
-			Expect(len(sdsResponse.Resources)).To(Equal(3))
+
+			// Expect 4 SDS certs:
+			// 1. client cert when this proxy is a downstream
+			// 2. mTLS validation cert when this proxy is an upstream
+			// 3. TLS validation cert when this proxy is an upstream
+			// 4. server cert when this proxy is an upstream
+			Expect(len(sdsResponse.Resources)).To(Equal(4))
 
 			secretOne := xds_auth.Secret{}
 			firstSecret := sdsResponse.Resources[0]
@@ -224,6 +254,15 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(secretThree.Name).To(Equal(envoy.SDSCert{
 				Name:     proxySvcAccount.String(),
 				CertType: envoy.RootCertTypeForHTTPS,
+			}.String()))
+
+			secretFour := xds_auth.Secret{}
+			fourthSecret := sdsResponse.Resources[3]
+			err = ptypes.UnmarshalAny(fourthSecret, &secretFour)
+			Expect(err).To(BeNil())
+			Expect(secretFour.Name).To(Equal(envoy.SDSCert{
+				Name:     proxyService.String(),
+				CertType: envoy.ServiceCertType,
 			}.String()))
 		})
 	})

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -1,11 +1,8 @@
 package envoy
 
 import (
-	"time"
-
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	. "github.com/onsi/ginkgo"
@@ -127,8 +124,7 @@ var _ = Describe("Test Envoy tools", func() {
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
 							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+							ResourceApiVersion: core.ApiVersion_V3,
 						},
 					}},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
@@ -141,8 +137,7 @@ var _ = Describe("Test Envoy tools", func() {
 								ConfigSourceSpecifier: &core.ConfigSource_Ads{
 									Ads: &core.AggregatedConfigSource{},
 								},
-								ResourceApiVersion:  core.ApiVersion_V3,
-								InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+								ResourceApiVersion: core.ApiVersion_V3,
 							},
 						},
 					},
@@ -190,8 +185,7 @@ var _ = Describe("Test Envoy tools", func() {
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
 							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+							ResourceApiVersion: core.ApiVersion_V3,
 						},
 					}},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
@@ -201,8 +195,7 @@ var _ = Describe("Test Envoy tools", func() {
 								ConfigSourceSpecifier: &core.ConfigSource_Ads{
 									Ads: &core.AggregatedConfigSource{},
 								},
-								ResourceApiVersion:  core.ApiVersion_V3,
-								InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
+								ResourceApiVersion: core.ApiVersion_V3,
 							},
 						},
 					},
@@ -248,25 +241,13 @@ var _ = Describe("Test Envoy tools", func() {
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name: "service-cert:default/bookbuyer",
-					SdsConfig: &core.ConfigSource{
-						ConfigSourceSpecifier: &core.ConfigSource_Ads{
-							Ads: &core.AggregatedConfigSource{},
-						},
-						ResourceApiVersion:  core.ApiVersion_V3,
-						InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-					},
+					Name:      "service-cert:default/bookbuyer",
+					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name: "root-cert-for-mtls-outbound:default/bookstore-v1",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_Ads{
-								Ads: &core.AggregatedConfigSource{},
-							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-						},
+						Name:      "root-cert-for-mtls-outbound:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,
@@ -290,25 +271,13 @@ var _ = Describe("Test Envoy tools", func() {
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name: "service-cert:default/bookstore-v1",
-					SdsConfig: &core.ConfigSource{
-						ConfigSourceSpecifier: &core.ConfigSource_Ads{
-							Ads: &core.AggregatedConfigSource{},
-						},
-						ResourceApiVersion:  core.ApiVersion_V3,
-						InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-					},
+					Name:      "service-cert:default/bookstore-v1",
+					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name: "root-cert-for-mtls-inbound:default/bookstore-v1",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_Ads{
-								Ads: &core.AggregatedConfigSource{},
-							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-						},
+						Name:      "root-cert-for-mtls-inbound:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,
@@ -332,25 +301,13 @@ var _ = Describe("Test Envoy tools", func() {
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
 				TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-					Name: "service-cert:default/bookstore-v1",
-					SdsConfig: &core.ConfigSource{
-						ConfigSourceSpecifier: &core.ConfigSource_Ads{
-							Ads: &core.AggregatedConfigSource{},
-						},
-						ResourceApiVersion:  core.ApiVersion_V3,
-						InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-					},
+					Name:      "service-cert:default/bookstore-v1",
+					SdsConfig: GetADSConfigSource(),
 				}},
 				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name: "root-cert-https:default/bookstore-v1",
-						SdsConfig: &core.ConfigSource{
-							ConfigSourceSpecifier: &core.ConfigSource_Ads{
-								Ads: &core.AggregatedConfigSource{},
-							},
-							ResourceApiVersion:  core.ApiVersion_V3,
-							InitialFetchTimeout: ptypes.DurationProto(0 * time.Second),
-						},
+						Name:      "root-cert-https:default/bookstore-v1",
+						SdsConfig: GetADSConfigSource(),
 					},
 				},
 				AlpnProtocols: nil,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Cherry-picks 2 SDS related bug fixes to v0.8:
- 93afc227: reverts SDS config fetch timeout
- 351db1b3: fix missing service cert referenced in LDS inbound filter chain 
---------

Backports SDS related bug fixes to the v0.8 branch.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`