### PR TITLE
envoy/lds: improve http stat prefix

### DIFF
--- a/pkg/envoy/lds/connection_manager.go
+++ b/pkg/envoy/lds/connection_manager.go
@@ -1,6 +1,8 @@
 package lds
 
 import (
+	"fmt"
+
 	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -16,14 +18,14 @@ import (
 )
 
 const (
-	statPrefix                          = "http"
+	meshHTTPConnManagerStatPrefix       = "mesh-http-conn-manager"
 	prometheusHTTPConnManagerStatPrefix = "prometheus-http-conn-manager"
 	prometheusInboundVirtualHostName    = "prometheus-inbound-virtual-host"
 )
 
 func getHTTPConnectionManager(routeName string, cfg configurator.Configurator, headers map[string]string) *xds_hcm.HttpConnectionManager {
 	connManager := &xds_hcm.HttpConnectionManager{
-		StatPrefix: statPrefix,
+		StatPrefix: fmt.Sprintf("%s.%s", meshHTTPConnManagerStatPrefix, routeName),
 		CodecType:  xds_hcm.HttpConnectionManager_AUTO,
 		HttpFilters: []*xds_hcm.HttpFilter{
 			{

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -95,6 +95,16 @@ var _ = Describe("Test getHTTPConnectionManager", func() {
 	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 
 	Context("Test creation of HTTP connection manager", func() {
+		It("Should have the correct StatPrefix", func() {
+			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).Times(1)
+			connManager := getHTTPConnectionManager("foo", mockConfigurator, nil)
+			Expect(connManager.StatPrefix).To(Equal("mesh-http-conn-manager.foo"))
+
+			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).Times(1)
+			connManager = getHTTPConnectionManager("bar", mockConfigurator, nil)
+			Expect(connManager.StatPrefix).To(Equal("mesh-http-conn-manager.bar"))
+		})
+
 		It("Returns proper Zipkin config given when tracing is enabled", func() {
 			mockConfigurator.EXPECT().GetTracingHost().Return(constants.DefaultTracingHost).Times(1)
 			mockConfigurator.EXPECT().GetTracingPort().Return(constants.DefaultTracingPort).Times(1)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The stat prefixes help debug issues faster by
examining stats corresponding to specific envoy
config. This change updates the stat prefix
for the http connection manager so that http
stats corresponding to inbound and outbound
route configurations are easy to locate
and parse.

Previously:
```
http.http.downstream_rq_timeout: 0
```

With this change:
```
http.mesh-http-conn-manager.RDS_Outbound.downstream_rq_timeout: 0
```

Part of #2156

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`