### PR TITLE
ads: Convert sendResponse to a variadic function; Simplify job dispatch

### DIFF
--- a/pkg/envoy/ads/jobs.go
+++ b/pkg/envoy/ads/jobs.go
@@ -3,19 +3,16 @@ package ads
 import (
 	"fmt"
 
-	mapset "github.com/deckarep/golang-set"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
-	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
-// proxyResponseJob is the workerpool job implementation for a Proxy response function
+// proxyResponseJob is the worker pool job implementation for a Proxy response function
 // It takes the parameters of `server.sendResponse` and allows to queue it as a job on a workerpool
 type proxyResponseJob struct {
-	typeurls  mapset.Set
+	typeURIs  []envoy.TypeURI
 	proxy     *envoy.Proxy
-	cfg       configurator.Configurator
 	adsStream *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer
 	request   *xds_discovery.DiscoveryRequest
 	xdsServer *Server
@@ -24,12 +21,17 @@ type proxyResponseJob struct {
 	done chan struct{}
 }
 
+// GetDoneCh returns the channel, which when closed, indicates the job has been finished.
+func (proxyJob *proxyResponseJob) GetDoneCh() <-chan struct{} {
+	return proxyJob.done
+}
+
 // Run implementation for `server.sendResponse` job
 func (proxyJob *proxyResponseJob) Run() {
-	err := (*proxyJob.xdsServer).sendResponse(proxyJob.typeurls, proxyJob.proxy, proxyJob.adsStream, proxyJob.request, proxyJob.cfg)
+	err := (*proxyJob.xdsServer).sendResponse(proxyJob.proxy, proxyJob.adsStream, proxyJob.request, proxyJob.xdsServer.cfg, proxyJob.typeURIs...)
 	if err != nil {
 		log.Error().Err(err).Msgf("Failed to create and send %v update to Envoy with xDS Certificate SerialNumber=%s for PodUUID=%s",
-			proxyJob.typeurls, proxyJob.proxy.GetCertificateSerialNumber(), proxyJob.proxy.GetPodUID())
+			proxyJob.typeURIs, proxyJob.proxy.GetCertificateSerialNumber(), proxyJob.proxy.GetPodUID())
 	}
 	close(proxyJob.done)
 }
@@ -42,6 +44,6 @@ func (proxyJob *proxyResponseJob) JobName() string {
 // Hash implementation for this job to hash into the worker queues
 func (proxyJob *proxyResponseJob) Hash() uint64 {
 	// Uses proxy hash to always serialize work for the same proxy to the same worker,
-	// this avoid out-of-order misshandling of envoy updates by multiple workers
+	// this avoid out-of-order mishandling of envoy updates by multiple workers
 	return proxyJob.proxy.GetHash()
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -38,12 +38,12 @@ func (s *Server) sendTypeResponse(typeURI envoy.TypeURI, proxy *envoy.Proxy, ser
 func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, request *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, typeURIsToSend ...envoy.TypeURI) error {
 	thereWereErrors := false
 
+	// A nil request indicates a request for all SDS responses
+	fullUpdateRequested := request == nil || envoy.TypeURI(request.TypeUrl).IsWildcard()
+
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
 	for _, typeURI := range typeURIsToSend {
-		// A nil request indicates a request for all SDS responses
-		fullUpdateRequested := request == nil || envoy.TypeURI(request.TypeUrl).IsWildcard()
-
 		// Handle request when is not provided, and the SDS case
 		var finalReq *xds_discovery.DiscoveryRequest
 		if fullUpdateRequested {

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -5,18 +5,17 @@ import (
 	"fmt"
 	"time"
 
-	mapset "github.com/deckarep/golang-set"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -129,13 +128,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(s).ToNot(BeNil())
 
 			mockCertManager.EXPECT().IssueCertificate(gomock.Any(), certDuration).Return(certPEM, nil).Times(1)
-			err := s.sendResponse(mapset.NewSetWith(
-				envoy.TypeCDS,
-				envoy.TypeEDS,
-				envoy.TypeLDS,
-				envoy.TypeRDS,
-				envoy.TypeSDS),
-				proxy, &server, nil, mockConfigurator)
+			err := s.sendResponse(proxy, &server, nil, mockConfigurator, envoy.XDSResponseOrder...)
 			Expect(err).To(BeNil())
 			Expect(actualResponses).ToNot(BeNil())
 			Expect(len(*actualResponses)).To(Equal(5))
@@ -215,7 +208,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(s).ToNot(BeNil())
 
 			mockCertManager.EXPECT().IssueCertificate(gomock.Any(), certDuration).Return(certPEM, nil).Times(1)
-			err := s.sendResponse(mapset.NewSetWith(envoy.TypeSDS), proxy, &server, nil, mockConfigurator)
+			err := s.sendResponse(proxy, &server, nil, mockConfigurator, envoy.TypeSDS)
 			Expect(err).To(BeNil())
 			Expect(actualResponses).ToNot(BeNil())
 			Expect(len(*actualResponses)).To(Equal(1))

--- a/pkg/workerpool/workerpool_test.go
+++ b/pkg/workerpool/workerpool_test.go
@@ -4,11 +4,11 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	tassert "github.com/stretchr/testify/assert"
 )
 
 func TestNewWorkerPool(t *testing.T) {
-	assert := assert.New(t)
+	assert := tassert.New(t)
 	wp := NewWorkerPool(0)
 
 	assert.Equal(wp.GetWorkerNumber(), runtime.GOMAXPROCS(-1))
@@ -23,6 +23,10 @@ func TestNewWorkerPool(t *testing.T) {
 type testJob struct {
 	jobDone chan struct{}
 	hash    uint64
+}
+
+func (tj *testJob) GetDoneCh() <-chan struct{} {
+	return tj.jobDone
 }
 
 func (tj *testJob) Run() {
@@ -40,7 +44,7 @@ func (tj *testJob) Hash() uint64 {
 
 // Uses AddJob, which relies on job hash for queue assignment
 func TestAddJob(t *testing.T) {
-	assert := assert.New(t)
+	assert := tassert.New(t)
 
 	njobs := 10 // also worker routines
 	wp := NewWorkerPool(njobs)
@@ -56,7 +60,7 @@ func TestAddJob(t *testing.T) {
 		wp.AddJob(&joblist[i])
 	}
 
-	// Verifiy all jobs ran through the workers
+	// Verify all jobs ran through the workers
 	for i := 0; i < njobs; i++ {
 		<-joblist[i].jobDone
 	}
@@ -71,7 +75,7 @@ func TestAddJob(t *testing.T) {
 
 // Uses AddJobRoundRobin, which relies on round robin for queue assignment
 func TestAddJobRoundRobin(t *testing.T) {
-	assert := assert.New(t)
+	assert := tassert.New(t)
 
 	njobs := 10 // also worker routines
 	wp := NewWorkerPool(njobs)
@@ -87,7 +91,7 @@ func TestAddJobRoundRobin(t *testing.T) {
 		wp.AddJobRoundRobin(&joblist[i])
 	}
 
-	// Verifiy all jobs ran through the workers
+	// Verify all jobs ran through the workers
 	for i := 0; i < njobs; i++ {
 		<-joblist[i].jobDone
 	}


### PR DESCRIPTION
This PR tackles converts `sendResponse` to a variadic function.
This removes the need to pass a `mapset` then iterate over a list while checking against the existence of an item in the map to ensure order.

Also in this PR:
  - change to `WorkerPool.AddJob()` to return the `done` channel of the job
  - for the previous point - added a `GetDoneCh() <-chan struct{}` to the `Job` interface.
  - removed unused `ADSUpdateStr`
  - renamed a few variables colliding with imported packages
  - fixed a few typos

Goal of this PR is to simplify and make the code easier to understand.

This will fix #3127