### PR TITLE
configurator: add test for invalid IP range format

### DIFF
--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -323,6 +323,20 @@ func TestValidateFields(t *testing.T) {
 			},
 		},
 		{
+			testName: "Reject configmap with invalid syntax for IP range",
+			configMap: corev1.ConfigMap{
+				Data: map[string]string{
+					"outbound_ip_range_exclusion_list": "1.1.1.1", // invalid syntax, must be 1.1.1.1/32
+				},
+			},
+			expRes: &v1beta1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Reason: mustBeValidIPRange,
+				},
+			},
+		},
+		{
 			testName: "Reject configmap with invalid outbound IP range exclusions",
 			configMap: corev1.ConfigMap{
 				Data: map[string]string{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a test that fails IP ranges of the form
a.b.c.d, because the expected range should be
of the form a.b.c.d/x.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`