### PR TITLE
Adding release_pull_request_template.md to release-v0.8 branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -1,0 +1,21 @@
+<!--
+
+Use the checklist below to ensure your release PR is complete before marking it ready for review.
+
+-->
+
+- [ ] I have cherry-picked any changes [labelled](https://github.com/openservicemesh/osm/labels) `needs-cherry-pick-vX.Y.Z`
+- [ ] I have made all of the following version and patch updates:
+  1. Updated the container image tag in charts/osm/values.yaml
+  2. Updated the chart **and** app version in charts/osm/Chart.yaml
+  3. Updated the default osm-controller image tag in osm cli
+  4. Updated the image tags used in the demo manifests
+  5. Regenerated the Helm chart README.md
+
+- [ ] I have checked that the base branch for this PR is correct as defined by the release guide
+<!--
+  If this PR is for updating the release branch, ensure the base branch is `release-vX.Y`.
+  If this PR is for making changes on the main branch, ensure the base branch is `main`. 
+-->
+
+Is this a release candidate?


### PR DESCRIPTION
I'd like to copy the file `.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md` from `main` to `release-v0.8` branch.

This allows us to have version links in documents.  I'm going to use this in the `docs/content/docs/release_guide.md` file, which currently points to `main` branch.

---

This is part of the #2854 effort