### PR TITLE
chore(charts/osm/templates): add objectSelector  for VWH

### DIFF
--- a/charts/osm/templates/validatingwebhook.yaml
+++ b/charts/osm/templates/validatingwebhook.yaml
@@ -18,6 +18,11 @@ webhooks:
   namespaceSelector:
     matchLabels:
       name: {{ include "osm.namespace" . }}
+  objectSelector:
+    matchLabels:
+      app.kubernetes.io/name: openservicemesh.io
+      app.kubernetes.io/instance: {{ .Values.OpenServiceMesh.meshName }}
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
   rules:
     - apiGroups:
         - ""


### PR DESCRIPTION
Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds objectSelector for ` app.kubernetes.io/name`, this allows us to narrow down the VWH to only look at OSM's configmaps so that if a user addds their own configmap to the `osm-system` namespace it will be overlooked by the VWH and resolves #2926 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No