### PR TITLE
e2e: Increase verification time for restart test, adds time checks

### DIFF
--- a/tests/e2e/e2e_controller_restart_test.go
+++ b/tests/e2e/e2e_controller_restart_test.go
@@ -113,13 +113,13 @@ func testHTTPTrafficWithControllerRestart() {
 			result := Td.HTTPRequest(clientToServer)
 
 			if result.Err != nil || result.StatusCode != 200 {
-				Td.T.Logf("> (%s) HTTP Req failed %d %v",
-					srcToDestStr, result.StatusCode, result.Err)
+				Td.T.Logf("%s > (%s) HTTP Req failed %d %v",
+					time.Now(), srcToDestStr, result.StatusCode, result.Err)
 				return false
 			}
-			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			Td.T.Logf("%s > (%s) HTTP Req succeeded: %d", time.Now(), srcToDestStr, result.StatusCode)
 			return true
-		}, 20, 40*time.Second)
+		}, 20, 80*time.Second)
 		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination service %s after osm-controller restart", srcPod.Name, dstSvc.Name)
 	})
 }


### PR DESCRIPTION
Seeing some instances of what seems slow curl turnaround execution,
increasing timing and adding time logs for the test to better
identify the cause.

```
STEP: Restarting OSM controller
STEP: [WaitForRepeatedSuccess] waiting 40s for 20 iterations to succeed
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
> (client/client -> server.server) HTTP Req succeeded: 200
[AfterEach] [Top Level]
(...)

 Failed testing HTTP traffic from source pod client to destination service server after osm-controller restart
    Expected
        <bool>: false
    to be true
```

Signed-off-by: edu <eduser25@gmail.com>

**Affected area**:

- Tests                  [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No