### PR TITLE
Copy K8sServiceAccount from pkg/service to pkg/identity

### DIFF
--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -1,6 +1,22 @@
 // Package identity implements types and utility routines related to the identity of a workload, as used within OSM.
 package identity
 
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string or vice versa
+	namespaceNameSeparator = "/"
+)
+
+var (
+	// ErrInvalidServiceAccountStringFormat is an error returned when the K8sServiceAccount string cannot be parsed (is invalid for some reason)
+	ErrInvalidServiceAccountStringFormat = errors.New("invalid namespaced service string format")
+)
+
 // ServiceIdentity is the type used to represent the identity for a service
 // For Kubernetes services this string will be in the format: <ServiceAccount>.<Namespace>.cluster.local
 type ServiceIdentity string
@@ -8,4 +24,40 @@ type ServiceIdentity string
 // String returns the ServiceIdentity as a string
 func (si ServiceIdentity) String() string {
 	return string(si)
+}
+
+// K8sServiceAccount is a type for a namespaced service account
+type K8sServiceAccount struct {
+	Namespace string
+	Name      string
+}
+
+// String returns the string representation of the service account object
+func (sa K8sServiceAccount) String() string {
+	return fmt.Sprintf("%s%s%s", sa.Namespace, namespaceNameSeparator, sa.Name)
+}
+
+// IsEmpty returns true if the given service account object is empty
+func (sa K8sServiceAccount) IsEmpty() bool {
+	return (K8sServiceAccount{}) == sa
+}
+
+// UnmarshalK8sServiceAccount unmarshals a K8sServiceAccount type from a string
+func UnmarshalK8sServiceAccount(str string) (*K8sServiceAccount, error) {
+	slices := strings.Split(str, namespaceNameSeparator)
+	if len(slices) != 2 {
+		return nil, ErrInvalidServiceAccountStringFormat
+	}
+
+	// Make sure the slices are not empty. Split might actually leave empty slices.
+	for _, sep := range slices {
+		if len(sep) == 0 {
+			return nil, ErrInvalidServiceAccountStringFormat
+		}
+	}
+
+	return &K8sServiceAccount{
+		Namespace: slices[0],
+		Name:      slices[1],
+	}, nil
 }

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -2,6 +2,7 @@
 package identity
 
 // ServiceIdentity is the type used to represent the identity for a service
+// For Kubernetes services this string will be in the format: <ServiceAccount>.<Namespace>.cluster.local
 type ServiceIdentity string
 
 // String returns the ServiceIdentity as a string

--- a/pkg/identity/types_test.go
+++ b/pkg/identity/types_test.go
@@ -1,0 +1,103 @@
+package identity
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	tassert "github.com/stretchr/testify/assert"
+	trequire "github.com/stretchr/testify/require"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test pkg/service functions", func() {
+	defer GinkgoRecover()
+
+	Context("Test K8sServiceAccount struct methods", func() {
+		namespace := uuid.New().String()
+		serviceAccountName := uuid.New().String()
+		sa := K8sServiceAccount{
+			Namespace: namespace,
+			Name:      serviceAccountName,
+		}
+
+		It("implements stringer interface correctly", func() {
+			Expect(sa.String()).To(Equal(fmt.Sprintf("%s/%s", namespace, serviceAccountName)))
+		})
+
+		It("implements IsEmpty correctly", func() {
+			Expect(sa.IsEmpty()).To(BeFalse())
+			Expect(K8sServiceAccount{}.IsEmpty()).To(BeTrue())
+		})
+	})
+})
+
+func TestUnmarshalK8sServiceAccount(t *testing.T) {
+	assert := tassert.New(t)
+	require := trequire.New(t)
+
+	namespace := "randomNamespace"
+	serviceName := "randomServiceAccountName"
+	svcAccount := &K8sServiceAccount{
+		Namespace: namespace,
+		Name:      serviceName,
+	}
+	str := svcAccount.String()
+	fmt.Println(str)
+
+	testCases := []struct {
+		name              string
+		expectedErr       bool
+		serviceAccountStr string
+	}{
+		{
+			name:              "successfully unmarshal service account",
+			expectedErr:       false,
+			serviceAccountStr: "randomNamespace/randomServiceAccountName",
+		},
+		{
+			name:              "incomplete namespaced service account name 1",
+			expectedErr:       true,
+			serviceAccountStr: "/svnc",
+		},
+		{
+			name:              "incomplete namespaced service account name 2",
+			expectedErr:       true,
+			serviceAccountStr: "svnc/",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "/svnc/",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "/",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "",
+		},
+		{
+			name:              "incomplete namespaced service account name 3",
+			expectedErr:       true,
+			serviceAccountStr: "test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := UnmarshalK8sServiceAccount(tc.serviceAccountStr)
+			if tc.expectedErr {
+				assert.NotNil(err)
+			} else {
+				require.Nil(err)
+				assert.Equal(svcAccount, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is the 1st part of:
 - **Moving K8sServiceAccount from pkg/service to pkg/identity** #3152

This PR merely creates a copy of `K8sServiceAccount` from `pkg/service` to `pkg/identity`.

The goal is to alleviate the review load from #3152.

Next step: **Change import of K8sServiceAccount from pkg/service to pkg/identity** #3154