### PR TITLE
feat(podLevelPortExclusion): Add outbound port exclusion list at pod level

### DIFF
--- a/docs/content/docs/tasks_usage/traffic_management/iptables_redirection.md
+++ b/docs/content/docs/tasks_usage/traffic_management/iptables_redirection.md
@@ -75,11 +75,15 @@ OSM provides a means to specify a global list of IP ranges to exclude from outbo
 
 Excluded IP ranges are stored in the `osm-config` ConfigMap with the key `outbound_ip_range_exclusion_list`, and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable IP ranges are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded IP ranges will not be intercepted for traffic redirection to the Envoy proxy sidecar.
 
-### Global outbound port exclusions
+### Outbound port exclusion
 
 Outbound TCP based traffic from applications is by default intercepted using the `iptables` rules programmed by OSM, and redirected to the Envoy proxy sidecar. In some cases, it might be desirable to not subject certain ports to be redirected and routed by the Envoy proxy sidecar based on service mesh policies. A common use case to exclude ports is to not route non-application logic based traffic via the Envoy proxy, such as control plane traffic. In such scenarios, excluding certain ports from being subject to service mesh traffic routing policies becomes necessary.
 
-OSM provides a means to specify a global list of IP ranges to exclude from outbound traffic interception in the following ways:
+#### 1. Global outbound port exclusions
+
+In this set up the port exclusions would be applicable to all pods/services on the mesh.
+
+OSM provides a means to specify a global list of ports to exclude from outbound traffic interception in the following ways:
 
 1. During OSM install using the `--set` option:
     ```bash
@@ -98,7 +102,19 @@ OSM provides a means to specify a global list of IP ranges to exclude from outbo
     osm mesh upgrade --outbound-port-exclusion-list "6379,7070"
     ```
 
-Excluded ports are stored in the `osm-config` ConfigMap with the key `outbound_port_exclusion_list`, and is read at the time of sidecar injection by `osm-injector`. These dynamically configurable ports are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded ports will not be intercepted for traffic redirection to the Envoy proxy sidecar.
+#### 2. Pod level outbound port exclusions
+
+In this setup the port exclusions would be applicable to a specific pod. 
+
+OSM provides a means to specify a list of ports to exclude from outbound traffic interception at pod level in the following way:
+
+1. By annotating the pod with  `openservicemesh.io/outbound-port-exclusion-list=<list of comma separated ports>` option:
+    ```bash
+    # To exclude the ports 6379 and 7070 from outbound interception on the pod
+    kubectl annotate pod <pod> openservicemesh.io/outbound-port-exclusion-list=6379,7070
+    ```
+
+Excluded ports are stored in the `osm-config` ConfigMap with the key `outbound_port_exclusion_list` and as an annotation on the pod. Both of these are read and merged at the time of sidecar injection by `osm-injector`. These dynamically configurable ports are programmed by the init container along with the static rules used to intercept and redirect traffic via the Envoy proxy sidecar. Excluded ports will not be intercepted for traffic redirection to the Envoy proxy sidecar.
 
 ## Sample demo
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -46,6 +46,7 @@ Independent of tiers, tests are also organized into buckets. Each bucket runs in
 | e2e_hashivault_test.go| 2 | 2
 | e2e_certmanager_test.go | 2 | 2
 | e2e_ip_exclusion_test.go | 2 | 3
+| e2e_port_exclusion_test.go | 2 | 3
 | e2e_grpc_secure_origination_test.go | 2 | 3
 | e2e_multiple_services_per_pod_test.go | 2 | 3
 | e2e_metrics_test.go | 2 | 4

--- a/tests/e2e/e2e_port_exclusion_test.go
+++ b/tests/e2e/e2e_port_exclusion_test.go
@@ -1,0 +1,193 @@
+package e2e
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Tests traffic via port exclusion",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 3,
+	},
+	func() {
+		Context("Test global port exclusion", func() {
+			testGlobalPortExclusion()
+		})
+
+		Context("Test pod level port exclusion", func() {
+			testPodLevelPortExclusion()
+		})
+	})
+
+func testGlobalPortExclusion() {
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
+
+	It("Tests HTTP traffic to external server via global port exclusion", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = false // explicitly set to false to demonstrate port exclusion
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
+		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
+
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+		}
+		// Only add source namespace to the mesh, destination is simulating an external cluster
+		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
+
+		// Set up the destination HTTP server. It is not part of the mesh
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      destName,
+				Namespace: destName,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		// The destination port will be programmed as an global port exclusion
+		destinationPort := fmt.Sprintf("%v", dstSvc.Spec.Ports[0].Port)
+		meshConfig.Spec.Traffic.OutboundPortExclusionList = []string{destinationPort}
+		_, err = Td.UpdateOSMConfig(meshConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		srcPod := setupSource(sourceName, false)
+
+		By("Using global port exclusion to access destination")
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
+
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination with port %s", srcPod.Name, destinationPort)
+	})
+}
+
+func testPodLevelPortExclusion() {
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
+
+	It("Tests HTTP traffic to external server via pod level port exclusion", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = false // explicitly set to false to demonstrate port exclusion
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+		}
+		// Only add source namespace to the mesh, destination is simulating an external cluster
+		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
+
+		// Set up the destination HTTP server. It is not part of the mesh
+		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			SimplePodAppDef{
+				Name:      destName,
+				Namespace: destName,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+			})
+
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+
+		// Set up the source curl client. It will be a part of the mesh
+		svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+			Name:      sourceName,
+			Namespace: sourceName,
+			Command:   []string{"sleep", "365d"},
+			Image:     "curlimages/curl",
+			Ports:     []int{80},
+		})
+
+		_, err = Td.CreateServiceAccount(sourceName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The destination port will be programmed as an annotation on the source pod for port exclusion
+		destinationPort := fmt.Sprintf("%v", dstSvc.Spec.Ports[0].Port)
+		podDef.Annotations = map[string]string{"openservicemesh.io/outbound-port-exclusion-list": destinationPort}
+
+		srcPod, err := Td.CreatePod(sourceName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateService(sourceName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+
+		By("Using pod level port exclusion to access destination")
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, 90*time.Second)
+
+		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic from source pod %s to destination with port %s", srcPod.Name, destinationPort)
+	})
+}


### PR DESCRIPTION
**Description**:

This commit adds support for a pod level annotation, that allows ports
mentioned as a part of this annotation to be excluded from proxy
redirection.

Fixes #3251

Signed-off-by: Sneha Chhabria snchh@microsoft.com

**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
