### PR TITLE
e2e/scale: update test install values

### DIFF
--- a/tests/framework/common_profile.go
+++ b/tests/framework/common_profile.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/olekukonko/tablewriter"
+
+	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,6 +124,11 @@ func (sd *DataHandle) Iterate(f func()) {
 		fmt.Printf("-- Successfully completed iteration %d - took %v\n", sd.Iterations, diff)
 		sd.OutputIteration(sd.Iterations, os.Stdout)
 		fmt.Println("--------")
+
+		restarts := Td.VerifyRestarts()
+		if restarts {
+			Fail("Failed at iteration %d, seen restarts", sd.Iterations)
+		}
 
 		// Increase iterations done
 		sd.Iterations++

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -27,13 +27,9 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 		})
 
 		It("Tests HTTP traffic from Clients to the traffic split Cluster IP", func() {
-			// Install OSM with all the requirements
 			var err error
-			// Prometheus scrapping is not scalable past a certain number of proxies given
-			// current configuration/constraints. We will disable getting proxy metrics
-			// while we focus on qualifying control plane.
-			// Note: this does not prevent osm metrics scraping.
-			Td.EnableNsMetricTag = false
+
+			// Install OSM with all the requirements
 			sd, err = scaleOSMInstall()
 			Expect(err).To(BeNil())
 


### PR DESCRIPTION
- Default error log level for scale tests to avoid
  log burden on the nodes (specially for envoy)
- Store only logs for control plane on test exit
- Set 1G request/limits for OSM in scale-tests
- Verify restarts of control plane processes after
  every test iteration.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

**Affected area**:

- Tests                  [X]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
X