### PR TITLE
chore(*): add app labels to all OSM resources

### DIFF
--- a/charts/osm/templates/_helpers.tpl
+++ b/charts/osm/templates/_helpers.tpl
@@ -8,3 +8,10 @@
 {{- $address := printf "jaeger.%s.svc.cluster.local" (include "osm.namespace" .) -}}
 {{ default $address .Values.OpenServiceMesh.tracing.address}} 
 {{- end -}}
+
+{{/* Labels to be added to all resources */}}
+{{- define "osm.labels" -}}
+app.kubernetes.io/name: openservicemesh.io
+app.kubernetes.io/instance: {{ .Values.OpenServiceMesh.meshName }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+{{- end -}}

--- a/charts/osm/templates/fluentbit-configmap.yaml
+++ b/charts/osm/templates/fluentbit-configmap.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: fluentbit-configmap
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 data:
   fluent-bit.conf: |-
     [SERVICE]

--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   name: osm-grafana-config
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 data:
   grafana.ini: |
@@ -28,6 +29,7 @@ metadata:
   name: osm-grafana-datasources
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 data:
   prometheus.yaml: |
@@ -64,6 +66,7 @@ metadata:
   name: osm-grafana-dashboard-definition-dataplane
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 data:
   osm-pod.json: |
@@ -81,6 +84,7 @@ metadata:
   name: osm-grafana-dashboard-definition-controlplane
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 data:
   osm-control-plane.json: |
@@ -96,6 +100,7 @@ metadata:
   name: osm-grafana-dashboards
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 data:
   dashboards.yaml: |

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: osm-grafana
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 spec:
   replicas: 1
@@ -16,6 +17,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "osm.labels" . | nindent 8 }}
         app: osm-grafana
     spec:
       serviceAccountName: osm-grafana

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
   name: osm-grafana
   namespace: {{ include "osm.namespace" . }}
@@ -13,6 +14,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
   name: {{.Release.Name}}-grafana
 rules: []
@@ -24,6 +26,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{.Release.Name}}-grafana
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 subjects:
   - kind: ServiceAccount

--- a/charts/osm/templates/grafana-svc.yaml
+++ b/charts/osm/templates/grafana-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   name: osm-grafana
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
 spec:
   ports:

--- a/charts/osm/templates/jaeger-deployment.yaml
+++ b/charts/osm/templates/jaeger-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: jaeger
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: jaeger
 spec:
   replicas: 1
@@ -14,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "osm.labels" . | nindent 8 }}
         app: jaeger
     spec:
       containers:

--- a/charts/osm/templates/jaeger-service.yaml
+++ b/charts/osm/templates/jaeger-service.yaml
@@ -5,6 +5,7 @@ metadata:
   name: jaeger
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: jaeger
 spec:
   selector:

--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -2,6 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-injector
   name: {{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}
 webhooks:

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: osm-config
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 data:
   permissive_traffic_policy_mode: {{ .Values.OpenServiceMesh.enablePermissiveTrafficPolicy | default "false" | quote }}
   egress: {{ .Values.OpenServiceMesh.enableEgress | quote }}

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: osm-controller
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-controller
     meshName: {{ .Values.OpenServiceMesh.meshName }}
     {{ if .Values.OpenServiceMesh.enforceSingleMesh }}enforceSingleMesh: "true"{{ end }}
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "osm.labels" . | nindent 8 }}
         app: osm-controller
   {{- if .Values.OpenServiceMesh.osmcontroller.podLabels }}
   {{- toYaml .Values.OpenServiceMesh.osmcontroller.podLabels | nindent 8 }}

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: osm-injector
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-injector
     meshName: {{ .Values.OpenServiceMesh.meshName }}
 spec:
@@ -14,6 +15,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "osm.labels" . | nindent 8 }}
         app: osm-injector
   {{- if .Values.OpenServiceMesh.injector.podLabels }}
   {{- toYaml .Values.OpenServiceMesh.injector.podLabels | nindent 8 }}

--- a/charts/osm/templates/osm-injector-service.yaml
+++ b/charts/osm/templates/osm-injector-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: osm-injector
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-injector
 spec:
   ports:

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
@@ -53,11 +55,15 @@ kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Release.Name }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}

--- a/charts/osm/templates/osm-service.yaml
+++ b/charts/osm/templates/osm-service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: osm-controller
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-controller
 spec:
   ports:
@@ -22,6 +23,7 @@ metadata:
   name: osm-config-validator
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-controller
 spec:
   ports:

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   name: osm-prometheus-server-conf
   namespace: {{ include "osm.namespace" . }}
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     name: osm-prometheus-server-conf
 data:
   prometheus.yml: |

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   name: osm-prometheus
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy:
@@ -14,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "osm.labels" . | nindent 8 }}
         app: osm-prometheus
     spec:
       containers:

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{.Release.Name}}-prometheus
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["nodes", "nodes/proxy",  "nodes/metrics", "services", "endpoints", "pods", "ingresses", "configmaps"]
@@ -17,6 +19,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{.Release.Name}}-prometheus
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: osm-prometheus
@@ -31,4 +35,6 @@ kind: ServiceAccount
 metadata:
   name: osm-prometheus
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/osm/templates/prometheus-svc.yaml
+++ b/charts/osm/templates/prometheus-svc.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: osm-prometheus
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
   annotations:
     prometheus.io/port: "{{.Values.OpenServiceMesh.prometheus.port}}"
     prometheus.io/scrape: "true"

--- a/charts/osm/templates/proxy-config.yaml
+++ b/charts/osm/templates/proxy-config.yaml
@@ -4,6 +4,8 @@ kind: Secret
 metadata:
   name: proxy-config
   namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
 stringData:
   HTTP_PROXY: {{ .Values.OpenServiceMesh.fluentBit.httpProxy | quote }}
   HTTPS_PROXY: {{ .Values.OpenServiceMesh.fluentBit.httpsProxy | quote }}

--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -2,6 +2,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
+    {{- include "osm.labels" . | nindent 4 }}
     app: osm-controller
   name: {{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}
 webhooks:

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/debugger"
+	"github.com/openservicemesh/osm/pkg/version"
 )
 
 const (
@@ -169,6 +170,10 @@ func GetCertificateFromSecret(ns string, secretName string, cert certificate.Cer
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: ns,
+			Labels: map[string]string{
+				constants.OSMAppNameLabelKey:    constants.OSMAppNameLabelValue,
+				constants.OSMAppVersionLabelKey: version.Version,
+			},
 		},
 		Data: secretData,
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -163,3 +163,11 @@ const (
 	// PrometheusPathAnnotation is the annotation used to configure the path to scrape on
 	PrometheusPathAnnotation = "prometheus.io/path"
 )
+
+// App labels as defined in the "osm.labels" template in _helpers.tpl of the Helm chart.
+const (
+	OSMAppNameLabelKey     = "app.kubernetes.io/name"
+	OSMAppNameLabelValue   = "openservicemesh.io"
+	OSMAppInstanceLabelKey = "app.kubernetes.io/instance"
+	OSMAppVersionLabelKey  = "app.kubernetes.io/version"
+)

--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/version"
 )
 
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Configurator) ([]byte, error) {
@@ -126,6 +127,11 @@ func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamesp
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
+			Labels: map[string]string{
+				constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+				constants.OSMAppInstanceLabelKey: wh.meshName,
+				constants.OSMAppVersionLabelKey:  version.Version,
+			},
 		},
 		Data: map[string][]byte{
 			envoyBootstrapConfigFile: yamlContent,

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/version"
 )
 
 var _ = Describe("Test functions creating Envoy bootstrap configuration", func() {
@@ -155,6 +156,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				kubeClient:          fake.NewSimpleClientset(),
 				kubeController:      k8s.NewMockController(gomock.NewController(GinkgoT())),
 				nonInjectNamespaces: mapset.NewSet(),
+				meshName:            "some-mesh",
 			}
 			name := uuid.New().String()
 			namespace := "a"
@@ -167,6 +169,11 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: "some-mesh",
+						constants.OSMAppVersionLabelKey:  version.Version,
+					},
 				},
 				Data: map[string][]byte{
 					envoyBootstrapConfigFile: []byte(getExpectedEnvoyYAML(expectedEnvoyBootstrapConfigFileName)),

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -25,6 +25,7 @@ type mutatingWebhook struct {
 	certManager    certificate.Manager
 	kubeController k8s.Controller
 	osmNamespace   string
+	meshName       string
 	cert           certificate.Certificater
 	configurator   configurator.Configurator
 

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -80,6 +80,7 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 		certManager:    certManager,
 		kubeController: kubeController,
 		osmNamespace:   osmNamespace,
+		meshName:       meshName,
 		cert:           webhookHandlerCert,
 		configurator:   cfg,
 


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change modifies all resources created by OSM to contain the
following labels:

    app.kubernetes.io/name: openservicemesh
    app.kubernetes.io/instance: <mesh name>
    app.kubernetes.io/version: <Chart.yaml appVersion>

These labels have been added as a helper template in the Helm chart
named "osm.labels". In addition, Envoy bootstrap secrets created by the
injector will also contain these labels. The osm-ca-bundle created by
osm-controller will contain the above labels besides
`app.kubernetes.io/instance` because the same secret may be used across
different OSM instances. The labels have not been added to SMI CRDs as
they are not directly owned by OSM.

No functional changes as no existing labels have been removed or
modified. Cleanup and consistency of existing labels may be done later.

Fixes #2925
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No