### PR TITLE
egress/catalog: implement egress traffic policy

### DIFF
--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -1,12 +1,188 @@
 package catalog
 
 import (
+	"fmt"
+	"net"
+	"strings"
+
+	mapset "github.com/deckarep/golang-set"
+	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
+
+	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+const (
+	protocolHTTP = "http"
 )
 
 // GetEgressTrafficPolicy returns the Egress traffic policy associated with the given service identity
 func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceIdentity) (*trafficpolicy.EgressTrafficPolicy, error) {
-	// TODO(#3045): Implement egres policies
-	return nil, nil
+	var trafficMatches []*trafficpolicy.TrafficMatch
+	var clusterConfigs []*trafficpolicy.EgressClusterConfig
+	allowedDestinationPorts := mapset.NewSet()
+	portToRouteConfigMap := make(map[int][]*trafficpolicy.EgressHTTPRouteConfig)
+
+	egressResources := mc.policyController.ListEgressPoliciesForSourceIdentity(serviceIdentity.ToK8sServiceAccount())
+
+	for _, egress := range egressResources {
+		for _, portSpec := range egress.Spec.Ports {
+			// ---
+			// Build the HTTP route configs for the given Egress policy
+			if strings.EqualFold(portSpec.Protocol, protocolHTTP) {
+				httpRouteConfigs, httpClusterConfigs := mc.buildHTTPRouteConfigs(egress, portSpec.Number)
+				portToRouteConfigMap[portSpec.Number] = append(portToRouteConfigMap[portSpec.Number], httpRouteConfigs...)
+				clusterConfigs = append(clusterConfigs, httpClusterConfigs...)
+			}
+
+			// ---
+			// TODO(#3045): Build the TCP route configs for the given Egress policy
+
+			// ---
+			// Build traffic matches for the given Egress policy.
+			// Traffic matches are used to match outbound traffic as egress traffic using the port numbers
+			// specified in Egress policies.
+			newlyAdded := allowedDestinationPorts.Add(portSpec)
+			if newlyAdded {
+				trafficMatches = append(trafficMatches, &trafficpolicy.TrafficMatch{
+					DestinationPort: portSpec,
+				})
+			}
+		}
+	}
+
+	return &trafficpolicy.EgressTrafficPolicy{
+		HTTPRouteConfigsPerPort: portToRouteConfigMap,
+		TrafficMatches:          trafficMatches,
+		ClustersConfigs:         clusterConfigs,
+	}, nil
+}
+
+func (mc *MeshCatalog) buildHTTPRouteConfigs(egressPolicy *policyV1alpha1.Egress, port int) ([]*trafficpolicy.EgressHTTPRouteConfig, []*trafficpolicy.EgressClusterConfig) {
+	if egressPolicy == nil {
+		return nil, nil
+	}
+
+	var routeConfigs []*trafficpolicy.EgressHTTPRouteConfig
+	var clusterConfigs []*trafficpolicy.EgressClusterConfig
+
+	// Before building the route configs, pre-compute the allowed IP ranges since they
+	// will be the same for every HTTP route config derived from the given Egress policy.
+	var allowedDestinationIPRanges []string
+	destIPSet := mapset.NewSet()
+	for _, ipRange := range egressPolicy.Spec.IPAddresses {
+		if _, _, err := net.ParseCIDR(ipRange); err != nil {
+			log.Error().Err(err).Msgf("Invalid IP range [%s] specified in egress policy %s/%s; will be skipped", ipRange, egressPolicy.Namespace, egressPolicy.Name)
+			continue
+		}
+		newlyAdded := destIPSet.Add(ipRange)
+		if newlyAdded {
+			allowedDestinationIPRanges = append(allowedDestinationIPRanges, ipRange)
+		}
+	}
+
+	// Check if there are object references to HTTP routes specified
+	// in the Egress policy's 'matches' attribute. If there are HTTP route
+	// matches, apply these routes.
+	var httpRouteMatches []trafficpolicy.HTTPRouteMatch
+	httpMatchSpecified := false
+	for _, match := range egressPolicy.Spec.Matches {
+		if match.APIGroup != nil && *match.APIGroup == smiSpecs.SchemeGroupVersion.String() && match.Kind == httpRouteGroupKind {
+			// HTTPRouteGroup resource referenced, build a routing rule from this resource
+			httpMatchSpecified = true
+
+			// A TypedLocalObjectReference (Spec.Matches) is a reference to another object in the same namespace
+			httpRouteName := fmt.Sprintf("%s/%s", egressPolicy.Namespace, match.Name)
+			if httpRouteGroup := mc.meshSpec.GetHTTPRouteGroup(httpRouteName); httpRouteGroup == nil {
+				log.Error().Msgf("Error fetching HTTPRouteGroup resource %s referenced in Egress policy %s/%s", httpRouteName, egressPolicy.Namespace, egressPolicy.Name)
+			} else {
+				matches := getHTTPRouteMatchesFromHTTPRouteGroup(httpRouteGroup)
+				httpRouteMatches = append(httpRouteMatches, matches...)
+			}
+		} else {
+			log.Error().Msgf("Unsupported match object specified: %v, ignoring it", match)
+		}
+	}
+
+	if !httpMatchSpecified {
+		// No HTTP match specified, use a wildcard
+		httpRouteMatches = append(httpRouteMatches, trafficpolicy.WildCardRouteMatch)
+	}
+
+	// Parse the hosts specified and build routing rules for the specified hosts
+	for _, host := range egressPolicy.Spec.Hosts {
+		// A route matching an HTTP host will include host header matching for the following:
+		// 1. host (ex. foo.com)
+		// 2. host:port (ex. foo.com:80)
+		hostnameWithPort := fmt.Sprintf("%s:%d", host, port)
+		hostnames := []string{host, hostnameWithPort}
+
+		// Create cluster config for this host and port combination
+		clusterName := hostnameWithPort
+		clusterConfig := &trafficpolicy.EgressClusterConfig{
+			Name: clusterName,
+			Host: host,
+			Port: port,
+		}
+		clusterConfigs = append(clusterConfigs, clusterConfig)
+
+		// Build egress routing rules from the given HTTP route matches and allowed destination attributes
+		var httpRoutingRules []*trafficpolicy.EgressHTTPRoutingRule
+		for _, match := range httpRouteMatches {
+			routeWeightedCluster := trafficpolicy.RouteWeightedClusters{
+				HTTPRouteMatch: match,
+				WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+					service.WeightedCluster{ClusterName: service.ClusterName(clusterName), Weight: constants.ClusterWeightAcceptAll},
+				}),
+			}
+			routingRule := &trafficpolicy.EgressHTTPRoutingRule{
+				Route:                      routeWeightedCluster,
+				AllowedDestinationIPRanges: allowedDestinationIPRanges,
+			}
+			httpRoutingRules = append(httpRoutingRules, routingRule)
+		}
+
+		// Hostnames and routing rules are computed for the given host, build an HTTP route config for it
+		hostSpecificRouteConfig := &trafficpolicy.EgressHTTPRouteConfig{
+			Name:         host,
+			Hostnames:    hostnames,
+			RoutingRules: httpRoutingRules,
+		}
+
+		routeConfigs = append(routeConfigs, hostSpecificRouteConfig)
+	}
+
+	return routeConfigs, clusterConfigs
+}
+
+func getHTTPRouteMatchesFromHTTPRouteGroup(httpRouteGroup *smiSpecs.HTTPRouteGroup) []trafficpolicy.HTTPRouteMatch {
+	if httpRouteGroup == nil {
+		return nil
+	}
+
+	var matches []trafficpolicy.HTTPRouteMatch
+	for _, match := range httpRouteGroup.Spec.Matches {
+		httpRouteMatch := trafficpolicy.HTTPRouteMatch{
+			Path:          match.PathRegex,
+			PathMatchType: trafficpolicy.PathMatchRegex,
+			Methods:       match.Methods,
+			Headers:       match.Headers,
+		}
+
+		// When pathRegex and/or methods are not defined, they should be wildcarded
+		if httpRouteMatch.Path == "" {
+			httpRouteMatch.Path = constants.RegexMatchAll
+		}
+		if len(httpRouteMatch.Methods) == 0 {
+			httpRouteMatch.Methods = []string{constants.WildcardHTTPMethod}
+		}
+
+		matches = append(matches, httpRouteMatch)
+	}
+
+	return matches
 }

--- a/pkg/catalog/egress_test.go
+++ b/pkg/catalog/egress_test.go
@@ -1,0 +1,669 @@
+package catalog
+
+import (
+	"fmt"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/golang/mock/gomock"
+	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
+	specs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
+	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/policy"
+
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+func TestGetEgressTrafficPolicy(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name                 string
+		egressPolicies       []*policyV1alpha1.Egress
+		egressPort           int
+		httpRouteGroups      []*specs.HTTPRouteGroup
+		expectedEgressPolicy *trafficpolicy.EgressTrafficPolicy
+		expectError          bool
+	}{
+		{
+			name: "multiple egress policies for HTTP ports",
+			egressPolicies: []*policyV1alpha1.Egress{
+				{
+					Spec: policyV1alpha1.EgressSpec{
+						Hosts: []string{
+							"foo.com",
+						},
+						Ports: []policyV1alpha1.PortSpec{
+							{
+								Number:   80,
+								Protocol: "http",
+							},
+						},
+					},
+				},
+				{
+					Spec: policyV1alpha1.EgressSpec{
+						Hosts: []string{
+							"bar.com",
+						},
+						Ports: []policyV1alpha1.PortSpec{
+							{
+								Number:   80,
+								Protocol: "http",
+							},
+						},
+					},
+				},
+				{
+					Spec: policyV1alpha1.EgressSpec{
+						Hosts: []string{
+							"baz.com",
+						},
+						Ports: []policyV1alpha1.PortSpec{
+							{
+								Number:   90,
+								Protocol: "http",
+							},
+						},
+					},
+				},
+			},
+			httpRouteGroups: nil, // no SMI HTTP route matches
+			expectedEgressPolicy: &trafficpolicy.EgressTrafficPolicy{
+				TrafficMatches: []*trafficpolicy.TrafficMatch{
+					{
+						DestinationPort: policyV1alpha1.PortSpec{
+							Number:   80, // Used by foo.com and bar.com
+							Protocol: "http",
+						},
+					},
+					{
+						DestinationPort: policyV1alpha1.PortSpec{
+							Number:   90, // Used by baz.com
+							Protocol: "http",
+						},
+					},
+				},
+				HTTPRouteConfigsPerPort: map[int][]*trafficpolicy.EgressHTTPRouteConfig{
+					80: {
+						{
+							Name: "foo.com",
+							Hostnames: []string{
+								"foo.com",
+								"foo.com:80",
+							},
+							RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+										WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+											service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+										}),
+									},
+									AllowedDestinationIPRanges: nil,
+								},
+							},
+						},
+						{
+							Name: "bar.com",
+							Hostnames: []string{
+								"bar.com",
+								"bar.com:80",
+							},
+							RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+										WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+											service.WeightedCluster{ClusterName: service.ClusterName("bar.com:80"), Weight: 100},
+										}),
+									},
+									AllowedDestinationIPRanges: nil,
+								},
+							},
+						},
+					},
+					90: {
+						{
+							Name: "baz.com",
+							Hostnames: []string{
+								"baz.com",
+								"baz.com:90",
+							},
+							RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+										WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+											service.WeightedCluster{ClusterName: service.ClusterName("baz.com:90"), Weight: 100},
+										}),
+									},
+									AllowedDestinationIPRanges: nil,
+								},
+							},
+						},
+					},
+				},
+				ClustersConfigs: []*trafficpolicy.EgressClusterConfig{
+					{
+						Name: "foo.com:80",
+						Host: "foo.com",
+						Port: 80,
+					},
+					{
+						Name: "bar.com:80",
+						Host: "bar.com",
+						Port: 80,
+					},
+					{
+						Name: "baz.com:90",
+						Host: "baz.com",
+						Port: 90,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "multiple egress policies for HTTP ports",
+			egressPolicies: []*policyV1alpha1.Egress{
+				{
+					Spec: policyV1alpha1.EgressSpec{
+						Hosts: []string{
+							"foo.com",
+						},
+						Ports: []policyV1alpha1.PortSpec{
+							{
+								Number:   80,
+								Protocol: "http",
+							},
+							{
+								Number:   100,
+								Protocol: "tcp", // This port should be ignored for HTTP routes
+							},
+						},
+					},
+				},
+				{
+					Spec: policyV1alpha1.EgressSpec{
+						Hosts: []string{
+							"bar.com",
+						},
+						Ports: []policyV1alpha1.PortSpec{
+							{
+								Number:   80,
+								Protocol: "http",
+							},
+						},
+					},
+				},
+			},
+			httpRouteGroups: nil, // no SMI HTTP route matches
+			expectedEgressPolicy: &trafficpolicy.EgressTrafficPolicy{
+				TrafficMatches: []*trafficpolicy.TrafficMatch{
+					{
+						DestinationPort: policyV1alpha1.PortSpec{
+							Number:   80, // Used by foo.com and bar.com
+							Protocol: "http",
+						},
+					},
+					{
+						DestinationPort: policyV1alpha1.PortSpec{
+							Number:   100, // Used by foo.com
+							Protocol: "tcp",
+						},
+					},
+				},
+				HTTPRouteConfigsPerPort: map[int][]*trafficpolicy.EgressHTTPRouteConfig{
+					80: {
+						{
+							Name: "foo.com",
+							Hostnames: []string{
+								"foo.com",
+								"foo.com:80",
+							},
+							RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+										WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+											service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+										}),
+									},
+									AllowedDestinationIPRanges: nil,
+								},
+							},
+						},
+						{
+							Name: "bar.com",
+							Hostnames: []string{
+								"bar.com",
+								"bar.com:80",
+							},
+							RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+										WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+											service.WeightedCluster{ClusterName: service.ClusterName("bar.com:80"), Weight: 100},
+										}),
+									},
+									AllowedDestinationIPRanges: nil,
+								},
+							},
+						},
+					},
+				},
+				ClustersConfigs: []*trafficpolicy.EgressClusterConfig{
+					{
+						Name: "foo.com:80",
+						Host: "foo.com",
+						Port: 80,
+					},
+					{
+						Name: "bar.com:80",
+						Host: "bar.com",
+						Port: 80,
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	testSourceIdentity := identity.ServiceIdentity("foo.bar.cluster.local")
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
+			mockPolicyController := policy.NewMockController(mockCtrl)
+
+			for _, rg := range tc.httpRouteGroups {
+				mockMeshSpec.EXPECT().GetHTTPRouteGroup(fmt.Sprintf("%s/%s", rg.Namespace, rg.Name)).Return(rg).AnyTimes()
+			}
+			mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(tc.egressPolicies).Times(1)
+
+			mc := &MeshCatalog{
+				meshSpec:         mockMeshSpec,
+				policyController: mockPolicyController,
+			}
+
+			egressPolicy, err := mc.GetEgressTrafficPolicy(testSourceIdentity)
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedEgressPolicy, egressPolicy)
+		})
+	}
+}
+
+func TestBuildHTTPRouteConfigs(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name                   string
+		egressPolicy           *policyV1alpha1.Egress
+		egressPort             int
+		httpRouteGroups        []*specs.HTTPRouteGroup
+		expectedRouteConfigs   []*trafficpolicy.EgressHTTPRouteConfig
+		expectedClusterConfigs []*trafficpolicy.EgressClusterConfig
+	}{
+		{
+			name: "egress policy with no SMI HTTP route matches specified",
+			egressPolicy: &policyV1alpha1.Egress{
+				Spec: policyV1alpha1.EgressSpec{
+					Hosts: []string{
+						"foo.com",
+						"bar.com",
+					},
+					Ports: []policyV1alpha1.PortSpec{
+						{
+							Number:   80,
+							Protocol: "http",
+						},
+					},
+				},
+			},
+			egressPort:      80,
+			httpRouteGroups: nil, // no matches specified in the egress policy via Spec.Matches
+			expectedRouteConfigs: []*trafficpolicy.EgressHTTPRouteConfig{
+				{
+					Name: "foo.com",
+					Hostnames: []string{
+						"foo.com",
+						"foo.com:80",
+					},
+					RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: nil,
+						},
+					},
+				},
+				{
+					Name: "bar.com",
+					Hostnames: []string{
+						"bar.com",
+						"bar.com:80",
+					},
+					RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("bar.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: nil,
+						},
+					},
+				},
+			},
+			expectedClusterConfigs: []*trafficpolicy.EgressClusterConfig{
+				{
+					Name: "foo.com:80",
+					Host: "foo.com",
+					Port: 80,
+				},
+				{
+					Name: "bar.com:80",
+					Host: "bar.com",
+					Port: 80,
+				},
+			},
+		},
+		{
+			name: "egress policy with SMI matching routes specified",
+			egressPolicy: &policyV1alpha1.Egress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "egress-1",
+					Namespace: "test",
+				},
+				Spec: policyV1alpha1.EgressSpec{
+					Hosts: []string{
+						"foo.com",
+					},
+					Ports: []policyV1alpha1.PortSpec{
+						{
+							Number:   80,
+							Protocol: "http",
+						},
+					},
+					Matches: []corev1.TypedLocalObjectReference{
+						{
+							APIGroup: pointer.StringPtr("specs.smi-spec.io/v1alpha4"),
+							Kind:     "HTTPRouteGroup",
+							Name:     "route-1",
+						},
+						{
+							APIGroup: pointer.StringPtr("specs.smi-spec.io/v1alpha4"),
+							Kind:     "HTTPRouteGroup",
+							Name:     "route-2",
+						},
+					},
+				},
+			},
+			egressPort: 80,
+			httpRouteGroups: []*specs.HTTPRouteGroup{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "specs.smi-spec.io/v1alpha4",
+						Kind:       "HTTPRouteGroup",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route-1",
+						Namespace: "test",
+					},
+					Spec: spec.HTTPRouteGroupSpec{
+						Matches: []specs.HTTPMatch{
+							{
+								Name:      "match-1",
+								PathRegex: "/foo",
+								Methods:   []string{"GET"},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "specs.smi-spec.io/v1alpha4",
+						Kind:       "HTTPRouteGroup",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route-2",
+						Namespace: "test",
+					},
+					Spec: spec.HTTPRouteGroupSpec{
+						Matches: []specs.HTTPMatch{
+							{
+								Name:      "match-2",
+								PathRegex: "/bar",
+								Methods:   []string{"GET"},
+							},
+						},
+					},
+				},
+			},
+			expectedRouteConfigs: []*trafficpolicy.EgressHTTPRouteConfig{
+				{
+					Name: "foo.com",
+					Hostnames: []string{
+						"foo.com",
+						"foo.com:80",
+					},
+					RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/foo",
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{"GET"},
+								},
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: nil,
+						},
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/bar",
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{"GET"},
+								},
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: nil,
+						},
+					},
+				},
+			},
+			expectedClusterConfigs: []*trafficpolicy.EgressClusterConfig{
+				{
+					Name: "foo.com:80",
+					Host: "foo.com",
+					Port: 80,
+				},
+			},
+		},
+		{
+			name: "egress policy with SMI matching routes and IP addresses specified",
+			egressPolicy: &policyV1alpha1.Egress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "egress-1",
+					Namespace: "test",
+				},
+				Spec: policyV1alpha1.EgressSpec{
+					Hosts: []string{
+						"foo.com",
+					},
+					Ports: []policyV1alpha1.PortSpec{
+						{
+							Number:   80,
+							Protocol: "http",
+						},
+					},
+					IPAddresses: []string{
+						"1.1.1.1/32",
+						"10.0.0.0/24",
+					},
+					Matches: []corev1.TypedLocalObjectReference{
+						{
+							APIGroup: pointer.StringPtr("specs.smi-spec.io/v1alpha4"),
+							Kind:     "HTTPRouteGroup",
+							Name:     "route-1",
+						},
+					},
+				},
+			},
+			egressPort: 80,
+			httpRouteGroups: []*specs.HTTPRouteGroup{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "specs.smi-spec.io/v1alpha4",
+						Kind:       "HTTPRouteGroup",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "route-1",
+						Namespace: "test",
+					},
+					Spec: spec.HTTPRouteGroupSpec{
+						Matches: []specs.HTTPMatch{
+							{
+								Name:      "match-1",
+								PathRegex: "/foo",
+								Methods:   []string{"GET"},
+							},
+						},
+					},
+				},
+			},
+			expectedRouteConfigs: []*trafficpolicy.EgressHTTPRouteConfig{
+				{
+					Name: "foo.com",
+					Hostnames: []string{
+						"foo.com",
+						"foo.com:80",
+					},
+					RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.HTTPRouteMatch{
+									Path:          "/foo",
+									PathMatchType: trafficpolicy.PathMatchRegex,
+									Methods:       []string{"GET"},
+								},
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: []string{"1.1.1.1/32", "10.0.0.0/24"},
+						},
+					},
+				},
+			},
+			expectedClusterConfigs: []*trafficpolicy.EgressClusterConfig{
+				{
+					Name: "foo.com:80",
+					Host: "foo.com",
+					Port: 80,
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
+			mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
+
+			for _, rg := range tc.httpRouteGroups {
+				mockMeshSpec.EXPECT().GetHTTPRouteGroup(fmt.Sprintf("%s/%s", rg.Namespace, rg.Name)).Return(rg).AnyTimes()
+			}
+
+			mc := &MeshCatalog{
+				meshSpec: mockMeshSpec,
+			}
+
+			routeConfigs, clusterConfigs := mc.buildHTTPRouteConfigs(tc.egressPolicy, tc.egressPort)
+			assert.ElementsMatch(tc.expectedRouteConfigs, routeConfigs)
+			assert.ElementsMatch(tc.expectedClusterConfigs, clusterConfigs)
+		})
+	}
+}
+
+func TestGetHTTPRouteMatchesFromHTTPRouteGroup(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name            string
+		httpRouteGroup  *specs.HTTPRouteGroup
+		expectedMatches []trafficpolicy.HTTPRouteMatch
+	}{
+		{
+			name: "multiple HTTP route matches",
+			httpRouteGroup: &specs.HTTPRouteGroup{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "specs.smi-spec.io/v1alpha4",
+					Kind:       "HTTPRouteGroup",
+				},
+				Spec: spec.HTTPRouteGroupSpec{
+					Matches: []specs.HTTPMatch{
+						{
+							Name:      "match-1",
+							PathRegex: "/foo",
+							Methods:   []string{"GET"},
+						},
+						{
+							Name:      "match-2",
+							PathRegex: "/bar",
+							Methods:   []string{"GET"},
+						},
+					},
+				},
+			},
+			expectedMatches: []trafficpolicy.HTTPRouteMatch{
+				{
+					Path:          "/foo",
+					PathMatchType: trafficpolicy.PathMatchRegex,
+					Methods:       []string{"GET"},
+				},
+				{
+					Path:          "/bar",
+					PathMatchType: trafficpolicy.PathMatchRegex,
+					Methods:       []string{"GET"},
+				},
+			},
+		},
+		{
+			name:            "nil HTTPRouteGroup",
+			httpRouteGroup:  nil,
+			expectedMatches: nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
+			actual := getHTTPRouteMatchesFromHTTPRouteGroup(tc.httpRouteGroup)
+
+			assert.ElementsMatch(tc.expectedMatches, actual)
+		})
+	}
+}

--- a/pkg/trafficpolicy/egress_types.go
+++ b/pkg/trafficpolicy/egress_types.go
@@ -1,8 +1,6 @@
 package trafficpolicy
 
 import (
-	mapset "github.com/deckarep/golang-set"
-
 	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 )
 
@@ -72,6 +70,5 @@ type EgressHTTPRoutingRule struct {
 	Route RouteWeightedClusters
 
 	// AllowedDestinationIPRanges defines the destination IP ranges allowed for the `Route` defined in the routing rule.
-	// Stores string type
-	AllowedDestinationIPRanges mapset.Set
+	AllowedDestinationIPRanges []string
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Implements the API in MeshCataloger to retrieve
the egress traffic policy for the given source
identity.

Updates the `AllowedDestinationIPRanges` type to
a slice for convenience. The catalog API guarantees
there will be no duplicates.

Next steps:
- Integrate API with XDS verticals

Part of #3045

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`