### PR TITLE
Removing unnecessary .String()

### DIFF
--- a/pkg/catalog/xds_certificates_test.go
+++ b/pkg/catalog/xds_certificates_test.go
@@ -445,7 +445,7 @@ var _ = Describe("Test XDS certificate tooling", func() {
 
 	Context("Test GetServiceAccountFromProxyCertificate", func() {
 		It("should correctly return the ServiceAccount encoded in the XDS certificate CN", func() {
-			cn := certificate.CommonName(fmt.Sprintf("%s.sa-name.sa-namespace", uuid.New().String()))
+			cn := certificate.CommonName(fmt.Sprintf("%s.sa-name.sa-namespace", uuid.New()))
 			svcAccount, err := GetServiceAccountFromProxyCertificate(cn)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(svcAccount).To(Equal(service.K8sServiceAccount{Name: "sa-name", Namespace: "sa-namespace"}))

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -208,7 +208,7 @@ func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]en
 	// Check if the service has been given Cluster IP
 	kubeService := c.kubeController.GetService(svc)
 	if kubeService == nil {
-		log.Error().Msgf("[%s] Could not find service %s", c.providerIdent, svc.String())
+		log.Error().Msgf("[%s] Could not find service %s", c.providerIdent, svc)
 		return nil, errServiceNotFound
 	}
 

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -38,20 +38,20 @@ type fakeClient struct {
 	svcAccountEndpoints map[service.K8sServiceAccount][]endpoint.Endpoint
 }
 
-// Retrieve the IP addresses comprising the given service.
+// ListEndpointsForService retrieves the IP addresses comprising the given service.
 func (f fakeClient) ListEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
 	if svc, ok := f.endpoints[svc.String()]; ok {
 		return svc
 	}
-	panic(fmt.Sprintf("You are asking for MeshService=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", svc.String(), f.endpoints))
+	panic(fmt.Sprintf("You are asking for MeshService=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", svc, f.endpoints))
 }
 
-// Retrieve the IP addresses comprising the given service account.
+// ListEndpointsForIdentity retrieves the IP addresses comprising the given service account.
 func (f fakeClient) ListEndpointsForIdentity(sa service.K8sServiceAccount) []endpoint.Endpoint {
 	if ep, ok := f.svcAccountEndpoints[sa]; ok {
 		return ep
 	}
-	panic(fmt.Sprintf("You are asking for K8sServiceAccount=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", sa.String(), f.svcAccountEndpoints))
+	panic(fmt.Sprintf("You are asking for K8sServiceAccount=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", sa, f.svcAccountEndpoints))
 }
 
 func (f fakeClient) GetServicesForServiceAccount(svcAccount service.K8sServiceAccount) ([]service.MeshService, error) {

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -134,7 +134,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *xds
 	for _, res := range resources {
 		proto, err := ptypes.MarshalAny(res)
 		if err != nil {
-			log.Error().Err(err).Msgf("Error marshalling resource %s for proxy %s", typeURL.String(), proxy.GetCertificateSerialNumber())
+			log.Error().Err(err).Msgf("Error marshalling resource %s for proxy %s", typeURL, proxy.GetCertificateSerialNumber())
 			continue
 		}
 		response.Resources = append(response.Resources, proto)

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -32,7 +32,7 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 	proxySvcAccount := service.K8sServiceAccount{Name: "test-sa", Namespace: "ns-1"}
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxyXDSCertCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), proxySvcAccount.Name, proxySvcAccount.Namespace))
+	proxyXDSCertCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), proxySvcAccount.Name, proxySvcAccount.Namespace))
 	testProxy := envoy.NewProxy(proxyXDSCertCN, certSerialNumber, nil)
 
 	testCases := []testCase{

--- a/pkg/envoy/eds/cluster_load_assignment.go
+++ b/pkg/envoy/eds/cluster_load_assignment.go
@@ -36,7 +36,7 @@ func newClusterLoadAssignment(serviceName service.MeshService, serviceEndpoints 
 	weight := uint32(100 / lenIPs)
 
 	for _, meshEndpoint := range serviceEndpoints {
-		log.Trace().Msgf("[EDS][ClusterLoadAssignment] Adding Endpoint: Cluster=%s, Services=%s, Endpoint=%+v, Weight=%d", serviceName.String(), serviceName.String(), meshEndpoint, weight)
+		log.Trace().Msgf("[EDS][ClusterLoadAssignment] Adding Endpoint: Cluster=%s, Services=%s, Endpoint=%+v, Weight=%d", serviceName, serviceName, meshEndpoint, weight)
 		lbEpt := xds_endpoint.LbEndpoint{
 			HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
 				Endpoint: &xds_endpoint.Endpoint{

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -46,7 +46,7 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_dis
 	for _, svc := range services {
 		ingressInboundPolicies, err := cataloger.GetIngressPoliciesForService(svc)
 		if err != nil {
-			log.Error().Err(err).Msgf("Error looking up ingress policies for service=%s", svc.String())
+			log.Error().Err(err).Msgf("Error looking up ingress policies for service=%s", svc)
 			return nil, err
 		}
 		ingressTrafficPolicies = trafficpolicy.MergeInboundPolicies(catalog.AllowPartialHostnamesMatch, ingressTrafficPolicies, ingressInboundPolicies...)

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -422,7 +422,7 @@ func TestGetSDSSecrets(t *testing.T) {
 				tc.prepare(&d)
 			}
 
-			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New().String(), "sa-1", "ns-1"))
+			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), "sa-1", "ns-1"))
 			certSerialNumber := certificate.SerialNumber("123456")
 			s := &sdsImpl{
 				svcAccount:  tc.proxySvcAccount,

--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -94,7 +94,7 @@ func GetKubernetesServerVersionNumber(kubeClient kubernetes.Interface) ([]int, e
 
 	ver, err := goversion.NewVersion(version.String())
 	if err != nil {
-		return nil, errors.Errorf("Error parsing k8s server version %s: %s", version.String(), err)
+		return nil, errors.Errorf("Error parsing k8s server version %s: %s", version, err)
 	}
 
 	return ver.Segments(), nil

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -55,7 +55,7 @@ func GrpcServe(ctx context.Context, grpcServer *grpc.Server, lis net.Listener, c
 		}
 		cancel()
 	}()
-	log.Info().Msgf("[grpc][%s] Started server on: %s", serverType, lis.Addr().String())
+	log.Info().Msgf("[grpc][%s] Started server on: %s", serverType, lis.Addr())
 
 	<-ctx.Done()
 

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -259,7 +259,7 @@ func (td *OsmTestData) getKubernetesServerVersionNumber() ([]int, error) {
 
 	ver, err := goversion.NewVersion(version.String())
 	if err != nil {
-		return nil, errors.Errorf("Error parsing k8s server version %s: %s", version.String(), err)
+		return nil, errors.Errorf("Error parsing k8s server version %s: %s", version, err)
 	}
 
 	return ver.Segments(), nil


### PR DESCRIPTION
This PR removes `.String()` for variables that implement stringer and are used in formatted strings.

I used this to find these:
```bash
grep -Iir ".String()" $(find . -name '*.go') | grep '\%s' | awk -F':' '{print $1}' | sort | uniq
```