### PR TITLE
Mesh config informer

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -60,6 +60,10 @@ spec:
                         - error
                         - critical
                         - off
+                    max_data_plane_connections:
+                      description: Max allowed data plane sidecar connections
+                      type: integer
+                      default: 0
                 traffic:
                   description: Configuration for traffic management
                   type: object
@@ -86,6 +90,10 @@ spec:
                   properties:
                     enable_debug_server:
                       description: Enables a debug endpoint on the osm-controller pod to list information regarding the mesh such as proxy connections, certificates, and SMI policies.
+                      type: boolean
+                      default: true
+                    prometheus_scraping:
+                      description: Enables Prometheus metrics scraping on sidecar proxies.
                       type: boolean
                       default: true
                     tracing:

--- a/go.mod
+++ b/go.mod
@@ -27,9 +27,8 @@ require (
 	github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b
 	github.com/mitchellh/gox v1.0.1
 	github.com/norwoodj/helm-docs v1.4.0
-	github.com/nxadm/tail v1.4.5 // indirect
 	github.com/olekukonko/tablewriter v0.0.2
-	github.com/onsi/ginkgo v1.14.1
+	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
@@ -41,6 +40,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 // indirect
 	golang.org/x/tools v0.1.1-0.20210319172145-bda8f5cee399 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,7 @@ github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-toolsmith/astcast v1.0.0 h1:JojxlmI6STnFVG9yOImLeGREv8W2ocNUM+iOhR6jE7g=
 github.com/go-toolsmith/astcast v1.0.0/go.mod h1:mt2OdQTeAQcY4DQgPSArJjHCcOwlX+Wl/kwN+LbLGQ4=
@@ -783,8 +784,8 @@ github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9a
 github.com/norwoodj/helm-docs v1.4.0 h1:Vfkp6xpW6kFJNPX1vY0gnGOcCxN8Gi9C7ahqxiXw0Ak=
 github.com/norwoodj/helm-docs v1.4.0/go.mod h1:z8Evt7esakCuqMKuwpVAAp4NyHgQbH3iGWsGmLuBcV0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
-github.com/nxadm/tail v1.4.5 h1:obHEce3upls1IBn1gTw/o7bCv7OJb6Ib/o7wNO+4eKw=
-github.com/nxadm/tail v1.4.5/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -798,8 +799,9 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.1 h1:jMU0WaQrP0a/YAEq8eJmJKjBoMs+pClEr1vDMlM/Do4=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
+github.com/onsi/ginkgo v1.16.1 h1:foqVmeWDD6yYpK+Yz3fHyNIxFYNxswxqNFjSKe+vI54=
+github.com/onsi/ginkgo v1.16.1/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvwxz1E=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1263,9 +1265,11 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 h1:g9s1Ppvvun/fI+BptTMj909BBIcGrzQ32k9FNlcevOE=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1359,6 +1363,7 @@ golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/tools v0.0.0-20201007032633-0806396f153e/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201013201025-64a9e34f3752/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1-0.20210319172145-bda8f5cee399 h1:O5bm8buX/OaamnfcBrkjn0SPUIU30jFmaS8lP+ikkxs=

--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -143,6 +143,17 @@ const (
 
 	// CertificateRotated is the type of announcement emitted when a certificate is rotated by the certificate provider
 	CertificateRotated AnnouncementType = "certificate-rotated"
+
+	// ---
+
+	// MeshConfigAdded is the type of announcement emitted when we observe an addition of a Kubernetes MeshConfig
+	MeshConfigAdded AnnouncementType = "meshconfig-added"
+
+	// MeshConfigDeleted the type of announcement emitted when we observe the deletion of a Kubernetes MeshConfig
+	MeshConfigDeleted AnnouncementType = "meshconfig-deleted"
+
+	// MeshConfigUpdated is the type of announcement emitted when we observe an update to a Kubernetes MeshConfig
+	MeshConfigUpdated AnnouncementType = "meshconfig-updated"
 )
 
 // Announcement is a struct for messages between various components of OSM signaling a need for a change in Envoy proxy configuration

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -25,6 +25,7 @@ type MeshConfigSpec struct {
 type SidecarSpec struct {
 	EnablePrivilegedInitContainer bool   `json:"enable_privileged_init_container,omitempty"`
 	LogLevel                      string `json:"log_level,omitempty" default:"error"`
+	MaxDataPlaneConnections       int    `json:"max_data_plane_connections"`
 }
 
 // TrafficSpec is the spec for OSM's traffic management configuration
@@ -37,8 +38,9 @@ type TrafficSpec struct {
 
 // ObservabilitySpec is the spec for OSM's observability related configuration
 type ObservabilitySpec struct {
-	EnableDebugServer bool        `json:"enable_debug_server,omitempty" default:"true"`
-	Tracing           TracingSpec `json:"tracing,omitempty"`
+	EnableDebugServer  bool        `json:"enable_debug_server,omitempty" default:"true"`
+	PrometheusScraping bool        `json:"prometheus_scraping,omitempty" default:"true"`
+	Tracing            TracingSpec `json:"tracing,omitempty"`
 }
 
 // TracingSpec is the spec for OSM's tracing configuration

--- a/pkg/configurator/crd_client.go
+++ b/pkg/configurator/crd_client.go
@@ -1,0 +1,191 @@
+package configurator
+
+import (
+	"strings"
+
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	informers "github.com/openservicemesh/osm/pkg/gen/client/config/informers/externalversions"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+)
+
+const (
+	meshConfigInformerName = "MeshConfig"
+	meshConfigProviderName = "OSM"
+)
+
+func newConfiguratorWithCRDClient(meshConfigClientSet versioned.Interface, stop <-chan struct{}, osmNamespace string) *CRDClient {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		meshConfigClientSet,
+		k8s.DefaultKubeEventResyncInterval,
+		informers.WithNamespace(osmNamespace),
+	)
+	informer := informerFactory.Config().V1alpha1().MeshConfigs().Informer()
+	crdClient := CRDClient{
+		informer:     informer,
+		cache:        informer.GetStore(),
+		cacheSynced:  make(chan interface{}),
+		osmNamespace: osmNamespace,
+	}
+
+	// configure listener
+	eventTypes := k8s.EventTypes{
+		Add:    announcements.MeshConfigAdded,
+		Update: announcements.MeshConfigUpdated,
+		Delete: announcements.MeshConfigDeleted,
+	}
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers(meshConfigInformerName, meshConfigProviderName, nil, eventTypes))
+
+	// start listener
+	go crdClient.runMeshConfigListener(stop)
+
+	// start informer
+	go informer.Run(stop)
+
+	return &crdClient
+}
+
+// Listens to ConfigMap events and notifies dispatcher to issue config updates to the envoys based
+// on config seen on the configmap
+func (c *CRDClient) runMeshConfigListener(stop <-chan struct{}) {
+	// Create the subscription channel synchronously
+	cfgSubChannel := events.GetPubSubInstance().Subscribe(
+		announcements.MeshConfigAdded,
+		announcements.MeshConfigDeleted,
+		announcements.MeshConfigUpdated,
+	)
+
+	// Defer unsubscription on async routine exit
+	defer events.GetPubSubInstance().Unsub(cfgSubChannel)
+
+	for {
+		select {
+		case msg := <-cfgSubChannel:
+			psubMsg, ok := msg.(events.PubSubMessage)
+			if !ok {
+				log.Error().Msgf("Type assertion failed for PubSubMessage, %v\n", msg)
+				continue
+			}
+
+			switch psubMsg.AnnouncementType {
+			case announcements.MeshConfigAdded:
+				meshConfigAddedMessageHandler(&psubMsg)
+			case announcements.MeshConfigDeleted:
+				meshConfigDeletedMessageHandler(&psubMsg)
+			case announcements.MeshConfigUpdated:
+				meshConfigUpdatedMessageHandler(&psubMsg)
+			}
+		case <-stop:
+			log.Trace().Msgf("MeshConfig event listener exiting")
+			return
+		}
+	}
+}
+
+// TODO: remove nolint after invocation implemented
+func (c *CRDClient) run(stop <-chan struct{}) { //nolint:golint,unused
+	go c.informer.Run(stop) // run the informer synchronization
+	log.Debug().Msgf("Started OSM MeshConfig informer")
+	log.Debug().Msg("[MeshConfig Client] Waiting for MeshConfig informer's cache to sync")
+	if !cache.WaitForCacheSync(stop, c.informer.HasSynced) {
+		log.Error().Msg("Failed initial cache sync for MeshConfig informer")
+		return
+	}
+
+	// Closing the cacheSynced channel signals to the rest of the system that caches have been synced.
+	close(c.cacheSynced)
+	log.Debug().Msg("[MeshConfig Client] Cache sync for MeshConfig informer finished")
+}
+
+// Parses a kubernetes config map object into an osm runtime object representing OSM's options/config
+func parseOSMMeshConfig(meshConfig *v1alpha1.MeshConfig) *osmConfig {
+	// Invalid values should be prevented once https://github.com/openservicemesh/osm/issues/1788
+	// is implemented.
+	//
+	// Unsupported fields in MeshConfig CRD:
+	// * PrometheusScraping
+	// * ConfigResyncInterval
+
+	osmConfig := osmConfig{}
+	osmConfig.PermissiveTrafficPolicyMode = meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode
+	osmConfig.Egress = meshConfig.Spec.Traffic.Egress
+	osmConfig.EnableDebugServer = meshConfig.Spec.Observability.EnableDebugServer
+	osmConfig.UseHTTPSIngress = meshConfig.Spec.Traffic.UseHTTPSIngress
+	osmConfig.TracingEnable = meshConfig.Spec.Observability.Tracing.Enable
+	osmConfig.EnvoyLogLevel = meshConfig.Spec.Sidecar.LogLevel
+	osmConfig.ServiceCertValidityDuration = meshConfig.Spec.Certificate.ServiceCertValidityDuration
+	osmConfig.OutboundIPRangeExclusionList = strings.Join(meshConfig.Spec.Traffic.OutboundIPRangeExclusionList, ",")
+	osmConfig.EnablePrivilegedInitContainer = meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer
+
+	if osmConfig.TracingEnable {
+		osmConfig.TracingAddress = meshConfig.Spec.Observability.Tracing.Address
+		osmConfig.TracingPort = int(meshConfig.Spec.Observability.Tracing.Port)
+		osmConfig.TracingEndpoint = meshConfig.Spec.Observability.Tracing.Endpoint
+	}
+
+	return &osmConfig
+}
+
+func meshConfigAddedMessageHandler(psubMsg *events.PubSubMessage) {
+	log.Debug().Msgf("[%s] OSM MeshConfig added event triggered a global proxy broadcast",
+		psubMsg.AnnouncementType)
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.ScheduleProxyBroadcast,
+		OldObj:           nil,
+		NewObj:           nil,
+	})
+}
+
+func meshConfigDeletedMessageHandler(psubMsg *events.PubSubMessage) {
+	// Ignore deletion. We expect config to be present
+	log.Debug().Msgf("[%s] OSM MeshConfig deleted event triggered a global proxy broadcast",
+		psubMsg.AnnouncementType)
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.ScheduleProxyBroadcast,
+		OldObj:           nil,
+		NewObj:           nil,
+	})
+}
+
+func meshConfigUpdatedMessageHandler(psubMsg *events.PubSubMessage) {
+	// Get config map
+	prevMeshConfigObj, okPrevCast := psubMsg.OldObj.(*v1alpha1.MeshConfig)
+	newMeshConfigObj, okNewCast := psubMsg.NewObj.(*v1alpha1.MeshConfig)
+	if !okPrevCast || !okNewCast {
+		log.Error().Msgf("[%s] Error casting old/new MeshConfigs objects (%v %v)",
+			psubMsg.AnnouncementType, okPrevCast, okNewCast)
+		return
+	}
+
+	// Parse old and new configs
+	prevMeshConfig := parseOSMMeshConfig(prevMeshConfigObj)
+	newMeshConfig := parseOSMMeshConfig(newMeshConfigObj)
+
+	// Determine if we should issue new global config update to all envoys
+	triggerGlobalBroadcast := false
+
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.Egress != newMeshConfig.Egress)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.PermissiveTrafficPolicyMode != newMeshConfig.PermissiveTrafficPolicyMode)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.UseHTTPSIngress != newMeshConfig.UseHTTPSIngress)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingEnable != newMeshConfig.TracingEnable)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingAddress != newMeshConfig.TracingAddress)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingEndpoint != newMeshConfig.TracingEndpoint)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingPort != newMeshConfig.TracingPort)
+
+	if triggerGlobalBroadcast {
+		log.Debug().Msgf("[%s] OSM MeshConfig update triggered global proxy broadcast",
+			psubMsg.AnnouncementType)
+		events.GetPubSubInstance().Publish(events.PubSubMessage{
+			AnnouncementType: announcements.ScheduleProxyBroadcast,
+			OldObj:           nil,
+			NewObj:           nil,
+		})
+	} else {
+		log.Trace().Msgf("[%s] OSM MeshConfig update, NOT triggering global proxy broadcast",
+			psubMsg.AnnouncementType)
+	}
+}

--- a/pkg/configurator/crd_client_test.go
+++ b/pkg/configurator/crd_client_test.go
@@ -1,0 +1,259 @@
+package configurator
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	tassert "github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testclient "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+)
+
+const (
+	osmMeshConfigName = "-test-osm-mesh-config-"
+)
+
+var _ = Describe("Test OSM MeshConfig parsing", func() {
+	meshConfigClientSet := testclient.NewSimpleClientset()
+
+	confChannel := events.GetPubSubInstance().Subscribe(
+		announcements.MeshConfigAdded,
+		announcements.MeshConfigDeleted,
+		announcements.MeshConfigUpdated)
+	defer events.GetPubSubInstance().Unsub(confChannel)
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	cfg := newConfiguratorWithCRDClient(meshConfigClientSet, stop, osmNamespace)
+	Expect(cfg).ToNot(BeNil())
+
+	meshConfig := v1alpha1.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: osmNamespace,
+			Name:      osmMeshConfigName,
+		},
+	}
+
+	if _, err := meshConfigClientSet.ConfigV1alpha1().MeshConfigs(osmNamespace).Create(context.TODO(), &meshConfig, metav1.CreateOptions{}); err != nil {
+		GinkgoT().Fatalf("[TEST] Error creating MeshConfig %s/%s/: %s", meshConfig.Namespace, meshConfig.Name, err.Error())
+	}
+	<-confChannel
+
+	Context("Ensure we are able to get reasonable defaults from MeshConfig", func() {
+
+		It("Tag matches const key for all fields of OSM MeshConfig struct", func() {
+			fieldNameTag := map[string]string{
+				"PermissiveTrafficPolicyMode":   PermissiveTrafficPolicyModeKey,
+				"Egress":                        egressKey,
+				"EnableDebugServer":             enableDebugServer,
+				"PrometheusScraping":            prometheusScrapingKey,
+				"TracingEnable":                 tracingEnableKey,
+				"TracingAddress":                tracingAddressKey,
+				"TracingPort":                   tracingPortKey,
+				"TracingEndpoint":               tracingEndpointKey,
+				"UseHTTPSIngress":               useHTTPSIngressKey,
+				"EnvoyLogLevel":                 envoyLogLevel,
+				"ServiceCertValidityDuration":   serviceCertValidityDurationKey,
+				"OutboundIPRangeExclusionList":  outboundIPRangeExclusionListKey,
+				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,
+				"ConfigResyncInterval":          configResyncInterval,
+				"MaxDataPlaneConnections":       maxDataPlaneConnectionsKey,
+			}
+			t := reflect.TypeOf(osmConfig{})
+
+			expectedNumberOfFields := t.NumField()
+			actualNumberOfFields := len(fieldNameTag)
+
+			Expect(expectedNumberOfFields).To(
+				Equal(actualNumberOfFields),
+				fmt.Sprintf("Fields have been added or removed from the osmConfig struct -- expected %d, actual %d; please correct this unit test", expectedNumberOfFields, actualNumberOfFields))
+
+			for fieldName, expectedTag := range fieldNameTag {
+				f, _ := t.FieldByName("PermissiveTrafficPolicyMode")
+				actualtag := f.Tag.Get("yaml")
+				Expect(actualtag).To(
+					Equal(PermissiveTrafficPolicyModeKey),
+					fmt.Sprintf("Field %s expected to have tag %s; found %s instead", fieldName, expectedTag, actualtag))
+			}
+		})
+	})
+})
+
+// Tests config map event trigger routine
+func TestMeshConfigEventTriggers(t *testing.T) {
+	assert := tassert.New(t)
+	meshConfigClientSet := testclient.NewSimpleClientset()
+
+	confChannel := events.GetPubSubInstance().Subscribe(
+		announcements.MeshConfigAdded,
+		announcements.MeshConfigDeleted,
+		announcements.MeshConfigUpdated)
+	defer events.GetPubSubInstance().Unsub(confChannel)
+
+	proxyBroadcastChannel := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
+	defer events.GetPubSubInstance().Unsub(proxyBroadcastChannel)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	_ = newConfiguratorWithCRDClient(meshConfigClientSet, stop, osmNamespace)
+
+	meshConfig := v1alpha1.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: osmNamespace,
+			Name:      osmMeshConfigName,
+		},
+	}
+
+	if _, err := meshConfigClientSet.ConfigV1alpha1().MeshConfigs(osmNamespace).Create(context.TODO(), &meshConfig, metav1.CreateOptions{}); err != nil {
+		GinkgoT().Fatalf("[TEST] Error creating MeshConfig %s/%s/: %s", meshConfig.Namespace, meshConfig.Name, err.Error())
+	}
+
+	// MeshConfig Create will generate a MeshConfig notification, and Configurator will issue a ProxyBroadcast for a Create as well
+	<-confChannel
+	<-proxyBroadcastChannel
+
+	tests := []struct {
+		deltaMeshConfigContents map[string]string
+		expectProxyBroadcast    bool
+	}{
+		{
+			deltaMeshConfigContents: map[string]string{
+				egressKey: "true",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				PermissiveTrafficPolicyModeKey: "true",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				useHTTPSIngressKey: "true",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				tracingEnableKey: "true",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				tracingAddressKey: "jaeger.jagnamespace.cluster.svc.local",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				tracingEndpointKey: "true",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				tracingPortKey: "3521",
+			},
+			expectProxyBroadcast: true,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				envoyLogLevel: "warn",
+			},
+			expectProxyBroadcast: false,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				enableDebugServer: "true",
+			},
+			expectProxyBroadcast: false,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				serviceCertValidityDurationKey: "30h",
+			},
+			expectProxyBroadcast: false,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				serviceCertValidityDurationKey: "30h",
+			},
+			expectProxyBroadcast: false,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				enablePrivilegedInitContainer: "true",
+			},
+			expectProxyBroadcast: false,
+		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				outboundIPRangeExclusionListKey: "true",
+			},
+			expectProxyBroadcast: false,
+		},
+	}
+
+	for _, tc := range tests {
+		// merge meshconfig
+		for mapKey, mapVal := range tc.deltaMeshConfigContents {
+			switch mapKey {
+			case egressKey:
+				meshConfig.Spec.Traffic.Egress, _ = strconv.ParseBool(mapVal)
+			case PermissiveTrafficPolicyModeKey:
+				meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode, _ = strconv.ParseBool(mapVal)
+			case useHTTPSIngressKey:
+				meshConfig.Spec.Traffic.UseHTTPSIngress, _ = strconv.ParseBool(mapVal)
+			case tracingEnableKey:
+				meshConfig.Spec.Observability.Tracing.Enable, _ = strconv.ParseBool(mapVal)
+			case tracingAddressKey:
+				meshConfig.Spec.Observability.Tracing.Address = mapVal
+			case tracingEndpointKey:
+				meshConfig.Spec.Observability.Tracing.Endpoint = mapVal
+			case tracingPortKey:
+				port, _ := strconv.ParseInt(mapVal, 10, 16)
+				meshConfig.Spec.Observability.Tracing.Port = int16(port)
+			case envoyLogLevel:
+				meshConfig.Spec.Sidecar.LogLevel = mapVal
+			case enableDebugServer:
+				meshConfig.Spec.Observability.EnableDebugServer, _ = strconv.ParseBool(mapVal)
+			case serviceCertValidityDurationKey:
+				meshConfig.Spec.Certificate.ServiceCertValidityDuration = mapVal
+			case enablePrivilegedInitContainer:
+				meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer, _ = strconv.ParseBool(mapVal)
+			case outboundIPRangeExclusionListKey:
+				meshConfig.Spec.Traffic.OutboundIPRangeExclusionList = strings.Split(mapVal, ",")
+			}
+		}
+
+		_, err := meshConfigClientSet.ConfigV1alpha1().MeshConfigs(osmNamespace).Update(context.TODO(), &meshConfig, metav1.UpdateOptions{})
+		assert.NoError(err)
+		<-confChannel
+
+		proxyEventReceived := false
+		select {
+		case <-proxyBroadcastChannel:
+			proxyEventReceived = true
+
+		case <-time.NewTimer(300 * time.Millisecond).C:
+			// one third of a second should be plenty
+		}
+		assert.Equal(tc.expectProxyBroadcast, proxyEventReceived)
+	}
+}

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -22,6 +22,15 @@ type Client struct {
 	cacheSynced      chan interface{}
 }
 
+// CRDClient is the k8s client struct for the MeshConfig CRD. The feature is in experimental stage.
+type CRDClient struct {
+	// TODO: rename it to `client`
+	osmNamespace string
+	informer     cache.SharedIndexInformer
+	cache        cache.Store
+	cacheSynced  chan interface{}
+}
+
 // Configurator is the controller interface for K8s namespaces
 type Configurator interface {
 	// GetOSMNamespace returns the namespace in which OSM controller pod resides


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
Add informer for MeshConfig CRD. This is a prerequisite for migrating from configuration using configmap to CRD.

MeshConfig CRD informer is developed but not used in this PR. In consequent PRs, osm controller will start to a meshConfig client, and update service mesh config accordingly. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]


Close #3038 

Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

`No`
