### PR TITLE
smi: add api to retrieve HTTPRouteGroup by its name

### DIFF
--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -188,6 +188,17 @@ func (c *client) ListHTTPTrafficSpecs() []*smiSpecs.HTTPRouteGroup {
 	return httpTrafficSpec
 }
 
+// GetHTTPRouteGroup returns an SMI HTTPRouteGroup resource given its name of the form <namespace>/<name>
+func (c *client) GetHTTPRouteGroup(namespacedName string) *smiSpecs.HTTPRouteGroup {
+	// client-go cache uses <namespace>/<name> as key
+	routeIf, exists, err := c.caches.HTTPRouteGroup.GetByKey(namespacedName)
+	if exists && err == nil {
+		route := routeIf.(*smiSpecs.HTTPRouteGroup)
+		return route
+	}
+	return nil
+}
+
 // ListTCPTrafficSpecs lists SMI TCPRoute resources
 func (c *client) ListTCPTrafficSpecs() []*smiSpecs.TCPRoute {
 	var tcpRouteSpec []*smiSpecs.TCPRoute

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -2,6 +2,7 @@ package smi
 
 import (
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
+	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
@@ -46,6 +47,11 @@ func (f fakeMeshSpec) ListServiceAccounts() []identity.K8sServiceAccount {
 // ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 func (f fakeMeshSpec) ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup {
 	return f.httpRouteGroups
+}
+
+// GetHTTPRouteGroup returns an SMI HTTPRouteGroup resource given its name of the form <namespace>/<name>
+func (f fakeMeshSpec) GetHTTPRouteGroup(_ string) *smiSpecs.HTTPRouteGroup {
+	return nil
 }
 
 // ListTCPTrafficSpecs lists SMI TCPRoute resources

--- a/pkg/smi/mock_meshspec_generated.go
+++ b/pkg/smi/mock_meshspec_generated.go
@@ -37,6 +37,20 @@ func (m *MockMeshSpec) EXPECT() *MockMeshSpecMockRecorder {
 	return m.recorder
 }
 
+// GetHTTPRouteGroup mocks base method
+func (m *MockMeshSpec) GetHTTPRouteGroup(arg0 string) *v1alpha4.HTTPRouteGroup {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHTTPRouteGroup", arg0)
+	ret0, _ := ret[0].(*v1alpha4.HTTPRouteGroup)
+	return ret0
+}
+
+// GetHTTPRouteGroup indicates an expected call of GetHTTPRouteGroup
+func (mr *MockMeshSpecMockRecorder) GetHTTPRouteGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPRouteGroup", reflect.TypeOf((*MockMeshSpec)(nil).GetHTTPRouteGroup), arg0)
+}
+
 // GetTCPRoute mocks base method
 func (m *MockMeshSpec) GetTCPRoute(arg0 string) *v1alpha4.TCPRoute {
 	m.ctrl.T.Helper()

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -57,6 +57,9 @@ type MeshSpec interface {
 	// ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup
 
+	// GetHTTPRouteGroup returns an SMI HTTPRouteGroup resource given its name of the form <namespace>/<name>
+	GetHTTPRouteGroup(string) *spec.HTTPRouteGroup
+
 	// ListTCPTrafficSpecs lists SMI TCPRoute resources
 	ListTCPTrafficSpecs() []*spec.TCPRoute
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds an API to retrieve an HTTPRouteGroup resource by
its name.

This is required by #3045 to lookup a specific HTTPRouteGroup
resource referenced in an Egress policy as a
TypedLocalObjectReference.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [X]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`