### PR TITLE
envoy/cds: build clusters based on egress cluster configs

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -16,6 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 const (
@@ -155,4 +157,72 @@ func getPrometheusCluster() *xds_cluster.Cluster {
 			},
 		},
 	}
+}
+
+// getEgressClusters returns a slice of XDS cluster objects for the given egress cluster configs.
+// If the cluster config is invalid, an error is logged and the corresponding cluster config is ignored.
+func getEgressClusters(clusterConfigs []*trafficpolicy.EgressClusterConfig) []*xds_cluster.Cluster {
+	if clusterConfigs == nil {
+		return nil
+	}
+
+	var egressClusters []*xds_cluster.Cluster
+	for _, config := range clusterConfigs {
+		if config.Host == "" {
+			log.Error().Msgf("Non DNS resolvable clusters are not supported for egress")
+			continue
+		}
+
+		if cluster, err := GetDNSResolvableEgressCluster(config); err != nil {
+			log.Error().Err(err).Msg("Error building cluster for the given egress cluster config")
+		} else {
+			egressClusters = append(egressClusters, cluster)
+		}
+	}
+
+	return egressClusters
+}
+
+// GetDNSResolvableEgressCluster returns an XDS cluster object that is resolved using DNS for the given egress cluster config.
+// If the egress cluster config is invalid, an error is returned.
+func GetDNSResolvableEgressCluster(config *trafficpolicy.EgressClusterConfig) (*xds_cluster.Cluster, error) {
+	if config == nil {
+		return nil, errors.New("Invalid egress cluster config: nil type")
+	}
+	if config.Name == "" {
+		return nil, errors.New("Invalid egress cluster config: Name unspecified")
+	}
+	if config.Host == "" {
+		return nil, errors.New("Invalid egress cluster config: Host unspecified")
+	}
+	if config.Port == 0 {
+		return nil, errors.New("Invalid egress cluster config: Port unspecified")
+	}
+
+	return &xds_cluster.Cluster{
+		Name:           config.Name,
+		AltStatName:    config.Name,
+		ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
+		ClusterDiscoveryType: &xds_cluster.Cluster_Type{
+			Type: xds_cluster.Cluster_STRICT_DNS,
+		},
+		LbPolicy: xds_cluster.Cluster_ROUND_ROBIN,
+		LoadAssignment: &xds_endpoint.ClusterLoadAssignment{
+			ClusterName: config.Name,
+			Endpoints: []*xds_endpoint.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*xds_endpoint.LbEndpoint{{
+						HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
+							Endpoint: &xds_endpoint.Endpoint{
+								Address: envoy.GetAddress(config.Host, uint32(config.Port)),
+							},
+						},
+						LoadBalancingWeight: &wrappers.UInt32Value{
+							Value: constants.ClusterWeightAcceptAll,
+						},
+					}},
+				},
+			},
+		},
+	}, nil
 }

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 func TestGetUpstreamServiceCluster(t *testing.T) {
@@ -216,4 +217,147 @@ func TestGetOutboundPassthroughCluster(t *testing.T) {
 	actual := getOutboundPassthroughCluster()
 
 	assert.Equal(expectedCluster, actual)
+}
+
+func TestGetEgressClusters(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name                 string
+		clusterConfigs       []*trafficpolicy.EgressClusterConfig
+		expectedClusterCount int
+	}{
+		{
+			name:                 "no cluster configs specified",
+			clusterConfigs:       nil,
+			expectedClusterCount: 0,
+		},
+		{
+			name: "all cluster configs are valid HTTP clusters",
+			clusterConfigs: []*trafficpolicy.EgressClusterConfig{
+				{
+					Name: "foo.com:80",
+					Host: "foo.com",
+					Port: 80,
+				},
+				{
+					Name: "bar.com:90",
+					Host: "bar.com",
+					Port: 90,
+				},
+			},
+			expectedClusterCount: 2,
+		},
+		{
+			name: "some cluster configs are invalid HTTP clusters",
+			clusterConfigs: []*trafficpolicy.EgressClusterConfig{
+				{
+					Name: "foo.com:80",
+					Host: "foo.com",
+					Port: 80,
+				},
+				{
+					// Host not specified, invalid cluster config
+					Name: "bar.com:90",
+					Port: 90,
+				},
+			},
+			expectedClusterCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getEgressClusters(tc.clusterConfigs)
+			assert.Len(actual, tc.expectedClusterCount)
+		})
+	}
+}
+
+func TestGetHTTPEgressCluster(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name            string
+		clusterConfig   *trafficpolicy.EgressClusterConfig
+		expectedCluster *xds_cluster.Cluster
+		expectError     bool
+	}{
+		{
+			name:            "egress cluster config is nil",
+			clusterConfig:   nil,
+			expectedCluster: nil,
+			expectError:     true,
+		},
+		{
+			name: "valid egress cluster config",
+			clusterConfig: &trafficpolicy.EgressClusterConfig{
+				Name: "foo.com:80",
+				Host: "foo.com",
+				Port: 80,
+			},
+			expectedCluster: &xds_cluster.Cluster{
+				Name:           "foo.com:80",
+				AltStatName:    "foo.com:80",
+				ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
+				ClusterDiscoveryType: &xds_cluster.Cluster_Type{
+					Type: xds_cluster.Cluster_STRICT_DNS,
+				},
+				LbPolicy: xds_cluster.Cluster_ROUND_ROBIN,
+				LoadAssignment: &xds_endpoint.ClusterLoadAssignment{
+					ClusterName: "foo.com:80",
+					Endpoints: []*xds_endpoint.LocalityLbEndpoints{
+						{
+							LbEndpoints: []*xds_endpoint.LbEndpoint{{
+								HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
+									Endpoint: &xds_endpoint.Endpoint{
+										Address: envoy.GetAddress("foo.com", 80),
+									},
+								},
+								LoadBalancingWeight: &wrappers.UInt32Value{
+									Value: constants.ClusterWeightAcceptAll,
+								},
+							}},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "egress cluster config Name unspecified",
+			clusterConfig: &trafficpolicy.EgressClusterConfig{
+				Host: "foo.com",
+				Port: 80,
+			},
+			expectedCluster: nil,
+			expectError:     true,
+		},
+		{
+			name: "egress cluster config Host unspecified",
+			clusterConfig: &trafficpolicy.EgressClusterConfig{
+				Name: "foo.com:80",
+				Port: 80,
+			},
+			expectedCluster: nil,
+			expectError:     true,
+		},
+		{
+			name: "egress cluster config Port unspecified",
+			clusterConfig: &trafficpolicy.EgressClusterConfig{
+				Name: "foo.com:80",
+				Host: "foo.com",
+			},
+			expectedCluster: nil,
+			expectError:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := GetDNSResolvableEgressCluster(tc.clusterConfig)
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedCluster, actual)
+		})
+	}
 }

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -46,6 +46,7 @@ func TestNewResponse(t *testing.T) {
 	mockCatalog.EXPECT().GetServicesForProxy(proxy).Return([]service.MeshService{tests.BookbuyerService}, nil).AnyTimes()
 	mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tests.BookbuyerServiceIdentity).Return([]service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service}).AnyTimes()
 	mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(tests.BookbuyerService).Return(map[uint32]string{uint32(80): "protocol"}, nil)
+	mockCatalog.EXPECT().GetEgressTrafficPolicy(tests.BookbuyerServiceIdentity).Return(nil, nil).AnyTimes()
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().IsEgressEnabled().Return(true).AnyTimes()
 	mockConfigurator.EXPECT().IsPrometheusScrapingEnabled().Return(true).AnyTimes()


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Builds egress clusters based on the given cluster configs.
HTTP based external clusters are resolved using DNS to
prevent malicious clients from pretending to access
the allowed host by setting the :host header in the
HTTP request while connecting to a different IP address
not associated with the actual host.

Part of #3045

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`