### PR TITLE
ads/rds: send always inbound/outbound resources

### DIFF
--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -66,19 +66,19 @@ func TestBuildRouteConfiguration(t *testing.T) {
 			name:                   "no policies provided",
 			inbound:                []*trafficpolicy.InboundTrafficPolicy{},
 			outbound:               []*trafficpolicy.OutboundTrafficPolicy{},
-			expectedRouteConfigLen: 0,
+			expectedRouteConfigLen: 2,
 		},
 		{
 			name:                   "inbound policy provided",
 			inbound:                []*trafficpolicy.InboundTrafficPolicy{testInbound},
 			outbound:               []*trafficpolicy.OutboundTrafficPolicy{},
-			expectedRouteConfigLen: 1,
+			expectedRouteConfigLen: 2,
 		},
 		{
 			name:                   "outbound policy provided",
 			inbound:                []*trafficpolicy.InboundTrafficPolicy{},
 			outbound:               []*trafficpolicy.OutboundTrafficPolicy{testOutbound},
-			expectedRouteConfigLen: 1,
+			expectedRouteConfigLen: 2,
 		},
 		{
 			name:                   "both inbound and outbound policies provided",
@@ -118,7 +118,7 @@ func TestBuildRouteConfiguration(t *testing.T) {
 			featureflags.Features.WASMStats = tc.wasmEnabled
 
 			actual := BuildRouteConfiguration([]*trafficpolicy.InboundTrafficPolicy{testInbound}, nil, &envoy.Proxy{})
-			tassert.Len(t, actual, 1)
+			tassert.Len(t, actual, 2)
 			tassert.Len(t, actual[0].ResponseHeadersToAdd, tc.expectedResponseHeaderLen)
 
 			featureflags.Features.WASMStats = oldWASMflag

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -51,11 +51,12 @@ var _ = Describe(``+
 			It("did not return an error", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resources).ToNot(BeNil())
-				Expect(len(resources)).To(Equal(1))
+				Expect(len(resources)).To(Equal(2))
 			})
 
 			// ---[  Prepare the config for testing  ]-------
-			routeCfg, ok := resources[0].(*xds_route.RouteConfiguration)
+			// Order matters, inbound is returned always in first index, outbound second one
+			routeCfg, ok := resources[1].(*xds_route.RouteConfiguration)
 			It("returns a response that can be unmarshalled into an xds RouteConfiguration struct", func() {
 				Expect(ok).To(BeTrue())
 				Expect(routeCfg.Name).To(Equal("rds-outbound"))


### PR DESCRIPTION
LDS refers to `rds-inbound` whenever a pod is backed by a service,
however RDS does not necessarily send `rds-inbound` unless there is
inbound routes for the proxy.

The net result is things work, but envoy will still perpetually try to request
`rds-inbound` as it will be kept referenced on LDS (now that we handle proto
resource diffs, this is a problem).

This change makes `rds-inbound` and `rds-outbound` to always be sent, even
when there are no routes in them. If envoy does not request for one or either of them,
they will just be ignored, but otherwise this is a guarantee to be consistent with a potential
LDS reference, when present.

Signed-off-by: edu <eduser25@gmail.com>

- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No