### PR TITLE
[RFC] fix(eds): only respond with endpoints whose proxies have connected

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -10,8 +10,9 @@ import (
 func Test(t *testing.T) {
 	assert := tassert.New(t)
 	ept := Endpoint{
-		IP:   net.ParseIP("9.9.9.9"),
-		Port: 1234,
+		IP:       net.ParseIP("9.9.9.9"),
+		Port:     1234,
+		ProxyUID: "uid",
 	}
-	assert.Equal(ept.String(), "(ip=9.9.9.9, port=1234)")
+	assert.Equal(ept.String(), "(ip=9.9.9.9, port=1234, proxy UID=uid)")
 }

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -59,11 +59,9 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 			}
 			var proxyUID string
 			if address.TargetRef != nil && address.TargetRef.Kind == "Pod" {
-				// A GetPod() method would speed this up
-				for _, pod := range c.kubeController.ListPods() {
-					if pod.Name == address.TargetRef.Name && pod.Namespace == address.TargetRef.Namespace {
-						proxyUID = pod.Labels[constants.EnvoyUniqueIDLabelName]
-					}
+				pod := c.kubeController.GetPod(address.TargetRef.Namespace, address.TargetRef.Name)
+				if pod != nil {
+					proxyUID = pod.Labels[constants.EnvoyUniqueIDLabelName]
 				}
 			}
 			for _, port := range kubernetesEndpoint.Ports {

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -36,12 +36,13 @@ type Provider interface {
 
 // Endpoint is a tuple of IP and Port representing an instance of a service
 type Endpoint struct {
-	net.IP `json:"ip"`
-	Port   `json:"port"`
+	net.IP   `json:"ip"`
+	Port     `json:"port"`
+	ProxyUID string `json:"proxy_uid"`
 }
 
 func (ep Endpoint) String() string {
-	return fmt.Sprintf("(ip=%s, port=%d)", ep.IP, ep.Port)
+	return fmt.Sprintf("(ip=%s, port=%d, proxy UID=%s)", ep.IP, ep.Port, ep.ProxyUID)
 }
 
 // Port is a numerical type representing a port on which a service is exposed

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -93,7 +93,7 @@ func (s *Server) newAggregatedDiscoveryResponse(proxy *envoy.Proxy, request *xds
 	}
 
 	log.Trace().Msgf("Invoking handler for type %s; request from Envoy with Node ID %s", typeURL, nodeID)
-	resources, err := handler(s.catalog, proxy, request, cfg, s.certManager)
+	resources, err := handler(s.catalog, proxy, request, cfg, s.certManager, s.proxyRegistry)
 	if err != nil {
 		log.Error().Err(err).Msgf("Handler errored TypeURL: %s, proxy: %s", request.TypeUrl, proxy.GetCertificateSerialNumber())
 		return nil, errCreatingResponse

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -35,7 +35,7 @@ func NewADSServer(meshCatalog catalog.MeshCataloger, proxyRegistry *registry.Pro
 	server := Server{
 		catalog:       meshCatalog,
 		proxyRegistry: proxyRegistry,
-		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error){
+		xdsHandlers: map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager, *registry.ProxyRegistry) ([]types.Resource, error){
 			envoy.TypeEDS: eds.NewResponse,
 			envoy.TypeCDS: cds.NewResponse,
 			envoy.TypeRDS: rds.NewResponse,

--- a/pkg/envoy/ads/types.go
+++ b/pkg/envoy/ads/types.go
@@ -25,7 +25,7 @@ var (
 type Server struct {
 	catalog        catalog.MeshCataloger
 	proxyRegistry  *registry.ProxyRegistry
-	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager) ([]types.Resource, error)
+	xdsHandlers    map[envoy.TypeURI]func(catalog.MeshCataloger, *envoy.Proxy, *xds_discovery.DiscoveryRequest, configurator.Configurator, certificate.Manager, *registry.ProxyRegistry) ([]types.Resource, error)
 	xdsLog         map[certificate.CommonName]map[envoy.TypeURI][]time.Time
 	xdsMapLogMutex sync.Mutex
 	osmNamespace   string

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -10,10 +10,11 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 )
 
 // NewResponse creates a new Cluster Discovery Response.
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, _ *registry.ProxyRegistry) ([]types.Resource, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -53,7 +53,7 @@ func TestNewResponse(t *testing.T) {
 	mockConfigurator.EXPECT().GetTracingHost().Return(constants.DefaultTracingHost).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingPort().Return(constants.DefaultTracingPort).AnyTimes()
 
-	resp, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+	resp, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil, nil)
 	assert.Nil(err)
 
 	// There are to any.Any resources in the ClusterDiscoveryStruct (Clusters)

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -1,8 +1,6 @@
 package eds
 
 import (
-	"strings"
-
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
@@ -51,12 +49,8 @@ func getEndpointsForProxy(meshCatalog catalog.MeshCataloger, proxyIdentity ident
 		}
 		var availableEndpoints []endpoint.Endpoint
 		for _, endpoint := range endpoints {
-			// A GetProxy method would speed this up
-			for cn := range proxyRegistry.ListConnectedProxies() {
-				if strings.HasPrefix(cn.String(), endpoint.ProxyUID+".") {
-					availableEndpoints = append(availableEndpoints, endpoint)
-					break
-				}
+			if proxyRegistry.IsProxyConnected(certificate.CommonName(endpoint.ProxyUID + "." + dstSvc.Name + "." + dstSvc.Namespace)) {
+				availableEndpoints = append(availableEndpoints, endpoint)
 			}
 		}
 		if len(availableEndpoints) > 0 {

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -74,7 +74,14 @@ func TestEndpointConfiguration(t *testing.T) {
 	assert.NotNil(proxy)
 
 	proxyRegistry := registry.NewProxyRegistry()
-	proxyRegistry.RegisterProxy(proxy)
+	proxies := []*envoy.Proxy{
+		envoy.NewProxy(tests.ProxyUUID+"."+tests.BookstoreApexServiceName+"."+tests.Namespace, "", nil),
+		envoy.NewProxy(tests.ProxyUUID+"."+tests.BookstoreV1ServiceName+"."+tests.Namespace, "", nil),
+		envoy.NewProxy(tests.ProxyUUID+"."+tests.BookstoreV2ServiceName+"."+tests.Namespace, "", nil),
+	}
+	for _, proxy := range proxies {
+		proxyRegistry.RegisterProxy(proxy)
+	}
 
 	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil, proxyRegistry)
 	assert.Nil(err)

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/featureflags"
 	"github.com/openservicemesh/osm/pkg/identity"
 )
@@ -17,7 +18,7 @@ import (
 // 1. Inbound listener to handle incoming traffic
 // 2. Outbound listener to handle outgoing traffic
 // 3. Prometheus listener for metrics
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, _ *registry.ProxyRegistry) ([]types.Resource, error) {
 	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -68,7 +68,7 @@ func TestListenerConfiguration(t *testing.T) {
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().IsEgressEnabled().Return(true).AnyTimes()
 
-	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
+	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil, nil)
 	assert.Empty(err)
 	assert.NotNil(resources)
 	// There are 3 listeners configured based on the configuration:

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -8,12 +8,13 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/envoy/route"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 // NewResponse creates a new Route Discovery Response.
-func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
+func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, _ *registry.ProxyRegistry) ([]types.Resource, error) {
 	var inboundTrafficPolicies []*trafficpolicy.InboundTrafficPolicy
 	var outboundTrafficPolicies []*trafficpolicy.OutboundTrafficPolicy
 	var ingressTrafficPolicies []*trafficpolicy.InboundTrafficPolicy

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -274,7 +274,7 @@ func TestNewResponse(t *testing.T) {
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(tc.ingressInboundPolicies, nil).AnyTimes()
 
-			resources, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil, nil)
 			assert.Nil(err)
 			assert.NotNil(resources)
 
@@ -510,7 +510,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()
 
-	resources, err := NewResponse(mockCatalog, testProxy, nil, mockConfigurator, nil)
+	resources, err := NewResponse(mockCatalog, testProxy, nil, mockConfigurator, nil, nil)
 	assert.Nil(err)
 
 	// Test rds-inbound route config

--- a/pkg/envoy/registry/registry.go
+++ b/pkg/envoy/registry/registry.go
@@ -5,6 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
@@ -47,4 +48,11 @@ func (pr *ProxyRegistry) UnregisterProxy(p *envoy.Proxy) {
 // GetConnectedProxyCount counts the number of connected proxies
 func (pr *ProxyRegistry) GetConnectedProxyCount() int {
 	return len(pr.ListConnectedProxies())
+}
+
+// IsProxyConnected returns whether or not the proxy identified by the given
+// certificate common name has connected to this registry instance.
+func (pr *ProxyRegistry) IsProxyConnected(cn certificate.CommonName) bool {
+	_, found := pr.connectedProxies.Load(cn)
+	return found
 }

--- a/pkg/envoy/registry/registry_test.go
+++ b/pkg/envoy/registry/registry_test.go
@@ -1,0 +1,43 @@
+package registry
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+func TestIsProxyConnected(t *testing.T) {
+	assert := tassert.New(t)
+	proxyRegistry := NewProxyRegistry()
+
+	cn1 := certificate.CommonName("common.name.1")
+	cn2 := certificate.CommonName("common.name.2")
+	proxy1 := envoy.NewProxy(cn1, "", nil)
+	proxy2 := envoy.NewProxy(cn2, "", nil)
+
+	assert.False(proxyRegistry.IsProxyConnected(cn1))
+	assert.False(proxyRegistry.IsProxyConnected(cn2))
+
+	proxyRegistry.RegisterProxy(proxy1)
+
+	assert.True(proxyRegistry.IsProxyConnected(cn1))
+	assert.False(proxyRegistry.IsProxyConnected(cn2))
+
+	proxyRegistry.RegisterProxy(proxy2)
+
+	assert.True(proxyRegistry.IsProxyConnected(cn1))
+	assert.True(proxyRegistry.IsProxyConnected(cn2))
+
+	proxyRegistry.UnregisterProxy(proxy1)
+
+	assert.False(proxyRegistry.IsProxyConnected(cn1))
+	assert.True(proxyRegistry.IsProxyConnected(cn2))
+
+	proxyRegistry.UnregisterProxy(proxy2)
+
+	assert.False(proxyRegistry.IsProxyConnected(cn1))
+	assert.False(proxyRegistry.IsProxyConnected(cn2))
+}

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -11,13 +11,14 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
 
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // NewResponse creates a new Secrets Discovery Response.
-func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, certManager certificate.Manager) ([]types.Resource, error) {
+func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, certManager certificate.Manager, _ *registry.ProxyRegistry) ([]types.Resource, error) {
 	log.Info().Msgf("Composing SDS Discovery Response for Envoy with certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 
 	// OSM currently relies on kubernetes ServiceAccount for service identity

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -63,12 +63,12 @@ func TestNewResponse(t *testing.T) {
 	meshCatalog := catalog.NewFakeMeshCatalog(fakeKubeClient)
 
 	// ----- Test with a rogue proxy (does not belong to the mesh)
-	actualSDSResponse, err := NewResponse(meshCatalog, badProxy, request, cfg, certManager)
+	actualSDSResponse, err := NewResponse(meshCatalog, badProxy, request, cfg, certManager, nil)
 	assert.Equal(err, catalog.ErrInvalidCertificateCN, "Expected a different error!")
 	assert.Nil(actualSDSResponse)
 
 	// ----- Test with an properly configured proxy
-	resources, err := NewResponse(meshCatalog, goodProxy, request, cfg, certManager)
+	resources, err := NewResponse(meshCatalog, goodProxy, request, cfg, certManager, nil)
 	assert.Equal(err, nil, fmt.Sprintf("Error evaluating sds.NewResponse(): %s", err))
 	assert.NotNil(resources)
 	assert.Equal(len(resources), 2)

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -253,6 +253,17 @@ func (c Client) ListPods() []*corev1.Pod {
 	return pods
 }
 
+// GetPod returns a Pod resource if found, nil otherwise.
+func (c Client) GetPod(namespace, name string) *corev1.Pod {
+	// client-go cache uses <namespace>/<name> as key
+	podIf, exists, err := c.informers[Pods].GetStore().GetByKey(namespace + "/" + name)
+	if exists && err == nil {
+		pod := podIf.(*corev1.Pod)
+		return pod
+	}
+	return nil
+}
+
 // GetEndpoints returns the endpoint for a given service, otherwise returns nil if not found
 // or error if the API errored out.
 func (c Client) GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error) {

--- a/pkg/kubernetes/mock_controller_generated.go
+++ b/pkg/kubernetes/mock_controller_generated.go
@@ -65,6 +65,20 @@ func (mr *MockControllerMockRecorder) GetNamespace(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockController)(nil).GetNamespace), arg0)
 }
 
+// GetPod mocks base method
+func (m *MockController) GetPod(arg0, arg1 string) *v1.Pod {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPod", arg0, arg1)
+	ret0, _ := ret[0].(*v1.Pod)
+	return ret0
+}
+
+// GetPod indicates an expected call of GetPod
+func (mr *MockControllerMockRecorder) GetPod(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPod", reflect.TypeOf((*MockController)(nil).GetPod), arg0, arg1)
+}
+
 // GetService mocks base method
 func (m *MockController) GetService(arg0 service.MeshService) *v1.Service {
 	m.ctrl.T.Helper()

--- a/pkg/kubernetes/types.go
+++ b/pkg/kubernetes/types.go
@@ -95,6 +95,9 @@ type Controller interface {
 	// ListPods returns a list of pods part of the mesh
 	ListPods() []*corev1.Pod
 
+	// GetPod returns the Pod with the given namespace and name.
+	GetPod(namespace string, name string) *corev1.Pod
+
 	// ListServiceIdentitiesForService lists ServiceAccounts associated with the given service
 	ListServiceIdentitiesForService(svc service.MeshService) ([]identity.K8sServiceAccount, error)
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -207,8 +207,9 @@ var (
 
 	// Endpoint is an endpoint object.
 	Endpoint = endpoint.Endpoint{
-		IP:   net.ParseIP(ServiceIP),
-		Port: endpoint.Port(ServicePort),
+		IP:       net.ParseIP(ServiceIP),
+		Port:     endpoint.Port(ServicePort),
+		ProxyUID: ProxyUUID,
 	}
 
 	// TrafficSplit is a traffic split SMI object.

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -47,7 +47,7 @@ var _ = Describe(``+
 			// ---[  Get the config from rds.NewResponse()  ]-------
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil, nil)
 			It("did not return an error", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resources).ToNot(BeNil())

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -238,7 +238,7 @@ func TestRDSRespose(t *testing.T) {
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()
 
-			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil)
+			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil, nil)
 			assert.Nil(err)
 			assert.NotNil(resources)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change modifies EDS responses from the osm-controller to only
include endpoints whose proxies have already connected to the control
plane. This prevents proxies from being configured to communicate with
proxies who have not yet connected to the control plane, and therefore
haven't been configured to accept traffic.

Broadly, the specific changes include:

- Adding a new `ProxyUID string` field to `endpoint.Endpoint` in order
to create a mapping of service endpoint to proxy. This value is scraped
from the Pod pointed to in the Kubernetes Endpoint's
`addresses[*].targetRef`.

- Modifying the signature of the `NewResponse(...)` xDS functions to
take a `*registry.ProxyRegistry` parameter so EDS can query which
proxies have connected.

- Adding additional logic when constructing each EDS response to filter
out endpoints whose proxies have not yet connected.

This change partially addresses #3044. Specifically, it only checks that
proxies have connected, but not that they've been configured.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No

---

Design Doc: [Envoy Endpoint Synchronization](https://docs.google.com/document/d/1M1-lKRIeZ53sKen1tfHG8Q9Etof6PHSVyFcu1o0oJGQ/edit#)
