### PR TITLE
rds: use consistent naming style for config name

### DIFF
--- a/docs/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md
+++ b/docs/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md
@@ -168,7 +168,7 @@ In permissive mode, OSM controller programs wildcard routes for client applicati
           "ads": {},
           "resource_api_version": "V3"
          },
-         "route_config_name": "RDS_Outbound"
+         "route_config_name": "rds-outbound"
         },
         "http_filters": [
          {
@@ -189,7 +189,7 @@ In permissive mode, OSM controller programs wildcard routes for client applicati
     ```json
     "route_config": {
       "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
-      "name": "RDS_Outbound",
+      "name": "rds-outbound",
       "virtual_hosts": [
        {
         "name": "outbound_virtual-host|httpbin.httpbin",
@@ -265,7 +265,7 @@ In permissive mode, OSM controller programs wildcard routes for client applicati
           "ads": {},
           "resource_api_version": "V3"
          },
-         "route_config_name": "RDS_Inbound"
+         "route_config_name": "rds-inbound"
         },
         "http_filters": [
          {
@@ -288,7 +288,7 @@ In permissive mode, OSM controller programs wildcard routes for client applicati
     ```json
     "route_config": {
       "@type": "type.googleapis.com/envoy.config.route.v3.RouteConfiguration",
-      "name": "RDS_Inbound",
+      "name": "rds-inbound",
       "virtual_hosts": [
        {
         "name": "inbound_virtual-host|httpbin.httpbin",

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -277,8 +277,8 @@ func TestNewResponse(t *testing.T) {
 			assert.NotNil(actual)
 
 			// The RDS response will have two route configurations
-			// 1. RDS_Inbound
-			// 2. RDS_Outbound
+			// 1. rds-inbound
+			// 2. rds-outbound
 			routeConfig := &xds_route.RouteConfiguration{}
 			assert.Equal(2, len(actual.GetResources()))
 
@@ -288,11 +288,11 @@ func TestNewResponse(t *testing.T) {
 				t.Fatal(unmarshallErr)
 			}
 
-			// The RDS_Inbound will have the following virtual hosts :
+			// The rds-inbound will have the following virtual hosts :
 			// inbound_virtual-host|bookstore-v1.default
 			// inbound_virtual-host|bookstore-apex
 			// inbound_virtual-host|bookstore-v1.default|*
-			assert.Equal("RDS_Inbound", routeConfig.Name)
+			assert.Equal("rds-inbound", routeConfig.Name)
 			assert.Equal(3, len(routeConfig.VirtualHosts))
 
 			assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
@@ -331,9 +331,9 @@ func TestNewResponse(t *testing.T) {
 				t.Fatal(unmarshallErr)
 			}
 
-			// The RDS_Outbound will have the following virtual hosts :
+			// The rds-outbound will have the following virtual hosts :
 			// outbound_virtual-host|bookstore-apex
-			assert.Equal("RDS_Outbound", routeConfig.Name)
+			assert.Equal("rds-outbound", routeConfig.Name)
 			assert.Equal(1, len(routeConfig.VirtualHosts))
 
 			assert.Equal("outbound_virtual-host|bookstore-apex", routeConfig.VirtualHosts[0].Name)
@@ -507,7 +507,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(unmarshallErr)
 	}
-	assert.Equal("RDS_Inbound", routeConfig.Name)
+	assert.Equal("rds-inbound", routeConfig.Name)
 	assert.Equal(2, len(routeConfig.VirtualHosts))
 
 	assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
@@ -526,7 +526,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(unmarshallErr)
 	}
-	assert.Equal("RDS_Outbound", routeConfig.Name)
+	assert.Equal("rds-outbound", routeConfig.Name)
 	assert.Equal(1, len(routeConfig.VirtualHosts))
 
 	assert.Equal("outbound_virtual-host|bookbuyer.default", routeConfig.VirtualHosts[0].Name)

--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -30,10 +30,10 @@ const (
 
 const (
 	//InboundRouteConfigName is the name of the route config that the envoy will identify
-	InboundRouteConfigName = "RDS_Inbound"
+	InboundRouteConfigName = "rds-inbound"
 
 	//OutboundRouteConfigName is the name of the route config that the envoy will identify
-	OutboundRouteConfigName = "RDS_Outbound"
+	OutboundRouteConfigName = "rds-outbound"
 
 	// inboundVirtualHost is the name of the virtual host on the inbound route configuration
 	inboundVirtualHost = "inbound_virtual-host"

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -61,7 +61,7 @@ var _ = Describe(``+
 			err = ptypes.UnmarshalAny(actual.Resources[0], &routeCfg)
 			It("returns a response that can be unmarshalled into an xds RouteConfiguration struct", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(routeCfg.Name).To(Equal("RDS_Outbound"))
+				Expect(routeCfg.Name).To(Equal("rds-outbound"))
 			})
 
 			const (

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -243,8 +243,8 @@ func TestRDSRespose(t *testing.T) {
 			assert.NotNil(actual)
 
 			// The RDS response will have two route configurations
-			// 1. RDS_Inbound
-			// 2. RDS_Outbound
+			// 1. rds-inbound
+			// 2. rds-outbound
 			routeConfig := &xds_route.RouteConfiguration{}
 			assert.Equal(2, len(actual.GetResources()))
 
@@ -254,10 +254,10 @@ func TestRDSRespose(t *testing.T) {
 				t.Fatal(unmarshallErr)
 			}
 
-			// The RDS_Inbound will have the following virtual hosts :
+			// The rds-inbound will have the following virtual hosts :
 			// inbound_virtual-host|bookstore-v1.default
 			// inbound_virtual-host|bookstore-apex
-			assert.Equal("RDS_Inbound", routeConfig.Name)
+			assert.Equal("rds-inbound", routeConfig.Name)
 			assert.Equal(2, len(routeConfig.VirtualHosts))
 
 			assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
@@ -286,9 +286,9 @@ func TestRDSRespose(t *testing.T) {
 				t.Fatal(unmarshallErr)
 			}
 
-			// The RDS_Outbound will have the following virtual hosts :
+			// The rds-outbound will have the following virtual hosts :
 			// outbound_virtual-host|bookstore-apex
-			assert.Equal("RDS_Outbound", routeConfig.Name)
+			assert.Equal("rds-outbound", routeConfig.Name)
 			assert.Equal(1, len(routeConfig.VirtualHosts))
 
 			assert.Equal("outbound_virtual-host|bookstore-apex", routeConfig.VirtualHosts[0].Name)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Use `resource-name` style for naming RDS configs to be
consistent with other config names (listener, filter chains,
virtual host, stats etc.).

No functional change.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`