### PR TITLE
smi/client: un-export internal pkg type

### DIFF
--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -35,8 +35,8 @@ type cacheCollection struct {
 	TrafficTarget  cache.Store
 }
 
-// Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
-type Client struct {
+// client is a type that implements the smi.MeshSpec interface related to Kubernetes SMI resources
+type client struct {
 	caches         *cacheCollection
 	cacheSynced    chan interface{}
 	providerIdent  string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Un-exports the SMI client type that implements
the MeshCataloger interface.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`