### PR TITLE
Convert some instances of K8sServiceAccount to ServiceIdentity

### DIFF
--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -63,7 +63,7 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 		upstreamSvc              service.MeshService
 		trafficTargets           []*access.TrafficTarget
 		services                 []service.MeshService
-		outboundServices         map[identity.K8sServiceAccount][]service.MeshService
+		outboundServices         map[identity.ServiceIdentity][]service.MeshService
 		outboundServiceEndpoints map[service.MeshService][]endpoint.Endpoint
 		expectedEndpoints        []endpoint.Endpoint
 	}{
@@ -75,8 +75,8 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			upstreamSvc:    tests.BookstoreV1Service,
 			trafficTargets: []*access.TrafficTarget{&tests.TrafficTarget},
 			services:       []service.MeshService{tests.BookstoreV1Service},
-			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
-				tests.BookstoreServiceAccount: {tests.BookstoreV1Service},
+			outboundServices: map[identity.ServiceIdentity][]service.MeshService{
+				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreV1Service: {tests.Endpoint},
@@ -92,8 +92,8 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			upstreamSvc:    tests.BookstoreV2Service,
 			trafficTargets: []*access.TrafficTarget{&tests.TrafficTarget},
 			services:       []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
-				tests.BookstoreServiceAccount: {tests.BookstoreV1Service, tests.BookstoreV2Service},
+			outboundServices: map[identity.ServiceIdentity][]service.MeshService{
+				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service, tests.BookstoreV2Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreV1Service: {tests.Endpoint},
@@ -113,9 +113,9 @@ func TestListAllowedEndpointsForService(t *testing.T) {
 			upstreamSvc:    tests.BookstoreV2Service,
 			trafficTargets: []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
 			services:       []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			outboundServices: map[identity.K8sServiceAccount][]service.MeshService{
-				tests.BookstoreServiceAccount:   {tests.BookstoreV1Service},
-				tests.BookstoreV2ServiceAccount: {tests.BookstoreV2Service},
+			outboundServices: map[identity.ServiceIdentity][]service.MeshService{
+				tests.BookstoreServiceIdentity:   {tests.BookstoreV1Service},
+				tests.BookstoreV2ServiceIdentity: {tests.BookstoreV2Service},
 			},
 			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
 				tests.BookstoreV1Service: {tests.Endpoint},

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -145,7 +145,7 @@ func trafficTargetIdentityToSvcAccount(identitySubject smiAccess.IdentityBinding
 // trafficTargetIdentityToServiceIdentity returns an identity of the form <namespace>/<service-account>
 func trafficTargetIdentityToServiceIdentity(identitySubject smiAccess.IdentityBindingSubject) identity.ServiceIdentity {
 	svcAccount := trafficTargetIdentityToSvcAccount(identitySubject)
-	return identity.GetKubernetesServiceIdentity(svcAccount, identity.ClusterLocalTrustDomain)
+	return identity.NewFromKubernetesServiceAccount(svcAccount, identity.ClusterLocalTrustDomain)
 }
 
 // trafficTargetIdentitiesToSvcAccounts returns a list of Service Accounts from the given list of identities from a Traffic Target

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -517,9 +517,9 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
 					},
 					TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
 						{
@@ -604,9 +604,9 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
 					},
 					TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
 						{
@@ -752,9 +752,9 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
 					},
 					TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
 						{
@@ -769,9 +769,9 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 				},
 				{
 					Name:        "ns-1/test-2",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+						identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 					},
 					TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
 						{
@@ -839,9 +839,9 @@ func TestListInboundTrafficTargetsWithRoutes(t *testing.T) {
 			expectedTrafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
 					},
 					TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
 						{

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -69,8 +69,14 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 }
 
 // ListEndpointsForIdentity retrieves the list of IP addresses for the given service account
-func (c Client) ListEndpointsForIdentity(sa identity.K8sServiceAccount) []endpoint.Endpoint {
-	log.Trace().Msgf("[%s] Getting Endpoints for service account %s on Kubernetes", c.providerIdent, sa)
+func (c Client) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdentity) []endpoint.Endpoint {
+	sa, err := serviceIdentity.GetKubernetesServiceAccount()
+	if err != nil {
+		log.Err(err).Msgf("Error getting the Kubernetes Service Account for Service Identity %s", serviceIdentity)
+		return nil
+	}
+
+	log.Trace().Msgf("[%s] Getting Endpoints for service account %s on Kubernetes", c.providerIdent, serviceIdentity)
 	var endpoints []endpoint.Endpoint
 
 	podList := c.kubeController.ListPods()

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -693,7 +693,7 @@ func TestListEndpointsForIdentity(t *testing.T) {
 			}
 			mockKubeController.EXPECT().ListPods().Return(pods).AnyTimes()
 
-			actual := provider.ListEndpointsForIdentity(tc.serviceAccount)
+			actual := provider.ListEndpointsForIdentity(tc.serviceAccount.ToServiceIdentity())
 			assert.NotNil(actual)
 			assert.ElementsMatch(actual, tc.expectedEndpoints)
 		})

--- a/pkg/endpoint/providers/kube/fake.go
+++ b/pkg/endpoint/providers/kube/fake.go
@@ -39,7 +39,7 @@ type fakeClient struct {
 	svcAccountEndpoints map[identity.K8sServiceAccount][]endpoint.Endpoint
 }
 
-// Retrieve the IP addresses comprising the given service.
+// ListEndpointsForService retrieves the IP addresses comprising the given service.
 func (f fakeClient) ListEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
 	if svc, ok := f.endpoints[svc.String()]; ok {
 		return svc
@@ -47,8 +47,13 @@ func (f fakeClient) ListEndpointsForService(svc service.MeshService) []endpoint.
 	panic(fmt.Sprintf("You are asking for MeshService=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", svc.String(), f.endpoints))
 }
 
-// Retrieve the IP addresses comprising the given service account.
-func (f fakeClient) ListEndpointsForIdentity(sa identity.K8sServiceAccount) []endpoint.Endpoint {
+// ListEndpointsForIdentity retrieves the IP addresses comprising the given service account.
+func (f fakeClient) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdentity) []endpoint.Endpoint {
+	sa, err := serviceIdentity.GetKubernetesServiceAccount()
+	if err != nil {
+		log.Err(err).Msg("Error getting Kubernetes Service Account for Service Identity")
+		panic("error getting kubernetes service account")
+	}
 	if ep, ok := f.svcAccountEndpoints[sa]; ok {
 		return ep
 	}

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -14,19 +14,19 @@ import (
 
 // Provider is an interface to be implemented by components abstracting Kubernetes, and other compute/cluster providers
 type Provider interface {
-	// Retrieve the IP addresses comprising the given service.
+	// ListEndpointsForService retrieves the IP addresses comprising the given service.
 	ListEndpointsForService(service.MeshService) []Endpoint
 
 	// ListEndpointsForIdentity retrieves the list of IP addresses for the given service account
-	ListEndpointsForIdentity(identity.K8sServiceAccount) []Endpoint
+	ListEndpointsForIdentity(serviceIdentity identity.ServiceIdentity) []Endpoint
 
-	// Retrieve the namespaced services for a given service account
+	// GetServicesForServiceAccount retrieves the namespaced services for a given service account
 	GetServicesForServiceAccount(identity.K8sServiceAccount) ([]service.MeshService, error)
 
 	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
 	GetTargetPortToProtocolMappingForService(service.MeshService) (map[uint32]string, error)
 
-	// Returns the expected endpoints that are to be reached when the service FQDN is resolved under
+	// GetResolvableEndpointsForService returns the expected endpoints that are to be reached when the service FQDN is resolved under
 	// the scope of the provider
 	GetResolvableEndpointsForService(service.MeshService) ([]Endpoint, error)
 

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -253,10 +253,10 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 	trafficTargets := []trafficpolicy.TrafficTargetWithRoutes{
 		{
 			Name:        "ns-1/test-1",
-			Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+			Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 			Sources: []identity.ServiceIdentity{
-				identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-				identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+				identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+				identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 			},
 			TCPRouteMatches: nil,
 		},
@@ -343,10 +343,10 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 	trafficTargets := []trafficpolicy.TrafficTargetWithRoutes{
 		{
 			Name:        "ns-1/test-1",
-			Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+			Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 			Sources: []identity.ServiceIdentity{
-				identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-				identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+				identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+				identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 			},
 			TCPRouteMatches: nil,
 		},

--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -10,7 +10,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
-	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
@@ -39,7 +38,7 @@ func (lb *listenerBuilder) buildRBACFilter() (*xds_listener.Filter, error) {
 
 // buildInboundRBACPolicies builds the RBAC policies based on allowed principals
 func (lb *listenerBuilder) buildInboundRBACPolicies() (*xds_network_rbac.RBAC, error) {
-	proxyIdentity := identity.ServiceIdentity(lb.svcAccount.String())
+	proxyIdentity := lb.svcAccount.ToServiceIdentity()
 	trafficTargets, err := lb.meshCatalog.ListInboundTrafficTargetsWithRoutes(lb.svcAccount)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error listing allowed inbound traffic targets for proxy identity %s", proxyIdentity)

--- a/pkg/envoy/lds/rbac_test.go
+++ b/pkg/envoy/lds/rbac_test.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
 
-	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
-
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -32,10 +30,10 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 			name: "traffic target without TCP routes",
 			trafficTarget: trafficpolicy.TrafficTargetWithRoutes{
 				Name:        "ns-1/test-1",
-				Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+				Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 				Sources: []identity.ServiceIdentity{
-					identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-					identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+					identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+					identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 				},
 				TCPRouteMatches: nil,
 			},
@@ -75,10 +73,10 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 			name: "traffic target with TCP routes",
 			trafficTarget: trafficpolicy.TrafficTargetWithRoutes{
 				Name:        "ns-1/test-1",
-				Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+				Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 				Sources: []identity.ServiceIdentity{
-					identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-					identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+					identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+					identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 				},
 				TCPRouteMatches: []trafficpolicy.TCPRouteMatch{
 					{
@@ -174,10 +172,10 @@ func TestBuildInboundRBACPolicies(t *testing.T) {
 			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 					},
 					TCPRouteMatches: nil,
 				},
@@ -194,17 +192,17 @@ func TestBuildInboundRBACPolicies(t *testing.T) {
 			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 					},
 				},
 				{
 					Name:        "ns-1/test-2",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-4.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-4.ns-2.cluster.local"),
 					},
 				},
 			},
@@ -260,10 +258,10 @@ func TestBuildRBACFilter(t *testing.T) {
 			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 					},
 					TCPRouteMatches: nil,
 				},
@@ -278,17 +276,17 @@ func TestBuildRBACFilter(t *testing.T) {
 			trafficTargets: []trafficpolicy.TrafficTargetWithRoutes{
 				{
 					Name:        "ns-1/test-1",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-2.ns-2.cluster.local"),
-						identity.ServiceIdentity("sa-3.ns-3.cluster.local"),
+						identity.NewFromServiceAccountString("sa-2.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-3.ns-3.cluster.local"),
 					},
 				},
 				{
 					Name:        "ns-1/test-2",
-					Destination: identity.ServiceIdentity("sa-1.ns-1.cluster.local"),
+					Destination: identity.NewFromServiceAccountString("sa-1.ns-1.cluster.local"),
 					Sources: []identity.ServiceIdentity{
-						identity.ServiceIdentity("sa-4.ns-2.cluster.local"),
+						identity.NewFromServiceAccountString("sa-4.ns-2.cluster.local"),
 					},
 				},
 			},

--- a/pkg/envoy/route/rbac.go
+++ b/pkg/envoy/route/rbac.go
@@ -43,7 +43,7 @@ func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule) (map[string]*any.An
 			// The downstream principal in an RBAC policy is an authenticated principal type, which
 			// means the principal must correspond to the fully qualified SAN in the certificate presented
 			// by the downstream.
-			downstreamPrincipal := identity.GetKubernetesServiceIdentity(downstreamIdentity, identity.ClusterLocalTrustDomain)
+			downstreamPrincipal := identity.NewFromKubernetesServiceAccount(downstreamIdentity, identity.ClusterLocalTrustDomain)
 			principalRule = rbac.RulesList{
 				OrRules: []rbac.Rule{
 					{Attribute: rbac.DownstreamAuthPrincipal, Value: downstreamPrincipal.String()},

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -43,8 +43,8 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request 
 
 	// 1. Issue a service certificate for this proxy
 	// OSM currently relies on kubernetes ServiceAccount for service identity
-	si := identity.GetKubernetesServiceIdentity(svcAccount, identity.ClusterLocalTrustDomain)
-	cert, err := certManager.IssueCertificate(certificate.CommonName(si), cfg.GetServiceCertValidityPeriod())
+	si := identity.NewFromKubernetesServiceAccount(svcAccount, identity.ClusterLocalTrustDomain)
+	cert, err := certManager.IssueCertificate(si.GetCertificateCommonName(), cfg.GetServiceCertValidityPeriod())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing a certificate for proxy with certificate SerialNumber=%s", proxy.GetCertificateSerialNumber())
 		return nil, err
@@ -202,7 +202,7 @@ func getSubjectAltNamesFromSvcAccount(svcAccounts []identity.K8sServiceAccount) 
 
 	for _, svcAccount := range svcAccounts {
 		// OSM currently relies on kubernetes ServiceAccount for service identity
-		si := identity.GetKubernetesServiceIdentity(svcAccount, identity.ClusterLocalTrustDomain)
+		si := identity.NewFromKubernetesServiceAccount(svcAccount, identity.ClusterLocalTrustDomain)
 		match := xds_matcher.StringMatcher{
 			MatchPattern: &xds_matcher.StringMatcher_Exact{
 				Exact: si.String(),

--- a/pkg/identity/errors.go
+++ b/pkg/identity/errors.go
@@ -1,0 +1,11 @@
+package identity
+
+import "errors"
+
+var (
+	// ErrInvalidNamespacedServiceStringFormat is an error returned when the K8sServiceAccount string cannot be parsed (is invalid for some reason)
+	ErrInvalidNamespacedServiceStringFormat = errors.New("invalid namespaced service string format")
+
+	// ErrNotAKubernetesServiceAccount is an error returned when the ServiceIdentity is expected to be derived from a Kubernetes Service Account, but this is not true.
+	ErrNotAKubernetesServiceAccount = errors.New("not a kubernetes service account based service identity")
+)

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -1,0 +1,39 @@
+package identity
+
+import (
+	"fmt"
+	"strings"
+)
+
+const fqdnSeparator = "."
+
+// NewFromServiceAccountString is a helper to convert "foo.bar.cluster.local" into ServiceIdentity
+func NewFromServiceAccountString(fqdn string) ServiceIdentity {
+	svcIdent, err := NewFromRFC1123(fqdn, KubernetesServiceAccount)
+	if err != nil {
+		log.Err(err).Msgf("Error converting %s to ServiceIdentity", fqdn)
+		return ServiceIdentity{}
+	}
+	return svcIdent
+}
+
+func NewFromRFC1123(fqdn string, kind ServiceIdentityKind) (ServiceIdentity, error) {
+	if kind != KubernetesServiceAccount {
+		panic(fmt.Sprintf("ServiceIdentity kind %q is not implemented", kind))
+	}
+
+	// By convention as of release-v0.8 ServiceIdentity is in the format: <ServiceAccount>.<Namespace>.cluster.local
+	// We can split by "." and will have service account in the first position and namespace in the second.
+	chunks := strings.Split(fqdn, fqdnSeparator)
+	name := chunks[0]
+	namespace := chunks[1]
+
+	return ServiceIdentity{
+		kind: KubernetesServiceAccount,
+		serviceAccount: K8sServiceAccount{
+			Namespace: namespace,
+			Name:      name,
+		},
+		trustDomain: strings.Join(chunks[2:], fqdnSeparator),
+	}, nil
+}

--- a/pkg/identity/kubernetes.go
+++ b/pkg/identity/kubernetes.go
@@ -16,3 +16,10 @@ func NewFromKubernetesServiceAccount(svcAccount K8sServiceAccount, trustDomain s
 		trustDomain: trustDomain,
 	}
 }
+
+func (si ServiceIdentity) GetKubernetesServiceAccount() (K8sServiceAccount, error) {
+	if si.kind != KubernetesServiceAccount {
+		return K8sServiceAccount{}, ErrNotAKubernetesServiceAccount
+	}
+	return si.serviceAccount, nil
+}

--- a/pkg/identity/kubernetes.go
+++ b/pkg/identity/kubernetes.go
@@ -1,18 +1,18 @@
 package identity
 
-import (
-	"strings"
-)
-
 const (
 	// ClusterLocalTrustDomain is the trust domain for the local kubernetes cluster
 	ClusterLocalTrustDomain = "cluster.local"
-
-	identityDelimiter = "."
 )
 
-// GetKubernetesServiceIdentity returns the ServiceIdentity based on Kubernetes ServiceAccount and a trust domain
-func GetKubernetesServiceIdentity(svcAccount K8sServiceAccount, trustDomain string) ServiceIdentity {
-	si := strings.Join([]string{svcAccount.Name, svcAccount.Namespace, trustDomain}, identityDelimiter)
-	return ServiceIdentity(si)
+// NewFromKubernetesServiceAccount returns the ServiceIdentity based on Kubernetes ServiceAccount and a trust domain
+func NewFromKubernetesServiceAccount(svcAccount K8sServiceAccount, trustDomain string) ServiceIdentity {
+	return ServiceIdentity{
+		kind: KubernetesServiceAccount,
+		serviceAccount: K8sServiceAccount{
+			Namespace: svcAccount.Namespace,
+			Name:      svcAccount.Name,
+		},
+		trustDomain: trustDomain,
+	}
 }

--- a/pkg/identity/kubernetes_test.go
+++ b/pkg/identity/kubernetes_test.go
@@ -18,21 +18,31 @@ func TestGetKubernetesServiceIdentity(t *testing.T) {
 		{
 			K8sServiceAccount{Name: "foo", Namespace: "bar"},
 			"cluster.local",
-			ServiceIdentity("foo.bar.cluster.local"),
+			ServiceIdentity{
+				kind:           KubernetesServiceAccount,
+				serviceAccount: K8sServiceAccount{Name: "foo", Namespace: "bar"},
+				trustDomain:    ClusterLocalTrustDomain,
+			},
 		},
 		{
 			K8sServiceAccount{Name: "foo", Namespace: "bar"},
-			"cluster.baz",
-			ServiceIdentity("foo.bar.cluster.baz"),
+			"cluster.baz.one.two.three.four",
+			ServiceIdentity{
+				kind:           KubernetesServiceAccount,
+				serviceAccount: K8sServiceAccount{Name: "foo", Namespace: "bar"},
+				trustDomain:    "cluster.baz.one.two.three.four",
+			},
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing GetKubernetesServiceIdentity for test case: %v", tc), func(t *testing.T) {
-			si := GetKubernetesServiceIdentity(tc.svcAccount, tc.trustDomain)
+		t.Run(fmt.Sprintf("Testing NewFromKubernetesServiceAccount for test case: %v", tc), func(t *testing.T) {
+			si := NewFromKubernetesServiceAccount(tc.svcAccount, tc.trustDomain)
 			assert.Equal(si, tc.expectedServiceIdentity)
 		})
 	}
 
-	assert.Equal(ServiceIdentity("foo").String(), "foo")
+	svcIdent, err := NewFromRFC1123("foo.bar.baz.one.two.three", KubernetesServiceAccount)
+	assert.Nil(err)
+	assert.Equal(svcIdent.String(), "foo.bar.baz.one.two.three")
 }

--- a/pkg/identity/suite_test.go
+++ b/pkg/identity/suite_test.go
@@ -1,0 +1,13 @@
+package identity
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHttpServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Identity Test Suite")
+}

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -2,7 +2,6 @@
 package identity
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -11,16 +10,11 @@ import (
 )
 
 const (
-	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string or vice versa
+	// namespaceNameSeparator used for marshalling/unmarshalling MeshService to a string or vice versa
 	namespaceNameSeparator = "/"
 )
 
 var log = logger.New("identity")
-
-var (
-	// ErrInvalidServiceAccountStringFormat is an error returned when the K8sServiceAccount string cannot be parsed (is invalid for some reason)
-	ErrInvalidServiceAccountStringFormat = errors.New("invalid namespaced service string format")
-)
 
 // ServiceIdentity is the type used to represent the identity for a service
 type ServiceIdentity struct {
@@ -97,13 +91,13 @@ func (sa K8sServiceAccount) ToServiceIdentity() ServiceIdentity {
 func UnmarshalK8sServiceAccount(str string) (*K8sServiceAccount, error) {
 	slices := strings.Split(str, namespaceNameSeparator)
 	if len(slices) != 2 {
-		return nil, ErrInvalidServiceAccountStringFormat
+		return nil, ErrInvalidNamespacedServiceStringFormat
 	}
 
 	// Make sure the slices are not empty. Split might actually leave empty slices.
 	for _, sep := range slices {
 		if len(sep) == 0 {
-			return nil, ErrInvalidServiceAccountStringFormat
+			return nil, ErrInvalidNamespacedServiceStringFormat
 		}
 	}
 

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -7,12 +7,15 @@ import (
 	"strings"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/logger"
 )
 
 const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string or vice versa
 	namespaceNameSeparator = "/"
 )
+
+var log = logger.New("identity")
 
 var (
 	// ErrInvalidServiceAccountStringFormat is an error returned when the K8sServiceAccount string cannot be parsed (is invalid for some reason)

--- a/pkg/identity/types_test.go
+++ b/pkg/identity/types_test.go
@@ -33,12 +33,14 @@ var _ = Describe("Test pkg/service functions", func() {
 		})
 
 		It("implements ToServiceIdentity() correctly", func() {
-			expected := ServiceIdentity(fmt.Sprintf("%s.%s.cluster.local", serviceAccountName, namespace))
+			fqdn := fmt.Sprintf("%s.%s.cluster.local", serviceAccountName, namespace)
+			expected, _ := NewFromRFC1123(fqdn, KubernetesServiceAccount)
 			Expect(sa.ToServiceIdentity()).To(Equal(expected))
 		})
 
 		It("implements ServiceIdentity.ToK8sServiceAccount() correctly", func() {
-			serviceIdent := ServiceIdentity(fmt.Sprintf("%s.%s.cluster.local", serviceAccountName, namespace))
+			fqdn := fmt.Sprintf("%s.%s.cluster.local", serviceAccountName, namespace)
+			serviceIdent, _ := NewFromRFC1123(fqdn, KubernetesServiceAccount)
 			expectedServiceAccount := sa
 			Expect(serviceIdent.ToK8sServiceAccount()).To(Equal(expectedServiceAccount))
 		})

--- a/pkg/identity/types_test.go
+++ b/pkg/identity/types_test.go
@@ -31,6 +31,17 @@ var _ = Describe("Test pkg/service functions", func() {
 			Expect(sa.IsEmpty()).To(BeFalse())
 			Expect(K8sServiceAccount{}.IsEmpty()).To(BeTrue())
 		})
+
+		It("implements ToServiceIdentity() correctly", func() {
+			expected := ServiceIdentity(fmt.Sprintf("%s.%s.cluster.local", serviceAccountName, namespace))
+			Expect(sa.ToServiceIdentity()).To(Equal(expected))
+		})
+
+		It("implements ServiceIdentity.ToK8sServiceAccount() correctly", func() {
+			serviceIdent := ServiceIdentity(fmt.Sprintf("%s.%s.cluster.local", serviceAccountName, namespace))
+			expectedServiceAccount := sa
+			Expect(serviceIdent.ToK8sServiceAccount()).To(Equal(expectedServiceAccount))
+		})
 	})
 })
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -295,11 +295,15 @@ var (
 		Name:      BookstoreServiceAccountName,
 	}
 
+	BookstoreServiceIdentity = BookstoreServiceAccount.ToServiceIdentity()
+
 	// BookstoreV2ServiceAccount is a namespaced service account.
 	BookstoreV2ServiceAccount = identity.K8sServiceAccount{
 		Namespace: Namespace,
 		Name:      BookstoreV2ServiceAccountName,
 	}
+
+	BookstoreV2ServiceIdentity = BookstoreV2ServiceAccount.ToServiceIdentity()
 
 	// BookbuyerServiceAccount is a namespaced bookbuyer account.
 	BookbuyerServiceAccount = identity.K8sServiceAccount{


### PR DESCRIPTION
This PR is the next step after:
  - **identity: Adding K8sServiceAccount.ToServiceIdentity(); Deprecating K8sServiceAccount** #3166

---

This PR is the first step in resolving #2218.