### PR TITLE
fix(cli): check mesh exists before namespace add

### DIFF
--- a/cmd/cli/mesh_list_test.go
+++ b/cmd/cli/mesh_list_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,13 +25,6 @@ var _ = Describe("Running the mesh list command", func() {
 			listCmd       *meshListCmd
 		)
 
-		// helper function that adds deployment to the clientset
-		addDeployment := func(depName, meshName, namespace string, osmVersion string, isMesh bool) {
-			dep := createDeployment(depName, meshName, osmVersion, isMesh)
-			_, err := fakeClientSet.AppsV1().Deployments(namespace).Create(context.TODO(), dep, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		}
-
 		// helper function that takes element from slice and returns the name for gomega struct
 		// https://onsi.github.io/gomega/#gstruct-testing-complex-data-types
 		idSelector := func(element interface{}) string {
@@ -47,9 +39,9 @@ var _ = Describe("Running the mesh list command", func() {
 		}
 
 		It("should print only correct meshes", func() {
-			addDeployment("osm-controller-1", "testMesh1", "testNs1", "testVersion0.1.2", true)
-			addDeployment("osm-controller-2", "testMesh2", "testNs2", "testVersion0.1.3", true)
-			addDeployment("not-osm-controller", "", "testNs3", "", false)
+			addDeployment(fakeClientSet, "osm-controller-1", "testMesh1", "testNs1", true)
+			addDeployment(fakeClientSet, "osm-controller-2", "testMesh2", "testNs2", true)
+			addDeployment(fakeClientSet, "not-osm-controller", "", "testNs3", false)
 
 			deployments, err = getControllerDeployments(listCmd.clientSet)
 			Expect(err).NotTo(HaveOccurred())
@@ -119,21 +111,3 @@ var _ = Describe("Running the mesh list command", func() {
 		})
 	})
 })
-
-func createDeployment(deploymentName, meshName string, osmVersion string, isMesh bool) *v1.Deployment {
-	labelMap := make(map[string]string)
-	if isMesh {
-		labelMap["app"] = constants.OSMControllerName
-		labelMap["meshName"] = meshName
-		labelMap[constants.OSMAppVersionLabelKey] = osmVersion
-	} else {
-		labelMap["app"] = "non-mesh-app"
-	}
-	dep := &v1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   deploymentName,
-			Labels: labelMap,
-		},
-	}
-	return dep
-}

--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -66,7 +66,7 @@ func createFakeController(fakeClient kubernetes.Interface) error {
 		return err
 	}
 
-	controllerDep := createDeployment("test-controller", testMesh, "testVersion0.1.2", true)
+	controllerDep := createDeployment("test-controller", testMesh, true)
 	if _, err := fakeClient.AppsV1().Deployments(controllerNs.Name).Create(context.TODO(), controllerDep, metav1.CreateOptions{}); err != nil {
 		return err
 	}

--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -77,7 +77,7 @@ func RestockBooks(amount int) {
 	client := &http.Client{}
 	requestBody := strings.NewReader(strconv.Itoa(1))
 	req, err := http.NewRequest("POST", chargeAccountURL, requestBody)
-	req.Header.Add("host", fmt.Sprintf("%s.%s", warehouseServiceName, bookwarehouseNamespace))
+	req.Host = (fmt.Sprintf("%s.%s", warehouseServiceName, bookwarehouseNamespace))
 
 	if err != nil {
 		log.Error().Err(err).Msgf("RestockBooks: error posting to %s", chargeAccountURL)

--- a/pkg/envoy/route/route_config_test.go
+++ b/pkg/envoy/route/route_config_test.go
@@ -236,14 +236,14 @@ func TestBuildVirtualHostStub(t *testing.T) {
 		{
 			name:         "inbound virtual host",
 			namePrefix:   inboundVirtualHost,
-			host:         httpHostHeader,
+			host:         httpHostHeaderKey,
 			domains:      []string{"domain1", "domain2"},
 			expectedName: "inbound_virtual-host|host",
 		},
 		{
 			name:         "outbound virtual host",
 			namePrefix:   outboundVirtualHost,
-			host:         httpHostHeader,
+			host:         httpHostHeaderKey,
 			domains:      []string{"domain1", "domain2"},
 			expectedName: "outbound_virtual-host|host",
 		},
@@ -439,9 +439,6 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
-						},
 					},
 				},
 			},
@@ -509,9 +506,6 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
-						},
 					},
 				},
 			},
@@ -558,9 +552,6 @@ func TestBuildRoute(t *testing.T) {
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
 						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
-						},
 					},
 				},
 			},
@@ -606,9 +597,6 @@ func TestBuildRoute(t *testing.T) {
 								},
 								TotalWeight: &wrappers.UInt32Value{Value: 100},
 							},
-						},
-						HostRewriteSpecifier: &xds_route.RouteAction_HostRewriteLiteral{
-							HostRewriteLiteral: "",
 						},
 					},
 				},
@@ -767,19 +755,21 @@ func TestGetHeadersForRoute(t *testing.T) {
 	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[1], actual[0].GetSafeRegexMatch().Regex)
 
-	// Returns only one HeaderMatcher for a route ignoring the host
+	// Returns only HeaderMatcher for the method and host header (:authority)
 	routePolicy = trafficpolicy.HTTPRouteMatch{
 		Path:          "/books-bought",
 		PathMatchType: trafficpolicy.PathMatchRegex,
 		Methods:       []string{"GET", "POST"},
 		Headers: map[string]string{
-			"user-agent": tests.HTTPUserAgent,
+			"host": tests.HTTPHostHeader,
 		},
 	}
 	actual = getHeadersForRoute(routePolicy.Methods[0], routePolicy.Headers)
 	assert.Equal(2, len(actual))
 	assert.Equal(methodHeaderKey, actual[0].Name)
 	assert.Equal(routePolicy.Methods[0], actual[0].GetSafeRegexMatch().Regex)
+	assert.Equal(authorityHeaderKey, actual[1].Name)
+	assert.Equal(tests.HTTPHostHeader, actual[1].GetSafeRegexMatch().Regex)
 }
 
 func TestLen(t *testing.T) {


### PR DESCRIPTION
The command `osm namespace` add should check if
the mesh exists before adding the namespace.
Otherwise the user may be mislead into thinking
that the namespace is part of a mesh despite
forgetting to run the install command.

Resolves #2494

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A
