### PR TITLE
dispatcher: Removing unnecessary .String()

### DIFF
--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -74,7 +74,7 @@ func (mc *MeshCatalog) dispatcher() {
 
 			// Identify if this is an actual delta, or just resync
 			delta := isDeltaUpdate(psubMessage)
-			log.Debug().Msgf("[Pubsub] %s - delta: %v", psubMessage.AnnouncementType.String(), delta)
+			log.Debug().Msgf("[Pubsub] %s - delta: %v", psubMessage.AnnouncementType, delta)
 
 			// Schedule an envoy broadcast update if we either:
 			// - detected a config delta


### PR DESCRIPTION
This PR removes an unnecessary `.String()`.
`AnnouncementType` implements Stringer, used by `%s` formatting.