### PR TITLE
rds: Alias deckarep/golang-set to mapset

### DIFF
--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	set "github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/golang/mock/gomock"
 	proto "github.com/golang/protobuf/ptypes"
@@ -112,9 +112,9 @@ func TestNewResponse(t *testing.T) {
 									PathMatchType: trafficpolicy.PathMatchRegex,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
-								WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+								WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 							},
-							AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+							AllowedServiceAccounts: mapset.NewSet(tests.BookstoreServiceAccount),
 						},
 					},
 				},
@@ -129,9 +129,9 @@ func TestNewResponse(t *testing.T) {
 									PathMatchType: trafficpolicy.PathMatchRegex,
 									Methods:       []string{constants.WildcardHTTPMethod},
 								},
-								WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+								WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 							},
-							AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+							AllowedServiceAccounts: mapset.NewSet(tests.BookstoreServiceAccount),
 						},
 					},
 				},
@@ -155,12 +155,12 @@ func TestNewResponse(t *testing.T) {
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: tests.BookstoreBuyHTTPRoute,
-								WeightedClusters: set.NewSet(service.WeightedCluster{
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
 									ClusterName: "default/bookstore-v1-local",
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: set.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -168,12 +168,12 @@ func TestNewResponse(t *testing.T) {
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: tests.BookstoreSellHTTPRoute,
-								WeightedClusters: set.NewSet(service.WeightedCluster{
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
 									ClusterName: "default/bookstore-v1-local",
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: set.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -198,12 +198,12 @@ func TestNewResponse(t *testing.T) {
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: tests.BookstoreBuyHTTPRoute,
-								WeightedClusters: set.NewSet(service.WeightedCluster{
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
 									ClusterName: "default/bookstore-v1-local",
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: set.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -211,12 +211,12 @@ func TestNewResponse(t *testing.T) {
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch: tests.BookstoreSellHTTPRoute,
-								WeightedClusters: set.NewSet(service.WeightedCluster{
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
 									ClusterName: "default/bookstore-v1-local",
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: set.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -231,7 +231,7 @@ func TestNewResponse(t *testing.T) {
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
 							HTTPRouteMatch: tests.WildCardRouteMatch,
-							WeightedClusters: set.NewSetFromSlice([]interface{}{
+							WeightedClusters: mapset.NewSetFromSlice([]interface{}{
 								service.WeightedCluster{ClusterName: "default/bookstore-v1", Weight: 0},
 								service.WeightedCluster{ClusterName: "default/bookstore-v2", Weight: 100},
 							}),
@@ -427,9 +427,9 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 							PathMatchType: trafficpolicy.PathMatchRegex,
 							Methods:       []string{constants.WildcardHTTPMethod},
 						},
-						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+						WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 					},
-					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+					AllowedServiceAccounts: mapset.NewSet(tests.BookstoreServiceAccount),
 				},
 			},
 		},
@@ -455,7 +455,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 						PathMatchType: trafficpolicy.PathMatchRegex,
 						Methods:       []string{constants.WildcardHTTPMethod},
 					},
-					WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+					WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 				},
 			},
 		},
@@ -473,9 +473,9 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 							PathMatchType: trafficpolicy.PathMatchRegex,
 							Methods:       []string{constants.WildcardHTTPMethod},
 						},
-						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+						WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 					},
-					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+					AllowedServiceAccounts: mapset.NewSet(tests.BookstoreServiceAccount),
 				},
 			},
 		},
@@ -490,9 +490,9 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 							PathMatchType: trafficpolicy.PathMatchRegex,
 							Methods:       []string{constants.WildcardHTTPMethod},
 						},
-						WeightedClusters: set.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+						WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 					},
-					AllowedServiceAccounts: set.NewSet(tests.BookstoreServiceAccount),
+					AllowedServiceAccounts: mapset.NewSet(tests.BookstoreServiceAccount),
 				},
 			},
 		},


### PR DESCRIPTION
This PR re-aliases `deckarep/golang-set` to `mapset` for consistency.