### PR TITLE
validatingWebhook: Add duration validation for config_resync_interval

### DIFF
--- a/pkg/configurator/validating_webhook.go
+++ b/pkg/configurator/validating_webhook.go
@@ -250,7 +250,7 @@ func (whc *webhookConfig) validateFields(configMap corev1.ConfigMap, resp *v1bet
 		if field == "envoy_log_level" && !checkEnvoyLogLevels(field, value) {
 			reasonForDenial(resp, mustBeValidLogLvl, field)
 		}
-		if field == "service_cert_validity_duration" {
+		if field == "service_cert_validity_duration" || field == "config_resync_interval" {
 			_, err := time.ParseDuration(value)
 			if err != nil {
 				reasonForDenial(resp, mustBeValidTime, field)


### PR DESCRIPTION
Adds duration value validation for `config_resync_interval` in
validating webhook.

Signed-off-by: Eduard Serra <eduser25@gmail.com>


- Control Plane          [ ]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No