### PR TITLE
chore(release) : cutting release v0.8.3

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.3-rc.1
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.8.3-rc.1
+appVersion: v0.8.3

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -91,7 +91,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.grafana.port | int | `3000` | Grafana port |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` | `osm-controller` pod PullPolicy |
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` | `osm-controller` image registry |
-| OpenServiceMesh.image.tag | string | `"v0.8.3-rc.1"` | `osm-controller` image tag |
+| OpenServiceMesh.image.tag | string | `"v0.8.3"` | `osm-controller` image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.injector | object | `{"podLabels":{},"replicaCount":1,"resource":{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}}` | Sidecar injector configuration |
 | OpenServiceMesh.meshName | string | `"osm"` | Name for the new control plane instance |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -11,7 +11,7 @@ OpenServiceMesh:
     # -- `osm-controller` pod PullPolicy
     pullPolicy: IfNotPresent
     # -- `osm-controller` image tag
-    tag: v0.8.3-rc.1
+    tag: v0.8.3
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
   # -- Envoy sidecar image

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -63,7 +63,7 @@ const (
 	defaultContainerRegistrySecret       = ""
 	defaultMeshName                      = "osm"
 	defaultOsmImagePullPolicy            = "IfNotPresent"
-	defaultOsmImageTag                   = "v0.8.3-rc.1"
+	defaultOsmImageTag                   = "v0.8.3"
 	defaultPrometheusRetentionTime       = constants.PrometheusDefaultRetentionTime
 	defaultVaultHost                     = ""
 	defaultVaultProtocol                 = "http"

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -112,7 +112,6 @@ In a browser, open up the following urls:
 - [http://localhost:8080](http://localhost:8080) - **bookbuyer**
 - [http://localhost:8083](http://localhost:8083) - **bookthief**
 - [http://localhost:8084](http://localhost:8084) - **bookstore**
-  - _Note: This page will not be available at this time in the demo. This will become available during the SMI Traffic Split configuration set up_
 - [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
   - _Note: This page will not be available at this time in the demo. This will become available during the SMI Traffic Split configuration set up_
 
@@ -211,7 +210,7 @@ kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/main/docs
 The counters should now be incrementing for the `bookbuyer`, and `bookstore` applications:
 
 - [http://localhost:8080](http://localhost:8080) - **bookbuyer**
-- [http://localhost:8081](http://localhost:8084) - **bookstore**
+- [http://localhost:8084](http://localhost:8084) - **bookstore**
 
 Note that the counter is _not_ incrementing for the `bookthief` application:
 
@@ -362,7 +361,7 @@ Wait for the changes to propagate and observe the counters increment for `bookst
 browser windows:
 
 - [http://localhost:8082](http://localhost:8082) - **bookstore-v2**
-- [http://localhost:8083](http://localhost:8083) - **bookstore**
+- [http://localhost:8083](http://localhost:8084) - **bookstore**
 
 Now, all traffic directed to the `bookstore` service is flowing to `bookstore-v2`.
 

--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: bookbuyer
       containers:
         - name: bookbuyer
-          image: openservicemesh/bookbuyer:v0.8.3-rc.1
+          image: openservicemesh/bookbuyer:v0.8.3
           imagePullPolicy: Always
           command: ["/bookbuyer"]
           env:

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookstore-v2
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:v0.8.3-rc.1
+          image: openservicemesh/bookstore:v0.8.3
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: bookstore
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:v0.8.3-rc.1
+          image: openservicemesh/bookstore:v0.8.3
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: bookthief
       containers:
         - name: bookthief
-          image: openservicemesh/bookthief:v0.8.3-rc.1
+          image: openservicemesh/bookthief:v0.8.3
           imagePullPolicy: Always
           command: ["/bookthief"]
           env:

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -52,6 +52,6 @@ spec:
       serviceAccountName: bookwarehouse
       containers:
         - name: bookwarehouse
-          image: openservicemesh/bookwarehouse:v0.8.3-rc.1
+          image: openservicemesh/bookwarehouse:v0.8.3
           imagePullPolicy: Always
           command: ["/bookwarehouse"]


### PR DESCRIPTION
**Description**:
 This PR cuts release v0.8.3 

   [X] I have cherry-picked any changes
- [X] I have made all of the following version and patch updates:
  1. Updated the container image tag in charts/osm/values.yaml
  2. Updated the chart **and** app version in charts/osm/Chart.yaml
  3. Updated the default osm-controller image tag in osm cli
  4. Updated the image tags used in the demo manifests
  5. Regenerated the Helm chart README.md

- [X] I have checked that the base branch for this PR is correct as defined by the release guide

