### PR TITLE
ref(pkg/*): rename GetServicesFromEnvoyCertificate

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -320,9 +320,9 @@ type MeshCataloger interface {
 	// ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
 	ExpectProxy(certificate.CommonName)
 
-    // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided,
-    // which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
-	GetServicesFromEnvoyCertificate(certificate.CommonName) ([]service.MeshService, error)
+  // GetServicesForProxy returns a list of services the given Envoy is a member of based on its certificate,
+  // which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
+	GetServicesForProxy(*envoy.Proxy) ([]service.MeshService, error)
 
 	// RegisterProxy registers a newly connected proxy with the service mesh catalog.
 	RegisterProxy(*envoy.Proxy)

--- a/docs/content/docs/design_concepts/interfaces.md
+++ b/docs/content/docs/design_concepts/interfaces.md
@@ -82,9 +82,9 @@ type MeshCataloger interface {
 	// ExpectProxy catalogs the fact that a certificate was issued for an Envoy proxy and this is expected to connect to XDS.
 	ExpectProxy(certificate.CommonName)
 
-    // GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided,
+    // GetServicesForProxy returns a list of services the given Envoy is a member of based on its certificate,
     // which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
-	GetServicesFromEnvoyCertificate(certificate.CommonName) ([]service.MeshService, error)
+	GetServicesForProxy(*envoy.Proxy) ([]service.MeshService, error)
 
 	// RegisterProxy registers a newly connected proxy with the service mesh catalog.
 	RegisterProxy(*envoy.Proxy)

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -8,8 +8,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	certificate "github.com/openservicemesh/osm/pkg/certificate"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
+	envoy "github.com/openservicemesh/osm/pkg/envoy"
 	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	smi "github.com/openservicemesh/osm/pkg/smi"
@@ -98,19 +98,19 @@ func (mr *MockMeshCatalogerMockRecorder) GetSMISpec() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSMISpec", reflect.TypeOf((*MockMeshCataloger)(nil).GetSMISpec))
 }
 
-// GetServicesFromEnvoyCertificate mocks base method
-func (m *MockMeshCataloger) GetServicesFromEnvoyCertificate(arg0 certificate.CommonName) ([]service.MeshService, error) {
+// GetServicesForProxy mocks base method
+func (m *MockMeshCataloger) GetServicesForProxy(arg0 *envoy.Proxy) ([]service.MeshService, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServicesFromEnvoyCertificate", arg0)
+	ret := m.ctrl.Call(m, "GetServicesForProxy", arg0)
 	ret0, _ := ret[0].([]service.MeshService)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetServicesFromEnvoyCertificate indicates an expected call of GetServicesFromEnvoyCertificate
-func (mr *MockMeshCatalogerMockRecorder) GetServicesFromEnvoyCertificate(arg0 interface{}) *gomock.Call {
+// GetServicesForProxy indicates an expected call of GetServicesForProxy
+func (mr *MockMeshCatalogerMockRecorder) GetServicesForProxy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServicesFromEnvoyCertificate", reflect.TypeOf((*MockMeshCataloger)(nil).GetServicesFromEnvoyCertificate), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServicesForProxy", reflect.TypeOf((*MockMeshCataloger)(nil).GetServicesForProxy), arg0)
 }
 
 // GetTargetPortToProtocolMappingForService mocks base method

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
@@ -74,8 +75,8 @@ type MeshCataloger interface {
 	// If no LB/virtual IPs are assigned to the service, GetResolvableServiceEndpoints will return ListEndpointsForService
 	GetResolvableServiceEndpoints(service.MeshService) ([]endpoint.Endpoint, error)
 
-	// GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
-	GetServicesFromEnvoyCertificate(certificate.CommonName) ([]service.MeshService, error)
+	// GetServicesForProxy returns a list of services the given Envoy is a member of based on its certificate, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
+	GetServicesForProxy(*envoy.Proxy) ([]service.MeshService, error)
 
 	// GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
 	GetIngressPoliciesForService(service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error)

--- a/pkg/catalog/xds_certificates.go
+++ b/pkg/catalog/xds_certificates.go
@@ -10,14 +10,17 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-// GetServicesFromEnvoyCertificate returns a list of services the given Envoy is a member of based
-// on the certificate provided, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
-func (mc *MeshCatalog) GetServicesFromEnvoyCertificate(cn certificate.CommonName) ([]service.MeshService, error) {
+// GetServicesForProxy returns a list of services the given Envoy is a member of based
+// on its certificate, which is a cert issued to an Envoy for XDS communication (not Envoy-to-Envoy).
+func (mc *MeshCatalog) GetServicesForProxy(p *envoy.Proxy) ([]service.MeshService, error) {
+	cn := p.GetCertificateCommonName()
+
 	pod, err := GetPodFromCertificate(cn, mc.kubeController)
 	if err != nil {
 		return nil, err

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -138,7 +138,7 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return(tc.proxyServices, nil).Times(0)
+			mockCatalog.EXPECT().GetServicesForProxy(gomock.Any()).Return(tc.proxyServices, nil).Times(0)
 			mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tc.proxySvcAccount).Return(tc.allowedOutboundServices).Times(1)
 
 			actual := makeRequestForAllSecrets(testProxy, mockCatalog)

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -14,7 +14,7 @@ import (
 
 // NewResponse creates a new Cluster Discovery Response.
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
-	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
+	svcList, err := meshCatalog.GetServicesForProxy(proxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -43,7 +43,7 @@ func TestNewResponse(t *testing.T) {
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(xdsCertificate, certSerialNumber, nil)
 
-	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(xdsCertificate).Return([]service.MeshService{tests.BookbuyerService}, nil).AnyTimes()
+	mockCatalog.EXPECT().GetServicesForProxy(proxy).Return([]service.MeshService{tests.BookbuyerService}, nil).AnyTimes()
 	mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tests.BookbuyerServiceIdentity).Return([]service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service}).AnyTimes()
 	mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(tests.BookbuyerService).Return(map[uint32]string{uint32(80): "protocol"}, nil)
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -18,7 +18,7 @@ import (
 // 2. Outbound listener to handle outgoing traffic
 // 3. Prometheus listener for metrics
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager) ([]types.Resource, error) {
-	svcList, err := meshCatalog.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
+	svcList, err := meshCatalog.GetServicesForProxy(proxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())
 		return nil, err

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -24,7 +24,7 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_dis
 		return nil, err
 	}
 
-	services, err := cataloger.GetServicesFromEnvoyCertificate(proxy.GetCertificateCommonName())
+	services, err := cataloger.GetServicesForProxy(proxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up services for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
 		return nil, err

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -269,7 +269,7 @@ func TestNewResponse(t *testing.T) {
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
+			mockCatalog.EXPECT().GetServicesForProxy(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 			mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(tc.expectedInboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(tc.ingressInboundPolicies, nil).AnyTimes()
@@ -503,7 +503,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 		},
 	}
 
-	mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
+	mockCatalog.EXPECT().GetServicesForProxy(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 	mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(testPermissiveInbound).AnyTimes()
 	mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(testPermissiveOutbound).AnyTimes()
 	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(testIngressInbound, nil).AnyTimes()

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -233,7 +233,7 @@ func TestRDSRespose(t *testing.T) {
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			mockCatalog.EXPECT().GetServicesFromEnvoyCertificate(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
+			mockCatalog.EXPECT().GetServicesForProxy(gomock.Any()).Return([]service.MeshService{tests.BookstoreV1Service}, nil).AnyTimes()
 			mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(tc.expectedInboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()


### PR DESCRIPTION
**Description**:

Renames GetServicesFromEnvoyCertificate to GetServicesForProxy to
increase readability and updates the parameter type from
certificate.CommmonName to *envoy.Proxy. Resolves #3117.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
no