### PR TITLE
catalog: fix flaky test relying on ordering

### DIFF
--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -64,7 +64,8 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			}
 			expectedList := []service.MeshService{expectedSvc, expectedSvc2}
 
-			Expect(meshServices).To(Equal(expectedList))
+			Expect(meshServices).Should(HaveLen(len(expectedList)))
+			Expect(meshServices).Should(ConsistOf(expectedList))
 		})
 
 		It("returns an error with an invalid CN", func() {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes a flaky test that relies on ordering of
values returned in the slice.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`