### PR TITLE
ingress: add support for Exact, Prefix and ImplementationSpecific path matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	k8s.io/apimachinery v0.20.5
 	k8s.io/cli-runtime v0.20.5
 	k8s.io/client-go v0.20.5
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	mvdan.cc/gofumpt v0.1.0 // indirect
 	sigs.k8s.io/controller-runtime v0.6.3
 	sigs.k8s.io/kind v0.9.0

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -2,11 +2,33 @@ package catalog
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
+	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
+
+const (
+	// prefixMatchPathElementsRegex is the regex pattern used to match zero or one grouping of path elements.
+	// A path element is of the form /p, /p1/p2, /p1/p2/p3 etc.
+	// This regex pattern is used to match paths in a way that is compatible with Kubernetes ingress requirements
+	// for Prefix path type, where the prefix must be an element wise prefix and not a string prefix.
+	// Ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types
+	// It is used to regex match paths such that request /foo matches /foo and /foo/bar, but not /foobar.
+	prefixMatchPathElementsRegex = `(\/.*)?$`
+
+	// commonRegexChars is a string comprising of characters commonly used in a regex
+	// It is used to guess whether a path specified appears as a regex.
+	// It is used as a fallback to match ingress paths whose PathType is set to be ImplementationSpecific.
+	commonRegexChars = `^$*+[]%|`
+)
+
+// Ensure the regex patteren for prefix matching for path elements compiles
+var _ = regexp.MustCompile(prefixMatchPathElementsRegex)
 
 // Ingress does not depend on k8s service accounts, program a wildcard (empty struct) to indicate
 // to RDS that an inbound traffic policy for ingress should not enforce service account based RBAC policies.
@@ -46,15 +68,56 @@ func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]
 				if ingressPath.Backend.ServiceName != svc.Name {
 					continue
 				}
-				routePolicy := trafficpolicy.WildCardRouteMatch
-				if ingressPath.Path != "" {
-					routePolicy.Path = ingressPath.Path
-					routePolicy.PathMatchType = trafficpolicy.PathMatchRegex
+
+				httpRouteMatch := trafficpolicy.HTTPRouteMatch{
+					Methods: []string{constants.WildcardHTTPMethod},
 				}
-				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(routePolicy, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
+
+				// Default ingress path type to PathTypeImplementationSpecific if unspecified
+				pathType := networkingV1beta1.PathTypeImplementationSpecific
+				if ingressPath.PathType != nil {
+					pathType = *ingressPath.PathType
+				}
+
+				switch pathType {
+				case networkingV1beta1.PathTypeExact:
+					// Exact match
+					// Request /foo matches path /foo, not /foobar or /foo/bar
+					httpRouteMatch.Path = ingressPath.Path
+					httpRouteMatch.PathMatchType = trafficpolicy.PathMatchExact
+
+				case networkingV1beta1.PathTypePrefix:
+					// Element wise prefix match
+					// Request /foo matches path /foo and /foo/bar, not /foobar
+					httpRouteMatch.Path = ingressPath.Path + prefixMatchPathElementsRegex
+					httpRouteMatch.PathMatchType = trafficpolicy.PathMatchRegex
+
+				case networkingV1beta1.PathTypeImplementationSpecific:
+					httpRouteMatch.Path = ingressPath.Path
+					// If the path looks like a regex, use regex matching.
+					// Else use string based prefix matching.
+					if strings.ContainsAny(ingressPath.Path, commonRegexChars) {
+						// Path contains regex characters, use regex matching for the path
+						// Request /foo/bar matches path /foo.*
+						httpRouteMatch.PathMatchType = trafficpolicy.PathMatchRegex
+					} else {
+						// String based prefix path matching
+						// Request /foo matches /foo/bar and /foobar
+						httpRouteMatch.PathMatchType = trafficpolicy.PathMatchPrefix
+					}
+
+				default:
+					log.Error().Msgf("Invalid pathType=%s unspecified for path %s in ingress resource %s/%s, ignoring this path", *ingressPath.PathType, ingressPath.Path, ingress.Namespace, ingress.Name)
+					continue
+				}
+
+				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(httpRouteMatch, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
 			}
 
-			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)
+			// Only create an ingress policy if the ingress policy resulted in valid rules
+			if len(ingressPolicy.Rules) > 0 {
+				inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)
+			}
 		}
 	}
 	return inboundIngressPolicies, nil

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -10,6 +10,7 @@ import (
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/ingress"
@@ -60,7 +61,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake1-path1",
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -79,7 +81,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake2-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeExact))),
+												Path:     "/fake2-path1",
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -107,7 +110,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
 									Path:          "/fake1-path1",
-									PathMatchType: trafficpolicy.PathMatchRegex,
+									PathMatchType: trafficpolicy.PathMatchPrefix,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{
@@ -129,7 +132,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
 									Path:          "/fake2-path1",
-									PathMatchType: trafficpolicy.PathMatchRegex,
+									PathMatchType: trafficpolicy.PathMatchExact,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{
@@ -171,7 +174,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypePrefix))),
+												Path:     "/fake1-path1",
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -190,7 +194,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake2-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypePrefix))),
+												Path:     "/fake2-path1",
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -235,7 +240,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
-									Path:          "/fake1-path1",
+									Path:          `/fake1-path1(\/.*)?$`,
 									PathMatchType: trafficpolicy.PathMatchRegex,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
@@ -257,7 +262,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
-									Path:          "/fake2-path1",
+									Path:          `/fake2-path1(\/.*)?$`,
 									PathMatchType: trafficpolicy.PathMatchRegex,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
@@ -293,7 +298,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Path:     "/fake1-path1",
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -325,7 +331,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake2-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Path:     "/fake2-path1",
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -353,7 +360,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
 									Path:          "/fake1-path1",
-									PathMatchType: trafficpolicy.PathMatchRegex,
+									PathMatchType: trafficpolicy.PathMatchPrefix,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{
@@ -375,7 +382,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
 									Path:          "/fake2-path1",
-									PathMatchType: trafficpolicy.PathMatchRegex,
+									PathMatchType: trafficpolicy.PathMatchPrefix,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{
@@ -410,7 +417,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Path:     `/fake1-path1.*`,
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -442,7 +450,106 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
 										Paths: []networkingV1beta1.HTTPIngressPath{
 											{
-												Path: "/fake1-path2",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Path:     `/fake1-path2(\/.*)?$`,
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          `/fake1-path1.*`,
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          `/fake1-path2(\/.*)?$`,
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Ingress rule with unset pathType must default to ImplementationSpecific",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												// PathType is unset, will default to ImplementationSpecific
+												Path: "/fake2-path1",
 												Backend: networkingV1beta1.IngressBackend{
 													ServiceName: "foo",
 													ServicePort: intstr.IntOrString{
@@ -470,7 +577,7 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
 									Path:          "/fake1-path1",
-									PathMatchType: trafficpolicy.PathMatchRegex,
+									PathMatchType: trafficpolicy.PathMatchPrefix,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{
@@ -480,11 +587,104 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 							},
 							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
 						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
-									Path:          "/fake1-path2",
-									PathMatchType: trafficpolicy.PathMatchRegex,
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Ingress rule with invalid pathType must be ignored",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												// PathType is invalid, this will be ignored and logged as an error
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr("invalid")),
+												Path:     "/fake2-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
 								WeightedClusters: mapset.NewSet(service.WeightedCluster{

--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -127,7 +127,7 @@ func buildInboundRoutes(rules []*trafficpolicy.Rule) []*xds_route.Route {
 
 		// Each HTTP method corresponds to a separate route
 		for _, method := range allowedMethods {
-			route := buildRoute(rule.Route.HTTPRouteMatch.Path, method, rule.Route.HTTPRouteMatch.Headers, rule.Route.WeightedClusters, 100, InboundRoute)
+			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, method, rule.Route.HTTPRouteMatch.Headers, rule.Route.WeightedClusters, 100, InboundRoute)
 			route.TypedPerFilterConfig = rbacPolicyForRoute
 			routes = append(routes, route)
 		}
@@ -139,20 +139,14 @@ func buildOutboundRoutes(outRoutes []*trafficpolicy.RouteWeightedClusters) []*xd
 	var routes []*xds_route.Route
 	for _, outRoute := range outRoutes {
 		emptyHeaders := map[string]string{}
-		routes = append(routes, buildRoute(constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), OutboundRoute))
+		routes = append(routes, buildRoute(trafficpolicy.PathMatchRegex, constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), OutboundRoute))
 	}
 	return routes
 }
 
-func buildRoute(pathRegex, method string, headersMap map[string]string, weightedClusters set.Set, totalWeight int, direction Direction) *xds_route.Route {
+func buildRoute(pathMatchTypeType trafficpolicy.PathMatchType, path string, method string, headersMap map[string]string, weightedClusters set.Set, totalWeight int, direction Direction) *xds_route.Route {
 	route := xds_route.Route{
 		Match: &xds_route.RouteMatch{
-			PathSpecifier: &xds_route.RouteMatch_SafeRegex{
-				SafeRegex: &xds_matcher.RegexMatcher{
-					EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},
-					Regex:      pathRegex,
-				},
-			},
 			Headers: getHeadersForRoute(method, headersMap),
 		},
 		Action: &xds_route.Route_Route{
@@ -163,6 +157,27 @@ func buildRoute(pathRegex, method string, headersMap map[string]string, weighted
 			},
 		},
 	}
+
+	switch pathMatchTypeType {
+	case trafficpolicy.PathMatchRegex:
+		route.Match.PathSpecifier = &xds_route.RouteMatch_SafeRegex{
+			SafeRegex: &xds_matcher.RegexMatcher{
+				EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},
+				Regex:      path,
+			},
+		}
+
+	case trafficpolicy.PathMatchExact:
+		route.Match.PathSpecifier = &xds_route.RouteMatch_Path{
+			Path: path,
+		}
+
+	case trafficpolicy.PathMatchPrefix:
+		route.Match.PathSpecifier = &xds_route.RouteMatch_Prefix{
+			Prefix: path,
+		}
+	}
+
 	return &route
 }
 

--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 
 	. "github.com/openservicemesh/osm/tests/framework"
 )
@@ -128,18 +129,17 @@ var _ = OSMDescribe("HTTP ingress",
 			ing := &v1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: svcDef.Name,
-					Annotations: map[string]string{
-						"kubernetes.io/ingress.class": "nginx",
-					},
 				},
 				Spec: v1beta1.IngressSpec{
+					IngressClassName: pointer.StringPtr("nginx"),
 					Rules: []v1beta1.IngressRule{
 						{
 							IngressRuleValue: v1beta1.IngressRuleValue{
 								HTTP: &v1beta1.HTTPIngressRuleValue{
 									Paths: []v1beta1.HTTPIngressPath{
 										{
-											Path: "/status/200",
+											Path:     "/status/200",
+											PathType: (*v1beta1.PathType)(pointer.StringPtr(string(v1beta1.PathTypeImplementationSpecific))),
 											Backend: v1beta1.IngressBackend{
 												ServiceName: svcDef.Name,
 												ServicePort: intstr.FromInt(80),


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, ingress programs all paths as regex path
matches in Envoy. This is incorrect because the
`pathType` specifier for a path in an ingress rule
is not honored. There are other limitations this
change addresses with respect to matching on HTTP
paths.

This change extends the ingress implementation to
adhere to the spec as follows:

1. Implements ingress routes based on the `pathType`
   specified for a path in an ingress rule. In addition
   to regex based path matching, exact and prefix based
   path matching is implemented.

2. `Prefix pathType` in k8s ingress is not a string prefix,
   but an element-wise prefix of paths. This is translated
   to a regex match in the envoy route. `Prefix pathType`
   in k8s ingress requires that request /foo match path
   /foo/bar and not match /foobar.

3. Implements `ImplementationSpecific pathType` routes
   by examining if the path appears to be a regex. If
   the path appears to be a regex, uses regex based path
   matching in the Envoy route, and string based prefix
   matching otherwise to be compatible with most ingress
   controllers (Nginx, Azure App Gateway Ingress, Contour etc.).
   This idea is inspired by https://projectcontour.io/, which
   provides the flexibility to do regex based path matching
   for ingress controllers that support it.

4. Implements capability to program Exact and Prefix based
   routes in Envoy, in addition to Regex matching.

The change also removes the existing limitations around only
being able to match paths specified in an ingress if it also
happens to be the appropriate regex match. Regex matching should
not be the default, but rather an option in cases where ingress
controllers support it. This change addresses this problem as
well and significantly improves the usability of ingress in OSM.

Part of #2798

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No code has been borrowed. The idea to handle `ImplementationSpecific` path matching
is inspired by  https://projectcontour.io/.