### PR TITLE
docs: Update Prerequisites section of OSM Manual Demo document

### DIFF
--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -13,7 +13,7 @@ The OSM Manual Install Demo Guide is a step by step set of instructions to quick
 
 ## Prerequisites
 This demo of OSM v0.8.2 requires:
-  - a cluster running Kubernetes v1.15.0 or greater
+  - a cluster running Kubernetes v1.18.0 or greater
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
 

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -13,7 +13,7 @@ The OSM Manual Install Demo Guide is a step by step set of instructions to quick
 
 ## Prerequisites
 This demo of OSM v0.8.2 requires:
-  - a cluster running Kubernetes v1.18.0 or greater
+  - a cluster running Kubernetes v1.17 or greater
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
 

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -10,15 +10,13 @@ weight: 2
 
 The OSM Manual Install Demo Guide is a step by step set of instructions to quickly demo OSM's key features.
 
-## Configure Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.15.0 or greater
-- Have `kubectl` CLI installed - [Install and Set Up Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- kubectl current context is configured for the target cluster install
-  - `kubectl config current-context`
-- Have a local clone of the OSM GitHub Repo
-  - `git clone https://github.com/openservicemesh/osm.git`
-  - `cd osm`
+## Prerequisites
+This demo of OSM v0.8.2 requires:
+  - a cluster running Kubernetes v1.15.0 or greater
+  - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
+  - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
+
 
 ## Build or Download the OSM CLI
 


### PR DESCRIPTION
This PR updates the **Prerequisites** section of the "OSM Manual Demo" document.

Goals:
  - simplify and clarify the verbiage
  - be explicit about the version of OSM this is relevant for (v0.8.2)

---

This is one of a few steps to update the entire doc as part of #2845

---

Once the entire doc is rewritten - all changes will be applied to the `release-v0.8` branch.