### PR TITLE
catalog: Remove ListEndpointsForService from MeshCataloger interface

### DIFF
--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ListEndpointsForService returns the list of provider endpoints corresponding to a service
-func (mc *MeshCatalog) ListEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {
+func (mc *MeshCatalog) listEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {
 	var endpoints []endpoint.Endpoint
 	for _, provider := range mc.endpointsProviders {
 		ep := provider.ListEndpointsForService(svc)
@@ -40,7 +40,7 @@ func (mc *MeshCatalog) GetResolvableServiceEndpoints(svc service.MeshService) ([
 // ListAllowedEndpointsForService returns only those endpoints for a service that belong to the allowed outbound service accounts
 // for the given downstream identity
 func (mc *MeshCatalog) ListAllowedEndpointsForService(downstreamIdentity service.K8sServiceAccount, upstreamSvc service.MeshService) ([]endpoint.Endpoint, error) {
-	outboundEndpoints, err := mc.ListEndpointsForService(upstreamSvc)
+	outboundEndpoints, err := mc.listEndpointsForService(upstreamSvc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up endpoints for upstream service %s", upstreamSvc)
 		return nil, err

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Test catalog functions", func() {
 	mc := newFakeMeshCatalog()
 	Context("Testing ListEndpointsForService()", func() {
 		It("lists endpoints for a given service", func() {
-			actual, err := mc.ListEndpointsForService(tests.BookstoreV1Service)
+			actual, err := mc.listEndpointsForService(tests.BookstoreV1Service)
 			Expect(err).ToNot(HaveOccurred())
 
 			expected := []endpoint.Endpoint{
@@ -83,7 +83,7 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			expectedEndpoints: []endpoint.Endpoint{tests.Endpoint},
 		},
 		{
-			name: `Traffic target defined for bookstore ServiceAccount. 
+			name: `Traffic target defined for bookstore ServiceAccount.
 			This service account has bookstore-v1 bookstore-v2 services,
 			but bookstore-v2 pod has service account bookstore-v2.
 			Hence no endpoints returned for bookstore-v2`,
@@ -104,7 +104,7 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			expectedEndpoints: []endpoint.Endpoint{},
 		},
 		{
-			name: `Traffic target defined for bookstore ServiceAccount. 
+			name: `Traffic target defined for bookstore ServiceAccount.
 			This service account has bookstore-v1 bookstore-v2 services,
 			since bookstore-v2 pod has service account bookstore-v2 which is allowed in the traffic target.
 			Hence endpoints returned for bookstore-v2`,

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -186,21 +186,6 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServicesForIdentity(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServicesForIdentity", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServicesForIdentity), arg0)
 }
 
-// ListEndpointsForService mocks base method
-func (m *MockMeshCataloger) ListEndpointsForService(arg0 service.MeshService) ([]endpoint.Endpoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEndpointsForService", arg0)
-	ret0, _ := ret[0].([]endpoint.Endpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListEndpointsForService indicates an expected call of ListEndpointsForService
-func (mr *MockMeshCatalogerMockRecorder) ListEndpointsForService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEndpointsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListEndpointsForService), arg0)
-}
-
 // ListInboundTrafficPolicies mocks base method
 func (m *MockMeshCataloger) ListInboundTrafficPolicies(arg0 service.K8sServiceAccount, arg1 []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -64,9 +64,6 @@ type MeshCataloger interface {
 	// ListServiceAccountsForService lists the service accounts associated with the given service
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
-	// ListEndpointsForService returns the list of individual instance endpoint backing a service
-	ListEndpointsForService(service.MeshService) ([]endpoint.Endpoint, error)
-
 	// ListAllowedEndpointsForService returns the list of endpoints backing a service and its allowed service accounts
 	ListAllowedEndpointsForService(service.K8sServiceAccount, service.MeshService) ([]endpoint.Endpoint, error)
 

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -216,7 +216,6 @@ func TestGetEndpointsForProxy(t *testing.T) {
 
 			for svc, endpoints := range tc.outboundServiceEndpoints {
 				mockEndpointProvider.EXPECT().ListEndpointsForService(svc).Return(endpoints).AnyTimes()
-				mockCatalog.EXPECT().ListEndpointsForService(svc).Return(endpoints, nil).AnyTimes()
 			}
 
 			mockCatalog.EXPECT().ListAllowedOutboundServiceAccounts(tc.proxyIdentity).Return(tc.allowedServiceAccounts, nil).AnyTimes()


### PR DESCRIPTION
This PR changes [the **MeshCataloger** interface](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L62-L132) by removing [ListEndpointsForService](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L88) from the interface.

The [ListEndpointsForService](https://github.com/openservicemesh/osm/pull/3113/files#diff-36dbb2945d53716f02bbfd8723c99ead936d22ceca948cf619a6d5466cf40c98L9) function is not used anywhere outside of `pkg/catalog` and could be privatized.