### PR TITLE
chore(release): Creating release v0.8.4-rc.1

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.8.3
+version: 0.8.4-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v0.8.3
+appVersion: v0.8.4-rc.1

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -91,7 +91,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.grafana.port | int | `3000` | Grafana port |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` | `osm-controller` pod PullPolicy |
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` | `osm-controller` image registry |
-| OpenServiceMesh.image.tag | string | `"v0.8.3"` | `osm-controller` image tag |
+| OpenServiceMesh.image.tag | string | `"v0.8.4-rc.1"` | `osm-controller` image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.inbound_extauthz | object | `{"address":"","enable":false,"failureModeAllow":false,"port":0,"statPrefix":"","timeout":"1s"}` | Inbound external authorization, allows configuring a remote service to provide external authorization upon request |
 | OpenServiceMesh.injector | object | `{"podLabels":{},"replicaCount":1,"resource":{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}}` | Sidecar injector configuration |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -11,7 +11,7 @@ OpenServiceMesh:
     # -- `osm-controller` pod PullPolicy
     pullPolicy: IfNotPresent
     # -- `osm-controller` image tag
-    tag: v0.8.3
+    tag: v0.8.4-rc.1
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
   # -- Envoy sidecar image

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -63,7 +63,7 @@ const (
 	defaultContainerRegistrySecret       = ""
 	defaultMeshName                      = "osm"
 	defaultOsmImagePullPolicy            = "IfNotPresent"
-	defaultOsmImageTag                   = "v0.8.3"
+	defaultOsmImageTag                   = "v0.8.4-rc.1"
 	defaultPrometheusRetentionTime       = constants.PrometheusDefaultRetentionTime
 	defaultVaultHost                     = ""
 	defaultVaultProtocol                 = "http"

--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -36,7 +36,7 @@ spec:
       serviceAccountName: bookbuyer
       containers:
         - name: bookbuyer
-          image: openservicemesh/bookbuyer:v0.8.3
+          image: openservicemesh/bookbuyer:v0.8.4-rc.1
           imagePullPolicy: Always
           command: ["/bookbuyer"]
           env:

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: bookstore-v2
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:v0.8.3
+          image: openservicemesh/bookstore:v0.8.4-rc.1
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -51,7 +51,7 @@ spec:
       serviceAccountName: bookstore
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:v0.8.3
+          image: openservicemesh/bookstore:v0.8.4-rc.1
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: bookthief
       containers:
         - name: bookthief
-          image: openservicemesh/bookthief:v0.8.3
+          image: openservicemesh/bookthief:v0.8.4-rc.1
           imagePullPolicy: Always
           command: ["/bookthief"]
           env:

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -52,6 +52,6 @@ spec:
       serviceAccountName: bookwarehouse
       containers:
         - name: bookwarehouse
-          image: openservicemesh/bookwarehouse:v0.8.3
+          image: openservicemesh/bookwarehouse:v0.8.4-rc.1
           imagePullPolicy: Always
           command: ["/bookwarehouse"]


### PR DESCRIPTION
This commit updates version and reference numbers to v0.8.4-rc.1.

- [x] I have cherry-picked any changes [labelled](https://github.com/openservicemesh/osm/labels) `needs-cherry-pick-vX.Y.Z`
- [x] I have made all of the following version and patch updates:
  1. Updated the container image tag in charts/osm/values.yaml
  2. Updated the chart **and** app version in charts/osm/Charts.yaml
  3. Updated the default osm-controller image tag in osm cli
  4. Updated the image tags used in demo manifests
  5. Regenerated Helm chart README.md

- [x] I have checked that the base branch for this PR is correcct as defined in the release guide

Is this a release candidate?
yes

Signed-off-by: Eduard Serra <eduser25@gmail.com>
