### PR TITLE
feat(cli): show mesh list on uninstall

### DIFF
--- a/cmd/cli/mesh_list_test.go
+++ b/cmd/cli/mesh_list_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Running the mesh list command", func() {
 		})
 		It("should print no meshes found message", func() {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(out.String()).To(Equal("No control planes found\n"))
+			Expect(out.String()).To(Equal("No osm mesh control planes found\n"))
 		})
 	})
 })

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -2,11 +2,23 @@ package main
 
 import (
 	"bufio"
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 )
 
 // confirm displays a prompt `s` to the user and returns a bool indicating yes / no
@@ -34,11 +46,151 @@ func confirm(stdin io.Reader, stdout io.Writer, s string, tries int) (bool, erro
 		case "n":
 			return false, nil
 		default:
+			fmt.Fprintf(stdout, "Invalid input.\n")
 			continue
 		}
 	}
 
 	return false, nil
+}
+
+// getPrettyPrintedMeshInfoList a pretty printed list of meshes.
+// If showIndex is true, then a 1-indexed number is prepended before each mesh.
+func getPrettyPrintedMeshInfoList(meshInfoList []meshInfo) string {
+	s := "\nMESH NAME\tNAMESPACE\tCONTROLLER PODS\tVERSION\tSMI SUPPORTED\n"
+
+	for _, meshInfo := range meshInfoList {
+		m := fmt.Sprintf(
+			"%s\t%s\t%s\t%s\t%s\n",
+			meshInfo.name,
+			meshInfo.namespace,
+			strings.Join(meshInfo.controllerPods, ","),
+			meshInfo.version,
+			strings.Join(meshInfo.smiSupportedVersions, ","),
+		)
+		s += m
+	}
+
+	return s
+}
+
+// getMeshInfoList returns a list of meshes (including the info of each mesh) within the cluster
+func getMeshInfoList(restConfig *rest.Config, clientSet kubernetes.Interface, localPort uint16) ([]meshInfo, error) {
+	var meshInfoList []meshInfo
+
+	osmControllerDeployments, err := getControllerDeployments(clientSet)
+	if err != nil {
+		return meshInfoList, errors.Errorf("Could not list deployments %v", err)
+	}
+	if len(osmControllerDeployments.Items) == 0 {
+		return meshInfoList, nil
+	}
+
+	for _, osmControllerDeployment := range osmControllerDeployments.Items {
+		meshName := osmControllerDeployment.ObjectMeta.Labels["meshName"]
+		meshNamespace := osmControllerDeployment.ObjectMeta.Namespace
+		meshControllerPods := getNamespacePods(clientSet, meshName, meshNamespace)
+
+		meshVersion := osmControllerDeployment.ObjectMeta.Labels[constants.OSMAppVersionLabelKey]
+		if meshVersion == "" {
+			meshVersion = "Unknown"
+		}
+
+		meshSmiSupportedVersions := []string{"Unknown"}
+		if pods, ok := meshControllerPods["Pods"]; ok && len(pods) > 0 {
+			smiMap, err := getSupportedSmiForControllerPod(meshControllerPods["Pods"][0], meshNamespace, restConfig, clientSet, localPort)
+			if err == nil {
+				meshSmiSupportedVersions = []string{}
+				for smi, version := range smiMap {
+					meshSmiSupportedVersions = append(meshSmiSupportedVersions, fmt.Sprintf("%s:%s", smi, version))
+				}
+			}
+		}
+
+		meshInfoList = append(meshInfoList, meshInfo{
+			name:                 meshName,
+			namespace:            meshNamespace,
+			controllerPods:       meshControllerPods["Pods"],
+			version:              meshVersion,
+			smiSupportedVersions: meshSmiSupportedVersions,
+		})
+	}
+
+	return meshInfoList, nil
+}
+
+// getNamespacePods returns a map of controller pods
+func getNamespacePods(clientSet kubernetes.Interface, m string, ns string) map[string][]string {
+	x := make(map[string][]string)
+
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": constants.OSMControllerName}}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+	pods, _ := clientSet.CoreV1().Pods(ns).List(context.TODO(), listOptions)
+
+	for pno := 0; pno < len(pods.Items); pno++ {
+		x["Pods"] = append(x["Pods"], pods.Items[pno].GetName())
+	}
+
+	return x
+}
+
+// getControllerDeployments returns a list of Deployments corresponding to osm-controller
+func getControllerDeployments(clientSet kubernetes.Interface) (*v1.DeploymentList, error) {
+	deploymentsClient := clientSet.AppsV1().Deployments("") // Get deployments from all namespaces
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": constants.OSMControllerName}}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+	return deploymentsClient.List(context.TODO(), listOptions)
+}
+
+// getMeshNames returns a set of mesh names corresponding to meshes within the cluster
+func getMeshNames(clientSet kubernetes.Interface) mapset.Set {
+	meshList := mapset.NewSet()
+
+	deploymentList, _ := getControllerDeployments(clientSet)
+	for _, elem := range deploymentList.Items {
+		meshList.Add(elem.ObjectMeta.Labels["meshName"])
+	}
+
+	return meshList
+}
+
+func getSupportedSmiForControllerPod(pod string, namespace string, restConfig *rest.Config, clientSet kubernetes.Interface, localPort uint16) (map[string]string, error) {
+	dialer, err := k8s.DialerToPod(restConfig, clientSet, pod, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", localPort, constants.OSMHTTPServerPort))
+	if err != nil {
+		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+	}
+
+	var smiSupported map[string]string
+
+	err = portForwarder.Start(func(pf *k8s.PortForwarder) error {
+		defer pf.Stop()
+		url := fmt.Sprintf("http://localhost:%d%s", localPort, constants.HTTPServerSmiVersionPath)
+
+		// #nosec G107: Potential HTTP request made with variable url
+		resp, err := http.Get(url)
+		if err != nil {
+			return errors.Errorf("Error fetching url %s: %s", url, err)
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&smiSupported); err != nil {
+			return errors.Errorf("Error rendering HTTP response: %s", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Errorf("Error retrieving supported SMI versions for pod %s in namespace %s: %s", pod, namespace, err)
+	}
+
+	return smiSupported, nil
 }
 
 func annotateErrorMessageWithOsmNamespace(errMsgFormat string, args ...interface{}) error {

--- a/cmd/cli/util_test.go
+++ b/cmd/cli/util_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	tassert "github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +81,47 @@ func TestAnnotateErrorMessageWithOsmNamespace(t *testing.T) {
 		})
 	}
 }
+
+var _ = Describe("Test getting pretty printed output of a list of meshes", func() {
+	var (
+		meshInfoList []meshInfo
+	)
+
+	Context("empty mesh list", func() {
+
+		meshInfoList = []meshInfo{}
+		pp := getPrettyPrintedMeshInfoList(meshInfoList)
+
+		It("should have correct output", func() {
+			Expect(pp).To(Equal("\nMESH NAME\tNAMESPACE\tCONTROLLER PODS\tVERSION\tSMI SUPPORTED\n"))
+		})
+	})
+
+	Context("non-empty mesh list", func() {
+
+		meshInfoList = []meshInfo{
+			{
+				name:                 "m1",
+				namespace:            "ns1",
+				controllerPods:       []string{"p1", "p2", "p3"},
+				version:              "v1",
+				smiSupportedVersions: []string{"s1", "s2", "s3"},
+			},
+			{
+				name:                 "m2",
+				namespace:            "ns2",
+				controllerPods:       []string{"p3", "p4", "p5"},
+				version:              "v2",
+				smiSupportedVersions: []string{"s3", "s4", "s5"},
+			},
+		}
+
+		It("should have correct output", func() {
+			Expect(getPrettyPrintedMeshInfoList(meshInfoList)).To(Equal("\nMESH NAME\tNAMESPACE\tCONTROLLER PODS\tVERSION\tSMI SUPPORTED\nm1\tns1\tp1,p2,p3\tv1\ts1,s2,s3\nm2\tns2\tp3,p4,p5\tv2\ts3,s4,s5\n"))
+		})
+
+	})
+})
 
 // helper function for tests that adds deployment to the clientset
 func addDeployment(fakeClientSet kubernetes.Interface, depName string, meshName string, namespace string, osmVersion string, isMesh bool) (*v1.Deployment, error) {


### PR DESCRIPTION
The current `osm uninstall` experience is
ambiguous as to which mesh it uninstall.
This modifies `osm uninstall` so that it
lists out all mesh deployments in the cluster
for better clarity as to which mesh is being
uninstalled.

Also refactors several cli helpers to
better serve the cli portion of the codebase.

Resolves #1839.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>


<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [X]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [X]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? No. If so, did you notify the maintainers and provide attribution? N/A.
