### PR TITLE
envoy/lds: update stat prefix for network RBAC

### DIFF
--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -60,7 +60,7 @@ func (lb *listenerBuilder) buildInboundRBACPolicies() (*xds_network_rbac.RBAC, e
 
 	// Create an inbound RBAC policy that denies a request by default, unless a policy explicitly allows it
 	networkRBACPolicy := &xds_network_rbac.RBAC{
-		StatPrefix: "RBAC",
+		StatPrefix: "network-", // will be displayed as network-rbac.<path>
 		Rules: &xds_rbac.RBAC{
 			Action:   xds_rbac.RBAC_ALLOW, // Allows the request if and only if there is a policy that matches the request
 			Policies: rbacPolicies,


### PR DESCRIPTION
**Description**:
Unlike other stats, the RBAC stat prefix gets suffixed
with `rbac`. This change updates the stat prefix for the
network RBAC policy type so it renders correctly:

previously:
`RBACrbac.allowed: 0`

now:
`network-rbac.allowed: 0`

Part of #2156

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [X]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`