### PR TITLE
[RFC] catalog: Remove ListServiceAccountsForService and add GetServiceAccountsForCert to MeshCataloger interface

### DIFF
--- a/pkg/catalog/certs.go
+++ b/pkg/catalog/certs.go
@@ -1,0 +1,59 @@
+package catalog
+
+import (
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/pkg/errors"
+)
+
+var errGotUnexpectedCertRequest = errors.New("errGotUnexpectedCertRequest")
+
+func (mc *MeshCatalog) GetServiceAccountsForCert(certType envoy.SDSCertType, certName string, svcAccount service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
+	// Program SAN matching based on SMI TrafficTarget policies
+	switch certType {
+	case envoy.RootCertTypeForMTLSOutbound:
+		// For the outbound certificate validation context, the SANs needs to match the list of service identities
+		// corresponding to the upstream service. This means, if the sdscert.Name points to service 'X',
+		// the SANs for this certificate should correspond to the service identities of 'X'.
+		meshSvc, err := service.UnmarshalMeshService(certName)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error unmarshalling upstream service for outbound cert %s", certName)
+			return nil, err
+		}
+		svcAccounts, err := mc.kubeController.ListServiceAccountsForService(*meshSvc) // was mc.ListServiceAccountsForService(*meshSvc)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error listing service accounts for service %s", meshSvc)
+			return nil, err
+		}
+		return svcAccounts, nil
+
+	case envoy.RootCertTypeForMTLSInbound:
+		// Verify that the SDS cert request corresponding to the mTLS root validation cert matches the identity
+		// of this proxy. If it doesn't, then something is wrong in the system.
+		svcAccountInRequest, err := service.UnmarshalK8sServiceAccount(certName)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error unmarshalling service account for inbound mTLS validation cert %s", certName)
+			return nil, err
+		}
+
+		if *svcAccountInRequest != svcAccount {
+			log.Error().Err(errGotUnexpectedCertRequest).Msgf("Request for SDS cert %s does not belong to proxy with identity %s", certName, svcAccount)
+			return nil, errGotUnexpectedCertRequest
+		}
+
+		// For the inbound certificate validation context, the SAN needs to match the list of all downstream
+		// service identities that are allowed to connect to this upstream identity. This means, if the upstream proxy
+		// identity is 'X', the SANs for this certificate should correspond to all the downstream identities
+		// allowed to access 'X'.
+		svcAccounts, err := mc.ListAllowedInboundServiceAccounts(svcAccount)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error listing inbound service accounts for proxy with ServiceAccount %s", svcAccount)
+			return nil, err
+		}
+		return svcAccounts, nil
+
+	default:
+		log.Debug().Msgf("SAN matching not needed for cert %s", certName)
+		return nil, nil
+	}
+}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -79,12 +79,6 @@ func (mc *MeshCatalog) GetServicesForServiceAccount(sa service.K8sServiceAccount
 	return services, nil
 }
 
-// ListServiceAccountsForService lists the service accounts associated with the given service
-func (mc *MeshCatalog) ListServiceAccountsForService(svc service.MeshService) ([]service.K8sServiceAccount, error) {
-	// Currently OSM uses kubernetes service accounts as service identities
-	return mc.kubeController.ListServiceAccountsForService(svc)
-}
-
 // GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
 // The ports returned are the actual ports on which the application exposes the service derived from the service's endpoints,
 // ie. 'spec.ports[].targetPort' instead of 'spec.ports[].port' for a Kubernetes service.

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -78,9 +78,6 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
-	// ListServiceAccountsForService lists the service accounts associated with the given service
-	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
-
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 
@@ -129,6 +126,9 @@ type MeshCataloger interface {
 
 	// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects composed of its routes for the given destination service account
 	ListInboundTrafficTargetsWithRoutes(service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error)
+
+	// GetServiceAccountsForCert gets service accounts for cert
+	GetServiceAccountsForCert(envoy.SDSCertType, string, service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 }
 type expectedProxy struct {
 	// The time the certificate, identified by CN, for the expected proxy was issued on


### PR DESCRIPTION
This is a **partial** PR. This is not intended to be merged.

This is a proposal to change [the **MeshCataloger** interface](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L62-L132):
1. remove [ListServiceAccountsForService](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L82)
2. add GetServiceAccountsForCert