### PR TITLE
feat(cli/install): remove install cmd cli flags

### DIFF
--- a/cmd/cli/mesh_upgrade.go
+++ b/cmd/cli/mesh_upgrade.go
@@ -15,9 +15,15 @@ import (
 )
 
 const (
-	defaultUseHTTPSIngress         = false
-	defaultEnableTracing           = true
-	defaultPrivilegedInitContainer = false
+	defaultUseHTTPSIngress               = false
+	defaultEnableTracing                 = true
+	defaultPrivilegedInitContainer       = false
+	defaultContainerRegistry             = "openservicemesh"
+	defaultOsmImageTag                   = "v0.8.3"
+	defaultEnablePermissiveTrafficPolicy = false
+	defaultEnableEgress                  = false
+	defaultEnableDebugServer             = false
+	defaultEnablePrometheusScraping      = true
 )
 
 const upgradeDesc = `

--- a/cmd/cli/mesh_upgrade_test.go
+++ b/cmd/cli/mesh_upgrade_test.go
@@ -51,7 +51,6 @@ func TestMeshUpgradeDefault(t *testing.T) {
 
 	i := getDefaultInstallCmd(ioutil.Discard)
 	i.chartPath = testChartPath
-
 	err := i.run(config)
 	a.Nil(err)
 
@@ -60,10 +59,9 @@ func TestMeshUpgradeDefault(t *testing.T) {
 	upgraded, err := action.NewGet(config).Run(u.meshName)
 	a.Nil(err)
 
-	osmImageTag, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.image.tag")
+	meshName, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.meshName")
 	a.Nil(err)
-	a.Equal(defaultOsmImageTag, osmImageTag)
-
+	a.Equal(defaultMeshName, meshName)
 	err = u.run(config)
 	a.Nil(err)
 }
@@ -149,9 +147,11 @@ func TestMeshUpgradeKeepsInstallOverrides(t *testing.T) {
 
 	i := getDefaultInstallCmd(ioutil.Discard)
 	i.chartPath = testChartPath
-	i.enableEgress = !defaultEnableEgress
-	i.osmImageTag = "installed"
-	i.envoyLogLevel = "trace"
+	i.setOptions = []string{
+		"OpenServiceMesh.enableEgress=true",
+		"OpenServiceMesh.osmImageTag=installed",
+		"OpenServiceMesh.envoyLogLevel=trace",
+	}
 
 	err := i.run(config)
 	a.Nil(err)

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -93,23 +93,23 @@ if [ "$CERT_MANAGER" = "vault" ]; then
   bin/osm install \
       --osm-namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
-      --certificate-manager="$CERT_MANAGER" \
-      --vault-host="$VAULT_HOST" \
-      --vault-token="$VAULT_TOKEN" \
-      --vault-protocol="$VAULT_PROTOCOL" \
-      --container-registry "$CTR_REGISTRY" \
-      --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
-      --osm-image-tag "$CTR_TAG" \
-      --osm-image-pull-policy "$IMAGE_PULL_POLICY" \
-      --enable-debug-server="$ENABLE_DEBUG_SERVER" \
-      --enable-egress="$ENABLE_EGRESS" \
-      --deploy-grafana="$DEPLOY_GRAFANA" \
-      --deploy-jaeger="$DEPLOY_JAEGER" \
-      --enable-fluentbit="$ENABLE_FLUENTBIT" \
-      --deploy-prometheus="$DEPLOY_PROMETHEUS" \
-      --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
-      --envoy-log-level="$ENVOY_LOG_LEVEL" \
-      --controller-log-level="trace" \
+      --set=OpenServiceMesh.certificateManager="$CERT_MANAGER" \
+      --set=OpenServiceMesh.vault.host="$VAULT_HOST" \
+      --set=OpenServiceMesh.vault.token="$VAULT_TOKEN" \
+      --set=OpenServiceMesh.vault.protocol="$VAULT_PROTOCOL" \
+      --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
+      --set=OpenServiceMesh.imagePullSecrets[0].name="$CTR_REGISTRY_CREDS_NAME" \
+      --set=OpenServiceMesh.image.tag="$CTR_TAG" \
+      --set=OpenServiceMesh.image.pullPolicy="$IMAGE_PULL_POLICY" \
+      --set=OpenServiceMesh.enableDebugServer="$ENABLE_DEBUG_SERVER" \
+      --set=OpenServiceMesh.enableEgress="$ENABLE_EGRESS" \
+      --set=OpenServiceMesh.deployGrafana="$DEPLOY_GRAFANA" \
+      --set=OpenServiceMesh.deployJaeger="$DEPLOY_JAEGER" \
+      --set=OpenServiceMesh.enableFluentbit="$ENABLE_FLUENTBIT" \
+      --set=OpenServiceMesh.deployPrometheus="$DEPLOY_PROMETHEUS" \
+      --set=OpenServiceMesh.enablePrometheusScraping="$ENABLE_PROMETHEUS_SCRAPING" \
+      --set=OpenServiceMesh.envoyLogLevel="$ENVOY_LOG_LEVEL" \
+      --set=OpenServiceMesh.controllerLogLevel="trace" \
       --timeout=90s \
       $optionalInstallArgs
 else
@@ -117,20 +117,20 @@ else
   bin/osm install \
       --osm-namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
-      --certificate-manager="$CERT_MANAGER" \
-      --container-registry "$CTR_REGISTRY" \
-      --container-registry-secret "$CTR_REGISTRY_CREDS_NAME" \
-      --osm-image-tag "$CTR_TAG" \
-      --osm-image-pull-policy "$IMAGE_PULL_POLICY" \
-      --enable-debug-server="$ENABLE_DEBUG_SERVER"\
-      --enable-egress="$ENABLE_EGRESS" \
-      --deploy-grafana="$DEPLOY_GRAFANA" \
-      --deploy-jaeger="$DEPLOY_JAEGER" \
-      --enable-fluentbit="$ENABLE_FLUENTBIT" \
-      --deploy-prometheus="$DEPLOY_PROMETHEUS" \
-      --enable-prometheus-scraping="$ENABLE_PROMETHEUS_SCRAPING" \
-      --envoy-log-level="$ENVOY_LOG_LEVEL" \
-      --controller-log-level="trace" \
+      --set=OpenServiceMesh.certificateManager="$CERT_MANAGER" \
+      --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
+      --set=OpenServiceMesh.imagePullSecrets[0].name="$CTR_REGISTRY_CREDS_NAME" \
+      --set=OpenServiceMesh.image.tag="$CTR_TAG" \
+      --set=OpenServiceMesh.image.pullPolicy="$IMAGE_PULL_POLICY" \
+      --set=OpenServiceMesh.enableDebugServer="$ENABLE_DEBUG_SERVER" \
+      --set=OpenServiceMesh.enableEgress="$ENABLE_EGRESS" \
+      --set=OpenServiceMesh.deployGrafana="$DEPLOY_GRAFANA" \
+      --set=OpenServiceMesh.deployJaeger="$DEPLOY_JAEGER" \
+      --set=OpenServiceMesh.enableFluentbit="$ENABLE_FLUENTBIT" \
+      --set=OpenServiceMesh.deployPrometheus="$DEPLOY_PROMETHEUS" \
+      --set=OpenServiceMesh.enablePrometheusScraping="$ENABLE_PROMETHEUS_SCRAPING" \
+      --set=OpenServiceMesh.envoyLogLevel="$ENVOY_LOG_LEVEL" \
+      --set=OpenServiceMesh.controllerLogLevel="trace" \
       --timeout=90s \
       $optionalInstallArgs
 fi

--- a/docs/content/docs/install/manual_demo/_index.md
+++ b/docs/content/docs/install/manual_demo/_index.md
@@ -56,7 +56,7 @@ This command enables
 [Prometheus](https://github.com/prometheus/prometheus),
 [Grafana](https://github.com/grafana/grafana), and
 [Jaeger](https://github.com/jaegertracing/jaeger) integrations.
-The `--enable-permissive-traffic-policy` options instructs OSM to ignore any policies and
+The `OpenServiceMesh.enablePermissiveTrafficPolicy` chart value instructs OSM to ignore any policies and
 let traffic flow freely between the pods. With Permissive Traffic Policy mode enabled, new pods
 will be injected with Envoy, but traffic will flow through the proxy and will not be blocked.
 
@@ -64,10 +64,10 @@ will be injected with Envoy, but traffic will flow through the proxy and will no
 
 ```bash
 osm install \
-    --enable-permissive-traffic-policy \
-    --deploy-prometheus \
-    --deploy-grafana \
-    --deploy-jaeger
+    --set=OpenServiceMesh.enablePermissiveTrafficPolicy=true
+    --set=OpenServiceMesh.deployPrometheus=true \
+    --set=OpenServiceMesh.deployGrafana=true \
+    --set=OpenServiceMesh.deployJaeger=true
 ```
 
 > Note: This document assumes you have already installed credentials for a Kubernetes cluster in ~/.kube/config and `kubectl cluster-info` executes successfully.
@@ -430,7 +430,7 @@ In permissive traffic policy mode, application connectivity within the mesh is a
 1. During install using `osm` CLI:
 
 ```bash
-osm install --enable-permissive-traffic-policy
+osm install --set=OpenServiceMesh.enablePermissiveTrafficPolicy=true
 ```
 
 1. Post install by updating the `osm-config` ConfigMap in the control plane's namespace (`osm-system` by default)

--- a/docs/content/docs/tasks_usage/certificates.md
+++ b/docs/content/docs/tasks_usage/certificates.md
@@ -54,7 +54,7 @@ Open Service Mesh includes a package, [tresor](https://github.com/openservicemes
   - To use this package in your Kubernetes cluster set the `CERT_MANAGER=tresor` variable in the Helm chart prior to deployment.
 
 Additionally:
-  - `--ca-bundle-secret-name` - this string is the name of the Kubernetes secret, where the CA root certificate and private key will be saved.
+  - `OpenServiceMesh.caBundleSecretName` - this string is the name of the Kubernetes secret, where the CA root certificate and private key will be saved.
 
 
 ### Using Hashicorp Vault
@@ -66,16 +66,16 @@ The following configuration parameters will be required for OSM to integrate wit
   - Vault token
   - Validity period for certificates
 
-CLI flags control how OSM integrates with Vault. The following OSM command line parameters must be configured to issue certificates with Vault:
-  - `--certificate-manager` - set this to `vault`
-  - `--vault-host` - host name of the Vault server (example: `vault.contoso.com`)
-  - `--vault-protocol` - protocol for Vault connection (`http` or `https`)
-  - `--vault-token` - token to be used by OSM to connect to Vault (this is issued on the Vault server for the particular role)
-  - `--vault-role` - role created on Vault server and dedicated to Open Service Mesh (example: `openservicemesh`)
-  - `--service-cert-validity-duration` - period for which each new certificate issued for service-to-service communication will be valid. It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix, ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
+`osm install` set flag control how OSM integrates with Vault. The following `osm install` set options must be configured to issue certificates with Vault:
+  - `--set OpenServiceMesh.certificateManager=vault` - set this to `vault`
+  - `--set OpenServiceMesh.vault.host` - host name of the Vault server (example: `vault.contoso.com`)
+  - `--set OpenServiceMesh.vault.protocol` - protocol for Vault connection (`http` or `https`)
+  - `--set OpenServiceMesh.vault.token` - token to be used by OSM to connect to Vault (this is issued on the Vault server for the particular role)
+  - `--set OpenServiceMesh.vault.role` - role created on Vault server and dedicated to Open Service Mesh (example: `openservicemesh`)
+  - `--set OpenServiceMesh.serviceCertValidityDuration` - period for which each new certificate issued for service-to-service communication will be valid. It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix, ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
 
 Additionally:
-  - `--ca-bundle-secret-name` - this string is the name of the Kubernetes secret where the service mesh root certificate will be stored. When using Vault (unlike Tresor) the root key will **not** be exported to this secret.
+  - `OpenServiceMesh.caBundleSecretName` - this string is the name of the Kubernetes secret where the service mesh root certificate will be stored. When using Vault (unlike Tresor) the root key will **not** be exported to this secret.
 
 
 #### Installing Hashi Vault
@@ -141,20 +141,20 @@ VAULT_TOKEN=xyz
 VAULT_ROLE=openservicemesh
 ```
 
-When running OSM on your local workstation, use the following CLI parameters:
+When running OSM on your local workstation, use the following `osm install` set options:
 ```
---certificate-manager="vault"
---vault-host="localhost"  # or the host where Vault is installed
---vault-protocol="http"
---vault-token="xyz"
---vault-role="openservicemesh'
---service-cert-validity-duration=24h
+--set OpenServiceMesh.certificateManager="vault"
+--set OpenServiceMesh.vault.host="localhost"  # or the host where Vault is installed
+--set OpenServiceMesh.vault.protocol="http"
+--set OpenServiceMesh.vault.token="xyz"
+--set OpenServiceMesh.vault.role="openservicemesh'
+--set OpenServiceMesh.serviceCertValidityDuration=24h
 ```
 
 #### How OSM Integrates with Vault
 
 When the OSM control plane starts, a new certificate issuer is instantiated.
-The kind of cert issuer is determined by the `--certificate-manager` CLI parameter.
+The kind of cert issuer is determined by the `OpenServiceMesh.certificateManager` set option.
 When this is set to `vault` OSM uses a Vault cert issuer.
 This is a Hashicorp Vault client, which satisfies the `certificate.Manager`
 interface. It provides the following methods:
@@ -240,8 +240,8 @@ default).
 
 Once ready, it is **required** to store the root CA certificate of your issuer
 as a Kubernetes secret in the OSM namespace (`osm-system` by default) at the
-`ca.crt` key. The target CA secret name can be configured on OSM with the flag
-`--ca-bundle-secret-name` (typically `osm-ca-bundle`).
+`ca.crt` key. The target CA secret name can be configured on OSM using
+`osm install --set OpenServiceMesh.caBundleSecretName=my-secret-name` (typically `osm-ca-bundle`).
 
 ```bash
 kubectl create secret -n osm-system generic osm-ca-bundle --from-file ca.tls
@@ -252,11 +252,7 @@ kubectl create secret -n osm-system generic osm-ca-bundle --from-file ca.tls
 In order for OSM to use cert-manager with the configured issuer, set the
 following CLI arguments on the `osm install` command:
 
-  - `--certificate-manager="cert-manager"` - Required to use cert-manager as the
-      provider.
-  - `--cert-manager-issuer-name` - The name of the [Cluster]Issuer resource
-      (defaulted to `osm-ca`).
-  - `--cert-manager-issuer-kind` - The kind of issuer (either `Issuer` or
-      `ClusterIssuer`, defaulted to `Issuer`).
-  - `--cert-manager-issuer-group` - The group that the issuer belongs to
-      (defaulted to `cert-manager.io` which is all core issuer types).
+  - `--set OpenServiceMesh.certificateManager="cert-manager"` - Required to use cert-manager as the provider.
+  - `--set OpenServiceMesh.certmanager.issuerName` - The name of the [Cluster]Issuer resource (defaulted to `osm-ca`).
+  - `--set OpenServiceMesh.certmanager.issuerKind` - The kind of issuer (either `Issuer` or `ClusterIssuer`, defaulted to `Issuer`).
+  - `--set OpenServiceMesh.certmanager.issuerGroup` - The group that the issuer belongs to (defaulted to `cert-manager.io` which is all core issuer types).

--- a/docs/content/docs/tasks_usage/logs.md
+++ b/docs/content/docs/tasks_usage/logs.md
@@ -12,14 +12,14 @@ Open Service Mesh (OSM) collects logs that are sent to stdout by default. When e
 ## Fluent Bit
 [Fluent Bit](https://fluentbit.io/) is an open source log processor and forwarder which allows you to collect data/logs and send them to multiple destinations. It can be used with OSM to forward OSM controller logs to a variety of outputs/log consumers by using its output plugins.
 
-OSM provides log forwarding by optionally deploying a Fluent Bit sidecar to the OSM controller using the `--enable-fluentbit` flag during installation. The user can then define where OSM logs should be forwarded using any of the available [Fluent Bit output plugins](https://docs.fluentbit.io/manual/pipeline/outputs).
+OSM provides log forwarding by optionally deploying a Fluent Bit sidecar to the OSM controller using the `--set=OpenServiceMesh.enableFluentbit=true` flag during installation. The user can then define where OSM logs should be forwarded using any of the available [Fluent Bit output plugins](https://docs.fluentbit.io/manual/pipeline/outputs).
 
 ### Configuring Log Forwarding with Fluent Bit
 By default, the Fluent Bit sidecar is configured to simply send logs to the Fluent Bit container's stdout. If you have installed OSM with Fluent Bit enabled, you may access these logs using `kubectl logs -n osm-system <osm-controller-name> -c fluentbit-logger`. This command will also help you find how your logs are formatted in case you need to change your parsers and filters. 
 
 To quickly bring up Fluent Bit with default values, use:
 ```console
-osm install --enable-fluentbit
+osm install --set=OpenServiceMesh.enableFluentbit=true
 ```
 By default, logs will be filtered to emit info level logs. You may change the log level to "debug", "warn", "fatal", "panic", "disabled" or "trace" during installation using `--set OpenServiceMesh.controllerLogLevel=<desired log level>` . To get _all_ logs, set the log level to trace.
 
@@ -42,7 +42,7 @@ To customize log forwarding to your output, follow these steps and then reinstal
 
 1. Once you have updated the Fluent Bit ConfigMap template, you can deploy Fluent Bit during OSM installation using:
     ```console
-    osm install --enable-fluentbit [--set OpenServiceMesh.controllerLogLevel=<desired log level>]
+    osm install --set=OpenServiceMesh.enableFluentbit=true [--set OpenServiceMesh.controllerLogLevel=<desired log level>]
     ```
     You should now be able to interact with error logs in the output of your choice as they get generated.
 
@@ -81,7 +81,7 @@ You may require outbound proxy support if your egress traffic is configured to g
 
 If you have already built OSM with the ConfigMap changes above, you can simply enable proxy support using the OSM CLI, replacing your values in the command below:
 ```
-osm install --enable-fluentbit --set OpenServiceMesh.fluentBit.enableProxySupport=true,OpenServiceMesh.fluentBit.httpProxy=<http-proxy-host:port>,OpenServiceMesh.fluentBit.httpsProxy=<https-proxy-host:port>
+osm install --set=OpenServiceMesh.enableFluentbit=true,OpenServiceMesh.fluentBit.enableProxySupport=true,OpenServiceMesh.fluentBit.httpProxy=<http-proxy-host:port>,OpenServiceMesh.fluentBit.httpsProxy=<https-proxy-host:port>
 ```
 
 Alternatively, you may change the values in the Helm chart by updating the following in `values.yaml`:
@@ -96,6 +96,6 @@ Alternatively, you may change the values in the Helm chart by updating the follo
 
 1. Install OSM with Fluent Bit enabled:
     ```console
-    osm install --enable-fluentbit
+    osm install --set=OpenServiceMesh.enableFluentbit=true
     ```
-> NOTE: Ensure that the [Fluent Bit image tag](https://github.com/openservicemesh/osm/blob/release-v0.8/charts/osm/values.yaml) is `1.6.4` or greater as it is required for this feature. 
+> NOTE: Ensure that the [Fluent Bit image tag](https://github.com/openservicemesh/osm/blob/release-v0.8/charts/osm/values.yaml) is `1.6.4` or greater as it is required for this feature.

--- a/docs/content/docs/tasks_usage/metrics.md
+++ b/docs/content/docs/tasks_usage/metrics.md
@@ -29,18 +29,13 @@ to automatically provision the metrics components and with the BYO method.
 
 By default, both Prometheus and Grafana are disabled.
 
-However, when configured with the `--deploy-prometheus` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `--deploy-grafana` flag to true when installing OSM using the `osm install` command.
+However, when configured with the `--set=OpenServiceMesh.deployPrometheus=true` flag, OSM installation will deploy a Prometheus instance to scrape the sidecar's metrics endpoints. Based on the metrics scraping configuration set by the user, OSM will annotate pods part of the mesh with necessary metrics annotations to have Prometheus reach and scrape the pods to collect relevant metrics. To install Grafana for metrics visualization, set the `--set=OpenServiceMesh.deployGrafana=true` flag to true when installing OSM using the `osm install` command.
 
-The automatic bring up can be overridden with the `osm install` option during install time:
+The automatic bring up can be overridden with the `osm install --set` flag during install time:
 
 ```bash
-osm install --help
-
-This command installs an osm control plane on the Kubernetes...
-...
---deploy-prometheus               Enable Prometheus deployment (default false)
---deploy-grafana                  Enable Grafana deployment (default false)
-...
+ osm install --set=OpenServiceMesh.deployPrometheus=true \
+             --set=OpenServiceMesh.deployGrafana=true
 ```
 
 Note that the Prometheus and Grafana instances deployed automatically by OSM have simple configurations that do not include high availability, persistent storage, or locked down security. If production-grade instances are required, pre-provision them and follow the BYO instructions on this page to integrate them with OSM.

--- a/docs/content/docs/tasks_usage/onboard_services.md
+++ b/docs/content/docs/tasks_usage/onboard_services.md
@@ -12,7 +12,7 @@ The following guide describes how to onboard a Kubernetes microservice to an OSM
 
 1. Configure and Install [Service Mesh Interface (SMI) policies](https://github.com/servicemeshinterface/smi-spec)
 
-    OSM conforms to the SMI specification. By default, OSM denies all traffic communications between Kubernetes services unless explicitly allowed by SMI policies. This behavior can be overridden with the `--enable-permissive-traffic-policy` flag on the `osm install` command, allowing SMI policies not to be enforced while allowing traffic and services to still take advantage of features such as mTLS-encrypted traffic, metrics, and tracing.
+    OSM conforms to the SMI specification. By default, OSM denies all traffic communications between Kubernetes services unless explicitly allowed by SMI policies. This behavior can be overridden with the `--set=OpenServiceMesh.enablePermissiveTrafficPolicy=true` flag on the `osm install` command, allowing SMI policies not to be enforced while allowing traffic and services to still take advantage of features such as mTLS-encrypted traffic, metrics, and tracing.
 
     For example SMI policies, please see the following examples:
     - [demo/deploy-traffic-specs.sh](https://github.com/openservicemesh/osm/blob/release-v0.8/demo/deploy-traffic-specs.sh)

--- a/docs/content/docs/tasks_usage/tracing.md
+++ b/docs/content/docs/tasks_usage/tracing.md
@@ -22,13 +22,13 @@ OSM CLI offers the capability to deploy a Jaeger instance with OSM's installatio
 ### Automatically Provision Jaeger
 By default, Jaeger deployment and tracing as a whole is disabled.
 
-A Jaeger instance can be automatically deployed by using the `--deploy-jaeger` OSM CLI flag at install time. This will provision a Jaeger pod in the mesh namespace.
+A Jaeger instance can be automatically deployed by using the `--set=OpenServiceMesh.deployJaeger=true` OSM CLI flag at install time. This will provision a Jaeger pod in the mesh namespace.
 
 Additionally, OSM has to be instructed to enable tracing on the proxies; this is done via the `tracing` section on the ConfigMap.
 
 The following command will both deploy Jaeger and configure the tracing parameters according to the address of the newly deployed instance of Jaeger during OSM installation:
 ```bash
-osm install --deploy-jaeger --set OpenServiceMesh.tracing.enable=true
+osm install --set=OpenServiceMesh.deployJaeger=true,OpenServiceMesh.tracing.enable=true
 ```
 
 This default bring-up uses the [All-in-one Jaeger executable](https://www.jaegertracing.io/docs/1.22/getting-started/#all-in-one) that launches the Jaeger UI, collector, query, and agent. 

--- a/docs/content/docs/tasks_usage/traffic_management/egress.md
+++ b/docs/content/docs/tasks_usage/traffic_management/egress.md
@@ -24,9 +24,9 @@ Enabling egress is done via a global setting. The setting is toggled on or off a
 ### Enabling egress
 Egress can be enabled during OSM install or post install. When egress is enabled, outbound traffic from pods are allowed to egress the pod as long as the traffic does not match in-mesh traffic policies that otherwise deny the traffic.
 
-1. During OSM install (default `--enable-egress=false`):
+1. During OSM install (default `OpenServiceMesh.enableEgress=false`):
 	```bash
-	osm install --enable-egress
+	osm install --set OpenServiceMesh.enableEgress=true
 	```
 
 2. After OSM has been installed:
@@ -41,7 +41,7 @@ Similar to enabling egress, egress can be disabled during OSM install or post in
 
 1. During OSM install:
 	```bash
-	bin osm install --enable-egress=false
+	osm install --set OpenServiceMesh.enableEgress=false
 	```
 
 2. After OSM has been installed:
@@ -67,7 +67,7 @@ The following demo shows a `curl` client making HTTPS requests to the external `
 
 1. Install OSM with egress enabled.
     ```bash
-    osm install --enable-egress=true
+    osm install --set OpenServiceMesh.enableEgress=true
     ```
 
 1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.

--- a/docs/content/docs/tasks_usage/traffic_management/iptables_redirection.md
+++ b/docs/content/docs/tasks_usage/traffic_management/iptables_redirection.md
@@ -108,7 +108,7 @@ The following demo shows an HTTP `curl` client making HTTP requests to the `http
 
 1. Install OSM with egress disabled.
     ```bash
-    osm install --enable-egress=false
+    osm install --set OpenServiceMesh.enableEgress=false
     ```
 
 1. Deploy the `curl` client into the `curl` namespace after enrolling its namespace to the mesh.

--- a/docs/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md
+++ b/docs/content/docs/tasks_usage/traffic_management/permissive_traffic_policy_mode.md
@@ -23,9 +23,9 @@ Permissive traffic policy mode can be enabled or disabled at the time of OSM ins
 
 Enabling permissive traffic policy mode implicitly disables SMI traffic policy mode.
 
-During OSM install:
+During OSM install using the `--set` flag:
 ```bash
-osm install --enable-permissive-traffic-policy=true
+osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=true
 ```
 
 After OSM has been installed:
@@ -37,9 +37,9 @@ osm mesh upgrade --enable-permissive-traffic-policy=true
 
 Disabling permissive traffic policy mode implicitly enables SMI traffic policy mode.
 
-During OSM install:
+During OSM install using the `--set` flag:
 ```bash
-osm install --enable-permissive-traffic-policy=false
+osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=false
 ```
 
 After OSM has been installed:
@@ -58,7 +58,7 @@ The following demo shows an HTTP `curl` client making HTTP requests to the `http
 
 1. Install OSM with permissive traffic policy mode enabled.
     ```bash
-    osm install --enable-permissive-traffic-policy=true
+    osm install --set OpenServiceMesh.enablePermissiveTrafficPolicy=true
     ```
 
 1. Deploy the `httpbin` service into the `httpbin` namespace after enrolling its namespace to the mesh. The `httpbin` service runs on port `14001`.

--- a/docs/content/docs/troubleshooting/observability/grafana.md
+++ b/docs/content/docs/troubleshooting/observability/grafana.md
@@ -10,7 +10,7 @@ If a Grafana instance installed with OSM can't be reached, perform the following
 
 1. Verify a Grafana Pod exists.
 
-    When installed with `osm install --deploy-grafana`, a Grafana Pod named something like `osm-grafana-7c88b9687d-tlzld` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
+    When installed with `osm install --set=OpenServiceMesh.deployGrafana=true`, a Grafana Pod named something like `osm-grafana-7c88b9687d-tlzld` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
 
     If no such Pod is found, verify the OSM Helm chart was installed with the `OpenServiceMesh.deployGrafana` parameter set to `true` with `helm`:
 
@@ -18,7 +18,7 @@ If a Grafana instance installed with OSM can't be reached, perform the following
     $ helm get values -a <mesh name> -n <OSM namespace>
     ```
 
-    If the parameter is set to anything but `true`, reinstall OSM with the `--deploy-grafana` flag on `osm install`.
+    If the parameter is set to anything but `true`, reinstall OSM with the `--set=OpenServiceMesh.deployGrafana=true` flag on `osm install`.
 
 1. Verify the Grafana Pod is healthy.
 

--- a/docs/content/docs/troubleshooting/observability/prometheus.md
+++ b/docs/content/docs/troubleshooting/observability/prometheus.md
@@ -10,7 +10,7 @@ If a Prometheus instance installed with OSM can't be reached, perform the follow
 
 1. Verify a Prometheus Pod exists.
 
-    When installed with `osm install --deploy-prometheus`, a Prometheus Pod named something like `osm-prometheus-5794755b9f-rnvlr` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
+    When installed with `osm install --set=OpenServiceMesh.deployPrometheus=true`, a Prometheus Pod named something like `osm-prometheus-5794755b9f-rnvlr` should exist in the namespace of the other OSM control plane components which named `osm-system` by default.
 
     If no such Pod is found, verify the OSM Helm chart was installed with the `OpenServiceMesh.deployPrometheus` parameter set to `true` with `helm`:
 
@@ -18,7 +18,7 @@ If a Prometheus instance installed with OSM can't be reached, perform the follow
     $ helm get values -a <mesh name> -n <OSM namespace>
     ```
 
-    If the parameter is set to anything but `true`, reinstall OSM with the `--deploy-prometheus` flag on `osm install`.
+    If the parameter is set to anything but `true`, reinstall OSM with the `--set=OpenServiceMesh.deployPrometheus=true` flag on `osm install`.
 
 1. Verify the Prometheus Pod is healthy.
 

--- a/docs/wip/demo_prometheus.md
+++ b/docs/wip/demo_prometheus.md
@@ -9,7 +9,7 @@ To get a taste of how OSM works with Prometheus, try installing a new mesh with 
 1. Install OSM with its own Prometheus instance:
 
     ```console
-    $ osm install --deploy-prometheus --enable-permissive-traffic-policy
+    $ osm install --set OpenServiceMesh.deployPrometheus=true,OpenServiceMesh.enablePermissiveTrafficPolicy=true
     OSM installed successfully in namespace [osm-system] with mesh name [osm]
     ```
 


### PR DESCRIPTION
Remove install command CLI flags in favor of using --set flag for overriding helm chart values and update docs referring to osm install cmd.

Reference: #3124

Signed-off-by: Cizer Pereira <mail@cizer.dev>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

As mentioned in #3124, if this PR merges - it will remove install cmd flags used specifically to override the default chart values defined in `charts/osm/values.yaml`, in favor of using the `--set` flag.

Removes few flag validation from `install.go` for instance validation of envoy and controller log level type.( which is already implemented using JSON schema(`values.schema.json`) validation)
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

  No