### PR TITLE
identity: Adding K8sServiceAccount.ToServiceIdentity() and ServiceIdentity.ToK8sServiceAccount()

### DIFF
--- a/pkg/identity/errors.go
+++ b/pkg/identity/errors.go
@@ -1,0 +1,8 @@
+package identity
+
+import "errors"
+
+var (
+	// ErrInvalidNamespacedServiceStringFormat is an error returned when the K8sServiceAccount string cannot be parsed (is invalid for some reason)
+	ErrInvalidNamespacedServiceStringFormat = errors.New("invalid namespaced service string format")
+)

--- a/pkg/identity/suite_test.go
+++ b/pkg/identity/suite_test.go
@@ -1,0 +1,13 @@
+package identity
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestHttpServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Identity Test Suite")
+}

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -2,20 +2,19 @@
 package identity
 
 import (
-	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/logger"
 )
 
 const (
-	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string or vice versa
+	// namespaceNameSeparator used for marshalling/unmarshalling MeshService to a string or vice versa
 	namespaceNameSeparator = "/"
 )
 
-var (
-	// ErrInvalidServiceAccountStringFormat is an error returned when the K8sServiceAccount string cannot be parsed (is invalid for some reason)
-	ErrInvalidServiceAccountStringFormat = errors.New("invalid namespaced service string format")
-)
+var log = logger.New("identity")
 
 // ServiceIdentity is the type used to represent the identity for a service
 // For Kubernetes services this string will be in the format: <ServiceAccount>.<Namespace>.cluster.local
@@ -24,6 +23,31 @@ type ServiceIdentity string
 // String returns the ServiceIdentity as a string
 func (si ServiceIdentity) String() string {
 	return string(si)
+}
+
+// GetSDSCSecretName returns a string key used as the name of Certificate in all SDS structs.
+func (si ServiceIdentity) GetSDSCSecretName() string {
+	// TODO(draychev): The cert names can be redone to move away from using "namespace/name" format [https://github.com/openservicemesh/osm/issues/2218]
+	// Currently this will be: "service-cert:default/bookbuyer"
+	return si.ToK8sServiceAccount().String()
+}
+
+// GetCertificateCommonName returns a certificate CommonName compliant with RFC-1123 (https://tools.ietf.org/html/rfc1123) DNS name.
+func (si ServiceIdentity) GetCertificateCommonName() certificate.CommonName {
+	return certificate.CommonName(si)
+}
+
+// ToK8sServiceAccount converts a ServiceIdentity to a K8sServiceAccount to help with transition from K8sServiceAccount to ServiceIdentity
+func (si ServiceIdentity) ToK8sServiceAccount() K8sServiceAccount {
+	// By convention as of release-v0.8 ServiceIdentity is in the format: <ServiceAccount>.<Namespace>.cluster.local
+	// We can split by "." and will have service account in the first position and namespace in the second.
+	chunks := strings.Split(si.String(), ".")
+	name := chunks[0]
+	namespace := chunks[1]
+	return K8sServiceAccount{
+		Namespace: namespace,
+		Name:      name,
+	}
 }
 
 // K8sServiceAccount is a type for a namespaced service account
@@ -42,17 +66,24 @@ func (sa K8sServiceAccount) IsEmpty() bool {
 	return (K8sServiceAccount{}) == sa
 }
 
+// ToServiceIdentity converts K8sServiceAccount to the newer ServiceIdentity
+// TODO(draychev): ToServiceIdentity is used in many places to ease with transition from K8sServiceAccount to ServiceIdentity and should be removed (not everywhere) - [https://github.com/openservicemesh/osm/issues/2218]
+func (sa K8sServiceAccount) ToServiceIdentity() ServiceIdentity {
+	return ServiceIdentity(fmt.Sprintf("%s.%s.%s", sa.Name, sa.Namespace, ClusterLocalTrustDomain))
+}
+
 // UnmarshalK8sServiceAccount unmarshals a K8sServiceAccount type from a string
-func UnmarshalK8sServiceAccount(str string) (*K8sServiceAccount, error) {
-	slices := strings.Split(str, namespaceNameSeparator)
+func UnmarshalK8sServiceAccount(svcAccount string) (*K8sServiceAccount, error) {
+	slices := strings.Split(svcAccount, namespaceNameSeparator)
 	if len(slices) != 2 {
-		return nil, ErrInvalidServiceAccountStringFormat
+		log.Error().Msgf("Error converting Service Account %s from string to K8sServiceAccount", svcAccount)
+		return nil, ErrInvalidNamespacedServiceStringFormat
 	}
 
 	// Make sure the slices are not empty. Split might actually leave empty slices.
 	for _, sep := range slices {
 		if len(sep) == 0 {
-			return nil, ErrInvalidServiceAccountStringFormat
+			return nil, ErrInvalidNamespacedServiceStringFormat
 		}
 	}
 

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -26,6 +26,7 @@ func (si ServiceIdentity) String() string {
 }
 
 // GetSDSCSecretName returns a string key used as the name of Certificate in all SDS structs.
+// TODO(draychev): Remove this once the transition to ServiceIdentity is complete [https://github.com/openservicemesh/osm/issues/3182]
 func (si ServiceIdentity) GetSDSCSecretName() string {
 	// TODO(draychev): The cert names can be redone to move away from using "namespace/name" format [https://github.com/openservicemesh/osm/issues/2218]
 	// Currently this will be: "service-cert:default/bookbuyer"
@@ -33,6 +34,7 @@ func (si ServiceIdentity) GetSDSCSecretName() string {
 }
 
 // GetCertificateCommonName returns a certificate CommonName compliant with RFC-1123 (https://tools.ietf.org/html/rfc1123) DNS name.
+// TODO(draychev): Remove this once the transition to ServiceIdentity is complete [https://github.com/openservicemesh/osm/issues/3182]
 func (si ServiceIdentity) GetCertificateCommonName() certificate.CommonName {
 	return certificate.CommonName(si)
 }

--- a/pkg/identity/types_test.go
+++ b/pkg/identity/types_test.go
@@ -31,6 +31,31 @@ var _ = Describe("Test pkg/service functions", func() {
 			Expect(sa.IsEmpty()).To(BeFalse())
 			Expect(K8sServiceAccount{}.IsEmpty()).To(BeTrue())
 		})
+
+		It("implements ServiceIdentity{}.GetSDSSecretName() correctly", func() {
+			serviceIdentity := ServiceIdentity("one.two.three.four.five")
+			actual := serviceIdentity.GetSDSCSecretName()
+			expected := "two/one"
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("implements K8sServiceAccount{}.ToServiceIdentity() correctly", func() {
+			actual := K8sServiceAccount{
+				Namespace: "ns",
+				Name:      "name",
+			}.ToServiceIdentity()
+			expected := ServiceIdentity("name.ns.cluster.local")
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("implements ServiceIdentity{}.ToK8sServiceAccount() correctly", func() {
+			actual := ServiceIdentity("name.ns.cluster.local").ToK8sServiceAccount()
+			expected := K8sServiceAccount{
+				Namespace: "ns",
+				Name:      "name",
+			}
+			Expect(actual).To(Equal(expected))
+		})
 	})
 })
 


### PR DESCRIPTION
This PR introduces a few (not yet used) functions to help with the transition from `K8sServiceAccount` to `ServiceIdentity` (#2218)

  - `ServiceIdentity{}.ToK8sServiceAccount()` converts a `ServiceIdentity` to a `K8sServiceAccount` - examples of how this will be used are here #3170

  - `K8sServiceAccount{}.ToServiceIdentity()` converts a `K8sServiceAccount` to a `ServiceIdentity` - examples are also in #3170

  - `ServiceIdentity{}.GetSDSCSecretName()` needed to create the string keys used as names for SDS Certs / Secrets - this is going to be used instead of `K8sServiceAccount{}.String()`

---

The type changes will arrive with another PR.

No functional code changes in this PR.

---


This is one of the few steps towards addressing: **Use ServiceIdentity type in catalog APIs instead of service.K8sServiceAccount** #2218

---


This is a small chunk from #3170 


---


### All PRs in the series:
  - [ ] **catalog: Rename ListAllowedInboundServiceAccounts to ListAllowedInboundServiceIdentities** #3176
  - [ ] **catalog: Rename ListAllowedOutboundServiceAccounts to ListAllowedOutboundServiceIdentities** #3178
  - [ ] **catalog: Rename ListServiceAccountsForService to ListServiceIdentitiesForService** #3180
  - [ ] **identity: Adding K8sServiceAccount.ToServiceIdentity() and ServiceIdentity.ToK8sServiceAccount()** #3179