### PR TITLE
sds: Factor out new function getServiceIdentitiesFromCert()

### DIFF
--- a/pkg/envoy/sds/errors.go
+++ b/pkg/envoy/sds/errors.go
@@ -5,5 +5,5 @@ import (
 )
 
 var (
-	errGotUnexpectedCertRequest = errors.New("got unexpected certificate request")
+	errCertMismatch = errors.New("certificate mismatch")
 )

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -144,7 +144,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdsCert envoy.SDSCe
 		return secret, nil
 	}
 
-	svcIdentities, err := getServiceIdentitiesFromCert(sdsCert, s.serviceIdentity, s.meshCatalog)
+	svcIdentitiesInCertRequest, err := getServiceIdentitiesFromCert(sdsCert, s.serviceIdentity, s.meshCatalog)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -153,6 +153,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 	return secret, nil
 }
 
+// given a requested SDS Cert, this function returns the Service Identities, which match that SDS Cert
 func getServiceIdentitiesFromCert(sdscert envoy.SDSCert, serviceIdentity identity.ServiceIdentity, meshCatalog catalog.MeshCataloger) ([]identity.ServiceIdentity, error) {
 	// Program SAN matching based on SMI TrafficTarget policies
 	switch sdscert.CertType {

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -153,7 +153,8 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdscert envoy.SDSCe
 	return secret, nil
 }
 
-// given a requested SDS Cert, this function returns the Service Identities, which match that SDS Cert
+// Given a requested SDS Cert, this function returns the Service Identities, which match that SDS Cert
+// Example: given "service-cert:namespace/service-account", this will return ServiceIdentity("namespace.service-account.cluster.local")
 func getServiceIdentitiesFromCert(sdscert envoy.SDSCert, serviceIdentity identity.ServiceIdentity, meshCatalog catalog.MeshCataloger) ([]identity.ServiceIdentity, error) {
 	// Program SAN matching based on SMI TrafficTarget policies
 	switch sdscert.CertType {

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -153,7 +153,7 @@ func (s *sdsImpl) getRootCert(cert certificate.Certificater, sdsCert envoy.SDSCe
 	return secret, nil
 }
 
-func getServiceIdentitiesFromCert(sdsCert envoy.SDSCert, svcIdentity identity.ServiceIdentity, mc catalog.MeshCataloger) ([]identity.ServiceIdentity, error) {
+func getServiceIdentitiesFromCert(sdsCert envoy.SDSCert, svcIdentity identity.ServiceIdentity, cataloger catalog.MeshCataloger) ([]identity.ServiceIdentity, error) {
 	// Configure SAN matching based on SMI TrafficTarget policies
 	if sdsCert.CertType == envoy.RootCertTypeForMTLSOutbound {
 		// For the outbound certificate validation context, the SANs needs to match the list of service identities

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -498,7 +498,7 @@ func TestGetSubjectAltNamesFromSvcAccount(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			actual := getSubjectAltNamesFromSvcAccount(tc.serviceIdentities)
+			actual := getSubjectAltNamesFromSvcIdentities(tc.serviceIdentities)
 			assert.ElementsMatch(actual, tc.expectedSANMatchers)
 		})
 	}


### PR DESCRIPTION
This PR factors out a new function called `getServiceIdentitiesFromCert()`.

This, I believe shows clearly the purpose of it - to compute the Subject Alt Names for the `MatchSubjectAltNames` Envoy config.

I think the purpose of this block of code, prior to this PR, is lost in the sheer volume of code.

---

In this PR:
 - carved out a block of code into `getServiceIdentitiesFromCert()`
 - no functional code changes
 - removed `switch / case` -- using `if / return` instead - for simplicity (fewer indentations)
 - renamed `errGotUnexpectedCertRequest` to `errCertMismatch` for clarity
 - renamed `getSubjectAltNamesFromSvcAccount` to `getSubjectAltNamesFromSvcIdentities` for correctness