### PR TITLE
fix(cli): check mesh exists before namespace add

### DIFF
--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -5,10 +5,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/onsi/gomega/gstruct"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -32,11 +31,43 @@ var _ = Describe("Running the namespace add command", func() {
 			err           error
 		)
 
+		Context("adding pre-existing namespace to non-existent mesh", func() {
+
+			BeforeEach(func() {
+				out = new(bytes.Buffer)
+				fakeClientSet = fake.NewSimpleClientset()
+
+				nsSpec := createNamespaceSpec(testNamespace, "", false)
+				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
+
+				namespaceAddCmd := &namespaceAddCmd{
+					out:        out,
+					meshName:   testMeshName,
+					namespaces: []string{testNamespace},
+					clientSet:  fakeClientSet,
+				}
+
+				err = namespaceAddCmd.run()
+			})
+
+			It("should error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should give error about non-existent mesh", func() {
+				Expect(err.Error()).To(Equal(fmt.Sprintf("Mesh [%s] does not exist. Please specify another mesh using --mesh-name or create a new mesh.", testMeshName)))
+			})
+		})
+
 		Context("given one namespace as an arg without sidecar injection enabled", func() {
 
 			BeforeEach(func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
+
+				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
 				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
@@ -79,6 +110,9 @@ var _ = Describe("Running the namespace add command", func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
 
+				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				Expect(err).To(BeNil())
+
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
 				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -119,6 +153,9 @@ var _ = Describe("Running the namespace add command", func() {
 			BeforeEach(func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
+
+				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", true)
 				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
@@ -167,6 +204,9 @@ var _ = Describe("Running the namespace add command", func() {
 				fakeClientSet = fake.NewSimpleClientset()
 				testNamespace2 = "namespace2"
 
+				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				Expect(err).To(BeNil())
+
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
 				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
@@ -213,6 +253,9 @@ var _ = Describe("Running the namespace add command", func() {
 				_, err = fakeClientSet.AppsV1().Deployments(testNamespace).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 
+				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				Expect(err).To(BeNil())
+
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
 				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
@@ -237,29 +280,71 @@ var _ = Describe("Running the namespace add command", func() {
 	})
 
 	Describe("with non-existent namespace", func() {
-		var (
-			out           *bytes.Buffer
-			fakeClientSet kubernetes.Interface
-			err           error
-		)
 
-		BeforeEach(func() {
-			out = new(bytes.Buffer)
-			fakeClientSet = fake.NewSimpleClientset()
+		Context("adding non-existent namespace to a non-existent mesh", func() {
 
-			namespaceAddCmd := &namespaceAddCmd{
-				out:        out,
-				meshName:   testMeshName,
-				namespaces: []string{testNamespace},
-				clientSet:  fakeClientSet,
-			}
+			var (
+				out           *bytes.Buffer
+				fakeClientSet kubernetes.Interface
+				err           error
+			)
 
-			err = namespaceAddCmd.run()
+			BeforeEach(func() {
+				out = new(bytes.Buffer)
+				fakeClientSet = fake.NewSimpleClientset()
+
+				nsSpec := createNamespaceSpec(testNamespace, "", false)
+				_, err = fakeClientSet.CoreV1().Namespaces().Create(context.TODO(), nsSpec, metav1.CreateOptions{})
+				Expect(err).To(BeNil())
+
+				namespaceAddCmd := &namespaceAddCmd{
+					out:        out,
+					meshName:   testMeshName,
+					namespaces: []string{testNamespace},
+					clientSet:  fakeClientSet,
+				}
+
+				err = namespaceAddCmd.run()
+			})
+
+			It("should error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should give error about non-existent mesh", func() {
+				Expect(err.Error()).To(Equal(fmt.Sprintf("Mesh [%s] does not exist. Please specify another mesh using --mesh-name or create a new mesh.", testMeshName)))
+			})
 		})
 
-		It("should error", func() {
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal(fmt.Sprintf("Could not add namespace [%s] to mesh [%s]: namespaces \"%s\" not found", testNamespace, testMeshName, testNamespace)))
+		Context("adding non-existent namespace to a mesh that exists", func() {
+
+			var (
+				out           *bytes.Buffer
+				fakeClientSet kubernetes.Interface
+				err           error
+			)
+
+			BeforeEach(func() {
+				out = new(bytes.Buffer)
+				fakeClientSet = fake.NewSimpleClientset()
+
+				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				Expect(err).To(BeNil())
+
+				namespaceAddCmd := &namespaceAddCmd{
+					out:        out,
+					meshName:   testMeshName,
+					namespaces: []string{testNamespace},
+					clientSet:  fakeClientSet,
+				}
+
+				err = namespaceAddCmd.run()
+			})
+
+			It("should error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(fmt.Sprintf("Could not add namespace [%s] to mesh [%s]: namespaces \"%s\" not found", testNamespace, testMeshName, testNamespace)))
+			})
 		})
 	})
 })


### PR DESCRIPTION
The command osm namespace add should check if
the mesh exists before adding the namespace.
Otherwise the user may be mislead into thinking
that the namespace is part of a mesh despite
forgetting to run the install command.

Resolves #2494

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A.
