### PR TITLE
bug(reconciler): fix name of mutating webhook in reconciler

### DIFF
--- a/cmd/osm-injector/reconcile.go
+++ b/cmd/osm-injector/reconcile.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -26,7 +24,7 @@ func createReconciler(kubeClient *kubernetes.Clientset) error {
 		Client:       mgr.GetClient(),
 		KubeClient:   kubeClient,
 		Scheme:       mgr.GetScheme(),
-		OsmWebhook:   fmt.Sprintf("osm-webhook-%s", meshName),
+		OsmWebhook:   webhookConfigName,
 		OsmNamespace: osmNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		log.Error().Err(err).Msg("Error creating controller to reconcile MutatingWebhookConfiguration")


### PR DESCRIPTION
**Description**:

 Fixing the name of the mutating webhook that the reconciler will operate on. 

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
