### PR TITLE
Fix typos in manual demo

### DIFF
--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -136,7 +136,6 @@ In a browser, open up the following urls:
 - [http://localhost:8080](http://localhost:8080) - **bookbuyer**
 - [http://localhost:8083](http://localhost:8083) - **bookthief**
 - [http://localhost:8084](http://localhost:8084) - **bookstore**
-  - _Note: This page will not be available at this time in the demo. This will become available during the SMI Traffic Split configuration set up_
 - [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
   - _Note: This page will not be available at this time in the demo. This will become available during the SMI Traffic Split configuration set up_
 
@@ -235,7 +234,7 @@ kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/release-v
 The counters should now be incrementing for the `bookbuyer`, and `bookstore` applications:
 
 - [http://localhost:8080](http://localhost:8080) - **bookbuyer**
-- [http://localhost:8081](http://localhost:8084) - **bookstore**
+- [http://localhost:8084](http://localhost:8084) - **bookstore**
 
 Note that the counter is _not_ incrementing for the `bookthief` application:
 
@@ -386,7 +385,7 @@ Wait for the changes to propagate and observe the counters increment for `bookst
 browser windows:
 
 - [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
-- [http://localhost:8083](http://localhost:8083) - **bookstore**
+- [http://localhost:8083](http://localhost:8084) - **bookstore**
 
 Now, all traffic directed to the `bookstore` service is flowing to `bookstore-v2`.
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Noticed some typos as I was testing the manual demo for v0.8.2 of osm-arc, creating this PR to address them. 
The bookstore service on :8084 is available initially with permissive_traffic_policy mode enabled, we should not be saying that it's unavailable initially. Moreover, as there is no separate bookstore v1 service on :8081 anymore, we should remove the ref to :8081. Finally, there was a typo where bookstore was stated to be on port :8083 instead of :8084. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [X]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

No
