### PR TITLE
envoy/lds: fix stat prefix for tcp-proxy filters

### DIFF
--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -532,7 +532,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 			upstream:      service.MeshService{Name: "foo", Namespace: "bar"},
 			trafficSplits: nil,
 			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
-				StatPrefix:       "outbound-mesh-tcp-filter-chain:bar/foo",
+				StatPrefix:       "outbound-mesh-tcp-proxy.bar/foo",
 				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: "bar/foo"},
 			},
 			expectError: false,
@@ -562,7 +562,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 				},
 			},
 			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
-				StatPrefix: "outbound-mesh-tcp-filter-chain:bar/foo",
+				StatPrefix: "outbound-mesh-tcp-proxy.bar/foo",
 				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_WeightedClusters{
 					WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
 						Clusters: []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
@@ -605,7 +605,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 				},
 			},
 			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
-				StatPrefix:       "outbound-mesh-tcp-filter-chain:bar/foo",
+				StatPrefix:       "outbound-mesh-tcp-proxy.bar/foo",
 				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: "bar/foo"},
 			},
 			expectError: false,
@@ -654,7 +654,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 				},
 			},
 			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
-				StatPrefix: "outbound-mesh-tcp-filter-chain:bar/foo",
+				StatPrefix: "outbound-mesh-tcp-proxy.bar/foo",
 				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_WeightedClusters{
 					WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
 						Clusters: []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{
@@ -697,7 +697,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 				},
 			},
 			expectedTCPProxyConfig: &xds_tcp_proxy.TcpProxy{
-				StatPrefix: "outbound-mesh-tcp-filter-chain:bar/foo",
+				StatPrefix: "outbound-mesh-tcp-proxy.bar/foo",
 				ClusterSpecifier: &xds_tcp_proxy.TcpProxy_WeightedClusters{
 					WeightedClusters: &xds_tcp_proxy.TcpProxy_WeightedCluster{
 						Clusters: []*xds_tcp_proxy.TcpProxy_WeightedCluster_ClusterWeight{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the stat prefix for the tcp proxy filters
to:
1. be consistent with other stat prefixes (HTTP conn
   manager)
2. Remove ':' from the prefix because it gets converted
   to an '_', and is reserved for displaying key:value.

Part of #2156

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`