### PR TITLE
Update to admissionregistration.k8s.io/v1

### DIFF
--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   labels:
@@ -39,3 +39,10 @@ webhooks:
         - CREATE
       resources:
         - pods
+  # Injector's mutating webhook has a side effect of creating k8s secret for the Envoy bootstrap config.
+  # For dry-run requests, this side effect is skipped.
+  # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
+  sideEffects: NoneOnDryRun
+  # Default timeout is 10s. Set this to 20s to account for slowness in scale environments
+  timeoutSeconds: 20
+  admissionReviewVersions: ["v1"]

--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
@@ -26,3 +26,5 @@ webhooks:
         - UPDATE
       resources:
         - configmaps
+  sideEffects: None
+  admissionReviewVersions: ["v1"]

--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -95,13 +95,13 @@ func DeleteWebhookConfiguration(client *kubernetes.Clientset, webhookConfigName 
 		GracePeriodSeconds: to.Int64Ptr(0),
 	}
 
-	_, err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.Background(), webhookConfigName, metav1.GetOptions{})
+	_, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), webhookConfigName, metav1.GetOptions{})
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting mutatingwebhookconfiguration %s", webhookConfigName)
 		return
 	}
 
-	if err := client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.Background(), webhookConfigName, deleteOptions); err != nil {
+	if err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), webhookConfigName, deleteOptions); err != nil {
 		log.Error().Err(err).Msgf("Error deleting mutatingwebhookconfiguration %s", webhookConfigName)
 	} else {
 		log.Info().Msgf("Deleted mutatingwebhookconfiguration: %s", webhookConfigName)

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -104,7 +104,7 @@ func init() {
 	flags.BoolVar(&optionalFeatures.WASMStats, "stats-wasm-experimental", false, "Enable a WebAssembly module that generates additional Envoy statistics.")
 
 	_ = clientgoscheme.AddToScheme(scheme)
-	_ = v1beta1.AddToScheme(scheme)
+	_ = admissionv1.AddToScheme(scheme)
 }
 
 func main() {

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +88,7 @@ func init() {
 	flags.StringVar(&certManagerOptions.IssuerGroup, "cert-manager-issuer-group", "cert-manager.io", "cert-manager issuer group")
 
 	_ = clientgoscheme.AddToScheme(scheme)
-	_ = v1beta1.AddToScheme(scheme)
+	_ = admissionv1.AddToScheme(scheme)
 }
 
 func main() {

--- a/pkg/configurator/validating_webhook.go
+++ b/pkg/configurator/validating_webhook.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -181,19 +181,21 @@ func (whc *webhookConfig) configMapHandler(w http.ResponseWriter, req *http.Requ
 	}
 }
 
-func (whc *webhookConfig) getAdmissionReqResp(admissionRequestBody []byte) (requestForNamespace string, admissionResp v1beta1.AdmissionReview) {
-	var admissionReq v1beta1.AdmissionReview
+func (whc *webhookConfig) getAdmissionReqResp(admissionRequestBody []byte) (requestForNamespace string, admissionResp admissionv1.AdmissionReview) {
+	var admissionReq admissionv1.AdmissionReview
 	if _, _, err := deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
 		log.Error().Err(err).Msg("Error decoding admission request body")
 		admissionResp.Response = webhook.AdmissionError(err)
 	} else {
 		admissionResp.Response = whc.validateConfigMap(admissionReq.Request)
 	}
+	admissionResp.TypeMeta = admissionReq.TypeMeta
+	admissionResp.Kind = admissionReq.Kind
 
 	return admissionReq.Request.Namespace, admissionResp
 }
 
-func (whc *webhookConfig) validateConfigMap(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
+func (whc *webhookConfig) validateConfigMap(req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	if req == nil {
 		log.Error().Msg("nil admission request")
 		return webhook.AdmissionError(errNilAdmissionRequest)
@@ -209,7 +211,7 @@ func (whc *webhookConfig) validateConfigMap(req *v1beta1.AdmissionRequest) *v1be
 	log.Trace().Msgf("Validation request: (new object: %v) (old object: %v)", string(req.Object.Raw), string(req.OldObject.Raw))
 
 	// Default response
-	resp := &v1beta1.AdmissionResponse{
+	resp := &admissionv1.AdmissionResponse{
 		Allowed: true,
 		Result:  &metav1.Status{Reason: ""},
 		UID:     req.UID,
@@ -227,7 +229,7 @@ func (whc *webhookConfig) validateConfigMap(req *v1beta1.AdmissionRequest) *v1be
 }
 
 // checkDefaultFields checks that all default fields for osm-config exist
-func checkDefaultFields(configMap corev1.ConfigMap, resp *v1beta1.AdmissionResponse) *v1beta1.AdmissionResponse {
+func checkDefaultFields(configMap corev1.ConfigMap, resp *admissionv1.AdmissionResponse) *admissionv1.AdmissionResponse {
 	data := make(map[string]struct{})
 	for field := range configMap.Data {
 		data[field] = struct{}{}
@@ -242,7 +244,7 @@ func checkDefaultFields(configMap corev1.ConfigMap, resp *v1beta1.AdmissionRespo
 }
 
 // validateFields checks whether the configmap field values are valid and rejects as necessary
-func (whc *webhookConfig) validateFields(configMap corev1.ConfigMap, resp *v1beta1.AdmissionResponse) *v1beta1.AdmissionResponse {
+func (whc *webhookConfig) validateFields(configMap corev1.ConfigMap, resp *admissionv1.AdmissionResponse) *admissionv1.AdmissionResponse {
 	for field, value := range configMap.Data {
 		if !checkBoolFields(field, value, boolFields) {
 			reasonForDenial(resp, mustBeBool, field)
@@ -320,8 +322,8 @@ func checkBoolFields(configMapField, configMapValue string, fields []string) boo
 	return true
 }
 
-// reasonForDenial rejects and appends rejection reason(s) to v1beta1.AdmissionResponse
-func reasonForDenial(resp *v1beta1.AdmissionResponse, mustBe string, field string) {
+// reasonForDenial rejects and appends rejection reason(s) to admissionv1.AdmissionResponse
+func reasonForDenial(resp *admissionv1.AdmissionResponse, mustBe string, field string) {
 	resp.Allowed = false
 	reason := "\n" + field + mustBe
 	resp.Result = &metav1.Status{
@@ -330,17 +332,22 @@ func reasonForDenial(resp *v1beta1.AdmissionResponse, mustBe string, field strin
 }
 
 // getPartialValidatingWebhookConfiguration returns only the portion of the ValidatingWebhookConfiguration that needs to be updated.
-func getPartialValidatingWebhookConfiguration(webhookName string, cert certificate.Certificater, webhookConfigName string) admissionv1beta1.ValidatingWebhookConfiguration {
-	return admissionv1beta1.ValidatingWebhookConfiguration{
+func getPartialValidatingWebhookConfiguration(webhookName string, cert certificate.Certificater, webhookConfigName string) admissionregv1.ValidatingWebhookConfiguration {
+	return admissionregv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigName,
 		},
-		Webhooks: []admissionv1beta1.ValidatingWebhook{
+		Webhooks: []admissionregv1.ValidatingWebhook{
 			{
 				Name: webhookName,
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregv1.WebhookClientConfig{
 					CABundle: cert.GetCertificateChain(),
 				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNone
+					return &sideEffect
+				}(),
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}
@@ -349,7 +356,7 @@ func getPartialValidatingWebhookConfiguration(webhookName string, cert certifica
 // updateValidatingWebhookCABundle updates the existing ValidatingWebhookConfiguration with the CA this OSM instance runs with.
 // It is necessary to perform this patch because the original ValidatingWebhookConfig YAML does not contain the root certificate.
 func updateValidatingWebhookCABundle(cert certificate.Certificater, webhookName string, clientSet kubernetes.Interface) error {
-	vwc := clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
+	vwc := clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 	if _, err := vwc.Get(context.Background(), webhookName, metav1.GetOptions{}); err != nil {
 		log.Error().Err(err).Msgf("Error getting ValidatingWebhookConfiguration %s; Will not update CA Bundle for webhook", webhookName)
 		return err

--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	tassert "github.com/stretchr/testify/assert"
-	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -35,7 +35,7 @@ const (
 	fakeField            = "field"
 	admissionRequestBody = `{
 		"kind": "AdmissionReview",
-		"apiVersion": "admission.k8s.io/v1beta1",
+		"apiVersion": "admission.k8s.io/v1",
 		"request": {
 		  "uid": "11111111-2222-3333-4444-555555555555",
 		  "kind": {
@@ -102,7 +102,7 @@ func TestConfigMapHandler(t *testing.T) {
 	whc.configMapHandler(w, req)
 	resp := w.Result()
 	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-	expRes := "{\"response\":{\"uid\":\"11111111-2222-3333-4444-555555555555\",\"allowed\":true,\"status\":{\"metadata\":{}}}}"
+	expRes := "{\"kind\":\"AdmissionReview\",\"apiVersion\":\"admission.k8s.io/v1\",\"response\":{\"uid\":\"11111111-2222-3333-4444-555555555555\",\"allowed\":true,\"status\":{\"metadata\":{}}}}"
 	assert.Equal(http.StatusOK, resp.StatusCode)
 	assert.Equal(expRes, string(bodyBytes))
 }
@@ -112,10 +112,10 @@ func TestGetAdmissionReqResp(t *testing.T) {
 
 	requestForNamespace, admissionResp := whc.getAdmissionReqResp([]byte(admissionRequestBody))
 
-	expectedAdmissionResponse := v1beta1.AdmissionReview{
-		TypeMeta: metav1.TypeMeta{Kind: "", APIVersion: ""},
+	expectedAdmissionResponse := admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{Kind: "AdmissionReview", APIVersion: "admission.k8s.io/v1"},
 		Request:  nil,
-		Response: &v1beta1.AdmissionResponse{
+		Response: &admissionv1.AdmissionResponse{
 			UID:              "11111111-2222-3333-4444-555555555555",
 			Allowed:          true,
 			Result:           &metav1.Status{},
@@ -133,13 +133,13 @@ func TestValidateConfigMap(t *testing.T) {
 
 	testCases := []struct {
 		testName string
-		req      *v1beta1.AdmissionRequest
-		expRes   *v1beta1.AdmissionResponse
+		req      *admissionv1.AdmissionRequest
+		expRes   *admissionv1.AdmissionResponse
 	}{
 		{
 			testName: "Admission request is nil",
 			req:      nil,
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Result: &metav1.Status{
 					Message: errors.New("nil admission request").Error(),
 				},
@@ -147,12 +147,12 @@ func TestValidateConfigMap(t *testing.T) {
 		},
 		{
 			testName: "Error decoding request",
-			req: &v1beta1.AdmissionRequest{
+			req: &admissionv1.AdmissionRequest{
 				Object: runtime.RawExtension{
 					Raw: []byte("asdf"),
 				},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Result: &metav1.Status{
 					Message: "couldn't get version/kind; json parse error: json: cannot unmarshal string into Go value of type struct { APIVersion string \"json:\\\"apiVersion,omitempty\\\"\"; Kind string \"json:\\\"kind,omitempty\\\"\" }",
 				},
@@ -160,7 +160,7 @@ func TestValidateConfigMap(t *testing.T) {
 		},
 		{
 			testName: "Allow updates to configmaps that are not osm-config",
-			req: &v1beta1.AdmissionRequest{
+			req: &admissionv1.AdmissionRequest{
 				UID: "1234",
 				Kind: metav1.GroupVersionKind{
 					Version: "/v1",
@@ -168,7 +168,7 @@ func TestValidateConfigMap(t *testing.T) {
 				},
 				Name: "notOsmConfig",
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: true,
 				Result:  &metav1.Status{Reason: ""},
 				UID:     "1234",
@@ -185,7 +185,7 @@ func TestValidateConfigMap(t *testing.T) {
 
 func TestCheckDefaultFields(t *testing.T) {
 	assert := tassert.New(t)
-	resp := &v1beta1.AdmissionResponse{
+	resp := &admissionv1.AdmissionResponse{
 		Allowed: true,
 		Result:  &metav1.Status{Reason: ""},
 	}
@@ -193,7 +193,7 @@ func TestCheckDefaultFields(t *testing.T) {
 	testCases := []struct {
 		testName  string
 		configMap corev1.ConfigMap
-		expRes    *v1beta1.AdmissionResponse
+		expRes    *admissionv1.AdmissionResponse
 	}{
 		{
 			testName: "Contains all default fields",
@@ -213,7 +213,7 @@ func TestCheckDefaultFields(t *testing.T) {
 					"enable_privileged_init_container": "",
 				},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: true,
 				Result:  &metav1.Status{Reason: ""},
 			},
@@ -226,7 +226,7 @@ func TestCheckDefaultFields(t *testing.T) {
 					"enable_debug_server": "",
 				},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result:  &metav1.Status{Reason: doesNotContainDef},
 			},
@@ -260,7 +260,7 @@ func TestValidateFields(t *testing.T) {
 	testCases := []struct {
 		testName  string
 		configMap corev1.ConfigMap
-		expRes    *v1beta1.AdmissionResponse
+		expRes    *admissionv1.AdmissionResponse
 	}{
 		{
 			testName: "Accept valid configMap update",
@@ -271,7 +271,7 @@ func TestValidateFields(t *testing.T) {
 					"service_cert_validity_duration": "24h",
 					"tracing_port":                   "9411"},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: true,
 				Result:  &metav1.Status{Reason: ""},
 			},
@@ -289,7 +289,7 @@ func TestValidateFields(t *testing.T) {
 					"envoy_log_level": "envoy",
 					"tracing_port":    "123456"},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Reason: mustBeBool + mustBeValidLogLvl + mustBeInPortRange + cannotChangeMetadata,
@@ -303,7 +303,7 @@ func TestValidateFields(t *testing.T) {
 					"service_cert_validity_duration": "1hw",
 					"tracing_port":                   "1.00"},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Reason: mustBeValidTime + mustbeInt,
@@ -317,7 +317,7 @@ func TestValidateFields(t *testing.T) {
 					"outbound_ip_range_exclusion_list": "1.1.1.1/32, 2.2.2.2/24",
 				},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: true,
 				Result:  &metav1.Status{Reason: ""},
 			},
@@ -329,7 +329,7 @@ func TestValidateFields(t *testing.T) {
 					"outbound_ip_range_exclusion_list": "1.1.1.1", // invalid syntax, must be 1.1.1.1/32
 				},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Reason: mustBeValidIPRange,
@@ -343,7 +343,7 @@ func TestValidateFields(t *testing.T) {
 					"outbound_ip_range_exclusion_list": "foobar",
 				},
 			},
-			expRes: &v1beta1.AdmissionResponse{
+			expRes: &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Reason: mustBeValidIPRange,
@@ -353,7 +353,7 @@ func TestValidateFields(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			resp := &v1beta1.AdmissionResponse{
+			resp := &admissionv1.AdmissionResponse{
 				Allowed: true,
 				Result:  &metav1.Status{Reason: ""},
 			}
@@ -401,16 +401,21 @@ func TestGetPartialValidatingWebhookConfiguration(t *testing.T) {
 	webhookConfigName := "-webhook-config-name-"
 	res := getPartialValidatingWebhookConfiguration(ValidatingWebhookName, cert, webhookConfigName)
 
-	expectedRes := admissionv1beta1.ValidatingWebhookConfiguration{
+	expectedRes := admissionregv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigName,
 		},
-		Webhooks: []admissionv1beta1.ValidatingWebhook{
+		Webhooks: []admissionregv1.ValidatingWebhook{
 			{
 				Name: ValidatingWebhookName,
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregv1.WebhookClientConfig{
 					CABundle: cert.GetCertificateChain(),
 				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNone
+					return &sideEffect
+				}(),
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}
@@ -424,15 +429,15 @@ func TestUpdateValidatingWebhookCABundle(t *testing.T) {
 	testWebhookServiceNamespace := "test-namespace"
 	testWebhookServiceName := "test-service-name"
 	testWebhookServicePath := "/path"
-	kubeClient := fake.NewSimpleClientset(&admissionv1beta1.ValidatingWebhookConfiguration{
+	kubeClient := fake.NewSimpleClientset(&admissionregv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookName,
 		},
-		Webhooks: []admissionv1beta1.ValidatingWebhook{
+		Webhooks: []admissionregv1.ValidatingWebhook{
 			{
 				Name: ValidatingWebhookName,
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
-					Service: &admissionv1beta1.ServiceReference{
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					Service: &admissionregv1.ServiceReference{
 						Namespace: testWebhookServiceNamespace,
 						Name:      testWebhookServiceName,
 						Path:      &testWebhookServicePath,

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -10,7 +10,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -59,7 +59,7 @@ var _ = Describe("Test all patch operations", func() {
 			mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
 			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
 
-			req := &v1beta1.AdmissionRequest{Namespace: namespace}
+			req := &admissionv1.AdmissionRequest{Namespace: namespace}
 			jsonPatches, err := wh.createPatch(&pod, req, proxyUUID)
 
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -12,15 +12,15 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"k8s.io/api/admission/v1beta1"
-	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	admissionRegistrationTypes "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
+	admissionRegistrationTypes "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers"
@@ -156,14 +156,16 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func (wh *mutatingWebhook) getAdmissionReqResp(proxyUUID uuid.UUID, admissionRequestBody []byte) (requestForNamespace string, admissionResp v1beta1.AdmissionReview) {
-	var admissionReq v1beta1.AdmissionReview
+func (wh *mutatingWebhook) getAdmissionReqResp(proxyUUID uuid.UUID, admissionRequestBody []byte) (requestForNamespace string, admissionResp admissionv1.AdmissionReview) {
+	var admissionReq admissionv1.AdmissionReview
 	if _, _, err := deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
 		log.Error().Err(err).Msg("Error decoding admission request body")
 		admissionResp.Response = webhook.AdmissionError(err)
 	} else {
 		admissionResp.Response = wh.mutate(admissionReq.Request, proxyUUID)
 	}
+	admissionResp.TypeMeta = admissionReq.TypeMeta
+	admissionResp.Kind = admissionReq.Kind
 
 	return admissionReq.Request.Namespace, admissionResp
 }
@@ -218,7 +220,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	log.Trace().Msgf("Done responding to admission request for pod with UUID %s in namespace %s", proxyUUID, requestForNamespace)
 }
 
-func (wh *mutatingWebhook) mutate(req *v1beta1.AdmissionRequest, proxyUUID uuid.UUID) *v1beta1.AdmissionResponse {
+func (wh *mutatingWebhook) mutate(req *admissionv1.AdmissionRequest, proxyUUID uuid.UUID) *admissionv1.AdmissionResponse {
 	if req == nil {
 		log.Error().Msg("nil admission Request")
 		return webhook.AdmissionError(errNilAdmissionRequest)
@@ -232,7 +234,7 @@ func (wh *mutatingWebhook) mutate(req *v1beta1.AdmissionRequest, proxyUUID uuid.
 	}
 
 	// Start building the response
-	resp := &v1beta1.AdmissionResponse{
+	resp := &admissionv1.AdmissionResponse{
 		Allowed: true,
 		UID:     req.UID,
 	}
@@ -329,24 +331,29 @@ func isAnnotatedForInjection(annotations map[string]string, objectKind string, o
 	return
 }
 
-func patchAdmissionResponse(resp *v1beta1.AdmissionResponse, patchBytes []byte) {
+func patchAdmissionResponse(resp *admissionv1.AdmissionResponse, patchBytes []byte) {
 	resp.Patch = patchBytes
-	pt := v1beta1.PatchTypeJSONPatch
+	pt := admissionv1.PatchTypeJSONPatch
 	resp.PatchType = &pt
 }
 
 // getPartialMutatingWebhookConfiguration returns only the portion of the MutatingWebhookConfiguration that needs to be updated.
-func getPartialMutatingWebhookConfiguration(cert certificate.Certificater, webhookConfigName string) admissionv1beta1.MutatingWebhookConfiguration {
-	return admissionv1beta1.MutatingWebhookConfiguration{
+func getPartialMutatingWebhookConfiguration(cert certificate.Certificater, webhookConfigName string) admissionregv1.MutatingWebhookConfiguration {
+	return admissionregv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: webhookConfigName,
 		},
-		Webhooks: []admissionv1beta1.MutatingWebhook{
+		Webhooks: []admissionregv1.MutatingWebhook{
 			{
 				Name: MutatingWebhookName,
-				ClientConfig: admissionv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregv1.WebhookClientConfig{
 					CABundle: cert.GetCertificateChain(),
 				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
+					return &sideEffect
+				}(),
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}
@@ -355,7 +362,7 @@ func getPartialMutatingWebhookConfiguration(cert certificate.Certificater, webho
 // updateMutatingWebhookCABundle updates the existing MutatingWebhookConfiguration with the CA this OSM instance runs with.
 // It is necessary to perform this patch because the original MutatingWebhookConfig YAML does not contain the root certificate.
 func updateMutatingWebhookCABundle(cert certificate.Certificater, webhookName string, clientSet kubernetes.Interface) error {
-	mwc := clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
+	mwc := clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations()
 
 	patchJSON, err := json.Marshal(getPartialMutatingWebhookConfiguration(cert, webhookName))
 	if err != nil {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/rs/zerolog/log"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,8 +38,8 @@ func GetAdmissionRequestBody(w http.ResponseWriter, req *http.Request) ([]byte, 
 }
 
 // AdmissionError wraps error as AdmissionResponse
-func AdmissionError(err error) *v1beta1.AdmissionResponse {
-	return &v1beta1.AdmissionResponse{
+func AdmissionError(err error) *admissionv1.AdmissionResponse {
+	return &admissionv1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: err.Error(),
 		},

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	tassert "github.com/stretchr/testify/assert"
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -67,7 +67,7 @@ func TestAdmissionError(t *testing.T) {
 	message := uuid.New().String()
 	err := errors.New(message)
 	actual := AdmissionError(err)
-	expected := v1beta1.AdmissionResponse{
+	expected := admissionv1.AdmissionResponse{
 		Result: &metav1.Status{
 			Message: message,
 		},

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -98,8 +98,8 @@ func (td *OsmTestData) CreateService(ns string, svc corev1.Service) (*corev1.Ser
 }
 
 // CreateMutatingWebhook is a wrapper to create a mutating webhook configuration
-func (td *OsmTestData) CreateMutatingWebhook(mwhc *v1beta1.MutatingWebhookConfiguration) (*v1beta1.MutatingWebhookConfiguration, error) {
-	mw, err := td.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Create(context.Background(), mwhc, metav1.CreateOptions{})
+func (td *OsmTestData) CreateMutatingWebhook(mwhc *admissionregv1.MutatingWebhookConfiguration) (*admissionregv1.MutatingWebhookConfiguration, error) {
+	mw, err := td.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), mwhc, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create MutatingWebhook: %v", err)
 		return nil, err
@@ -108,8 +108,8 @@ func (td *OsmTestData) CreateMutatingWebhook(mwhc *v1beta1.MutatingWebhookConfig
 }
 
 // GetMutatingWebhook is a wrapper to get a mutating webhook configuration
-func (td *OsmTestData) GetMutatingWebhook(mwhcName string) (*v1beta1.MutatingWebhookConfiguration, error) {
-	mwhc, err := td.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.Background(), mwhcName, metav1.GetOptions{})
+func (td *OsmTestData) GetMutatingWebhook(mwhcName string) (*admissionregv1.MutatingWebhookConfiguration, error) {
+	mwhc, err := td.Client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), mwhcName, metav1.GetOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not get MutatingWebhook: %v", err)
 		return nil, err

--- a/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
+++ b/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -122,22 +122,27 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 		})
 	})
 
-func getTestMWHC(webhookName, testWebhookServiceNamespace, testWebhookServiceName, testWebhookServicePath string) *v1beta1.MutatingWebhookConfiguration {
-	return &v1beta1.MutatingWebhookConfiguration{
+func getTestMWHC(webhookName, testWebhookServiceNamespace, testWebhookServiceName, testWebhookServicePath string) *admissionregv1.MutatingWebhookConfiguration {
+	return &admissionregv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   webhookName,
 			Labels: Td.GetTestNamespaceSelectorMap(),
 		},
-		Webhooks: []v1beta1.MutatingWebhook{
+		Webhooks: []admissionregv1.MutatingWebhook{
 			{
 				Name: injector.MutatingWebhookName,
-				ClientConfig: v1beta1.WebhookClientConfig{
-					Service: &v1beta1.ServiceReference{
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					Service: &admissionregv1.ServiceReference{
 						Namespace: testWebhookServiceNamespace,
 						Name:      testWebhookServiceName,
 						Path:      &testWebhookServicePath,
 					},
 				},
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
+					return &sideEffect
+				}(),
+				AdmissionReviewVersions: []string{"v1"},
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"some-key": "some-value",


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
OSM has been using admissionregistration.k8s.io/v1beta1
API for the admission webhooks (injector and config
validator webhooks). The v1beta1 API was deprecated
in v1.16 and will not be served in v1.22. Since
OSM only supports versions >= v1.17, this change
upgrades to the v1 API available since v1.16.

v1 API requires additional fields on the webhook
configurations to be set, namely `sideEffects` and
`admissionReviewVersions`. Since the injector
webhook has a sideEffect (creating k8s secret
for the Envoy bootstrap config), the side effect
has been skipped for dry-run requests as indicated
in the [API](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects)


Also updates the injector's timeout to 20s. Previously
this defaulted to 30s as the default timeout with v1beta1.
Since the default timeout wth v1 has changed to 10s, sets
the timeout to 20s to account for slowness in scale env.

Resolves #3030

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`