### PR TITLE
catalog: Remove GetServicesForServiceAccount from MeshCataloger interface

### DIFF
--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -97,21 +97,6 @@ func (mr *MockMeshCatalogerMockRecorder) GetSMISpec() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSMISpec", reflect.TypeOf((*MockMeshCataloger)(nil).GetSMISpec))
 }
 
-// GetServicesForServiceAccount mocks base method
-func (m *MockMeshCataloger) GetServicesForServiceAccount(arg0 service.K8sServiceAccount) ([]service.MeshService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServicesForServiceAccount", arg0)
-	ret0, _ := ret[0].([]service.MeshService)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetServicesForServiceAccount indicates an expected call of GetServicesForServiceAccount
-func (mr *MockMeshCatalogerMockRecorder) GetServicesForServiceAccount(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServicesForServiceAccount", reflect.TypeOf((*MockMeshCataloger)(nil).GetServicesForServiceAccount), arg0)
-}
-
 // GetServicesFromEnvoyCertificate mocks base method
 func (m *MockMeshCataloger) GetServicesFromEnvoyCertificate(arg0 certificate.CommonName) ([]service.MeshService, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -100,7 +100,7 @@ func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(identity service.K
 	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
 		for _, source := range t.Spec.Sources {
 			if source.Name == identity.Name && source.Namespace == identity.Namespace { // found outbound
-				destServices, err := mc.GetServicesForServiceAccount(service.K8sServiceAccount{
+				destServices, err := mc.getServicesForServiceAccount(service.K8sServiceAccount{
 					Name:      t.Spec.Destination.Name,
 					Namespace: t.Spec.Destination.Namespace,
 				})
@@ -185,7 +185,7 @@ func (mc *MeshCatalog) getDestinationServicesFromTrafficTarget(t *access.Traffic
 		Name:      t.Spec.Destination.Name,
 		Namespace: t.Spec.Destination.Namespace,
 	}
-	destServices, err := mc.GetServicesForServiceAccount(sa)
+	destServices, err := mc.getServicesForServiceAccount(sa)
 	if err != nil {
 		return nil, errors.Errorf("Error finding Services for Service Account %#v: %v", sa, err)
 	}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -54,8 +54,8 @@ func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.Me
 	return apexList
 }
 
-// GetServicesForServiceAccount returns a list of services corresponding to a service account
-func (mc *MeshCatalog) GetServicesForServiceAccount(sa service.K8sServiceAccount) ([]service.MeshService, error) {
+// getServicesForServiceAccount returns a list of services corresponding to a service account
+func (mc *MeshCatalog) getServicesForServiceAccount(sa service.K8sServiceAccount) ([]service.MeshService, error) {
 	var services []service.MeshService
 	for _, provider := range mc.endpointsProviders {
 		providerServices, err := provider.GetServicesForServiceAccount(sa)

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -79,9 +79,6 @@ type MeshCataloger interface {
 	// GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
 	GetServicesFromEnvoyCertificate(certificate.CommonName) ([]service.MeshService, error)
 
-	// GetServicesForServiceAccount returns a list of services corresponding to a service account
-	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
-
 	// GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
 	GetIngressPoliciesForService(service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error)
 


### PR DESCRIPTION
This PR changes [the **MeshCataloger** interface](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L62-L132) by removing [GetServicesForServiceAccount ](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L112) from it.

I see that we are not using `GetServicesForServiceAccount()` anywhere outside of `pkg/catalog`. It seems unnecessary to have this exposed via Interface to the rest of the world.  I propose we privatize [GetServicesForServiceAccount ](https://github.com/openservicemesh/osm/blob/release-v0.8/pkg/catalog/types.go#L112) and remove it from `MeshCataloger` interface.
