### PR TITLE
Create preset meshconfig

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,7 +193,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           K8S_NAMESPACE: "osm-system"
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Tier 1\]\[Bucket ${{ matrix.bucket }}\]' -ginkgo.skip='Upgrade'
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.skip='Upgrade'
         continue-on-error: true
       - name: Upload PR test logs
         if: ${{ steps.pr_test.conclusion != 'skipped' }}

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -39,7 +39,7 @@ rules:
     verbs: ["list"]
   - apiGroups: ["config.openservicemesh.io"]
     resources: ["meshconfigs"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["split.smi-spec.io"]
     resources: ["trafficsplits"]
     verbs: ["list", "get", "watch"]

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: config.openservicemesh.io/v1alpha1
+kind: MeshConfig
+metadata:
+  name: preset-mesh-config
+spec:
+  sidecar:
+    enablePrivilegedInitContainer: {{.Values.OpenServiceMesh.enablePrivilegedInitContainer}}
+    logLevel: {{.Values.OpenServiceMesh.envoyLogLevel}}
+    maxDataPlaneConnections: {{.Values.OpenServiceMesh.maxDataPlaneConnections}}
+    envoyImage: {{.Values.OpenServiceMesh.sidecarImage}}
+    initContainerImage: "openservicemesh/init:v0.8.3"
+  traffic:
+    enableEgress: {{.Values.OpenServiceMesh.enableEgress}}
+    useHTTPSIngress: {{.Values.OpenServiceMesh.useHTTPSIngress}}
+    enablePermissiveTrafficPolicyMode: {{.Values.OpenServiceMesh.enablePermissiveTrafficPolicy}}
+  observability:
+    enableDebugServer: {{.Values.OpenServiceMesh.enableDebugServer}}
+    prometheusScraping: {{.Values.OpenServiceMesh.enablePrometheusScraping}}
+    tracing:
+      enable: {{.Values.OpenServiceMesh.tracing.enable}}
+      {{- if .Values.OpenServiceMesh.tracing.enable }}
+      port: {{.Values.OpenServiceMesh.tracing.port}}
+      address: {{.Values.OpenServiceMesh.tracing.address | quote}}
+      endpoint: {{.Values.OpenServiceMesh.tracing.endpoint  | quote}}
+      {{- end }}
+  certificate:
+    serviceCertValidityDuration: {{.Values.OpenServiceMesh.serviceCertValidityDuration}}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -463,6 +463,7 @@
                                 true
                             ]
                         }
+
                     },
                     "additionalProperties": true
                 },

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -170,4 +170,3 @@ OpenServiceMesh:
     # Enable OSM's Egress policy API
     # If specified, fine grained control over Egress (external) traffic is enforced
     enableEgressPolicy: false
-

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -170,3 +170,4 @@ OpenServiceMesh:
     # Enable OSM's Egress policy API
     # If specified, fine grained control over Egress (external) traffic is enforced
     enableEgressPolicy: false
+

--- a/tests/e2e/e2e_init_controller_test.go
+++ b/tests/e2e/e2e_init_controller_test.go
@@ -16,6 +16,8 @@ var _ = OSMDescribe("Test init-osm-controller functionalities",
 		Context("When osm-controller starts in fresh environment", func() {
 			It("creates default MeshConfig resource", func() {
 				instOpts := Td.GetOSMInstallOpts()
+				instOpts.EnvoyLogLevel = "info"
+				instOpts.EnableDebugServer = false
 
 				// Install OSM
 				Expect(Td.InstallOSM(instOpts)).To(Succeed())
@@ -25,7 +27,7 @@ var _ = OSMDescribe("Test init-osm-controller functionalities",
 				// validate osm MeshConfig
 				Expect(meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode).Should(BeFalse())
 				Expect(meshConfig.Spec.Traffic.EnableEgress).Should(BeFalse())
-				Expect(meshConfig.Spec.Sidecar.LogLevel).Should(Equal("error"))
+				Expect(meshConfig.Spec.Sidecar.LogLevel).Should(Equal("info"))
 				Expect(meshConfig.Spec.Observability.PrometheusScraping).Should(BeTrue())
 				Expect(meshConfig.Spec.Observability.EnableDebugServer).Should(BeFalse())
 				Expect(meshConfig.Spec.Observability.Tracing.Enable).Should(BeFalse())

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -115,6 +115,14 @@ var (
 	defaultOSMLogLevel = "trace"
 	// Test folder base default value
 	testFolderBase = "/tmp"
+	// default enable tracing
+	defaultEnableTracing = false
+	// default enable prometheus scraping
+	defaultEnablePrometheusScraping = false
+	// default service cert validity duration
+	defaultServiceCertValidityDuration = "24h"
+	// default enable privileged init container
+	defaultEnablePrivilegedInitContainer = false
 )
 
 // OSMDescribeInfo is a struct to represent the Tier and Bucket of a given e2e test
@@ -420,11 +428,15 @@ type InstallOSMOpts struct {
 	CertmanagerIssuerKind  string
 	CertmanagerIssuerName  string
 
-	EgressEnabled        bool
-	EnablePermissiveMode bool
-	OSMLogLevel          string
-	EnvoyLogLevel        string
-	EnableDebugServer    bool
+	EgressEnabled                 bool
+	EnablePermissiveMode          bool
+	OSMLogLevel                   string
+	EnvoyLogLevel                 string
+	EnableDebugServer             bool
+	EnableTracing                 bool
+	EnablePrivilegedInitContainer bool
+	EnablePrometheusScraping      bool
+	ServiceCertValidityDuration   string
 
 	SetOverrides []string
 }
@@ -432,15 +444,19 @@ type InstallOSMOpts struct {
 // GetOSMInstallOpts initializes install options for OSM
 func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 	return InstallOSMOpts{
-		ControlPlaneNS:          td.OsmNamespace,
-		CertManager:             defaultCertManager,
-		ContainerRegistryLoc:    td.CtrRegistryServer,
-		ContainerRegistrySecret: td.CtrRegistryPassword,
-		OsmImagetag:             td.OsmImageTag,
-		DeployGrafana:           defaultDeployGrafana,
-		DeployPrometheus:        defaultDeployPrometheus,
-		DeployJaeger:            defaultDeployJaeger,
-		DeployFluentbit:         defaultDeployFluentbit,
+		ControlPlaneNS:                td.OsmNamespace,
+		CertManager:                   defaultCertManager,
+		ContainerRegistryLoc:          td.CtrRegistryServer,
+		ContainerRegistrySecret:       td.CtrRegistryPassword,
+		OsmImagetag:                   td.OsmImageTag,
+		DeployGrafana:                 defaultDeployGrafana,
+		DeployPrometheus:              defaultDeployPrometheus,
+		DeployJaeger:                  defaultDeployJaeger,
+		DeployFluentbit:               defaultDeployFluentbit,
+		EnableTracing:                 defaultEnableTracing,
+		EnablePrivilegedInitContainer: defaultEnablePrivilegedInitContainer,
+		EnablePrometheusScraping:      defaultEnablePrometheusScraping,
+		ServiceCertValidityDuration:   defaultServiceCertValidityDuration,
 
 		VaultHost:     "vault." + td.OsmNamespace + ".svc.cluster.local",
 		VaultProtocol: "http",
@@ -568,6 +584,10 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		fmt.Sprintf("OpenServiceMesh.deployPrometheus=%v", instOpts.DeployPrometheus),
 		fmt.Sprintf("OpenServiceMesh.deployJaeger=%v", instOpts.DeployJaeger),
 		fmt.Sprintf("OpenServiceMesh.enableFluentbit=%v", instOpts.DeployFluentbit),
+		fmt.Sprintf("OpenServiceMesh.enablePrometheusScraping=%v", instOpts.EnablePrometheusScraping),
+		fmt.Sprintf("OpenServiceMesh.tracing.enable=%v", instOpts.EnableTracing),
+		fmt.Sprintf("OpenServiceMesh.enablePrivilegedInitContainer=%v", instOpts.EnablePrivilegedInitContainer),
+		fmt.Sprintf("OpenServiceMesh.serviceCertValidityDuration=%v", instOpts.ServiceCertValidityDuration),
 	)
 
 	switch instOpts.CertManager {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

We still need to support setting mesh configurations from CLI during installation. This was removed when migrating from osm-config configmap to MeshConfig CRD.

In this PR, `osm install` will create a MeshConfig resource `preset-mesh-config` using Helm. `init-osm-controller` container will check it and create a `osm-mesh-config` MeshConfig if does not exist. In this case, it actually means that OSM is in the fresh installation process.. However if `osm-mesh-config` exists, `init-osm-controller` respects the existing MeshConfig, and ignores the preset. This implies that OSM is in upgrade process.

Note that, in this PR, we are not fixing the issue that `osm upgrade` will also take arguments to update MeshConfig. 

Issue #3301 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [X]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?

`No`