### PR TITLE
docs: Update the download and install section of the OSM Manual Demo document

### DIFF
--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -20,9 +20,29 @@ The OSM Manual Install Demo Guide is a step by step set of instructions to quick
   - `git clone https://github.com/openservicemesh/osm.git`
   - `cd osm`
 
-## Build or Download the OSM CLI
 
-Use the [installation guide](../../install) to install the `osm` cli.
+## Download the OSM command-line tool
+
+The `osm` command-line tool contains everything needed to install and configure Open Service Mesh.
+The binary is available on the [OSM GitHub releases page](https://github.com/openservicemesh/osm/releases/).
+
+Download the 64-bit GNU/Linux or macOS binary of OSM v0.8.2:
+```bash
+system=$(uname -s)
+release=v0.8.2
+curl -L https://github.com/openservicemesh/osm/releases/download/${release}/osm-${release}-${system}-amd64.tar.gz | tar -vxzf -
+./${system}-amd64/osm version
+```
+
+Download the Windows OSM v0.8.2 binary via Powershell:
+```powershell
+wget  https://github.com/openservicemesh/osm/releases/download/v0.8.2/osm-v0.8.2-windows-amd64.zip -o osm.zip
+unzip osm.zip
+.\windows-amd64\osm.exe version
+```
+
+The `osm` CLI can be compiled from source using [this guide](../../install/_index.md).
+
 
 ## Install OSM Control Plane
 

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -21,7 +21,7 @@ The OSM Manual Install Demo Guide is a step by step set of instructions to quick
   - `cd osm`
 
 
-## Download the OSM command-line tool
+## Download and install the OSM command-line tool
 
 The `osm` command-line tool contains everything needed to install and configure Open Service Mesh.
 The binary is available on the [OSM GitHub releases page](https://github.com/openservicemesh/osm/releases/).

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -26,6 +26,8 @@ The OSM Manual Install Demo Guide is a step by step set of instructions to quick
 The `osm` command-line tool contains everything needed to install and configure Open Service Mesh.
 The binary is available on the [OSM GitHub releases page](https://github.com/openservicemesh/osm/releases/).
 
+### For GNU/Linux and macOS
+
 Download the 64-bit GNU/Linux or macOS binary of OSM v0.8.2:
 ```bash
 system=$(uname -s)
@@ -34,7 +36,9 @@ curl -L https://github.com/openservicemesh/osm/releases/download/${release}/osm-
 ./${system}-amd64/osm version
 ```
 
-Download the Windows OSM v0.8.2 binary via Powershell:
+### For Windows
+
+Download the 64-bit Windows OSM v0.8.2 binary via Powershell:
 ```powershell
 wget  https://github.com/openservicemesh/osm/releases/download/v0.8.2/osm-v0.8.2-windows-amd64.zip -o osm.zip
 unzip osm.zip


### PR DESCRIPTION
This PR updates the **Download and install** section of the "OSM Manual Demo" document.

Goals:
  - simplify and clarify the verbiage
  - point to v0.8.2 release be explicit about the version of OSM this is relevant for (v0.8.2)
  - include instructions on downloading it on GNU/Linux, macOS, and Windows

---

This is one of a few steps to update the entire doc as part of #2845

Related PRs:
  - #3010

---

Once the entire doc is rewritten - all changes will be applied to the `release-v0.8` branch.