### PR TITLE
configurator: fixes for configurator event listener

### DIFF
--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -25,11 +25,10 @@ const (
 )
 
 var _ = Describe("Test OSM ConfigMap parsing", func() {
-	defer GinkgoRecover()
-
 	kubeClient := testclient.NewSimpleClientset()
 
-	stop := make(<-chan struct{})
+	stop := make(chan struct{})
+	defer close(stop)
 	cfg := newConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 	Expect(cfg).ToNot(BeNil())
 
@@ -138,7 +137,8 @@ func TestConfigMapEventTriggers(t *testing.T) {
 	proxyBroadcastChannel := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
 	defer events.GetPubSubInstance().Unsub(proxyBroadcastChannel)
 
-	stop := make(<-chan struct{})
+	stop := make(chan struct{})
+	defer close(stop)
 	newConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
 
 	configMap := v1.ConfigMap{

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -269,13 +269,18 @@ func TestCreateUpdateConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert := tassert.New(t)
-
 			kubeClient := testclient.NewSimpleClientset()
-			stop := make(chan struct{})
-			cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+
+			// Prepare the pubsub channel
 			confChannel := events.GetPubSubInstance().Subscribe(announcements.ConfigMapAdded, announcements.ConfigMapUpdated)
 			defer events.GetPubSubInstance().Unsub(confChannel)
 
+			// Create configurator
+			stop := make(chan struct{})
+			defer close(stop)
+			cfg := NewConfigurator(kubeClient, stop, osmNamespace, osmConfigMapName)
+
+			// Issue config map create
 			configMap := v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,


### PR DESCRIPTION
There might be a race on Pubsub library creation and use, where Pubsub
could have potentially not finished subscribing due to the nature
of Go, and we might miss an event as a consequence in some corner cases.

Subscribing uses unbuffered channel message passing to subscribe internally,
inside pubsub lib. A goroutine handles the actual subscription (adding the sub channel to maps, etc).
Depending on scheduling, a quick publish on a channel recently subscribed to
could theoretically loose the event if the scheduler didn't fully finish the subscribe
handler (ie. the routine yielded for whatever reason).

The result is the test is stuck waiting for a notification that might have happened before
subscription was committed.

```
2021-04-12T19:58:14.6347348Z goroutine 222 [chan receive, 1 minutes]:
2021-04-12T19:58:14.6350220Z github.com/openservicemesh/osm/pkg/configurator.TestCreateUpdateConfig.func27(0xc000313980)
2021-04-12T19:58:14.6352102Z 	/home/runner/work/osm/osm/pkg/configurator/methods_test.go:290 +0x40e
2021-04-12T19:58:14.6352797Z testing.tRunner(0xc000313980, 0xc00045b250)
2021-04-12T19:58:14.6353542Z 	/opt/hostedtoolcache/go/1.15.11/x64/src/testing/testing.go:1123 +0xef
2021-04-12T19:58:14.6354555Z created by testing.(*T).Run
2021-04-12T19:58:14.6355278Z 	/opt/hostedtoolcache/go/1.15.11/x64/src/testing/testing.go:1168 +0x2b3
```

- Changing the initialization order on `methods_test.go` to give more time to Pubsub to ensure
  subscription was committed.
- Also adding close/stop statements to configurator to cleanup and stop dangling go-routines
  from multiple configurators.

This is just a mitigation though. A full fix should synchronously ensure a subscription was committed
on Pubsub backend.

```
go test . -test.failfast -count 100 -run TestConfigMapEventTriggers
ok  	github.com/openservicemesh/osm/pkg/configurator	220.582s
go test . -test.failfast -count 100 -run TestCreateUpdateConfig
ok  	github.com/openservicemesh/osm/pkg/configurator	122.199s
```


- Tests                  [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No