### PR TITLE
docs: Verbose kubectl commands to get k8s deployments etc for Manual Demo

### DIFF
--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -126,8 +126,25 @@ A Kubernetes Service, Deployment, and Service Account for applications `bookbuye
 To view these resources on your cluster, run the following commands:
 
 ```bash
-kubectl get svc --all-namespaces
-kubectl get deployment --all-namespaces
+kubectl get deployments -n bookbuyer
+kubectl get deployments -n bookthief
+kubectl get deployments -n bookstore
+kubectl get deployments -n bookwarehouse
+
+kubectl get pods -n bookbuyer
+kubectl get pods -n bookthief
+kubectl get pods -n bookstore
+kubectl get pods -n bookwarehouse
+
+kubectl get services -n bookbuyer
+kubectl get services -n bookthief
+kubectl get services -n bookstore
+kubectl get services -n bookwarehouse
+
+kubectl get endpoints -n bookbuyer
+kubectl get endpoints -n bookthief
+kubectl get endpoints -n bookstore
+kubectl get endpoints -n bookwarehouse
 ```
 
 In addition to Kubernetes Services and Deployments, a [Kubernetes Service Account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) was also created for each Deployment. The Service Account services as the application's identity which will be used later in the demo to create service to service access control policies.


### PR DESCRIPTION
This PR changes the Manual Demo doc and expands a few `kubectl` commands to fetch more resources (Deployments, Pods, Endpoints etc.) and focuses on specific namespaces instead of `--all-namespaces`

---

This PR is a chunk from #2845