### PR TITLE
Delete service.K8sServiceAccount

### DIFF
--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,11 +1,6 @@
 // Package service models an instance of a service managed by OSM controller and utility routines associated with it.
 package service
 
-import (
-	"fmt"
-	"strings"
-)
-
 const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
 	// or viceversa
@@ -21,22 +16,6 @@ type MeshService struct {
 	Name string
 }
 
-// K8sServiceAccount is a type for a namespaced service account
-type K8sServiceAccount struct {
-	Namespace string
-	Name      string
-}
-
-// String returns the string representation of the service account object
-func (sa K8sServiceAccount) String() string {
-	return fmt.Sprintf("%s%s%s", sa.Namespace, namespaceNameSeparator, sa.Name)
-}
-
-// IsEmpty returns true if the given service account object is empty
-func (sa K8sServiceAccount) IsEmpty() bool {
-	return (K8sServiceAccount{}) == sa
-}
-
 // ClusterName is a type for a service name
 type ClusterName string
 
@@ -49,24 +28,4 @@ func (c ClusterName) String() string {
 type WeightedCluster struct {
 	ClusterName ClusterName `json:"cluster_name:omitempty"`
 	Weight      int         `json:"weight:omitempty"`
-}
-
-// UnmarshalK8sServiceAccount unmarshals a K8sServiceAccount type from a string
-func UnmarshalK8sServiceAccount(str string) (*K8sServiceAccount, error) {
-	slices := strings.Split(str, namespaceNameSeparator)
-	if len(slices) != 2 {
-		return nil, errInvalidMeshServiceFormat
-	}
-
-	// Make sure the slices are not empty. Split might actually leave empty slices.
-	for _, sep := range slices {
-		if len(sep) == 0 {
-			return nil, errInvalidMeshServiceFormat
-		}
-	}
-
-	return &K8sServiceAccount{
-		Namespace: slices[0],
-		Name:      slices[1],
-	}, nil
 }

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -1,12 +1,7 @@
 package service
 
 import (
-	"fmt"
-	"testing"
-
 	"github.com/google/uuid"
-	tassert "github.com/stretchr/testify/assert"
-	trequire "github.com/stretchr/testify/require"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,24 +9,6 @@ import (
 
 var _ = Describe("Test pkg/service functions", func() {
 	defer GinkgoRecover()
-
-	Context("Test K8sServiceAccount struct methods", func() {
-		namespace := uuid.New().String()
-		serviceAccountName := uuid.New().String()
-		sa := K8sServiceAccount{
-			Namespace: namespace,
-			Name:      serviceAccountName,
-		}
-
-		It("implements stringer interface correctly", func() {
-			Expect(sa.String()).To(Equal(fmt.Sprintf("%s/%s", namespace, serviceAccountName)))
-		})
-
-		It("implements IsEmpty correctly", func() {
-			Expect(sa.IsEmpty()).To(BeFalse())
-			Expect(K8sServiceAccount{}.IsEmpty()).To(BeTrue())
-		})
-	})
 
 	Context("Test ClusterName String method", func() {
 		clusterNameStr := uuid.New().String()
@@ -42,71 +19,3 @@ var _ = Describe("Test pkg/service functions", func() {
 		})
 	})
 })
-
-func TestUnmarshalK8sServiceAccount(t *testing.T) {
-	assert := tassert.New(t)
-	require := trequire.New(t)
-
-	namespace := "randomNamespace"
-	serviceName := "randomServiceAccountName"
-	svcAccount := &K8sServiceAccount{
-		Namespace: namespace,
-		Name:      serviceName,
-	}
-	str := svcAccount.String()
-	fmt.Println(str)
-
-	testCases := []struct {
-		name              string
-		expectedErr       bool
-		serviceAccountStr string
-	}{
-		{
-			name:              "successfully unmarshal service account",
-			expectedErr:       false,
-			serviceAccountStr: "randomNamespace/randomServiceAccountName",
-		},
-		{
-			name:              "incomplete namespaced service account name 1",
-			expectedErr:       true,
-			serviceAccountStr: "/svnc",
-		},
-		{
-			name:              "incomplete namespaced service account name 2",
-			expectedErr:       true,
-			serviceAccountStr: "svnc/",
-		},
-		{
-			name:              "incomplete namespaced service account name 3",
-			expectedErr:       true,
-			serviceAccountStr: "/svnc/",
-		},
-		{
-			name:              "incomplete namespaced service account name 3",
-			expectedErr:       true,
-			serviceAccountStr: "/",
-		},
-		{
-			name:              "incomplete namespaced service account name 3",
-			expectedErr:       true,
-			serviceAccountStr: "",
-		},
-		{
-			name:              "incomplete namespaced service account name 3",
-			expectedErr:       true,
-			serviceAccountStr: "test",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := UnmarshalK8sServiceAccount(tc.serviceAccountStr)
-			if tc.expectedErr {
-				assert.NotNil(err)
-			} else {
-				require.Nil(err)
-				assert.Equal(svcAccount, actual)
-			}
-		})
-	}
-}


### PR DESCRIPTION
This PR is the 3rd part of:
 - **Moving K8sServiceAccount from pkg/service to pkg/identity** #3152

This PR deletes `service.K8sServiceAccount` from `pkg/service` (we already have it in `pkg/identity`).

The goal is to alleviate the review load from #3152.

Previous step: **Change import of K8sServiceAccount from pkg/service to pkg/identity** #3154