### PR TITLE
feat(portExclusion): adding outbound port exclusion list to osm

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.osmcontroller.resource.requests.cpu | string | `"0.5"` |  |
 | OpenServiceMesh.osmcontroller.resource.requests.memory | string | `"128M"` |  |
 | OpenServiceMesh.outboundIPRangeExclusionList | list | `[]` | Optional parameter to specify a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
+| OpenServiceMesh.outboundPortExclusionList | list | `[]` | Optional parameter to specify a global list of ports to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
 | OpenServiceMesh.prometheus.port | int | `7070` | Prometheus port |
 | OpenServiceMesh.prometheus.resources | object | `{"limits":{"cpu":1,"memory":"2G"},"requests":{"cpu":0.5,"memory":"512M"}}` | Resource limits for prometheus instance |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus retention time |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -81,6 +81,10 @@ spec:
                       description: Global list of IP address ranges to exclude from outbound traffic interception by the sidecar proxy.
                       type: string
                       pattern: ((?:\d{1,3}.){3}\d{1,3})\/(\d{1,2})(,((?:\d{1,3}.){3}\d{1,3})\/(\d{1,2}))*$
+                    outboundPortExclusionList:
+                      description: Global list of ports to exclude from outbound traffic interception by the sidecar proxy.
+                      type: integer
+                      pattern: ^[1-9]\d*$
                     useHTTPSIngress:
                       description: Enable HTTPS ingress on the mesh
                       type: boolean

--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -27,3 +27,7 @@ data:
 {{- if .Values.OpenServiceMesh.outboundIPRangeExclusionList }}
   outbound_ip_range_exclusion_list: {{ join "," .Values.OpenServiceMesh.outboundIPRangeExclusionList | quote }}
 {{- end}}
+
+{{- if .Values.OpenServiceMesh.outboundPortExclusionList }}
+  outbound_port_exclusion_list: {{ join "," .Values.OpenServiceMesh.outboundPortExclusionList | quote }}
+{{- end}}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -145,6 +145,10 @@ OpenServiceMesh:
   # If specified, must be a list of IP ranges of the form a.b.c.d/x.
   outboundIPRangeExclusionList: []
 
+  # -- Optional parameter to specify a global list of ports to exclude from outbound traffic interception by the sidecar proxy.
+  # If specified, must be a list of positive integers.
+  outboundPortExclusionList: []
+
   # -- Sidecar injector configuration
   injector:
     replicaCount: 1

--- a/cmd/cli/mesh_upgrade.go
+++ b/cmd/cli/mesh_upgrade.go
@@ -71,6 +71,7 @@ type meshUpgradeCmd struct {
 	tracingPort                   uint16
 	tracingEndpoint               string
 	outboundIPRangeExclusionList  []string
+	outboundPortExclusionList     []string
 	enablePrivilegedInitContainer *bool
 }
 
@@ -152,6 +153,7 @@ func newMeshUpgradeCmd(config *helm.Configuration, out io.Writer) *cobra.Command
 	f.Uint16Var(&upg.tracingPort, "tracing-port", 0, "Tracing server port")
 	f.StringVar(&upg.tracingEndpoint, "tracing-endpoint", "", "Tracing server endpoint")
 	f.StringSliceVar(&upg.outboundIPRangeExclusionList, "outbound-ip-range-exclusion-list", nil, "A global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. Pass once per IP range or a single comma separated list of IP ranges of the form a.b.c.d/x")
+	f.StringSliceVar(&upg.outboundPortExclusionList, "outbound-port-exclusion-list", nil, "A global list of ports to exclude from outbound traffic interception by the sidecar proxy. Pass once per port or a single comma separated list of ports")
 	f.BoolVar(upg.enablePrivilegedInitContainer, "enable-privileged-init-container", defaultPrivilegedInitContainer, "Run init container in privileged mode")
 
 	return cmd
@@ -237,6 +239,9 @@ func (u *meshUpgradeCmd) resolveValues(config *helm.Configuration) (map[string]i
 	}
 	if len(u.outboundIPRangeExclusionList) > 0 {
 		vals["outboundIPRangeExclusionList"] = u.outboundIPRangeExclusionList
+	}
+	if len(u.outboundPortExclusionList) > 0 {
+		vals["outboundPortExclusionList"] = u.outboundPortExclusionList
 	}
 	if u.enablePrivilegedInitContainer != nil {
 		vals["enablePrivilegedInitContainer"] = *u.enablePrivilegedInitContainer

--- a/cmd/cli/mesh_upgrade_test.go
+++ b/cmd/cli/mesh_upgrade_test.go
@@ -87,6 +87,7 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	u.envoyImage = "envoyproxy/envoy-alpine:v0.00.0"
 	u.tracingEndpoint = "/here"
 	u.outboundIPRangeExclusionList = []string{"0.0.0.0/0", "1.1.1.1/1"}
+	u.outboundPortExclusionList = []string{"6379", "7070"}
 	u.enablePrivilegedInitContainer = new(bool)
 	*u.enablePrivilegedInitContainer = true
 
@@ -119,6 +120,10 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	outboundIPRangeExclusionList, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.outboundIPRangeExclusionList")
 	a.Nil(err)
 	a.Equal([]string{"0.0.0.0/0", "1.1.1.1/1"}, outboundIPRangeExclusionList)
+
+	outboundPortExclusionList, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.outboundPortExclusionList")
+	a.Nil(err)
+	a.Equal([]string{"6379", "7070"}, outboundPortExclusionList)
 
 	enablePrivilegedInitContainer, err := chartutil.Values(upgraded.Config).PathValue("OpenServiceMesh.enablePrivilegedInitContainer")
 	a.Nil(err)

--- a/docs/content/docs/osm_config_map.md
+++ b/docs/content/docs/osm_config_map.md
@@ -24,6 +24,7 @@ kubectl get configmap osm-config -n osm-system -o yaml
 | envoy_image | OpenServiceMesh.envoyImage | string | any supported Envoy image of the form envoyproxy/envoy-alpine:vx.xx.x | `"envoyproxy/envoy-alpine:v1.17.2"` | Sets the Envoy proxy sidecar image, only applicable to newly created pods joining the mesh. To update the sidecar image for existing pods, restart the deployment with `kubectl rollout restart`. |
 | max_data_plane_connections | OpenServiceMesh.maxDataPlaneConnections | int | any positive integer value | `"0"` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | outbound_ip_range_exclusion_list | OpenServiceMesh.outboundIPRangeExclusionList | string | comma separated list of IP ranges of the form a.b.c.d/x | `-`| Global list of IP address ranges to exclude from outbound traffic interception by the sidecar proxy. |
+| outbound_port_exclusion_list | OpenServiceMesh.outboundPortExclusionList | string | comma separated list of ports | `-`| Global list of ports to exclude from outbound traffic interception by the sidecar proxy. |
 | permissive_traffic_policy_mode | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | true, false | `"false"` | Setting to `true`, enables allow-all mode in the mesh i.e. no traffic policy enforcement in the mesh. If set to `false`, enables deny-all traffic policy in mesh i.e. an `SMI Traffic Target` is necessary for services to communicate. |
 | prometheus_scraping | OpenServiceMesh.enablePrometheusScraping | bool | true, false | `"true"` | Enables Prometheus metrics scraping on sidecar proxies. |
 | service_cert_validity_duration | OpenServiceMesh.serviceCertValidityDuration | string | 24h, 1h30m (any time duration) | `"24h"` | Sets the service certificate validity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix. |
@@ -62,6 +63,7 @@ Error: invalid argument "3" for "--enable-egress" flag: strconv.ParseBool: parsi
 | envoy_image | `--envoy-image` | string | `"envoyproxy/envoy-alpine:v1.17.2"` |
 | max_data_plane_connections |`--max-data-plane-connections` | int | `"0"` |
 | outbound_ip_range_exclusion_list | `--outbound-ip-range-exclusion-list` | string | `-`|
+| outbound_port_exclusion_list | `--outbound-port-exclusion-list` | string | `-`|
 | permissive_traffic_policy_mode | `--enable-permissive-traffic-policy` | bool | `"false"` |
 | prometheus_scraping |`--enable-prometheus-scraping` | bool | `"true"` |
 | service_cert_validity_duration | `--service-cert-validity-duration` | string | `"24h"` |
@@ -99,6 +101,7 @@ use_https_ingress: must be a boolean
 | envoy_image | string | `"envoyproxy/envoy-alpine:v1.17.2"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"envoy_image":"envoyproxy/envoy-alpine:v1.17.2"}}' --type=merge` |
 | max_data_plane_connections | int | `"0"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"max_data_plane_connections":"1000"}}' --type=merge` |
 | outbound_ip_range_exclusion_list | string | `-`| `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"outbound_ip_range_exclusion_list":"1.2.3.4/0"}}' --type=merge` |
+| outbound_port_exclusion_list | string | `-`| `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"outbound_port_exclusion_list":"6379"}}' --type=merge` |
 | service_cert_validity_duration | string | `"24h"` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"service_cert_validity_duration":"2m"}}' --type=merge` |
 | tracing_address | string | `jaeger.osm-system.svc.cluster.local` | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"tracing_address":"1.2a.b.c3"}}' --type=merge` |
 | tracing_endpoint | string | /api/v2/spans | `kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"tracing_endpoint":"/abracadabra"}}' --type=merge` |
@@ -126,6 +129,7 @@ kubectl describe validatingwebhookconfiguration osm-webhook-osm
 | envoy_image | `must be of the form envoyproxy/envoy-alpine:v<major>.<minor>.<patch>`
 | max_data_plane_connections | `must be a positive integer` |
 | outbound_ip_range_exclusion_list | `must be a list of valid IP addresses of the form a.b.c.d/x` |
+| outbound_port_exclusion_list | `must be a positive integer` |
 | permissive_traffic_policy_mode | `must be a boolean` |
 | prometheus_scraping | `must be a boolean` |
 | service_cert_validity_duration | `invalid time format must be a sequence of decimal numbers each with optional fraction and a unit suffix` |

--- a/docs/content/docs/tasks_usage/traffic_management/iptables_redirection.md
+++ b/docs/content/docs/tasks_usage/traffic_management/iptables_redirection.md
@@ -75,6 +75,31 @@ OSM provides a means to specify a global list of IP ranges to exclude from outbo
 
 Excluded IP ranges are stored in the `osm-config` ConfigMap with the key `outbound_ip_range_exclusion_list`, and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable IP ranges are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded IP ranges will not be intercepted for traffic redirection to the Envoy proxy sidecar.
 
+### Global outbound port exclusions
+
+Outbound TCP based traffic from applications is by default intercepted using the `iptables` rules programmed by OSM, and redirected to the Envoy proxy sidecar. In some cases, it might be desirable to not subject certain ports to be redirected and routed by the Envoy proxy sidecar based on service mesh policies. A common use case to exclude ports is to not route non-application logic based traffic via the Envoy proxy, such as control plane traffic. In such scenarios, excluding certain ports from being subject to service mesh traffic routing policies becomes necessary.
+
+OSM provides a means to specify a global list of IP ranges to exclude from outbound traffic interception in the following ways:
+
+1. During OSM install using the `--set` option:
+    ```bash
+    # To exclude the ports 6379 and 7070 from outbound interception
+    osm install --set="OpenServiceMesh.outboundPortExclusionList={6379,7070}
+    ```
+
+1. By setting the `outbound_port_exclusion_list` key in the `osm-config` ConfigMap:
+    ```bash
+    ## Assumes OSM is installed in the osm-system namespace
+    kubectl patch ConfigMap osm-config -n osm-system -p '{"data":{"outbound_port_exclusion_list":"6379, 7070"}}' --type=merge
+    ```
+
+1. By uppgrading the Helm chart directly if OSM was installed using Helm:
+    ```bash
+    osm mesh upgrade --outbound-port-exclusion-list "6379,7070"
+    ```
+
+Excluded ports are stored in the `osm-config` ConfigMap with the key `outbound_port_exclusion_list`, and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable ports are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded ports will not be intercepted for traffic redirection to the Envoy proxy sidecar.
+
 ## Sample demo
 
 ### Traffic redirection with IP range exclusions

--- a/docs/content/docs/troubleshooting/traffic/iptables_redirection.md
+++ b/docs/content/docs/troubleshooting/traffic/iptables_redirection.md
@@ -112,3 +112,61 @@ In the example above, the following `iptables` commands are responsible for expl
 iptables -t nat -I PROXY_OUTPUT -d 1.1.1.1/32 -j RETURN
 iptables -t nat -I PROXY_OUTPUT -d 2.2.2.2/24 -j RETURN
 ```
+
+## When outbound port exclusions are configured
+
+By default, all traffic using TCP as the underlying transport protocol are redirected via the Envoy proxy sidecar container. This means all TCP based outbound traffic from applications are redirected and routed via the Envoy proxy sidecar based on service mesh policies. When outbound port exclusions are configured, traffic belonging to these ports will not be proxied to the Envoy sidecar.
+
+If outbound ports are configured to be excluded but being subject to service mesh policies, verify they are configured as expected.
+
+### 1. Confirm outbound ports are correctly configured in the `osm-config` ConfigMap
+
+Confirm the outbound ports to be excluded are set correctly:
+
+```console
+# Assumes OSM is installed in the osm-system namespace
+$ kubectl get configmap -n osm-system osm-config -o jsonpath='{.data.outbound_port_exclusion_list}{"\n"}'
+6379, 7070
+```
+
+The output shows the IP ranges that are excluded from outbound traffic redirection, `6379 and 7070` in the example above.
+
+### 2. Confirm outbound ports are included in init container spec
+
+When outbound IP range exclusions are configured, OSM's `osm-injector` service reads this configuration from the `osm-config` ConfigMap and programs `iptables` rules corresponding to these ranges so that they are excluded from outbound traffic redirection via the Envoy sidecar proxy.
+
+Confirm OSM's `osm-init` init container spec has rules corresponding to the configured outbound ports to exclude.
+
+```console
+$ kubectl describe pod test-58d4f8ff58-wtz4f -n test
+Name:         test-58d4f8ff58-wtz4f
+Namespace:    test
+...
+...
+Init Containers:
+  osm-init:
+    Container ID:  containerd://98840f655f2310b2f441e11efe9dfcf894e4c57e4e26b928542ee698159100c0
+    Image:         openservicemesh/init:2c18593efc7a31986a6ae7f412e73b6067e11a57
+    Image ID:      docker.io/openservicemesh/init@sha256:24456a8391bce5d254d5a1d557d0c5e50feee96a48a9fe4c622036f4ab2eaf8e
+    Port:          <none>
+    Host Port:     <none>
+    Command:
+      /bin/sh
+    Args:
+      -c
+      iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1500 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT && iptables -t nat -I PROXY_OUTPUT -p tcp --match multiport --dports 6379,7070 -j RETURN
+    State:          Terminated
+      Reason:       Completed
+      Exit Code:    0
+      Started:      Mon, 22 Mar 2021 09:26:14 -0700
+      Finished:     Mon, 22 Mar 2021 09:26:14 -0700
+    Ready:          True
+    Restart Count:  0
+    Environment:    <none>
+    Mounts:
+      /var/run/secrets/kubernetes.io/serviceaccount from frontend-token-5g488 (ro)
+```
+
+In the example above, the following `iptables` commands are responsible for explicitly ignoring the configured outbound ports (`6379 and 7070`) from being redirected to the Envoy proxy sidecar.
+```console
+iptables -t nat -I PROXY_OUTPUT -p tcp --match multiport --dports 6379,7070 -j RETURN

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -34,6 +34,7 @@ type SidecarSpec struct {
 type TrafficSpec struct {
 	EnableEgress                      bool     `json:"enableEgress,omitempty" yaml:"enableEgress,omitempty"`
 	OutboundIPRangeExclusionList      []string `json:"outboundIPRangeExclusionList,omitempty" yaml:"outboundIPRangeExclusionList,omitempty"`
+	OutboundPortExclusionList         []string `json:"outboundPortExclusionList,omitempty" yaml:"outboundPortExclusionList,omitempty"`
 	UseHTTPSIngress                   bool     `json:"useHTTPSIngress,omitempty" yaml:"useHTTPSIngress,omitempty"`
 	EnablePermissiveTrafficPolicyMode bool     `json:"enablePermissiveTrafficPolicyMode,omitempty" yaml:"enablePermissiveTrafficPolicyMode,omitempty"`
 }

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -174,6 +174,11 @@ func (in *TrafficSpec) DeepCopyInto(out *TrafficSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.OutboundPortExclusionList != nil {
+		in, out := &in.OutboundPortExclusionList, &out.OutboundPortExclusionList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -59,6 +59,9 @@ const (
 	// outboundIPRangeExclusionListKey is the key name used to specify the ip ranges to exclude from outbound sidecar interception
 	outboundIPRangeExclusionListKey = "outbound_ip_range_exclusion_list"
 
+	// outboundPortExclusionListKey is the key name used to specify the ports to exclude from outbound sidecar interception
+	outboundPortExclusionListKey = "outbound_port_exclusion_list"
+
 	// enablePrivilegedInitContainer is the key name used to specify whether init containers should be privileged in the ConfigMap
 	enablePrivilegedInitContainer = "enable_privileged_init_container"
 
@@ -246,6 +249,9 @@ type osmConfig struct {
 	// OutboundIPRangeExclusionList is the list of outbound IP ranges to exclude from sidecar interception
 	OutboundIPRangeExclusionList string `yaml:"outbound_ip_range_exclusion_list"`
 
+	// OutboundPortExclusionList is the list of outbound ports to exclude from sidecar interception
+	OutboundPortExclusionList string `yaml:"outbound_port_exclusion_list"`
+
 	EnablePrivilegedInitContainer bool `yaml:"enable_privileged_init_container"`
 
 	// ConfigResyncInterval is a flag to configure resync interval for regular proxy broadcast updates
@@ -304,6 +310,7 @@ func parseOSMConfigMap(configMap *v1.ConfigMap) *osmConfig {
 	osmConfigMap.EnvoyImage, _ = GetStringValueForKey(configMap, envoyImage)
 	osmConfigMap.ServiceCertValidityDuration, _ = GetStringValueForKey(configMap, serviceCertValidityDurationKey)
 	osmConfigMap.OutboundIPRangeExclusionList, _ = GetStringValueForKey(configMap, outboundIPRangeExclusionListKey)
+	osmConfigMap.OutboundPortExclusionList, _ = GetStringValueForKey(configMap, outboundPortExclusionListKey)
 	osmConfigMap.EnablePrivilegedInitContainer, _ = GetBoolValueForKey(configMap, enablePrivilegedInitContainer)
 	osmConfigMap.ConfigResyncInterval, _ = GetStringValueForKey(configMap, configResyncInterval)
 

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"EnvoyImage":                    envoyImage,
 				"ServiceCertValidityDuration":   serviceCertValidityDurationKey,
 				"OutboundIPRangeExclusionList":  outboundIPRangeExclusionListKey,
+				"OutboundPortExclusionList":     outboundPortExclusionListKey,
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,
 				"ConfigResyncInterval":          configResyncInterval,
 			}
@@ -251,6 +252,12 @@ func TestConfigMapEventTriggers(t *testing.T) {
 		{
 			deltaConfigMapContents: map[string]string{
 				outboundIPRangeExclusionListKey: "true",
+			},
+			expectProxyBroadcast: false,
+		},
+		{
+			deltaConfigMapContents: map[string]string{
+				outboundPortExclusionListKey: "true",
 			},
 			expectProxyBroadcast: false,
 		},

--- a/pkg/configurator/crd_client.go
+++ b/pkg/configurator/crd_client.go
@@ -120,6 +120,7 @@ func parseOSMMeshConfig(meshConfig *v1alpha1.MeshConfig) *osmConfig {
 	osmConfig.EnvoyImage = meshConfig.Spec.Sidecar.EnvoyImage
 	osmConfig.ServiceCertValidityDuration = meshConfig.Spec.Certificate.ServiceCertValidityDuration
 	osmConfig.OutboundIPRangeExclusionList = strings.Join(meshConfig.Spec.Traffic.OutboundIPRangeExclusionList, ",")
+	osmConfig.OutboundPortExclusionList = strings.Join(meshConfig.Spec.Traffic.OutboundPortExclusionList, ",")
 	osmConfig.EnablePrivilegedInitContainer = meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer
 
 	if osmConfig.TracingEnable {

--- a/pkg/configurator/crd_client_test.go
+++ b/pkg/configurator/crd_client_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Test OSM MeshConfig parsing", func() {
 				"EnvoyImage":                    envoyImage,
 				"ServiceCertValidityDuration":   serviceCertValidityDurationKey,
 				"OutboundIPRangeExclusionList":  outboundIPRangeExclusionListKey,
+				"OutboundPortExclusionList":     outboundPortExclusionListKey,
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,
 				"ConfigResyncInterval":          configResyncInterval,
 				"MaxDataPlaneConnections":       maxDataPlaneConnectionsKey,
@@ -209,6 +210,12 @@ func TestMeshConfigEventTriggers(t *testing.T) {
 			},
 			expectProxyBroadcast: false,
 		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				outboundPortExclusionListKey: "true",
+			},
+			expectProxyBroadcast: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -240,6 +247,8 @@ func TestMeshConfigEventTriggers(t *testing.T) {
 				meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer, _ = strconv.ParseBool(mapVal)
 			case outboundIPRangeExclusionListKey:
 				meshConfig.Spec.Traffic.OutboundIPRangeExclusionList = strings.Split(mapVal, ",")
+			case outboundPortExclusionListKey:
+				meshConfig.Spec.Traffic.OutboundPortExclusionList = strings.Split(mapVal, ",")
 			}
 		}
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -145,6 +145,21 @@ func (c *Client) GetOutboundIPRangeExclusionList() []string {
 	return exclusionList
 }
 
+// GetOutboundPortExclusionList returns the list of ports (positive integers) to exclude from outbound sidecar interception
+func (c *Client) GetOutboundPortExclusionList() []string {
+	portsStr := c.getConfigMap().OutboundPortExclusionList
+	if portsStr == "" {
+		return nil
+	}
+
+	portExclusionList := strings.Split(portsStr, ",")
+	for i := range portExclusionList {
+		portExclusionList[i] = strings.TrimSpace(portExclusionList[i])
+	}
+
+	return portExclusionList
+}
+
 // IsPrivilegedInitContainer returns whether init containers should be privileged
 func (c *Client) IsPrivilegedInitContainer() bool {
 	return c.getConfigMap().EnablePrivilegedInitContainer

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -237,6 +237,19 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 		},
 		{
+			name:                 "GetOutboundPortExclusionList",
+			initialConfigMapData: map[string]string{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Nil(cfg.GetOutboundPortExclusionList())
+			},
+			updatedConfigMapData: map[string]string{
+				outboundPortExclusionListKey: "7070, 6080",
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal([]string{"7070", "6080"}, cfg.GetOutboundPortExclusionList())
+			},
+		},
+		{
 			name: "IsPrivilegedInitContainer",
 			initialConfigMapData: map[string]string{
 				enablePrivilegedInitContainer: "true",

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -133,6 +133,20 @@ func (mr *MockConfiguratorMockRecorder) GetOutboundIPRangeExclusionList() *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundIPRangeExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundIPRangeExclusionList))
 }
 
+// GetOutboundPortExclusionList mocks base method
+func (m *MockConfigurator) GetOutboundPortExclusionList() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOutboundPortExclusionList")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetOutboundPortExclusionList indicates an expected call of GetOutboundPortExclusionList
+func (mr *MockConfiguratorMockRecorder) GetOutboundPortExclusionList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundPortExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundPortExclusionList))
+}
+
 // GetServiceCertValidityPeriod mocks base method
 func (m *MockConfigurator) GetServiceCertValidityPeriod() time.Duration {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -81,6 +81,9 @@ type Configurator interface {
 	// GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
 	GetOutboundIPRangeExclusionList() []string
 
+	// GetOutboundPortExclusionList returns the list of ports to exclude from outbound sidecar interception
+	GetOutboundPortExclusionList() []string
+
 	// IsPrivilegedInitContainer determines whether init containers should be privileged
 	IsPrivilegedInitContainer() bool
 

--- a/pkg/configurator/validating_webhook.go
+++ b/pkg/configurator/validating_webhook.go
@@ -73,6 +73,8 @@ const (
 
 	mustBeValidIPRange = ": must be a list of valid IP addresses of the form a.b.c.d/x"
 
+	mustBeValidPort = ": must be a positive integer"
+
 	// cannotChangeMetadata is the reason for denial for changes to configmap metadata
 	cannotChangeMetadata = ": cannot change metadata"
 
@@ -280,6 +282,9 @@ func (whc *webhookConfig) validateFields(configMap corev1.ConfigMap, resp *admis
 		if field == outboundIPRangeExclusionListKey && !checkOutboundIPRangeExclusionList(value) {
 			reasonForDenial(resp, mustBeValidIPRange, field)
 		}
+		if field == outboundPortExclusionListKey && !checkOutboundPortExclusionList(value) {
+			reasonForDenial(resp, mustBeValidPort, field)
+		}
 		if field == maxDataPlaneConnectionsKey {
 			maxNum, err := strconv.Atoi(value)
 			if err != nil || maxNum < 0 {
@@ -325,6 +330,18 @@ func checkOutboundIPRangeExclusionList(ipRangesStr string) bool {
 	for i := range exclusionList {
 		ipAddress := strings.TrimSpace(exclusionList[i])
 		if _, _, err := net.ParseCIDR(ipAddress); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func checkOutboundPortExclusionList(portsStr string) bool {
+	portsExclusionList := strings.Split(portsStr, ",")
+	for i := range portsExclusionList {
+		port := strings.TrimSpace(portsExclusionList[i])
+		intVal, err := strconv.Atoi(port)
+		if err != nil || intVal <= 0 {
 			return false
 		}
 	}

--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -280,6 +280,7 @@ func TestValidateFields(t *testing.T) {
 					"service_cert_validity_duration":   "24h",
 					"tracing_port":                     "9411",
 					"outbound_ip_range_exclusion_list": "1.1.1.1/32, 2.2.2.2/24",
+					"outbound_port_exclusion_list":     "6379, 7070",
 					"max_data_plane_connections":       "1000",
 				},
 			},
@@ -375,6 +376,18 @@ func TestValidateFields(t *testing.T) {
 			},
 		},
 		{
+			testName: "Reject configmap with invalid syntax for port",
+			configMap: corev1.ConfigMap{
+				Data: map[string]string{
+					"outbound_port_exclusion_list": "-6379", // invalid syntax, must be 6379
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result:  &metav1.Status{Reason: "\noutbound_port_exclusion_list" + mustBeValidPort},
+			},
+		},
+		{
 			testName: "Reject configmap with invalid outbound IP range exclusions",
 			configMap: corev1.ConfigMap{
 				Data: map[string]string{
@@ -384,6 +397,18 @@ func TestValidateFields(t *testing.T) {
 			expectedResponse: &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result:  &metav1.Status{Reason: "\noutbound_ip_range_exclusion_list" + mustBeValidIPRange},
+			},
+		},
+		{
+			testName: "Reject configmap with invalid outbound port exclusions",
+			configMap: corev1.ConfigMap{
+				Data: map[string]string{
+					"outbound_port_exclusion_list": "foobar",
+				},
+			},
+			expectedResponse: &admissionv1.AdmissionResponse{
+				Allowed: false,
+				Result:  &metav1.Status{Reason: "\noutbound_port_exclusion_list" + mustBeValidPort},
 			},
 		},
 		{

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -6,8 +6,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func getInitContainerSpec(containerName string, containerImage string, outboundIPRangeExclusionList []string, enablePrivilegedInitContainer bool) corev1.Container {
-	iptablesInitCommandsList := generateIptablesCommands(outboundIPRangeExclusionList)
+func getInitContainerSpec(containerName string, containerImage string, outboundIPRangeExclusionList []string, outboundPortExclusionList []string,
+	enablePrivilegedInitContainer bool) corev1.Container {
+	iptablesInitCommandsList := generateIptablesCommands(outboundIPRangeExclusionList, outboundPortExclusionList)
 	iptablesInitCommand := strings.Join(iptablesInitCommandsList, " && ")
 
 	return corev1.Container{

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -20,11 +20,69 @@ func TestGetInitContainerSpec(t *testing.T) {
 	testCases := []struct {
 		name                         string
 		outboundIPRangeExclusionList []string
+		outboundPortExclusionList    []string
 		privileged                   bool
 		expectedSpec                 v1.Container
 	}{
 		{
-			name:                         "init container without outbound exclusion list",
+			name:                         "init container without outbound ip range exclusion list",
+			outboundIPRangeExclusionList: nil,
+			outboundPortExclusionList:    nil,
+			privileged:                   privilegedFalse,
+			expectedSpec: v1.Container{
+				Name:    "-container-name-",
+				Image:   "-init-container-image-",
+				Command: []string{"/bin/sh"},
+				Args: []string{
+					"-c",
+					"iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1500 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT",
+				},
+				WorkingDir: "",
+				Resources:  v1.ResourceRequirements{},
+				SecurityContext: &v1.SecurityContext{
+					Capabilities: &v1.Capabilities{
+						Add: []v1.Capability{
+							"NET_ADMIN",
+						},
+					},
+					Privileged: &privilegedFalse,
+				},
+				Stdin:     false,
+				StdinOnce: false,
+				TTY:       false,
+			},
+		},
+		{
+			name:                         "init container with outbound ip range exclusion list",
+			outboundIPRangeExclusionList: []string{"1.1.1.1/32", "10.0.0.10/24"},
+			outboundPortExclusionList:    nil,
+			privileged:                   privilegedFalse,
+			expectedSpec: v1.Container{
+				Name:    "-container-name-",
+				Image:   "-init-container-image-",
+				Command: []string{"/bin/sh"},
+				Args: []string{
+					"-c",
+					"iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1500 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT && iptables -t nat -I PROXY_OUTPUT -d 1.1.1.1/32 -j RETURN && iptables -t nat -I PROXY_OUTPUT -d 10.0.0.10/24 -j RETURN",
+				},
+				WorkingDir: "",
+				Resources:  v1.ResourceRequirements{},
+				SecurityContext: &v1.SecurityContext{
+					Capabilities: &v1.Capabilities{
+						Add: []v1.Capability{
+							"NET_ADMIN",
+						},
+					},
+					Privileged: &privilegedFalse,
+				},
+				Stdin:     false,
+				StdinOnce: false,
+				TTY:       false,
+			},
+		},
+		{
+			name:                         "init container without outbound port exclusion list",
+			outboundPortExclusionList:    nil,
 			outboundIPRangeExclusionList: nil,
 			privileged:                   privilegedFalse,
 			expectedSpec: v1.Container{
@@ -51,8 +109,9 @@ func TestGetInitContainerSpec(t *testing.T) {
 			},
 		},
 		{
-			name:                         "init container with outbound exclusion list",
-			outboundIPRangeExclusionList: []string{"1.1.1.1/32", "10.0.0.10/24"},
+			name:                         "init container with outbound port exclusion list",
+			outboundIPRangeExclusionList: nil,
+			outboundPortExclusionList:    []string{"6060", "7070"},
 			privileged:                   privilegedFalse,
 			expectedSpec: v1.Container{
 				Name:    "-container-name-",
@@ -60,7 +119,7 @@ func TestGetInitContainerSpec(t *testing.T) {
 				Command: []string{"/bin/sh"},
 				Args: []string{
 					"-c",
-					"iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1500 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT && iptables -t nat -I PROXY_OUTPUT -d 1.1.1.1/32 -j RETURN && iptables -t nat -I PROXY_OUTPUT -d 10.0.0.10/24 -j RETURN",
+					"iptables -t nat -N PROXY_INBOUND && iptables -t nat -N PROXY_IN_REDIRECT && iptables -t nat -N PROXY_OUTPUT && iptables -t nat -N PROXY_REDIRECT && iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001 && iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT && iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT && iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1500 -j RETURN && iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN && iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT && iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003 && iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN && iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT && iptables -t nat -I PROXY_OUTPUT -p tcp --match multiport --dports 6060,7070 -j RETURN",
 				},
 				WorkingDir: "",
 				Resources:  v1.ResourceRequirements{},
@@ -80,6 +139,7 @@ func TestGetInitContainerSpec(t *testing.T) {
 		{
 			name:                         "init container with privileged true",
 			outboundIPRangeExclusionList: nil,
+			outboundPortExclusionList:    nil,
 			privileged:                   privilegedTrue,
 			expectedSpec: v1.Container{
 				Name:    "-container-name-",
@@ -108,7 +168,7 @@ func TestGetInitContainerSpec(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			actual := getInitContainerSpec(containerName, containerImage, tc.outboundIPRangeExclusionList, tc.privileged)
+			actual := getInitContainerSpec(containerName, containerImage, tc.outboundIPRangeExclusionList, tc.outboundPortExclusionList, tc.privileged)
 			assert.Equal(tc.expectedSpec, actual)
 		})
 	}

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -54,7 +54,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	pod.Spec.Volumes = append(pod.Spec.Volumes, getVolumeSpec(envoyBootstrapConfigName)...)
 
 	// Add the Init Container
-	initContainer := getInitContainerSpec(constants.InitContainerName, wh.config.InitContainerImage, wh.configurator.GetOutboundIPRangeExclusionList(), wh.configurator.IsPrivilegedInitContainer())
+	initContainer := getInitContainerSpec(constants.InitContainerName, wh.config.InitContainerImage, wh.configurator.GetOutboundIPRangeExclusionList(), wh.configurator.GetOutboundPortExclusionList(), wh.configurator.IsPrivilegedInitContainer())
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
 	// Add the Envoy sidecar

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -59,6 +59,7 @@ var _ = Describe("Test all patch operations", func() {
 			mockConfigurator.EXPECT().GetEnvoyImage().Return("").Times(1)
 			mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
 			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
+			mockConfigurator.EXPECT().GetOutboundPortExclusionList().Return(nil).Times(1)
 
 			req := &admissionv1.AdmissionRequest{Namespace: namespace}
 			jsonPatches, err := wh.createPatch(&pod, req, proxyUUID)


### PR DESCRIPTION
**Description**:

This PR adds support for global outbound port exclusion via the
configmap and meshconfig in osm.

Fixes #3249

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
