### PR TITLE
docs: correct minimum supported k8s version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Read more about [OSM's high level goals, design, and architecture](DESIGN.md).
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.15.0 or greater
+- Kubernetes cluster running Kubernetes v1.18.0 or greater
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -25,7 +25,7 @@ OSM runs an Envoy based control plane on Kubernetes, can be configured with SMI 
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.15.0 or greater
+- Kubernetes cluster running Kubernetes v1.18.0 or greater
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/docs/content/docs/install/_index.md
+++ b/docs/content/docs/install/_index.md
@@ -8,7 +8,7 @@ weight: 3
 
 ## Prerequisites
 
-- Kubernetes cluster running Kubernetes v1.15.0 or greater
+- Kubernetes cluster running Kubernetes v1.18.0 or greater
 - The [osm CLI](#set-up-the-osm-cli) or the [helm 3 CLI](https://helm.sh/docs/intro/install/)
 
 ## Set up the OSM CLI

--- a/docs/demos/first_steps.md
+++ b/docs/demos/first_steps.md
@@ -22,7 +22,7 @@ This document will walk you through the steps to:
 
 ## Prerequisites
 This demo of OSM v0.8.0 requires:
-  - a cluster running Kubernetes v1.15.0 or greater
+  - a cluster running Kubernetes v1.18.0 or greater
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

OSM support k8s versions >= 1.18.0, as specified
by `kubeVersion` in `charts/osm/Chart.yaml`.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`