### PR TITLE
catalog: Rename ListAllowedInboundServiceAccounts to ListAllowedInboundServiceIdentities

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -302,8 +302,8 @@ type MeshCataloger interface {
 	// GetSMISpec returns the SMI spec
 	GetSMISpec() smi.MeshSpec
 
-	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
-	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	// ListAllowedInboundServiceIdentities lists the downstream service identities that can connect to the given service account
+	ListAllowedInboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)

--- a/docs/content/docs/design_concepts/interfaces.md
+++ b/docs/content/docs/design_concepts/interfaces.md
@@ -64,8 +64,8 @@ type MeshCataloger interface {
 	// GetSMISpec returns the SMI spec
 	GetSMISpec() smi.MeshSpec
 
-	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
-	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	// ListAllowedInboundServiceIdentities lists the downstream service identities that can connect to the given service account
+	ListAllowedInboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -143,19 +143,19 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedEndpointsForService(arg0, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedEndpointsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedEndpointsForService), arg0, arg1)
 }
 
-// ListAllowedInboundServiceAccounts mocks base method
-func (m *MockMeshCataloger) ListAllowedInboundServiceAccounts(arg0 identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
+// ListAllowedInboundServiceIdentities mocks base method
+func (m *MockMeshCataloger) ListAllowedInboundServiceIdentities(arg0 identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedInboundServiceAccounts", arg0)
+	ret := m.ctrl.Call(m, "ListAllowedInboundServiceIdentities", arg0)
 	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListAllowedInboundServiceAccounts indicates an expected call of ListAllowedInboundServiceAccounts
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedInboundServiceAccounts(arg0 interface{}) *gomock.Call {
+// ListAllowedInboundServiceIdentities indicates an expected call of ListAllowedInboundServiceIdentities
+func (mr *MockMeshCatalogerMockRecorder) ListAllowedInboundServiceIdentities(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedInboundServiceAccounts", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedInboundServiceAccounts), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedInboundServiceIdentities", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedInboundServiceIdentities), arg0)
 }
 
 // ListAllowedOutboundServiceAccounts mocks base method

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -21,8 +21,8 @@ const (
 	httpRouteGroupKind = "HTTPRouteGroup"
 )
 
-// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given upstream service account
-func (mc *MeshCatalog) ListAllowedInboundServiceAccounts(upstream identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
+// ListAllowedInboundServiceIdentities lists the downstream service identities that can connect to the given upstream service account
+func (mc *MeshCatalog) ListAllowedInboundServiceIdentities(upstream identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	return mc.getAllowedDirectionalServiceAccounts(upstream, inbound)
 }
 

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
-func TestListAllowedInboundServiceAccounts(t *testing.T) {
+func TestListAllowedInboundServiceIdentities(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -189,7 +189,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 			// Mock TrafficTargets returned by MeshSpec, should return all TrafficTargets relevant for this test
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).Times(1)
 
-			actual, err := meshCatalog.ListAllowedInboundServiceAccounts(tc.svcAccount)
+			actual, err := meshCatalog.ListAllowedInboundServiceIdentities(tc.svcAccount)
 			assert.Equal(err != nil, tc.expectError)
 			assert.ElementsMatch(actual, tc.expectedInboundSvcAccounts)
 		})

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -57,8 +57,8 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
 	ListAllowedOutboundServicesForIdentity(identity.K8sServiceAccount) []service.MeshService
 
-	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
-	ListAllowedInboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
+	// ListAllowedInboundServiceIdentities lists the downstream service accounts that can connect to the given service account
+	ListAllowedInboundServiceIdentities(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
 
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -183,7 +183,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 		// service identities that are allowed to connect to this upstream identity. This means, if the upstream proxy
 		// identity is 'X', the SANs for this certificate should correspond to all the downstream identities
 		// allowed to access 'X'.
-		svcAccounts, err := s.meshCatalog.ListAllowedInboundServiceAccounts(s.svcAccount)
+		svcAccounts, err := s.meshCatalog.ListAllowedInboundServiceIdentities(s.svcAccount)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error listing inbound service accounts for proxy with ServiceAccount %s", s.svcAccount)
 			return nil, err

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -117,7 +117,7 @@ func TestGetRootCert(t *testing.T) {
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-3"},
 				}
-				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListAllowedInboundServiceIdentities(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 
@@ -313,7 +313,7 @@ func TestGetSDSSecrets(t *testing.T) {
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-3"},
 				}
-				d.mockCatalog.EXPECT().ListAllowedInboundServiceAccounts(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListAllowedInboundServiceIdentities(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}).Return(allowedInboundSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 


### PR DESCRIPTION
This PR renames ` ListAllowedInboundServiceAccounts` to `ListAllowedInboundServiceIdentities`

The type changes will arrive with another PR.

No functional code changes in this PR.

---

This is one of the few steps towards addressing: **Use ServiceIdentity type in catalog APIs instead of service.K8sServiceAccount** #2218

---


This is a small chunk from #3170 


---


### All PRs in the series:
  - [ ] **catalog: Rename ListAllowedInboundServiceAccounts to ListAllowedInboundServiceIdentities** #3176
  - [ ] **catalog: Rename ListAllowedOutboundServiceAccounts to ListAllowedOutboundServiceIdentities** #3178
  - [ ] **catalog: Rename ListServiceAccountsForService to ListServiceIdentitiesForService** #3180
  - [ ] **identity: Adding K8sServiceAccount.ToServiceIdentity() and ServiceIdentity.ToK8sServiceAccount()** #3179