### PR TITLE
ingress: dynamically initialize versioned ingress clients

### DIFF
--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -47,7 +47,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	certManager := tresor.NewFakeCertManager(cfg)
 
 	mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(gomock.Any()).Return(nil, nil).AnyTimes()
-	mockIngressMonitor.EXPECT().GetAPIVersion().Return(ingress.IngressNetworkingV1beta1).AnyTimes()
+	mockIngressMonitor.EXPECT().GetIngressNetworkingV1(gomock.Any()).Return(nil, nil).AnyTimes()
 
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {

--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -1431,7 +1431,6 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 	type testCase struct {
 		name                    string
 		svc                     service.MeshService
-		apiVersion              ingress.APIVersion
 		ingressesV1beta1        []*networkingV1beta1.Ingress
 		ingressesV1             []*networkingV1.Ingress
 		expectedTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
@@ -1440,9 +1439,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:       "Ingress v1 with multiple rules",
-			svc:        service.MeshService{Name: "foo", Namespace: "testns"},
-			apiVersion: ingress.IngressNetworkingV1,
+			name: "Ingress v1 with multiple rules",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
 			ingressesV1: []*networkingV1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1549,9 +1547,8 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 			excpectError: false,
 		},
 		{
-			name:       "Ingress v1beta1 with with multiple rules",
-			svc:        service.MeshService{Name: "foo", Namespace: "testns"},
-			apiVersion: ingress.IngressNetworkingV1beta1,
+			name: "Ingress v1beta1 with with multiple rules",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
 			ingressesV1beta1: []*networkingV1beta1.Ingress{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1656,24 +1653,138 @@ func TestGetIngressPoliciesForService(t *testing.T) {
 			excpectError: false,
 		},
 		{
-			name:                    "Unsupported ingress version",
-			apiVersion:              ingress.APIVersion(99),
-			excpectError:            true,
+			name: "Ingress v1 and v1beta both present",
+			svc:  service.MeshService{Name: "foo", Namespace: "testns"},
+			ingressesV1: []*networkingV1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-1",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1.IngressSpec{
+						Rules: []networkingV1.IngressRule{
+							{
+								Host: "fake1.com",
+								IngressRuleValue: networkingV1.IngressRuleValue{
+									HTTP: &networkingV1.HTTPIngressRuleValue{
+										Paths: []networkingV1.HTTPIngressPath{
+											{
+												Path:     "/fake1-path1",
+												PathType: (*networkingV1.PathType)(pointer.StringPtr(string(networkingV1.PathTypeImplementationSpecific))),
+												Backend: networkingV1.IngressBackend{
+													Service: &networkingV1.IngressServiceBackend{
+														Name: "foo",
+														Port: networkingV1.ServiceBackendPort{
+															Number: fakeIngressPort,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ingressesV1beta1: []*networkingV1beta1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ingress-2",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							constants.OSMKubeResourceMonitorAnnotation: "enabled",
+						},
+					},
+					Spec: networkingV1beta1.IngressSpec{
+						Rules: []networkingV1beta1.IngressRule{
+							{
+								Host: "fake2.com",
+								IngressRuleValue: networkingV1beta1.IngressRuleValue{
+									HTTP: &networkingV1beta1.HTTPIngressRuleValue{
+										Paths: []networkingV1beta1.HTTPIngressPath{
+											{
+												PathType: (*networkingV1beta1.PathType)(pointer.StringPtr(string(networkingV1beta1.PathTypeExact))),
+												Path:     "/fake2-path1",
+												Backend: networkingV1beta1.IngressBackend{
+													ServiceName: "foo",
+													ServicePort: intstr.IntOrString{
+														Type:   intstr.Int,
+														IntVal: fakeIngressPort,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTrafficPolicies: []*trafficpolicy.InboundTrafficPolicy{
+				{
+					Name: "ingress-1.testns|fake1.com",
+					Hostnames: []string{
+						"fake1.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake1-path1",
+									PathMatchType: trafficpolicy.PathMatchPrefix,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+				{
+					Name: "ingress-2.testns|fake2.com",
+					Hostnames: []string{
+						"fake2.com",
+					},
+					Rules: []*trafficpolicy.Rule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/fake2-path1",
+									PathMatchType: trafficpolicy.PathMatchExact,
+									Methods:       []string{constants.WildcardHTTPMethod},
+								},
+								WeightedClusters: mapset.NewSet(service.WeightedCluster{
+									ClusterName: "testns/foo",
+									Weight:      100,
+								}),
+							},
+							AllowedServiceAccounts: mapset.NewSet(wildcardServiceAccount),
+						},
+					},
+				},
+			},
+			excpectError: false,
+		},
+		{
+			name:                    "No ingresses",
+			excpectError:            false,
 			expectedTrafficPolicies: nil,
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			mockIngressMonitor.EXPECT().GetAPIVersion().Return(tc.apiVersion).Times(1)
-
-			switch tc.apiVersion {
-			case ingress.IngressNetworkingV1:
-				mockIngressMonitor.EXPECT().GetIngressNetworkingV1(tc.svc).Return(tc.ingressesV1, nil).Times(1)
-
-			case ingress.IngressNetworkingV1beta1:
-				mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(tc.svc).Return(tc.ingressesV1beta1, nil).Times(1)
-			}
+			mockIngressMonitor.EXPECT().GetIngressNetworkingV1(tc.svc).Return(tc.ingressesV1, nil).Times(1)
+			mockIngressMonitor.EXPECT().GetIngressNetworkingV1beta1(tc.svc).Return(tc.ingressesV1beta1, nil).Times(1)
 
 			actualPolicies, err := meshCatalog.GetIngressPoliciesForService(tc.svc)
 

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -17,30 +17,18 @@ import (
 
 // NewIngressClient implements ingress.Monitor and creates the Kubernetes client to monitor Ingress resources.
 func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{}, cfg configurator.Configurator) (Monitor, error) {
-	// TODO(#2798): Dynamically retrieve configured version
-	// Currently, since only networking.k8s.io/v1beta1 is supported, hardcode this.
-	requestedAPIVersion := IngressNetworkingV1beta1
-
-	var informer cache.SharedIndexInformer
-	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
-
-	switch requestedAPIVersion {
-	case IngressNetworkingV1:
-		informer = informerFactory.Networking().V1().Ingresses().Informer()
-
-	case IngressNetworkingV1beta1:
-		informer = informerFactory.Networking().V1beta1().Ingresses().Informer()
-
-	default:
-		return nil, ErrUnsupportedAPIVersion
+	k8sServerVersion, err := k8s.GetKubernetesServerVersionNumber(kubeClient)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error retrieving k8s server version required to initialize ingress client")
+		return nil, err
 	}
 
-	client := Client{
-		informer:       informer,
-		cache:          informer.GetStore(),
-		cacheSynced:    make(chan interface{}),
-		kubeController: kubeController,
-		apiVersion:     requestedAPIVersion,
+	// Initialize the version specific ingress informers and caches
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, k8s.DefaultKubeEventResyncInterval)
+	ingressEventTypes := k8s.EventTypes{
+		Add:    announcements.IngressAdded,
+		Update: announcements.IngressUpdated,
+		Delete: announcements.IngressDeleted,
 	}
 
 	shouldObserve := func(obj interface{}) bool {
@@ -48,12 +36,26 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 		return kubeController.IsMonitoredNamespace(ns)
 	}
 
-	ingrEventTypes := k8s.EventTypes{
-		Add:    announcements.IngressAdded,
-		Update: announcements.IngressUpdated,
-		Delete: announcements.IngressDeleted,
+	client := Client{
+		cacheSynced:    make(chan interface{}),
+		kubeController: kubeController,
 	}
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers("Ingress", "Kubernetes", shouldObserve, ingrEventTypes))
+
+	// If k8s server version >= 1.19, initialize the v1 informer
+	// Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
+	if k8sServerVersion[0] >= 1 && k8sServerVersion[1] >= 19 {
+		client.informerV1 = informerFactory.Networking().V1().Ingresses().Informer()
+		client.cacheV1 = client.informerV1.GetStore()
+		client.informerV1.AddEventHandler(k8s.GetKubernetesEventHandlers("IngressV1", "Kubernetes", shouldObserve, ingressEventTypes))
+	}
+
+	// If k8s server version is < 1.22, initialize the v1beta informer
+	// Ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
+	if k8sServerVersion[0] >= 1 && k8sServerVersion[1] < 22 {
+		client.informerV1beta1 = informerFactory.Networking().V1beta1().Ingresses().Informer()
+		client.cacheV1Beta1 = client.informerV1beta1.GetStore()
+		client.informerV1beta1.AddEventHandler(k8s.GetKubernetesEventHandlers("IngressV1beta1", "Kubernetes", shouldObserve, ingressEventTypes))
+	}
 
 	if err := client.run(stop); err != nil {
 		log.Error().Err(err).Msg("Could not start Kubernetes Ingress client")
@@ -67,36 +69,47 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 func (c *Client) run(stop <-chan struct{}) error {
 	log.Info().Msg("Ingress client started")
 
-	if c.informer == nil {
+	if c.informerV1 == nil && c.informerV1beta1 == nil {
 		return errInitInformers
 	}
 
-	go c.informer.Run(stop)
-	log.Info().Msgf("Waiting for Ingress informer cache sync")
-	if !cache.WaitForCacheSync(stop, c.informer.HasSynced) {
+	informerCollection := map[string]cache.SharedIndexInformer{
+		"IngressV1":      c.informerV1,
+		"IngressV1beta1": c.informerV1beta1,
+	}
+
+	var pendingCacheSync []cache.InformerSynced
+	for name, informer := range informerCollection {
+		// Depending on k8s server version, an informer may or may not be initialized
+		if informer == nil {
+			continue
+		}
+		log.Info().Msgf("Starting ingress informer: %s", name)
+		go informer.Run(stop)
+		pendingCacheSync = append(pendingCacheSync, informer.HasSynced)
+	}
+
+	log.Info().Msgf("Waiting for ingress informer's cache to sync")
+	if !cache.WaitForCacheSync(stop, pendingCacheSync...) {
 		return errSyncingCaches
 	}
 
-	// Closing the cacheSynced channel signals to the rest of the system that... caches have been synced.
+	// Closing the cacheSynced channel signals to the rest of the system that caches have been synced.
 	close(c.cacheSynced)
 
-	log.Info().Msgf("Cache sync finished for Ingress informer")
+	log.Info().Msgf("Cache sync finished for ingress informer")
 	return nil
-}
-
-// GetAPIVersion returns the ingress API version
-func (c Client) GetAPIVersion() APIVersion {
-	return c.apiVersion
 }
 
 // GetIngressNetworkingV1beta1 returns the networking.k8s.io/v1beta1 ingress resources whose backends correspond to the service
 func (c Client) GetIngressNetworkingV1beta1(meshService service.MeshService) ([]*networkingV1beta1.Ingress, error) {
-	if c.GetAPIVersion() != IngressNetworkingV1beta1 {
-		return nil, errUnexpectedAPIVersion
+	if c.cacheV1Beta1 == nil {
+		// The v1beta1 version is not served by the controller, return an empty list
+		return nil, nil
 	}
 
 	var ingressResources []*networkingV1beta1.Ingress
-	for _, ingressInterface := range c.cache.List() {
+	for _, ingressInterface := range c.cacheV1Beta1.List() {
 		ingress, ok := ingressInterface.(*networkingV1beta1.Ingress)
 		if !ok {
 			log.Error().Msg("Failed type assertion for Ingress in ingress cache")
@@ -134,12 +147,13 @@ func (c Client) GetIngressNetworkingV1beta1(meshService service.MeshService) ([]
 
 // GetIngressNetworkingV1 returns the networking.k8s.io/v1 ingress resources whose backends correspond to the service
 func (c Client) GetIngressNetworkingV1(meshService service.MeshService) ([]*networkingV1.Ingress, error) {
-	if c.GetAPIVersion() != IngressNetworkingV1 {
-		return nil, errUnexpectedAPIVersion
+	if c.cacheV1 == nil {
+		// The v1 version is not served by the controller, return an empty list
+		return nil, nil
 	}
 
 	var ingressResources []*networkingV1.Ingress
-	for _, ingressInterface := range c.cache.List() {
+	for _, ingressInterface := range c.cacheV1.List() {
 		ingress, ok := ingressInterface.(*networkingV1.Ingress)
 		if !ok {
 			log.Error().Msg("Failed type assertion for Ingress in ingress cache")

--- a/pkg/ingress/errors.go
+++ b/pkg/ingress/errors.go
@@ -6,9 +6,6 @@ var (
 	errSyncingCaches = errors.New("Failed initial cache sync for Ingress informer")
 	errInitInformers = errors.New("Ingress informer not initialized")
 
-	// errUnexpectedAPIVersion indicates the requested ingress version is unexpected
-	errUnexpectedAPIVersion = errors.New("Unexpected ingress API version")
-
 	// ErrUnsupportedAPIVersion indicates the requested version of ingress is unsupported
 	ErrUnsupportedAPIVersion = errors.New("Unsupported ingress API version")
 )

--- a/pkg/ingress/mock_client_generated.go
+++ b/pkg/ingress/mock_client_generated.go
@@ -36,20 +36,6 @@ func (m *MockMonitor) EXPECT() *MockMonitorMockRecorder {
 	return m.recorder
 }
 
-// GetAPIVersion mocks base method
-func (m *MockMonitor) GetAPIVersion() APIVersion {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAPIVersion")
-	ret0, _ := ret[0].(APIVersion)
-	return ret0
-}
-
-// GetAPIVersion indicates an expected call of GetAPIVersion
-func (mr *MockMonitorMockRecorder) GetAPIVersion() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIVersion", reflect.TypeOf((*MockMonitor)(nil).GetAPIVersion))
-}
-
 // GetIngressNetworkingV1 mocks base method
 func (m *MockMonitor) GetIngressNetworkingV1(arg0 service.MeshService) ([]*v1.Ingress, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -15,31 +15,18 @@ var (
 	log = logger.New("kube-ingress")
 )
 
-// APIVersion is the API version for the ingress resource
-type APIVersion int
-
-const (
-	// IngressNetworkingV1 refers to the networking.k8s.io/v1 ingress API
-	IngressNetworkingV1 APIVersion = iota
-
-	// IngressNetworkingV1beta1 refers to the networking.k8s.io/v1beta1 ingress API
-	IngressNetworkingV1beta1 APIVersion = iota
-)
-
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
-	informer       cache.SharedIndexInformer
-	cache          cache.Store
-	cacheSynced    chan interface{}
-	kubeController k8s.Controller
-	apiVersion     APIVersion
+	informerV1      cache.SharedIndexInformer
+	cacheV1         cache.Store
+	informerV1beta1 cache.SharedIndexInformer
+	cacheV1Beta1    cache.Store
+	cacheSynced     chan interface{}
+	kubeController  k8s.Controller
 }
 
 // Monitor is the client interface for K8s Ingress resource
 type Monitor interface {
-	// GetAPIVersion returns the ingress API version
-	GetAPIVersion() APIVersion
-
 	// GetIngressNetworkingV1beta1 returns the networking.k8s.io/v1beta1 ingress resources whose backends correspond to the service
 	GetIngressNetworkingV1beta1(service.MeshService) ([]*networkingV1beta1.Ingress, error)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change implements the capability to serve multiple
versions of the ingress API based on [Proposal 1](https://docs.google.com/document/d/19rqJaJD_kDEfrvk7J0N--x45IYqUSmrJHo2PdYkC3Bg/edit#heading=h.hkcgqkq1jn5t?usp=sharing).

It does the following:
1. Figures out the k8s server version at runtime.
2. Initializes the appropriate versioned ingress
   informers/caches depending on if the k8s server
   version supports the ingress api version.
3. Updates `mesh-catalog` to build routes based on
   all api versions of the ingress resource.
4. Updates tests to handle multiple versions of
   ingress.

Part of #2798

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`