### PR TITLE
envoy/cds: support TCP based egress clusters

### DIFF
--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -64,7 +64,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	// Add an outbound passthrough cluster for egress if global mesh-wide Egress is enabled
 	if cfg.IsEgressEnabled() {
-		clusters = append(clusters, getOutboundPassthroughCluster())
+		clusters = append(clusters, getOriginalDestinationEgressCluster(envoy.OutboundPassthroughCluster))
 	}
 
 	// Add an inbound prometheus cluster (from Prometheus to localhost)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Adds capability for TCP based egress cluster configs,
ie. configs without the HTTP Host set.
- Consolidates duplicate code for the original destination
cluster type.
- Un-exports pkg scoped function

Part of #3045

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`