### PR TITLE
OSM PodSecurityPolicy

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -107,6 +107,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.port | int | `7070` | Prometheus port |
 | OpenServiceMesh.prometheus.resources | object | `{"limits":{"cpu":1,"memory":"2G"},"requests":{"cpu":0.5,"memory":"512M"}}` | Resource limits for prometheus instance |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus retention time |
+| OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.replicaCount | int | `1` | `osm-controller` replicas |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Sets the service certificatevalidity duration |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.2"` | Envoy sidecar image |

--- a/charts/osm/templates/cleanup-hook-rbac.yaml
+++ b/charts/osm/templates/cleanup-hook-rbac.yaml
@@ -1,3 +1,57 @@
+{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-cleanup-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook: post-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -12,6 +66,13 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["delete"]
+
+  {{- if .Values.OpenServiceMesh.pspEnabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["{{ .Release.Name }}-cleanup-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -20,6 +20,13 @@ spec:
         {{- include "osm.labels" . | nindent 8 }}
         app: osm-grafana
     spec:
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+        supplementalGroups: [5555]
+      {{- end }}
       serviceAccountName: osm-grafana
       containers:
         - name: grafana

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -1,4 +1,55 @@
 {{- if .Values.OpenServiceMesh.deployGrafana}}
+{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-grafana-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -17,7 +68,13 @@ metadata:
     {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
   name: {{.Release.Name}}-grafana
-rules: []
+rules:
+  {{- if .Values.OpenServiceMesh.pspEnabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["{{ .Release.Name }}-grafana-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+  {{- end }}
 
 ---
 

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -26,6 +26,13 @@ spec:
         prometheus.io/port: '9091'
     spec:
       serviceAccountName: {{ .Release.Name }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+        supplementalGroups: [5555]
+      {{- end }}
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -25,6 +25,13 @@ spec:
         prometheus.io/port: '9091'
     spec:
       serviceAccountName: {{ .Release.Name }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+        supplementalGroups: [5555]
+      {{- end }}
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -1,3 +1,54 @@
+{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: osm-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  allowedCapabilities:
+    - NET_ADMIN
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -69,8 +120,14 @@ rules:
     resources: ["securitycontextconstraints"]
     verbs: ["use"]
   {{- end }}
----
 
+  {{- if .Values.OpenServiceMesh.pspEnabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["osm-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+  {{- end }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -19,6 +19,13 @@ spec:
         {{- include "osm.labels" . | nindent 8 }}
         app: osm-prometheus
     spec:
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+        supplementalGroups: [5555]
+      {{- end }}
       containers:
       - name: prometheus
         ports:

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,4 +1,55 @@
 {{- if .Values.OpenServiceMesh.deployPrometheus }}
+{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-prometheus-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,6 +65,12 @@ rules:
     verbs: ["list", "get", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
+  {{- if .Values.OpenServiceMesh.pspEnabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["{{ .Release.Name }}-prometheus-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -616,6 +616,15 @@
                         }
                     },
                     "additionalProperties": true
+                },
+                "pspEnabled": {
+                    "$id": "#/properties/OpenServiceMesh/properties/pspEnabled",
+                    "type": "boolean",
+                    "title": "The pspEnabled schema",
+                    "description": "Indicates whether OSM should run with PodSecurityPolicies",
+                    "examples": [
+                        false
+                    ]
                 }
             },
             "additionalProperties": true

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -171,3 +171,5 @@ OpenServiceMesh:
     # If specified, fine grained control over Egress (external) traffic is enforced
     enableEgressPolicy: false
 
+  # -- Run OSM with PodSecurityPolicy configured
+  pspEnabled: false

--- a/docs/content/docs/install/_index.md
+++ b/docs/content/docs/install/_index.md
@@ -99,6 +99,10 @@ To install OSM on OpenShift:
         oc adm policy add-scc-to-user privileged -z <service account name> -n <service account namespace>
        ```
 
+### Pod Security Policy
+
+If you are running OSM in a cluster with PSPs enabled, pass in `--set OpenServiceMesh.pspEnabled=true` to your `osm install` or `helm install` CLI command.
+
 ## Inspect OSM Components
 
 A few components will be installed by default into the `osm-system` Namespace. Inspect them by using the following `kubectl` command:


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds PSPs for existing RBACs (prometheus, grafana, osm, clean up job). This allows the chart to be installed and uninstalled in PSP enabled clusters.

Fluentbit and Jaeger to follow.

Fixes #1941
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [X]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No