### PR TITLE
Change import of K8sServiceAccount from pkg/service to pkg/identity

### DIFF
--- a/pkg/catalog/debugger.go
+++ b/pkg/catalog/debugger.go
@@ -5,11 +5,11 @@ import (
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 )
 
 // ListSMIPolicies returns all policies OSM is aware of.
-func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget) {
+func (mc *MeshCatalog) ListSMIPolicies() ([]*split.TrafficSplit, []identity.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget) {
 	trafficSplits := mc.meshSpec.ListTrafficSplits()
 	serviceAccounts := mc.meshSpec.ListServiceAccounts()
 	trafficSpecs := mc.meshSpec.ListHTTPTrafficSpecs()

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -39,7 +40,7 @@ func (mc *MeshCatalog) GetResolvableServiceEndpoints(svc service.MeshService) ([
 
 // ListAllowedEndpointsForService returns only those endpoints for a service that belong to the allowed outbound service accounts
 // for the given downstream identity
-func (mc *MeshCatalog) ListAllowedEndpointsForService(downstreamIdentity service.K8sServiceAccount, upstreamSvc service.MeshService) ([]endpoint.Endpoint, error) {
+func (mc *MeshCatalog) ListAllowedEndpointsForService(downstreamIdentity identity.K8sServiceAccount, upstreamSvc service.MeshService) ([]endpoint.Endpoint, error) {
 	outboundEndpoints, err := mc.listEndpointsForService(upstreamSvc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up endpoints for upstream service %s", upstreamSvc)
@@ -69,7 +70,7 @@ func (mc *MeshCatalog) ListAllowedEndpointsForService(downstreamIdentity service
 }
 
 // listEndpointsforIdentity retrieves the list of endpoints for the given service account
-func (mc *MeshCatalog) listEndpointsforIdentity(sa service.K8sServiceAccount) []endpoint.Endpoint {
+func (mc *MeshCatalog) listEndpointsforIdentity(sa identity.K8sServiceAccount) []endpoint.Endpoint {
 	var endpoints []endpoint.Endpoint
 	for _, provider := range mc.endpointsProviders {
 		ep := provider.ListEndpointsForIdentity(sa)

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -58,11 +59,11 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
-		proxyIdentity            service.K8sServiceAccount
+		proxyIdentity            identity.K8sServiceAccount
 		upstreamSvc              service.MeshService
 		trafficTargets           []*access.TrafficTarget
 		services                 []service.MeshService
-		outboundServices         map[service.K8sServiceAccount][]service.MeshService
+		outboundServices         map[identity.K8sServiceAccount][]service.MeshService
 		outboundServiceEndpoints map[service.MeshService][]endpoint.Endpoint
 		expectedEndpoints        []endpoint.Endpoint
 	}{
@@ -74,7 +75,7 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			upstreamSvc:    tests.BookstoreV1Service,
 			trafficTargets: []*access.TrafficTarget{&tests.TrafficTarget},
 			services:       []service.MeshService{tests.BookstoreV1Service},
-			outboundServices: map[service.K8sServiceAccount][]service.MeshService{
+			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
@@ -91,7 +92,7 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			upstreamSvc:    tests.BookstoreV2Service,
 			trafficTargets: []*access.TrafficTarget{&tests.TrafficTarget},
 			services:       []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			outboundServices: map[service.K8sServiceAccount][]service.MeshService{
+			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service, tests.BookstoreV2Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
@@ -112,7 +113,7 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			upstreamSvc:    tests.BookstoreV2Service,
 			trafficTargets: []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
 			services:       []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			outboundServices: map[service.K8sServiceAccount][]service.MeshService{
+			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
 				tests.BookstoreServiceAccount:   {tests.BookstoreV1Service},
 				tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
 			},

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -100,9 +101,9 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV1Service).Return([]service.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV2Service).Return([]service.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookbuyerService).Return([]service.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV1Service).Return([]identity.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV2Service).Return([]identity.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookbuyerService).Return([]identity.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
 		mockIngressMonitor, stop, cfg, endpointProviders...)

--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -6,6 +6,7 @@ import (
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -20,7 +21,7 @@ const (
 // ListInboundTrafficPolicies returns all inbound traffic policies
 // 1. from service discovery for permissive mode
 // 2. for the given service account and upstream services from SMI Traffic Target and Traffic Split
-func (mc *MeshCatalog) ListInboundTrafficPolicies(upstreamIdentity service.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
+func (mc *MeshCatalog) ListInboundTrafficPolicies(upstreamIdentity identity.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
 		inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
 		for _, svc := range upstreamServices {
@@ -37,7 +38,7 @@ func (mc *MeshCatalog) ListInboundTrafficPolicies(upstreamIdentity service.K8sSe
 
 // listInboundPoliciesFromTrafficTargets builds inbound traffic policies for all inbound services
 // when the given service account matches a destination in the Traffic Target resource
-func (mc *MeshCatalog) listInboundPoliciesFromTrafficTargets(upstreamIdentity service.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
+func (mc *MeshCatalog) listInboundPoliciesFromTrafficTargets(upstreamIdentity identity.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
 	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
 
 	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
@@ -60,7 +61,7 @@ func (mc *MeshCatalog) listInboundPoliciesFromTrafficTargets(upstreamIdentity se
 // listInboundPoliciesForTrafficSplits loops through all SMI TrafficTarget resources and returns inbound policies for apex services based on the following conditions:
 // 1. the given upstream identity matches the destination specified in a TrafficTarget resource
 // 2. the given list of upstream services are backends specified in a TrafficSplit resource
-func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity service.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
+func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity identity.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
 	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
 
 	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -28,11 +29,11 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		downstreamSA            service.K8sServiceAccount
-		upstreamSA              service.K8sServiceAccount
+		downstreamSA            identity.K8sServiceAccount
+		upstreamSA              identity.K8sServiceAccount
 		upstreamServices        []service.MeshService
 		meshServices            []service.MeshService
-		meshServiceAccounts     []service.K8sServiceAccount
+		meshServiceAccounts     []identity.K8sServiceAccount
 		trafficSpec             spec.HTTPRouteGroup
 		trafficSplit            split.TrafficSplit
 		expectedInboundPolicies []*trafficpolicy.InboundTrafficPolicy
@@ -50,7 +51,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 				Name:      "bookstore",
 				Namespace: "default",
 			}},
-			meshServiceAccounts: []service.K8sServiceAccount{},
+			meshServiceAccounts: []identity.K8sServiceAccount{},
 			trafficSpec: spec.HTTPRouteGroup{
 				TypeMeta: v1.TypeMeta{
 					APIVersion: "specs.smi-spec.io/v1alpha4",
@@ -107,7 +108,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -120,7 +121,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -145,7 +146,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 				Name:      "bookstore-apex",
 				Namespace: "default",
 			}},
-			meshServiceAccounts: []service.K8sServiceAccount{},
+			meshServiceAccounts: []identity.K8sServiceAccount{},
 			trafficSpec: spec.HTTPRouteGroup{
 				TypeMeta: v1.TypeMeta{
 					APIVersion: "specs.smi-spec.io/v1alpha4",
@@ -219,7 +220,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -232,7 +233,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -262,7 +263,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -275,7 +276,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -291,7 +292,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 			upstreamSA:          tests.BookbuyerServiceAccount,
 			upstreamServices:    []service.MeshService{tests.BookbuyerService},
 			meshServices:        []service.MeshService{tests.BookbuyerService, tests.BookstoreV1Service, tests.BookstoreV2Service},
-			meshServiceAccounts: []service.K8sServiceAccount{tests.BookbuyerServiceAccount, tests.BookstoreServiceAccount},
+			meshServiceAccounts: []identity.K8sServiceAccount{tests.BookbuyerServiceAccount, tests.BookstoreServiceAccount},
 			trafficSpec:         spec.HTTPRouteGroup{},
 			trafficSplit:        split.TrafficSplit{},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
@@ -376,8 +377,8 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		downstreamSA            service.K8sServiceAccount
-		upstreamSA              service.K8sServiceAccount
+		downstreamSA            identity.K8sServiceAccount
+		upstreamSA              identity.K8sServiceAccount
 		upstreamServices        []service.MeshService
 		meshServices            []service.MeshService
 		trafficSpec             spec.HTTPRouteGroup
@@ -386,11 +387,11 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 	}{
 		{
 			name: "inbound policies in same namespaces, without traffic split",
-			downstreamSA: service.K8sServiceAccount{
+			downstreamSA: identity.K8sServiceAccount{
 				Name:      "bookbuyer",
 				Namespace: "default",
 			},
-			upstreamSA: service.K8sServiceAccount{
+			upstreamSA: identity.K8sServiceAccount{
 				Name:      "bookstore",
 				Namespace: "default",
 			},
@@ -438,11 +439,11 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 		},
 		{
 			name: "inbound policies in same namespaces, with traffic split",
-			downstreamSA: service.K8sServiceAccount{
+			downstreamSA: identity.K8sServiceAccount{
 				Name:      "bookbuyer",
 				Namespace: "default",
 			},
-			upstreamSA: service.K8sServiceAccount{
+			upstreamSA: identity.K8sServiceAccount{
 				Name:      "bookstore",
 				Namespace: "default",
 			},
@@ -530,7 +531,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -543,7 +544,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -554,11 +555,11 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 		},
 		{
 			name: "inbound policies in same namespaces, with traffic split with namespaced root service",
-			downstreamSA: service.K8sServiceAccount{
+			downstreamSA: identity.K8sServiceAccount{
 				Name:      "bookbuyer",
 				Namespace: "default",
 			},
-			upstreamSA: service.K8sServiceAccount{
+			upstreamSA: identity.K8sServiceAccount{
 				Name:      "bookstore",
 				Namespace: "default",
 			},
@@ -646,7 +647,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -659,7 +660,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -707,19 +708,19 @@ func TestBuildInboundPolicies(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		sourceSA                service.K8sServiceAccount
-		destSA                  service.K8sServiceAccount
+		sourceSA                identity.K8sServiceAccount
+		destSA                  identity.K8sServiceAccount
 		inboundService          service.MeshService
 		trafficSpec             spec.HTTPRouteGroup
 		expectedInboundPolicies []*trafficpolicy.InboundTrafficPolicy
 	}{
 		{
 			name: "inbound policies in different namespaces",
-			sourceSA: service.K8sServiceAccount{
+			sourceSA: identity.K8sServiceAccount{
 				Name:      "bookbuyer",
 				Namespace: "bookbuyer-ns",
 			},
-			destSA: service.K8sServiceAccount{
+			destSA: identity.K8sServiceAccount{
 				Name:      "bookstore",
 				Namespace: "bookstore-ns",
 			},
@@ -782,7 +783,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "bookbuyer-ns",
 							}),
@@ -795,7 +796,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "bookbuyer-ns",
 							}),
@@ -806,11 +807,11 @@ func TestBuildInboundPolicies(t *testing.T) {
 		},
 		{
 			name: "inbound policies in same namespaces",
-			sourceSA: service.K8sServiceAccount{
+			sourceSA: identity.K8sServiceAccount{
 				Name:      "bookbuyer",
 				Namespace: "default",
 			},
-			destSA: service.K8sServiceAccount{
+			destSA: identity.K8sServiceAccount{
 				Name:      "bookstore",
 				Namespace: "default",
 			},
@@ -873,7 +874,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -886,7 +887,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -1005,19 +1006,19 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		downstreamSA            service.K8sServiceAccount
-		upstreamSA              service.K8sServiceAccount
+		downstreamSA            identity.K8sServiceAccount
+		upstreamSA              identity.K8sServiceAccount
 		upstreamServices        []service.MeshService
 		trafficSpec             spec.HTTPRouteGroup
 		expectedInboundPolicies []*trafficpolicy.InboundTrafficPolicy
 	}{
 		{
 			name: "inbound policies in same namespaces",
-			downstreamSA: service.K8sServiceAccount{
+			downstreamSA: identity.K8sServiceAccount{
 				Name:      "bookbuyer",
 				Namespace: "default",
 			},
-			upstreamSA: service.K8sServiceAccount{
+			upstreamSA: identity.K8sServiceAccount{
 				Name:      "bookstore",
 				Namespace: "default",
 			},
@@ -1080,7 +1081,7 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),
@@ -1093,7 +1094,7 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      "bookbuyer",
 								Namespace: "default",
 							}),

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -9,6 +9,7 @@ import (
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -33,7 +34,7 @@ var _ = regexp.MustCompile(prefixMatchPathElementsRegex)
 
 // Ingress does not depend on k8s service accounts, program a wildcard (empty struct) to indicate
 // to RDS that an inbound traffic policy for ingress should not enforce service account based RBAC policies.
-var wildcardServiceAccount = service.K8sServiceAccount{}
+var wildcardServiceAccount = identity.K8sServiceAccount{}
 
 // GetIngressPoliciesForService returns a list of inbound traffic policies for a service as defined in observed ingress k8s resources.
 func (mc *MeshCatalog) GetIngressPoliciesForService(svc service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -10,7 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
-	"github.com/openservicemesh/osm/pkg/identity"
+	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -128,7 +129,7 @@ func (mr *MockMeshCatalogerMockRecorder) GetTargetPortToProtocolMappingForServic
 }
 
 // ListAllowedEndpointsForService mocks base method
-func (m *MockMeshCataloger) ListAllowedEndpointsForService(arg0 service.K8sServiceAccount, arg1 service.MeshService) ([]endpoint.Endpoint, error) {
+func (m *MockMeshCataloger) ListAllowedEndpointsForService(arg0 identity.K8sServiceAccount, arg1 service.MeshService) ([]endpoint.Endpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllowedEndpointsForService", arg0, arg1)
 	ret0, _ := ret[0].([]endpoint.Endpoint)
@@ -143,10 +144,10 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedEndpointsForService(arg0, ar
 }
 
 // ListAllowedInboundServiceAccounts mocks base method
-func (m *MockMeshCataloger) ListAllowedInboundServiceAccounts(arg0 service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
+func (m *MockMeshCataloger) ListAllowedInboundServiceAccounts(arg0 identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllowedInboundServiceAccounts", arg0)
-	ret0, _ := ret[0].([]service.K8sServiceAccount)
+	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -158,10 +159,10 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedInboundServiceAccounts(arg0 
 }
 
 // ListAllowedOutboundServiceAccounts mocks base method
-func (m *MockMeshCataloger) ListAllowedOutboundServiceAccounts(arg0 service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
+func (m *MockMeshCataloger) ListAllowedOutboundServiceAccounts(arg0 identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllowedOutboundServiceAccounts", arg0)
-	ret0, _ := ret[0].([]service.K8sServiceAccount)
+	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -173,7 +174,7 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServiceAccounts(arg0
 }
 
 // ListAllowedOutboundServicesForIdentity mocks base method
-func (m *MockMeshCataloger) ListAllowedOutboundServicesForIdentity(arg0 service.K8sServiceAccount) []service.MeshService {
+func (m *MockMeshCataloger) ListAllowedOutboundServicesForIdentity(arg0 identity.K8sServiceAccount) []service.MeshService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllowedOutboundServicesForIdentity", arg0)
 	ret0, _ := ret[0].([]service.MeshService)
@@ -187,7 +188,7 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServicesForIdentity(
 }
 
 // ListInboundTrafficPolicies mocks base method
-func (m *MockMeshCataloger) ListInboundTrafficPolicies(arg0 service.K8sServiceAccount, arg1 []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
+func (m *MockMeshCataloger) ListInboundTrafficPolicies(arg0 identity.K8sServiceAccount, arg1 []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInboundTrafficPolicies", arg0, arg1)
 	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
@@ -201,7 +202,7 @@ func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficPolicies(arg0, arg1 i
 }
 
 // ListInboundTrafficTargetsWithRoutes mocks base method
-func (m *MockMeshCataloger) ListInboundTrafficTargetsWithRoutes(arg0 service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
+func (m *MockMeshCataloger) ListInboundTrafficTargetsWithRoutes(arg0 identity.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInboundTrafficTargetsWithRoutes", arg0)
 	ret0, _ := ret[0].([]trafficpolicy.TrafficTargetWithRoutes)
@@ -216,7 +217,7 @@ func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficTargetsWithRoutes(arg
 }
 
 // ListOutboundTrafficPolicies mocks base method
-func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
+func (m *MockMeshCataloger) ListOutboundTrafficPolicies(arg0 identity.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListOutboundTrafficPolicies", arg0)
 	ret0, _ := ret[0].([]*trafficpolicy.OutboundTrafficPolicy)
@@ -230,10 +231,10 @@ func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interf
 }
 
 // ListServiceAccountsForService mocks base method
-func (m *MockMeshCataloger) ListServiceAccountsForService(arg0 service.MeshService) ([]service.K8sServiceAccount, error) {
+func (m *MockMeshCataloger) ListServiceAccountsForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceAccountsForService", arg0)
-	ret0, _ := ret[0].([]service.K8sServiceAccount)
+	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -60,10 +61,10 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		downstreamSA        service.K8sServiceAccount
+		downstreamSA        identity.K8sServiceAccount
 		apexMeshServices    []service.MeshService
 		meshServices        []service.MeshService
-		meshServiceAccounts []service.K8sServiceAccount
+		meshServiceAccounts []identity.K8sServiceAccount
 		trafficsplits       []*split.TrafficSplit
 		traffictargets      []*access.TrafficTarget
 		trafficspecs        []*spec.HTTPRouteGroup
@@ -75,7 +76,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			downstreamSA:        tests.BookbuyerServiceAccount,
 			apexMeshServices:    []service.MeshService{},
 			meshServices:        []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			meshServiceAccounts: []service.K8sServiceAccount{},
+			meshServiceAccounts: []identity.K8sServiceAccount{},
 			trafficsplits:       []*split.TrafficSplit{},
 			traffictargets:      []*access.TrafficTarget{&tests.TrafficTarget},
 			trafficspecs:        []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
@@ -92,7 +93,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 				},
 			},
 			meshServices:        []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			meshServiceAccounts: []service.K8sServiceAccount{},
+			meshServiceAccounts: []identity.K8sServiceAccount{},
 			trafficsplits:       []*split.TrafficSplit{&tests.TrafficSplit},
 			traffictargets:      []*access.TrafficTarget{&tests.TrafficTarget},
 			trafficspecs:        []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
@@ -143,7 +144,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 				},
 			},
 			meshServices:        []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			meshServiceAccounts: []service.K8sServiceAccount{},
+			meshServiceAccounts: []identity.K8sServiceAccount{},
 			trafficsplits:       []*split.TrafficSplit{&tests.TrafficSplit},
 			traffictargets:      []*access.TrafficTarget{},
 			trafficspecs:        []*spec.HTTPRouteGroup{},
@@ -169,7 +170,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			downstreamSA:        tests.BookbuyerServiceAccount,
 			apexMeshServices:    []service.MeshService{},
 			meshServices:        []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			meshServiceAccounts: []service.K8sServiceAccount{},
+			meshServiceAccounts: []identity.K8sServiceAccount{},
 			trafficsplits:       []*split.TrafficSplit{},
 			traffictargets:      []*access.TrafficTarget{},
 			trafficspecs:        []*spec.HTTPRouteGroup{},
@@ -181,7 +182,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			downstreamSA:        tests.BookbuyerServiceAccount,
 			apexMeshServices:    []service.MeshService{},
 			meshServices:        []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookbuyerService},
-			meshServiceAccounts: []service.K8sServiceAccount{tests.BookbuyerServiceAccount, tests.BookstoreServiceAccount},
+			meshServiceAccounts: []identity.K8sServiceAccount{tests.BookbuyerServiceAccount, tests.BookstoreServiceAccount},
 			trafficsplits:       []*split.TrafficSplit{},
 			traffictargets:      []*access.TrafficTarget{},
 			trafficspecs:        []*spec.HTTPRouteGroup{},
@@ -636,7 +637,7 @@ func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		serviceAccount service.K8sServiceAccount
+		serviceAccount identity.K8sServiceAccount
 		expectedList   []service.MeshService
 		permissiveMode bool
 	}{
@@ -648,7 +649,7 @@ func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
 		},
 		{
 			name: "traffic targets not configured for service account",
-			serviceAccount: service.K8sServiceAccount{
+			serviceAccount: identity.K8sServiceAccount{
 				Name:      "some-name",
 				Namespace: "some-ns",
 			},
@@ -794,11 +795,11 @@ func TestBuildOutboundPolicies(t *testing.T) {
 		meshSpec:           mockMeshSpec,
 		endpointsProviders: []endpoint.Provider{mockEndpointProvider},
 	}
-	sourceSA := service.K8sServiceAccount{
+	sourceSA := identity.K8sServiceAccount{
 		Name:      "bookbuyer",
 		Namespace: "bookbuyer-ns",
 	}
-	destSA := service.K8sServiceAccount{
+	destSA := identity.K8sServiceAccount{
 		Name:      "bookstore",
 		Namespace: "bookstore-ns",
 	}
@@ -882,7 +883,7 @@ func TestListOutboundPoliciesForTrafficTargets(t *testing.T) {
 
 	testCases := []struct {
 		name             string
-		serviceAccount   service.K8sServiceAccount
+		serviceAccount   identity.K8sServiceAccount
 		apexMeshServices []service.MeshService
 		traffictargets   []*access.TrafficTarget
 		trafficspecs     []*spec.HTTPRouteGroup
@@ -952,7 +953,7 @@ func TestGetDestinationServicesFromTrafficTarget(t *testing.T) {
 		endpointsProviders: []endpoint.Provider{mockEndpointProvider},
 	}
 
-	destSA := service.K8sServiceAccount{
+	destSA := identity.K8sServiceAccount{
 		Name:      "bookstore",
 		Namespace: "bookstore-ns",
 	}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/utils"
@@ -55,7 +56,7 @@ func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.Me
 }
 
 // getServicesForServiceAccount returns a list of services corresponding to a service account
-func (mc *MeshCatalog) getServicesForServiceAccount(sa service.K8sServiceAccount) ([]service.MeshService, error) {
+func (mc *MeshCatalog) getServicesForServiceAccount(sa identity.K8sServiceAccount) ([]service.MeshService, error) {
 	var services []service.MeshService
 	for _, provider := range mc.endpointsProviders {
 		providerServices, err := provider.GetServicesForServiceAccount(sa)
@@ -80,7 +81,7 @@ func (mc *MeshCatalog) getServicesForServiceAccount(sa service.K8sServiceAccount
 }
 
 // ListServiceAccountsForService lists the service accounts associated with the given service
-func (mc *MeshCatalog) ListServiceAccountsForService(svc service.MeshService) ([]service.K8sServiceAccount, error) {
+func (mc *MeshCatalog) ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
 	// Currently OSM uses kubernetes service accounts as service identities
 	return mc.kubeController.ListServiceAccountsForService(svc)
 }

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/kubernetes"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -225,17 +226,17 @@ func TestListServiceAccountsForService(t *testing.T) {
 
 	testCases := []struct {
 		svc                 service.MeshService
-		expectedSvcAccounts []service.K8sServiceAccount
+		expectedSvcAccounts []identity.K8sServiceAccount
 		expectedError       error
 	}{
 		{
 			service.MeshService{Name: "foo", Namespace: "ns-1"},
-			[]service.K8sServiceAccount{{Name: "sa-1", Namespace: "ns-1"}, {Name: "sa-2", Namespace: "ns-1"}},
+			[]identity.K8sServiceAccount{{Name: "sa-1", Namespace: "ns-1"}, {Name: "sa-2", Namespace: "ns-1"}},
 			nil,
 		},
 		{
 			service.MeshService{Name: "foo", Namespace: "ns-1"},
-			[]service.K8sServiceAccount{{Name: "sa-1", Namespace: "ns-1"}, {Name: "sa-2", Namespace: "ns-1"}},
+			[]identity.K8sServiceAccount{{Name: "sa-1", Namespace: "ns-1"}, {Name: "sa-2", Namespace: "ns-1"}},
 			nil,
 		},
 		{

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -7,7 +7,6 @@ import (
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
@@ -23,17 +22,17 @@ const (
 )
 
 // ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given upstream service account
-func (mc *MeshCatalog) ListAllowedInboundServiceAccounts(upstream service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
+func (mc *MeshCatalog) ListAllowedInboundServiceAccounts(upstream identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	return mc.getAllowedDirectionalServiceAccounts(upstream, inbound)
 }
 
 // ListAllowedOutboundServiceAccounts lists the upstream service accounts the given downstream service account can connect to
-func (mc *MeshCatalog) ListAllowedOutboundServiceAccounts(downstream service.K8sServiceAccount) ([]service.K8sServiceAccount, error) {
+func (mc *MeshCatalog) ListAllowedOutboundServiceAccounts(downstream identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	return mc.getAllowedDirectionalServiceAccounts(downstream, outbound)
 }
 
 // ListInboundTrafficTargetsWithRoutes returns a list traffic target objects composed of its routes for the given destination service account
-func (mc *MeshCatalog) ListInboundTrafficTargetsWithRoutes(upstream service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
+func (mc *MeshCatalog) ListInboundTrafficTargetsWithRoutes(upstream identity.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error) {
 	var trafficTargets []trafficpolicy.TrafficTargetWithRoutes
 
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
@@ -79,8 +78,8 @@ func (mc *MeshCatalog) ListInboundTrafficTargetsWithRoutes(upstream service.K8sS
 	return trafficTargets, nil
 }
 
-func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcAccount service.K8sServiceAccount, direction trafficDirection) ([]service.K8sServiceAccount, error) {
-	var allowedSvcAccounts []service.K8sServiceAccount
+func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcAccount identity.K8sServiceAccount, direction trafficDirection) ([]identity.K8sServiceAccount, error) {
+	var allowedSvcAccounts []identity.K8sServiceAccount
 	allowed := mapset.NewSet()
 
 	allTrafficTargets := mc.meshSpec.ListTrafficTargets()
@@ -130,14 +129,14 @@ func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcAccount service.K
 	}
 
 	for svcAccount := range allowed.Iter() {
-		allowedSvcAccounts = append(allowedSvcAccounts, svcAccount.(service.K8sServiceAccount))
+		allowedSvcAccounts = append(allowedSvcAccounts, svcAccount.(identity.K8sServiceAccount))
 	}
 
 	return allowedSvcAccounts, nil
 }
 
-func trafficTargetIdentityToSvcAccount(identitySubject smiAccess.IdentityBindingSubject) service.K8sServiceAccount {
-	return service.K8sServiceAccount{
+func trafficTargetIdentityToSvcAccount(identitySubject smiAccess.IdentityBindingSubject) identity.K8sServiceAccount {
+	return identity.K8sServiceAccount{
 		Name:      identitySubject.Name,
 		Namespace: identitySubject.Namespace,
 	}
@@ -150,15 +149,15 @@ func trafficTargetIdentityToServiceIdentity(identitySubject smiAccess.IdentityBi
 }
 
 // trafficTargetIdentitiesToSvcAccounts returns a list of Service Accounts from the given list of identities from a Traffic Target
-func trafficTargetIdentitiesToSvcAccounts(identities []smiAccess.IdentityBindingSubject) []service.K8sServiceAccount {
-	serviceAccountsMap := map[service.K8sServiceAccount]bool{}
+func trafficTargetIdentitiesToSvcAccounts(identities []smiAccess.IdentityBindingSubject) []identity.K8sServiceAccount {
+	serviceAccountsMap := map[identity.K8sServiceAccount]bool{}
 
 	for _, id := range identities {
 		sa := trafficTargetIdentityToSvcAccount(id)
 		serviceAccountsMap[sa] = true
 	}
 
-	serviceAccounts := []service.K8sServiceAccount{}
+	serviceAccounts := []identity.K8sServiceAccount{}
 	for k := range serviceAccountsMap {
 		serviceAccounts = append(serviceAccounts, k)
 	}

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -11,8 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
+
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -29,8 +29,8 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 
 	testCases := []struct {
 		trafficTargets             []*smiAccess.TrafficTarget
-		svcAccount                 service.K8sServiceAccount
-		expectedInboundSvcAccounts []service.K8sServiceAccount
+		svcAccount                 identity.K8sServiceAccount
+		expectedInboundSvcAccounts []identity.K8sServiceAccount
 		expectError                bool
 	}{
 		// Test case 1 begin ------------------------------------
@@ -84,13 +84,13 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			},
 
 			// given service account to test
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-2",
 				Namespace: "ns-2",
 			},
 
 			// allowed inbound service accounts: 1 match
-			[]service.K8sServiceAccount{
+			[]identity.K8sServiceAccount{
 				{
 					Name:      "sa-1",
 					Namespace: "ns-1",
@@ -130,7 +130,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			},
 
 			// given service account to test
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-1",
 				Namespace: "ns-1",
 			},
@@ -171,7 +171,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			},
 
 			// given service account to test
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-1",
 				Namespace: "ns-1",
 			},
@@ -208,8 +208,8 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 
 	testCases := []struct {
 		trafficTargets              []*smiAccess.TrafficTarget
-		svcAccount                  service.K8sServiceAccount
-		expectedOutboundSvcAccounts []service.K8sServiceAccount
+		svcAccount                  identity.K8sServiceAccount
+		expectedOutboundSvcAccounts []identity.K8sServiceAccount
 		expectError                 bool
 	}{
 		// Test case 1 begin ------------------------------------
@@ -263,13 +263,13 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			},
 
 			// given service account to test
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-1",
 				Namespace: "ns-1",
 			},
 
 			// allowed inbound service accounts: 2 matches
-			[]service.K8sServiceAccount{
+			[]identity.K8sServiceAccount{
 				{
 					Name:      "sa-2",
 					Namespace: "ns-2",
@@ -313,7 +313,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			},
 
 			// given service account to test
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-2",
 				Namespace: "ns-2",
 			},
@@ -354,7 +354,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			},
 
 			// given service account to test
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-1",
 				Namespace: "ns-1",
 			},
@@ -384,7 +384,7 @@ func TestTrafficTargetIdentityToSvcAccount(t *testing.T) {
 
 	testCases := []struct {
 		identity               smiAccess.IdentityBindingSubject
-		expectedServiceAccount service.K8sServiceAccount
+		expectedServiceAccount identity.K8sServiceAccount
 	}{
 		{
 			smiAccess.IdentityBindingSubject{
@@ -392,7 +392,7 @@ func TestTrafficTargetIdentityToSvcAccount(t *testing.T) {
 				Name:      "sa-2",
 				Namespace: "ns-2",
 			},
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-2",
 				Namespace: "ns-2",
 			},
@@ -403,7 +403,7 @@ func TestTrafficTargetIdentityToSvcAccount(t *testing.T) {
 				Name:      "sa-1",
 				Namespace: "ns-1",
 			},
-			service.K8sServiceAccount{
+			identity.K8sServiceAccount{
 				Name:      "sa-1",
 				Namespace: "ns-1",
 			},
@@ -433,7 +433,7 @@ func TestTrafficTargetIdentitiesToSvcAccounts(t *testing.T) {
 		},
 	}
 
-	expected := []service.K8sServiceAccount{
+	expected := []identity.K8sServiceAccount{
 		{
 			Name:      "example1",
 			Namespace: "default1",
@@ -457,7 +457,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 		name               string
 		trafficTargets     []*smiAccess.TrafficTarget
 		tcpRoutes          map[string]*smiSpecs.TCPRoute
-		upstreamSvcAccount service.K8sServiceAccount
+		upstreamSvcAccount identity.K8sServiceAccount
 
 		expectedTrafficTargets []trafficpolicy.TrafficTargetWithRoutes
 		expectError            bool
@@ -512,7 +512,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 				},
 			},
 
-			upstreamSvcAccount: service.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
+			upstreamSvcAccount: identity.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
 
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
@@ -599,7 +599,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 				},
 			},
 
-			upstreamSvcAccount: service.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
+			upstreamSvcAccount: identity.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
 
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
@@ -747,7 +747,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 				},
 			},
 
-			upstreamSvcAccount: service.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
+			upstreamSvcAccount: identity.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
 
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
@@ -834,7 +834,7 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 				},
 			},
 
-			upstreamSvcAccount: service.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
+			upstreamSvcAccount: identity.K8sServiceAccount{Namespace: "ns-1", Name: "sa-1"},
 
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -6,11 +6,13 @@ package catalog
 
 import (
 	"github.com/google/uuid"
+
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -47,25 +49,25 @@ type MeshCataloger interface {
 	GetSMISpec() smi.MeshSpec
 
 	// ListInboundTrafficPolicies returns all inbound traffic policies related to the given service account and inbound services
-	ListInboundTrafficPolicies(service.K8sServiceAccount, []service.MeshService) []*trafficpolicy.InboundTrafficPolicy
+	ListInboundTrafficPolicies(identity.K8sServiceAccount, []service.MeshService) []*trafficpolicy.InboundTrafficPolicy
 
 	// ListOutboundTrafficPolicies returns all outbound traffic policies related to the given service account
-	ListOutboundTrafficPolicies(service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy
+	ListOutboundTrafficPolicies(identity.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy
 
 	// ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
-	ListAllowedOutboundServicesForIdentity(service.K8sServiceAccount) []service.MeshService
+	ListAllowedOutboundServicesForIdentity(identity.K8sServiceAccount) []service.MeshService
 
 	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
-	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	ListAllowedInboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
 
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
-	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	ListAllowedOutboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
 
 	// ListServiceAccountsForService lists the service accounts associated with the given service
-	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
+	ListServiceAccountsForService(service.MeshService) ([]identity.K8sServiceAccount, error)
 
 	// ListAllowedEndpointsForService returns the list of endpoints backing a service and its allowed service accounts
-	ListAllowedEndpointsForService(service.K8sServiceAccount, service.MeshService) ([]endpoint.Endpoint, error)
+	ListAllowedEndpointsForService(identity.K8sServiceAccount, service.MeshService) ([]endpoint.Endpoint, error)
 
 	// GetResolvableServiceEndpoints returns the resolvable set of endpoint over which a service is accessible using its FQDN.
 	// These are the endpoint destinations we'd expect client applications sends the traffic towards to, when attempting to
@@ -90,7 +92,7 @@ type MeshCataloger interface {
 	GetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
 
 	// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects composed of its routes for the given destination service account
-	ListInboundTrafficTargetsWithRoutes(service.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error)
+	ListInboundTrafficTargetsWithRoutes(identity.K8sServiceAccount) ([]trafficpolicy.TrafficTargetWithRoutes, error)
 }
 
 // certificateCommonNameMeta is the type that stores the metadata present in the CommonName field in a proxy's certificate

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -160,8 +161,8 @@ func NewCertCommonNameWithProxyID(proxyUUID uuid.UUID, serviceAccount, namespace
 }
 
 // GetServiceAccountFromProxyCertificate returns the ServiceAccount information encoded in the certificate CN
-func GetServiceAccountFromProxyCertificate(cn certificate.CommonName) (service.K8sServiceAccount, error) {
-	var svcAccount service.K8sServiceAccount
+func GetServiceAccountFromProxyCertificate(cn certificate.CommonName) (identity.K8sServiceAccount, error) {
+	var svcAccount identity.K8sServiceAccount
 	cnMeta, err := getCertificateCommonNameMeta(cn)
 	if err != nil {
 		return svcAccount, err

--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -448,13 +449,13 @@ var _ = Describe("Test XDS certificate tooling", func() {
 			cn := certificate.CommonName(fmt.Sprintf("%s.sa-name.sa-namespace", uuid.New().String()))
 			svcAccount, err := GetServiceAccountFromProxyCertificate(cn)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(svcAccount).To(Equal(service.K8sServiceAccount{Name: "sa-name", Namespace: "sa-namespace"}))
+			Expect(svcAccount).To(Equal(identity.K8sServiceAccount{Name: "sa-name", Namespace: "sa-namespace"}))
 		})
 
 		It("should correctly error when the XDS certificate CN is invalid", func() {
 			svcAccount, err := GetServiceAccountFromProxyCertificate(certificate.CommonName("invalid"))
 			Expect(err).To(HaveOccurred())
-			Expect(svcAccount).To(Equal(service.K8sServiceAccount{}))
+			Expect(svcAccount).To(Equal(identity.K8sServiceAccount{}))
 		})
 	})
 })

--- a/pkg/debugger/mock_debugger_generated.go
+++ b/pkg/debugger/mock_debugger_generated.go
@@ -11,7 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	envoy "github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/identity"
+	identity "github.com/openservicemesh/osm/pkg/identity"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"

--- a/pkg/debugger/mock_debugger_generated.go
+++ b/pkg/debugger/mock_debugger_generated.go
@@ -11,7 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	envoy "github.com/openservicemesh/osm/pkg/envoy"
-	service "github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -92,11 +92,11 @@ func (mr *MockMeshCatalogDebuggerMockRecorder) ListMonitoredNamespaces() *gomock
 }
 
 // ListSMIPolicies mocks base method
-func (m *MockMeshCatalogDebugger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []service.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
+func (m *MockMeshCatalogDebugger) ListSMIPolicies() ([]*v1alpha2.TrafficSplit, []identity.K8sServiceAccount, []*v1alpha4.HTTPRouteGroup, []*v1alpha3.TrafficTarget) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSMIPolicies")
 	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
-	ret1, _ := ret[1].([]service.K8sServiceAccount)
+	ret1, _ := ret[1].([]identity.K8sServiceAccount)
 	ret2, _ := ret[2].([]*v1alpha4.HTTPRouteGroup)
 	ret3, _ := ret[3].([]*v1alpha3.TrafficTarget)
 	return ret0, ret1, ret2, ret3

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/openservicemesh/osm/pkg/identity"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
+
+	"github.com/openservicemesh/osm/pkg/identity"
 )
 
 type policies struct {

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/openservicemesh/osm/pkg/identity"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 type policies struct {
-	TrafficSplits   []*split.TrafficSplit       `json:"traffic_splits"`
-	ServiceAccounts []service.K8sServiceAccount `json:"service_accounts"`
-	RouteGroups     []*spec.HTTPRouteGroup      `json:"route_groups"`
-	TrafficTargets  []*access.TrafficTarget     `json:"traffic_targets"`
+	TrafficSplits   []*split.TrafficSplit        `json:"traffic_splits"`
+	ServiceAccounts []identity.K8sServiceAccount `json:"service_accounts"`
+	RouteGroups     []*spec.HTTPRouteGroup       `json:"route_groups"`
+	TrafficTargets  []*access.TrafficTarget      `json:"traffic_targets"`
 }
 
 func (ds DebugConfig) getOSMConfigHandler() http.Handler {

--- a/pkg/debugger/policy_test.go
+++ b/pkg/debugger/policy_test.go
@@ -11,7 +11,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -34,7 +34,7 @@ func TestGetSMIPolicies(t *testing.T) {
 					Name:      "bar",
 				}},
 		},
-		[]service.K8sServiceAccount{
+		[]identity.K8sServiceAccount{
 			tests.BookbuyerServiceAccount,
 		},
 		[]*spec.HTTPRouteGroup{

--- a/pkg/debugger/types.go
+++ b/pkg/debugger/types.go
@@ -14,9 +14,9 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/registry"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 var log = logger.New("debugger")
@@ -42,7 +42,7 @@ type CertificateManagerDebugger interface {
 // MeshCatalogDebugger is an interface with methods for debugging Mesh Catalog.
 type MeshCatalogDebugger interface {
 	// ListSMIPolicies lists the SMI policies detected by OSM.
-	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
+	ListSMIPolicies() ([]*split.TrafficSplit, []identity.K8sServiceAccount, []*spec.HTTPRouteGroup, []*access.TrafficTarget)
 
 	// ListMonitoredNamespaces lists the namespaces that the control plan knows about.
 	ListMonitoredNamespaces() []string

--- a/pkg/endpoint/mock_provider_generated.go
+++ b/pkg/endpoint/mock_provider_generated.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	"github.com/openservicemesh/osm/pkg/identity"
+	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 )
 

--- a/pkg/endpoint/mock_provider_generated.go
+++ b/pkg/endpoint/mock_provider_generated.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -64,7 +65,7 @@ func (mr *MockProviderMockRecorder) GetResolvableEndpointsForService(arg0 interf
 }
 
 // GetServicesForServiceAccount mocks base method
-func (m *MockProvider) GetServicesForServiceAccount(arg0 service.K8sServiceAccount) ([]service.MeshService, error) {
+func (m *MockProvider) GetServicesForServiceAccount(arg0 identity.K8sServiceAccount) ([]service.MeshService, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServicesForServiceAccount", arg0)
 	ret0, _ := ret[0].([]service.MeshService)
@@ -94,7 +95,7 @@ func (mr *MockProviderMockRecorder) GetTargetPortToProtocolMappingForService(arg
 }
 
 // ListEndpointsForIdentity mocks base method
-func (m *MockProvider) ListEndpointsForIdentity(arg0 service.K8sServiceAccount) []Endpoint {
+func (m *MockProvider) ListEndpointsForIdentity(arg0 identity.K8sServiceAccount) []Endpoint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEndpointsForIdentity", arg0)
 	ret0, _ := ret[0].([]Endpoint)

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -68,7 +69,7 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 }
 
 // ListEndpointsForIdentity retrieves the list of IP addresses for the given service account
-func (c Client) ListEndpointsForIdentity(sa service.K8sServiceAccount) []endpoint.Endpoint {
+func (c Client) ListEndpointsForIdentity(sa identity.K8sServiceAccount) []endpoint.Endpoint {
 	log.Trace().Msgf("[%s] Getting Endpoints for service account %s on Kubernetes", c.providerIdent, sa)
 	var endpoints []endpoint.Endpoint
 
@@ -95,7 +96,7 @@ func (c Client) ListEndpointsForIdentity(sa service.K8sServiceAccount) []endpoin
 }
 
 // GetServicesForServiceAccount retrieves a list of services for the given service account.
-func (c Client) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {
+func (c Client) GetServicesForServiceAccount(svcAccount identity.K8sServiceAccount) ([]service.MeshService, error) {
 	services := mapset.NewSet()
 
 	for _, pod := range c.kubeController.ListPods() {

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -367,7 +368,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		<-podsAndServiceChannel
 
-		givenSvcAccount := service.K8sServiceAccount{
+		givenSvcAccount := identity.K8sServiceAccount{
 			Namespace: testNamespace,
 			Name:      "test-service-account", // Should match the service account in the Pod spec above
 		}
@@ -442,7 +443,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		<-podsChannel
 
-		givenSvcAccount := service.K8sServiceAccount{
+		givenSvcAccount := identity.K8sServiceAccount{
 			Namespace: testNamespace,
 			Name:      "test-service-account", // Should match the service account in the Deployment spec above
 		}
@@ -510,7 +511,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		<-podsChannel
 
-		givenSvcAccount := service.K8sServiceAccount{
+		givenSvcAccount := identity.K8sServiceAccount{
 			Namespace: testNamespace,
 			Name:      "test-service-account", // Should match the service account in the Deployment spec above
 		}
@@ -597,7 +598,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		<-podsAndServiceChannel
 
-		givenSvcAccount := service.K8sServiceAccount{
+		givenSvcAccount := identity.K8sServiceAccount{
 			Namespace: testNamespace,
 			Name:      "test-service-account", // Should match the service account in the Deployment spec above
 		}
@@ -623,14 +624,14 @@ func TestListEndpointsForIdentity(t *testing.T) {
 
 	testCases := []struct {
 		name                            string
-		serviceAccount                  service.K8sServiceAccount
-		outboundServiceAccountEndpoints map[service.K8sServiceAccount][]endpoint.Endpoint
+		serviceAccount                  identity.K8sServiceAccount
+		outboundServiceAccountEndpoints map[identity.K8sServiceAccount][]endpoint.Endpoint
 		expectedEndpoints               []endpoint.Endpoint
 	}{
 		{
 			name:           "get endpoints for pod with only one ip",
 			serviceAccount: tests.BookstoreServiceAccount,
-			outboundServiceAccountEndpoints: map[service.K8sServiceAccount][]endpoint.Endpoint{
+			outboundServiceAccountEndpoints: map[identity.K8sServiceAccount][]endpoint.Endpoint{
 				tests.BookstoreServiceAccount: {{
 					IP: net.ParseIP(tests.ServiceIP),
 				}},
@@ -642,7 +643,7 @@ func TestListEndpointsForIdentity(t *testing.T) {
 		{
 			name:           "get endpoints for pod with multiple ips",
 			serviceAccount: tests.BookstoreServiceAccount,
-			outboundServiceAccountEndpoints: map[service.K8sServiceAccount][]endpoint.Endpoint{
+			outboundServiceAccountEndpoints: map[identity.K8sServiceAccount][]endpoint.Endpoint{
 				tests.BookstoreServiceAccount: {
 					endpoint.Endpoint{
 						IP: net.ParseIP(tests.ServiceIP),

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -19,12 +20,12 @@ func NewFakeProvider() endpoint.Provider {
 			tests.BookbuyerService.String():     {tests.Endpoint},
 			tests.BookstoreApexService.String(): {tests.Endpoint},
 		},
-		services: map[service.K8sServiceAccount][]service.MeshService{
+		services: map[identity.K8sServiceAccount][]service.MeshService{
 			tests.BookstoreServiceAccount:   {tests.BookstoreV1Service, tests.BookstoreApexService},
 			tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
 			tests.BookbuyerServiceAccount:   {tests.BookbuyerService},
 		},
-		svcAccountEndpoints: map[service.K8sServiceAccount][]endpoint.Endpoint{
+		svcAccountEndpoints: map[identity.K8sServiceAccount][]endpoint.Endpoint{
 			tests.BookstoreServiceAccount:   {tests.Endpoint, tests.Endpoint},
 			tests.BookstoreV2ServiceAccount: {tests.Endpoint},
 			tests.BookbuyerServiceAccount:   {tests.Endpoint},
@@ -34,8 +35,8 @@ func NewFakeProvider() endpoint.Provider {
 
 type fakeClient struct {
 	endpoints           map[string][]endpoint.Endpoint
-	services            map[service.K8sServiceAccount][]service.MeshService
-	svcAccountEndpoints map[service.K8sServiceAccount][]endpoint.Endpoint
+	services            map[identity.K8sServiceAccount][]service.MeshService
+	svcAccountEndpoints map[identity.K8sServiceAccount][]endpoint.Endpoint
 }
 
 // Retrieve the IP addresses comprising the given service.
@@ -47,14 +48,14 @@ func (f fakeClient) ListEndpointsForService(svc service.MeshService) []endpoint.
 }
 
 // Retrieve the IP addresses comprising the given service account.
-func (f fakeClient) ListEndpointsForIdentity(sa service.K8sServiceAccount) []endpoint.Endpoint {
+func (f fakeClient) ListEndpointsForIdentity(sa identity.K8sServiceAccount) []endpoint.Endpoint {
 	if ep, ok := f.svcAccountEndpoints[sa]; ok {
 		return ep
 	}
 	panic(fmt.Sprintf("You are asking for K8sServiceAccount=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", sa.String(), f.svcAccountEndpoints))
 }
 
-func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {
+func (f fakeClient) GetServicesForServiceAccount(svcAccount identity.K8sServiceAccount) ([]service.MeshService, error) {
 	services, ok := f.services[svcAccount]
 	if !ok {
 		return nil, errors.Errorf("ServiceAccount %s is not in cache: %+v", svcAccount, f.services)

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -17,10 +18,10 @@ type Provider interface {
 	ListEndpointsForService(service.MeshService) []Endpoint
 
 	// ListEndpointsForIdentity retrieves the list of IP addresses for the given service account
-	ListEndpointsForIdentity(service.K8sServiceAccount) []Endpoint
+	ListEndpointsForIdentity(identity.K8sServiceAccount) []Endpoint
 
 	// Retrieve the namespaced services for a given service account
-	GetServicesForServiceAccount(service.K8sServiceAccount) ([]service.MeshService, error)
+	GetServicesForServiceAccount(identity.K8sServiceAccount) ([]service.MeshService, error)
 
 	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
 	GetTargetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -24,13 +25,13 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 	type testCase struct {
 		name                     string
-		proxySvcAccount          service.K8sServiceAccount
+		proxySvcAccount          identity.K8sServiceAccount
 		proxyServices            []service.MeshService
 		allowedOutboundServices  []service.MeshService
 		expectedDiscoveryRequest *xds_discovery.DiscoveryRequest
 	}
 
-	proxySvcAccount := service.K8sServiceAccount{Name: "test-sa", Namespace: "ns-1"}
+	proxySvcAccount := identity.K8sServiceAccount{Name: "test-sa", Namespace: "ns-1"}
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxyXDSCertCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), proxySvcAccount.Name, proxySvcAccount.Namespace))
 	testProxy := envoy.NewProxy(proxyXDSCertCN, certSerialNumber, nil)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -14,9 +14,9 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
@@ -271,6 +271,6 @@ func isCNforProxy(proxy *envoy.Proxy, cn certificate.CommonName) bool {
 		return false
 	}
 
-	identityForCN := service.K8sServiceAccount{Name: chunks[0], Namespace: chunks[1]}
+	identityForCN := identity.K8sServiceAccount{Name: chunks[0], Namespace: chunks[1]}
 	return identityForCN == proxyIdentity
 }

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -23,7 +24,7 @@ const (
 )
 
 // getUpstreamServiceCluster returns an Envoy Cluster corresponding to the given upstream service
-func getUpstreamServiceCluster(downstreamIdentity service.K8sServiceAccount, upstreamSvc service.MeshService, cfg configurator.Configurator) (*xds_cluster.Cluster, error) {
+func getUpstreamServiceCluster(downstreamIdentity identity.K8sServiceAccount, upstreamSvc service.MeshService, cfg configurator.Configurator) (*xds_cluster.Cluster, error) {
 	clusterName := upstreamSvc.String()
 	marshalledUpstreamTLSContext, err := ptypes.MarshalAny(
 		envoy.GetUpstreamTLSContext(downstreamIdentity, upstreamSvc))

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -36,7 +37,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 }
 
 // getEndpointsForProxy returns only those service endpoints that belong to the allowed outbound service accounts for the proxy
-func getEndpointsForProxy(meshCatalog catalog.MeshCataloger, proxyIdentity service.K8sServiceAccount) (map[service.MeshService][]endpoint.Endpoint, error) {
+func getEndpointsForProxy(meshCatalog catalog.MeshCataloger, proxyIdentity identity.K8sServiceAccount) (map[service.MeshService][]endpoint.Endpoint, error) {
 	allowedServicesEndpoints := make(map[service.MeshService][]endpoint.Endpoint)
 
 	for _, dstSvc := range meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity) {

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -93,13 +94,13 @@ func TestGetEndpointsForProxy(t *testing.T) {
 
 	testCases := []struct {
 		name                            string
-		proxyIdentity                   service.K8sServiceAccount
+		proxyIdentity                   identity.K8sServiceAccount
 		trafficTargets                  []*access.TrafficTarget
-		allowedServiceAccounts          []service.K8sServiceAccount
+		allowedServiceAccounts          []identity.K8sServiceAccount
 		services                        []service.MeshService
-		outboundServices                map[service.K8sServiceAccount][]service.MeshService
+		outboundServices                map[identity.K8sServiceAccount][]service.MeshService
 		outboundServiceEndpoints        map[service.MeshService][]endpoint.Endpoint
-		outboundServiceAccountEndpoints map[service.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint
+		outboundServiceAccountEndpoints map[identity.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint
 		expectedEndpoints               map[service.MeshService][]endpoint.Endpoint
 	}{
 		{
@@ -108,15 +109,15 @@ func TestGetEndpointsForProxy(t *testing.T) {
 			Hence one endpoint for bookstore-v1 should be in the expected list`,
 			proxyIdentity:          tests.BookbuyerServiceAccount,
 			trafficTargets:         []*access.TrafficTarget{&tests.TrafficTarget},
-			allowedServiceAccounts: []service.K8sServiceAccount{tests.BookstoreServiceAccount},
+			allowedServiceAccounts: []identity.K8sServiceAccount{tests.BookstoreServiceAccount},
 			services:               []service.MeshService{tests.BookstoreV1Service},
-			outboundServices: map[service.K8sServiceAccount][]service.MeshService{
+			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreV1Service: {tests.Endpoint},
 			},
-			outboundServiceAccountEndpoints: map[service.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint{
+			outboundServiceAccountEndpoints: map[identity.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service: {tests.Endpoint}},
 			},
 			expectedEndpoints: map[service.MeshService][]endpoint.Endpoint{
@@ -130,9 +131,9 @@ func TestGetEndpointsForProxy(t *testing.T) {
 			Hence this endpoint (9.9.9.9) shouldn't be in bookstore-v1's expected list`,
 			proxyIdentity:          tests.BookbuyerServiceAccount,
 			trafficTargets:         []*access.TrafficTarget{&tests.TrafficTarget},
-			allowedServiceAccounts: []service.K8sServiceAccount{tests.BookstoreServiceAccount},
+			allowedServiceAccounts: []identity.K8sServiceAccount{tests.BookstoreServiceAccount},
 			services:               []service.MeshService{tests.BookstoreV1Service},
-			outboundServices: map[service.K8sServiceAccount][]service.MeshService{
+			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
@@ -141,7 +142,7 @@ func TestGetEndpointsForProxy(t *testing.T) {
 					Port: endpoint.Port(tests.ServicePort),
 				}},
 			},
-			outboundServiceAccountEndpoints: map[service.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint{
+			outboundServiceAccountEndpoints: map[identity.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service: {tests.Endpoint}},
 			},
 			expectedEndpoints: map[service.MeshService][]endpoint.Endpoint{
@@ -153,9 +154,9 @@ func TestGetEndpointsForProxy(t *testing.T) {
 			Hence one endpoint should be in bookstore-v1's and bookstore-v2's expected list`,
 			proxyIdentity:          tests.BookbuyerServiceAccount,
 			trafficTargets:         []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
-			allowedServiceAccounts: []service.K8sServiceAccount{tests.BookstoreServiceAccount, tests.BookstoreV2ServiceAccount},
+			allowedServiceAccounts: []identity.K8sServiceAccount{tests.BookstoreServiceAccount, tests.BookstoreV2ServiceAccount},
 			services:               []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			outboundServices: map[service.K8sServiceAccount][]service.MeshService{
+			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
 				tests.BookstoreServiceAccount:   {tests.BookstoreV1Service},
 				tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
 			},
@@ -166,7 +167,7 @@ func TestGetEndpointsForProxy(t *testing.T) {
 					Port: endpoint.Port(tests.ServicePort),
 				}},
 			},
-			outboundServiceAccountEndpoints: map[service.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint{
+			outboundServiceAccountEndpoints: map[identity.K8sServiceAccount]map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreServiceAccount: {tests.BookstoreV1Service: {tests.Endpoint}},
 				tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service: {endpoint.Endpoint{
 					IP:   net.ParseIP("9.9.9.9"),

--- a/pkg/envoy/lds/rbac_test.go
+++ b/pkg/envoy/lds/rbac_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
+
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
@@ -154,7 +154,7 @@ func TestBuildInboundRBACPolicies(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
-	proxySvcAccount := service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}
+	proxySvcAccount := identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}
 
 	lb := &listenerBuilder{
 		meshCatalog: mockCatalog,
@@ -241,7 +241,7 @@ func TestBuildRBACFilter(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
-	proxySvcAccount := service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}
+	proxySvcAccount := identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}
 
 	lb := &listenerBuilder{
 		meshCatalog: mockCatalog,

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/featureflags"
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 )
 
 // NewResponse creates a new Listener Discovery Response.
@@ -99,7 +99,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	return ldsResources, nil
 }
 
-func newListenerBuilder(meshCatalog catalog.MeshCataloger, svcAccount service.K8sServiceAccount, cfg configurator.Configurator, statsHeaders map[string]string) *listenerBuilder {
+func newListenerBuilder(meshCatalog catalog.MeshCataloger, svcAccount identity.K8sServiceAccount, cfg configurator.Configurator, statsHeaders map[string]string) *listenerBuilder {
 	return &listenerBuilder{
 		meshCatalog:  meshCatalog,
 		svcAccount:   svcAccount,

--- a/pkg/envoy/lds/types.go
+++ b/pkg/envoy/lds/types.go
@@ -4,8 +4,9 @@ package lds
 import (
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
+
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/logger"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 var (
@@ -14,7 +15,7 @@ var (
 
 // listenerBuilder is a type containing data to build the listener configurations
 type listenerBuilder struct {
-	svcAccount   service.K8sServiceAccount
+	svcAccount   identity.K8sServiceAccount
 	meshCatalog  catalog.MeshCataloger
 	cfg          configurator.Configurator
 	statsHeaders map[string]string

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
-	service "github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
@@ -50,7 +50,7 @@ type PodMetadata struct {
 	Name           string
 	Namespace      string
 	IP             string
-	ServiceAccount service.K8sServiceAccount
+	ServiceAccount identity.K8sServiceAccount
 	Cluster        string
 	EnvoyNodeID    string
 	WorkloadKind   string

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -35,8 +36,8 @@ func TestNewResponse(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
-		downstreamSA             service.K8sServiceAccount
-		upstreamSA               service.K8sServiceAccount
+		downstreamSA             identity.K8sServiceAccount
+		upstreamSA               identity.K8sServiceAccount
 		upstreamServices         []service.MeshService
 		meshServices             []service.MeshService
 		trafficSpec              spec.HTTPRouteGroup
@@ -159,7 +160,7 @@ func TestNewResponse(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -172,7 +173,7 @@ func TestNewResponse(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -202,7 +203,7 @@ func TestNewResponse(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -215,7 +216,7 @@ func TestNewResponse(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),

--- a/pkg/envoy/route/rbac.go
+++ b/pkg/envoy/route/rbac.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
+
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
@@ -32,7 +32,7 @@ func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule) (map[string]*any.An
 	var principalRuleList []rbac.RulesList
 	for downstream := range rule.AllowedServiceAccounts.Iter() {
 		var principalRule rbac.RulesList
-		downstreamIdentity := downstream.(service.K8sServiceAccount)
+		downstreamIdentity := downstream.(identity.K8sServiceAccount)
 
 		if downstreamIdentity.IsEmpty() {
 			// When the downstream identity in a traffic policy rule is set to be empty, it implies

--- a/pkg/envoy/route/rbac_test.go
+++ b/pkg/envoy/route/rbac_test.go
@@ -12,7 +12,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -34,8 +34,8 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 					WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 				},
 				AllowedServiceAccounts: mapset.NewSetFromSlice([]interface{}{
-					service.K8sServiceAccount{Name: "foo", Namespace: "ns-1"},
-					service.K8sServiceAccount{Name: "bar", Namespace: "ns-2"},
+					identity.K8sServiceAccount{Name: "foo", Namespace: "ns-1"},
+					identity.K8sServiceAccount{Name: "bar", Namespace: "ns-2"},
 				}),
 			},
 			expectedRBACPolicy: &xds_rbac.Policy{
@@ -75,7 +75,7 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 					WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 				},
 				AllowedServiceAccounts: mapset.NewSetFromSlice([]interface{}{
-					service.K8sServiceAccount{}, // setting an empty service account will result in all downstreams being allowed
+					identity.K8sServiceAccount{}, // setting an empty service account will result in all downstreams being allowed
 				}),
 			},
 			expectedRBACPolicy: &xds_rbac.Policy{

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/featureflags"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -150,14 +151,14 @@ func TestBuildIngressRouteConfiguration(t *testing.T) {
 								HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
 								WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{}),
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{}),
 						},
 						{
 							Route: trafficpolicy.RouteWeightedClusters{
 								HTTPRouteMatch:   tests.BookstoreSellHTTPRoute,
 								WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{}),
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{}),
 						},
 					},
 				},
@@ -170,7 +171,7 @@ func TestBuildIngressRouteConfiguration(t *testing.T) {
 								HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
 								WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{}),
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{}),
 						},
 					},
 				},
@@ -283,7 +284,7 @@ func TestBuildInboundRoutes(t *testing.T) {
 						WeightedClusters: mapset.NewSet(testWeightedCluster),
 					},
 					AllowedServiceAccounts: mapset.NewSetFromSlice(
-						[]interface{}{service.K8sServiceAccount{Name: "foo", Namespace: "bar"}},
+						[]interface{}{identity.K8sServiceAccount{Name: "foo", Namespace: "bar"}},
 					),
 				},
 			},

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -167,7 +168,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 	case envoy.RootCertTypeForMTLSInbound:
 		// Verify that the SDS cert request corresponding to the mTLS root validation cert matches the identity
 		// of this proxy. If it doesn't, then something is wrong in the system.
-		svcAccountInRequest, err := service.UnmarshalK8sServiceAccount(sdscert.Name)
+		svcAccountInRequest, err := identity.UnmarshalK8sServiceAccount(sdscert.Name)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error unmarshalling service account for inbound mTLS validation cert %s", sdscert)
 			return nil, err
@@ -196,7 +197,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 	return secret, nil
 }
 
-func getSubjectAltNamesFromSvcAccount(svcAccounts []service.K8sServiceAccount) []*xds_matcher.StringMatcher {
+func getSubjectAltNamesFromSvcAccount(svcAccounts []identity.K8sServiceAccount) []*xds_matcher.StringMatcher {
 	var matchSANs []*xds_matcher.StringMatcher
 
 	for _, svcAccount := range svcAccounts {

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -92,7 +93,7 @@ func TestGetRootCert(t *testing.T) {
 	type testCase struct {
 		name            string
 		sdsCert         envoy.SDSCert
-		proxySvcAccount service.K8sServiceAccount
+		proxySvcAccount identity.K8sServiceAccount
 		prepare         func(d *dynamicMock)
 
 		// expectations
@@ -108,15 +109,15 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-1/sa-1",
 				CertType: envoy.RootCertTypeForMTLSInbound,
 			},
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
-				allowedInboundSvcAccounts := []service.K8sServiceAccount{
+				allowedInboundSvcAccounts := []identity.K8sServiceAccount{
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-3"},
 				}
-				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 
@@ -133,11 +134,11 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-2/service-2",
 				CertType: envoy.RootCertTypeForMTLSOutbound,
 			},
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
-				associatedSvcAccounts := []service.K8sServiceAccount{
+				associatedSvcAccounts := []identity.K8sServiceAccount{
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-2"},
 				}
@@ -158,7 +159,7 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-2/service-2",
 				CertType: envoy.RootCertTypeForMTLSOutbound,
 			},
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).Times(1)
@@ -178,7 +179,7 @@ func TestGetRootCert(t *testing.T) {
 				Name:     "ns-1/sa-5", // this does not match the proxy's service account, so should error
 				CertType: envoy.RootCertTypeForMTLSInbound,
 			},
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
@@ -283,7 +284,7 @@ func TestGetSDSSecrets(t *testing.T) {
 
 	type testCase struct {
 		name            string
-		proxySvcAccount service.K8sServiceAccount
+		proxySvcAccount identity.K8sServiceAccount
 		prepare         func(d *dynamicMock)
 
 		// sdsCertType must match the requested cert type. used by the test for business logic
@@ -304,15 +305,15 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 1: root-cert-for-mtls-inbound requested -------------------------------
 		{
 			name:            "test root-cert-for-mtls-inbound cert type request",
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
-				allowedInboundSvcAccounts := []service.K8sServiceAccount{
+				allowedInboundSvcAccounts := []identity.K8sServiceAccount{
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-3"},
 				}
-				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 
@@ -328,11 +329,11 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 2: root-cert-for-mtls-outbound requested -------------------------------
 		{
 			name:            "test root-cert-for-mtls-outbound cert type request",
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
-				associatedSvcAccounts := []service.K8sServiceAccount{
+				associatedSvcAccounts := []identity.K8sServiceAccount{
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-2"},
 				}
@@ -353,7 +354,7 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 3: root-cert-for-https requested -------------------------------
 		{
 			name:            "test root-cert-https cert type request",
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).Times(1)
@@ -372,7 +373,7 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 4: service-cert requested -------------------------------
 		{
 			name:            "test service-cert cert type request",
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: func(d *dynamicMock) {
 				d.mockCertificater.EXPECT().GetCertificateChain().Return([]byte("foo")).Times(1)
@@ -391,7 +392,7 @@ func TestGetSDSSecrets(t *testing.T) {
 		// Test case 5: invalid cert type requested -------------------------------
 		{
 			name:            "test invalid cert type request",
-			proxySvcAccount: service.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
+			proxySvcAccount: identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"},
 
 			prepare: nil,
 
@@ -469,13 +470,13 @@ func TestGetSubjectAltNamesFromSvcAccount(t *testing.T) {
 	assert := tassert.New(t)
 
 	type testCase struct {
-		svcAccounts         []service.K8sServiceAccount
+		svcAccounts         []identity.K8sServiceAccount
 		expectedSANMatchers []*xds_matcher.StringMatcher
 	}
 
 	testCases := []testCase{
 		{
-			svcAccounts: []service.K8sServiceAccount{
+			svcAccounts: []identity.K8sServiceAccount{
 				{Name: "sa-1", Namespace: "ns-1"},
 				{Name: "sa-2", Namespace: "ns-2"},
 			},

--- a/pkg/envoy/sds/types.go
+++ b/pkg/envoy/sds/types.go
@@ -5,8 +5,9 @@ import (
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
+
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/logger"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 var (
@@ -15,7 +16,7 @@ var (
 
 // sdsImpl is the type that implements the internal functionality of SDS
 type sdsImpl struct {
-	svcAccount  service.K8sServiceAccount
+	svcAccount  identity.K8sServiceAccount
 	meshCatalog catalog.MeshCataloger
 	cfg         configurator.Configurator
 	certManager certificate.Manager

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -218,7 +219,7 @@ func getCommonTLSContext(tlsSDSCert, peerValidationSDSCert SDSCert) *xds_auth.Co
 }
 
 // GetDownstreamTLSContext creates a downstream Envoy TLS Context to be configured on the upstream for the given upstream's identity
-func GetDownstreamTLSContext(upstreamIdentity service.K8sServiceAccount, mTLS bool) *xds_auth.DownstreamTlsContext {
+func GetDownstreamTLSContext(upstreamIdentity identity.K8sServiceAccount, mTLS bool) *xds_auth.DownstreamTlsContext {
 	upstreamSDSCert := SDSCert{
 		Name:     upstreamIdentity.String(),
 		CertType: ServiceCertType,
@@ -251,7 +252,7 @@ func GetDownstreamTLSContext(upstreamIdentity service.K8sServiceAccount, mTLS bo
 }
 
 // GetUpstreamTLSContext creates an upstream Envoy TLS Context for the given downstream identity and upstream service pair
-func GetUpstreamTLSContext(downstreamIdentity service.K8sServiceAccount, upstreamSvc service.MeshService) *xds_auth.UpstreamTlsContext {
+func GetUpstreamTLSContext(downstreamIdentity identity.K8sServiceAccount, upstreamSvc service.MeshService) *xds_auth.UpstreamTlsContext {
 	downstreamSDSCert := SDSCert{
 		Name:     downstreamIdentity.String(),
 		CertType: ServiceCertType,
@@ -313,7 +314,7 @@ func ParseEnvoyServiceNodeID(serviceNodeID string) (*PodMetadata, error) {
 		UID:            chunks[0],
 		Namespace:      chunks[1],
 		IP:             chunks[2],
-		ServiceAccount: service.K8sServiceAccount{Name: chunks[3], Namespace: chunks[1]},
+		ServiceAccount: identity.K8sServiceAccount{Name: chunks[3], Namespace: chunks[1]},
 		EnvoyNodeID:    chunks[4],
 	}
 

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -175,7 +175,7 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test GetDownstreamTLSContext()", func() {
 		It("should return TLS context", func() {
-			tlsContext := GetDownstreamTLSContext(service.K8sServiceAccount{Name: "foo", Namespace: "test"}, true)
+			tlsContext := GetDownstreamTLSContext(identity.K8sServiceAccount{Name: "foo", Namespace: "test"}, true)
 
 			expectedTLSContext := &auth.DownstreamTlsContext{
 				CommonTlsContext: &auth.CommonTlsContext{

--- a/pkg/identity/kubernetes.go
+++ b/pkg/identity/kubernetes.go
@@ -2,8 +2,6 @@ package identity
 
 import (
 	"strings"
-
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 const (
@@ -14,7 +12,7 @@ const (
 )
 
 // GetKubernetesServiceIdentity returns the ServiceIdentity based on Kubernetes ServiceAccount and a trust domain
-func GetKubernetesServiceIdentity(svcAccount service.K8sServiceAccount, trustDomain string) ServiceIdentity {
+func GetKubernetesServiceIdentity(svcAccount K8sServiceAccount, trustDomain string) ServiceIdentity {
 	si := strings.Join([]string{svcAccount.Name, svcAccount.Namespace, trustDomain}, identityDelimiter)
 	return ServiceIdentity(si)
 }

--- a/pkg/identity/kubernetes_test.go
+++ b/pkg/identity/kubernetes_test.go
@@ -5,25 +5,23 @@ import (
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
-
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 func TestGetKubernetesServiceIdentity(t *testing.T) {
 	assert := tassert.New(t)
 
 	testCases := []struct {
-		svcAccount              service.K8sServiceAccount
+		svcAccount              K8sServiceAccount
 		trustDomain             string
 		expectedServiceIdentity ServiceIdentity
 	}{
 		{
-			service.K8sServiceAccount{Name: "foo", Namespace: "bar"},
+			K8sServiceAccount{Name: "foo", Namespace: "bar"},
 			"cluster.local",
 			ServiceIdentity("foo.bar.cluster.local"),
 		},
 		{
-			service.K8sServiceAccount{Name: "foo", Namespace: "bar"},
+			K8sServiceAccount{Name: "foo", Namespace: "bar"},
 			"cluster.baz",
 			ServiceIdentity("foo.bar.cluster.baz"),
 		},

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -266,8 +267,8 @@ func (c Client) GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error)
 }
 
 // ListServiceAccountsForService lists ServiceAccounts associated with the given service
-func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]service.K8sServiceAccount, error) {
-	var svcAccounts []service.K8sServiceAccount
+func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
+	var svcAccounts []identity.K8sServiceAccount
 
 	k8sSvc := c.GetService(svc)
 	if k8sSvc == nil {
@@ -284,7 +285,7 @@ func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]servic
 			continue
 		}
 		if selector.Matches(labels.Set(pod.Labels)) {
-			podSvcAccount := service.K8sServiceAccount{
+			podSvcAccount := identity.K8sServiceAccount{
 				Name:      pod.Spec.ServiceAccountName,
 				Namespace: pod.Namespace, // ServiceAccount must belong to the same namespace as the pod
 			}
@@ -293,7 +294,7 @@ func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]servic
 	}
 
 	for svcAcc := range svcAccountsSet.Iter() {
-		svcAccounts = append(svcAccounts, svcAcc.(service.K8sServiceAccount))
+		svcAccounts = append(svcAccounts, svcAcc.(identity.K8sServiceAccount))
 	}
 	return svcAccounts, nil
 }

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -295,7 +296,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 				announcements.ServiceAccountDeleted,
 				announcements.ServiceAccountUpdated)
 			defer events.GetPubSubInstance().Unsub(serviceChannel)
-			testSvcAccounts := []service.K8sServiceAccount{
+			testSvcAccounts := []identity.K8sServiceAccount{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
 			}
@@ -448,7 +449,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 
-			expectedSvcAccounts := []service.K8sServiceAccount{
+			expectedSvcAccounts := []identity.K8sServiceAccount{
 				{Name: pod1.Spec.ServiceAccountName, Namespace: pod1.Namespace},
 				{Name: pod2.Spec.ServiceAccountName, Namespace: pod2.Namespace},
 			}
@@ -544,7 +545,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 
-			expectedSvcAccounts := []service.K8sServiceAccount{}
+			expectedSvcAccounts := []identity.K8sServiceAccount{}
 			Expect(svcAccounts).Should(HaveLen(0))
 			Expect(svcAccounts).Should(ConsistOf(expectedSvcAccounts))
 		})

--- a/pkg/kubernetes/mock_controller_generated.go
+++ b/pkg/kubernetes/mock_controller_generated.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	"github.com/openservicemesh/osm/pkg/identity"
+	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	v1 "k8s.io/api/core/v1"
 )

--- a/pkg/kubernetes/mock_controller_generated.go
+++ b/pkg/kubernetes/mock_controller_generated.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	v1 "k8s.io/api/core/v1"
 )
@@ -136,10 +137,10 @@ func (mr *MockControllerMockRecorder) ListServiceAccounts() *gomock.Call {
 }
 
 // ListServiceAccountsForService mocks base method
-func (m *MockController) ListServiceAccountsForService(arg0 service.MeshService) ([]service.K8sServiceAccount, error) {
+func (m *MockController) ListServiceAccountsForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceAccountsForService", arg0)
-	ret0, _ := ret[0].([]service.K8sServiceAccount)
+	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -95,7 +96,7 @@ type Controller interface {
 	ListPods() []*corev1.Pod
 
 	// ListServiceAccountsForService lists ServiceAccounts associated with the given service
-	ListServiceAccountsForService(svc service.MeshService) ([]service.K8sServiceAccount, error)
+	ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error)
 
 	// GetEndpoints returns the endpoints for a given service, if found
 	GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error)

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -19,8 +19,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	a "github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // We have a few different k8s clients. This identifies these in logs.
@@ -229,8 +229,8 @@ func (c *Client) ListTrafficTargets() []*smiAccess.TrafficTarget {
 }
 
 // ListServiceAccounts lists ServiceAccounts specified in SMI TrafficTarget resources
-func (c *Client) ListServiceAccounts() []service.K8sServiceAccount {
-	var serviceAccounts []service.K8sServiceAccount
+func (c *Client) ListServiceAccounts() []identity.K8sServiceAccount {
+	var serviceAccounts []identity.K8sServiceAccount
 	for _, targetIface := range c.caches.TrafficTarget.List() {
 		trafficTarget := targetIface.(*smiAccess.TrafficTarget)
 
@@ -240,7 +240,7 @@ func (c *Client) ListServiceAccounts() []service.K8sServiceAccount {
 				// Doesn't belong to namespaces we are observing
 				continue
 			}
-			namespacedServiceAccount := service.K8sServiceAccount{
+			namespacedServiceAccount := identity.K8sServiceAccount{
 				Namespace: sources.Namespace,
 				Name:      sources.Name,
 			}
@@ -252,7 +252,7 @@ func (c *Client) ListServiceAccounts() []service.K8sServiceAccount {
 			// Doesn't belong to namespaces we are observing
 			continue
 		}
-		namespacedServiceAccount := service.K8sServiceAccount{
+		namespacedServiceAccount := identity.K8sServiceAccount{
 			Namespace: trafficTarget.Spec.Destination.Namespace,
 			Name:      trafficTarget.Spec.Destination.Name,
 		}

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -6,7 +6,7 @@ import (
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -15,7 +15,7 @@ type fakeMeshSpec struct {
 	httpRouteGroups []*spec.HTTPRouteGroup
 	tcpRoutes       []*spec.TCPRoute
 	trafficTargets  []*access.TrafficTarget
-	serviceAccounts []service.K8sServiceAccount
+	serviceAccounts []identity.K8sServiceAccount
 }
 
 // NewFakeMeshSpecClient creates a fake Mesh Spec used for testing.
@@ -25,7 +25,7 @@ func NewFakeMeshSpecClient() MeshSpec {
 		httpRouteGroups: []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 		tcpRoutes:       []*spec.TCPRoute{&tests.TCPRoute},
 		trafficTargets:  []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
-		serviceAccounts: []service.K8sServiceAccount{
+		serviceAccounts: []identity.K8sServiceAccount{
 			tests.BookstoreServiceAccount,
 			tests.BookstoreV2ServiceAccount,
 			tests.BookbuyerServiceAccount,
@@ -39,7 +39,7 @@ func (f fakeMeshSpec) ListTrafficSplits() []*split.TrafficSplit {
 }
 
 // ListServiceAccounts fetches all service accounts declared with SMI Spec for the fake Mesh Spec.
-func (f fakeMeshSpec) ListServiceAccounts() []service.K8sServiceAccount {
+func (f fakeMeshSpec) ListServiceAccounts() []identity.K8sServiceAccount {
 	return f.serviceAccounts
 }
 

--- a/pkg/smi/mock_meshspec_generated.go
+++ b/pkg/smi/mock_meshspec_generated.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	"github.com/openservicemesh/osm/pkg/identity"
+	identity "github.com/openservicemesh/osm/pkg/identity"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"

--- a/pkg/smi/mock_meshspec_generated.go
+++ b/pkg/smi/mock_meshspec_generated.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	service "github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	v1alpha3 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha2 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
@@ -66,10 +66,10 @@ func (mr *MockMeshSpecMockRecorder) ListHTTPTrafficSpecs() *gomock.Call {
 }
 
 // ListServiceAccounts mocks base method
-func (m *MockMeshSpec) ListServiceAccounts() []service.K8sServiceAccount {
+func (m *MockMeshSpec) ListServiceAccounts() []identity.K8sServiceAccount {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceAccounts")
-	ret0, _ := ret[0].([]service.K8sServiceAccount)
+	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	return ret0
 }
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 var (
@@ -52,7 +52,7 @@ type MeshSpec interface {
 	ListTrafficSplits() []*split.TrafficSplit
 
 	// ListServiceAccounts lists ServiceAccount resources specified in SMI TrafficTarget resources
-	ListServiceAccounts() []service.K8sServiceAccount
+	ListServiceAccounts() []identity.K8sServiceAccount
 
 	// ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -16,6 +16,7 @@ import (
 	tresorPem "github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests/certificates"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -289,19 +290,19 @@ var (
 	}
 
 	// BookstoreServiceAccount is a namespaced service account.
-	BookstoreServiceAccount = service.K8sServiceAccount{
+	BookstoreServiceAccount = identity.K8sServiceAccount{
 		Namespace: Namespace,
 		Name:      BookstoreServiceAccountName,
 	}
 
 	// BookstoreV2ServiceAccount is a namespaced service account.
-	BookstoreV2ServiceAccount = service.K8sServiceAccount{
+	BookstoreV2ServiceAccount = identity.K8sServiceAccount{
 		Namespace: Namespace,
 		Name:      BookstoreV2ServiceAccountName,
 	}
 
 	// BookbuyerServiceAccount is a namespaced bookbuyer account.
-	BookbuyerServiceAccount = service.K8sServiceAccount{
+	BookbuyerServiceAccount = identity.K8sServiceAccount{
 		Namespace: Namespace,
 		Name:      BookbuyerServiceAccountName,
 	}

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -60,7 +61,7 @@ func (rwc *RouteWeightedClusters) TotalClustersWeight() int {
 // AddRule adds a Rule to an InboundTrafficPolicy based on the given HTTP route match, weighted cluster, and allowed service account
 //	parameters. If a Rule for the given HTTP route match exists, it will add the given service account to the Rule. If the the given route
 //	match is not already associated with a Rule, it will create a Rule for the given route and service account.
-func (in *InboundTrafficPolicy) AddRule(route RouteWeightedClusters, allowedServiceAccount service.K8sServiceAccount) {
+func (in *InboundTrafficPolicy) AddRule(route RouteWeightedClusters, allowedServiceAccount identity.K8sServiceAccount) {
 	routeExists := false
 	for _, rule := range in.Rules {
 		if reflect.DeepEqual(rule.Route, route) {

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -6,6 +6,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	tassert "github.com/stretchr/testify/assert"
 
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -37,12 +38,12 @@ var (
 		Weight:      100,
 	}
 
-	testServiceAccount1 = service.K8sServiceAccount{
+	testServiceAccount1 = identity.K8sServiceAccount{
 		Name:      "testServiceAccount1",
 		Namespace: "testNamespace1",
 	}
 
-	testServiceAccount2 = service.K8sServiceAccount{
+	testServiceAccount2 = identity.K8sServiceAccount{
 		Name:      "testServiceAccount2",
 		Namespace: "testNamespace2",
 	}
@@ -64,7 +65,7 @@ func TestAddRule(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		existingRules         []*Rule
-		allowedServiceAccount service.K8sServiceAccount
+		allowedServiceAccount identity.K8sServiceAccount
 		route                 RouteWeightedClusters
 		expectedRules         []*Rule
 	}{

--- a/pkg/utils/serviceaccount.go
+++ b/pkg/utils/serviceaccount.go
@@ -1,14 +1,13 @@
 package utils
 
 import (
+	"github.com/openservicemesh/osm/pkg/identity"
 	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // SvcAccountToK8sSvcAccount converts a Kubernetes service to a MeshService.
-func SvcAccountToK8sSvcAccount(svcAccount *corev1.ServiceAccount) service.K8sServiceAccount {
-	return service.K8sServiceAccount{
+func SvcAccountToK8sSvcAccount(svcAccount *corev1.ServiceAccount) identity.K8sServiceAccount {
+	return identity.K8sServiceAccount{
 		Namespace: svcAccount.Namespace,
 		Name:      svcAccount.Name,
 	}

--- a/pkg/utils/serviceaccount.go
+++ b/pkg/utils/serviceaccount.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/openservicemesh/osm/pkg/identity"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openservicemesh/osm/pkg/identity"
 )
 
 // SvcAccountToK8sSvcAccount converts a Kubernetes service to a MeshService.

--- a/pkg/utils/serviceaccount_test.go
+++ b/pkg/utils/serviceaccount_test.go
@@ -5,7 +5,7 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -14,7 +14,7 @@ func TestSvcAccountToK8sSvcAccount(t *testing.T) {
 
 	sa := tests.NewServiceAccountFixture(tests.BookbuyerServiceAccountName, tests.Namespace)
 	svcAccount := SvcAccountToK8sSvcAccount(sa)
-	expectedSvcAccount := service.K8sServiceAccount{
+	expectedSvcAccount := identity.K8sServiceAccount{
 		Name:      tests.BookbuyerServiceAccountName,
 		Namespace: tests.Namespace,
 	}

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/rds"
+	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
@@ -36,8 +37,8 @@ func TestRDSRespose(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
-		downstreamSA             service.K8sServiceAccount
-		upstreamSA               service.K8sServiceAccount
+		downstreamSA             identity.K8sServiceAccount
+		upstreamSA               identity.K8sServiceAccount
 		upstreamServices         []service.MeshService
 		meshServices             []service.MeshService
 		trafficSpec              spec.HTTPRouteGroup
@@ -123,7 +124,7 @@ func TestRDSRespose(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -136,7 +137,7 @@ func TestRDSRespose(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -166,7 +167,7 @@ func TestRDSRespose(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),
@@ -179,7 +180,7 @@ func TestRDSRespose(t *testing.T) {
 									Weight:      100,
 								}),
 							},
-							AllowedServiceAccounts: mapset.NewSet(service.K8sServiceAccount{
+							AllowedServiceAccounts: mapset.NewSet(identity.K8sServiceAccount{
 								Name:      tests.BookbuyerServiceAccountName,
 								Namespace: tests.Namespace,
 							}),


### PR DESCRIPTION
This PR is the 2nd part of:
 - **Moving K8sServiceAccount from pkg/service to pkg/identity** #3152

This PR changes all imports needing `K8sServiceAccount` from `pkg/service` to `pkg/identity`.

> Note: There are **no functional code changes**.

The goal is to alleviate the review load from #3152.

Previous step: **Copy K8sServiceAccount from pkg/service to pkg/identity** #3153
Next step: **Delete service.K8sServiceAccount** #3155