### PR TITLE
prometheus: add deployment resource values to values.yaml

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -104,6 +104,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.osmcontroller.resource.requests.memory | string | `"128M"` |  |
 | OpenServiceMesh.outboundIPRangeExclusionList | list | `[]` | Optional parameter to specify a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
 | OpenServiceMesh.prometheus.port | int | `7070` | Prometheus port |
+| OpenServiceMesh.prometheus.resources | object | `{"limits":{"cpu":1,"memory":"2G"},"requests":{"cpu":0.5,"memory":"512M"}}` | Resource limits for prometheus instance |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus retention time |
 | OpenServiceMesh.replicaCount | int | `1` | `osm-controller` replicas |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Sets the service certificatevalidity duration |

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -32,11 +32,11 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: 500m
-            memory: 2G
+            cpu: {{.Values.OpenServiceMesh.prometheus.resources.limits.cpu}}
+            memory: {{.Values.OpenServiceMesh.prometheus.resources.limits.memory}}
           requests:
-            cpu: 100m
-            memory: 256M
+            cpu: {{.Values.OpenServiceMesh.prometheus.resources.requests.cpu}}
+            memory: {{.Values.OpenServiceMesh.prometheus.resources.requests.memory}}
         volumeMounts:
         - mountPath: /etc/prometheus/
           name: prometheus-config-volume

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -26,6 +26,14 @@ OpenServiceMesh:
         memory: "128M"
     podLabels: {}
   prometheus:
+    # -- Resource limits for prometheus instance
+    resources:
+      limits:
+        cpu: 1
+        memory: 2G
+      requests:
+        cpu: 0.5
+        memory: 512M
     # -- Prometheus port
     port: 7070
     retention:


### PR DESCRIPTION
This commit adds prometheus resource configurability through
`values.yaml`.

Based on https://github.com/eduser25/osm/actions/runs/720587234:
- Bumped requested Mem to 512M, which is the highest of the lowest we can go with
(should support up to 100pods consistently without having prom get killed if the node under
memory pressure form other pods).
- Also adjusted CPU requested. 100m is too low for even 100 pods.
Half vcpu should be a more solid value to consistently support the values we advertise.

- Metrics                [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No