### PR TITLE
feat(routes) : configure inbound and outbound routes with host headers

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -77,6 +77,8 @@ func RestockBooks(amount int) {
 	client := &http.Client{}
 	requestBody := strings.NewReader(strconv.Itoa(1))
 	req, err := http.NewRequest("POST", chargeAccountURL, requestBody)
+	req.Header.Add("host", fmt.Sprintf("%s.%s", warehouseServiceName, bookwarehouseNamespace))
+
 	if err != nil {
 		log.Error().Err(err).Msgf("RestockBooks: error posting to %s", chargeAccountURL)
 		return

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -66,6 +66,9 @@ spec:
           image: "${CTR_REGISTRY}/bookwarehouse:${CTR_TAG}"
           imagePullPolicy: Always
           command: ["/bookwarehouse"]
+          env:
+            - name: IDENTITY
+              value: bookwarehouse
 
       imagePullSecrets:
         - name: "$CTR_REGISTRY_CREDS_NAME"

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -30,6 +30,20 @@ func (mc *MeshCatalog) isTrafficSplitBackendService(svc service.MeshService) boo
 	return false
 }
 
+// isTrafficSplitApexService returns true if the given service is an apex service in any traffic split
+func (mc *MeshCatalog) isTrafficSplitApexService(svc service.MeshService) bool {
+	for _, split := range mc.meshSpec.ListTrafficSplits() {
+		apexService := service.MeshService{
+			Name:      kubernetes.GetServiceFromHostname(split.Spec.Service),
+			Namespace: split.Namespace,
+		}
+		if svc.Equals(apexService) {
+			return true
+		}
+	}
+	return false
+}
+
 // getApexServicesForBackendService returns a list of services that serve as the apex service in a traffic split where the
 // given service is a backend
 func (mc *MeshCatalog) getApexServicesForBackendService(targetService service.MeshService) []service.MeshService {

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -236,14 +236,14 @@ func TestBuildVirtualHostStub(t *testing.T) {
 		{
 			name:         "inbound virtual host",
 			namePrefix:   inboundVirtualHost,
-			host:         "host",
+			host:         httpHostHeader,
 			domains:      []string{"domain1", "domain2"},
 			expectedName: "inbound_virtual-host|host",
 		},
 		{
 			name:         "outbound virtual host",
 			namePrefix:   outboundVirtualHost,
-			host:         "host",
+			host:         httpHostHeader,
 			domains:      []string{"domain1", "domain2"},
 			expectedName: "outbound_virtual-host|host",
 		},
@@ -439,6 +439,9 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
+						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
+							HostRewriteLiteral: "",
+						},
 					},
 				},
 			},
@@ -506,6 +509,9 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
+						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
+							HostRewriteLiteral: "",
+						},
 					},
 				},
 			},
@@ -552,6 +558,9 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
+						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
+							HostRewriteLiteral: "",
+						},
 					},
 				},
 			},
@@ -597,6 +606,9 @@ func TestBuildRoute(t *testing.T) {
 								},
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
+						},
+						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
+							HostRewriteLiteral: "",
 						},
 					},
 				},

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -98,6 +98,9 @@ const (
 
 	// HTTPUserAgent is the User Agent in the HTTP header
 	HTTPUserAgent = "test-UA"
+
+	//HTTPHostHeader is the host name in the HTTP header
+	HTTPHostHeader = "osm.mesh"
 )
 
 var (
@@ -192,6 +195,17 @@ var (
 		Methods:       []string{"GET"},
 		Headers: map[string]string{
 			"user-agent": HTTPUserAgent,
+		},
+	}
+
+	// BookstoreBuyHTTPRouteWithHost is an HTTP route to buy books
+	BookstoreBuyHTTPRouteWithHost = trafficpolicy.HTTPRouteMatch{
+		Path:          BookstoreBuyPath,
+		PathMatchType: trafficpolicy.PathMatchRegex,
+		Methods:       []string{"GET"},
+		Headers: map[string]string{
+			"user-agent": HTTPUserAgent,
+			"host":       HTTPHostHeader,
 		},
 	}
 
@@ -335,6 +349,46 @@ var (
 					Methods:   []string{"GET"},
 					Headers: map[string]string{
 						"user-agent": HTTPUserAgent,
+					},
+				},
+				{
+					Name:      SellBooksMatchName,
+					PathRegex: BookstoreSellPath,
+					Methods:   []string{"GET"},
+					Headers: map[string]string{
+						"user-agent": HTTPUserAgent,
+					},
+				},
+				{
+					Name: WildcardWithHeadersMatchName,
+					Headers: map[string]string{
+						"user-agent": HTTPUserAgent,
+					},
+				},
+			},
+		},
+	}
+
+	// HTTPRouteGroupWithHost is the HTTP route group SMI object having a host header.
+	HTTPRouteGroupWithHost = spec.HTTPRouteGroup{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "specs.smi-spec.io/v1alpha4",
+			Kind:       "HTTPRouteGroup",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: "default",
+			Name:      RouteGroupName,
+		},
+
+		Spec: spec.HTTPRouteGroupSpec{
+			Matches: []spec.HTTPMatch{
+				{
+					Name:      BuyBooksMatchName,
+					PathRegex: BookstoreBuyPath,
+					Methods:   []string{"GET"},
+					Headers: map[string]string{
+						"user-agent": HTTPUserAgent,
+						"host":       HTTPHostHeader,
 					},
 				},
 				{

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -189,7 +189,7 @@ func mergeRules(originalRules, latestRules []*Rule) []*Rule {
 
 // mergeRoutesWeightedClusters merges two slices of RouteWeightedClusters and returns a slice where there is one RouteWeightedCluster
 //	for any HTTPRouteMatch. Where there is an overlap in HTTPRouteMatch between the originalRoutes and latestRoutes, the WeightedClusters
-//  specified in the latestRoutes will be kept since there can only be one set of WeightedClusters per HTTPRouteMatch.
+//  will be unioned as there can only be one set of WeightedClusters per HTTPRouteMatch.
 func mergeRoutesWeightedClusters(originalRoutes, latestRoutes []*RouteWeightedClusters) []*RouteWeightedClusters {
 	for _, latest := range latestRoutes {
 		foundRoute := false
@@ -197,7 +197,7 @@ func mergeRoutesWeightedClusters(originalRoutes, latestRoutes []*RouteWeightedCl
 			if reflect.DeepEqual(original.HTTPRouteMatch, latest.HTTPRouteMatch) {
 				foundRoute = true
 				if !reflect.DeepEqual(original.WeightedClusters, latest.WeightedClusters) {
-					original.WeightedClusters = latest.WeightedClusters
+					original.WeightedClusters = original.WeightedClusters.Union(latest.WeightedClusters)
 				}
 				continue
 			}

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -669,7 +669,7 @@ func TestMergeRouteWeightedClusters(t *testing.T) {
 			expectedRoutes: []*RouteWeightedClusters{&testRoute},
 		},
 		{
-			name:           "routes have same match conditions but different weighted clusters, apply latest weighted clusters",
+			name:           "routes have same match conditions but different weighted clusters, union the weighted clusters",
 			originalRoutes: []*RouteWeightedClusters{&testRoute},
 			latestRoutes: []*RouteWeightedClusters{{
 				HTTPRouteMatch:   testHTTPRouteMatch,
@@ -677,7 +677,7 @@ func TestMergeRouteWeightedClusters(t *testing.T) {
 			}},
 			expectedRoutes: []*RouteWeightedClusters{{
 				HTTPRouteMatch:   testHTTPRouteMatch,
-				WeightedClusters: mapset.NewSet(testWeightedCluster2),
+				WeightedClusters: mapset.NewSet(testWeightedCluster, testWeightedCluster2),
 			}},
 		},
 	}
@@ -745,7 +745,7 @@ func TestTotalClustersWeight(t *testing.T) {
 	}{
 		{
 			name:           "route with single cluster",
-			route:          testRoute,
+			route:          testRoute2,
 			expectedWeight: 100,
 		},
 		{


### PR DESCRIPTION
This commit adds new inbound and outbound traffic policies if host
header is provided in the route.

Sample configuration on envoy where the host header is re-written for bookwarehouse based on traffic spec : https://github.com/openservicemesh/osm/blob/77826735a5c6b125f7942092d96c96e6e60b26c1/demo/deploy-traffic-specs.sh#L48

![image](https://user-images.githubusercontent.com/59101963/116305412-9a24dd80-a758-11eb-8df4-f17964beff01.png)

Note: This feature is currently only supported for host headers with host names belonging to k8s services due to #3150 

Part of  #2369

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
