### PR TITLE
ingress: prepare for supporting multiple ingress versions

### DIFF
--- a/mockspec/rules
+++ b/mockspec/rules
@@ -5,6 +5,9 @@
 # pkg/smi
 smi; pkg/smi/mock_meshspec_generated.go; github.com/openservicemesh/osm/pkg/smi; MeshSpec
 
+# pkg/ingress
+ingress; pkg/ingress/mock_client_generated.go; github.com/openservicemesh/osm/pkg/ingress; Monitor
+
 # pkg/kubernetes
 kubernetes; pkg/kubernetes/mock_controller_generated.go; github.com/openservicemesh/osm/pkg/kubernetes; Controller
 
@@ -13,9 +16,6 @@ debugger; pkg/debugger/mock_debugger_generated.go; github.com/openservicemesh/os
 
 # pkg/health
 health; pkg/health/mock_probes_generated.go; github.com/openservicemesh/osm/pkg/health; Probes
-
-# pkg/ingress
-ingress; pkg/ingress/mock_client_generated.go; github.com/openservicemesh/osm/pkg/ingress; Monitor
 
 # pkg/endpoint
 endpoint; pkg/endpoint/mock_provider_generated.go; github.com/openservicemesh/osm/pkg/endpoint; Provider

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -46,7 +46,8 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 
 	certManager := tresor.NewFakeCertManager(cfg)
 
-	mockIngressMonitor.EXPECT().GetIngressResources(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockIngressMonitor.EXPECT().GetAPIVersion().Return(ingress.IngressNetworkingV1beta1).AnyTimes()
 
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -703,7 +703,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			mockIngressMonitor.EXPECT().GetIngressResources(tc.svc).Return(tc.ingresses, nil).Times(1)
+			mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(tc.svc).Return(tc.ingresses, nil).Times(1)
+			mockIngressMonitor.EXPECT().GetAPIVersion().Return(ingress.IngressNetworkingV1beta1).Times(1)
 
 			actualPolicies, err := meshCatalog.GetIngressPoliciesForService(tc.svc)
 

--- a/pkg/ingress/errors.go
+++ b/pkg/ingress/errors.go
@@ -5,4 +5,10 @@ import "github.com/pkg/errors"
 var (
 	errSyncingCaches = errors.New("Failed initial cache sync for Ingress informer")
 	errInitInformers = errors.New("Ingress informer not initialized")
+
+	// errUnexpectedAPIVersion indicates the requested ingress version is unexpected
+	errUnexpectedAPIVersion = errors.New("Unexpected ingress API version")
+
+	// ErrUnsupportedAPIVersion indicates the requested version of ingress is unsupported
+	ErrUnsupportedAPIVersion = errors.New("Unsupported ingress API version")
 )

--- a/pkg/ingress/mock_client_generated.go
+++ b/pkg/ingress/mock_client_generated.go
@@ -35,17 +35,31 @@ func (m *MockMonitor) EXPECT() *MockMonitorMockRecorder {
 	return m.recorder
 }
 
-// GetIngressResources mocks base method
-func (m *MockMonitor) GetIngressResources(arg0 service.MeshService) ([]*v1beta1.Ingress, error) {
+// GetAPIVersion mocks base method
+func (m *MockMonitor) GetAPIVersion() APIVersion {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIngressResources", arg0)
+	ret := m.ctrl.Call(m, "GetAPIVersion")
+	ret0, _ := ret[0].(APIVersion)
+	return ret0
+}
+
+// GetAPIVersion indicates an expected call of GetAPIVersion
+func (mr *MockMonitorMockRecorder) GetAPIVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIVersion", reflect.TypeOf((*MockMonitor)(nil).GetAPIVersion))
+}
+
+// GetIngressNetworkingV1beta1 mocks base method
+func (m *MockMonitor) GetIngressNetworkingV1beta1(arg0 service.MeshService) ([]*v1beta1.Ingress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIngressNetworkingV1beta1", arg0)
 	ret0, _ := ret[0].([]*v1beta1.Ingress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetIngressResources indicates an expected call of GetIngressResources
-func (mr *MockMonitorMockRecorder) GetIngressResources(arg0 interface{}) *gomock.Call {
+// GetIngressNetworkingV1beta1 indicates an expected call of GetIngressNetworkingV1beta1
+func (mr *MockMonitorMockRecorder) GetIngressNetworkingV1beta1(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressResources", reflect.TypeOf((*MockMonitor)(nil).GetIngressResources), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressNetworkingV1beta1", reflect.TypeOf((*MockMonitor)(nil).GetIngressNetworkingV1beta1), arg0)
 }

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -14,16 +14,31 @@ var (
 	log = logger.New("kube-ingress")
 )
 
+// APIVersion is the API version for the ingress resource
+type APIVersion int
+
+const (
+	// IngressNetworkingV1 refers to the networking.k8s.io/v1 ingress API
+	IngressNetworkingV1 APIVersion = iota
+
+	// IngressNetworkingV1beta1 refers to the networking.k8s.io/v1beta1 ingress API
+	IngressNetworkingV1beta1 APIVersion = iota
+)
+
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
 	informer       cache.SharedIndexInformer
 	cache          cache.Store
 	cacheSynced    chan interface{}
 	kubeController k8s.Controller
+	apiVersion     APIVersion
 }
 
 // Monitor is the client interface for K8s Ingress resource
 type Monitor interface {
-	// GetIngressResources returns the ingress resources whose backends correspond to the service
-	GetIngressResources(service.MeshService) ([]*networkingV1beta1.Ingress, error)
+	// GetAPIVersion returns the ingress API version
+	GetAPIVersion() APIVersion
+
+	// GetIngressNetworkingV1beta1 returns the ingress resources whose backends correspond to the service
+	GetIngressNetworkingV1beta1(service.MeshService) ([]*networkingV1beta1.Ingress, error)
 }


### PR DESCRIPTION
This change is in preparation to support multiple versions
of the ingress API: networking.k8s.io/v1beta & v1.

The v1beta1 API has been deprecated in k8s 1.19, and will
be unusable in 1.22. However since OSM supports versions
`>= 1.18`, the v1beta1 API must still be supported. Moreover,
existing users could be leveraging the older v1beta1 API.
This change introduces versioning for ingress resources,
with the goal to support ingress v1 and making the
version configurable in subsequent changes.

Also updates the ordering of mock generation to avoid
dependency issues.

Part of #2798

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`