### PR TITLE
egress: extend API for TCP and HTTPS traffic

### DIFF
--- a/charts/osm/crds/policy.yaml
+++ b/charts/osm/crds/policy.yaml
@@ -40,8 +40,6 @@ spec:
               type: object
               required:
                 - sources
-                - hosts
-                - ipAddresses
                 - ports
               properties:
                 sources:

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b
 	github.com/mitchellh/gox v1.0.1
+	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/norwoodj/helm-docs v1.4.0
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/onsi/ginkgo v1.16.1

--- a/go.sum
+++ b/go.sum
@@ -736,6 +736,8 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
 github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
+github.com/mitchellh/hashstructure/v2 v2.0.1 h1:L60q1+q7cXE4JeEJJKMnh2brFIe3rZxCihYAB61ypAY=
+github.com/mitchellh/hashstructure/v2 v2.0.1/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -188,6 +188,9 @@ const (
 	// HTTP protocol
 	ProtocolHTTP = "http"
 
+	// HTTPS protocol
+	ProtocolHTTPS = "https"
+
 	// TCP protocol
 	ProtocolTCP = "tcp"
 

--- a/pkg/trafficpolicy/egress_types.go
+++ b/pkg/trafficpolicy/egress_types.go
@@ -1,9 +1,5 @@
 package trafficpolicy
 
-import (
-	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
-)
-
 // EgressTrafficPolicy is the type used to represent the different egress traffic policy configurations
 // applicable to a client of Egress destinations.
 type EgressTrafficPolicy struct {
@@ -26,8 +22,28 @@ type EgressTrafficPolicy struct {
 
 // TrafficMatch is the type used to represent attributes used to match Egress traffic
 type TrafficMatch struct {
-	// DestinationPort defines the destination port's specification - port's number and protocol
-	DestinationPort policyV1alpha1.PortSpec
+	// DestinationPort defines the destination port number
+	DestinationPort int
+
+	// DestinationProtocol defines the protocol served by DestinationPort
+	DestinationProtocol string
+
+	// DestinationIPRanges defines the list of destination IP ranges
+	// +optional
+	DestinationIPRanges []string
+
+	// ServerNames defines the list of server names to be used as SNI when the
+	// DestinationProtocol is TLS based, ex. when the DestinationProtocol is 'https'
+	// +optional
+	ServerNames []string
+
+	// Cluster defines the cluster associated with this TrafficMatch, if possible.
+	// A TrafficMatch corresponding to an HTTP based cluster will not make use of
+	// this property since the cluster is determined based on the computed routes.
+	// A TraficMatch corresponding to a TCP based cluster will make use of this
+	// property to associate the match with the corresponding cluster.
+	// +optional
+	Cluster string
 }
 
 // EgressClusterConfig is the type used to represent an external cluster corresponding to a

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	mapset "github.com/deckarep/golang-set"
+	hashstructure "github.com/mitchellh/hashstructure/v2"
 	"github.com/pkg/errors"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -240,4 +241,47 @@ func convertToInterface(slice []string) []interface{} {
 		sliceInterface[i] = slice[i]
 	}
 	return sliceInterface
+}
+
+// DeduplicateTrafficMatches deduplicates the given slice of TrafficMatch objects, and an error
+// if the deduplication cannot be performed.
+// The order of elements in a slice field does not determine uniqueness.
+func DeduplicateTrafficMatches(matches []*TrafficMatch) ([]*TrafficMatch, error) {
+	var dedupedMatces []*TrafficMatch
+	matchesMap := make(map[uint64]*TrafficMatch)
+
+	for _, match := range matches {
+		hash, err := hashstructure.Hash(match, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+		if err != nil {
+			return nil, err
+		}
+		matchesMap[hash] = match
+	}
+
+	for _, match := range matchesMap {
+		dedupedMatces = append(dedupedMatces, match)
+	}
+
+	return dedupedMatces, nil
+}
+
+// DeduplicateClusterConfigs deduplicates the given slice of EgressClusterConfig objects, and an error
+// if the deduplication cannot be performed.
+func DeduplicateClusterConfigs(configs []*EgressClusterConfig) ([]*EgressClusterConfig, error) {
+	var dedupedConfigs []*EgressClusterConfig
+	configMap := make(map[uint64]*EgressClusterConfig)
+
+	for _, config := range configs {
+		hash, err := hashstructure.Hash(config, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
+		if err != nil {
+			return nil, err
+		}
+		configMap[hash] = config
+	}
+
+	for _, match := range configMap {
+		dedupedConfigs = append(dedupedConfigs, match)
+	}
+
+	return dedupedConfigs, nil
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The current implementation of the egress policy API
only supports building HTTP based configs. This change
extends the API and code to build configs for TCP
and HTTPS egress destinations.

Notable changes:
- hosts is optional for TCP
- ipAddresses is optional for HTTP
- MeshCataloger builds configs for TCP, HTTPS ports
- Deduplication helpers for TrafficMatch and
  EgressClusterConfig types

Part of #3045

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`