### PR TITLE
ingress: add support for ingress v1

### DIFF
--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	networkingV1 "k8s.io/api/networking/v1"
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -39,8 +40,7 @@ var wildcardServiceAccount = service.K8sServiceAccount{}
 func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
 	switch mc.ingressMonitor.GetAPIVersion() {
 	case ingress.IngressNetworkingV1:
-		// TODO: Implement this as a part of issue #2798
-		return nil, ingress.ErrUnsupportedAPIVersion
+		return mc.getIngressPoliciesNetworkingV1(svc)
 
 	case ingress.IngressNetworkingV1beta1:
 		return mc.getIngressPoliciesNetworkingV1beta1(svc)
@@ -113,6 +113,95 @@ func (mc *MeshCatalog) getIngressPoliciesNetworkingV1beta1(svc service.MeshServi
 					httpRouteMatch.PathMatchType = trafficpolicy.PathMatchRegex
 
 				case networkingV1beta1.PathTypeImplementationSpecific:
+					httpRouteMatch.Path = ingressPath.Path
+					// If the path looks like a regex, use regex matching.
+					// Else use string based prefix matching.
+					if strings.ContainsAny(ingressPath.Path, commonRegexChars) {
+						// Path contains regex characters, use regex matching for the path
+						// Request /foo/bar matches path /foo.*
+						httpRouteMatch.PathMatchType = trafficpolicy.PathMatchRegex
+					} else {
+						// String based prefix path matching
+						// Request /foo matches /foo/bar and /foobar
+						httpRouteMatch.PathMatchType = trafficpolicy.PathMatchPrefix
+					}
+
+				default:
+					log.Error().Msgf("Invalid pathType=%s unspecified for path %s in ingress resource %s/%s, ignoring this path", *ingressPath.PathType, ingressPath.Path, ingress.Namespace, ingress.Name)
+					continue
+				}
+
+				ingressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(httpRouteMatch, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
+			}
+
+			// Only create an ingress policy if the ingress policy resulted in valid rules
+			if len(ingressPolicy.Rules) > 0 {
+				inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)
+			}
+		}
+	}
+	return inboundIngressPolicies, nil
+}
+
+// getIngressPoliciesNetworkingV1 returns the list of inbound traffic policies associated with networking.k8s.io/v1 ingress resources for the given service
+func (mc *MeshCatalog) getIngressPoliciesNetworkingV1(svc service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
+	inboundIngressPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+
+	ingresses, err := mc.ingressMonitor.GetIngressNetworkingV1(svc)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to get ingress resources for service %s", svc)
+		return inboundIngressPolicies, err
+	}
+	if len(ingresses) == 0 {
+		log.Trace().Msgf("No ingress resources found for service %s", svc)
+		return inboundIngressPolicies, err
+	}
+
+	ingressWeightedCluster := getDefaultWeightedClusterForService(svc)
+
+	for _, ingress := range ingresses {
+		if ingress.Spec.DefaultBackend != nil && ingress.Spec.DefaultBackend.Service.Name == svc.Name {
+			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
+			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(trafficpolicy.WildCardRouteMatch, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
+			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
+		}
+
+		for _, rule := range ingress.Spec.Rules {
+			domain := rule.Host
+			if domain == "" {
+				domain = constants.WildcardHTTPMethod
+			}
+			ingressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, domain), []string{domain})
+
+			for _, ingressPath := range rule.HTTP.Paths {
+				if ingressPath.Backend.Service.Name != svc.Name {
+					continue
+				}
+
+				httpRouteMatch := trafficpolicy.HTTPRouteMatch{
+					Methods: []string{constants.WildcardHTTPMethod},
+				}
+
+				// Default ingress path type to PathTypeImplementationSpecific if unspecified
+				pathType := networkingV1.PathTypeImplementationSpecific
+				if ingressPath.PathType != nil {
+					pathType = *ingressPath.PathType
+				}
+
+				switch pathType {
+				case networkingV1.PathTypeExact:
+					// Exact match
+					// Request /foo matches path /foo, not /foobar or /foo/bar
+					httpRouteMatch.Path = ingressPath.Path
+					httpRouteMatch.PathMatchType = trafficpolicy.PathMatchExact
+
+				case networkingV1.PathTypePrefix:
+					// Element wise prefix match
+					// Request /foo matches path /foo and /foo/bar, not /foobar
+					httpRouteMatch.Path = ingressPath.Path + prefixMatchPathElementsRegex
+					httpRouteMatch.PathMatchType = trafficpolicy.PathMatchRegex
+
+				case networkingV1.PathTypeImplementationSpecific:
 					httpRouteMatch.Path = ingressPath.Path
 					// If the path looks like a regex, use regex matching.
 					// Else use string based prefix matching.

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -7,6 +7,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
+	networkingV1 "k8s.io/api/networking/v1"
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -22,7 +23,7 @@ var (
 	fakeIngressPort int32 = 80
 )
 
-func TestGetIngressPoliciesForService(t *testing.T) {
+func TestGetIngressPoliciesNetworkingV1beta1(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -704,7 +705,975 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
 			mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(tc.svc).Return(tc.ingresses, nil).Times(1)
-			mockIngressMonitor.EXPECT().GetAPIVersion().Return(ingress.IngressNetworkingV1beta1).Times(1)
+
+			actualPolicies, err := meshCatalog.getIngressPoliciesNetworkingV1beta1(tc.svc)
+
+			assert.Equal(tc.excpectError, err != nil)
+			assert.ElementsMatch(tc.expectedTrafficPolicies, actualPolicies)
+		})
+	}
+}
+
+func TestGetIngressPoliciesNetworkingV1(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockIngressMonitor := ingress.NewMockMonitor(mockCtrl)
+	meshCatalog := &MeshCatalog{
+		ingressMonitor: mockIngressMonitor,
+	}
+
+	type testCase struct {
+		name                    string
+		svc                     service.MeshService
+		ingresses               []*networkingV1.Ingress
+		expectedTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
+		excpectError            bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "Ingress rule with multiple rules and no default backend",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeExact))),
+												Path:     "/fake2-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchExact,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Ingress rule with multiple rules and a default backend",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						DefaultBackend: &networkingV1.IngressBackend{
+							Service: &networkingV1.IngressServiceBackend{
+								Name: "foo",
+								Port: networkingV1.ServiceBackendPort{
+									Number: fakeIngressPort,
+								},
+							},
+						},
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypePrefix))),
+												Path:     "/fake1-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypePrefix))),
+												Path:     "/fake2-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|*",
+					Hostnames: []string{
+						"*",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          `/fake1-path1(/.*)?$`,
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          `/fake2-path1(/.*)?$`,
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Multiple ingresses matching different hosts",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Path:     "/fake1-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-2",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Path:     "/fake2-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-2.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Multiple ingresses matching same hosts with different rules",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Path:     `/fake1-path1.*`,
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-2",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Path:     `/fake1-path2(/.*)?$`,
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          `/fake1-path1.*`,
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          `/fake1-path2(/.*)?$`,
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Ingress rule with unset pathType must default to ImplementationSpecific",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												// PathType is unset, will default to ImplementationSpecific
+												Path: "/fake2-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name: "Ingress rule with invalid pathType must be ignored",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingresses: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												// PathType is invalid, this will be ignored and logged as an error
+												PathType: (*networkingV1.PathType)(pointer.StringPtr("invalid")),
+												Path:     "/fake2-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockIngressMonitor.EXPECT().GetIngressNetworkingV1(tc.svc).Return(tc.ingresses, nil).Times(1)
+
+			actualPolicies, err := meshCatalog.getIngressPoliciesNetworkingV1(tc.svc)
+
+			assert.Equal(tc.excpectError, err != nil)
+			assert.ElementsMatch(tc.expectedTrafficPolicies, actualPolicies)
+		})
+	}
+}
+
+func TestGetIngressPoliciesForService(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockIngressMonitor := ingress.NewMockMonitor(mockCtrl)
+	meshCatalog := &MeshCatalog{
+		ingressMonitor: mockIngressMonitor,
+	}
+
+	type testCase struct {
+		name                    string
+		svc                     service.MeshService
+		apiVersion              ingress.APIVersion
+		ingressesV1beta1        []*networkingV1beta1.Ingress
+		ingressesV1             []*networkingV1.Ingress
+		expectedTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
+		excpectError            bool
+	}
+
+	testCases := []testCase{
+		{
+			name:       "Ingress v1 with multiple rules",
+			svc:        service.MeshService{Name: "foo", Namespace: "testns"},
+			apiVersion: ingress.IngressNetworkingV1,
+			ingressesV1: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeExact))),
+												Path:     "/fake2-path1",
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchExact,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name:       "Ingress v1beta1 with with multiple rules",
+			svc:        service.MeshService{Name: "foo", Namespace: "testns"},
+			apiVersion: ingress.IngressNetworkingV1beta1,
+			ingressesV1beta1: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeImplementationSpecific))),
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeExact))),
+												Path:     "/fake2-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-1.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchExact,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name:                    "Unsupported ingress version",
+			apiVersion:              ingress.APIVersion(99),
+			excpectError:            true,
+			expectedTrafficPolicies: nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockIngressMonitor.EXPECT().GetAPIVersion().Return(tc.apiVersion).Times(1)
+
+			switch tc.apiVersion {
+			case ingress.IngressNetworkingV1:
+				mockIngressMonitor.EXPECT().GetIngressNetworkingV1(tc.svc).Return(tc.ingressesV1, nil).Times(1)
+
+			case ingress.IngressNetworkingV1beta1:
+				mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(tc.svc).Return(tc.ingressesV1beta1, nil).Times(1)
+			}
 
 			actualPolicies, err := meshCatalog.GetIngressPoliciesForService(tc.svc)
 

--- a/pkg/ingress/mock_client_generated.go
+++ b/pkg/ingress/mock_client_generated.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	service "github.com/openservicemesh/osm/pkg/service"
+	v1 "k8s.io/api/networking/v1"
 	v1beta1 "k8s.io/api/networking/v1beta1"
 )
 
@@ -47,6 +48,21 @@ func (m *MockMonitor) GetAPIVersion() APIVersion {
 func (mr *MockMonitorMockRecorder) GetAPIVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIVersion", reflect.TypeOf((*MockMonitor)(nil).GetAPIVersion))
+}
+
+// GetIngressNetworkingV1 mocks base method
+func (m *MockMonitor) GetIngressNetworkingV1(arg0 service.MeshService) ([]*v1.Ingress, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIngressNetworkingV1", arg0)
+	ret0, _ := ret[0].([]*v1.Ingress)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIngressNetworkingV1 indicates an expected call of GetIngressNetworkingV1
+func (mr *MockMonitorMockRecorder) GetIngressNetworkingV1(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressNetworkingV1", reflect.TypeOf((*MockMonitor)(nil).GetIngressNetworkingV1), arg0)
 }
 
 // GetIngressNetworkingV1beta1 mocks base method

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -2,6 +2,7 @@
 package ingress
 
 import (
+	networkingV1 "k8s.io/api/networking/v1"
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
@@ -39,6 +40,9 @@ type Monitor interface {
 	// GetAPIVersion returns the ingress API version
 	GetAPIVersion() APIVersion
 
-	// GetIngressNetworkingV1beta1 returns the ingress resources whose backends correspond to the service
+	// GetIngressNetworkingV1beta1 returns the networking.k8s.io/v1beta1 ingress resources whose backends correspond to the service
 	GetIngressNetworkingV1beta1(service.MeshService) ([]*networkingV1beta1.Ingress, error)
+
+	// GetIngressNetworkingV1 returns the networking.k8s.io/v1 ingress resources whose backends correspond to the service
+	GetIngressNetworkingV1(service.MeshService) ([]*networkingV1.Ingress, error)
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds support to parse and build traffic policies
from the networking.k8s.io/v1 ingress api.

The key differences from v1beta1 -> v1 are:
- spec.backend -> spec.defaultBackend
- backend.serviceName -> backend.service.name
- backend.servicePort -> backend.service.port.number

The core logic to parse and build routes for v1beta1 and
v1 objects are exactly the same, with only the objects
being different as noted above. The logic and test cases
have been duplicated for v1beta1 and v1 api because
abstracting the differences in the object attributes
seemed hacky. This also simplifies the process when
a particular api needs to be deprecated, which would
simply require deleting the code corresponding to the
given version without affecting other versions.

Part of #2798

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`