### PR TITLE
smi/client: warn if requested resource is not monitored

### DIFF
--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -194,6 +194,10 @@ func (c *client) GetHTTPRouteGroup(namespacedName string) *smiSpecs.HTTPRouteGro
 	routeIf, exists, err := c.caches.HTTPRouteGroup.GetByKey(namespacedName)
 	if exists && err == nil {
 		route := routeIf.(*smiSpecs.HTTPRouteGroup)
+		if !c.kubeController.IsMonitoredNamespace(route.Namespace) {
+			log.Warn().Msgf("HTTPRouteGroup %s found, but belongs to a namespace that is not monitored, ignoring it", namespacedName)
+			return nil
+		}
 		return route
 	}
 	return nil
@@ -219,6 +223,10 @@ func (c *client) GetTCPRoute(namespacedName string) *smiSpecs.TCPRoute {
 	routeIf, exists, err := c.caches.TCPRoute.GetByKey(namespacedName)
 	if exists && err == nil {
 		route := routeIf.(*smiSpecs.TCPRoute)
+		if !c.kubeController.IsMonitoredNamespace(route.Namespace) {
+			log.Warn().Msgf("TCPRoute %s found, but belongs to a namespace that is not monitored, ignoring it", namespacedName)
+			return nil
+		}
 		return route
 	}
 	return nil


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Logs a warning if a requested resource via a `Get` API
call is found but does not belong to a monitored namespace.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [X]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`