### PR TITLE
xDS: address some xDS issues

### DIFF
--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -24,6 +24,9 @@ func (t TypeURI) String() string {
 
 // Short returns an abbreviated version of the TypeURI, which is easier to spot in logs and metrics.
 func (t TypeURI) Short() string {
+	if t == TypeWildcard {
+		return Wildcard
+	}
 	return utils.GetLastChunkOfSlashed(t.String())
 }
 
@@ -81,6 +84,9 @@ const (
 
 	// TypeADS is not actually used by Envoy - but useful within OSM for logging
 	TypeADS TypeURI = "ADS"
+
+	// Wildcard short name for empty TypeURL
+	Wildcard string = "Wildcard"
 )
 
 const (


### PR DESCRIPTION
Commit addresses nonce handling mostly. It adds resource subscription/checking on OSM's side, and improves handling of some other nonce situations.

- Adds resource comparison and checks, when a request is seen and nonce ACKs last version, a comparison to make sure resources ACKd by envoy are the same as the ones we sent is put in place.
Now will do resource comparison when no-error and nonce is matched.

- Force update when no nonce is seen on message such as uninitialized nonce (first message on stream guaranteed). This is mostly wildcard situation, as LDS/CDS will wildcard the request on the first one. These first requests come with no acknowledged nonce.

- Also moves some code in `ads/response.go` to avoid storing new nonce/version/resources until
send has succeeded; a failed `Send` before could have left incorrect state in the proxy datastructure.

Signed-off-by: Eduard Serra <eduser25@gmail.com>


- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
Yes,
Implementation of ADS stream `shouldRespond` by Istio has been checked upon to implement our handling.
https://github.com/istio/istio/blob/da6178604559bdf2c707a57f452d16bee0de90c8/pilot/pkg/xds/ads.go#L347