### PR TITLE
envoy: Refactor sendResponse to increase readability

### DIFF
--- a/pkg/envoy/ads/profile.go
+++ b/pkg/envoy/ads/profile.go
@@ -16,16 +16,13 @@ const (
 	MaxXdsLogsPerProxy = 20
 )
 
-func xdsPathTimeTrack(t time.Time, log *zerolog.Event, tURIStr string, proxyXdsCertSerialNum string, success *bool) {
-	elapsed := time.Since(t)
+func xdsPathTimeTrack(startedAt time.Time, log *zerolog.Event, typeURI envoy.TypeURI, proxy *envoy.Proxy, success bool) {
+	elapsed := time.Since(startedAt)
 
-	log.Msgf("[%s] processing for Proxy Serial=%s took %s",
-		tURIStr,
-		proxyXdsCertSerialNum,
-		elapsed)
+	log.Msgf("[%s] processing for Proxy with Certificate SerialNumber=%s took %s", typeURI, proxy.GetCertificateSerialNumber(), elapsed)
 
 	metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime.
-		WithLabelValues(tURIStr, fmt.Sprintf("%t", *success)).
+		WithLabelValues(typeURI.String(), fmt.Sprintf("%t", success)).
 		Observe(elapsed.Seconds())
 }
 

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -73,14 +73,13 @@ func (s *Server) sendResponse(typeURIsToSend mapset.Set,
 		// Handle request when is not provided, and the SDS case
 		var finalReq *xds_discovery.DiscoveryRequest
 		if fullUpdateRequested {
-			finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: typeURI.String()}
 			if typeURI == envoy.TypeSDS {
 				finalReq = makeRequestForAllSecrets(proxy, s.catalog)
 				if finalReq == nil {
 					continue
 				}
 			} else {
-				finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: string(typeURI)}
+				finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: typeURI.String()}
 			}
 		} else {
 			finalReq = request

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -70,7 +70,7 @@ func (s *Server) sendResponse(typeURIsToSend mapset.Set,
 		fullUpdateRequested := request != nil && envoy.TypeURI(request.TypeUrl).IsWildcard()
 
 		// Handle request when is not provided, and the SDS case
-		finalReq := request
+		var finalReq *xds_discovery.DiscoveryRequest
 		if request == nil || fullUpdateRequested {
 			finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: typeURI.String()}
 			if typeURI == envoy.TypeSDS {
@@ -78,7 +78,11 @@ func (s *Server) sendResponse(typeURIsToSend mapset.Set,
 				if finalReq == nil {
 					continue
 				}
+			} else {
+				finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: string(typeURI)}
 			}
+		} else {
+			finalReq = request
 		}
 
 		if err := s.sendTypeResponse(typeURI, proxy, server, finalReq, cfg); err != nil {

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -67,11 +67,12 @@ func (s *Server) sendResponse(typeURIsToSend mapset.Set,
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
 	for _, typeURI := range typesToSend {
-		fullUpdateRequested := request != nil && envoy.TypeURI(request.TypeUrl).IsWildcard()
+		// A nil request indicates a request for all SDS responses
+		fullUpdateRequested := request == nil || envoy.TypeURI(request.TypeUrl).IsWildcard()
 
 		// Handle request when is not provided, and the SDS case
 		var finalReq *xds_discovery.DiscoveryRequest
-		if request == nil || fullUpdateRequested {
+		if fullUpdateRequested {
 			finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: typeURI.String()}
 			if typeURI == envoy.TypeSDS {
 				finalReq = makeRequestForAllSecrets(proxy, s.catalog)

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -7,6 +7,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes"
+	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -18,72 +19,78 @@ const (
 )
 
 // Wrapper to create and send a discovery response to an envoy server
-func (s *Server) sendTypeResponse(tURI envoy.TypeURI,
-	proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer,
-	req *xds_discovery.DiscoveryRequest, cfg configurator.Configurator) error {
+func (s *Server) sendTypeResponse(typeURI envoy.TypeURI, proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, req *xds_discovery.DiscoveryRequest, cfg configurator.Configurator) error {
 	// Tracks the success of this TypeURI response operation; accounts also for receipt on envoy server side
-	success := false
-	xdsShortName := envoy.XDSShortURINames[tURI]
-	defer xdsPathTimeTrack(time.Now(), log.Debug(), xdsShortName, proxy.GetCertificateSerialNumber().String(), &success)
+	startedAt := time.Now()
+	log.Trace().Msgf("[%s] Creating response for proxy with SerialNumber=%s on Pod with UID=%s", typeURI.Short(), proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 
-	log.Trace().Msgf("[%s] Creating response for proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-
-	discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, req, cfg)
-	if err != nil {
-		log.Error().Err(err).Msgf("[%s] Failed to create response for proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+	if discoveryResponse, err := s.newAggregatedDiscoveryResponse(proxy, req, cfg); err != nil {
+		log.Error().Err(err).Msgf("[%s] Failed to create response for proxy with SerialNumber=%s on Pod with UID=%s", typeURI.Short(), proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+		xdsPathTimeTrack(startedAt, log.Debug(), typeURI, proxy, false)
+		return err
+	} else if err := (*server).Send(discoveryResponse); err != nil {
+		log.Error().Err(err).Msgf("[%s] Error sending to proxy with SerialNumber=%s on Pod with UID=%s", typeURI.Short(), proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
+		xdsPathTimeTrack(startedAt, log.Debug(), typeURI, proxy, false)
 		return err
 	}
 
-	if err := (*server).Send(discoveryResponse); err != nil {
-		log.Error().Err(err).Msgf("[%s] Error sending to proxy with SerialNumber=%s on Pod with UID=%s", xdsShortName, proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
-		return err
-	}
-
-	success = true // read by deferred function
+	xdsPathTimeTrack(startedAt, log.Debug(), typeURI, proxy, true)
 	return nil
 }
 
 // sendResponse takes a set of TypeURIs which will be called to generate the xDS resources
 // for, and will have them sent to the proxy server.
 // If no DiscoveryRequest is passed, an empty one for the TypeURI is created
+// TODO(draychev): Convert to variadic function: https://github.com/openservicemesh/osm/issues/3127
 func (s *Server) sendResponse(typeURIsToSend mapset.Set,
 	proxy *envoy.Proxy,
 	server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer,
 	request *xds_discovery.DiscoveryRequest,
 	cfg configurator.Configurator) error {
-	success := true
-	if typeURIsToSend.Cardinality() == len(envoy.XDSResponseOrder) {
-		defer xdsPathTimeTrack(time.Now(), log.Info(), ADSUpdateStr, proxy.GetCertificateSerialNumber().String(), &success)
+	// Order is important: CDS, EDS, LDS, RDS
+	// See: https://github.com/envoyproxy/go-control-plane/issues/59
+	var typesToSend []envoy.TypeURI
+	for _, typeURI := range envoy.XDSResponseOrder {
+		if typeURIsToSend.Contains(typeURI) {
+			typesToSend = append(typesToSend, typeURI)
+		}
 	}
+
+	if len(typesToSend) < 1 {
+		// This should never happen.
+		log.Error().Msg("The list of discovery responses passed to sendResponse() is empty. This is an invalid invocation of sendResponse().")
+		return errors.New("list of discovery responses is empty")
+	}
+
+	thereWereErrors := false
 
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
-	for _, typeURI := range envoy.XDSResponseOrder {
-		if !typeURIsToSend.Contains(typeURI) {
-			continue
-		}
+	for _, typeURI := range typesToSend {
+		fullUpdateRequested := request != nil && envoy.TypeURI(request.TypeUrl).IsWildcard()
 
 		// Handle request when is not provided, and the SDS case
-		var finalReq *xds_discovery.DiscoveryRequest
-		if request == nil || request.TypeUrl == envoy.TypeWildcard.String() {
+		finalReq := request
+		if request == nil || fullUpdateRequested {
+			finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: typeURI.String()}
 			if typeURI == envoy.TypeSDS {
 				finalReq = makeRequestForAllSecrets(proxy, s.catalog)
 				if finalReq == nil {
 					continue
 				}
-			} else {
-				finalReq = &xds_discovery.DiscoveryRequest{TypeUrl: string(typeURI)}
 			}
-		} else {
-			finalReq = request
 		}
 
-		err := s.sendTypeResponse(typeURI, proxy, server, finalReq, cfg)
-		if err != nil {
-			log.Error().Err(err).Msgf("Failed to create %s update for Proxy %s",
-				envoy.XDSShortURINames[typeURI], proxy.GetCertificateCommonName())
-			success = false
+		if err := s.sendTypeResponse(typeURI, proxy, server, finalReq, cfg); err != nil {
+			log.Error().Err(err).Msgf("Creating %s update for Proxy %s", typeURI.Short(), proxy.GetCertificateCommonName())
+			thereWereErrors = true
 		}
+	}
+
+	isFullUpdate := len(typesToSend) == len(envoy.XDSResponseOrder)
+	if isFullUpdate {
+		success := !thereWereErrors
+		xdsPathTimeTrack(time.Now(), log.Info(), envoy.TypeADS, proxy, success)
 	}
 
 	return nil

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -4,6 +4,7 @@ package envoy
 
 import (
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/utils"
 )
 
 var (
@@ -19,6 +20,16 @@ type TypeURI string
 
 func (t TypeURI) String() string {
 	return string(t)
+}
+
+// Short returns an abbreviated version of the TypeURI, which is easier to spot in logs and metrics.
+func (t TypeURI) Short() string {
+	return utils.GetLastChunkOfSlashed(t.String())
+}
+
+// IsWildcard returns true when the TypeURI is the one requesting ALL discovery types.
+func (t TypeURI) IsWildcard() bool {
+	return t == TypeWildcard
 }
 
 // ValidURI defines valid URIs
@@ -42,6 +53,7 @@ var XDSShortURINames = map[TypeURI]string{
 	TypeEDS: "EDS",
 }
 
+// Envoy TypeURIs
 const (
 	// TypeWildcard is the Wildcard type URI.
 	TypeWildcard TypeURI = ""
@@ -67,6 +79,11 @@ const (
 	// TypeZipkinConfig is an Envoy type URI.
 	TypeZipkinConfig TypeURI = "type.googleapis.com/envoy.config.trace.v3.ZipkinConfig"
 
+	// TypeADS is not actually used by Envoy - but useful within OSM for logging
+	TypeADS TypeURI = "ADS"
+)
+
+const (
 	accessLogPath = "/dev/stdout"
 
 	// localClusterSuffix is the tag to append to the local cluster name corresponding to a service cluster.


### PR DESCRIPTION
This PR refactors the `sendResponse` function.

Goals:
 - make it easier to read and understand
 - remove indentation levels
 - remove single letter variables
 - use concrete types instead of strings
 - introduce new variables to capture state and improve readability (`fullUpdateRequested`, `thereWereErrors`)
 - remove unnecessary `else` clauses

