### PR TITLE
fix(cli): print namespace and mesh for commands

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -339,7 +339,7 @@ func (i *installCmd) validateOptions() error {
 	if osmControllerDeployments != nil && len(osmControllerDeployments.Items) > 0 {
 		return errNamespaceAlreadyHasController(settings.Namespace())
 	} else if err != nil {
-		return fmt.Errorf("Error ensuring no osm-controller running in namespace %s:%s", settings.Namespace(), err)
+		return annotateErrorMessageWithOsmNamespace("Error ensuring no osm-controller running in OSM namespace [%s]: %s", settings.Namespace(), err)
 	}
 
 	// validate the envoy log level type
@@ -418,5 +418,5 @@ func errMeshAlreadyExists(name string) error {
 }
 
 func errNamespaceAlreadyHasController(namespace string) error {
-	return errors.Errorf("Namespace %s has an osm controller. Please specify a new namespace using --osm-namespace", namespace)
+	return annotateErrorMessageWithOsmNamespace("Namespace [%s] already has an osm controller.", namespace)
 }

--- a/cmd/cli/mesh_upgrade.go
+++ b/cmd/cli/mesh_upgrade.go
@@ -178,7 +178,7 @@ func (u *meshUpgradeCmd) run(config *helm.Configuration) error {
 		return err
 	}
 
-	fmt.Fprintf(u.out, "OSM successfully upgraded mesh %s\n", u.meshName)
+	fmt.Fprintf(u.out, "OSM successfully upgraded mesh [%s] in namespace [%s]\n", u.meshName, settings.Namespace())
 	return nil
 }
 

--- a/cmd/cli/proxy_get_test.go
+++ b/cmd/cli/proxy_get_test.go
@@ -46,3 +46,33 @@ func TestIsMeshedPod(t *testing.T) {
 		})
 	}
 }
+
+func TestAnnotateErrMsgWithPodNamespaceMsg(t *testing.T) {
+	assert := tassert.New(t)
+
+	type test struct {
+		errorMsg     string
+		podName      string
+		podNamespace string
+		annotatedMsg string
+	}
+
+	podNamespaceActionableMsg := "Note: Use the flag --namespace to modify the intended pod namespace."
+
+	testCases := []test{
+		{
+			"Proxy get command error for pod name [%s] in pod namespace [%s]",
+			"test-pod-name",
+			"test-namespace",
+			"Proxy get command error for pod name [test-pod-name] in pod namespace [test-namespace]\n\n" + podNamespaceActionableMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing annotated error message for pod name [%s] in pod namespace [%s]", tc.podName, tc.podNamespace), func(t *testing.T) {
+			assert.Equal(
+				tc.annotatedMsg,
+				annotateErrMsgWithPodNamespaceMsg(tc.errorMsg, tc.podName, tc.podNamespace).Error())
+		})
+	}
+}

--- a/cmd/cli/trafficpolicy_check.go
+++ b/cmd/cli/trafficpolicy_check.go
@@ -89,12 +89,12 @@ func (cmd *trafficPolicyCheckCmd) run() error {
 	// Validate input for options
 	srcNs, srcPodName, err := unmarshalNamespacedPod(cmd.sourcePod)
 	if err != nil {
-		return errors.Errorf("Invalid argument specified for the source pod: %s", err)
+		return errors.Errorf("Invalid argument specified for the source pod [%s/%s]: %s", srcNs, srcPodName, err)
 	}
 
 	dstNs, dstPodName, err := unmarshalNamespacedPod(cmd.destinationPod)
 	if err != nil {
-		return errors.Errorf("Invalid argument specified for the destination pod: %s", err)
+		return errors.Errorf("Invalid argument specified for the destination pod [%s/%s]: %s", dstNs, dstPodName, err)
 	}
 
 	srcPod, err := cmd.getMeshedPod(srcNs, srcPodName)

--- a/cmd/cli/uninstall.go
+++ b/cmd/cli/uninstall.go
@@ -92,7 +92,7 @@ func (d *uninstallCmd) run() error {
 	}
 
 	if err == nil {
-		fmt.Fprintf(d.out, "OSM [mesh name: %s] uninstalled\n", d.meshName)
+		fmt.Fprintf(d.out, "OSM [mesh name: %s] in namespace [%s] uninstalled\n", d.meshName, settings.Namespace())
 	}
 
 	if d.deleteNamespace {

--- a/cmd/cli/uninstall_test.go
+++ b/cmd/cli/uninstall_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Running the uninstall command", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should give a message confirming the successful uninstall", func() {
-				Expect(out.String()).To(ContainSubstring("OSM [mesh name: testing] uninstalled\n"))
+				Expect(out.String()).To(ContainSubstring("OSM [mesh name: testing] in namespace [osm-system] uninstalled\n"))
 			})
 
 		})
@@ -260,7 +260,7 @@ var _ = Describe("Running the uninstall command", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("should give a message confirming the uninstall of OSM", func() {
-				Expect(out.String()).To(ContainSubstring("OSM [mesh name: " + meshName + "] uninstalled\n"))
+				Expect(out.String()).To(ContainSubstring("OSM [mesh name: " + meshName + "] in namespace [" + settings.Namespace() + "] uninstalled\n"))
 			})
 			It("should give a message confirming the deletion on namespace", func() {
 				Expect(out.String()).To(ContainSubstring("OSM namespace [" + settings.Namespace() + "] deleted successfully\n"))

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // confirm displays a prompt `s` to the user and returns a bool indicating yes / no
@@ -37,4 +39,25 @@ func confirm(stdin io.Reader, stdout io.Writer, s string, tries int) (bool, erro
 	}
 
 	return false, nil
+}
+
+func annotateErrorMessageWithOsmNamespace(errMsgFormat string, args ...interface{}) error {
+	osmNamespaceErrorMsg := fmt.Sprintf(
+		"Note: The command failed when run in the OSM namespace [%s].\n"+
+			"Use the global flag --osm-namespace if [%s] is not the intended OSM namespace.",
+		settings.Namespace(), settings.Namespace())
+
+	return annotateErrorMessageWithActionableMessage(osmNamespaceErrorMsg, errMsgFormat, args...)
+}
+
+func annotateErrorMessageWithActionableMessage(actionableMessage string, errMsgFormat string, args ...interface{}) error {
+	if !strings.HasSuffix(errMsgFormat, "\n") {
+		errMsgFormat += "\n"
+	}
+
+	if !strings.HasSuffix(errMsgFormat, "\n\n") {
+		errMsgFormat += "\n"
+	}
+
+	return errors.Errorf(errMsgFormat+actionableMessage, args...)
 }

--- a/cmd/cli/util_test.go
+++ b/cmd/cli/util_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestAnnotateErrorMessageWithActionableMessage(t *testing.T) {
+	assert := tassert.New(t)
+
+	type test struct {
+		errorMsg     string
+		name         string
+		namespace    string
+		exceptionMsg string
+		annotatedMsg string
+	}
+
+	actionableMsg := "Use flags to modify the command to suit your needs"
+
+	testCases := []test{
+		{
+			"Error message with args such as [name: %s], [namespace: %s], and [err: %s]",
+			"osm-name",
+			"osm-namespace",
+			"osm-exception",
+			"Error message with args such as [name: osm-name], [namespace: osm-namespace], and [err: osm-exception]\n\n" + actionableMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Testing annotated error message", func(t *testing.T) {
+			assert.Equal(
+				tc.annotatedMsg,
+				annotateErrorMessageWithActionableMessage(actionableMsg, tc.errorMsg, tc.name, tc.namespace, tc.exceptionMsg).Error())
+		})
+	}
+}
+
+func TestAnnotateErrorMessageWithOsmNamespace(t *testing.T) {
+	assert := tassert.New(t)
+
+	type test struct {
+		errorMsg     string
+		name         string
+		namespace    string
+		exceptionMsg string
+		annotatedMsg string
+	}
+
+	osmNamespaceErrorMsg := fmt.Sprintf(
+		"Note: The command failed when run in the OSM namespace [%s].\n"+
+			"Use the global flag --osm-namespace if [%s] is not the intended OSM namespace.",
+		settings.Namespace(), settings.Namespace())
+
+	testCases := []test{
+		{
+			"Error message with args such as [name: %s], [namespace: %s], and [err: %s]",
+			"osm-name",
+			"osm-namespace",
+			"osm-exception",
+			"Error message with args such as [name: osm-name], [namespace: osm-namespace], and [err: osm-exception]\n\n" + osmNamespaceErrorMsg,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("Testing annotated error message", func(t *testing.T) {
+			assert.Equal(
+				tc.annotatedMsg,
+				annotateErrorMessageWithOsmNamespace(tc.errorMsg, tc.name, tc.namespace, tc.exceptionMsg).Error())
+		})
+	}
+}


### PR DESCRIPTION
Adds annotated diagnostic and error messages for various
commands. These annotations print the OSM namespace
and mesh name, which improves the CLI UX. Fixes #2455.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds annotated diagnostic and error messages for various
commands. These annotations print the OSM namespace
and mesh name, which improves the CLI UX. Fixes #2455.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A.
