### PR TITLE
cfgmap: add ticker config

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -55,6 +55,9 @@ const (
 
 	// enablePrivilegedInitContainer is the key name used to specify whether init containers should be privileged in the ConfigMap
 	enablePrivilegedInitContainer = "enable_privileged_init_container"
+
+	// configResyncInterval is the key name used to configure the resync interval for regular proxy broadcast updates
+	configResyncInterval = "config_resync_interval"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -223,6 +226,9 @@ type osmConfig struct {
 	OutboundIPRangeExclusionList string `yaml:"outbound_ip_range_exclusion_list"`
 
 	EnablePrivilegedInitContainer bool `yaml:"enable_privileged_init_container"`
+
+	// ConfigResyncInterval is a flag to configure resync interval for regular proxy broadcast updates
+	ConfigResyncInterval string `yaml:"config_resync_interval"`
 }
 
 func (c *Client) run(stop <-chan struct{}) {
@@ -276,6 +282,7 @@ func parseOSMConfigMap(configMap *v1.ConfigMap) *osmConfig {
 	osmConfigMap.ServiceCertValidityDuration, _ = GetStringValueForKey(configMap, serviceCertValidityDurationKey)
 	osmConfigMap.OutboundIPRangeExclusionList, _ = GetStringValueForKey(configMap, outboundIPRangeExclusionListKey)
 	osmConfigMap.EnablePrivilegedInitContainer, _ = GetBoolValueForKey(configMap, enablePrivilegedInitContainer)
+	osmConfigMap.ConfigResyncInterval, _ = GetStringValueForKey(configMap, configResyncInterval)
 
 	if osmConfigMap.TracingEnable {
 		osmConfigMap.TracingAddress, _ = GetStringValueForKey(configMap, tracingAddressKey)

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"ServiceCertValidityDuration":   serviceCertValidityDurationKey,
 				"OutboundIPRangeExclusionList":  outboundIPRangeExclusionListKey,
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,
+				"ConfigResyncInterval":          configResyncInterval,
 			}
 			t := reflect.TypeOf(osmConfig{})
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -135,3 +135,15 @@ func (c *Client) GetOutboundIPRangeExclusionList() []string {
 func (c *Client) IsPrivilegedInitContainer() bool {
 	return c.getConfigMap().EnablePrivilegedInitContainer
 }
+
+// GetConfigResyncInterval returns the duration for resync interval.
+// If error or non-parsable value, returns 0 duration
+func (c *Client) GetConfigResyncInterval() time.Duration {
+	resyncDuration := c.getConfigMap().ConfigResyncInterval
+	duration, err := time.ParseDuration(resyncDuration)
+	if err != nil {
+		log.Debug().Err(err).Msgf("Error parsing config resync interval: %s", duration)
+		return time.Duration(0)
+	}
+	return duration
+}

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -53,6 +53,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 				enablePrivilegedInitContainer:  "true",
 				envoyLogLevel:                  "error",
 				serviceCertValidityDurationKey: "24h",
+				configResyncInterval:           "2m",
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				expectedConfig := &osmConfig{
@@ -65,6 +66,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 					EnablePrivilegedInitContainer: true,
 					EnvoyLogLevel:                 "error",
 					ServiceCertValidityDuration:   "24h",
+					ConfigResyncInterval:          "2m",
 				}
 				expectedConfigBytes, err := marshalConfigToJSON(expectedConfig)
 				assert.Nil(err)
@@ -230,6 +232,36 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.False(cfg.IsPrivilegedInitContainer())
+			},
+		},
+		{
+			name:                 "GetResyncInterval",
+			initialConfigMapData: map[string]string{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				interval := cfg.GetConfigResyncInterval()
+				assert.Equal(interval, time.Duration(0))
+			},
+			updatedConfigMapData: map[string]string{
+				configResyncInterval: "2m",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				interval := cfg.GetConfigResyncInterval()
+				assert.Equal(time.Duration(2*time.Minute), interval)
+			},
+		},
+		{
+			name:                 "NegativeGetResyncInterval",
+			initialConfigMapData: map[string]string{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				interval := cfg.GetConfigResyncInterval()
+				assert.Equal(interval, time.Duration(0))
+			},
+			updatedConfigMapData: map[string]string{
+				configResyncInterval: "Non-duration string",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				interval := cfg.GetConfigResyncInterval()
+				assert.Equal(interval, time.Duration(0))
 			},
 		},
 	}

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -49,6 +49,20 @@ func (mr *MockConfiguratorMockRecorder) GetConfigMap() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockConfigurator)(nil).GetConfigMap))
 }
 
+// GetConfigResyncInterval mocks base method
+func (m *MockConfigurator) GetConfigResyncInterval() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigResyncInterval")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// GetConfigResyncInterval indicates an expected call of GetConfigResyncInterval
+func (mr *MockConfiguratorMockRecorder) GetConfigResyncInterval() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigResyncInterval", reflect.TypeOf((*MockConfigurator)(nil).GetConfigResyncInterval))
+}
+
 // GetEnvoyLogLevel mocks base method
 func (m *MockConfigurator) GetEnvoyLogLevel() string {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -68,4 +68,8 @@ type Configurator interface {
 
 	// IsPrivilegedInitContainer determines whether init containers should be privileged
 	IsPrivilegedInitContainer() bool
+
+	// GetConfigResyncInterval returns the duration for resync interval.
+	// If error or non-parsable value, returns 0 duration
+	GetConfigResyncInterval() time.Duration
 }


### PR DESCRIPTION
Adds ticker config in config map.
Off by default if either empty or non-duration value passed
as a string.

Imposed minimum configurable limit will be in place in ticker
class in next commit.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No