### PR TITLE
envoy/route: un-export package local variables

### DIFF
--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -21,11 +21,11 @@ import (
 type Direction int
 
 const (
-	// OutboundRoute is the direction for an outbound route
-	OutboundRoute Direction = iota
+	// outboundRoute is the direction for an outbound route
+	outboundRoute Direction = iota
 
-	// InboundRoute is the direction for an inbound route
-	InboundRoute
+	// inboundRoute is the direction for an inbound route
+	inboundRoute
 )
 
 const (
@@ -47,8 +47,8 @@ const (
 	// ingressVirtualHost is the prefix for the virtual host's name in the ingress route configuration
 	ingressVirtualHost = "ingress_virtual-host"
 
-	// MethodHeaderKey is the key of the header for HTTP methods
-	MethodHeaderKey = ":method"
+	// methodHeaderKey is the key of the header for HTTP methods
+	methodHeaderKey = ":method"
 
 	// httpHostHeader is the name of the HTTP host header
 	httpHostHeader = "host"
@@ -159,7 +159,7 @@ func buildInboundRoutes(rules []*trafficpolicy.Rule) []*xds_route.Route {
 
 		// Each HTTP method corresponds to a separate route
 		for _, method := range allowedMethods {
-			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, method, rule.Route.HTTPRouteMatch.Headers, rule.Route.WeightedClusters, 100, InboundRoute)
+			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, method, rule.Route.HTTPRouteMatch.Headers, rule.Route.WeightedClusters, 100, inboundRoute)
 			route.TypedPerFilterConfig = rbacPolicyForRoute
 			routes = append(routes, route)
 		}
@@ -171,7 +171,7 @@ func buildOutboundRoutes(outRoutes []*trafficpolicy.RouteWeightedClusters) []*xd
 	var routes []*xds_route.Route
 	for _, outRoute := range outRoutes {
 		emptyHeaders := map[string]string{}
-		routes = append(routes, buildRoute(trafficpolicy.PathMatchRegex, constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), OutboundRoute))
+		routes = append(routes, buildRoute(trafficpolicy.PathMatchRegex, constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), outboundRoute))
 	}
 	return routes
 }
@@ -224,7 +224,7 @@ func buildWeightedCluster(weightedClusters mapset.Set, totalWeight int, directio
 		cluster := clusterInterface.(service.WeightedCluster)
 		clusterName := string(cluster.ClusterName)
 		total += cluster.Weight
-		if direction == InboundRoute {
+		if direction == inboundRoute {
 			// An inbound route is associated with a local cluster. The inbound route is applied
 			// on the destination cluster, and the destination clusters that accept inbound
 			// traffic have the name of the form 'someClusterName-local`.
@@ -235,7 +235,7 @@ func buildWeightedCluster(weightedClusters mapset.Set, totalWeight int, directio
 			Weight: &wrappers.UInt32Value{Value: uint32(cluster.Weight)},
 		})
 	}
-	if direction == OutboundRoute {
+	if direction == outboundRoute {
 		total = totalWeight
 	}
 	wc.TotalWeight = &wrappers.UInt32Value{Value: uint32(total)}
@@ -279,7 +279,7 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 
 	// add methods header
 	methodsHeader := &xds_route.HeaderMatcher{
-		Name: MethodHeaderKey,
+		Name: methodHeaderKey,
 		HeaderMatchSpecifier: &xds_route.HeaderMatcher_SafeRegexMatch{
 			SafeRegexMatch: &xds_matcher.RegexMatcher{
 				EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -378,7 +378,7 @@ func TestBuildRoute(t *testing.T) {
 			method:        "GET",
 			headersMap:    map[string]string{"header1": "header1-val", "header2": "header2-val"},
 			totalWeight:   100,
-			direction:     OutboundRoute,
+			direction:     outboundRoute,
 			weightedClusters: mapset.NewSetFromSlice([]interface{}{
 				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 30},
 				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2"), Weight: 70},
@@ -453,7 +453,7 @@ func TestBuildRoute(t *testing.T) {
 			method:        "GET",
 			headersMap:    map[string]string{"header1": "header1-val", "header2": "header2-val"},
 			totalWeight:   100,
-			direction:     InboundRoute,
+			direction:     inboundRoute,
 			weightedClusters: mapset.NewSetFromSlice([]interface{}{
 				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100},
 			}),
@@ -523,7 +523,7 @@ func TestBuildRoute(t *testing.T) {
 			method:        "GET",
 			headersMap:    nil,
 			totalWeight:   100,
-			direction:     InboundRoute,
+			direction:     inboundRoute,
 			weightedClusters: mapset.NewSetFromSlice([]interface{}{
 				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100},
 			}),
@@ -572,7 +572,7 @@ func TestBuildRoute(t *testing.T) {
 			method:        "GET",
 			headersMap:    nil,
 			totalWeight:   100,
-			direction:     InboundRoute,
+			direction:     inboundRoute,
 			weightedClusters: mapset.NewSetFromSlice([]interface{}{
 				service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1"), Weight: 100},
 			}),
@@ -648,13 +648,13 @@ func TestBuildWeightedCluster(t *testing.T) {
 			name:             "outbound",
 			weightedClusters: weightedClusters,
 			totalWeight:      100,
-			direction:        OutboundRoute,
+			direction:        outboundRoute,
 		},
 		{
 			name:             "inbound",
 			weightedClusters: weightedClusters,
 			totalWeight:      100,
-			direction:        InboundRoute,
+			direction:        inboundRoute,
 		},
 	}
 
@@ -751,7 +751,7 @@ func TestGetHeadersForRoute(t *testing.T) {
 	}
 	actual := getHeadersForRoute(routePolicy.Methods[0], routePolicy.Headers)
 	assert.Equal(2, len(actual))
-	assert.Equal(MethodHeaderKey, actual[0].Name)
+	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[0], actual[0].GetSafeRegexMatch().Regex)
 	assert.Equal(userAgentHeader, actual[1].Name)
 	assert.Equal(routePolicy.Headers[userAgentHeader], actual[1].GetSafeRegexMatch().Regex)
@@ -764,7 +764,7 @@ func TestGetHeadersForRoute(t *testing.T) {
 	}
 	actual = getHeadersForRoute(routePolicy.Methods[1], routePolicy.Headers)
 	assert.Equal(1, len(actual))
-	assert.Equal(MethodHeaderKey, actual[0].Name)
+	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[1], actual[0].GetSafeRegexMatch().Regex)
 
 	// Returns only one HeaderMatcher for a route ignoring the host
@@ -778,7 +778,7 @@ func TestGetHeadersForRoute(t *testing.T) {
 	}
 	actual = getHeadersForRoute(routePolicy.Methods[0], routePolicy.Headers)
 	assert.Equal(2, len(actual))
-	assert.Equal(MethodHeaderKey, actual[0].Name)
+	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[0], actual[0].GetSafeRegexMatch().Regex)
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Un-exports variables used within the package scope.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`