### PR TITLE
docs/manifests: Cleanup client services - not needed in v0.8.2

### DIFF
--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -1,32 +1,21 @@
-# Deploy bookbuyer Namespace
+# Create bookbuyer Namespace
 apiVersion: v1
 kind: Namespace
 metadata:
   name: bookbuyer
+
 ---
-# Deploy bookbuyer Service Account
+
+# Create bookbuyer Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookbuyer
   namespace: bookbuyer
+
 ---
-# Deploy bookbuyer Service
-apiVersion: v1
-kind: Service
-metadata:
-  name: bookbuyer
-  namespace: bookbuyer
-  labels:
-    app: bookbuyer
-spec:
-  ports:
-  - port: 9999
-    name: dummy-unused-port
-  selector:
-    app: bookbuyer
----
-# Deploy bookbuyer Deployment
+
+# Create bookbuyer Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -1,5 +1,4 @@
----
-# Deploy bookstore-v2 Service
+# Create bookstore-v2 Service
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,15 +12,19 @@ spec:
     name: bookstore-port
   selector:
     app: bookstore-v2
+
 ---
-# Deploy bookstore-v2 Service Account
+
+# Create bookstore-v2 Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookstore-v2
   namespace: bookstore
+
 ---
-# Deploy bookstore-v2 Deployment
+
+# Create bookstore-v2 Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,7 +55,9 @@ spec:
               value: bookwarehouse
             - name: IDENTITY
               value: bookstore-v2
+
 ---
+
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha3
 metadata:

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -1,10 +1,12 @@
-# Deploy bookstore Namespace
+# Create bookstore Namespace
 apiVersion: v1
 kind: Namespace
 metadata:
   name: bookstore
+
 ---
-# Deploy bookstore Service
+
+# Create bookstore Service
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,15 +20,19 @@ spec:
     name: bookstore-port
   selector:
     app: bookstore
+
 ---
-# Deploy bookstore Service Account
+
+# Create bookstore Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookstore
   namespace: bookstore
+
 ---
-# Deploy bookstore Deployment
+
+# Create bookstore Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -1,32 +1,21 @@
-# Deploy bookthief Namespace
+# Create bookthief Namespace
 apiVersion: v1
 kind: Namespace
 metadata:
   name: bookthief
+
 ---
-# Deploy bookthief ServiceAccount
+
+# Create bookthief ServiceAccount
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookthief
   namespace: bookthief
+
 ---
-# Deploy bookthief Service
-apiVersion: v1
-kind: Service
-metadata:
-  name: bookthief
-  namespace: bookthief
-  labels:
-    app: bookthief
-spec:
-  ports:
-  - port: 9999
-    name: dummy-unused-port
-  selector:
-    app: bookthief
----
-# Deploy bookthief Deployment
+
+# Create bookthief Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -1,17 +1,21 @@
-# Deploy bookwarehouse Namespace
+# Create bookwarehouse Namespace
 apiVersion: v1
 kind: Namespace
 metadata:
   name: bookwarehouse
+
 ---
-# Deploy bookwarehouse Service Account
+
+# Create bookwarehouse Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: bookwarehouse
   namespace: bookwarehouse
+
 ---
-# Deploy bookwarehouse Service
+
+# Create bookwarehouse Service
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,8 +29,10 @@ spec:
     name: bookwarehouse-port
   selector:
     app: bookwarehouse
+
 ---
-# Deploy bookwarehouse Deployment
+
+# Create bookwarehouse Deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
# This PR updates branch `release-v0.8`

This PR removes the `bookbuyer` and `bookthief` Services, which are no longer needed for OSM v0.8 and above to operate.

Additionally - rewording YAML comments from "Deploy ..." to "Create ..."  (create deployment, create service account etc.)

---

The following PR makes the same change on `main` branch: #3008

---

This is part of the #2854 effort