### PR TITLE
ref(catalog): factor out proxy registry functionality

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -29,9 +29,6 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 		kubeController: kubeController,
 	}
 
-	// Run release certificate handler, which listens to podDelete events
-	mc.releaseCertificateHandler()
-
 	go mc.dispatcher()
 	ticker.InitTicker(cfg)
 

--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -1,63 +1,12 @@
 package catalog
 
 import (
-	"time"
-
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"
 )
-
-// ListExpectedProxies lists the Envoy proxies yet to connect and the time their XDS certificate was issued.
-func (mc *MeshCatalog) ListExpectedProxies() map[certificate.CommonName]time.Time {
-	proxies := make(map[certificate.CommonName]time.Time)
-
-	mc.expectedProxies.Range(func(cnInterface, expectedProxyInterface interface{}) bool {
-		cn := cnInterface.(certificate.CommonName)
-		props := expectedProxyInterface.(expectedProxy)
-
-		_, isConnected := mc.connectedProxies.Load(cn)
-		_, isDisconnected := mc.disconnectedProxies.Load(cn)
-
-		if !isConnected && !isDisconnected {
-			proxies[cn] = props.certificateIssuedAt
-		}
-
-		return true // continue the iteration
-	})
-
-	return proxies
-}
-
-// ListConnectedProxies lists the Envoy proxies already connected and the time they first connected.
-func (mc *MeshCatalog) ListConnectedProxies() map[certificate.CommonName]*envoy.Proxy {
-	proxies := make(map[certificate.CommonName]*envoy.Proxy)
-	mc.connectedProxies.Range(func(cnIface, propsIface interface{}) bool {
-		cn := cnIface.(certificate.CommonName)
-		props := propsIface.(connectedProxy)
-		if _, isDisconnected := mc.disconnectedProxies.Load(cn); !isDisconnected {
-			proxies[cn] = props.proxy
-		}
-		return true // continue the iteration
-	})
-	return proxies
-}
-
-// ListDisconnectedProxies lists the Envoy proxies disconnected and the time last seen.
-func (mc *MeshCatalog) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
-	proxies := make(map[certificate.CommonName]time.Time)
-	mc.disconnectedProxies.Range(func(cnInterface, disconnectedProxyInterface interface{}) bool {
-		cn := cnInterface.(certificate.CommonName)
-		props := disconnectedProxyInterface.(disconnectedProxy)
-		proxies[cn] = props.lastSeen
-		return true // continue the iteration
-	})
-	return proxies
-}
 
 // ListSMIPolicies returns all policies OSM is aware of.
 func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget) {

--- a/pkg/catalog/debugger_test.go
+++ b/pkg/catalog/debugger_test.go
@@ -4,78 +4,11 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 var _ = Describe("Test catalog proxy register/unregister", func() {
 	mc := newFakeMeshCatalog()
-	certCommonName := certificate.CommonName("foo")
-	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-
-	Context("Test register/unregister proxies", func() {
-		It("no proxies expected, connected or disconnected", func() {
-			expectedProxies := mc.ListExpectedProxies()
-			Expect(len(expectedProxies)).To(Equal(0))
-
-			connectedProxies := mc.ListConnectedProxies()
-			Expect(len(connectedProxies)).To(Equal(0))
-
-			disconnectedProxies := mc.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(0))
-		})
-
-		It("expect one proxy to connect", func() {
-			// mc.RegisterProxy(proxy)
-			mc.ExpectProxy(certCommonName)
-
-			expectedProxies := mc.ListExpectedProxies()
-			Expect(len(expectedProxies)).To(Equal(1))
-
-			connectedProxies := mc.ListConnectedProxies()
-			Expect(len(connectedProxies)).To(Equal(0))
-
-			disconnectedProxies := mc.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(0))
-
-			_, ok := expectedProxies[certCommonName]
-			Expect(ok).To(BeTrue())
-		})
-
-		It("one proxy connected to OSM", func() {
-			mc.RegisterProxy(proxy)
-
-			expectedProxies := mc.ListExpectedProxies()
-			Expect(len(expectedProxies)).To(Equal(0))
-
-			connectedProxies := mc.ListConnectedProxies()
-			Expect(len(connectedProxies)).To(Equal(1))
-
-			disconnectedProxies := mc.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(0))
-
-			_, ok := connectedProxies[certCommonName]
-			Expect(ok).To(BeTrue())
-		})
-
-		It("one proxy disconnected from OSM", func() {
-			mc.UnregisterProxy(proxy)
-
-			expectedProxies := mc.ListExpectedProxies()
-			Expect(len(expectedProxies)).To(Equal(0))
-
-			connectedProxies := mc.ListConnectedProxies()
-			Expect(len(connectedProxies)).To(Equal(0))
-
-			disconnectedProxies := mc.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(1))
-
-			_, ok := disconnectedProxies[certCommonName]
-			Expect(ok).To(BeTrue())
-		})
-	})
 
 	Context("Test ListMonitoredNamespaces", func() {
 		It("lists monitored namespaces", func() {

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -10,7 +10,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
-	envoy "github.com/openservicemesh/osm/pkg/envoy"
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -37,32 +36,6 @@ func NewMockMeshCataloger(ctrl *gomock.Controller) *MockMeshCataloger {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMeshCataloger) EXPECT() *MockMeshCatalogerMockRecorder {
 	return m.recorder
-}
-
-// ExpectProxy mocks base method
-func (m *MockMeshCataloger) ExpectProxy(arg0 certificate.CommonName) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ExpectProxy", arg0)
-}
-
-// ExpectProxy indicates an expected call of ExpectProxy
-func (mr *MockMeshCatalogerMockRecorder) ExpectProxy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpectProxy", reflect.TypeOf((*MockMeshCataloger)(nil).ExpectProxy), arg0)
-}
-
-// GetConnectedProxyCount mocks base method
-func (m *MockMeshCataloger) GetConnectedProxyCount() int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConnectedProxyCount")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// GetConnectedProxyCount indicates an expected call of GetConnectedProxyCount
-func (mr *MockMeshCatalogerMockRecorder) GetConnectedProxyCount() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectedProxyCount", reflect.TypeOf((*MockMeshCataloger)(nil).GetConnectedProxyCount))
 }
 
 // GetIngressPoliciesForService mocks base method
@@ -299,28 +272,4 @@ func (m *MockMeshCataloger) ListServiceAccountsForService(arg0 service.MeshServi
 func (mr *MockMeshCatalogerMockRecorder) ListServiceAccountsForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListServiceAccountsForService), arg0)
-}
-
-// RegisterProxy mocks base method
-func (m *MockMeshCataloger) RegisterProxy(arg0 *envoy.Proxy) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterProxy", arg0)
-}
-
-// RegisterProxy indicates an expected call of RegisterProxy
-func (mr *MockMeshCatalogerMockRecorder) RegisterProxy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterProxy", reflect.TypeOf((*MockMeshCataloger)(nil).RegisterProxy), arg0)
-}
-
-// UnregisterProxy mocks base method
-func (m *MockMeshCataloger) UnregisterProxy(arg0 *envoy.Proxy) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UnregisterProxy", arg0)
-}
-
-// UnregisterProxy indicates an expected call of UnregisterProxy
-func (mr *MockMeshCatalogerMockRecorder) UnregisterProxy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterProxy", reflect.TypeOf((*MockMeshCataloger)(nil).UnregisterProxy), arg0)
 }

--- a/pkg/debugger/mock_debugger_generated.go
+++ b/pkg/debugger/mock_debugger_generated.go
@@ -77,48 +77,6 @@ func (m *MockMeshCatalogDebugger) EXPECT() *MockMeshCatalogDebuggerMockRecorder 
 	return m.recorder
 }
 
-// ListConnectedProxies mocks base method
-func (m *MockMeshCatalogDebugger) ListConnectedProxies() map[certificate.CommonName]*envoy.Proxy {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListConnectedProxies")
-	ret0, _ := ret[0].(map[certificate.CommonName]*envoy.Proxy)
-	return ret0
-}
-
-// ListConnectedProxies indicates an expected call of ListConnectedProxies
-func (mr *MockMeshCatalogDebuggerMockRecorder) ListConnectedProxies() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConnectedProxies", reflect.TypeOf((*MockMeshCatalogDebugger)(nil).ListConnectedProxies))
-}
-
-// ListDisconnectedProxies mocks base method
-func (m *MockMeshCatalogDebugger) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDisconnectedProxies")
-	ret0, _ := ret[0].(map[certificate.CommonName]time.Time)
-	return ret0
-}
-
-// ListDisconnectedProxies indicates an expected call of ListDisconnectedProxies
-func (mr *MockMeshCatalogDebuggerMockRecorder) ListDisconnectedProxies() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDisconnectedProxies", reflect.TypeOf((*MockMeshCatalogDebugger)(nil).ListDisconnectedProxies))
-}
-
-// ListExpectedProxies mocks base method
-func (m *MockMeshCatalogDebugger) ListExpectedProxies() map[certificate.CommonName]time.Time {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExpectedProxies")
-	ret0, _ := ret[0].(map[certificate.CommonName]time.Time)
-	return ret0
-}
-
-// ListExpectedProxies indicates an expected call of ListExpectedProxies
-func (mr *MockMeshCatalogDebuggerMockRecorder) ListExpectedProxies() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExpectedProxies", reflect.TypeOf((*MockMeshCatalogDebugger)(nil).ListExpectedProxies))
-}
-
 // ListMonitoredNamespaces mocks base method
 func (m *MockMeshCatalogDebugger) ListMonitoredNamespaces() []string {
 	m.ctrl.T.Helper()

--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -20,7 +20,7 @@ func (ds DebugConfig) getProxies() http.Handler {
 	// the type (map) required by the printProxies function.
 	listConnected := func() map[certificate.CommonName]time.Time {
 		proxies := make(map[certificate.CommonName]time.Time)
-		for cn, proxy := range ds.meshCatalogDebugger.ListConnectedProxies() {
+		for cn, proxy := range ds.proxyRegistry.ListConnectedProxies() {
 			proxies[cn] = (*proxy).GetConnectedAt()
 		}
 		return proxies
@@ -35,8 +35,7 @@ func (ds DebugConfig) getProxies() http.Handler {
 		} else {
 			printProxies(w, listConnected(), "Connected")
 			// TODO(#2481): Print expected proxies once #2481 is addressed
-			//printProxies(w, ds.meshCatalogDebugger.ListExpectedProxies(), "Expected")
-			printProxies(w, ds.meshCatalogDebugger.ListDisconnectedProxies(), "Disconnected")
+			printProxies(w, ds.proxyRegistry.ListDisconnectedProxies(), "Disconnected")
 		}
 	})
 }

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
@@ -37,11 +38,12 @@ func (ds DebugConfig) GetHandlers() map[string]http.Handler {
 }
 
 // NewDebugConfig returns an implementation of DebugConfig interface.
-func NewDebugConfig(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, kubeConfig *rest.Config, kubeClient kubernetes.Interface, cfg configurator.Configurator, kubeController k8s.Controller) DebugConfig {
+func NewDebugConfig(certDebugger CertificateManagerDebugger, xdsDebugger XDSDebugger, meshCatalogDebugger MeshCatalogDebugger, proxyRegistry *registry.ProxyRegistry, kubeConfig *rest.Config, kubeClient kubernetes.Interface, cfg configurator.Configurator, kubeController k8s.Controller) DebugConfig {
 	return DebugConfig{
 		certDebugger:        certDebugger,
 		xdsDebugger:         xdsDebugger,
 		meshCatalogDebugger: meshCatalogDebugger,
+		proxyRegistry:       proxyRegistry,
 		kubeClient:          kubeClient,
 		kubeController:      kubeController,
 

--- a/pkg/debugger/server_test.go
+++ b/pkg/debugger/server_test.go
@@ -8,6 +8,7 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
@@ -22,10 +23,12 @@ func TestGetHandlers(t *testing.T) {
 	mockConfig := configurator.NewMockConfigurator(mockCtrl)
 	client := testclient.NewSimpleClientset()
 	mockKubeController := k8s.NewMockController(mockCtrl)
+	proxyRegistry := registry.NewProxyRegistry()
 
 	ds := NewDebugConfig(mockCertDebugger,
 		mockXdsDebugger,
 		mockCatalogDebugger,
+		proxyRegistry,
 		nil,
 		client,
 		mockConfig,

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -25,6 +26,7 @@ type DebugConfig struct {
 	certDebugger        CertificateManagerDebugger
 	xdsDebugger         XDSDebugger
 	meshCatalogDebugger MeshCatalogDebugger
+	proxyRegistry       *registry.ProxyRegistry
 	kubeConfig          *rest.Config
 	kubeClient          kubernetes.Interface
 	kubeController      k8s.Controller
@@ -39,15 +41,6 @@ type CertificateManagerDebugger interface {
 
 // MeshCatalogDebugger is an interface with methods for debugging Mesh Catalog.
 type MeshCatalogDebugger interface {
-	// ListExpectedProxies lists the Envoy proxies yet to connect and the time their XDS certificate was issued.
-	ListExpectedProxies() map[certificate.CommonName]time.Time
-
-	// ListConnectedProxies lists the Envoy proxies already connected and the time they first connected.
-	ListConnectedProxies() map[certificate.CommonName]*envoy.Proxy
-
-	// ListDisconnectedProxies lists the Envoy proxies disconnected and the time last seen.
-	ListDisconnectedProxies() map[certificate.CommonName]time.Time
-
 	// ListSMIPolicies lists the SMI policies detected by OSM.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -8,11 +8,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 )
 
-func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}, catalog catalog.MeshCataloger) {
+func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}, proxyRegistry *registry.ProxyRegistry) {
 	defer close(requests)
 	defer close(quit)
 	for {
@@ -28,14 +28,14 @@ func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery
 		}
 		if !proxy.HasPodMetadata() {
 			// Set the Pod metadata on the given proxy only once. This could arrive with the first few XDS requests.
-			recordEnvoyPodMetadata(request, proxy, catalog)
+			recordEnvoyPodMetadata(request, proxy, proxyRegistry)
 		}
 		log.Trace().Msgf("[grpc] Received DiscoveryRequest from Envoy with certificate SerialNumber %s", proxy.GetCertificateSerialNumber())
 		requests <- *request
 	}
 }
 
-func recordEnvoyPodMetadata(request *xds_discovery.DiscoveryRequest, proxy *envoy.Proxy, catalog catalog.MeshCataloger) {
+func recordEnvoyPodMetadata(request *xds_discovery.DiscoveryRequest, proxy *envoy.Proxy, proxyRegistry *registry.ProxyRegistry) {
 	if request != nil && request.Node != nil {
 		if meta, err := envoy.ParseEnvoyServiceNodeID(request.Node.Id); err != nil {
 			log.Error().Err(err).Msgf("Error parsing Envoy Node ID: %s", request.Node.Id)
@@ -46,8 +46,8 @@ func recordEnvoyPodMetadata(request *xds_discovery.DiscoveryRequest, proxy *envo
 			// Set the Pod Metadata, which will be used in the RegisterProxy() invocation below!
 			proxy.PodMetadata = meta
 
-			// We call RegisterProxy again, for a second time, on the MeshCatalog to update the index on pod metadata
-			catalog.RegisterProxy(proxy) // Second of Two invocations. First one was on establishing the gRPC stream.
+			// We call RegisterProxy again, for a second time, on the ProxyRegistry to update the index on pod metadata
+			proxyRegistry.RegisterProxy(proxy) // Second of Two invocations. First one was on establishing the gRPC stream.
 		}
 	}
 }

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -50,6 +51,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 	labels := map[string]string{constants.EnvoyUniqueIDLabelName: tests.ProxyUUID}
 	mc := catalog.NewFakeMeshCatalog(kubeClient)
+	proxyRegistry := registry.NewProxyRegistry()
 
 	// Create a Pod
 	pod := tests.NewPodFixture(namespace, fmt.Sprintf("pod-0-%s", uuid.New()), tests.BookstoreServiceAccountName, tests.PodLabels)
@@ -122,7 +124,7 @@ var _ = Describe("Test ADS response functions", func() {
 		mockConfigurator.EXPECT().IsDebugServerEnabled().Return(true).AnyTimes()
 
 		It("returns Aggregated Discovery Service response", func() {
-			s := NewADSServer(mc, true, tests.Namespace, mockConfigurator, mockCertManager)
+			s := NewADSServer(mc, proxyRegistry, true, tests.Namespace, mockConfigurator, mockCertManager)
 
 			Expect(s).ToNot(BeNil())
 
@@ -208,7 +210,7 @@ var _ = Describe("Test ADS response functions", func() {
 		mockConfigurator.EXPECT().IsDebugServerEnabled().Return(true).AnyTimes()
 
 		It("returns Aggregated Discovery Service response", func() {
-			s := NewADSServer(mc, true, tests.Namespace, mockConfigurator, mockCertManager)
+			s := NewADSServer(mc, proxyRegistry, true, tests.Namespace, mockConfigurator, mockCertManager)
 
 			Expect(s).ToNot(BeNil())
 

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy/eds"
 	"github.com/openservicemesh/osm/pkg/envoy/lds"
 	"github.com/openservicemesh/osm/pkg/envoy/rds"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/envoy/sds"
 	"github.com/openservicemesh/osm/pkg/utils"
 	"github.com/openservicemesh/osm/pkg/workerpool"
@@ -30,9 +31,10 @@ const (
 )
 
 // NewADSServer creates a new Aggregated Discovery Service server
-func NewADSServer(meshCatalog catalog.MeshCataloger, enableDebug bool, osmNamespace string, cfg configurator.Configurator, certManager certificate.Manager) *Server {
+func NewADSServer(meshCatalog catalog.MeshCataloger, proxyRegistry *registry.ProxyRegistry, enableDebug bool, osmNamespace string, cfg configurator.Configurator, certManager certificate.Manager) *Server {
 	server := Server{
-		catalog: meshCatalog,
+		catalog:       meshCatalog,
+		proxyRegistry: proxyRegistry,
 		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error){
 			envoy.TypeEDS: eds.NewResponse,
 			envoy.TypeCDS: cds.NewResponse,

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/workerpool"
 )
@@ -23,6 +24,7 @@ var (
 // Server implements the Envoy xDS Aggregate Discovery Services
 type Server struct {
 	catalog        catalog.MeshCataloger
+	proxyRegistry  *registry.ProxyRegistry
 	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error)
 	xdsLog         map[certificate.CommonName]map[envoy.TypeURI][]time.Time
 	xdsMapLogMutex sync.Mutex

--- a/pkg/envoy/registry/debugger.go
+++ b/pkg/envoy/registry/debugger.go
@@ -1,0 +1,34 @@
+package registry
+
+import (
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+// ListConnectedProxies lists the Envoy proxies already connected and the time they first connected.
+func (pr *ProxyRegistry) ListConnectedProxies() map[certificate.CommonName]*envoy.Proxy {
+	proxies := make(map[certificate.CommonName]*envoy.Proxy)
+	pr.connectedProxies.Range(func(cnIface, propsIface interface{}) bool {
+		cn := cnIface.(certificate.CommonName)
+		props := propsIface.(connectedProxy)
+		if _, isDisconnected := pr.disconnectedProxies.Load(cn); !isDisconnected {
+			proxies[cn] = props.proxy
+		}
+		return true // continue the iteration
+	})
+	return proxies
+}
+
+// ListDisconnectedProxies lists the Envoy proxies disconnected and the time last seen.
+func (pr *ProxyRegistry) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
+	proxies := make(map[certificate.CommonName]time.Time)
+	pr.disconnectedProxies.Range(func(cnInterface, disconnectedProxyInterface interface{}) bool {
+		cn := cnInterface.(certificate.CommonName)
+		props := disconnectedProxyInterface.(disconnectedProxy)
+		proxies[cn] = props.lastSeen
+		return true // continue the iteration
+	})
+	return proxies
+}

--- a/pkg/envoy/registry/debugger_test.go
+++ b/pkg/envoy/registry/debugger_test.go
@@ -1,0 +1,52 @@
+package registry
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+var _ = Describe("Test catalog proxy register/unregister", func() {
+	proxyRegistry := NewProxyRegistry()
+	certCommonName := certificate.CommonName("foo")
+	certSerialNumber := certificate.SerialNumber("123456")
+	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+
+	Context("Test register/unregister proxies", func() {
+		It("no proxies connected or disconnected", func() {
+			connectedProxies := proxyRegistry.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(0))
+
+			disconnectedProxies := proxyRegistry.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(0))
+		})
+
+		It("one proxy connected to OSM", func() {
+			proxyRegistry.RegisterProxy(proxy)
+
+			connectedProxies := proxyRegistry.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(1))
+
+			disconnectedProxies := proxyRegistry.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(0))
+
+			_, ok := connectedProxies[certCommonName]
+			Expect(ok).To(BeTrue())
+		})
+
+		It("one proxy disconnected from OSM", func() {
+			proxyRegistry.UnregisterProxy(proxy)
+
+			connectedProxies := proxyRegistry.ListConnectedProxies()
+			Expect(len(connectedProxies)).To(Equal(0))
+
+			disconnectedProxies := proxyRegistry.ListDisconnectedProxies()
+			Expect(len(disconnectedProxies)).To(Equal(1))
+
+			_, ok := disconnectedProxies[certCommonName]
+			Expect(ok).To(BeTrue())
+		})
+	})
+})

--- a/pkg/envoy/registry/registry.go
+++ b/pkg/envoy/registry/registry.go
@@ -1,24 +1,21 @@
-package catalog
+package registry
 
 import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
-// ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
-func (mc *MeshCatalog) ExpectProxy(cn certificate.CommonName) {
-	mc.expectedProxies.Store(cn, expectedProxy{
-		certificateIssuedAt: time.Now(),
-	})
+// NewProxyRegistry initializes a new empty *ProxyRegistry.
+func NewProxyRegistry() *ProxyRegistry {
+	return &ProxyRegistry{}
 }
 
 // RegisterProxy implements MeshCatalog and registers a newly connected proxy.
-func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
-	mc.connectedProxies.Store(proxy.GetCertificateCommonName(), connectedProxy{
+func (pr *ProxyRegistry) RegisterProxy(proxy *envoy.Proxy) {
+	pr.connectedProxies.Store(proxy.GetCertificateCommonName(), connectedProxy{
 		proxy:       proxy,
 		connectedAt: time.Now(),
 	})
@@ -28,19 +25,19 @@ func (mc *MeshCatalog) RegisterProxy(proxy *envoy.Proxy) {
 		podUID := types.UID(proxy.PodMetadata.UID)
 
 		// Create a PodUID to Certificate CN map so we can easily determine the CN from the PodUID
-		mc.podUIDToCN.Store(podUID, proxy.GetCertificateCommonName())
+		pr.podUIDToCN.Store(podUID, proxy.GetCertificateCommonName())
 
 		// Create a PodUID to Cert Serial Number so we can easily look-up the SerialNumber of the cert issued to a proxy for a given Pod.
-		mc.podUIDToCertificateSerialNumber.Store(podUID, proxy.GetCertificateSerialNumber())
+		pr.podUIDToCertificateSerialNumber.Store(podUID, proxy.GetCertificateSerialNumber())
 	}
 	log.Debug().Msgf("Registered new proxy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 }
 
 // UnregisterProxy unregisters the given proxy from the catalog.
-func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
-	mc.connectedProxies.Delete(p.GetCertificateCommonName())
+func (pr *ProxyRegistry) UnregisterProxy(p *envoy.Proxy) {
+	pr.connectedProxies.Delete(p.GetCertificateCommonName())
 
-	mc.disconnectedProxies.Store(p.GetCertificateCommonName(), disconnectedProxy{
+	pr.disconnectedProxies.Store(p.GetCertificateCommonName(), disconnectedProxy{
 		lastSeen: time.Now(),
 	})
 
@@ -48,6 +45,6 @@ func (mc *MeshCatalog) UnregisterProxy(p *envoy.Proxy) {
 }
 
 // GetConnectedProxyCount counts the number of connected proxies
-func (mc *MeshCatalog) GetConnectedProxyCount() int {
-	return len(mc.ListConnectedProxies())
+func (pr *ProxyRegistry) GetConnectedProxyCount() int {
+	return len(pr.ListConnectedProxies())
 }

--- a/pkg/envoy/registry/suite_test.go
+++ b/pkg/envoy/registry/suite_test.go
@@ -1,0 +1,13 @@
+package registry
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCatalog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Envoy Registry Test Suite")
+}

--- a/pkg/envoy/registry/types.go
+++ b/pkg/envoy/registry/types.go
@@ -1,0 +1,36 @@
+package registry
+
+import (
+	"sync"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var log = logger.New("proxy-registry")
+
+// ProxyRegistry keeps track of Envoy proxies as they connect and disconnect
+// from the control plane.
+type ProxyRegistry struct {
+	connectedProxies    sync.Map
+	disconnectedProxies sync.Map
+
+	// Maintain a mapping of pod UID to CN of the Envoy on the given pod
+	podUIDToCN sync.Map
+
+	// Maintain a mapping of pod UID to certificate SerialNumber of the Envoy on the given pod
+	podUIDToCertificateSerialNumber sync.Map
+}
+
+type connectedProxy struct {
+	// Proxy which connected to the XDS control plane
+	proxy *envoy.Proxy
+
+	// When the proxy connected to the XDS control plane
+	connectedAt time.Time
+}
+
+type disconnectedProxy struct {
+	lastSeen time.Time
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change removes methods from the MeshCataloger interface pertaining
to tracking proxies as they connect and disconnect. The following
methods have been removed:

    ExpectProxy(certificate.CommonName)
    RegisterProxy(*envoy.Proxy)
    UnregisterProxy(*envoy.Proxy)

The same functionality is now in a new package pkg/envoy/registry
encapsulated in a new `*ProxyRegistry` struct. No functional changes.

Fixes #3105, fixes #3106
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No