### PR TITLE
ref(pkg/*): move envoy proxy image to OSM's ConfigMap

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -64,6 +64,11 @@ spec:
                       description: Max allowed data plane sidecar connections
                       type: integer
                       default: 0
+                    envoyImage:
+                      description: Image for the Envoy sidecar
+                      type: string
+                      default: "envoyproxy/envoy-alpine:v1.17.2"
+                      pattern: envoyproxy\/envoy-alpine:v\d+\.\d+\.\d+$
                 traffic:
                   description: Configuration for traffic management
                   type: object

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -9,6 +9,7 @@ data:
   permissive_traffic_policy_mode: {{ .Values.OpenServiceMesh.enablePermissiveTrafficPolicy | default "false" | quote }}
   egress: {{ .Values.OpenServiceMesh.enableEgress | quote }}
   envoy_log_level: {{ .Values.OpenServiceMesh.envoyLogLevel | quote }}
+  envoy_image: {{ .Values.OpenServiceMesh.sidecarImage | quote }}
   enable_privileged_init_container: {{ .Values.OpenServiceMesh.enablePrivilegedInitContainer | quote }}
   enable_debug_server: {{ .Values.OpenServiceMesh.enableDebugServer | quote }}
   prometheus_scraping: {{ .Values.OpenServiceMesh.enablePrometheusScraping | quote }}

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -43,7 +43,6 @@ spec:
             "--osm-namespace", "{{ include "osm.namespace" . }}",
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--init-container-image", "{{.Values.OpenServiceMesh.image.registry}}/init:{{ .Values.OpenServiceMesh.image.tag }}",
-            "--sidecar-image", "{{.Values.OpenServiceMesh.sidecarImage}}",
             "--webhook-config-name", "{{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",

--- a/cmd/cli/mesh_upgrade.go
+++ b/cmd/cli/mesh_upgrade.go
@@ -62,6 +62,7 @@ type meshUpgradeCmd struct {
 	enableEgress                  *bool
 	enableDebugServer             *bool
 	envoyLogLevel                 string
+	envoyImage                    string
 	enablePrometheusScraping      *bool
 	useHTTPSIngress               *bool
 	serviceCertValidityDuration   time.Duration
@@ -142,6 +143,7 @@ func newMeshUpgradeCmd(config *helm.Configuration, out io.Writer) *cobra.Command
 	f.BoolVar(upg.enableEgress, "enable-egress", defaultEnableEgress, "Enable egress in the mesh")
 	f.BoolVar(upg.enableDebugServer, "enable-debug-server", defaultEnableDebugServer, "Enable the debug HTTP server")
 	f.StringVar(&upg.envoyLogLevel, "envoy-log-level", "", "Envoy log level is used to specify the level of logs collected from envoy and needs to be one of these (trace, debug, info, warning, warn, error, critical, off)")
+	f.StringVar(&upg.envoyImage, "envoy-image", "", "Set the image for the Envoy proxy sidecar")
 	f.BoolVar(upg.enablePrometheusScraping, "enable-prometheus-scraping", defaultEnablePrometheusScraping, "Enable Prometheus metrics scraping on sidecar proxies")
 	f.BoolVar(upg.useHTTPSIngress, "use-https-ingress", defaultUseHTTPSIngress, "Enable HTTPS Ingress")
 	f.DurationVar(&upg.serviceCertValidityDuration, "service-cert-validity-duration", 0, "Service certificate validity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix")
@@ -201,6 +203,9 @@ func (u *meshUpgradeCmd) resolveValues(config *helm.Configuration) (map[string]i
 	}
 	if len(u.envoyLogLevel) > 0 {
 		vals["envoyLogLevel"] = u.envoyLogLevel
+	}
+	if len(u.envoyImage) > 0 {
+		vals["sidecarImage"] = u.envoyImage
 	}
 	if u.enablePrometheusScraping != nil {
 		vals["enablePrometheusScraping"] = *u.enablePrometheusScraping

--- a/cmd/cli/mesh_upgrade_test.go
+++ b/cmd/cli/mesh_upgrade_test.go
@@ -84,6 +84,7 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	u.enableEgress = new(bool)
 	*u.enableEgress = true
 	u.envoyLogLevel = "trace"
+	u.envoyImage = "envoyproxy/envoy-alpine:v0.00.0"
 	u.tracingEndpoint = "/here"
 	u.outboundIPRangeExclusionList = []string{"0.0.0.0/0", "1.1.1.1/1"}
 	u.enablePrivilegedInitContainer = new(bool)
@@ -106,6 +107,10 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	envoyLogLevel, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.envoyLogLevel")
 	a.Nil(err)
 	a.Equal("trace", envoyLogLevel)
+
+	envoyImage, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.sidecarImage")
+	a.Nil(err)
+	a.Equal("envoyproxy/envoy-alpine:v0.00.0", envoyImage)
 
 	tracingEndpoint, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.tracing.endpoint")
 	a.Nil(err)

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -69,7 +69,6 @@ func init() {
 	// sidecar injector options
 	flags.IntVar(&injectorConfig.ListenPort, "webhook-port", constants.InjectorWebhookPort, "Webhook port for sidecar-injector")
 	flags.StringVar(&injectorConfig.InitContainerImage, "init-container-image", "", "InitContainer image")
-	flags.StringVar(&injectorConfig.SidecarImage, "sidecar-image", "", "Sidecar proxy Container image")
 
 	// Generic certificate manager/provider options
 	flags.StringVar(&certProviderKind, "certificate-manager", providers.TresorKind.String(), fmt.Sprintf("Certificate manager, one of [%v]", providers.ValidCertificateProviders))
@@ -223,10 +222,6 @@ func validateCLIParams() error {
 
 	if injectorConfig.InitContainerImage == "" {
 		return errors.New("Please specify the init container image using --init-container-image")
-	}
-
-	if injectorConfig.SidecarImage == "" {
-		return errors.Errorf("Please specify the sidecar image using --sidecar-image")
 	}
 
 	if webhookConfigName == "" {

--- a/docs/content/docs/osm_config_map.md
+++ b/docs/content/docs/osm_config_map.md
@@ -20,6 +20,7 @@ kubectl get configmap osm-config -n osm-system -o yaml
 | enable_debug_server | OpenServiceMesh.enableDebugServer | bool | true, false| `"true"` | Enables a debug endpoint on the osm-controller pod to list information regarding the mesh such as proxy connections, certificates, and SMI policies. |
 | enable_privileged_init_container| OpenServiceMesh.enablePrivilegedInitContainer | bool | true, false | `"false"` | Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN. |
 | envoy_log_level | OpenServiceMesh.envoyLogLevel | string | trace, debug, info, warning, warn, error, critical, off | `"error"` | Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh. To update the log level for existing pods, restart the deployment with `kubectl rollout restart`. |
+| envoy_image | OpenServiceMesh.envoyImage | string | any supported Envoy image of the form envoyproxy/envoy-alpine:vx.xx.x | `"envoyproxy/envoy-alpine:v1.17.2"` | Sets the Envoy proxy sidecar image, only applicable to newly created pods joining the mesh. To update the sidecar image for existing pods, restart the deployment with `kubectl rollout restart`. |
 | max_data_plane_connections | OpenServiceMesh.maxDataPlaneConnections | int | any positive integer value | `"0"` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | outbound_ip_range_exclusion_list | OpenServiceMesh.outboundIPRangeExclusionList | string | comma separated list of IP ranges of the form a.b.c.d/x | `-`| Global list of IP address ranges to exclude from outbound traffic interception by the sidecar proxy. |
 | permissive_traffic_policy_mode | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | true, false | `"false"` | Setting to `true`, enables allow-all mode in the mesh i.e. no traffic policy enforcement in the mesh. If set to `false`, enables deny-all traffic policy in mesh i.e. an `SMI Traffic Target` is necessary for services to communicate. |
@@ -57,6 +58,7 @@ Error: invalid argument "3" for "--enable-egress" flag: strconv.ParseBool: parsi
 | enable_debug_server | `--enable-debug-server` | bool | `"true"` |
 | enable_privileged_init_container| `--enable-privileged-init-container` | bool | `"false"` |
 | envoy_log_level | `--envoy-log-level` | string | `"error"` |
+| envoy_image | `--envoy-image` | string | `"envoyproxy/envoy-alpine:v1.17.2"` |
 | max_data_plane_connections |`--max-data-plane-connections` | int | `"0"` |
 | outbound_ip_range_exclusion_list | `--outbound-ip-range-exclusion-list` | string | `-`|
 | permissive_traffic_policy_mode | `--enable-permissive-traffic-policy` | bool | `"false"` |
@@ -93,6 +95,7 @@ use_https_ingress: must be a boolean
 |-----|------|---------------|--------------------------------|
 | enable_debug_server | bool | `"true"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"enable_debug_server":"false"}}' --type=merge` |
 | envoy_log_level | string | `"error"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"envoy_log_level":"info"}}' --type=merge` |
+| envoy_image | string | `"envoyproxy/envoy-alpine:v1.17.2"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"envoy_image":"envoyproxy/envoy-alpine:v1.17.2"}}' --type=merge` |
 | max_data_plane_connections | int | `"0"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"max_data_plane_connections":"1000"}}' --type=merge` |
 | outbound_ip_range_exclusion_list | string | `-`| `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"outbound_ip_range_exclusion_list":"1.2.3.4/0"}}' --type=merge` |
 | service_cert_validity_duration | string | `"24h"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"service_cert_validity_duration":"2m"}}' --type=merge` |
@@ -119,6 +122,7 @@ kubectl describe validatingwebhookconfiguration osm-webhook-osm
 | enable_debug_server | `must be a boolean` |
 | enable_privileged_init_container| `must be a boolean` |
 | envoy_log_level | `invalid log level` |
+| envoy_image | `must be of the form envoyproxy/envoy-alpine:v<major>.<minor>.<patch>`
 | max_data_plane_connections | `must be a positive integer` |
 | outbound_ip_range_exclusion_list | `must be a list of valid IP addresses of the form a.b.c.d/x` |
 | permissive_traffic_policy_mode | `must be a boolean` |
@@ -135,6 +139,7 @@ kubectl describe validatingwebhookconfiguration osm-webhook-osm
 - enable_debug_server
 - enable_privileged_init_container
 - envoy_log_level
+- envoy_image
 - max_data_plane_connections
 - permissive_traffic_policy_mode
 - prometheus_scraping

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -25,6 +25,7 @@ type MeshConfigSpec struct {
 type SidecarSpec struct {
 	EnablePrivilegedInitContainer bool   `json:"enablePrivilegedInitContainer,omitempty" yaml:"enablePrivilegedInitContainer,omitempty"`
 	LogLevel                      string `json:"logLevel,omitempty" yaml:"logLevel,omitempty"`
+	EnvoyImage                    string `json:"envoyImage,omitempty" yaml:"envoyImage,omitempty"`
 	MaxDataPlaneConnections       int    `json:"maxMaxPlaneConnections,omitempty" yaml:"max_data_plane_connections,omitempty"`
 	ConfigResyncInterval          string `json:"configResyncInterval,omitempty" yaml:"config_resync_interval,omitempty"`
 }

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -50,6 +50,9 @@ const (
 	// envoyLogLevel is the key name used to specify the log level of Envoy proxy in the ConfigMap
 	envoyLogLevel = "envoy_log_level"
 
+	// envoyImage is the key name used to specify the image of the Envoy proxy in the ConfigMap
+	envoyImage = "envoy_image"
+
 	// serviceCertValidityDurationKey is the key name used to specify the validity duration of service certificates in the ConfigMap
 	serviceCertValidityDurationKey = "service_cert_validity_duration"
 
@@ -232,6 +235,9 @@ type osmConfig struct {
 	// EnvoyLogLevel is a string that defines the log level for envoy proxies
 	EnvoyLogLevel string `yaml:"envoy_log_level"`
 
+	// EnvoyImage is the sidecar image
+	EnvoyImage string `yaml:"envoy_image"`
+
 	// ServiceCertValidityDuration is a string that defines the validity duration of service certificates
 	// It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix.
 	// Ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
@@ -295,6 +301,7 @@ func parseOSMConfigMap(configMap *v1.ConfigMap) *osmConfig {
 	osmConfigMap.MaxDataPlaneConnections, _ = GetIntValueForKey(configMap, maxDataPlaneConnectionsKey)
 	osmConfigMap.TracingEnable, _ = GetBoolValueForKey(configMap, tracingEnableKey)
 	osmConfigMap.EnvoyLogLevel, _ = GetStringValueForKey(configMap, envoyLogLevel)
+	osmConfigMap.EnvoyImage, _ = GetStringValueForKey(configMap, envoyImage)
 	osmConfigMap.ServiceCertValidityDuration, _ = GetStringValueForKey(configMap, serviceCertValidityDurationKey)
 	osmConfigMap.OutboundIPRangeExclusionList, _ = GetStringValueForKey(configMap, outboundIPRangeExclusionListKey)
 	osmConfigMap.EnablePrivilegedInitContainer, _ = GetBoolValueForKey(configMap, enablePrivilegedInitContainer)

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"UseHTTPSIngress":               useHTTPSIngressKey,
 				"MaxDataPlaneConnections":       maxDataPlaneConnectionsKey,
 				"EnvoyLogLevel":                 envoyLogLevel,
+				"EnvoyImage":                    envoyImage,
 				"ServiceCertValidityDuration":   serviceCertValidityDurationKey,
 				"OutboundIPRangeExclusionList":  outboundIPRangeExclusionListKey,
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,

--- a/pkg/configurator/crd_client.go
+++ b/pkg/configurator/crd_client.go
@@ -117,6 +117,7 @@ func parseOSMMeshConfig(meshConfig *v1alpha1.MeshConfig) *osmConfig {
 	osmConfig.UseHTTPSIngress = meshConfig.Spec.Traffic.UseHTTPSIngress
 	osmConfig.TracingEnable = meshConfig.Spec.Observability.Tracing.Enable
 	osmConfig.EnvoyLogLevel = meshConfig.Spec.Sidecar.LogLevel
+	osmConfig.EnvoyImage = meshConfig.Spec.Sidecar.EnvoyImage
 	osmConfig.ServiceCertValidityDuration = meshConfig.Spec.Certificate.ServiceCertValidityDuration
 	osmConfig.OutboundIPRangeExclusionList = strings.Join(meshConfig.Spec.Traffic.OutboundIPRangeExclusionList, ",")
 	osmConfig.EnablePrivilegedInitContainer = meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer

--- a/pkg/configurator/crd_client_test.go
+++ b/pkg/configurator/crd_client_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Test OSM MeshConfig parsing", func() {
 				"TracingEndpoint":               tracingEndpointKey,
 				"UseHTTPSIngress":               useHTTPSIngressKey,
 				"EnvoyLogLevel":                 envoyLogLevel,
+				"EnvoyImage":                    envoyImage,
 				"ServiceCertValidityDuration":   serviceCertValidityDurationKey,
 				"OutboundIPRangeExclusionList":  outboundIPRangeExclusionListKey,
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -109,6 +109,15 @@ func (c *Client) GetEnvoyLogLevel() string {
 	return constants.DefaultEnvoyLogLevel
 }
 
+// GetEnvoyImage returns the envoy image
+func (c *Client) GetEnvoyImage() string {
+	image := c.getConfigMap().EnvoyImage
+	if image != "" {
+		return image
+	}
+	return constants.DefaultEnvoyImage
+}
+
 // GetServiceCertValidityPeriod returns the validity duration for service certificates, and a default in case of invalid duration
 func (c *Client) GetServiceCertValidityPeriod() time.Duration {
 	durationStr := c.getConfigMap().ServiceCertValidityDuration

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -52,6 +52,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 				useHTTPSIngressKey:             "true",
 				enablePrivilegedInitContainer:  "true",
 				envoyLogLevel:                  "error",
+				envoyImage:                     "envoyproxy/envoy-alpine:v0.0.0",
 				serviceCertValidityDurationKey: "24h",
 				configResyncInterval:           "2m",
 				maxDataPlaneConnectionsKey:     "0",
@@ -66,6 +67,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 					UseHTTPSIngress:               true,
 					EnablePrivilegedInitContainer: true,
 					EnvoyLogLevel:                 "error",
+					EnvoyImage:                    "envoyproxy/envoy-alpine:v0.0.0",
 					ServiceCertValidityDuration:   "24h",
 					ConfigResyncInterval:          "2m",
 					MaxDataPlaneConnections:       0,
@@ -191,6 +193,19 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal("info", cfg.GetEnvoyLogLevel())
+			},
+		},
+		{
+			name:                 "GetEnvoyImage",
+			initialConfigMapData: map[string]string{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal("envoyproxy/envoy-alpine:v1.17.2", cfg.GetEnvoyImage())
+			},
+			updatedConfigMapData: map[string]string{
+				envoyImage: "envoyproxy/envoy-alpine:v1.17.1",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal("envoyproxy/envoy-alpine:v1.17.1", cfg.GetEnvoyImage())
 			},
 		},
 		{

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -63,6 +63,20 @@ func (mr *MockConfiguratorMockRecorder) GetConfigResyncInterval() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigResyncInterval", reflect.TypeOf((*MockConfigurator)(nil).GetConfigResyncInterval))
 }
 
+// GetEnvoyImage mocks base method
+func (m *MockConfigurator) GetEnvoyImage() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnvoyImage")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetEnvoyImage indicates an expected call of GetEnvoyImage
+func (mr *MockConfiguratorMockRecorder) GetEnvoyImage() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvoyImage", reflect.TypeOf((*MockConfigurator)(nil).GetEnvoyImage))
+}
+
 // GetEnvoyLogLevel mocks base method
 func (m *MockConfigurator) GetEnvoyLogLevel() string {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -72,6 +72,9 @@ type Configurator interface {
 	// GetEnvoyLogLevel returns the envoy log level
 	GetEnvoyLogLevel() string
 
+	// GetEnvoyImage returns the envoy image
+	GetEnvoyImage() string
+
 	// GetServiceCertValidityPeriod returns the validity duration for service certificates
 	GetServiceCertValidityPeriod() time.Duration
 

--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -206,6 +206,7 @@ func TestCheckDefaultFields(t *testing.T) {
 					"tracing_enable":                   "",
 					"use_https_ingress":                "",
 					"envoy_log_level":                  "",
+					"envoy_image":                      "",
 					"service_cert_validity_duration":   "",
 					"tracing_address":                  "",
 					"tracing_port":                     "",
@@ -229,6 +230,7 @@ func TestCheckDefaultFields(t *testing.T) {
 					"prometheus_scraping":            "",
 					"use_https_ingress":              "",
 					"envoy_log_level":                "",
+					"envoy_image":                    "",
 					"service_cert_validity_duration": "",
 					"tracing_enable":                 "",
 					"max_data_plane_connections":     "",
@@ -430,6 +432,21 @@ func TestCheckEnvoyLogLevels(t *testing.T) {
 
 	for lvl, expRes := range tests {
 		res := checkEnvoyLogLevels(fakeField, lvl)
+		assert.Equal(expRes, res)
+	}
+}
+
+func TestCheckEnvoyImage(t *testing.T) {
+	assert := tassert.New(t)
+	tests := map[string]bool{
+		"envoyproxy/envoy-alpine:v1.17.2": true,
+		"envoyproxy/envoy-alpine:v1.1.1":  true,
+		"envoyproxy/envoy-alpine":         false,
+		"envoyproxy/envoy:v1.17.2":        false,
+	}
+
+	for image, expRes := range tests {
+		res := checkEnvoyImage(fakeField, image)
 		assert.Equal(expRes, res)
 	}
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -55,6 +55,9 @@ const (
 	// DefaultEnvoyLogLevel is the default envoy log level if not defined in the osm configmap
 	DefaultEnvoyLogLevel = "error"
 
+	// DefaultEnvoyImage is the default envoy proxy sidecar image if not defined in the osm configmap
+	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.17.2"
+
 	// EnvoyPrometheusInboundListenerPort is Envoy's inbound listener port number for prometheus
 	EnvoyPrometheusInboundListenerPort = 15010
 

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -245,7 +245,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 	Context("test getEnvoySidecarContainerSpec()", func() {
 		It("creates Envoy sidecar spec", func() {
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("debug").Times(1)
-			actual := getEnvoySidecarContainerSpec(pod, envoyImage, mockConfigurator, originalHealthProbes)
+			mockConfigurator.EXPECT().GetEnvoyImage().Return(envoyImage).Times(1)
+			actual := getEnvoySidecarContainerSpec(pod, mockConfigurator, originalHealthProbes)
 
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -16,7 +16,7 @@ const (
 	envoyProxyConfigPath     = "/etc/envoy"
 )
 
-func getEnvoySidecarContainerSpec(pod *corev1.Pod, envoyImage string, cfg configurator.Configurator, originalHealthProbes healthProbes) corev1.Container {
+func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator, originalHealthProbes healthProbes) corev1.Container {
 	// nodeID and clusterID are required for Envoy proxy to start.
 	nodeID := pod.Spec.ServiceAccountName
 	// cluster ID will be used as an identifier to the tracing sink
@@ -34,7 +34,7 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, envoyImage string, cfg config
 
 	return corev1.Container{
 		Name:            constants.EnvoyContainerName,
-		Image:           envoyImage,
+		Image:           cfg.GetEnvoyImage(),
 		ImagePullPolicy: corev1.PullAlways,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser: func() *int64 {

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -58,7 +58,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
 	// Add the Envoy sidecar
-	sidecar := getEnvoySidecarContainerSpec(pod, wh.config.SidecarImage, wh.configurator, originalHealthProbes)
+	sidecar := getEnvoySidecarContainerSpec(pod, wh.configurator, originalHealthProbes)
 	pod.Spec.Containers = append(pod.Spec.Containers, sidecar)
 
 	enableMetrics, err := wh.isMetricsEnabled(namespace)

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Test all patch operations", func() {
 			pod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, nil)
 			pod.Annotations = nil
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("").Times(1)
+			mockConfigurator.EXPECT().GetEnvoyImage().Return("").Times(1)
 			mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
 			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
 

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -38,8 +38,6 @@ type Config struct {
 	ListenPort int
 
 	InitContainerImage string
-
-	SidecarImage string
 }
 
 // Context needed to compose the Envoy bootstrap YAML.

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -491,7 +491,6 @@ var _ = Describe("Testing Injector Functions", func() {
 	It("creates new webhook", func() {
 		injectorConfig := Config{
 			InitContainerImage: "-testInitContainerImage-",
-			SidecarImage:       "-testSidecarImage-",
 		}
 		kubeClient := fake.NewSimpleClientset()
 		var kubeController k8s.Controller


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Moves the envoy proxy image information from the osm-injector
deployment to OSM's ConfigMap. This change allows the image to be
patched without having to patch the osm-injector deployment. 
Resolves #3135.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ X ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
no