### PR TITLE
catalog: Rename ListAllowedOutboundServiceAccounts to ListAllowedOutboundServiceIdentities

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -305,8 +305,8 @@ type MeshCataloger interface {
 	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
 	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
-	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
-	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	// ListAllowedOutboundServiceIdentities lists the upstream service identities the given service account can connect to
+	ListAllowedOutboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
 	// ListServiceAccountsForService lists the service accounts associated with the given service
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)

--- a/docs/content/docs/design_concepts/interfaces.md
+++ b/docs/content/docs/design_concepts/interfaces.md
@@ -67,8 +67,8 @@ type MeshCataloger interface {
 	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
 	ListAllowedInboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
-	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
-	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	// ListAllowedOutboundServiceIdentities lists the upstream service identities the given service account can connect to
+	ListAllowedOutboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
 	// ListServiceAccountsForService lists the service accounts associated with the given service
 	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -47,7 +47,7 @@ func (mc *MeshCatalog) ListAllowedEndpointsForService(downstreamIdentity identit
 		return nil, err
 	}
 
-	destSvcAccounts, err := mc.ListAllowedOutboundServiceAccounts(downstreamIdentity)
+	destSvcAccounts, err := mc.ListAllowedOutboundServiceIdentities(downstreamIdentity)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up outbound service accounts for downstream identity %s", downstreamIdentity)
 		return nil, err

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -158,19 +158,19 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedInboundServiceAccounts(arg0 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedInboundServiceAccounts", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedInboundServiceAccounts), arg0)
 }
 
-// ListAllowedOutboundServiceAccounts mocks base method
-func (m *MockMeshCataloger) ListAllowedOutboundServiceAccounts(arg0 identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
+// ListAllowedOutboundServiceIdentities mocks base method
+func (m *MockMeshCataloger) ListAllowedOutboundServiceIdentities(arg0 identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedOutboundServiceAccounts", arg0)
+	ret := m.ctrl.Call(m, "ListAllowedOutboundServiceIdentities", arg0)
 	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListAllowedOutboundServiceAccounts indicates an expected call of ListAllowedOutboundServiceAccounts
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServiceAccounts(arg0 interface{}) *gomock.Call {
+// ListAllowedOutboundServiceIdentities indicates an expected call of ListAllowedOutboundServiceIdentities
+func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServiceIdentities(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServiceAccounts", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServiceAccounts), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServiceIdentities", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServiceIdentities), arg0)
 }
 
 // ListAllowedOutboundServicesForIdentity mocks base method

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -26,8 +26,8 @@ func (mc *MeshCatalog) ListAllowedInboundServiceAccounts(upstream identity.K8sSe
 	return mc.getAllowedDirectionalServiceAccounts(upstream, inbound)
 }
 
-// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given downstream service account can connect to
-func (mc *MeshCatalog) ListAllowedOutboundServiceAccounts(downstream identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
+// ListAllowedOutboundServiceIdentities lists the upstream service identities the given downstream service account can connect to
+func (mc *MeshCatalog) ListAllowedOutboundServiceIdentities(downstream identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error) {
 	return mc.getAllowedDirectionalServiceAccounts(downstream, outbound)
 }
 

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -196,7 +196,7 @@ func TestListAllowedInboundServiceAccounts(t *testing.T) {
 	}
 }
 
-func TestListAllowedOutboundServiceAccounts(t *testing.T) {
+func TestListAllowedOutboundServiceIdentities(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -372,7 +372,7 @@ func TestListAllowedOutboundServiceAccounts(t *testing.T) {
 			// Mock TrafficTargets returned by MeshSpec, should return all TrafficTargets relevant for this test
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).Times(1)
 
-			actual, err := meshCatalog.ListAllowedOutboundServiceAccounts(tc.svcAccount)
+			actual, err := meshCatalog.ListAllowedOutboundServiceIdentities(tc.svcAccount)
 			assert.Equal(err != nil, tc.expectError)
 			assert.ElementsMatch(actual, tc.expectedOutboundSvcAccounts)
 		})

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -60,8 +60,8 @@ type MeshCataloger interface {
 	// ListAllowedInboundServiceAccounts lists the downstream service accounts that can connect to the given service account
 	ListAllowedInboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
 
-	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
-	ListAllowedOutboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
+	// ListAllowedOutboundServiceIdentities lists the upstream service identities the given service account can connect to
+	ListAllowedOutboundServiceIdentities(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
 
 	// ListServiceAccountsForService lists the service accounts associated with the given service
 	ListServiceAccountsForService(service.MeshService) ([]identity.K8sServiceAccount, error)

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -219,7 +219,7 @@ func TestGetEndpointsForProxy(t *testing.T) {
 				mockEndpointProvider.EXPECT().ListEndpointsForService(svc).Return(endpoints).AnyTimes()
 			}
 
-			mockCatalog.EXPECT().ListAllowedOutboundServiceAccounts(tc.proxyIdentity).Return(tc.allowedServiceAccounts, nil).AnyTimes()
+			mockCatalog.EXPECT().ListAllowedOutboundServiceIdentities(tc.proxyIdentity).Return(tc.allowedServiceAccounts, nil).AnyTimes()
 
 			var pods []*v1.Pod
 			for sa, services := range tc.outboundServices {


### PR DESCRIPTION
This PR renames `ListAllowedOutboundServiceAccounts ` to `ListAllowedOutboundServiceIdentities`

The type changes will arrive with another PR.

No functional code changes in this PR.

---


This is one of the few steps towards addressing: **Use ServiceIdentity type in catalog APIs instead of service.K8sServiceAccount** #2218

---


This is a small chunk from #3170 


---


### All PRs in the series:
  - [x] **catalog: Rename ListAllowedInboundServiceAccounts to ListAllowedInboundServiceIdentities** #3176
  - [ ] **catalog: Rename ListAllowedOutboundServiceAccounts to ListAllowedOutboundServiceIdentities** #3178
  - [x] **catalog: Rename ListServiceAccountsForService to ListServiceIdentitiesForService** #3180
  - [x] **identity: Adding K8sServiceAccount.ToServiceIdentity() and ServiceIdentity.ToK8sServiceAccount()** #3179