### PR TITLE
e2e: fix ginkgo panic recoveries

### DIFF
--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -70,6 +70,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 
 				wg.Add(1)
 				go func(wg *sync.WaitGroup, srcClient string) {
+					defer GinkgoRecover()
 					defer wg.Done()
 					Expect(Td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService)).To(Succeed())
 				}(&wg, destApp)
@@ -95,6 +96,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 
 					wg.Add(1)
 					go func(wg *sync.WaitGroup, srcClient string) {
+						defer GinkgoRecover()
 						defer wg.Done()
 						Expect(Td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService)).To(Succeed())
 					}(&wg, srcClient)

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -31,7 +31,6 @@ var _ = OSMDescribe("Test traffic split where root service is same as backend se
 	})
 
 func testRecursiveTrafficSplit(appProtocol string) {
-	defer GinkgoRecover()
 	const (
 		// to name the header we will use to identify the server that replies
 		HTTPHeaderName = "podname"
@@ -108,6 +107,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
 			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
 		}()
@@ -134,6 +134,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 
 			wg.Add(1)
 			go func(app string) {
+				defer GinkgoRecover()
 				defer wg.Done()
 				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
 			}(clientApp)

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -112,6 +112,7 @@ func testTrafficSplit(appProtocol string) {
 		}
 		wg.Add(1)
 		go func() {
+			defer GinkgoRecover()
 			defer wg.Done()
 			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
 		}()
@@ -138,6 +139,7 @@ func testTrafficSplit(appProtocol string) {
 
 			wg.Add(1)
 			go func(app string) {
+				defer GinkgoRecover()
 				defer wg.Done()
 				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
 			}(clientApp)

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/fatih/color"
+	. "github.com/onsi/ginkgo"
 )
 
 const (
@@ -236,6 +237,7 @@ func (td *OsmTestData) MultipleHTTPRequest(requests *HTTPMultipleRequest) HTTPMu
 
 		wg.Add(1)
 		go func(ns string, podname string, htReq HTTPRequestDef) {
+			defer GinkgoRecover()
 			defer wg.Done()
 			r := td.HTTPRequest(htReq)
 

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 				}
 				wg.Add(1)
 				go func() {
+					defer GinkgoRecover()
 					defer wg.Done()
 					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
 				}()
@@ -148,6 +149,7 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 
 					wg.Add(1)
 					go func(app string) {
+						defer GinkgoRecover()
 						defer wg.Done()
 						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
 					}(clientApp)

--- a/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
+++ b/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
@@ -77,6 +77,7 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 				Expect(err).NotTo(HaveOccurred(), "failed to setup controller")
 
 				go func() {
+					defer GinkgoRecover()
 					err := mgr.Start(stopCh)
 					Expect(err).NotTo(HaveOccurred(), "failed to start manager")
 				}()


### PR DESCRIPTION
Cleanup will be skipped and test will exit bypassing cleanup
if a different context goroutine panics or asserts without
deferring the ginkgo recover function.

This causes logs to not be collected in some situations (ie,
when a test has some goroutines waiting for NS to come up
but they don't).

Signed-off-by: edu <eduser25@gmail.com>

- Tests                  [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No