### PR TITLE
catalog: simplify inbound route for permissive mode

### DIFF
--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -315,7 +315,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 								HTTPRouteMatch:   tests.WildCardRouteMatch,
 								WeightedClusters: mapset.NewSet(tests.BookbuyerDefaultWeightedCluster),
 							},
-							AllowedServiceAccounts: mapset.NewSet(tests.BookbuyerServiceAccount, tests.BookstoreServiceAccount),
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
 						},
 					},
 				},
@@ -971,13 +971,7 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
-								Name:      "bookstore",
-								Namespace: "bookstore-ns",
-							}, service.K8sServiceAccount{
-								Name:      "bookbuyer",
-								Namespace: "bookbuyer-ns",
-							}),
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
 						},
 					},
 				},
@@ -993,15 +987,9 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			k8sService := tests.NewServiceFixture(tc.meshService.Name, tc.meshService.Namespace, map[string]string{})
-			k8sServiceAccounts := []*corev1.ServiceAccount{}
-
-			for name, namespace := range tc.serviceAccounts {
-				k8sServiceAccounts = append(k8sServiceAccounts, tests.NewServiceAccountFixture(name, namespace))
-			}
 
 			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
 			mockKubeController.EXPECT().GetService(tc.meshService).Return(k8sService)
-			mockKubeController.EXPECT().ListServiceAccounts().Return(k8sServiceAccounts)
 			actual := mc.buildInboundPermissiveModePolicies(tc.meshService)
 			assert.Len(actual, len(tc.expectedInboundPolicies))
 			assert.ElementsMatch(tc.expectedInboundPolicies, actual)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change simplifies the inbound route for permissive
mode by using the concept of a wildcard service account
to allow all downstream service accounts that the
corresponding RBAC policy must allow. This is similar
to what is done for ingress where all service account
are allowed to access a given upstream via RBAC.
This optimization allows building the inbound route
for a service in permissive mode in O(1) time as
opposed to O(n) where n is the number of service
accounts in the mesh.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`