### PR TITLE
fix(hostHeaders) : updating host headers configuration on envoy

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -77,7 +77,7 @@ func RestockBooks(amount int) {
 	client := &http.Client{}
 	requestBody := strings.NewReader(strconv.Itoa(1))
 	req, err := http.NewRequest("POST", chargeAccountURL, requestBody)
-	req.Header.Add("host", fmt.Sprintf("%s.%s", warehouseServiceName, bookwarehouseNamespace))
+	req.Host = (fmt.Sprintf("%s.%s", warehouseServiceName, bookwarehouseNamespace))
 
 	if err != nil {
 		log.Error().Err(err).Msgf("RestockBooks: error posting to %s", chargeAccountURL)

--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -50,10 +50,10 @@ const (
 	// methodHeaderKey is the key of the header for HTTP methods
 	methodHeaderKey = ":method"
 
-	// httpHostHeader is the name of the HTTP host header
-	httpHostHeader = "host"
+	// httpHostHeaderKey is the name of the HTTP host header in HTTPRouteMatch.Headers, specified via SMI
+	httpHostHeaderKey = "host"
 
-	// authorityHeaderKey is the key of the header for HTTP methods
+	// authorityHeaderKey is the key corresponding to the HTTP Host/Authority header programmed as a header matcher in an Envoy route
 	authorityHeaderKey = ":authority"
 )
 
@@ -289,7 +289,7 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 	headers = append(headers, methodsHeader)
 
 	// add host headers
-	if hostHeaderValue, ok := headersMap[httpHostHeader]; ok {
+	if hostHeaderValue, ok := headersMap[httpHostHeaderKey]; ok {
 		hostHeader := &xds_route.HeaderMatcher{
 			Name: authorityHeaderKey,
 			HeaderMatchSpecifier: &xds_route.HeaderMatcher_SafeRegexMatch{
@@ -305,7 +305,7 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 	// add all other custom headers
 	for headerKey, headerValue := range headersMap {
 		// omit the host header as this is configured above
-		if headerKey == httpHostHeader {
+		if headerKey == httpHostHeaderKey {
 			continue
 		}
 		header := xds_route.HeaderMatcher{

--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -50,7 +50,7 @@ const (
 	// methodHeaderKey is the key of the header for HTTP methods
 	methodHeaderKey = ":method"
 
-	// httpHostHeaderKey is the name of the HTTP host header in HTTPRouteMatch.Headers, specified via SMI
+	// httpHostHeaderKey is the name of the HTTP host header in HTTPRouteMatch.Headers
 	httpHostHeaderKey = "host"
 
 	// authorityHeaderKey is the key corresponding to the HTTP Host/Authority header programmed as a header matcher in an Envoy route

--- a/pkg/envoy/route/route_config.go
+++ b/pkg/envoy/route/route_config.go
@@ -52,6 +52,9 @@ const (
 
 	// httpHostHeader is the name of the HTTP host header
 	httpHostHeader = "host"
+
+	// authorityHeaderKey is the key of the header for HTTP methods
+	authorityHeaderKey = ":authority"
 )
 
 // BuildRouteConfiguration constructs the Envoy constructs ([]*xds_route.RouteConfiguration) for implementing inbound and outbound routes
@@ -177,7 +180,6 @@ func buildOutboundRoutes(outRoutes []*trafficpolicy.RouteWeightedClusters) []*xd
 }
 
 func buildRoute(pathMatchTypeType trafficpolicy.PathMatchType, path string, method string, headersMap map[string]string, weightedClusters mapset.Set, totalWeight int, direction Direction) *xds_route.Route {
-	hostHeader := headersMap[httpHostHeader]
 	route := xds_route.Route{
 		Match: &xds_route.RouteMatch{
 			Headers: getHeadersForRoute(method, headersMap),
@@ -186,9 +188,6 @@ func buildRoute(pathMatchTypeType trafficpolicy.PathMatchType, path string, meth
 			Route: &xds_route.RouteAction{
 				ClusterSpecifier: &xds_route.RouteAction_WeightedClusters{
 					WeightedClusters: buildWeightedCluster(weightedClusters, totalWeight, direction),
-				},
-				HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-					HostRewriteLiteral: hostHeader,
 				},
 			},
 		},
@@ -289,9 +288,23 @@ func getHeadersForRoute(method string, headersMap map[string]string) []*xds_rout
 	}
 	headers = append(headers, methodsHeader)
 
+	// add host headers
+	if hostHeaderValue, ok := headersMap[httpHostHeader]; ok {
+		hostHeader := &xds_route.HeaderMatcher{
+			Name: authorityHeaderKey,
+			HeaderMatchSpecifier: &xds_route.HeaderMatcher_SafeRegexMatch{
+				SafeRegexMatch: &xds_matcher.RegexMatcher{
+					EngineType: &xds_matcher.RegexMatcher_GoogleRe2{GoogleRe2: &xds_matcher.RegexMatcher_GoogleRE2{}},
+					Regex:      hostHeaderValue,
+				},
+			},
+		}
+		headers = append(headers, hostHeader)
+	}
+
 	// add all other custom headers
 	for headerKey, headerValue := range headersMap {
-		// omit the host header as this is configured in the HostRewriteSpecifier
+		// omit the host header as this is configured above
 		if headerKey == httpHostHeader {
 			continue
 		}

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -236,14 +236,14 @@ func TestBuildVirtualHostStub(t *testing.T) {
 		{
 			name:         "inbound virtual host",
 			namePrefix:   inboundVirtualHost,
-			host:         httpHostHeader,
+			host:         httpHostHeaderKey,
 			domains:      []string{"domain1", "domain2"},
 			expectedName: "inbound_virtual-host|host",
 		},
 		{
 			name:         "outbound virtual host",
 			namePrefix:   outboundVirtualHost,
-			host:         httpHostHeader,
+			host:         httpHostHeaderKey,
 			domains:      []string{"domain1", "domain2"},
 			expectedName: "outbound_virtual-host|host",
 		},

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -439,9 +439,6 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
-						},
 					},
 				},
 			},
@@ -509,9 +506,6 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
-						},
 					},
 				},
 			},
@@ -558,9 +552,6 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
-						},
 					},
 				},
 			},
@@ -606,9 +597,6 @@ func TestBuildRoute(t *testing.T) {
 								},
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
-						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
 						},
 					},
 				},
@@ -767,19 +755,21 @@ func TestGetHeadersForRoute(t *testing.T) {
 	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[1], actual[0].GetSafeRegexMatch().Regex)
 
-	// Returns only one HeaderMatcher for a route ignoring the host
+	// Returns only HeaderMatcher for the method and host header (:authority)
 	routePolicy = trafficpolicy.HTTPRouteMatch{
 		Path:          "/books-bought",
 		PathMatchType: trafficpolicy.PathMatchRegex,
 		Methods:       []string{"GET", "POST"},
 		Headers: map[string]string{
-			"user-agent": tests.HTTPUserAgent,
+			"host": tests.HTTPHostHeader,
 		},
 	}
 	actual = getHeadersForRoute(routePolicy.Methods[0], routePolicy.Headers)
 	assert.Equal(2, len(actual))
 	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[0], actual[0].GetSafeRegexMatch().Regex)
+	assert.Equal(authorityHeaderKey, actual[1].Name)
+	assert.Equal(tests.HTTPHostHeader, actual[1].GetSafeRegexMatch().Regex)
 }
 
 func TestLen(t *testing.T) {


### PR DESCRIPTION
**Description**:

This commit removed host rewite and adds a header match when host header
is provided via SMI

Fixes #3283

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
