### PR TITLE
Removing ListSMIPolicies() and ListMonitoredNamespaces() from MeshCataloger interface

### DIFF
--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -14,9 +14,6 @@ import (
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
-	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
-	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface
@@ -261,20 +258,6 @@ func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficTargetsWithRoutes(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInboundTrafficTargetsWithRoutes", reflect.TypeOf((*MockMeshCataloger)(nil).ListInboundTrafficTargetsWithRoutes), arg0)
 }
 
-// ListMonitoredNamespaces mocks base method
-func (m *MockMeshCataloger) ListMonitoredNamespaces() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMonitoredNamespaces")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// ListMonitoredNamespaces indicates an expected call of ListMonitoredNamespaces
-func (mr *MockMeshCatalogerMockRecorder) ListMonitoredNamespaces() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMonitoredNamespaces", reflect.TypeOf((*MockMeshCataloger)(nil).ListMonitoredNamespaces))
-}
-
 // ListOutboundTrafficPolicies mocks base method
 func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
 	m.ctrl.T.Helper()
@@ -287,23 +270,6 @@ func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 service.K8sServiceA
 func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundTrafficPolicies), arg0)
-}
-
-// ListSMIPolicies mocks base method
-func (m *MockMeshCataloger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSMIPolicies")
-	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
-	ret1, _ := ret[1].([]service.K8sServiceAccount)
-	ret2, _ := ret[2].([]*v1alpha4.HTTPRouteGroup)
-	ret3, _ := ret[3].([]*v1alpha3.TrafficTarget)
-	return ret0, ret1, ret2, ret3
-}
-
-// ListSMIPolicies indicates an expected call of ListSMIPolicies
-func (mr *MockMeshCatalogerMockRecorder) ListSMIPolicies() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSMIPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListSMIPolicies))
 }
 
 // ListServiceAccountsForService mocks base method

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -9,9 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
-	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
-	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -81,9 +78,6 @@ type MeshCataloger interface {
 	// ListServiceAccountsForService lists the service accounts associated with the given service
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
-	// ListSMIPolicies lists SMI policies.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
-
 	// ListEndpointsForService returns the list of individual instance endpoint backing a service
 	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
 
@@ -114,15 +108,12 @@ type MeshCataloger interface {
 	// GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
 	GetIngressPoliciesForService(service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error)
 
-	// ListMonitoredNamespaces lists namespaces monitored by the control plane
-	ListMonitoredNamespaces() []string
-
 	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
 	// The ports returned are the actual ports on which the application exposes the service derived from the service's endpoints,
 	// ie. 'spec.ports[].targetPort' instead of 'spec.ports[].port' for a Kubernetes service.
 	GetTargetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
 
-	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
+	// GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
 	// where the ports returned are the ones used by downstream clients in their requests. This can be different from the ports
 	// actually exposed by the application binary, ie. 'spec.ports[].port' instead of 'spec.ports[].targetPort' for a Kubernetes service.
 	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)

--- a/pkg/debugger/namespace.go
+++ b/pkg/debugger/namespace.go
@@ -13,7 +13,11 @@ type namespaces struct {
 func (ds DebugConfig) getMonitoredNamespacesHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var n namespaces
-		n.Namespaces = ds.meshCatalogDebugger.ListMonitoredNamespaces()
+		var err error
+		n.Namespaces, err = ds.kubeController.ListMonitoredNamespaces()
+		if err != nil {
+			log.Error().Err(err).Msgf("Error marshalling policy %+v", n)
+		}
 
 		jsonPolicies, err := json.Marshal(n)
 		if err != nil {

--- a/pkg/debugger/namespace_test.go
+++ b/pkg/debugger/namespace_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
 
@@ -13,11 +15,11 @@ import (
 // Tests getMonitoredNamespaces through HTTP handler returns a the list of monitored namespaces
 func TestMonitoredNamespaceHandler(t *testing.T) {
 	assert := tassert.New(t)
-	mockCtrl := gomock.NewController(t)
-	mock := NewMockMeshCatalogDebugger(mockCtrl)
+
+	mockKubeController := k8s.NewMockController(gomock.NewController(t))
 
 	ds := DebugConfig{
-		meshCatalogDebugger: mock,
+		kubeController: mockKubeController,
 	}
 	monitoredNamespacesHandler := ds.getMonitoredNamespacesHandler()
 
@@ -26,7 +28,7 @@ func TestMonitoredNamespaceHandler(t *testing.T) {
 		tests.BookstoreV1Service.Namespace, // default
 	})
 
-	mock.EXPECT().ListMonitoredNamespaces().Return(uniqueNs)
+	mockKubeController.EXPECT().ListMonitoredNamespaces().Return(uniqueNs, nil)
 
 	responseRecorder := httptest.NewRecorder()
 	monitoredNamespacesHandler.ServeHTTP(responseRecorder, nil)


### PR DESCRIPTION
This PR removes `ListSMIPolicies()` and `ListMonitoredNamespaces()` from `MeshCataloger` interface.
`MeshCataloger` does not need or required these.

On the other hand these are required by the [MeshCatalogDebugger interface](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/debugger/types.go#L41-L56).

fix #3084