### PR TITLE
egress/v1alpha1: add types and API stub in catalog

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -50,6 +50,11 @@ rules:
     resources: ["httproutegroups", "tcproutes"]
     verbs: ["list", "get", "watch"]
 
+  # OSM's custom policy API
+  - apiGroups: ["policy.openservicemesh.io"]
+    resources: ["egresses"]
+    verbs: ["list", "get", "watch"]
+
   # Used for interacting with cert-manager CertificateRequest resources.
   - apiGroups: ["cert-manager.io"]
     resources: ["certificaterequests"]

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
+	"github.com/openservicemesh/osm/pkg/policy"
 	"github.com/openservicemesh/osm/pkg/signals"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/version"
@@ -196,12 +197,18 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Ingress monitor client")
 	}
 
+	policyController, err := policy.NewPolicyController(kubeConfig, kubernetesClient, stop)
+	if err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller for policy.openservicemesh.io")
+	}
+
 	meshCatalog := catalog.NewMeshCatalog(
 		kubernetesClient,
 		kubeClient,
 		meshSpec,
 		certManager,
 		ingressClient,
+		policyController,
 		stop,
 		cfg,
 		endpointsProviders...)

--- a/mockspec/rules
+++ b/mockspec/rules
@@ -14,6 +14,9 @@ policy; pkg/policy/mock_client_generated.go; github.com/openservicemesh/osm/pkg/
 # pkg/kubernetes
 kubernetes; pkg/kubernetes/mock_controller_generated.go; github.com/openservicemesh/osm/pkg/kubernetes; Controller
 
+# pkg/catalog
+catalog; pkg/catalog/mock_catalog_generated.go; github.com/openservicemesh/osm/pkg/catalog; MeshCataloger
+
 # pkg/debugger
 debugger; pkg/debugger/mock_debugger_generated.go; github.com/openservicemesh/osm/pkg/debugger; CertificateManagerDebugger,MeshCatalogDebugger,XDSDebugger
 
@@ -25,9 +28,6 @@ endpoint; pkg/endpoint/mock_provider_generated.go; github.com/openservicemesh/os
 
 # pkg/configurator
 configurator; pkg/configurator/mock_client_generated.go; github.com/openservicemesh/osm/pkg/configurator; Configurator
-
-# pkg/catalog
-catalog; pkg/catalog/mock_catalog_generated.go; github.com/openservicemesh/osm/pkg/catalog; MeshCataloger
 
 # pkg/certificate
 certificate; pkg/certificate/mock_certificate_generated.go; github.com/openservicemesh/osm/pkg/certificate; Certificater,Manager

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -8,18 +8,20 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/policy"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/ticker"
 )
 
 // NewMeshCatalog creates a new service catalog
-func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
+func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, policyController policy.Controller, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
 	log.Info().Msg("Create a new Service MeshCatalog.")
 	mc := MeshCatalog{
 		endpointsProviders: endpointsProviders,
 		meshSpec:           meshSpec,
 		certManager:        certManager,
 		ingressMonitor:     ingressMonitor,
+		policyController:   policyController,
 		configurator:       cfg,
 
 		// Kubernetes needed to determine what Services a pod that connects to XDS belongs to.

--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -40,6 +40,7 @@ func (mc *MeshCatalog) dispatcher() {
 		a.TrafficTargetAdded, a.TrafficTargetDeleted, a.TrafficTargetUpdated, // traffic target
 		a.IngressAdded, a.IngressDeleted, a.IngressUpdated, // Ingress
 		a.TCPRouteAdded, a.TCPRouteDeleted, a.TCPRouteUpdated, // TCProute
+		a.EgressAdded, a.EgressDeleted, a.EgressUpdated, // Egress
 	)
 
 	// State and channels for event-coalescing

--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -1,0 +1,12 @@
+package catalog
+
+import (
+	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+// GetEgressTrafficPolicy returns the Egress traffic policy associated with the given service identity
+func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceIdentity) (*trafficpolicy.EgressTrafficPolicy, error) {
+	// TODO(#3045): Implement egres policies
+	return nil, nil
+}

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint/providers/kube"
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/policy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -36,6 +37,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockKubeController := k8s.NewMockController(mockCtrl)
 	mockIngressMonitor := ingress.NewMockMonitor(mockCtrl)
+	mockPolicyController := policy.NewMockController(mockCtrl)
 
 	endpointProviders := []endpoint.Provider{
 		kube.NewFakeProvider(),
@@ -131,5 +133,5 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 	mockMeshSpec.EXPECT().ListTrafficSplits().Return([]*split.TrafficSplit{}).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, kubeClient, mockMeshSpec, certManager,
-		mockIngressMonitor, stop, mockConfigurator, endpointProviders...)
+		mockIngressMonitor, mockPolicyController, stop, mockConfigurator, endpointProviders...)
 }

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -38,6 +38,21 @@ func (m *MockMeshCataloger) EXPECT() *MockMeshCatalogerMockRecorder {
 	return m.recorder
 }
 
+// GetEgressTrafficPolicy mocks base method
+func (m *MockMeshCataloger) GetEgressTrafficPolicy(arg0 identity.ServiceIdentity) (*trafficpolicy.EgressTrafficPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEgressTrafficPolicy", arg0)
+	ret0, _ := ret[0].(*trafficpolicy.EgressTrafficPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEgressTrafficPolicy indicates an expected call of GetEgressTrafficPolicy
+func (mr *MockMeshCatalogerMockRecorder) GetEgressTrafficPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEgressTrafficPolicy", reflect.TypeOf((*MockMeshCataloger)(nil).GetEgressTrafficPolicy), arg0)
+}
+
 // GetIngressPoliciesForService mocks base method
 func (m *MockMeshCataloger) GetIngressPoliciesForService(arg0 service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/ingress"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/policy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -41,6 +42,10 @@ type MeshCatalog struct {
 	// calls through kubeClient and instead relies on background cache synchronization and local
 	// lookups
 	kubeController k8s.Controller
+
+	// policyController implements the functionality related to the resources part of the policy.openrservicemesh.io
+	// API group, such as egress.
+	policyController policy.Controller
 }
 
 // MeshCataloger is the mechanism by which the Service Mesh controller discovers all Envoy proxies connected to the catalog.
@@ -96,6 +101,9 @@ type MeshCataloger interface {
 
 	// ListMeshServicesForIdentity lists the services for a given service identity.
 	ListMeshServicesForIdentity(identity.ServiceIdentity) []service.MeshService
+
+	// GetEgressTrafficPolicy returns the Egress traffic policy associated with the given service identity
+	GetEgressTrafficPolicy(identity.ServiceIdentity) (*trafficpolicy.EgressTrafficPolicy, error)
 }
 
 // certificateCommonNameMeta is the type that stores the metadata present in the CommonName field in a proxy's certificate

--- a/pkg/trafficpolicy/egress_types.go
+++ b/pkg/trafficpolicy/egress_types.go
@@ -1,0 +1,77 @@
+package trafficpolicy
+
+import (
+	mapset "github.com/deckarep/golang-set"
+
+	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+)
+
+// EgressTrafficPolicy is the type used to represent the different egress traffic policy configurations
+// applicable to a client of Egress destinations.
+type EgressTrafficPolicy struct {
+	// TrafficMatches defines the list of traffic matches for matching Egress traffic.
+	// The matches specified are used to match outbound traffic as Egress traffic, and
+	// subject matching traffic to Egress traffic policies.
+	TrafficMatches []*TrafficMatch
+
+	// HTTPRouteConfigsPerPort defines the Egress HTTP route configurations per port.
+	// Egress HTTP routes are grouped based on their port to avoid route conflicts that
+	// can arise when the same host headers are to be routed differently based on the
+	// port specified in an egress policy.
+	HTTPRouteConfigsPerPort map[int][]*EgressHTTPRouteConfig
+
+	// ClustersConfigs defines the list of Egress cluster configurations.
+	// The specified config is used to program external clusters corresponding to
+	// the external endpoints defined in an Egress policy.
+	ClustersConfigs []*EgressClusterConfig
+}
+
+// TrafficMatch is the type used to represent attributes used to match Egress traffic
+type TrafficMatch struct {
+	// DestinationPort defines the destination port's specification - port's number and protocol
+	DestinationPort policyV1alpha1.PortSpec
+}
+
+// EgressClusterConfig is the type used to represent an external cluster corresponding to a
+// destination specified in an Egress policy.
+type EgressClusterConfig struct {
+	// Name defines the name of the external cluster
+	Name string
+
+	// Host defines the DNS resolvabe hostname for the external cluster.
+	// If specified, the cluster's address will be resolved using DNS.
+	// HTTP based clusters will set the Host attribute.
+	// If unspecified, the cluster's address will be resolved to its original
+	// destination in the request prior to being redirected by iptables.
+	// TCP based clusters will not set the Host attribute.
+	// +optional
+	Host string
+
+	// Port defines the port number of the external cluster's endpoint
+	Port int
+}
+
+// EgressHTTPRouteConfig is the type used to represent an HTTP route configuration along with associated routing rules
+type EgressHTTPRouteConfig struct {
+	// Name defines the name of the Egress HTTP route configuration
+	Name string
+
+	// Hostnames defines the list of hostnames corresponding to the Egress HTTP route configuration.
+	// The Hostnames match against the :host header in the HTTP request and subject matching requests
+	// to the routing rules defined by `RoutingRules`.
+	Hostnames []string
+
+	// RoutingRules defines the list of routes for the Egress HTTP route configuration, and corresponding
+	// rules to be applied to those routes.
+	RoutingRules []*EgressHTTPRoutingRule
+}
+
+// EgressHTTPRoutingRule is the type used to represent an Egress HTTP routing rule with its route and associated permissions
+type EgressHTTPRoutingRule struct {
+	// Route defines the HTTP route match and its associated cluster.
+	Route RouteWeightedClusters
+
+	// AllowedDestinationIPRanges defines the destination IP ranges allowed for the `Route` defined in the routing rule.
+	// Stores string type
+	AllowedDestinationIPRanges mapset.Set
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change does the following:
- Starts the k8s controller for the policy API
- Initializes catalog with the policy controller
- Adds the egress trafficpolicy types
- Adds an API in catalog to retrieve egress policy
  for the given source identity (implementation
  is stubbed out to be added in a subsequent PR).

Next steps:
- Implement the API in catalog (replace stub)
- Envoy XDS changes (LDS, RDS, CDS etc.)

Part of #3045

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`