### PR TITLE
catalog: Rename ListServiceAccountsForService to ListServiceIdentitiesForService

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -308,8 +308,8 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
-	// ListServiceAccountsForService lists the service accounts associated with the given service
-	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
+	// ListServiceIdentitiesForService lists the service identities associated with the given service
+	ListServiceIdentitiesForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)

--- a/docs/content/docs/design_concepts/interfaces.md
+++ b/docs/content/docs/design_concepts/interfaces.md
@@ -70,8 +70,8 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
-	// ListServiceAccountsForService lists the service accounts associated with the given service
-	ListServiceAccountsForService(service.MeshService) ([]service.K8sServiceAccount, error)
+	// ListServiceIdentitiesForService lists the service identities associated with the given service
+	ListServiceIdentitiesForService(service.MeshService) ([]service.K8sServiceAccount, error)
 
 	// ListSMIPolicies lists SMI policies.
 	ListSMIPolicies() ([]*split.TrafficSplit, []service.K8sServiceAccount, []*spec.HTTPRouteGroup, []*target.TrafficTarget)

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -101,9 +101,9 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface) *MeshCatalog {
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV1Service).Return([]identity.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV2Service).Return([]identity.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookbuyerService).Return([]identity.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookstoreV1Service).Return([]identity.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookstoreV2Service).Return([]identity.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookbuyerService).Return([]identity.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
 		mockIngressMonitor, stop, cfg, endpointProviders...)

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -230,17 +230,17 @@ func (mr *MockMeshCatalogerMockRecorder) ListOutboundTrafficPolicies(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundTrafficPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundTrafficPolicies), arg0)
 }
 
-// ListServiceAccountsForService mocks base method
-func (m *MockMeshCataloger) ListServiceAccountsForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
+// ListServiceIdentitiesForService mocks base method
+func (m *MockMeshCataloger) ListServiceIdentitiesForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServiceAccountsForService", arg0)
+	ret := m.ctrl.Call(m, "ListServiceIdentitiesForService", arg0)
 	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListServiceAccountsForService indicates an expected call of ListServiceAccountsForService
-func (mr *MockMeshCatalogerMockRecorder) ListServiceAccountsForService(arg0 interface{}) *gomock.Call {
+// ListServiceIdentitiesForService indicates an expected call of ListServiceIdentitiesForService
+func (mr *MockMeshCatalogerMockRecorder) ListServiceIdentitiesForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountsForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListServiceAccountsForService), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceIdentitiesForService", reflect.TypeOf((*MockMeshCataloger)(nil).ListServiceIdentitiesForService), arg0)
 }

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -80,10 +80,10 @@ func (mc *MeshCatalog) getServicesForServiceAccount(sa identity.K8sServiceAccoun
 	return services, nil
 }
 
-// ListServiceAccountsForService lists the service accounts associated with the given service
-func (mc *MeshCatalog) ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
+// ListServiceIdentitiesForService lists the service identities associated with the given service
+func (mc *MeshCatalog) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
 	// Currently OSM uses kubernetes service accounts as service identities
-	return mc.kubeController.ListServiceAccountsForService(svc)
+	return mc.kubeController.ListServiceIdentitiesForService(svc)
 }
 
 // GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -214,7 +214,7 @@ func TestIsTrafficSplitBackendService(t *testing.T) {
 	}
 }
 
-func TestListServiceAccountsForService(t *testing.T) {
+func TestListServiceIdentitiesForService(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -248,9 +248,9 @@ func TestListServiceAccountsForService(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			mockKubeController.EXPECT().ListServiceAccountsForService(tc.svc).Return(tc.expectedSvcAccounts, tc.expectedError).Times(1)
+			mockKubeController.EXPECT().ListServiceIdentitiesForService(tc.svc).Return(tc.expectedSvcAccounts, tc.expectedError).Times(1)
 
-			svcAccounts, err := mc.ListServiceAccountsForService(tc.svc)
+			svcAccounts, err := mc.ListServiceIdentitiesForService(tc.svc)
 			assert.ElementsMatch(svcAccounts, tc.expectedSvcAccounts)
 			assert.Equal(err, tc.expectedError)
 		})

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -63,8 +63,8 @@ type MeshCataloger interface {
 	// ListAllowedOutboundServiceAccounts lists the upstream service accounts the given service account can connect to
 	ListAllowedOutboundServiceAccounts(identity.K8sServiceAccount) ([]identity.K8sServiceAccount, error)
 
-	// ListServiceAccountsForService lists the service accounts associated with the given service
-	ListServiceAccountsForService(service.MeshService) ([]identity.K8sServiceAccount, error)
+	// ListServiceIdentitiesForService lists the service identities associated with the given service
+	ListServiceIdentitiesForService(service.MeshService) ([]identity.K8sServiceAccount, error)
 
 	// ListAllowedEndpointsForService returns the list of endpoints backing a service and its allowed service accounts
 	ListAllowedEndpointsForService(identity.K8sServiceAccount, service.MeshService) ([]endpoint.Endpoint, error)

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -158,7 +158,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 			log.Error().Err(err).Msgf("Error unmarshalling upstream service for outbound cert %s", sdscert)
 			return nil, err
 		}
-		svcAccounts, err := s.meshCatalog.ListServiceAccountsForService(*meshSvc)
+		svcAccounts, err := s.meshCatalog.ListServiceIdentitiesForService(*meshSvc)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error listing service accounts for service %s", meshSvc)
 			return nil, err

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -142,7 +142,7 @@ func TestGetRootCert(t *testing.T) {
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-2"},
 				}
-				d.mockCatalog.EXPECT().ListServiceAccountsForService(service.MeshService{Name: "service-2", Namespace: "ns-2"}).Return(associatedSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListServiceIdentitiesForService(service.MeshService{Name: "service-2", Namespace: "ns-2"}).Return(associatedSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 
@@ -337,7 +337,7 @@ func TestGetSDSSecrets(t *testing.T) {
 					{Name: "sa-2", Namespace: "ns-2"},
 					{Name: "sa-3", Namespace: "ns-2"},
 				}
-				d.mockCatalog.EXPECT().ListServiceAccountsForService(
+				d.mockCatalog.EXPECT().ListServiceIdentitiesForService(
 					service.MeshService{Name: "service-2", Namespace: "ns-2"}).Return(associatedSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -266,8 +266,8 @@ func (c Client) GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error)
 	return nil, nil
 }
 
-// ListServiceAccountsForService lists ServiceAccounts associated with the given service
-func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
+// ListServiceIdentitiesForService lists ServiceAccounts associated with the given service
+func (c Client) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
 	var svcAccounts []identity.K8sServiceAccount
 
 	k8sSvc := c.GetService(svc)

--- a/pkg/kubernetes/client_test.go
+++ b/pkg/kubernetes/client_test.go
@@ -345,7 +345,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 		})
 	})
 
-	Context("Test ListServiceAccountsForService()", func() {
+	Context("Test ListServiceIdentitiesForService()", func() {
 		var kubeClient *testclient.Clientset
 		var kubeController Controller
 		var err error
@@ -445,7 +445,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 			meshSvc := service.MeshService{Name: svc.Name, Namespace: svc.Namespace}
 
-			svcAccounts, err := kubeController.ListServiceAccountsForService(meshSvc)
+			svcAccounts, err := kubeController.ListServiceIdentitiesForService(meshSvc)
 
 			Expect(err).ToNot(HaveOccurred())
 
@@ -541,7 +541,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 			meshSvc := service.MeshService{Name: svc.Name, Namespace: svc.Namespace}
 
-			svcAccounts, err := kubeController.ListServiceAccountsForService(meshSvc)
+			svcAccounts, err := kubeController.ListServiceIdentitiesForService(meshSvc)
 
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/kubernetes/mock_controller_generated.go
+++ b/pkg/kubernetes/mock_controller_generated.go
@@ -136,19 +136,19 @@ func (mr *MockControllerMockRecorder) ListServiceAccounts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccounts", reflect.TypeOf((*MockController)(nil).ListServiceAccounts))
 }
 
-// ListServiceAccountsForService mocks base method
-func (m *MockController) ListServiceAccountsForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
+// ListServiceIdentitiesForService mocks base method
+func (m *MockController) ListServiceIdentitiesForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServiceAccountsForService", arg0)
+	ret := m.ctrl.Call(m, "ListServiceIdentitiesForService", arg0)
 	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListServiceAccountsForService indicates an expected call of ListServiceAccountsForService
-func (mr *MockControllerMockRecorder) ListServiceAccountsForService(arg0 interface{}) *gomock.Call {
+// ListServiceIdentitiesForService indicates an expected call of ListServiceIdentitiesForService
+func (mr *MockControllerMockRecorder) ListServiceIdentitiesForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountsForService", reflect.TypeOf((*MockController)(nil).ListServiceAccountsForService), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceIdentitiesForService", reflect.TypeOf((*MockController)(nil).ListServiceIdentitiesForService), arg0)
 }
 
 // ListServices mocks base method

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -95,8 +95,8 @@ type Controller interface {
 	// ListPods returns a list of pods part of the mesh
 	ListPods() []*corev1.Pod
 
-	// ListServiceAccountsForService lists ServiceAccounts associated with the given service
-	ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error)
+	// ListServiceIdentitiesForService lists ServiceAccounts associated with the given service
+	ListServiceIdentitiesForService(svc service.MeshService) ([]identity.K8sServiceAccount, error)
 
 	// GetEndpoints returns the endpoints for a given service, if found
 	GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error)


### PR DESCRIPTION
This PR renames `ListServiceAccountsForService` to `ListServiceIdentitiesForService`

The type changes will arrive with another PR.

No functional code changes in this PR.

---


This is one of the few steps towards addressing: **Use ServiceIdentity type in catalog APIs instead of service.K8sServiceAccount** #2218

---


This is a small chunk from #3170 


---


### All PRs in the series:
  - [ ] **catalog: Rename ListAllowedInboundServiceAccounts to ListAllowedInboundServiceIdentities** #3176
  - [ ] **catalog: Rename ListAllowedOutboundServiceAccounts to ListAllowedOutboundServiceIdentities** #3178
  - [ ] **catalog: Rename ListServiceAccountsForService to ListServiceIdentitiesForService** #3180
  - [ ] **identity: Adding K8sServiceAccount.ToServiceIdentity() and ServiceIdentity.ToK8sServiceAccount()** #3179