### PR TITLE
feat(cli): change uninstall cmd to match install

### DIFF
--- a/cmd/cli/mesh.go
+++ b/cmd/cli/mesh.go
@@ -21,7 +21,6 @@ func newMeshCmd(config *action.Configuration, in io.Reader, out io.Writer) *cobr
 		Long:  meshDescription,
 		Args:  cobra.NoArgs,
 	}
-	cmd.AddCommand(newMeshUninstall(config, in, out))
 	cmd.AddCommand(newMeshList(out))
 	cmd.AddCommand(newMeshUpgradeCmd(config, out))
 

--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -45,6 +45,7 @@ func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args 
 		newVersionCmd(out),
 		newProxyCmd(config, out),
 		newTrafficPolicyCmd(out),
+		newUninstallCmd(config, in, out),
 	)
 
 	_ = flags.Parse(args)

--- a/cmd/cli/uninstall.go
+++ b/cmd/cli/uninstall.go
@@ -17,7 +17,7 @@ the mesh was installed in.
 Only use this in non-production and test environments.
 `
 
-type meshUninstallCmd struct {
+type uninstallCmd struct {
 	out      io.Writer
 	in       io.Reader
 	meshName string
@@ -25,8 +25,8 @@ type meshUninstallCmd struct {
 	client   *action.Uninstall
 }
 
-func newMeshUninstall(config *action.Configuration, in io.Reader, out io.Writer) *cobra.Command {
-	uninstall := &meshUninstallCmd{
+func newUninstallCmd(config *action.Configuration, in io.Reader, out io.Writer) *cobra.Command {
+	uninstall := &uninstallCmd{
 		out: out,
 		in:  in,
 	}
@@ -50,7 +50,7 @@ func newMeshUninstall(config *action.Configuration, in io.Reader, out io.Writer)
 	return cmd
 }
 
-func (d *meshUninstallCmd) run() error {
+func (d *uninstallCmd) run() error {
 	if !d.force {
 		confirm, err := confirm(d.in, d.out, fmt.Sprintf("Uninstall OSM [mesh name: %s] ?", d.meshName), 3)
 		if !confirm || err != nil {

--- a/cmd/cli/uninstall_test.go
+++ b/cmd/cli/uninstall_test.go
@@ -18,11 +18,11 @@ const (
 	meshName = "testing"
 )
 
-var _ = Describe("Running the mesh uninstall command", func() {
+var _ = Describe("Running the uninstall command", func() {
 	Context("default parameters", func() {
 		var (
-			uninstallCmd *meshUninstallCmd
-			force        bool
+			cmd   *uninstallCmd
+			force bool
 		)
 
 		When("the mesh exists", func() {
@@ -47,7 +47,7 @@ var _ = Describe("Running the mesh uninstall command", func() {
 			in := new(bytes.Buffer)
 			in.Write([]byte("y\n"))
 			force = false
-			uninstallCmd = &meshUninstallCmd{
+			cmd = &uninstallCmd{
 				out:      out,
 				in:       in,
 				client:   helm.NewUninstall(testConfig),
@@ -55,7 +55,7 @@ var _ = Describe("Running the mesh uninstall command", func() {
 				force:    force,
 			}
 
-			err = uninstallCmd.run()
+			err = cmd.run()
 
 			It("should prompt for confirmation", func() {
 				Expect(out.String()).To(ContainSubstring("Uninstall OSM [mesh name: testing] ? [y/n]: "))
@@ -91,7 +91,7 @@ var _ = Describe("Running the mesh uninstall command", func() {
 			in := new(bytes.Buffer)
 			in.Write([]byte("y\n"))
 			force = false
-			uninstallCmd = &meshUninstallCmd{
+			cmd = &uninstallCmd{
 				out:      out,
 				in:       in,
 				client:   helm.NewUninstall(testConfig),
@@ -99,7 +99,7 @@ var _ = Describe("Running the mesh uninstall command", func() {
 				force:    force,
 			}
 
-			err = uninstallCmd.run()
+			err = cmd.run()
 
 			It("should prompt for confirmation", func() {
 				Expect(out.String()).To(ContainSubstring("Uninstall OSM [mesh name: testing] ? [y/n]: "))
@@ -115,8 +115,8 @@ var _ = Describe("Running the mesh uninstall command", func() {
 	})
 	Context("custom parameters", func() {
 		var (
-			uninstallCmd *meshUninstallCmd
-			force        bool
+			cmd   *uninstallCmd
+			force bool
 		)
 		When("force is true", func() {
 			store := storage.Init(driver.NewMemory())
@@ -139,7 +139,7 @@ var _ = Describe("Running the mesh uninstall command", func() {
 			out := new(bytes.Buffer)
 			in := new(bytes.Buffer)
 			force = true
-			uninstallCmd = &meshUninstallCmd{
+			cmd = &uninstallCmd{
 				out:      out,
 				in:       in,
 				client:   helm.NewUninstall(testConfig),
@@ -147,7 +147,7 @@ var _ = Describe("Running the mesh uninstall command", func() {
 				force:    force,
 			}
 
-			err = uninstallCmd.run()
+			err = cmd.run()
 
 			It("should not prompt for confirmation", func() {
 				Expect(out.String()).NotTo(ContainSubstring("Uninstall OSM [mesh name: testing] ? [y/n]: "))

--- a/demo/clean-kubernetes.sh
+++ b/demo/clean-kubernetes.sh
@@ -5,7 +5,7 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 
-bin/osm mesh uninstall -f --mesh-name "$MESH_NAME" --osm-namespace "$K8S_NAMESPACE"
+bin/osm uninstall -f --mesh-name "$MESH_NAME" --osm-namespace "$K8S_NAMESPACE"
 
 for ns in "$BOOKWAREHOUSE_NAMESPACE" "$BOOKBUYER_NAMESPACE" "$BOOKSTORE_NAMESPACE" "$BOOKTHIEF_NAMESPACE" "$K8S_NAMESPACE"; do
     kubectl delete namespace "$ns" --ignore-not-found --wait &

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -431,7 +431,7 @@ kubectl delete ns bookbuyer bookthief bookstore bookwarehouse
 
 To uninstall OSM, run
 ```bash
-osm mesh uninstall
+osm uninstall
 ```
 
 For more details about uninstalling OSM, see the [uninstallation guide](../uninstallation_guide/).

--- a/docs/content/docs/install/uninstallation_guide.md
+++ b/docs/content/docs/install/uninstallation_guide.md
@@ -98,16 +98,16 @@ Use the `osm` CLI to uninstall the OSM control plane from a Kubernetes cluster. 
 1. Prometheus, Grafana, Jaeger, and Fluentbit resources installed by OSM
 1. Mutating webhook and validating webhook
 
-Run `osm mesh uninstall`:
+Run `osm uninstall`:
 
 ```console
 # Uninstall osm control plane components
-$ osm mesh uninstall --mesh-name=<mesh-name>
+$ osm uninstall --mesh-name=<mesh-name>
 Uninstall OSM [mesh name: <mesh-name>] ? [y/n]: y
 OSM [mesh name: <mesh-name>] uninstalled
 ```
 
-Run `osm mesh uninstall --help` for more options.
+Run `osm uninstall --help` for more options.
 
 ### Remove User Provided Resources
 

--- a/docs/content/docs/todo/uninstall_osm.md
+++ b/docs/content/docs/todo/uninstall_osm.md
@@ -47,14 +47,14 @@ Delete all Kubernetes resources associated with OSM control plane.
 ### Experience
 CLI command:
 ```bash
-osm mesh uninstall MESH_NAME
+osm uninstall MESH_NAME
 ```
 
 ### Solution
 The CLI command will uninstall the `osm-controller` Deployment, Service and any other resources associated with the OSM control plane with the given MESH_NAME.
 
 #### Implementation Details
-The `osm` CLI uses Helm libraries and a Helm chart under the hood to install an OSM control plane in a Kubernetes cluster. It also creates a namespace (`osm-system` by default) to house the Kubernetes resources defined in and installed using the Helm chart. The `osm mesh uninstall` command works by deleting the Helm release associated with the control plane. The Helm release lives in the same namespace as the OSM control plane installation. The namespace will not be deleted because we don't know what else for now the user has installed in that namespace. Because the SMI CRDs live in the chart's `crds/` directory, they are protected from any delete action in Helm.
+The `osm` CLI uses Helm libraries and a Helm chart under the hood to install an OSM control plane in a Kubernetes cluster. It also creates a namespace (`osm-system` by default) to house the Kubernetes resources defined in and installed using the Helm chart. The `osm uninstall` command works by deleting the Helm release associated with the control plane. The Helm release lives in the same namespace as the OSM control plane installation. The namespace will not be deleted because we don't know what else for now the user has installed in that namespace. Because the SMI CRDs live in the chart's `crds/` directory, they are protected from any delete action in Helm.
 
 ### Testing
 This command and all associated functionality should be unit tested. This command should be added to the simulations run by CI.

--- a/docs/wip/demo_prometheus.md
+++ b/docs/wip/demo_prometheus.md
@@ -112,7 +112,7 @@ To get a taste of how OSM works with Prometheus, try installing a new mesh with 
     Then, uninstall OSM:
 
     ```
-    $ osm mesh uninstall
+    $ osm uninstall
     Uninstall OSM [mesh name: osm] ? [y/n]: y
     OSM [mesh name: osm] uninstalled
     ```


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

Change the `osm uninstall` cmd to be a first-level
subcommand. Extracts cmd from `osm mesh uninstall`.

Update relevant docs to reflect this new change.

Resolves #2793.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A,
