### PR TITLE
charts/osm: add schema for injector and fix podLabels schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,9 +108,16 @@ clean-osm:
 chart-readme:
 	go run github.com/norwoodj/helm-docs/cmd/helm-docs -c charts -t charts/osm/README.md.gotmpl
 
-.PHONY: chart-checks
-chart-checks: chart-readme
+.PHONY: chart-check-readme
+chart-check-readme: chart-readme
 	@git diff --exit-code charts/osm/README.md || { echo "----- Please commit the changes made by 'make chart-readme' -----"; exit 1; }
+
+.PHONY: helm-lint
+helm-lint:
+	@helm lint charts/osm/ || { echo "----- Schema validation failed for OSM chart values -----"; exit 1; }
+
+.PHONY: chart-checks
+chart-checks: chart-check-readme helm-lint
 
 .PHONY: check-mocks
 check-mocks:

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -34,7 +34,8 @@
                 "tracing",
                 "webhookConfigNamePrefix",
                 "osmcontroller",
-                "enablePrivilegedInitContainer"
+                "enablePrivilegedInitContainer",
+                "injector"
             ],
             "properties": {
                 "replicaCount": {
@@ -112,17 +113,15 @@
                                             "description": "The resources requests memory for the osmcontroller."
                                         }
                                     }
-                                },
-                                "podLabels": {
-                                    "$id": "#/properties/OpenServiceMesh/properties/osmcontroller/properties/podLabels",
-                                    "type": "array",
-                                    "title": "The podLabels schema",
-                                    "description": "Labels for the osmcontroller pod.",
-                                    "items": {
-                                        "type": "string"
-                                    }
                                 }
                             }
+                        },
+                        "podLabels": {
+                            "$id": "#/properties/OpenServiceMesh/properties/osmcontroller/properties/podLabels",
+                            "type": "object",
+                            "title": "The podLabels schema",
+                            "description": "Labels for the osmcontroller pod.",
+                            "default": {}
                         }
                     },
                     "additionalProperties": true
@@ -487,6 +486,95 @@
                     "examples": [
                         false
                     ]
+                },
+                "injector": {
+                    "$id": "#/properties/OpenServiceMesh/properties/injector",
+                    "type": "object",
+                    "title": "The sidecar injector schema",
+                    "description": "Sidecar injector configurations",
+                    "required": [
+                        "replicaCount",
+                        "resource"
+                    ],
+                    "properties": {
+                        "replicaCount": {
+                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/replicaCount",
+                            "type": "integer",
+                            "title": "The replicaCount schema",
+                            "description": "The number of replicas of the osm-injector pod.",
+                            "examples": [
+                                1
+                            ]
+                        },
+                        "resource": {
+                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource",
+                            "type": "object",
+                            "title": "The resource schema",
+                            "description": "The resource configuration for osm-injector.",
+                            "required": [
+                                "limits",
+                                "requests"
+                            ],
+                            "properties": {
+                                "limits": {
+                                    "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource/properties/limits",
+                                    "type": "object",
+                                    "title": "The resource limits schema",
+                                    "description": "The resources limits for osm-injector",
+                                    "required": [
+                                        "cpu",
+                                        "memory"
+                                    ],
+                                    "properties": {
+                                        "cpu": {
+                                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource/properties/limits/properties/cpu",
+                                            "type": "string",
+                                            "title": "The resource limits cpu schema",
+                                            "description": "The resources limits cpu for osm-injector"
+                                        },
+                                        "memory": {
+                                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource/properties/limits/properties/memory",
+                                            "type": "string",
+                                            "title": "The resource limits memory schema",
+                                            "description": "The resources limits cpu for osm-injector"
+                                        }
+                                    }
+                                },
+                                "requests": {
+                                    "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource/properties/requests",
+                                    "type": "object",
+                                    "title": "The resource requests schema",
+                                    "description": "The resources requests for osm-injector",
+                                    "required": [
+                                        "cpu",
+                                        "memory"
+                                    ],
+                                    "properties": {
+                                        "cpu": {
+                                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource/properties/requests/properties/cpu",
+                                            "type": "string",
+                                            "title": "The resource requests cpu schema",
+                                            "description": "The resources requests cpu for osm-injector."
+                                        },
+                                        "memory": {
+                                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/resource/properties/requests/properties/memory",
+                                            "type": "string",
+                                            "title": "The resource requests memory schema",
+                                            "description": "The resources requests memory for osm-injector."
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "podLabels": {
+                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/podLabels",
+                            "type": "object",
+                            "title": "The podLabels schema",
+                            "description": "Labels for the osm-injector pod.",
+                            "default": {}
+                        }
+                    },
+                    "additionalProperties": true
                 }
             },
             "additionalProperties": true


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds a schema for injector's properties and fixes the podLabels
schema for osmController, which was incorrectly defined under
`osmController.resource` in 04780f07.

Adds check to ensure chart values are always validated by
its schema. `make chart-checks` is invoked in the CI.

Resolves #3023

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`