### PR TITLE
feat(rbac): Add FluentBit PodSecurityPolicy

### DIFF
--- a/charts/osm/templates/_helpers.tpl
+++ b/charts/osm/templates/_helpers.tpl
@@ -24,3 +24,12 @@ securityContext:
     fsGroup: 2000
     supplementalGroups: [5555]
 {{- end -}}
+
+{{/* Security context values for fluentbit */}}
+{{- define "fluentbit.securityContext" -}}
+securityContext:
+    runAsUser: 0
+    capabilities:
+        drop:
+            - ALL
+{{- end -}}

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         prometheus.io/port: '9091'
     spec:
       serviceAccountName: {{ .Release.Name }}
-      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       nodeSelector:
@@ -126,6 +126,9 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.name
+          {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
+          {{- include "fluentbit.securityContext" . | nindent 10 }}
+          {{- end }}
           volumeMounts:
           - name: config
             mountPath: /fluent-bit/etc

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -25,12 +25,21 @@ spec:
     - 'downwardAPI'
     # Assume that persistentVolumes set up by the cluster admin are safe to use.
     - 'persistentVolumeClaim'
+    {{- if .Values.OpenServiceMesh.enableFluentbit }}
+    - 'hostPath'
+    {{- end }}
   hostNetwork: false
   hostIPC: false
   hostPID: false
   runAsUser:
+    {{- if not .Values.OpenServiceMesh.enableFluentbit }}
     # Require the container to run without root privileges.
     rule: 'MustRunAsNonRoot'
+    {{- end }}
+    {{- if .Values.OpenServiceMesh.enableFluentbit }}
+    # Allow root privileges to allow fluentbit access to logs.
+    rule: 'RunAsAny'
+    {{- end }}
   seLinux:
     # This policy assumes the nodes are using AppArmor rather than SELinux.
     rule: 'RunAsAny'
@@ -47,6 +56,15 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+  {{- if .Values.OpenServiceMesh.enableFluentbit }}
+  allowedHostPaths:
+  - pathPrefix: "/var/log/containers"
+    readOnly: true
+  - pathPrefix: "/var/log/pods"
+    readOnly: true
+  - pathPrefix: "/var/lib/docker/containers"
+    readOnly: true
+  {{- end }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds PodSecurityPolicy for Jaeger and modifies OSM PSP to include hostPath when FluentBit is enabled.
Fixes #1941 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [X]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No