### PR TITLE
test/scale: disallow scraping envoy proxies at scale

### DIFF
--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -29,6 +29,11 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
 			// Install OSM with all the requirements
 			var err error
+			// Prometheus scrapping is not scalable past a certain number of proxies given
+			// current configuration/constraints. We will disable getting proxy metrics
+			// while we focus on qualifying control plane.
+			// Note: this does not prevent osm metrics scraping.
+			Td.EnableNsMetricTag = false
 			sd, err = scaleOSMInstall()
 			Expect(err).To(BeNil())
 


### PR DESCRIPTION
At +1000 proxies, our prometheus will start taking +4G of mem. If it has not been
bestowed enough memory, it will eventually be OOM killed for this test.
Since this test is mostly qualifying control plane, we will stop scrapping the
proxies for the time being.

Mesh-wise control plane metrics are still being scrapped (which are still
of interest to this test).

Signed-off-by: Eduard Serra <eduser25@gmail.com>

- Tests                  [x]
- Performance            [x]

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
