### PR TITLE
charts/crd: fix scope of meshconfig CRD

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -20,7 +20,7 @@ metadata:
   name: meshconfigs.config.openservicemesh.io
 spec:
   group: config.openservicemesh.io
-  scope: Cluster
+  scope: Namespaced
   names:
     kind: MeshConfig
     listKind: MeshConfigList


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The MeshConfig CRD applies to a control plane
instance running in a given namespace. The CRD
needs to be scoped to a namespace so that multiple
meshes (control plane instances) can each have
their own config CRD.

Not scoping the CRD will also result in client-go
returning meshconfig resources with an empty namespace,
which will break checks in the control plane that
check for the object's namespace to match.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`