### PR TITLE
smi/client: remove unnecessary prefix in log message

### DIFF
--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -2,7 +2,6 @@ package smi
 
 import (
 	"reflect"
-	"strings"
 
 	"github.com/pkg/errors"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
@@ -73,7 +72,7 @@ func (c *client) run(stop <-chan struct{}) error {
 		hasSynced = append(hasSynced, informer.HasSynced)
 	}
 
-	log.Info().Msgf("[SMI client] Waiting for informers' cache to sync: %+v", strings.Join(names, ", "))
+	log.Info().Msgf("Waiting for informers %v caches to sync", names)
 	if !cache.WaitForCacheSync(stop, hasSynced...) {
 		return errSyncingCaches
 	}
@@ -81,7 +80,7 @@ func (c *client) run(stop <-chan struct{}) error {
 	// Closing the cacheSynced channel signals to the rest of the system that... caches have been synced.
 	close(c.cacheSynced)
 
-	log.Info().Msgf("[SMI client] Cache sync finished for %+v", names)
+	log.Info().Msgf("Cache sync finished for informers %v", names)
 	return nil
 }
 

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	log = logger.New("mesh-spec")
+	log = logger.New("smi-mesh-spec")
 )
 
 // informerCollection is a struct of the Kubernetes informers used for SMI resources


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The logger logs the component `smi-mesh-spec` in this case
for logs emitted by this package. The prefixing of log
messages removed in this change predates the usage of
the logger currently being used. The additional prefix
is not required and is also inconsistent with existing
log messages.

Also tweaks the log message.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`