### PR TITLE
config: add prometheus_scraping flag to trigger envoy reconfig on change

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -163,6 +163,7 @@ func (c *Client) configMapListener() {
 				triggerGlobalBroadcast = triggerGlobalBroadcast || (prevConfigMap.TracingAddress != newConfigMap.TracingAddress)
 				triggerGlobalBroadcast = triggerGlobalBroadcast || (prevConfigMap.TracingEndpoint != newConfigMap.TracingEndpoint)
 				triggerGlobalBroadcast = triggerGlobalBroadcast || (prevConfigMap.TracingPort != newConfigMap.TracingPort)
+				triggerGlobalBroadcast = triggerGlobalBroadcast || (prevConfigMap.PrometheusScraping != newConfigMap.PrometheusScraping)
 
 				if triggerGlobalBroadcast {
 					log.Debug().Msgf("[%s] OSM ConfigMap update triggered global proxy broadcast",


### PR DESCRIPTION
Was not listed to update proxies; new configs have to be pushed to updated lds
when config changes.

Signed-off-by: edu <eduser25@gmail.com>

- Metrics                [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No