### PR TITLE
charts/crds: add CRD for egress policy API

### DIFF
--- a/charts/osm/crds/policy.yaml
+++ b/charts/osm/crds/policy.yaml
@@ -1,0 +1,92 @@
+# Custom Resource Definition (CRD) for OSM's policy specification.
+#
+# Copyright Open Service Mesh authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: egresses.policy.openservicemesh.io
+spec:
+  group: policy.openservicemesh.io
+  scope: Namespaced
+  names:
+    kind: Egress
+    listKind: EgressList
+    shortNames:
+      - egress
+    singular: egress
+    plural: egresses
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - sources
+                - hosts
+                - ipAddresses
+                - ports
+              properties:
+                sources:
+                  description: Sources the egress policy is applicable to.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - kind
+                      - name
+                      - namespace
+                    properties:
+                      kind:
+                        description: Kind of this source.
+                        type: string
+                        enum:
+                          - ServiceAccount
+                      name:
+                        description: Name of this source.
+                        type: string
+                      namespace:
+                        description: Namespace of this source.
+                        type: string
+                hosts:
+                  description: Hosts that the sources are allowed to direct external traffic to.
+                  type: array
+                  items:
+                    type: string
+                ipAddresses:
+                  description: IP address ranges that the sources are allowed to direct external traffic to.
+                  type: array
+                  items:
+                    type: string
+                ports:
+                  description: Ports that the sources are allowed to direct external traffic to.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - number
+                      - protocol
+                    properties:
+                      number:
+                        description: Port number of this port.
+                        type: integer
+                      protocol:
+                        description: Protocol served by this port.
+                        type: string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds the CRD for egresses.policy.openservicemesh.io
API.

Part of #3045

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`