### PR TITLE
feat(proxyResources): Add configurable proxy resources in configmap

### DIFF
--- a/charts/osm/templates/osm-configmap.yaml
+++ b/charts/osm/templates/osm-configmap.yaml
@@ -32,3 +32,8 @@ data:
 {{- if .Values.OpenServiceMesh.outboundPortExclusionList }}
   outbound_port_exclusion_list: {{ join "," .Values.OpenServiceMesh.outboundPortExclusionList | quote }}
 {{- end}}
+
+  proxy_limit_cpu: {{ .Values.OpenServiceMesh.injector.proxyResources.limits.cpu }}
+  proxy_limit_memory: {{ .Values.OpenServiceMesh.injector.proxyResources.limits.memory }}
+  proxy_requests_cpu: {{ .Values.OpenServiceMesh.injector.proxyResources.requests.cpu }}
+  proxy_requests_memory: {{ .Values.OpenServiceMesh.injector.proxyResources.requests.memory }}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -158,6 +158,15 @@ OpenServiceMesh:
         cpu: "0.3"
         memory: "64M"
     podLabels: {}
+    # Allows specifying resource constraints for proxy containers
+    # Missing or empty value in configmap implies `Resources` value will not be configured in the injected proxies.
+    proxyResources:
+      limits:
+        cpu: ""
+        memory: ""
+      requests:
+        cpu: ""
+        memory: ""
 
   # -- Run init container in privileged mode
   enablePrivilegedInitContainer: false

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -70,6 +70,18 @@ const (
 
 	// configResyncInterval is the key name used to configure the resync interval for regular proxy broadcast updates
 	configResyncInterval = "config_resync_interval"
+
+	// proxyLimitCPU is the cpu limit to apply to injected proxy containers
+	proxyLimitCPU = "proxy_limit_cpu"
+
+	// proxyLimitMemory is the memory limit to apply to injected proxy containers
+	proxyLimitMemory = "proxy_limit_memory"
+
+	// proxyRequestsCPU is the cpu request to apply to injected proxy containers
+	proxyRequestsCPU = "proxy_requests_cpu"
+
+	// proxyRequestsMemory is the memory request to apply to injected proxy containers
+	proxyRequestsMemory = "proxy_requests_memory"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -262,6 +274,18 @@ type osmConfig struct {
 
 	// ConfigResyncInterval is a flag to configure resync interval for regular proxy broadcast updates
 	ConfigResyncInterval string `yaml:"config_resync_interval"`
+
+	// ProxyLimitCPU is the cpu limit to apply to injected proxy containers
+	ProxyLimitCPU string `yaml:"proxy_limit_cpu"`
+
+	// ProxyLimitMemory is the memory limit to apply to injected proxy containers
+	ProxyLimitMemory string `yaml:"proxy_limit_memory"`
+
+	// ProxyRequestsCPU is the cpu request to apply to injected proxy containers
+	ProxyRequestsCPU string `yaml:"proxy_requests_cpu"`
+
+	// ProxyRequestsMemory is the memory request to apply to injected proxy containers
+	ProxyRequestsMemory string `yaml:"proxy_requests_memory"`
 }
 
 func (c *Client) run(stop <-chan struct{}) {
@@ -320,6 +344,10 @@ func parseOSMConfigMap(configMap *v1.ConfigMap) *osmConfig {
 	osmConfigMap.OutboundPortExclusionList, _ = GetStringValueForKey(configMap, outboundPortExclusionListKey)
 	osmConfigMap.EnablePrivilegedInitContainer, _ = GetBoolValueForKey(configMap, enablePrivilegedInitContainer)
 	osmConfigMap.ConfigResyncInterval, _ = GetStringValueForKey(configMap, configResyncInterval)
+	osmConfigMap.ProxyLimitCPU, _ = GetStringValueForKey(configMap, proxyLimitCPU)
+	osmConfigMap.ProxyLimitMemory, _ = GetStringValueForKey(configMap, proxyLimitMemory)
+	osmConfigMap.ProxyRequestsCPU, _ = GetStringValueForKey(configMap, proxyRequestsCPU)
+	osmConfigMap.ProxyRequestsMemory, _ = GetStringValueForKey(configMap, proxyRequestsMemory)
 
 	if osmConfigMap.TracingEnable {
 		osmConfigMap.TracingAddress, _ = GetStringValueForKey(configMap, tracingAddressKey)

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -71,6 +71,10 @@ var _ = Describe("Test OSM ConfigMap parsing", func() {
 				"OutboundPortExclusionList":     outboundPortExclusionListKey,
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,
 				"ConfigResyncInterval":          configResyncInterval,
+				"ProxyLimitCpu":                 proxyLimitCPU,
+				"ProxyLimitMemory":              proxyLimitMemory,
+				"ProxyRequestsCpu":              proxyRequestsCPU,
+				"ProxyRequestsMemory":           proxyRequestsMemory,
 			}
 			t := reflect.TypeOf(osmConfig{})
 

--- a/pkg/configurator/crd_client_test.go
+++ b/pkg/configurator/crd_client_test.go
@@ -75,7 +75,12 @@ var _ = Describe("Test OSM MeshConfig parsing", func() {
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainer,
 				"ConfigResyncInterval":          configResyncInterval,
 				"MaxDataPlaneConnections":       maxDataPlaneConnectionsKey,
+				"ProxyLimitCpu":                 proxyLimitCPU,
+				"ProxyLimitMemory":              proxyLimitMemory,
+				"ProxyRequestsCpu":              proxyRequestsCPU,
+				"ProxyRequestsMemory":           proxyRequestsMemory,
 			}
+
 			t := reflect.TypeOf(osmConfig{})
 
 			expectedNumberOfFields := t.NumField()

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -184,4 +187,48 @@ func (c *Client) GetConfigResyncInterval() time.Duration {
 		return time.Duration(0)
 	}
 	return duration
+}
+
+// GetProxyResources returns the `Resources` configured for proxies, if any
+func (c *Client) GetProxyResources() corev1.ResourceRequirements {
+	cfgMap := c.getConfigMap()
+	reqs := corev1.ResourceRequirements{}
+
+	if cfgMap.ProxyLimitCPU != "" {
+		cpuLimitQuant, err := resource.ParseQuantity(cfgMap.ProxyLimitCPU)
+		if err != nil {
+			log.Error().Err(err).Msg("Error parsing CPU Limit quantity for injected proxies")
+		} else {
+			reqs.Limits["cpu"] = cpuLimitQuant
+		}
+	}
+
+	if cfgMap.ProxyLimitMemory != "" {
+		memoryLimitQuant, err := resource.ParseQuantity(cfgMap.ProxyLimitMemory)
+		if err != nil {
+			log.Error().Err(err).Msg("Error parsing Memory Limit quantity for injected proxies")
+		} else {
+			reqs.Limits["memory"] = memoryLimitQuant
+		}
+	}
+
+	if cfgMap.ProxyRequestsCPU != "" {
+		cpuRequestQuant, err := resource.ParseQuantity(cfgMap.ProxyRequestsCPU)
+		if err != nil {
+			log.Error().Err(err).Msg("Error parsing CPU Requests quantity for injected proxies")
+		} else {
+			reqs.Requests["cpu"] = cpuRequestQuant
+		}
+	}
+
+	if cfgMap.ProxyRequestsMemory != "" {
+		memoryRequestsQuant, err := resource.ParseQuantity(cfgMap.ProxyRequestsMemory)
+		if err != nil {
+			log.Error().Err(err).Msg("Error parsing Memory Requests quantity for injected proxies")
+		} else {
+			reqs.Requests["memory"] = memoryRequestsQuant
+		}
+	}
+
+	return reqs
 }

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockConfigurator is a mock of Configurator interface
@@ -159,6 +160,20 @@ func (m *MockConfigurator) GetOutboundPortExclusionList() []string {
 func (mr *MockConfiguratorMockRecorder) GetOutboundPortExclusionList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundPortExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundPortExclusionList))
+}
+
+// GetProxyResources mocks base method
+func (m *MockConfigurator) GetProxyResources() v1.ResourceRequirements {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProxyResources")
+	ret0, _ := ret[0].(v1.ResourceRequirements)
+	return ret0
+}
+
+// GetProxyResources indicates an expected call of GetProxyResources
+func (mr *MockConfiguratorMockRecorder) GetProxyResources() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProxyResources", reflect.TypeOf((*MockConfigurator)(nil).GetProxyResources))
 }
 
 // GetServiceCertValidityPeriod mocks base method

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -4,6 +4,7 @@ package configurator
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -93,4 +94,7 @@ type Configurator interface {
 	// GetConfigResyncInterval returns the duration for resync interval.
 	// If error or non-parsable value, returns 0 duration
 	GetConfigResyncInterval() time.Duration
+
+	// GetProxyResources returns the `Resources` configured for proxies, if any
+	GetProxyResources() corev1.ResourceRequirements
 }

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -48,7 +48,8 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator
 			ReadOnly:  true,
 			MountPath: envoyProxyConfigPath,
 		}},
-		Command: []string{"envoy"},
+		Resources: cfg.GetProxyResources(),
+		Command:   []string{"envoy"},
 		Args: []string{
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Test all patch operations", func() {
 			mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
 			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
 			mockConfigurator.EXPECT().GetOutboundPortExclusionList().Return(nil).Times(1)
+			mockConfigurator.EXPECT().GetProxyResources().Return(corev1.ResourceRequirements{}).Times(1)
 
 			req := &admissionv1.AdmissionRequest{Namespace: namespace}
 			jsonPatches, err := wh.createPatch(&pod, req, proxyUUID)


### PR DESCRIPTION
(Tentative, WIP, TBD, seems this might be adding too much in configmap and
CRD could do a better job adding resource map types).

NOTE: This commit has not taken care to add this values to CRD-based config.
Commit becomes way too large.

Adds configurability of resource limits and requests for injected proxy
containers using ConfigMap.

Fixes #2472

Signed-off-by: edu <eduser25@gmail.com>

- New Functionality      [x]
- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No