### PR TITLE
fix(cli): note ignored namespaces in "osm namespace list"

### DIFF
--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -77,15 +77,18 @@ func (l *namespaceListCmd) run() error {
 	}
 
 	w := newTabWriter(l.out)
-	fmt.Fprintln(w, "NAMESPACE\tMESH\tSIDECAR-INJECTION\t")
+	fmt.Fprintln(w, "NAMESPACE\tMESH\tSIDECAR-INJECTION")
 	for _, ns := range namespaces.Items {
 		osmName := ns.ObjectMeta.Labels[constants.OSMKubeResourceMonitorAnnotation]
 		sidecarInjectionEnabled, ok := ns.ObjectMeta.Annotations[constants.SidecarInjectionAnnotation]
 		if !ok {
 			sidecarInjectionEnabled = "-" // not set
 		}
+		if _, ignored := ns.Labels[ignoreLabel]; ignored {
+			sidecarInjectionEnabled = "disabled (ignored)"
+		}
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t\n", ns.Name, osmName, sidecarInjectionEnabled)
+		fmt.Fprintf(w, "%s\t%s\t%s\n", ns.Name, osmName, sidecarInjectionEnabled)
 	}
 	_ = w.Flush()
 

--- a/cmd/cli/namespace_list_test.go
+++ b/cmd/cli/namespace_list_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func TestNamespaceList(t *testing.T) {
+	tests := []struct {
+		name       string
+		meshName   string
+		namespaces []*corev1.Namespace
+		expected   string
+	}{
+		{
+			name:     "no namespaces no mesh specified",
+			expected: "No namespaces in any mesh\n",
+		},
+		{
+			name:     "no namespaces with mesh specified",
+			meshName: "my-mesh",
+			expected: "No namespaces in mesh [my-mesh]\n",
+		},
+		{
+			name: "one namespace injection not set",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh",
+						},
+					},
+				},
+			},
+			expected: "NAMESPACE\tMESH\tSIDECAR-INJECTION\nns\tmy-mesh\t-\n",
+		},
+		{
+			name: "one namespace injection enabled",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh",
+						},
+						Annotations: map[string]string{
+							constants.SidecarInjectionAnnotation: "enabled",
+						},
+					},
+				},
+			},
+			expected: "NAMESPACE\tMESH\tSIDECAR-INJECTION\nns\tmy-mesh\tenabled\n",
+		},
+		{
+			name: "one namespace injection ignored",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh",
+							ignoreLabel: "any value",
+						},
+						Annotations: map[string]string{
+							constants.SidecarInjectionAnnotation: "enabled",
+						},
+					},
+				},
+			},
+			expected: "NAMESPACE\tMESH\tSIDECAR-INJECTION\nns\tmy-mesh\tdisabled (ignored)\n",
+		},
+		{
+			name: "two namespaces different meshes no mesh specified",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh2",
+						},
+					},
+				},
+			},
+			expected: "NAMESPACE\tMESH\tSIDECAR-INJECTION\nns1\tmy-mesh1\t-\nns2\tmy-mesh2\t-\n",
+		},
+		{
+			name:     "two namespaces different meshes with mesh specified",
+			meshName: "my-mesh2",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns1",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh1",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ns2",
+						Labels: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "my-mesh2",
+						},
+					},
+				},
+			},
+			expected: "NAMESPACE\tMESH\tSIDECAR-INJECTION\nns2\tmy-mesh2\t-\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			buf := bytes.NewBuffer(nil)
+
+			objs := make([]runtime.Object, len(test.namespaces))
+			for i := range test.namespaces {
+				objs[i] = test.namespaces[i]
+			}
+
+			cmd := namespaceListCmd{
+				out:       buf,
+				meshName:  test.meshName,
+				clientSet: fake.NewSimpleClientset(objs...),
+			}
+
+			assert.Nil(cmd.run())
+
+			expected := bytes.NewBuffer(nil)
+			expTw := newTabWriter(expected)
+			_, err := expTw.Write([]byte(test.expected))
+			assert.Nil(err)
+			assert.Nil(expTw.Flush())
+
+			assert.Equal(expected.String(), buf.String())
+		})
+	}
+}


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change fixes a bug in the `osm namespace list` command where after
doing `osm namespace add bookbuyer` and then `osm namespace ignore bookbuyer`,
`osm namespace list` would incorrectly show sidecar injection enabled in
the bookbuyer namespace. This change notates namespaces with both the
sidecar injection annotation "enabled" and the ignore label set as
`disabled (ignored)` in the `SIDECAR-INJECTION column` of the command's
output.

Unit tests have also been added to the `osm namespace list` command.

Fixes #2965
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No