### PR TITLE
style(crd): change MeshConfig fields to camelCase

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -43,11 +43,11 @@ spec:
                   description: Configuration for Envoy sidecar
                   type: object
                   properties:
-                    enable_privileged_init_container:
+                    enablePriviledgedInitContainer:
                       description: Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.
                       type: boolean
                       default: false
-                    log_level:
+                    logLevel:
                       description: Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.
                       type: string
                       default: "error"
@@ -60,7 +60,7 @@ spec:
                         - error
                         - critical
                         - off
-                    max_data_plane_connections:
+                    maxDataPlaneConnections:
                       description: Max allowed data plane sidecar connections
                       type: integer
                       default: 0
@@ -68,19 +68,19 @@ spec:
                   description: Configuration for traffic management
                   type: object
                   properties:
-                    enable_egress:
+                    enableEgress:
                       description: Enables egress in the mesh
                       type: boolean
                       default: false
-                    outbound_ip_range_exclusion_list:
+                    outboundIPRangeExclusionList:
                       description: Global list of IP address ranges to exclude from outbound traffic interception by the sidecar proxy.
                       type: string
                       pattern: ((?:\d{1,3}.){3}\d{1,3})\/(\d{1,2})(,((?:\d{1,3}.){3}\d{1,3})\/(\d{1,2}))*$
-                    use_https_ingress:
+                    useHTTPSIngress:
                       description: Enable HTTPS ingress on the mesh
                       type: boolean
                       default: false
-                    enable_permissive_traffic_policy_mode:
+                    enablePermissiveTrafficPolicyMode:
                       description: True for allowing traffic to flow between client and service pods within the mesh without SMI traffic policies, i.e. no traffic policy enforcement in the mesh. If set to false, enables deny-all traffic policy in mesh i.e. an SMI Traffic Target is necessary for services to communicate.
                       type: boolean
                       default: false
@@ -88,11 +88,11 @@ spec:
                   description: Configuration for observing the service mesh, including metrics, logs, tracing etc,.
                   type: object
                   properties:
-                    enable_debug_server:
+                    enableDebugServer:
                       description: Enables a debug endpoint on the osm-controller pod to list information regarding the mesh such as proxy connections, certificates, and SMI policies.
                       type: boolean
                       default: true
-                    prometheus_scraping:
+                    prometheusScrapping:
                       description: Enables Prometheus metrics scraping on sidecar proxies.
                       type: boolean
                       default: true
@@ -120,7 +120,7 @@ spec:
                   description: Configuration for traffic management
                   type: object
                   properties:
-                    service_cert_validity_duration:
+                    serviceCertValidityDuration:
                       description: Sets the service certificate validity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix.
                       type: string
                       default: "24h"

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -7,60 +7,61 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type MeshConfig struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline" yaml:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Spec MeshConfigSpec `json:"spec,omitempty"`
+	Spec MeshConfigSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
 }
 
 // MeshConfigSpec is the spec for OSM's configuration
 type MeshConfigSpec struct {
-	Sidecar       SidecarSpec       `json:"sidecar,omitempty"`
-	Traffic       TrafficSpec       `json:"traffic,omitempty"`
-	Observability ObservabilitySpec `json:"observability,omitempty"`
-	Certificate   CertificateSpec   `json:"certificate,omitempty"`
+	Sidecar       SidecarSpec       `json:"sidecar,omitempty" yaml:"sidecar,omitempty"`
+	Traffic       TrafficSpec       `json:"traffic,omitempty" yaml:"traffic,omitempty"`
+	Observability ObservabilitySpec `json:"observability,omitempty" yaml:"observability,omitempty"`
+	Certificate   CertificateSpec   `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 }
 
 // SidecarSpec is the spec for OSM's sidecar configuration
 type SidecarSpec struct {
-	EnablePrivilegedInitContainer bool   `json:"enable_privileged_init_container,omitempty"`
-	LogLevel                      string `json:"log_level,omitempty" default:"error"`
-	MaxDataPlaneConnections       int    `json:"max_data_plane_connections"`
+	EnablePrivilegedInitContainer bool   `json:"enablePrivilegedInitContainer,omitempty" yaml:"enablePrivilegedInitContainer,omitempty"`
+	LogLevel                      string `json:"logLevel,omitempty" yaml:"logLevel,omitempty" default:"error"`
+	MaxDataPlaneConnections       int    `json:"maxMaxPlaneConnections,omitempty" yaml:"max_data_plane_connections,omitempty"`
+	ConfigResyncInterval          string `json:"configResyncInterval,omitempty" yaml:"config_resync_interval,omitempty"`
 }
 
 // TrafficSpec is the spec for OSM's traffic management configuration
 type TrafficSpec struct {
-	Egress                            bool     `json:"egress,omitempty"`
-	OutboundIPRangeExclusionList      []string `json:"outbound_ip_range_exclusion_list,omitempty"`
-	UseHTTPSIngress                   bool     `json:"use_https_ingress,omitempty"`
-	EnablePermissiveTrafficPolicyMode bool     `json:"enable_permissive_traffic_policy_mode,omitempty"`
+	EnableEgress                      bool     `json:"enableEgress,omitempty" yaml:"enableEgress,omitempty"`
+	OutboundIPRangeExclusionList      []string `json:"outboundIPRangeExclusionList,omitempty" yaml:"outboundIPRangeExclusionList,omitempty"`
+	UseHTTPSIngress                   bool     `json:"useHTTPSIngress,omitempty" yaml:"useHTTPSIngress,omitempty"`
+	EnablePermissiveTrafficPolicyMode bool     `json:"enablePermissiveTrafficPolicyMode,omitempty" yaml:"enablePermissiveTrafficPolicyMode,omitempty"`
 }
 
 // ObservabilitySpec is the spec for OSM's observability related configuration
 type ObservabilitySpec struct {
-	EnableDebugServer  bool        `json:"enable_debug_server,omitempty" default:"true"`
-	PrometheusScraping bool        `json:"prometheus_scraping,omitempty" default:"true"`
-	Tracing            TracingSpec `json:"tracing,omitempty"`
+	EnableDebugServer  bool        `json:"enableDebugServer,omitempty" yaml:"enableDebugServer,omitempty" default:"true"`
+	PrometheusScraping bool        `json:"prometheusScraping,omitempty" yaml:"prometheusScraping,omitempty" default:"true"`
+	Tracing            TracingSpec `json:"tracing,omitempty" yaml:"tracing,omitempty"`
 }
 
 // TracingSpec is the spec for OSM's tracing configuration
 type TracingSpec struct {
-	Enable   bool   `json:"enable,omitempty"`
-	Port     int16  `json:"port,omitempty"`
-	Address  string `json:"address,omitempty"`
-	Endpoint string `json:"endpoint,omitempty"`
+	Enable   bool   `json:"enable,omitempty" yaml:"enable,omitempty"`
+	Port     int16  `json:"port,omitempty" yaml:"port,omitempty"`
+	Address  string `json:"address,omitempty" yaml:"address,omitempty"`
+	Endpoint string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
 }
 
 // CertificateSpec is the spec for OSM's certificate management configuration
 type CertificateSpec struct {
-	ServiceCertValidityDuration string `json:"service_cert_validity_duration,omitempty" default:"24h"`
+	ServiceCertValidityDuration string `json:"serviceCertValidityDuration,omitempty" yaml:"serviceCertValidityDuration,omitempty" default:"24h"`
 }
 
 // MeshConfigList lists the MeshConfig objects
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type MeshConfigList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline" yaml:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
-	Items []MeshConfig `json:"items"`
+	Items []MeshConfig `json:"items" yaml:"items"`
 }

--- a/pkg/configurator/crd_client.go
+++ b/pkg/configurator/crd_client.go
@@ -112,7 +112,7 @@ func parseOSMMeshConfig(meshConfig *v1alpha1.MeshConfig) *osmConfig {
 
 	osmConfig := osmConfig{}
 	osmConfig.PermissiveTrafficPolicyMode = meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode
-	osmConfig.Egress = meshConfig.Spec.Traffic.Egress
+	osmConfig.Egress = meshConfig.Spec.Traffic.EnableEgress
 	osmConfig.EnableDebugServer = meshConfig.Spec.Observability.EnableDebugServer
 	osmConfig.UseHTTPSIngress = meshConfig.Spec.Traffic.UseHTTPSIngress
 	osmConfig.TracingEnable = meshConfig.Spec.Observability.Tracing.Enable

--- a/pkg/configurator/crd_client_test.go
+++ b/pkg/configurator/crd_client_test.go
@@ -215,7 +215,7 @@ func TestMeshConfigEventTriggers(t *testing.T) {
 		for mapKey, mapVal := range tc.deltaMeshConfigContents {
 			switch mapKey {
 			case egressKey:
-				meshConfig.Spec.Traffic.Egress, _ = strconv.ParseBool(mapVal)
+				meshConfig.Spec.Traffic.EnableEgress, _ = strconv.ParseBool(mapVal)
 			case PermissiveTrafficPolicyModeKey:
 				meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode, _ = strconv.ParseBool(mapVal)
 			case useHTTPSIngressKey:


### PR DESCRIPTION
change MeshConfig CRD fields to camelCase naming convention

Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Change MeshConfig CRD fields to camelCase naming convention.

In Kubernetes the CRD fields uses camelCase for naming.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

`No`