### PR TITLE
fix(install): Adds hostaccess SCC when fluentbit is enabled on OpenShift

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -48,6 +48,13 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]
     verbs: ["list", "get", "watch", "create", "delete"]
+
+  {{- if and (.Capabilities.APIVersions.Has "security.openshift.io/v1") .Values.OpenServiceMesh.enableFluentbit }}
+  - apiGroups: ["security.openshift.io"]
+    resourceNames: ["hostaccess"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+  {{- end }}
 ---
 
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes #3230

Adds hostaccess SCC when fluentbit is deployed on OpenShift so that osm-controller can be scheduled without manually adding the scc.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No
