### PR TITLE
egress/api: add ipAddresses field to match TCP based traffic

### DIFF
--- a/pkg/apis/policy/v1alpha1/egress.go
+++ b/pkg/apis/policy/v1alpha1/egress.go
@@ -34,6 +34,10 @@ type EgressSpec struct {
 	// +optional
 	Hosts []string `json:"hosts,omitempty"`
 
+	// IPAddresses defines the list of external IP addresses the Egress policy is applicable to
+	// +optional
+	IPAddresses []string `json:"ipAddresses,omitempty"`
+
 	// Ports defines the list of ports the Egress policy is applicable to
 	Ports []PortSpec `json:"ports"`
 

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -95,6 +95,11 @@ func (in *EgressSpec) DeepCopyInto(out *EgressSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IPAddresses != nil {
+		in, out := &in.IPAddresses, &out.IPAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]PortSpec, len(*in))


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an optional `ipAddresses` field to the egress API to specify
a list of IP ranges the egress policy applies to. This is specifically
required when more than 1 external TCP endpoints use the same port
because just port alone will not be sufficient to route traffic
differently for the different endpoints.

Part of #3045 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`