### PR TITLE
dispatcher: Remove unnecessary comment; rename variable for correctness

### DIFF
--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -64,10 +64,8 @@ func (mc *MeshCatalog) dispatcher() {
 	for {
 		select {
 		case message := <-subChannel:
-
-			// New message from pubsub
-			psubMessage, castOk := message.(events.PubSubMessage)
-			if !castOk {
+			psubMessage, ok := message.(events.PubSubMessage)
+			if !ok {
 				log.Error().Msgf("Error casting PubSubMessage: %v", psubMessage)
 				continue
 			}


### PR DESCRIPTION
This PR removes a comment (seems unnecessary).
Also renames `castOk` to `ok` to make this more Go idiomatic. Also to correct `cast`, which is technically `type assertion`.