### PR TITLE
envoy: optimize SDS secrets per proxy

### DIFF
--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -49,19 +49,16 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 			expectedDiscoveryRequest: &xds_discovery.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					// 1. Client service cert
+					// 1. Proxy's own cert to present to peer during mTLS/TLS handshake
 					"service-cert:ns-1/test-sa",
 
 					// 2. Outbound validation certs to validate upstreams
 					"root-cert-for-mtls-outbound:ns-2/service-2",
 					"root-cert-for-mtls-outbound:ns-3/service-3",
 
-					// 3. Server service cert
-					"service-cert:ns-1/service-1",
-
-					// 4. Inbound validation certs to validate downstreams
-					"root-cert-for-mtls-inbound:ns-1/service-1",
-					"root-cert-https:ns-1/service-1",
+					// 3. Inbound validation certs to validate downstreams
+					"root-cert-for-mtls-inbound:ns-1/test-sa",
+					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -76,12 +73,16 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 			expectedDiscoveryRequest: &xds_discovery.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					// 1. Client service cert
+					// 1. Proxy's own cert to present to peer during mTLS/TLS handshake
 					"service-cert:ns-1/test-sa",
 
 					// 2. Outbound validation certs to validate upstreams
 					"root-cert-for-mtls-outbound:ns-2/service-2",
 					"root-cert-for-mtls-outbound:ns-3/service-3",
+
+					// 3. Inbound validation certs to validate downstreams
+					"root-cert-for-mtls-inbound:ns-1/test-sa",
+					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -95,15 +96,12 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 			expectedDiscoveryRequest: &xds_discovery.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					// 1. Client service cert
+					// 1. Proxy's own cert to present to peer during mTLS/TLS handshake
 					"service-cert:ns-1/test-sa",
 
-					// 3. Server service cert
-					"service-cert:ns-1/service-1",
-
 					// 4. Inbound validation certs to validate downstreams
-					"root-cert-for-mtls-inbound:ns-1/service-1",
-					"root-cert-https:ns-1/service-1",
+					"root-cert-for-mtls-inbound:ns-1/test-sa",
+					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -121,22 +119,16 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 			expectedDiscoveryRequest: &xds_discovery.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					// 1. Client service cert
+					// 1. Proxy's own cert to present to peer during mTLS/TLS handshake
 					"service-cert:ns-1/test-sa",
 
 					// 2. Outbound validation certs to validate upstreams
 					"root-cert-for-mtls-outbound:ns-2/service-2",
 					"root-cert-for-mtls-outbound:ns-3/service-3",
 
-					// 3. Server service cert
-					"service-cert:ns-1/service-1",
-					"service-cert:ns-4/service-4",
-
 					// 4. Inbound validation certs to validate downstreams
-					"root-cert-for-mtls-inbound:ns-1/service-1",
-					"root-cert-https:ns-1/service-1",
-					"root-cert-for-mtls-inbound:ns-4/service-4",
-					"root-cert-https:ns-4/service-4",
+					"root-cert-for-mtls-inbound:ns-1/test-sa",
+					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -144,7 +136,7 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return(tc.proxyServices, nil).Times(1)
+			mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return(tc.proxyServices, nil).Times(0)
 			mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tc.proxySvcAccount).Return(tc.allowedOutboundServices).Times(1)
 
 			actual := makeRequestForAllSecrets(testProxy, mockCatalog)

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -110,7 +110,7 @@ func (lb *listenerBuilder) getInboundMeshHTTPFilterChain(proxyService service.Me
 	}
 
 	// Construct downstream TLS context
-	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(proxyService, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.svcAccount, true /* mTLS */))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
 		return nil, err
@@ -159,7 +159,7 @@ func (lb *listenerBuilder) getInboundMeshTCPFilterChain(proxyService service.Mes
 	}
 
 	// Construct downstream TLS context
-	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(proxyService, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.svcAccount, true /* mTLS */))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
 		return nil, err

--- a/pkg/envoy/sds/errors.go
+++ b/pkg/envoy/sds/errors.go
@@ -1,0 +1,9 @@
+package sds
+
+import (
+	"errors"
+)
+
+var (
+	errGotUnexpectedCertRequest = errors.New("got unexpected certificate request")
+)

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -69,7 +69,7 @@ func TestNewResponse(t *testing.T) {
 	actualSDSResponse, err = NewResponse(meshCatalog, goodProxy, request, cfg, certManager)
 	assert.Equal(err, nil, fmt.Sprintf("Error evaluating sds.NewResponse(): %s", err))
 	assert.NotNil(actualSDSResponse)
-	assert.Equal(len(actualSDSResponse.Resources), 3)
+	assert.Equal(len(actualSDSResponse.Resources), 2) // service-cert and root-cert-https
 	assert.Equal(actualSDSResponse.TypeUrl, "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret")
 }
 
@@ -103,7 +103,7 @@ func TestGetRootCert(t *testing.T) {
 		{
 			name: "test inbound MTLS certificate validation",
 			sdsCert: envoy.SDSCert{
-				Name:     "ns-1/service-1",
+				Name:     "ns-1/sa-1",
 				CertType: envoy.RootCertTypeForMTLSInbound,
 			},
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
@@ -168,6 +168,27 @@ func TestGetRootCert(t *testing.T) {
 			expectError:  false,
 		},
 		// Test case 3 end -------------------------------
+
+		// Test case 4: tests SDS secret for inbound TLS secret with unexpected service account ---------------
+		{
+			name: "test inbound MTLS certificate validation",
+			sdsCert: envoy.SDSCert{
+				Name:     "ns-1/sa-5", // this does not match the proxy's service account, so should error
+				CertType: envoy.RootCertTypeForMTLSInbound,
+			},
+			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+
+			prepare: func(d *dynamicMock) {
+				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
+				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
+			},
+
+			// expectations
+			expectedSANs: nil,
+			expectError:  true,
+		},
+		// Test case 4 end -------------------------------
+
 	}
 
 	for i, tc := range testCases {
@@ -200,8 +221,10 @@ func TestGetRootCert(t *testing.T) {
 			sdsSecret, err := s.getRootCert(d.mockCertificater, tc.sdsCert)
 			assert.Equal(err != nil, tc.expectError)
 
-			actualSANs := subjectAltNamesToStr(sdsSecret.GetValidationContext().GetMatchSubjectAltNames())
-			assert.ElementsMatch(actualSANs, tc.expectedSANs)
+			if err != nil {
+				actualSANs := subjectAltNamesToStr(sdsSecret.GetValidationContext().GetMatchSubjectAltNames())
+				assert.ElementsMatch(actualSANs, tc.expectedSANs)
+			}
 		})
 	}
 }
@@ -292,7 +315,7 @@ func TestGetSDSSecrets(t *testing.T) {
 			},
 
 			sdsCertType:    envoy.RootCertTypeForMTLSInbound,
-			requestedCerts: []string{"root-cert-for-mtls-inbound:ns-1/service-1"}, // root-cert requested
+			requestedCerts: []string{"root-cert-for-mtls-inbound:ns-1/sa-1"}, // root-cert requested
 
 			// expectations
 			expectedSANs:        []string{"sa-2.ns-2.cluster.local", "sa-3.ns-3.cluster.local"},
@@ -346,7 +369,7 @@ func TestGetSDSSecrets(t *testing.T) {
 
 		// Test case 4: service-cert requested -------------------------------
 		{
-			name:            "test root-cert-https cert type request",
+			name:            "test service-cert cert type request",
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
@@ -355,7 +378,7 @@ func TestGetSDSSecrets(t *testing.T) {
 			},
 
 			sdsCertType:    envoy.ServiceCertType,
-			requestedCerts: []string{"service-cert:ns-1/service-1"}, // service-cert requested
+			requestedCerts: []string{"service-cert:ns-1/sa-1"}, // service-cert requested
 
 			// expectations
 			expectedSANs:        []string{},
@@ -365,7 +388,7 @@ func TestGetSDSSecrets(t *testing.T) {
 
 		// Test case 5: invalid cert type requested -------------------------------
 		{
-			name:            "test root-cert-https cert type request",
+			name:            "test invalid cert type request",
 			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: nil,

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -73,8 +73,11 @@ var validCertTypes = map[SDSCertType]interface{}{
 // It is set as a part of configuring the UpstreamTLSContext.
 var ALPNInMesh = []string{"osm"}
 
-// UnmarshalSDSCert parses and returns Certificate type and a service given a
-// correctly formatted string, otherwise returns error
+// UnmarshalSDSCert parses the SDS resource name and returns an SDSCert object and an error if any
+// Examples:
+// 1. Unmarshalling 'service-cert:foo/bar' returns SDSCert{CertType: service-cert, Name: foo/bar}, nil
+// 2. Unmarshalling 'root-cert-for-mtls-inbound:foo/bar' returns SDSCert{CertType: root-cert-for-mtls-inbound, Name: foo/bar}, nil
+// 3. Unmarshalling 'invalid-cert' returns nil, error
 func UnmarshalSDSCert(str string) (*SDSCert, error) {
 	var ret SDSCert
 
@@ -214,10 +217,10 @@ func getCommonTLSContext(tlsSDSCert, peerValidationSDSCert SDSCert) *xds_auth.Co
 	}
 }
 
-// GetDownstreamTLSContext creates a downstream Envoy TLS Context
-func GetDownstreamTLSContext(upstreamSvc service.MeshService, mTLS bool) *xds_auth.DownstreamTlsContext {
+// GetDownstreamTLSContext creates a downstream Envoy TLS Context to be configured on the upstream for the given upstream's identity
+func GetDownstreamTLSContext(upstreamIdentity service.K8sServiceAccount, mTLS bool) *xds_auth.DownstreamTlsContext {
 	upstreamSDSCert := SDSCert{
-		Name:     upstreamSvc.String(),
+		Name:     upstreamIdentity.String(),
 		CertType: ServiceCertType,
 	}
 
@@ -229,13 +232,13 @@ func GetDownstreamTLSContext(upstreamSvc service.MeshService, mTLS bool) *xds_au
 		// TLS based cert validation (used for ingress)
 		downstreamPeerValidationCertType = RootCertTypeForHTTPS
 	}
-	// The downstream peer validation SDS cert points to a cert with the name 'upstreamSvc' only
-	// because we use a single DownstreamTlsContext for all inbound traffic to the given 'upstreamSvc'.
+	// The downstream peer validation SDS cert points to a cert with the name 'upstreamIdentity' only
+	// because we use a single DownstreamTlsContext for all inbound traffic to the given upstream with the identity 'upstreamIdentity'.
 	// This single DownstreamTlsContext is used to validate all allowed inbound SANs. The
 	// 'RootCertTypeForMTLSInbound' cert type used for in-mesh downstreams, while 'RootCertTypeForHTTPS'
 	// cert type is used for non-mesh downstreams such as ingress.
 	downstreamPeerValidationSDSCert := SDSCert{
-		Name:     upstreamSvc.String(),
+		Name:     upstreamIdentity.String(),
 		CertType: downstreamPeerValidationCertType,
 	}
 

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -119,7 +120,7 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetDownstreamTLSContext()", func() {
 		It("should return TLS context", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreV1Service, true)
+			tlsContext := GetDownstreamTLSContext(service.K8sServiceAccount{Name: "foo", Namespace: "test"}, true)
 
 			expectedTLSContext := &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{
@@ -129,7 +130,7 @@ var _ = Describe("Test Envoy tools", func() {
 					},
 					TlsCertificates: nil,
 					TlsCertificateSdsSecretConfigs: []*auth.SdsSecretConfig{{
-						Name: "service-cert:default/bookstore-v1",
+						Name: "service-cert:test/foo",
 						SdsConfig: &core.ConfigSource{
 							ConfigSourceSpecifier: &core.ConfigSource_Ads{
 								Ads: &core.AggregatedConfigSource{},
@@ -140,7 +141,7 @@ var _ = Describe("Test Envoy tools", func() {
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
 							Name: SDSCert{
-								Name:     "default/bookstore-v1",
+								Name:     "test/foo",
 								CertType: RootCertTypeForMTLSInbound,
 							}.String(),
 							SdsConfig: &core.ConfigSource{
@@ -165,14 +166,14 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetDownstreamTLSContext() for mTLS", func() {
 		It("should return TLS context with client certificate validation enabled", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreV1Service, true)
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreServiceAccount, true)
 			Expect(tlsContext.RequireClientCertificate).To(Equal(&wrappers.BoolValue{Value: true}))
 		})
 	})
 
 	Context("Test GetDownstreamTLSContext() for TLS", func() {
 		It("should return TLS context with client certificate validation disabled", func() {
-			tlsContext := GetDownstreamTLSContext(tests.BookstoreV1Service, false)
+			tlsContext := GetDownstreamTLSContext(tests.BookstoreServiceAccount, false)
 			Expect(tlsContext.RequireClientCertificate).To(Equal(&wrappers.BoolValue{Value: false}))
 		})
 	})

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,7 +1,10 @@
 // Package service models an instance of a service managed by OSM controller and utility routines associated with it.
 package service
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
@@ -46,4 +49,24 @@ func (c ClusterName) String() string {
 type WeightedCluster struct {
 	ClusterName ClusterName `json:"cluster_name:omitempty"`
 	Weight      int         `json:"weight:omitempty"`
+}
+
+// UnmarshalK8sServiceAccount unmarshals a K8sServiceAccount type from a string
+func UnmarshalK8sServiceAccount(str string) (*K8sServiceAccount, error) {
+	slices := strings.Split(str, namespaceNameSeparator)
+	if len(slices) != 2 {
+		return nil, errInvalidMeshServiceFormat
+	}
+
+	// Make sure the slices are not empty. Split might actually leave empty slices.
+	for _, sep := range slices {
+		if len(sep) == 0 {
+			return nil, errInvalidMeshServiceFormat
+		}
+	}
+
+	return &K8sServiceAccount{
+		Namespace: slices[0],
+		Name:      slices[1],
+	}, nil
 }

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/google/uuid"
+	tassert "github.com/stretchr/testify/assert"
+	trequire "github.com/stretchr/testify/require"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,3 +42,71 @@ var _ = Describe("Test pkg/service functions", func() {
 		})
 	})
 })
+
+func TestUnmarshalK8sServiceAccount(t *testing.T) {
+	assert := tassert.New(t)
+	require := trequire.New(t)
+
+	namespace := "randomNamespace"
+	serviceName := "randomServiceAccountName"
+	svcAccount := &K8sServiceAccount{
+		Namespace: namespace,
+		Name:      serviceName,
+	}
+	str := svcAccount.String()
+	fmt.Println(str)
+
+	testCases := []struct {
+		name              string
+		expectedErr       bool
+		serviceAccountStr string
+	}{
+		{
+			name:              "successfully unmarshal service account",
+			expectedErr:       false,
+			serviceAccountStr: "randomNamespace/randomServiceAccountName",
+		},
+		{
+			name:              "incomplete namespaced service account name 1",
+			expectedErr:       true,
+			serviceAccountStr: "/svnc",
+		},
+		{
+			name:              "incomplete namespaced service account name 2",
+			expectedErr:       true,
+			serviceAccountStr: "svnc/",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "/svnc/",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "/",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := UnmarshalK8sServiceAccount(tc.serviceAccountStr)
+			if tc.expectedErr {
+				assert.NotNil(err)
+			} else {
+				require.Nil(err)
+				assert.Equal(svcAccount, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Since all proxy certs are based on the proxy identity
(service account), the existing implementation results
in multiple SDS secrets with the exact same certificate.
This happens because even though a given proxy presents
the same certificate during a TLS handshake to its peer
proxy regardless of whether it is an upstream or downstream,
the SDS service-cert secret was being created once per
direction (inbound and outbound connections).

Additionally, the root validation certs on the inbound
listener's DownstreamTlsContext are the same regardless
of the number of services associated with the proxy. So
it makes more sense to associate the inbound root validation
certificates with the proxy's service account instead, since
otherwise there would be duplicate SDS secrets for the
exact same proxy certificate.

This change addresses the above 2 issues as follows:
1. All certs on the inbound listener's DownstreamTlsContext
   are based on the proxy's service account. This ensures
   duplicate SDS secrets are not necessary, and there is
   a 1-1 mapping between SDS secret and its certificate.
   Multiple services on the proxy will share the same SDS
   secret (previously each service would refer to a different
   SDS secret but having the exact same certificate).

2. The proxy uses the same service-cert referenced by the
   same SDS secret to present its certificate to its peer
   during a TLS/mTLS handshake. This means the service-cert
   referenced in the UpstreamTlsContext and DownstreamTlsContext
   are the same when the proxy is connecting to an upstream
   cluster or accepting a connection from a downstream client.

Resolves #2954

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [X]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`