### PR TITLE
[RFC] Replacing empty slice literals with nil slice declarations

### DIFF
--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -22,7 +22,7 @@ const (
 // 2. for the given service account and upstream services from SMI Traffic Target and Traffic Split
 func (mc *MeshCatalog) ListInboundTrafficPolicies(upstreamIdentity service.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
-		inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+		var inboundPolicies []*trafficpolicy.InboundTrafficPolicy
 		for _, svc := range upstreamServices {
 			inboundPolicies = trafficpolicy.MergeInboundPolicies(DisallowPartialHostnamesMatch, inboundPolicies, mc.buildInboundPermissiveModePolicies(svc)...)
 		}
@@ -38,7 +38,7 @@ func (mc *MeshCatalog) ListInboundTrafficPolicies(upstreamIdentity service.K8sSe
 // listInboundPoliciesFromTrafficTargets builds inbound traffic policies for all inbound services
 // when the given service account matches a destination in the Traffic Target resource
 func (mc *MeshCatalog) listInboundPoliciesFromTrafficTargets(upstreamIdentity service.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
-	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	var inboundPolicies []*trafficpolicy.InboundTrafficPolicy
 
 	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
 		if !isValidTrafficTarget(t) {
@@ -61,7 +61,7 @@ func (mc *MeshCatalog) listInboundPoliciesFromTrafficTargets(upstreamIdentity se
 // 1. the given upstream identity matches the destination specified in a TrafficTarget resource
 // 2. the given list of upstream services are backends specified in a TrafficSplit resource
 func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity service.K8sServiceAccount, upstreamServices []service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
-	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	var inboundPolicies []*trafficpolicy.InboundTrafficPolicy
 
 	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
 		if !isValidTrafficTarget(t) {
@@ -109,7 +109,7 @@ func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity serv
 }
 
 func (mc *MeshCatalog) buildInboundPolicies(t *access.TrafficTarget, svc service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
-	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	var inboundPolicies []*trafficpolicy.InboundTrafficPolicy
 
 	// fetch all routes referenced in traffic target
 	routeMatches, err := mc.routesFromRules(t.Spec.Rules, t.Namespace)
@@ -141,7 +141,7 @@ func (mc *MeshCatalog) buildInboundPolicies(t *access.TrafficTarget, svc service
 }
 
 func (mc *MeshCatalog) buildInboundPermissiveModePolicies(svc service.MeshService) []*trafficpolicy.InboundTrafficPolicy {
-	inboundPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	var inboundPolicies []*trafficpolicy.InboundTrafficPolicy
 
 	hostnames, err := mc.getServiceHostnames(svc, true)
 	if err != nil {
@@ -163,7 +163,7 @@ func (mc *MeshCatalog) buildInboundPermissiveModePolicies(svc service.MeshServic
 // routesFromRules takes a set of traffic target rules and the namespace of the traffic target and returns a list of
 //	http route matches (trafficpolicy.HTTPRouteMatch)
 func (mc *MeshCatalog) routesFromRules(rules []access.TrafficTargetRule, trafficTargetNamespace string) ([]trafficpolicy.HTTPRouteMatch, error) {
-	routes := []trafficpolicy.HTTPRouteMatch{}
+	var routes []trafficpolicy.HTTPRouteMatch
 
 	specMatchRoute, err := mc.getHTTPPathsPerRoute() // returns map[traffic_spec_name]map[match_name]trafficpolicy.HTTPRoute
 	if err != nil {

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -340,7 +340,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 				configurator:       mockConfigurator,
 			}
 
-			services := []*corev1.Service{}
+			var services []*corev1.Service
 			for _, meshSvc := range tc.meshServices {
 				k8sService := tests.NewServiceFixture(meshSvc.Name, meshSvc.Namespace, map[string]string{})
 				mockKubeController.EXPECT().GetService(meshSvc).Return(k8sService).AnyTimes()
@@ -350,7 +350,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
 
 			if tc.permissiveMode {
-				serviceAccounts := []*corev1.ServiceAccount{}
+				var serviceAccounts []*corev1.ServiceAccount
 				for _, sa := range tc.meshServiceAccounts {
 					k8sSvcAccount := tests.NewServiceAccountFixture(sa.Name, sa.Namespace)
 					serviceAccounts = append(serviceAccounts, k8sSvcAccount)

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -1168,7 +1168,7 @@ func TestRoutesFromRules(t *testing.T) {
 				},
 			},
 			namespace:      tests.Namespace,
-			expectedRoutes: []trafficpolicy.HTTPRouteMatch{},
+			expectedRoutes: nil,
 		},
 	}
 

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -63,7 +63,7 @@ func buildIngressPolicyName(name, namespace, host string) string {
 
 // getIngressPoliciesNetworkingV1beta1 returns the list of inbound traffic policies associated with networking.k8s.io/v1beta1 ingress resources for the given service
 func (mc *MeshCatalog) getIngressPoliciesNetworkingV1beta1(svc service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
-	inboundIngressPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	var inboundIngressPolicies []*trafficpolicy.InboundTrafficPolicy
 
 	ingresses, err := mc.ingressMonitor.GetIngressNetworkingV1beta1(svc)
 	if err != nil {
@@ -152,7 +152,7 @@ func (mc *MeshCatalog) getIngressPoliciesNetworkingV1beta1(svc service.MeshServi
 
 // getIngressPoliciesNetworkingV1 returns the list of inbound traffic policies associated with networking.k8s.io/v1 ingress resources for the given service
 func (mc *MeshCatalog) getIngressPoliciesNetworkingV1(svc service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
-	inboundIngressPolicies := []*trafficpolicy.InboundTrafficPolicy{}
+	var inboundIngressPolicies []*trafficpolicy.InboundTrafficPolicy
 
 	ingresses, err := mc.ingressMonitor.GetIngressNetworkingV1(svc)
 	if err != nil {

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -16,7 +16,7 @@ import (
 // 2. for the given service account from SMI Traffic Target and Traffic Split
 func (mc *MeshCatalog) ListOutboundTrafficPolicies(downstreamIdentity service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
-		outboundPolicies := []*trafficpolicy.OutboundTrafficPolicy{}
+		var outboundPolicies []*trafficpolicy.OutboundTrafficPolicy
 		mergedPolicies := trafficpolicy.MergeOutboundPolicies(DisallowPartialHostnamesMatch, outboundPolicies, mc.buildOutboundPermissiveModePolicies()...)
 		outboundPolicies = mergedPolicies
 		return outboundPolicies
@@ -32,7 +32,7 @@ func (mc *MeshCatalog) ListOutboundTrafficPolicies(downstreamIdentity service.K8
 // listOutboundPoliciesForTrafficTargets loops through all SMI Traffic Target resources and returns outbound traffic policies
 // when the given service account matches a source in the Traffic Target resource
 func (mc *MeshCatalog) listOutboundPoliciesForTrafficTargets(downstreamIdentity service.K8sServiceAccount) []*trafficpolicy.OutboundTrafficPolicy {
-	outboundPolicies := []*trafficpolicy.OutboundTrafficPolicy{}
+	var outboundPolicies []*trafficpolicy.OutboundTrafficPolicy
 
 	for _, t := range mc.meshSpec.ListTrafficTargets() { // loop through all traffic targets
 		if !isValidTrafficTarget(t) {
@@ -51,7 +51,7 @@ func (mc *MeshCatalog) listOutboundPoliciesForTrafficTargets(downstreamIdentity 
 }
 
 func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespace string) []*trafficpolicy.OutboundTrafficPolicy {
-	outboundPoliciesFromSplits := []*trafficpolicy.OutboundTrafficPolicy{}
+	var outboundPoliciesFromSplits []*trafficpolicy.OutboundTrafficPolicy
 
 	apexServices := mapset.NewSet()
 	for _, split := range mc.meshSpec.ListTrafficSplits() {
@@ -67,7 +67,7 @@ func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespa
 		}
 		policy := trafficpolicy.NewOutboundTrafficPolicy(buildPolicyName(svc, sourceNamespace == svc.Namespace), hostnames)
 
-		weightedClusters := []service.WeightedCluster{}
+		var weightedClusters []service.WeightedCluster
 		for _, backend := range split.Spec.Backends {
 			ms := service.MeshService{Name: backend.Service, Namespace: split.ObjectMeta.Namespace}
 			wc := service.WeightedCluster{
@@ -124,7 +124,7 @@ func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(identity service.K
 }
 
 func (mc *MeshCatalog) buildOutboundPermissiveModePolicies() []*trafficpolicy.OutboundTrafficPolicy {
-	outPolicies := []*trafficpolicy.OutboundTrafficPolicy{}
+	var outPolicies []*trafficpolicy.OutboundTrafficPolicy
 
 	k8sServices := mc.kubeController.ListServices()
 	var destServices []service.MeshService
@@ -151,7 +151,7 @@ func (mc *MeshCatalog) buildOutboundPermissiveModePolicies() []*trafficpolicy.Ou
 }
 
 func (mc *MeshCatalog) buildOutboundPolicies(source service.K8sServiceAccount, t *access.TrafficTarget) []*trafficpolicy.OutboundTrafficPolicy {
-	outPolicies := []*trafficpolicy.OutboundTrafficPolicy{}
+	var outPolicies []*trafficpolicy.OutboundTrafficPolicy
 
 	// fetch services running workloads with destination service account
 	destServices, err := mc.getDestinationServicesFromTrafficTarget(t)

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -265,7 +265,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 				mockKubeController.EXPECT().GetService(ms).Return(apexK8sService).AnyTimes()
 			}
 
-			services := []*corev1.Service{}
+			var services []*corev1.Service
 			for _, ms := range tc.meshServices {
 				k8sService := tests.NewServiceFixture(ms.Name, ms.Namespace, map[string]string{})
 				mockKubeController.EXPECT().GetService(ms).Return(k8sService).AnyTimes()
@@ -273,7 +273,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			}
 
 			if tc.permissiveMode {
-				serviceAccounts := []*corev1.ServiceAccount{}
+				var serviceAccounts []*corev1.ServiceAccount
 				for _, sa := range tc.meshServiceAccounts {
 					k8sSvcAccount := tests.NewServiceAccountFixture(sa.Name, sa.Namespace)
 					serviceAccounts = append(serviceAccounts, k8sSvcAccount)
@@ -761,7 +761,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			k8sServices := []*corev1.Service{}
+			var k8sServices []*corev1.Service
 
 			for name, namespace := range tc.services {
 				svcFixture := tests.NewServiceFixture(name, namespace, map[string]string{})

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -32,7 +32,7 @@ func (mc *MeshCatalog) isTrafficSplitBackendService(svc service.MeshService) boo
 // getApexServicesForBackendService returns a list of services that serve as the apex service in a traffic split where the
 // given service is a backend
 func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.MeshService) []service.MeshService {
-	apexList := []service.MeshService{}
+	var apexList []service.MeshService
 	apexSet := mapset.NewSet()
 	for _, split := range mc.meshSpec.ListTrafficSplits() {
 		for _, backend := range split.Spec.Backends {
@@ -139,7 +139,7 @@ func (mc *MeshCatalog) GetPortToProtocolMappingForService(svc service.MeshServic
 
 // listMeshServices returns all services in the mesh
 func (mc *MeshCatalog) listMeshServices() []service.MeshService {
-	services := []service.MeshService{}
+	var services []service.MeshService
 	for _, svc := range mc.kubeController.ListServices() {
 		services = append(services, utils.K8sSvcToMeshSvc(svc))
 	}

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -519,8 +519,8 @@ func TestListMeshServices(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			k8sServices := []*corev1.Service{}
-			expectedMeshServices := []service.MeshService{}
+			var k8sServices []*corev1.Service
+			var expectedMeshServices []service.MeshService
 
 			for name, namespace := range tc.services {
 				k8sServices = append(k8sServices, tests.NewServiceFixture(name, namespace, map[string]string{}))

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -158,7 +158,7 @@ func trafficTargetIdentitiesToSvcAccounts(identities []smiAccess.IdentityBinding
 		serviceAccountsMap[sa] = true
 	}
 
-	serviceAccounts := []service.K8sServiceAccount{}
+	var serviceAccounts []service.K8sServiceAccount
 	for k := range serviceAccountsMap {
 		serviceAccounts = append(serviceAccounts, k)
 	}

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -65,7 +65,7 @@ func TestNewResponse(t *testing.T) {
 	// 5. Passthrough cluster for egress
 	numExpectedClusters := 6 // source and destination clusters
 	assert.Equal(numExpectedClusters, len(resp))
-	actualClusters := []*xds_cluster.Cluster{}
+	var actualClusters []*xds_cluster.Cluster
 	for idx := range resp {
 		cl, ok := resp[idx].(*xds_cluster.Cluster)
 		require.True(ok)
@@ -283,7 +283,7 @@ func TestNewResponse(t *testing.T) {
 		"envoy-tracing-cluster",
 	}
 
-	foundClusters := []string{}
+	var foundClusters []string
 
 	for _, a := range actualClusters {
 		fmt.Println(a.Name)

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -278,7 +278,7 @@ func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.
 	}
 
 	// For deterministic ordering
-	sortedEndpoints := []string{}
+	var sortedEndpoints []string
 	endpointSet.Each(func(elem interface{}) bool {
 		sortedEndpoints = append(sortedEndpoints, elem.(string))
 		return false

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -30,7 +30,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		return nil, err
 	}
 
-	ldsResources := []types.Resource{}
+	var ldsResources []types.Resource
 
 	var statsHeaders map[string]string
 	if featureflags.IsWASMStatsEnabled() {

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -36,7 +36,7 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_dis
 	outboundTrafficPolicies = cataloger.ListOutboundTrafficPolicies(proxyIdentity)
 
 	routeConfiguration := route.BuildRouteConfiguration(inboundTrafficPolicies, outboundTrafficPolicies, proxy)
-	rdsResources := []types.Resource{}
+	var rdsResources []types.Resource
 
 	for _, config := range routeConfiguration {
 		rdsResources = append(rdsResources, config)

--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -56,7 +56,7 @@ const (
 
 // BuildRouteConfiguration constructs the Envoy constructs ([]*xds_route.RouteConfiguration) for implementing inbound and outbound routes
 func BuildRouteConfiguration(inbound []*trafficpolicy.InboundTrafficPolicy, outbound []*trafficpolicy.OutboundTrafficPolicy, proxy *envoy.Proxy) []*xds_route.RouteConfiguration {
-	routeConfiguration := []*xds_route.RouteConfiguration{}
+	var routeConfiguration []*xds_route.RouteConfiguration
 
 	if len(inbound) > 0 {
 		inboundRouteConfig := NewRouteConfigurationStub(InboundRouteConfigName)

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -33,7 +33,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request 
 		svcAccount:  svcAccount,
 	}
 
-	sdsResources := []types.Resource{}
+	var sdsResources []types.Resource
 
 	// The DiscoveryRequest contains the requested certs
 	requestedCerts := request.ResourceNames

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -544,7 +544,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 
-			expectedSvcAccounts := []service.K8sServiceAccount{}
+			var expectedSvcAccounts []service.K8sServiceAccount
 			Expect(svcAccounts).Should(HaveLen(0))
 			Expect(svcAccounts).Should(ConsistOf(expectedSvcAccounts))
 		})

--- a/pkg/kubernetes/events/event_pubsub.go
+++ b/pkg/kubernetes/events/event_pubsub.go
@@ -23,7 +23,7 @@ type osmPubsub struct {
 
 // Subscribe is the Subscribe implementation for PubSub
 func (c *osmPubsub) Subscribe(aTypes ...announcements.AnnouncementType) chan interface{} {
-	subTypes := []string{}
+	var subTypes []string
 	for _, v := range aTypes {
 		subTypes = append(subTypes, string(v))
 	}

--- a/pkg/strings/which.go
+++ b/pkg/strings/which.go
@@ -5,7 +5,7 @@ type Which []string
 
 // NotEqual returns a new slice of strings from an existing slice that do not match a given string
 func (which Which) NotEqual(rightSide string) []string {
-	notEqual := []string{}
+	var notEqual []string
 	for _, leftSide := range which {
 		if leftSide != rightSide {
 			notEqual = append(notEqual, leftSide)

--- a/pkg/strings/which_test.go
+++ b/pkg/strings/which_test.go
@@ -12,7 +12,7 @@ func TestWhichNotEqual(t *testing.T) {
 	listOfAlpha := Which{"a", "a"}
 	listOfStuff := Which{"a", "b"}
 
-	assertion.Equal(listOfAlpha.NotEqual("a"), []string{})
+	assertion.Nil(listOfAlpha.NotEqual("a"))
 	assertion.Equal(listOfAlpha.NotEqual("b"), []string{"a", "a"})
 	assertion.Equal(listOfStuff.NotEqual("a"), []string{"b"})
 }

--- a/pkg/tests/helpers.go
+++ b/pkg/tests/helpers.go
@@ -12,7 +12,7 @@ import (
 func GetUnique(slice []string) []string {
 	// Map as a set
 	uniqueSet := make(map[string]struct{})
-	uniqueList := []string{}
+	var uniqueList []string
 
 	for _, item := range slice {
 		uniqueSet[item] = struct{}{}

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -211,7 +211,7 @@ func mergeRoutesWeightedClusters(originalRoutes, latestRoutes []*RouteWeightedCl
 // slicesUnionIfSubset returns the union of the two slices if either slices is a subset of the other
 func slicesUnionIfSubset(first, second []string) []string {
 	areSubsets := false
-	unionSlice := []string{}
+	var unionSlice []string
 	firstIntf := convertToInterface(first)
 	secondIntf := convertToInterface(second)
 

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -19,7 +19,7 @@ func TestNewGrpc(t *testing.T) {
 	certPem := adsCert.GetCertificateChain()
 	keyPem := adsCert.GetPrivateKey()
 	rootPem := adsCert.GetIssuingCA()
-	emptyByteArray := []byte{}
+	var emptyByteArray []byte
 
 	type newGrpcTest struct {
 		serverType    string

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -37,7 +37,7 @@ func TestSetupMutualTLS(t *testing.T) {
 	goodCertPem := adsCert.GetCertificateChain()
 	goodKeyPem := adsCert.GetPrivateKey()
 	goodCA := adsCert.GetIssuingCA()
-	emptyByteArray := []byte{}
+	var emptyByteArray []byte
 
 	setupMutualTLStests := []setupMutualTLStest{
 		{emptyByteArray, goodKeyPem, goodCA, "[grpc][mTLS][ADS] Failed loading Certificate ([]) and Key "},

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -50,9 +50,9 @@ func testRecursiveTrafficSplit(appProtocol string) {
 	numberOfServerServices := 1
 	serverReplicaSet := 1
 
-	clientServices := []string{}
+	var clientServices []string
 	serverServices := []string{trafficSplitName}
-	allNamespaces := []string{}
+	var allNamespaces []string
 
 	for i := 0; i < numberOfClientServices; i++ {
 		clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -38,9 +38,9 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 			numberOfServerServices := 5
 			serverReplicaSet := 2
 
-			clientServices := []string{}
-			serverServices := []string{}
-			allNamespaces := []string{}
+			var clientServices []string
+			var serverServices []string
+			var allNamespaces []string
 
 			for i := 0; i < numberOfClientServices; i++ {
 				clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -50,9 +50,9 @@ func testTrafficSplit(appProtocol string) {
 	numberOfServerServices := 5
 	serverReplicaSet := 2
 
-	clientServices := []string{}
-	serverServices := []string{}
-	allNamespaces := []string{}
+	var clientServices []string
+	var serverServices []string
+	var allNamespaces []string
 
 	for i := 0; i < numberOfClientServices; i++ {
 		clientServices = append(clientServices, fmt.Sprintf("%s%d", clientAppBaseName, i))

--- a/tests/framework/common_metrics.go
+++ b/tests/framework/common_metrics.go
@@ -97,7 +97,7 @@ func (p *Prometheus) GetCPULoadAvgforContainer(ns string, podName string, contai
 // GetCPULoadsForContainer convenience wrapper to get 1m, 5m and 15m cpu loads for a resource
 func (p *Prometheus) GetCPULoadsForContainer(ns string, podName string, containerName string, t time.Time) (float64, float64, float64, error) {
 	timeBuckets := []time.Duration{1 * time.Minute, 5 * time.Minute, 15 * time.Minute}
-	loads := []float64{}
+	var loads []float64
 
 	for _, bucketTime := range timeBuckets {
 		val, err := p.GetCPULoadAvgforContainer(ns, podName, containerName, bucketTime, t)

--- a/tests/framework/common_profile.go
+++ b/tests/framework/common_profile.go
@@ -184,7 +184,7 @@ func (sd *DataHandle) OutputIteration(iterNumber int, f *os.File) {
 
 	sd.IterateTrackedPods(func(pod *corev1.Pod) {
 		for _, cont := range pod.Spec.Containers {
-			tableRow := []string{}
+			var tableRow []string
 
 			resSeen := Resource{
 				Namespace:     pod.Namespace,
@@ -229,7 +229,7 @@ func (sd *DataHandle) OutputIterationTable(f *os.File) {
 	// Print all iteration information for all seen resources
 	table := tablewriter.NewWriter(f)
 	header := []string{"It", "Duration", "NPods"}
-	rows := [][]string{}
+	var rows [][]string
 
 	// Set up columns "It", "Duration", "NPods"
 	var prevItDuration time.Duration

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -255,14 +255,14 @@ func (td *OsmTestData) MultipleHTTPRequest(requests *HTTPMultipleRequest) HTTPMu
 // PrettyPrintHTTPResults prints pod results per namespace
 func (td *OsmTestData) PrettyPrintHTTPResults(results *HTTPMultipleResults) {
 	// We sort the keys to always walk the maps deterministically.
-	namespaceKeys := []string{}
+	var namespaceKeys []string
 	for nsKey := range *results {
 		namespaceKeys = append(namespaceKeys, nsKey)
 	}
 	sort.Strings(namespaceKeys)
 
 	for _, ns := range namespaceKeys {
-		podKeys := []string{}
+		var podKeys []string
 		for podKey := range (*results)[ns] {
 			podKeys = append(podKeys, podKey)
 		}

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -66,9 +66,9 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 			// Scale loop
 			sd.Iterate(func() {
 				// The following section computes the clients and servers (quantity and names) to be run this iteration
-				clientServices := []string{}
-				serverServices := []string{}
-				allNamespaces := []string{}
+				var clientServices []string
+				var serverServices []string
+				var allNamespaces []string
 
 				// All servers services for a traffic split live in the same namespace
 				serverNamespace := fmt.Sprintf("%s-%d", serverNamespacePrefix, totalNumberOfServerNamespaces)


### PR DESCRIPTION
This PR replaces empty slice declaration using a nil slice declaration.

This does functionally change the code. These are not equivalent, however the second one seems to be subtly more efficient.

Found these using:
```bash
grep -Iir ":= \[\]" $(find . -name '*.go') | grep '\{\}'
```

---

# Proposal
Make it a guideline (so where possible) for OSM contributions to use a nil slice declaration.
So prefer `var x []string`, and not `x := []string{}`