### PR TITLE
feat(pkg/trafficpolicy) : updating merge logic for inbound and outbound traffic policies

### DIFF
--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -10,6 +10,13 @@ import (
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
+const (
+	// AllowPartialHostnamesMatch is used to allow a partial/subset match on hostnames in traffic policies
+	AllowPartialHostnamesMatch bool = true
+	// DisallowPartialHostnamesMatch is used to disallow a partial/subset match on hostnames in traffic policies
+	DisallowPartialHostnamesMatch bool = false
+)
+
 // ListInboundTrafficPolicies returns all inbound traffic policies
 // 1. from service discovery for permissive mode
 // 2. for the given service account and upstream services from SMI Traffic Target and Traffic Split
@@ -17,14 +24,14 @@ func (mc *MeshCatalog) ListInboundTrafficPolicies(upstreamIdentity service.K8sSe
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
 		inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
 		for _, svc := range upstreamServices {
-			inboundPolicies = trafficpolicy.MergeInboundPolicies(false, inboundPolicies, mc.buildInboundPermissiveModePolicies(svc)...)
+			inboundPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundPolicies, mc.buildInboundPermissiveModePolicies(svc)...)
 		}
 		return inboundPolicies
 	}
 
 	inbound := mc.listInboundPoliciesFromTrafficTargets(upstreamIdentity, upstreamServices)
 	inboundPoliciesFRomSplits := mc.listInboundPoliciesForTrafficSplits(upstreamIdentity, upstreamServices)
-	inbound = trafficpolicy.MergeInboundPolicies(false, inbound, inboundPoliciesFRomSplits...)
+	inbound = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inbound, inboundPoliciesFRomSplits...)
 	return inbound
 }
 
@@ -43,7 +50,7 @@ func (mc *MeshCatalog) listInboundPoliciesFromTrafficTargets(upstreamIdentity se
 		}
 
 		for _, svc := range upstreamServices {
-			inboundPolicies = trafficpolicy.MergeInboundPolicies(false, inboundPolicies, mc.buildInboundPolicies(t, svc)...)
+			inboundPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundPolicies, mc.buildInboundPolicies(t, svc)...)
 		}
 	}
 
@@ -94,7 +101,7 @@ func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity serv
 						servicePolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(routeMatch, []service.WeightedCluster{weightedCluster}), sourceServiceAccount)
 					}
 				}
-				inboundPolicies = trafficpolicy.MergeInboundPolicies(false, inboundPolicies, servicePolicy)
+				inboundPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundPolicies, servicePolicy)
 			}
 		}
 	}

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -81,7 +81,7 @@ func (mc *MeshCatalog) getIngressPoliciesNetworkingV1beta1(svc service.MeshServi
 		if ingress.Spec.Backend != nil && ingress.Spec.Backend.ServiceName == svc.Name {
 			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
 			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(trafficpolicy.WildCardRouteMatch, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
-			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
+			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundIngressPolicies, wildcardIngressPolicy)
 		}
 
 		for _, rule := range ingress.Spec.Rules {
@@ -143,7 +143,7 @@ func (mc *MeshCatalog) getIngressPoliciesNetworkingV1beta1(svc service.MeshServi
 
 			// Only create an ingress policy if the ingress policy resulted in valid rules
 			if len(ingressPolicy.Rules) > 0 {
-				inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)
+				inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundIngressPolicies, ingressPolicy)
 			}
 		}
 	}
@@ -170,7 +170,7 @@ func (mc *MeshCatalog) getIngressPoliciesNetworkingV1(svc service.MeshService) (
 		if ingress.Spec.DefaultBackend != nil && ingress.Spec.DefaultBackend.Service.Name == svc.Name {
 			wildcardIngressPolicy := trafficpolicy.NewInboundTrafficPolicy(buildIngressPolicyName(ingress.ObjectMeta.Name, ingress.ObjectMeta.Namespace, constants.WildcardHTTPMethod), []string{constants.WildcardHTTPMethod})
 			wildcardIngressPolicy.AddRule(*trafficpolicy.NewRouteWeightedCluster(trafficpolicy.WildCardRouteMatch, []service.WeightedCluster{ingressWeightedCluster}), wildcardServiceAccount)
-			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, wildcardIngressPolicy)
+			inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundIngressPolicies, wildcardIngressPolicy)
 		}
 
 		for _, rule := range ingress.Spec.Rules {
@@ -232,7 +232,7 @@ func (mc *MeshCatalog) getIngressPoliciesNetworkingV1(svc service.MeshService) (
 
 			// Only create an ingress policy if the ingress policy resulted in valid rules
 			if len(ingressPolicy.Rules) > 0 {
-				inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(false, inboundIngressPolicies, ingressPolicy)
+				inboundIngressPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundIngressPolicies, ingressPolicy)
 			}
 		}
 	}

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -17,14 +17,14 @@ import (
 func (mc *MeshCatalog) ListOutboundTrafficPolicies(downstreamIdentity service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
 		outboundPolicies := []*trafficpolicy.OutboundTrafficPolicy{}
-		mergedPolicies := trafficpolicy.MergeOutboundPolicies(outboundPolicies, mc.buildOutboundPermissiveModePolicies()...)
+		mergedPolicies := trafficpolicy.MergeOutboundPolicies(DisallowPartialHostnamesMatch, outboundPolicies, mc.buildOutboundPermissiveModePolicies()...)
 		outboundPolicies = mergedPolicies
 		return outboundPolicies
 	}
 
 	outbound := mc.listOutboundPoliciesForTrafficTargets(downstreamIdentity)
 	outboundPoliciesFromSplits := mc.listOutboundTrafficPoliciesForTrafficSplits(downstreamIdentity.Namespace)
-	outbound = trafficpolicy.MergeOutboundPolicies(outbound, outboundPoliciesFromSplits...)
+	outbound = trafficpolicy.MergeOutboundPolicies(DisallowPartialHostnamesMatch, outbound, outboundPoliciesFromSplits...)
 
 	return outbound
 }
@@ -41,7 +41,7 @@ func (mc *MeshCatalog) listOutboundPoliciesForTrafficTargets(downstreamIdentity 
 
 		for _, source := range t.Spec.Sources {
 			if source.Name == downstreamIdentity.Name && source.Namespace == downstreamIdentity.Namespace { // found outbound
-				mergedPolicies := trafficpolicy.MergeOutboundPolicies(outboundPolicies, mc.buildOutboundPolicies(downstreamIdentity, t)...)
+				mergedPolicies := trafficpolicy.MergeOutboundPolicies(DisallowPartialHostnamesMatch, outboundPolicies, mc.buildOutboundPolicies(downstreamIdentity, t)...)
 				outboundPolicies = mergedPolicies
 				break
 			}

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -49,7 +49,7 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_dis
 			log.Error().Err(err).Msgf("Error looking up ingress policies for service=%s", svc.String())
 			return nil, err
 		}
-		ingressTrafficPolicies = trafficpolicy.MergeInboundPolicies(true, ingressTrafficPolicies, ingressInboundPolicies...)
+		ingressTrafficPolicies = trafficpolicy.MergeInboundPolicies(catalog.AllowPartialHostnamesMatch, ingressTrafficPolicies, ingressInboundPolicies...)
 	}
 	if len(ingressTrafficPolicies) > 0 {
 		ingressRouteConfig := route.BuildIngressConfiguration(ingressTrafficPolicies, proxy)

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -2,6 +2,7 @@ package trafficpolicy
 
 import (
 	"reflect"
+	"sort"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
@@ -102,22 +103,25 @@ func (out *OutboundTrafficPolicy) AddRoute(httpRouteMatch HTTPRouteMatch, weight
 }
 
 // MergeInboundPolicies merges latest InboundTrafficPolicies into a slice of InboundTrafficPolicies that already exists (original)
-// allowPartialHostnamesMatch is set to true when we intend to merge ingress policies with traffic policies
+// allowPartialHostnamesMatch when set to true merges inbound policies by partially comparing (subset of one another) the hostnames of the original traffic policy to the latest traffic policy
+// A partial match on hostnames should be allowed for the following scenarios :
+// 1. when an ingress policy is being merged with other ingress traffic policies or
+// 2. when a policy having its hostnames from a host header needs to be merged with other inbound traffic policies
+// in either of these cases the will be only a single hostname and there is a possibility that this hostname is part of an existing traffic policy
+// hence the rules need to be merged
 func MergeInboundPolicies(allowPartialHostnamesMatch bool, original []*InboundTrafficPolicy, latest ...*InboundTrafficPolicy) []*InboundTrafficPolicy {
 	for _, l := range latest {
 		foundHostnames := false
 		for _, or := range original {
 			if !allowPartialHostnamesMatch {
-				// For an traffic target inbound policy the hostnames list should fully intersect
-				// to merge the rules
 				if reflect.DeepEqual(or.Hostnames, l.Hostnames) {
 					foundHostnames = true
 					or.Rules = mergeRules(or.Rules, l.Rules)
 				}
 			} else {
-				// When an inbound traffic policy is being merged with an ingress traffic policy the hostnames is not the entire comprehensive list of kubernetes service names
-				// and will just be a subset to merge the rules
-				if subset(or.Hostnames, l.Hostnames) {
+				// If l.Hostnames is a subset of or.Hostnames or vice versa then we need to get a union of the two
+				if hostsUnion := slicesUnionIfSubset(or.Hostnames, l.Hostnames); len(hostsUnion) > 0 {
+					or.Hostnames = hostsUnion
 					foundHostnames = true
 					or.Rules = mergeRules(or.Rules, l.Rules)
 				}
@@ -131,14 +135,29 @@ func MergeInboundPolicies(allowPartialHostnamesMatch bool, original []*InboundTr
 }
 
 // MergeOutboundPolicies merges two slices of *OutboundTrafficPolicies so that there is only one traffic policy for a given set of a hostnames
-func MergeOutboundPolicies(original []*OutboundTrafficPolicy, latest ...*OutboundTrafficPolicy) []*OutboundTrafficPolicy {
+// allowPartialHostnamesMatch when set to true merges outbound policies by partially comparing (subset of one another) the hostnames of the original traffic policy to the latest traffic policy
+// Two outbound traffic policies can be merged by comparing their hostnames either partially or completely. A partial match on hostnames should be allowed for the following scenarios :
+// when a policy having its hostnames from a host header needs to be merged with other outbound policies
+// This is because there will be a single hostname (from the host header) and there is a possibility that this hostname is part of an existing traffic policy
+// hence the rules need to be merged
+func MergeOutboundPolicies(allowPartialHostnamesMatch bool, original []*OutboundTrafficPolicy, latest ...*OutboundTrafficPolicy) []*OutboundTrafficPolicy {
 	for _, l := range latest {
 		foundHostnames := false
 		for _, or := range original {
-			if reflect.DeepEqual(or.Hostnames, l.Hostnames) {
-				foundHostnames = true
-				mergedRoutes := mergeRoutesWeightedClusters(or.Routes, l.Routes)
-				or.Routes = mergedRoutes
+			if !allowPartialHostnamesMatch {
+				if reflect.DeepEqual(or.Hostnames, l.Hostnames) {
+					foundHostnames = true
+					mergedRoutes := mergeRoutesWeightedClusters(or.Routes, l.Routes)
+					or.Routes = mergedRoutes
+				}
+			} else {
+				// If l.Hostnames is a subset of or.Hostnames or vice versa then we need to get a union of the two
+				if hostsUnion := slicesUnionIfSubset(or.Hostnames, l.Hostnames); len(hostsUnion) > 0 {
+					or.Hostnames = hostsUnion
+					foundHostnames = true
+					mergedRoutes := mergeRoutesWeightedClusters(or.Routes, l.Routes)
+					or.Routes = mergedRoutes
+				}
 			}
 		}
 		if !foundHostnames {
@@ -189,18 +208,35 @@ func mergeRoutesWeightedClusters(originalRoutes, latestRoutes []*RouteWeightedCl
 	return originalRoutes
 }
 
-// subset returns true if the second array is completely contained in the first array
-func subset(first, second []string) bool {
-	set := make(map[string]bool)
-	for _, value := range first {
-		set[value] = true
+// slicesUnionIfSubset returns the union of the two slices if either slices is a subset of the other
+func slicesUnionIfSubset(first, second []string) []string {
+	areSubsets := false
+	unionSlice := []string{}
+	firstIntf := convertToInterface(first)
+	secondIntf := convertToInterface(second)
+
+	firstSet := mapset.NewSetFromSlice(firstIntf)
+	secondSet := mapset.NewSetFromSlice(secondIntf)
+
+	if firstSet.IsSubset(secondSet) || secondSet.IsSubset(firstSet) {
+		areSubsets = true
 	}
 
-	for _, value := range second {
-		if _, found := set[value]; !found {
-			return false
+	if areSubsets {
+		union := firstSet.Union(secondSet)
+		for intf := range union.Iter() {
+			unionSlice = append(unionSlice, intf.(string))
 		}
+		sort.Strings(unionSlice)
+		return unionSlice
 	}
+	return unionSlice
+}
 
-	return true
+func convertToInterface(slice []string) []interface{} {
+	sliceInterface := make([]interface{}, len(slice))
+	for i := range slice {
+		sliceInterface[i] = slice[i]
+	}
+	return sliceInterface
 }

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -256,6 +256,16 @@ func TestMergeInboundPolicies(t *testing.T) {
 		Route:                  testRoute2,
 		AllowedServiceAccounts: mapset.NewSet(testServiceAccount2),
 	}
+	testRule1Modified := Rule{
+		Route: RouteWeightedClusters{
+			HTTPRouteMatch: HTTPRouteMatch{
+				Path:          "/hello",
+				PathMatchType: PathMatchRegex,
+				Methods:       []string{"*"},
+			},
+			WeightedClusters: mapset.NewSet(testWeightedCluster),
+		},
+	}
 	testCases := []struct {
 		name            string
 		originalInbound []*InboundTrafficPolicy
@@ -308,6 +318,27 @@ func TestMergeInboundPolicies(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "hostnames match but rules differ",
+			originalInbound: []*InboundTrafficPolicy{
+				{
+					Hostnames: testHostnames,
+					Rules:     []*Rule{&testRule1, &testRule2},
+				},
+			},
+			newInbound: []*InboundTrafficPolicy{
+				{
+					Hostnames: testHostnames,
+					Rules:     []*Rule{&testRule1Modified},
+				},
+			},
+			expectedInbound: []*InboundTrafficPolicy{
+				{
+					Hostnames: testHostnames,
+					Rules:     []*Rule{&testRule1, &testRule2, &testRule1Modified},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -318,7 +349,7 @@ func TestMergeInboundPolicies(t *testing.T) {
 	}
 }
 
-func TestMergeInboundPoliciesWithIngress(t *testing.T) {
+func TestMergeInboundPoliciesWithPartialHostnames(t *testing.T) {
 	assert := tassert.New(t)
 
 	testRule1 := Rule{
@@ -340,66 +371,20 @@ func TestMergeInboundPoliciesWithIngress(t *testing.T) {
 		},
 	}
 	testCases := []struct {
-		name              string
-		originalInbound   []*InboundTrafficPolicy
-		newIngressInbound []*InboundTrafficPolicy
-		expectedInbound   []*InboundTrafficPolicy
+		name            string
+		originalInbound []*InboundTrafficPolicy
+		newInbound      []*InboundTrafficPolicy
+		expectedInbound []*InboundTrafficPolicy
 	}{
 		{
-			name: "hostnames match",
+			name: "hostnames is a subset",
 			originalInbound: []*InboundTrafficPolicy{
 				{
 					Hostnames: testHostnames,
 					Rules:     []*Rule{&testRule1, &testRule2},
 				},
 			},
-			newIngressInbound: []*InboundTrafficPolicy{
-				{
-					Hostnames: testHostnames,
-					Rules:     []*Rule{&testRule2},
-				},
-			},
-			expectedInbound: []*InboundTrafficPolicy{
-				{
-					Hostnames: testHostnames,
-					Rules:     []*Rule{&testRule1, &testRule2},
-				},
-			},
-		},
-		{
-			name: "hostnames do not match",
-			originalInbound: []*InboundTrafficPolicy{
-				{
-					Hostnames: testHostnames,
-					Rules:     []*Rule{&testRule1, &testRule2},
-				},
-			},
-			newIngressInbound: []*InboundTrafficPolicy{
-				{
-					Hostnames: testHostnames2,
-					Rules:     []*Rule{&testRule2},
-				},
-			},
-			expectedInbound: []*InboundTrafficPolicy{
-				{
-					Hostnames: testHostnames2,
-					Rules:     []*Rule{&testRule2},
-				},
-				{
-					Hostnames: testHostnames,
-					Rules:     []*Rule{&testRule1, &testRule2},
-				},
-			},
-		},
-		{
-			name: "hostnames in ingress is a subset",
-			originalInbound: []*InboundTrafficPolicy{
-				{
-					Hostnames: testHostnames,
-					Rules:     []*Rule{&testRule1, &testRule2},
-				},
-			},
-			newIngressInbound: []*InboundTrafficPolicy{
+			newInbound: []*InboundTrafficPolicy{
 				{
 					Hostnames: []string{"testHostname1"},
 					Rules:     []*Rule{&testRule2},
@@ -413,14 +398,14 @@ func TestMergeInboundPoliciesWithIngress(t *testing.T) {
 			},
 		},
 		{
-			name: "hostnames in ingress is a subset but rules differ",
+			name: "hostnames is a subset but rules differ",
 			originalInbound: []*InboundTrafficPolicy{
 				{
 					Hostnames: testHostnames,
 					Rules:     []*Rule{&testRule1, &testRule2},
 				},
 			},
-			newIngressInbound: []*InboundTrafficPolicy{
+			newInbound: []*InboundTrafficPolicy{
 				{
 					Hostnames: []string{"testHostname1"},
 					Rules:     []*Rule{&testRule1Modified},
@@ -437,8 +422,8 @@ func TestMergeInboundPoliciesWithIngress(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := MergeInboundPolicies(true, tc.originalInbound, tc.newIngressInbound...)
-			assert.ElementsMatch(tc.expectedInbound, actual)
+			actual := MergeInboundPolicies(true, tc.originalInbound, tc.newInbound...)
+			assert.ElementsMatch(actual, tc.expectedInbound)
 		})
 	}
 }
@@ -535,6 +520,7 @@ func TestMergeOutboundPolicies(t *testing.T) {
 	testCases := []struct {
 		name                                               string
 		originalPolicies, latestPolicies, expectedPolicies []*OutboundTrafficPolicy
+		allowPartialHostnamesMatch                         bool
 	}{
 		{
 			name: "hostnames don't match",
@@ -560,6 +546,7 @@ func TestMergeOutboundPolicies(t *testing.T) {
 					Routes:    []*RouteWeightedClusters{&testRoute},
 				},
 			},
+			allowPartialHostnamesMatch: false,
 		},
 		{
 			name: "hostnames match",
@@ -581,6 +568,7 @@ func TestMergeOutboundPolicies(t *testing.T) {
 					Routes:    []*RouteWeightedClusters{&testRoute, &testRoute2},
 				},
 			},
+			allowPartialHostnamesMatch: false,
 		},
 		{
 			name: "hostnames match, routes match",
@@ -602,6 +590,7 @@ func TestMergeOutboundPolicies(t *testing.T) {
 					Routes:    []*RouteWeightedClusters{&testRoute},
 				},
 			},
+			allowPartialHostnamesMatch: false,
 		},
 		{
 			name: "hostnames match, routes have same match conditions but diff weighted clusters",
@@ -626,12 +615,35 @@ func TestMergeOutboundPolicies(t *testing.T) {
 					Routes:    []*RouteWeightedClusters{&testRoute},
 				},
 			},
+			allowPartialHostnamesMatch: false,
+		},
+		{
+			name: "hostnames partially match",
+			originalPolicies: []*OutboundTrafficPolicy{
+				{
+					Hostnames: testHostnames,
+					Routes:    []*RouteWeightedClusters{&testRoute},
+				},
+			},
+			latestPolicies: []*OutboundTrafficPolicy{
+				{
+					Hostnames: []string{"testHostname1"},
+					Routes:    []*RouteWeightedClusters{&testRoute},
+				},
+			},
+			expectedPolicies: []*OutboundTrafficPolicy{
+				{
+					Hostnames: testHostnames,
+					Routes:    []*RouteWeightedClusters{&testRoute},
+				},
+			},
+			allowPartialHostnamesMatch: true,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := MergeOutboundPolicies(tc.originalPolicies, tc.latestPolicies...)
-			assert.ElementsMatch(tc.expectedPolicies, actual)
+			actual := MergeOutboundPolicies(tc.allowPartialHostnamesMatch, tc.originalPolicies, tc.latestPolicies...)
+			assert.ElementsMatch(actual, tc.expectedPolicies)
 		})
 	}
 }
@@ -769,7 +781,7 @@ func newTestOutboundPolicy(name string, routes []*RouteWeightedClusters) *Outbou
 	}
 }
 
-func TestSubset(t *testing.T) {
+func TestSlicesUnionIfSubset(t *testing.T) {
 	first := []string{"bookstore.bookstore",
 		"bookstore.bookstore.svc.cluster.local",
 		"bookstore:80",
@@ -784,10 +796,18 @@ func TestSubset(t *testing.T) {
 
 	second := []string{"bookstore.bookstore.svc.cluster.local"}
 	assert := tassert.New(t)
-	isSubset := subset(first, second)
-	assert.True(isSubset)
+	hostsUnion := slicesUnionIfSubset(first, second)
+	assert.NotEqual(len(hostsUnion), 0)
+	assert.ElementsMatch(first, hostsUnion)
+
+	hostsUnion = slicesUnionIfSubset(second, first)
+	assert.NotEqual(len(hostsUnion), 0)
+	assert.ElementsMatch(first, hostsUnion)
 
 	third := []string{"bookstore.bookstore.svc.cluster.local", "foo.com"}
-	isSubset = subset(first, third)
-	assert.False(isSubset)
+	hostsUnion = slicesUnionIfSubset(first, third)
+	assert.Equal(len(hostsUnion), 0)
+
+	hostsUnion = slicesUnionIfSubset(third, first)
+	assert.Equal(len(hostsUnion), 0)
 }


### PR DESCRIPTION
**Description**:

This commit allows partial hostname matches while merging both inbound
and outbound traffic policies. This change is necessary to support host
headers that users will specify as a part of the TrafficSpec and as this
will be a single host, so can only partially match to an existing
traffic policy and if that is the case the two policies should be
merged.

The commit also improves the logic of the 'subset` function in this
package. It checks is either slice is a subset of the other and returns a union of them

This is part of #2369

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
