### PR TITLE
fix(test): fix type definition of outboundPortExclusionList

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -91,7 +91,7 @@ spec:
                       description: Global list of ports to exclude from outbound traffic interception by the sidecar proxy.
                       type: array
                       items:
-                        type: integer
+                        type: string
                         pattern: ^[1-9]\d*$
                     useHTTPSIngress:
                       description: Enable HTTPS ingress on the mesh


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Fix type definition of outboundPortExclusionList field in MeshConfig.

It should be an array of strings.

This PR fixes the test below:

```
 Unexpected error: 
827 <*errors.errorString | 0xc0015ccaa0>: { 
828 s: "UpdateOSMConfig(): MeshConfig.config.openservicemesh.io \"osm-mesh-config\" is invalid: spec.traffic.outboundPortExclusionList: Invalid value: \"string\": spec.traffic.outboundPortExclusionList in body must be of type integer: \"string\"", 
829 } 
830 UpdateOSMConfig(): MeshConfig.config.openservicemesh.io "osm-mesh-config" is invalid: spec.traffic.outboundPortExclusionList: Invalid value: "string": spec.traffic.outboundPortExclusionList in body must be of type integer: "string" 
831 occurred 
832 
833 /home/runner/work/osm/osm/tests/e2e/e2e_port_exclusion_test.go:70
```

However during the test, other cases might fail on CI, but not on CI. Will investigate further in a separate PR.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

`No`