### PR TITLE
feat(cli): show osm version for osm mesh list

### DIFF
--- a/cmd/cli/mesh_list.go
+++ b/cmd/cli/mesh_list.go
@@ -64,12 +64,13 @@ func (l *meshListCmd) run() error {
 
 	w := newTabWriter(l.out)
 
-	fmt.Fprintln(w, "\nMESH NAME\tNAMESPACE\tCONTROLLER PODS")
+	fmt.Fprintln(w, "\nMESH NAME\tNAMESPACE\tCONTROLLER PODS\tVERSION")
 	for _, elem := range list.Items {
 		m := elem.ObjectMeta.Labels["meshName"]
 		ns := elem.ObjectMeta.Namespace
 		x := getNamespacePods(l.clientSet, m, ns)
-		fmt.Fprintf(w, "%s\t%s\t%s\n", m, ns, strings.Join(x["Pods"], ","))
+		v := elem.ObjectMeta.Labels[constants.OSMAppVersionLabelKey]
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", m, ns, strings.Join(x["Pods"], ","), v)
 	}
 	_ = w.Flush()
 

--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -66,7 +66,7 @@ func createFakeController(fakeClient kubernetes.Interface) error {
 		return err
 	}
 
-	controllerDep := createDeployment("test-controller", testMesh, true)
+	controllerDep := createDeployment("test-controller", testMesh, "testVersion0.1.2", true)
 	if _, err := fakeClient.AppsV1().Deployments(controllerNs.Name).Create(context.TODO(), controllerDep, metav1.CreateOptions{}); err != nil {
 		return err
 	}

--- a/docs/content/docs/control_plane_health_probes.md
+++ b/docs/content/docs/control_plane_health_probes.md
@@ -122,9 +122,9 @@ If any health probes are consistently failing, perform the following steps to id
     ```console
     $ osm mesh list
     
-    MESH NAME   NAMESPACE      CONTROLLER PODS
-    osm         osm-system     osm-controller-5494bcffb6-qpjdv
-    osm2        osm-system-2   osm-controller-48fd3c810d-sornc
+    MESH NAME   NAMESPACE      CONTROLLER PODS                   VERSION
+    osm         osm-system     osm-controller-5494bcffb6-qpjdv   v0.8.2
+    osm2        osm-system-2   osm-controller-48fd3c810d-sornc   v0.8.2
     ```
 
     Note how `osm-system` is present in the following list:


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Show the OSM control plane version when osm mesh list
is run. This uses the OSM version label that is present
in all OSM resources.

This leverages the work previously done in PR #3068.
This resolves issue #2848.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [x]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A.
