### PR TITLE
feat(osm/Chart.yaml): Pre-install check for k8s version

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -19,3 +19,6 @@ version: 0.8.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: v0.8.2
+
+# This specifies a particular range of k8s versions that the application is compatible with. 
+kubeVersion: ">= 1.18.0"

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -21,11 +21,8 @@ var _ = OSMDescribe("Test HTTP traffic for different k8s versions",
 		Context("Version v1.19.7", func() {
 			testK8sVersion("v1.19.7")
 		})
-		Context("Version v1.18.15", func() {
-			testK8sVersion("v1.18.15")
-		})
-		Context("Version v1.17.17", func() {
-			testK8sVersion("v1.17.17")
+		Context("Version v1.18.0", func() {
+			testK8sVersion("v1.18.0")
 		})
 	})
 


### PR DESCRIPTION
Description: Add a pre-install check to ensure that the kubernetes cluster is a supported version for the current version of OSM. We were initially considering limiting this to downstream charts, but this change may be relevant upstream as well. 

Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
