### PR TITLE
Moving the location of MeshService.String()

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -15,10 +15,6 @@ func (ms MeshService) ServerName() string {
 	return strings.Join([]string{ms.Name, ms.Namespace, "svc", "cluster", "local"}, ".")
 }
 
-func (ms MeshService) String() string {
-	return strings.Join([]string{ms.Namespace, namespaceNameSeparator, ms.Name}, "")
-}
-
 // UnmarshalMeshService unmarshals a NamespaceService type from a string
 func UnmarshalMeshService(str string) (*MeshService, error) {
 	slices := strings.Split(str, namespaceNameSeparator)

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,6 +1,8 @@
 // Package service models an instance of a service managed by OSM controller and utility routines associated with it.
 package service
 
+import "fmt"
+
 const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
 	// or viceversa
@@ -14,6 +16,10 @@ type MeshService struct {
 
 	// The name of the service
 	Name string
+}
+
+func (ms MeshService) String() string {
+	return fmt.Sprintf("%s%s%s", ms.Namespace, namespaceNameSeparator, ms.Name)
 }
 
 // ClusterName is a type for a service name

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 
 	. "github.com/onsi/ginkgo"
@@ -10,7 +12,7 @@ import (
 var _ = Describe("Test pkg/service functions", func() {
 	defer GinkgoRecover()
 
-	Context("Test ClusterName String method", func() {
+	Context("Test ClusterName's String method", func() {
 		clusterNameStr := uuid.New().String()
 		cn := ClusterName(clusterNameStr)
 
@@ -18,4 +20,18 @@ var _ = Describe("Test pkg/service functions", func() {
 			Expect(cn.String()).To(Equal(clusterNameStr))
 		})
 	})
+
+	Context("Test MeshService's String method", func() {
+		namespace := uuid.New().String()
+		name := uuid.New().String()
+		ms := MeshService{
+			Namespace: namespace,
+			Name:      name,
+		}
+
+		It("implements stringer correctly", func() {
+			Expect(ms.String()).To(Equal(fmt.Sprintf("%s/%s", namespace, name)))
+		})
+	})
+
 })


### PR DESCRIPTION
This PR:
 - moves the location of `MeshService` `String()` from `pkg/service/service.go` to `pkg/service/types.go` -- to be close to the `MeshService{}` definition
 - also changes the implementation of the `MeshService` stringer interface -- preserves the output