### PR TITLE
feat(cli): show supported smi for osm mesh list

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -237,6 +237,8 @@ func main() {
 	httpServer.AddHandler("/metrics", metricsstore.DefaultMetricsStore.Handler())
 	// Version
 	httpServer.AddHandler("/version", version.GetVersionHandler())
+	// Supported SMI Versions
+	httpServer.AddHandler(constants.HTTPServerSmiVersionPath, smi.GetSmiClientVersionHTTPHandler())
 
 	// Start HTTP server
 	err = httpServer.Start()

--- a/docs/content/docs/control_plane_health_probes.md
+++ b/docs/content/docs/control_plane_health_probes.md
@@ -121,10 +121,10 @@ If any health probes are consistently failing, perform the following steps to id
 
     ```console
     $ osm mesh list
-    
-    MESH NAME   NAMESPACE      CONTROLLER PODS                   VERSION
-    osm         osm-system     osm-controller-5494bcffb6-qpjdv   v0.8.3
-    osm2        osm-system-2   osm-controller-48fd3c810d-sornc   v0.8.3
+
+    MESH NAME   NAMESPACE      CONTROLLER PODS                  VERSION     SMI SUPPORTED
+    osm         osm-system     osm-controller-5494bcffb6-qpjdv  v0.8.3      TrafficSplit:split.smi-spec.io/v1alpha2,TrafficTarget:access.smi-spec.io/v1alpha3,HTTPRouteGroup:specs.smi-spec.io/v1alpha4,TCPRoute:specs.smi-spec.io/v1alpha4
+    osm2        osm-system-2   osm-controller-48fd3c810d-sornc  v0.8.3      TrafficSplit:split.smi-spec.io/v1alpha2,TrafficTarget:access.smi-spec.io/v1alpha3,HTTPRouteGroup:specs.smi-spec.io/v1alpha4,TCPRoute:specs.smi-spec.io/v1alpha4
     ```
 
     Note how `osm-system` is present in the following list:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -171,3 +171,8 @@ const (
 	OSMAppInstanceLabelKey = "app.kubernetes.io/instance"
 	OSMAppVersionLabelKey  = "app.kubernetes.io/version"
 )
+
+// OSM HTTP Server Paths
+const (
+	HTTPServerSmiVersionPath = "/smi/version"
+)

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -1,6 +1,9 @@
 package smi
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -277,4 +280,22 @@ func (c *client) ListServiceAccounts() []identity.K8sServiceAccount {
 		serviceAccounts = append(serviceAccounts, namespacedServiceAccount)
 	}
 	return serviceAccounts
+}
+
+// GetSmiClientVersionHTTPHandler returns an http handler that returns supported smi version information
+func GetSmiClientVersionHTTPHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		versionInfo := map[string]string{
+			"TrafficTarget":  smiAccess.SchemeGroupVersion.String(),
+			"HTTPRouteGroup": smiSpecs.SchemeGroupVersion.String(),
+			"TCPRoute":       smiSpecs.SchemeGroupVersion.String(),
+			"TrafficSplit":   smiSplit.SchemeGroupVersion.String(),
+		}
+
+		if jsonVersionInfo, err := json.Marshal(versionInfo); err != nil {
+			log.Error().Err(err).Msgf("Error marshaling version info struct: %+v", versionInfo)
+		} else {
+			_, _ = fmt.Fprint(w, string(jsonVersionInfo))
+		}
+	})
 }


### PR DESCRIPTION
Adds supported smi version info in the output
of `osm mesh list`. Also adds a supported http
endpoint in the osm controller (/smi/version)
that returns a JSON reponse containing supported
smi versions.

Resolves #2849.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A
