### PR TITLE
ads: change xDS path responses to generic interface

### DIFF
--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -26,7 +27,7 @@ const ServerType = "ADS"
 func NewADSServer(meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamespace string, cfg configurator.Configurator, certManager certificate.Manager) *Server {
 	server := Server{
 		catalog: meshCatalog,
-		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) (*xds_discovery.DiscoveryResponse, error){
+		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error){
 			envoy.TypeEDS: eds.NewResponse,
 			envoy.TypeCDS: cds.NewResponse,
 			envoy.TypeRDS: rds.NewResponse,

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -21,7 +22,7 @@ var (
 // Server implements the Envoy xDS Aggregate Discovery Services
 type Server struct {
 	catalog        catalog.MeshCataloger
-	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) (*xds_discovery.DiscoveryResponse, error)
+	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error)
 	xdsLog         map[certificate.CommonName]map[envoy.TypeURI][]time.Time
 	xdsMapLogMutex sync.Mutex
 	osmNamespace   string

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -64,13 +64,12 @@ func TestNewResponse(t *testing.T) {
 	// 4. Tracing cluster
 	// 5. Passthrough cluster for egress
 	numExpectedClusters := 6 // source and destination clusters
-	assert.Equal(numExpectedClusters, len((*resp).Resources))
+	assert.Equal(numExpectedClusters, len(resp))
 	actualClusters := []*xds_cluster.Cluster{}
-	for _, resource := range (*resp).Resources {
-		cl := xds_cluster.Cluster{}
-		err = ptypes.UnmarshalAny(resource, &cl)
-		require.Nil(err)
-		actualClusters = append(actualClusters, &cl)
+	for idx := range resp {
+		cl, ok := resp[idx].(*xds_cluster.Cluster)
+		require.True(ok)
+		actualClusters = append(actualClusters, cl)
 	}
 	expectedLocalCluster := &xds_cluster.Cluster{
 		TransportSocketMatches: nil,

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -8,7 +8,6 @@ import (
 
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	tassert "github.com/stretchr/testify/assert"
@@ -72,21 +71,20 @@ func TestEndpointConfiguration(t *testing.T) {
 	assert.NotNil(meshCatalog)
 	assert.NotNil(proxy)
 
-	actual, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
+	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
 	assert.Nil(err)
-	assert.NotNil(actual)
+	assert.NotNil(resources)
 
 	// There are 3 endpoints configured based on the configuration:
 	// 1. Bookstore
 	// 2. Bookstore-v1
 	// 3. Bookstore-v2
-	assert.Len(actual.Resources, 3)
+	assert.Len(resources, 3)
 
-	loadAssignment := xds_endpoint.ClusterLoadAssignment{}
+	loadAssignment, ok := resources[0].(*xds_endpoint.ClusterLoadAssignment)
 
 	// validating an endpoint
-	err = ptypes.UnmarshalAny(actual.Resources[0], &loadAssignment)
-	assert.Nil(err)
+	assert.True(ok)
 	assert.Len(loadAssignment.Endpoints, 1)
 }
 

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -2,7 +2,7 @@ package lds
 
 import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"github.com/golang/protobuf/ptypes"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -17,7 +17,7 @@ import (
 // 1. Inbound listener to handle incoming traffic
 // 2. Outbound listener to handle outgoing traffic
 // 3. Prometheus listener for metrics
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) (*xds_discovery.DiscoveryResponse, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
@@ -30,9 +30,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		return nil, err
 	}
 
-	resp := &xds_discovery.DiscoveryResponse{
-		TypeUrl: string(envoy.TypeLDS),
-	}
+	ldsResources := []types.Resource{}
 
 	var statsHeaders map[string]string
 	if featureflags.IsWASMStatsEnabled() {
@@ -53,12 +51,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 			log.Debug().Msgf("Not programming Outbound listener for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
 				proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		} else {
-			if marshalledOutbound, err := ptypes.MarshalAny(outboundListener); err != nil {
-				log.Error().Err(err).Msgf("Failed to marshal outbound listener config for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
-					proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-			} else {
-				resp.Resources = append(resp.Resources, marshalledOutbound)
-			}
+			ldsResources = append(ldsResources, outboundListener)
 		}
 	}
 
@@ -89,12 +82,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	if len(inboundListener.FilterChains) > 0 {
 		// Inbound filter chains can be empty if the there both ingress and in-mesh policies are not configured.
 		// Configuring a listener without a filter chain is an error.
-		if marshalledInbound, err := ptypes.MarshalAny(inboundListener); err != nil {
-			log.Error().Err(err).Msgf("Error marshalling inbound listener config for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
-				proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-		} else {
-			resp.Resources = append(resp.Resources, marshalledInbound)
-		}
+		ldsResources = append(ldsResources, inboundListener)
 	}
 
 	if cfg.IsPrometheusScrapingEnabled() {
@@ -104,16 +92,11 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 			log.Error().Err(err).Msgf("Error building Prometheus listener config for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
 				proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		} else {
-			if marshalledPrometheus, err := ptypes.MarshalAny(prometheusListener); err != nil {
-				log.Error().Err(err).Msgf("Error marshalling Prometheus listener config for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
-					proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-			} else {
-				resp.Resources = append(resp.Resources, marshalledPrometheus)
-			}
+			ldsResources = append(ldsResources, prometheusListener)
 		}
 	}
 
-	return resp, nil
+	return ldsResources, nil
 }
 
 func newListenerBuilder(meshCatalog catalog.MeshCataloger, svcAccount service.K8sServiceAccount, cfg configurator.Configurator, statsHeaders map[string]string) *listenerBuilder {

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -7,7 +7,6 @@ import (
 	set "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/mock/gomock"
-	proto "github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
@@ -274,21 +273,18 @@ func TestNewResponse(t *testing.T) {
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(tc.ingressInboundPolicies, nil).AnyTimes()
 
-			actual, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
 			assert.Nil(err)
-			assert.NotNil(actual)
+			assert.NotNil(resources)
 
 			// The RDS response will have two route configurations
 			// 1. rds-inbound
 			// 2. rds-outbound
-			routeConfig := &xds_route.RouteConfiguration{}
-			assert.Equal(2, len(actual.GetResources()))
+			assert.Equal(2, len(resources))
 
 			// Check the inbound route configuration
-			unmarshallErr := proto.UnmarshalAny(actual.GetResources()[0], routeConfig)
-			if err != nil {
-				t.Fatal(unmarshallErr)
-			}
+			routeConfig, ok := resources[0].(*xds_route.RouteConfiguration)
+			assert.True(ok)
 
 			// The rds-inbound will have the following virtual hosts :
 			// inbound_virtual-host|bookstore-v1.default
@@ -328,10 +324,8 @@ func TestNewResponse(t *testing.T) {
 			assert.Equal(routeConfig.VirtualHosts[2].Routes[0].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
 
 			// Check the outbound route configuration
-			unmarshallErr = proto.UnmarshalAny(actual.GetResources()[1], routeConfig)
-			if err != nil {
-				t.Fatal(unmarshallErr)
-			}
+			routeConfig, ok = resources[1].(*xds_route.RouteConfiguration)
+			assert.True(ok)
 
 			// The rds-outbound will have the following virtual hosts :
 			// outbound_virtual-host|bookstore-apex
@@ -505,14 +499,12 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()
 
-	actual, err := NewResponse(mockCatalog, testProxy, nil, mockConfigurator, nil)
+	resources, err := NewResponse(mockCatalog, testProxy, nil, mockConfigurator, nil)
 	assert.Nil(err)
 
-	routeConfig := &xds_route.RouteConfiguration{}
-	unmarshallErr := proto.UnmarshalAny(actual.GetResources()[0], routeConfig)
-	if err != nil {
-		t.Fatal(unmarshallErr)
-	}
+	routeConfig, ok := resources[0].(*xds_route.RouteConfiguration)
+	assert.True(ok)
+
 	assert.Equal("rds-inbound", routeConfig.Name)
 	assert.Equal(2, len(routeConfig.VirtualHosts))
 
@@ -527,11 +519,9 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	assert.Equal(1, len(routeConfig.VirtualHosts[1].Routes))
 	assert.Equal(tests.BookstoreBuyHTTPRoute.Path, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
 
-	routeConfig = &xds_route.RouteConfiguration{}
-	unmarshallErr = proto.UnmarshalAny(actual.GetResources()[1], routeConfig)
-	if err != nil {
-		t.Fatal(unmarshallErr)
-	}
+	routeConfig, ok = resources[1].(*xds_route.RouteConfiguration)
+	assert.True(ok)
+
 	assert.Equal("rds-outbound", routeConfig.Name)
 	assert.Equal(1, len(routeConfig.VirtualHosts))
 

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/mock/gomock"
@@ -66,11 +67,12 @@ func TestNewResponse(t *testing.T) {
 	assert.Nil(actualSDSResponse)
 
 	// ----- Test with an properly configured proxy
-	actualSDSResponse, err = NewResponse(meshCatalog, goodProxy, request, cfg, certManager)
+	resources, err := NewResponse(meshCatalog, goodProxy, request, cfg, certManager)
 	assert.Equal(err, nil, fmt.Sprintf("Error evaluating sds.NewResponse(): %s", err))
-	assert.NotNil(actualSDSResponse)
-	assert.Equal(len(actualSDSResponse.Resources), 2) // service-cert and root-cert-https
-	assert.Equal(actualSDSResponse.TypeUrl, "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret")
+	assert.NotNil(resources)
+	assert.Equal(len(resources), 2)
+	_, ok := resources[0].(*xds_auth.Secret)
+	assert.True(ok)
 }
 
 func TestGetRootCert(t *testing.T) {

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -8,7 +8,6 @@ import (
 
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	"github.com/onsi/ginkgo"
@@ -48,19 +47,17 @@ var _ = Describe(``+
 			// ---[  Get the config from rds.NewResponse()  ]-------
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			actual, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
 			It("did not return an error", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).ToNot(BeNil())
-				Expect(len(actual.Resources)).To(Equal(1))
+				Expect(resources).ToNot(BeNil())
+				Expect(len(resources)).To(Equal(1))
 			})
 
 			// ---[  Prepare the config for testing  ]-------
-			routeCfg := xds_route.RouteConfiguration{}
-
-			err = ptypes.UnmarshalAny(actual.Resources[0], &routeCfg)
+			routeCfg, ok := resources[0].(*xds_route.RouteConfiguration)
 			It("returns a response that can be unmarshalled into an xds RouteConfiguration struct", func() {
-				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
 				Expect(routeCfg.Name).To(Equal("rds-outbound"))
 			})
 

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -7,7 +7,6 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/mock/gomock"
-	proto "github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
@@ -238,21 +237,18 @@ func TestRDSRespose(t *testing.T) {
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()
 
-			actual, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
 			assert.Nil(err)
-			assert.NotNil(actual)
+			assert.NotNil(resources)
 
 			// The RDS response will have two route configurations
 			// 1. rds-inbound
 			// 2. rds-outbound
-			routeConfig := &xds_route.RouteConfiguration{}
-			assert.Equal(2, len(actual.GetResources()))
+			assert.Equal(2, len(resources))
 
 			// Check the inbound route configuration
-			unmarshallErr := proto.UnmarshalAny(actual.GetResources()[0], routeConfig)
-			if err != nil {
-				t.Fatal(unmarshallErr)
-			}
+			routeConfig, ok := resources[0].(*xds_route.RouteConfiguration)
+			assert.True(ok)
 
 			// The rds-inbound will have the following virtual hosts :
 			// inbound_virtual-host|bookstore-v1.default
@@ -281,10 +277,8 @@ func TestRDSRespose(t *testing.T) {
 			assert.Equal(routeConfig.VirtualHosts[1].Routes[1].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
 
 			// Check the outbound route configuration
-			unmarshallErr = proto.UnmarshalAny(actual.GetResources()[1], routeConfig)
-			if err != nil {
-				t.Fatal(unmarshallErr)
-			}
+			routeConfig, ok = resources[1].(*xds_route.RouteConfiguration)
+			assert.True(ok)
 
 			// The rds-outbound will have the following virtual hosts :
 			// outbound_virtual-host|bookstore-apex


### PR DESCRIPTION
Currently, each xDS path will marshal and create each DiscoveryResponses
on the same vertical. This limits the vision that ads/server has over responses,
and and in addition causes the marshalling logic to exist in all paths.

This commit decouples getting the xDS resources from the Marshal/SendToServer
logic.

This removes some common code for all xDS paths, but more
importantly enable us to unlock additional features such as global consistency
checks between Requests/Responses, use of xDS server cache implementations,
etc.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No