### PR TITLE
e2e: Fix resource consumption of Prometheus

### DIFF
--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -28,7 +28,12 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 			// Install OSM
 			installOpts := Td.GetOSMInstallOpts()
 			installOpts.DeployPrometheus = true
-			installOpts.SetOverrides = []string{"OpenServiceMesh.enableWASMStatsExperimental=true"}
+			installOpts.SetOverrides = []string{
+				"OpenServiceMesh.enableWASMStatsExperimental=true",
+				// These values are based on successful runs on OSM's CI values
+				"OpenServiceMesh.osmcontroller.resource.requests.cpu=100m",
+				"OpenServiceMesh.osmcontroller.resource.requests.memory=256M",
+			}
 			Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 			// Create Test NS

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -77,8 +77,17 @@ var _ = OSMDescribe("Upgrade from latest",
 							},
 						},
 					},
+					"prometheus": map[string]interface{}{
+						"resource": map[string]interface{}{
+							"requests": map[string]interface{}{
+								"cpu":    "0.1",
+								"memory": "256M",
+							},
+						},
+					},
 				},
 			}
+
 			chartPath, err := i.LocateChart("osm", helmEnv)
 			Expect(err).NotTo(HaveOccurred())
 			ch, err := loader.Load(chartPath)


### PR DESCRIPTION
CI is failing due to low resorce provision on CI.

Making sure limits are set to allow Prometheus to run
in restricted resource environments.

Signed-off-by: Eduard Serra <eduser25@gmail.com>
- Tests                  [x]
- CI System              [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No