### PR TITLE
ads: sendResponse to workequeue/jobs

### DIFF
--- a/pkg/envoy/ads/jobs.go
+++ b/pkg/envoy/ads/jobs.go
@@ -1,0 +1,47 @@
+package ads
+
+import (
+	"fmt"
+
+	mapset "github.com/deckarep/golang-set"
+	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+// proxyResponseJob is the workerpool job implementation for a Proxy response function
+// It takes the parameters of `server.sendResponse` and allows to queue it as a job on a workerpool
+type proxyResponseJob struct {
+	typeurls  mapset.Set
+	proxy     *envoy.Proxy
+	cfg       configurator.Configurator
+	adsStream *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer
+	request   *xds_discovery.DiscoveryRequest
+	xdsServer *Server
+
+	// Optional waiter
+	done chan struct{}
+}
+
+// Run implementation for `server.sendResponse` job
+func (proxyJob *proxyResponseJob) Run() {
+	err := (*proxyJob.xdsServer).sendResponse(proxyJob.typeurls, proxyJob.proxy, proxyJob.adsStream, proxyJob.request, proxyJob.cfg)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to create and send %v update to Envoy with xDS Certificate SerialNumber=%s for PodUUID=%s",
+			proxyJob.typeurls, proxyJob.proxy.GetCertificateSerialNumber(), proxyJob.proxy.GetPodUID())
+	}
+	close(proxyJob.done)
+}
+
+// JobName implementation for this job, for logging purposes
+func (proxyJob *proxyResponseJob) JobName() string {
+	return fmt.Sprintf("sendJob-%s", proxyJob.proxy.GetCertificateSerialNumber())
+}
+
+// Hash implementation for this job to hash into the worker queues
+func (proxyJob *proxyResponseJob) Hash() uint64 {
+	// Uses proxy hash to always serialize work for the same proxy to the same worker,
+	// this avoid out-of-order misshandling of envoy updates by multiple workers
+	return proxyJob.proxy.GetHash()
+}

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -17,10 +17,16 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy/rds"
 	"github.com/openservicemesh/osm/pkg/envoy/sds"
 	"github.com/openservicemesh/osm/pkg/utils"
+	"github.com/openservicemesh/osm/pkg/workerpool"
 )
 
-// ServerType is the type identifier for the ADS server
-const ServerType = "ADS"
+const (
+	// ServerType is the type identifier for the ADS server
+	ServerType = "ADS"
+
+	// workerPoolSize is the default number of workerpool workers (0 is GOMAXPROCS)
+	workerPoolSize = 0
+)
 
 // NewADSServer creates a new Aggregated Discovery Service server
 func NewADSServer(meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamespace string, cfg configurator.Configurator, certManager certificate.Manager) *Server {
@@ -38,6 +44,7 @@ func NewADSServer(meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamesp
 		certManager:    certManager,
 		xdsMapLogMutex: sync.Mutex{},
 		xdsLog:         make(map[certificate.CommonName]map[envoy.TypeURI][]time.Time),
+		workqueues:     workerpool.NewWorkerPool(workerPoolSize),
 	}
 
 	return &server

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/workerpool"
 )
 
 var (
@@ -28,4 +29,5 @@ type Server struct {
 	cfg            configurator.Configurator
 	certManager    certificate.Manager
 	ready          bool
+	workqueues     *workerpool.WorkerPool
 }

--- a/pkg/utils/stringhash.go
+++ b/pkg/utils/stringhash.go
@@ -1,0 +1,15 @@
+package utils
+
+import "hash/fnv"
+
+// HashFromString calculates an FNV-1 hash from a given string,
+// returns it as a uint64 and error, if any
+func HashFromString(s string) (uint64, error) {
+	h := fnv.New64()
+	_, err := h.Write([]byte(s))
+	if err != nil {
+		return 0, err
+	}
+
+	return h.Sum64(), nil
+}

--- a/pkg/utils/stringhash_test.go
+++ b/pkg/utils/stringhash_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestHashFromString(t *testing.T) {
+	assert := tassert.New(t)
+
+	stringHash, err := HashFromString("some string")
+	assert.NoError(err)
+	assert.NotZero(stringHash)
+
+	emptyStringHash, err := HashFromString("")
+	assert.NoError(err)
+	assert.Equal(emptyStringHash, uint64(14695981039346656037))
+
+	assert.NotEqual(stringHash, emptyStringHash)
+}


### PR DESCRIPTION
This change makes envoy configurations to be serialized in a preset,
constant number of go routines as opposed to having each envoy using
his own ADS worker/goroutine context to compute its configuration.

This change helps in making the runtime more deterministic as the number
of active work/ers to be scheduled by the scheduler will remain mostly
constant regardless of the number of proxies connected. 

- This prevents too many active workers starving other critical routines, which include
liveness probes, dispatcher routine, or other lower level library routines like
Kubernetes informers or other network-related routines (grpc steams).
- This patch allows also to better determine how much time an envoy update
actually takes, as before it depended directly and entirely on how much other work the
scheduler had to schedule at any one time.
- Theoretically, too much concurrent work before could make one routine lock a Kubernetes
cache resource and have a full spin of other routines just to have them yield,
because none of the others could proceed as the first one could have yielded while
still holding a cache lock during a cache lookup, thus making the scheduler 
unnecessarily juggle active work.

Doc:
https://docs.google.com/document/d/1r-hwp81N84kVFECr4AykNEjyqbi4npGfaJA2vRujrgQ/edit#

In this patch, the ADS routine will wait for the job to finish to avoid queuing
up more work.

Signed-off-by: edu <eduser25@gmail.com>

**Affected area**:

- Control Plane          [x]
- Performance            [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No