### PR TITLE
envoy/lds: add support for egress lds configs

### DIFF
--- a/pkg/envoy/lds/egress.go
+++ b/pkg/envoy/lds/egress.go
@@ -1,0 +1,124 @@
+package lds
+
+import (
+	"fmt"
+	"net"
+
+	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy/route"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+const (
+	egressHTTPFilterChainPrefix = "egress-http"
+	egressTCPFilterChainPrefix  = "egress-tcp"
+)
+
+var (
+	// httpProtocols is the list of allowed HTTP protocols that the downstream can use in
+	// an HTTP request that will be subjected to HTTP routing rules.
+	// *Note: HTTP2 over TLS (h2) traffic is not subjected to HTTP based routing rules because the
+	// traffic is encrypted and will be proxied as a TCP stream instead.
+	httpProtocols = []string{"http/1.0", "http/1.1", "h2c"}
+)
+
+// getEgressFilterChainsForMatches returns a slice of egress filter chains for the given traffic matches
+func (lb *listenerBuilder) getEgressFilterChainsForMatches(matches []*trafficpolicy.TrafficMatch) []*xds_listener.FilterChain {
+	var filterChains []*xds_listener.FilterChain
+
+	for _, match := range matches {
+		switch match.DestinationProtocol {
+		case constants.ProtocolHTTP:
+			// HTTP protocol --> HTTPConnectionManager filter
+			if filterChain, err := lb.getEgressHTTPFilterChain(match.DestinationPort); err != nil {
+				log.Error().Err(err).Msgf("Error building egress HTTP filter chain for port [%d]", match.DestinationPort)
+			} else {
+				filterChains = append(filterChains, filterChain)
+			}
+
+		case constants.ProtocolTCP, constants.ProtocolHTTPS:
+			// TCP or HTTPS protocol --> TCPProxy filter
+			if filterChain, err := lb.getEgressTCPFilterChain(*match); err != nil {
+				log.Error().Err(err).Msgf("Error building egress filter chain for match [%v]", *match)
+			} else {
+				filterChains = append(filterChains, filterChain)
+			}
+		}
+	}
+
+	return filterChains
+}
+
+func (lb *listenerBuilder) getEgressHTTPFilterChain(destinationPort int) (*xds_listener.FilterChain, error) {
+	filter, err := lb.getOutboundHTTPFilter(route.GetEgressRouteConfigNameForPort(destinationPort))
+	if err != nil {
+		log.Error().Err(err).Msgf("Error building HTTP filter chain for destination port [%d]", destinationPort)
+		return nil, err
+	}
+
+	filterChainName := fmt.Sprintf("%s.%d", egressHTTPFilterChainPrefix, destinationPort)
+	return &xds_listener.FilterChain{
+		Name:    filterChainName,
+		Filters: []*xds_listener.Filter{filter},
+		FilterChainMatch: &xds_listener.FilterChainMatch{
+			DestinationPort: &wrapperspb.UInt32Value{
+				Value: uint32(destinationPort),
+			},
+			ApplicationProtocols: httpProtocols,
+		},
+	}, nil
+}
+
+func (lb *listenerBuilder) getEgressTCPFilterChain(match trafficpolicy.TrafficMatch) (*xds_listener.FilterChain, error) {
+	tcpProxy := &xds_tcp_proxy.TcpProxy{
+		StatPrefix:       fmt.Sprintf("%s.%d", egressTCPProxyStatPrefix, match.DestinationPort),
+		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: match.Cluster},
+	}
+
+	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshalling TcpProxy for TrafficMatch %v", match)
+		return nil, err
+	}
+
+	tcpFilter := &xds_listener.Filter{
+		Name:       wellknown.TCPProxy,
+		ConfigType: &xds_listener.Filter_TypedConfig{TypedConfig: marshalledTCPProxy},
+	}
+
+	var destinationPrefixes []*xds_core.CidrRange
+	for _, ipRange := range match.DestinationIPRanges {
+		ip, ipNet, err := net.ParseCIDR(ipRange)
+		if err != nil {
+			log.Error().Err(err).Msgf("Error parsing IP range %s while building TCP filter chain for match %v, skipping", ipRange, match)
+			continue
+		}
+
+		prefixLen, _ := ipNet.Mask.Size()
+		destinationPrefixes = append(destinationPrefixes, &xds_core.CidrRange{
+			AddressPrefix: ip.String(),
+			PrefixLen: &wrapperspb.UInt32Value{
+				Value: uint32(prefixLen),
+			},
+		})
+	}
+
+	return &xds_listener.FilterChain{
+		Name:    fmt.Sprintf("%s.%d", egressTCPFilterChainPrefix, match.DestinationPort),
+		Filters: []*xds_listener.Filter{tcpFilter},
+		FilterChainMatch: &xds_listener.FilterChainMatch{
+			DestinationPort: &wrapperspb.UInt32Value{
+				Value: uint32(match.DestinationPort),
+			},
+			ServerNames:  match.ServerNames,
+			PrefixRanges: destinationPrefixes,
+		},
+	}, nil
+}

--- a/pkg/envoy/lds/egress_test.go
+++ b/pkg/envoy/lds/egress_test.go
@@ -1,0 +1,231 @@
+package lds
+
+import (
+	"testing"
+
+	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/mock/gomock"
+	tassert "github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/featureflags"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+func init() {
+	// Initialize the Egress policy feature
+	featureflags.Initialize(featureflags.OptionalFeatures{
+		EgressPolicy: true,
+	})
+}
+
+func TestGetEgressHTTPFilterChain(t *testing.T) {
+	assert := tassert.New(t)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name                     string
+		destinationPort          int
+		expectedFilterChainMatch *xds_listener.FilterChainMatch
+		expectError              bool
+	}{
+		{
+			name:            "egress HTTP filter chain for port 80",
+			destinationPort: 80,
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort:      &wrapperspb.UInt32Value{Value: 80},
+				ApplicationProtocols: []string{"http/1.0", "http/1.1", "h2c"},
+			},
+			expectError: false,
+		},
+		{
+			name:            "egress HTTP filter chain for port 100",
+			destinationPort: 100,
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort:      &wrapperspb.UInt32Value{Value: 100},
+				ApplicationProtocols: []string{"http/1.0", "http/1.1", "h2c"},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+			lb := &listenerBuilder{
+				cfg: mockConfigurator,
+			}
+			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
+
+			actual, err := lb.getEgressHTTPFilterChain(tc.destinationPort)
+
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedFilterChainMatch, actual.FilterChainMatch)
+			assert.Len(actual.Filters, 1) // Single HTTPConnectionManager filter
+			assert.Equal(wellknown.HTTPConnectionManager, actual.Filters[0].Name)
+		})
+	}
+}
+
+func TestGetEgressTCPFilterChain(t *testing.T) {
+	assert := tassert.New(t)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name                     string
+		trafficMatch             trafficpolicy.TrafficMatch
+		expectedFilterChainMatch *xds_listener.FilterChainMatch
+		expectError              bool
+	}{
+		{
+			name: "egress TCP filter chain for port match",
+			trafficMatch: trafficpolicy.TrafficMatch{
+				DestinationPort:     80,
+				DestinationProtocol: "tcp",
+			},
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort: &wrapperspb.UInt32Value{Value: 80},
+			},
+			expectError: false,
+		},
+		{
+			name: "egress TCP filter chain for port and IP ranges match",
+			trafficMatch: trafficpolicy.TrafficMatch{
+				DestinationPort:     100,
+				DestinationProtocol: "tcp",
+				DestinationIPRanges: []string{"10.0.0.0/24", "8.8.8.8/32"},
+			},
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort: &wrapperspb.UInt32Value{Value: 100},
+				PrefixRanges: []*xds_core.CidrRange{
+					{
+						AddressPrefix: "10.0.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: 24,
+						},
+					},
+					{
+						AddressPrefix: "8.8.8.8",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: 32,
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "egress TCP filter chain for port, IP ranges and SNI match",
+			trafficMatch: trafficpolicy.TrafficMatch{
+				DestinationPort:     100,
+				DestinationProtocol: "tcp",
+				DestinationIPRanges: []string{"10.0.0.0/24", "8.8.8.8/32"},
+				ServerNames:         []string{"foo.com"},
+			},
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort: &wrapperspb.UInt32Value{Value: 100},
+				PrefixRanges: []*xds_core.CidrRange{
+					{
+						AddressPrefix: "10.0.0.0",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: 24,
+						},
+					},
+					{
+						AddressPrefix: "8.8.8.8",
+						PrefixLen: &wrapperspb.UInt32Value{
+							Value: 32,
+						},
+					},
+				},
+				ServerNames: []string{"foo.com"},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lb := &listenerBuilder{}
+
+			actual, err := lb.getEgressTCPFilterChain(tc.trafficMatch)
+
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedFilterChainMatch, actual.FilterChainMatch)
+			assert.Len(actual.Filters, 1) // Single TCPProxy filter
+			assert.Equal(wellknown.TCPProxy, actual.Filters[0].Name)
+		})
+	}
+}
+
+func TestGetEgressFilterChainsForMatches(t *testing.T) {
+	assert := tassert.New(t)
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	testCases := []struct {
+		name                     string
+		trafficMatches           []*trafficpolicy.TrafficMatch
+		expectedFilterChainCount int
+	}{
+		{
+			name: "Multiple valid traffic matches",
+			trafficMatches: []*trafficpolicy.TrafficMatch{
+				{
+					DestinationPort:     100,
+					DestinationProtocol: "http",
+					ServerNames:         []string{"foo.com"},
+				},
+				{
+					DestinationPort:     100,
+					DestinationProtocol: "https",
+					DestinationIPRanges: []string{"10.0.0.0/24", "8.8.8.8/32"},
+					ServerNames:         []string{"foo.com"},
+				},
+				{
+					DestinationPort:     100,
+					DestinationProtocol: "tcp",
+					DestinationIPRanges: []string{"10.0.0.0/24", "8.8.8.8/32"},
+				},
+			},
+			expectedFilterChainCount: 3, // 1 for each match
+		},
+		{
+			name: "Invalid traffic matches should be ignored",
+			trafficMatches: []*trafficpolicy.TrafficMatch{
+				{
+					DestinationPort:     100,
+					DestinationProtocol: "http",
+					ServerNames:         []string{"foo.com"},
+				},
+				{
+					DestinationPort:     100,
+					DestinationProtocol: "invalid",
+				},
+			},
+			expectedFilterChainCount: 1, // 1 for the valid match, match with invalid protocol is ignored
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+			lb := &listenerBuilder{
+				cfg: mockConfigurator,
+			}
+			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
+
+			actual := lb.getEgressFilterChainsForMatches(tc.trafficMatches)
+
+			assert.Len(actual, tc.expectedFilterChainCount)
+		})
+	}
+}

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -228,13 +228,13 @@ func (lb *listenerBuilder) getInboundTCPFilters(proxyService service.MeshService
 	return filters, nil
 }
 
-// getOutboundHTTPFilter returns an HTTP connection manager network filter used to filter outbound HTTP traffic
-func (lb *listenerBuilder) getOutboundHTTPFilter() (*xds_listener.Filter, error) {
+// getOutboundHTTPFilter returns an HTTP connection manager network filter used to filter outbound HTTP traffic for the given route configuration
+func (lb *listenerBuilder) getOutboundHTTPFilter(routeConfigName string) (*xds_listener.Filter, error) {
 	var marshalledFilter *any.Any
 	var err error
 
 	marshalledFilter, err = ptypes.MarshalAny(
-		getHTTPConnectionManager(route.OutboundRouteConfigName, lb.cfg, lb.statsHeaders))
+		getHTTPConnectionManager(routeConfigName, lb.cfg, lb.statsHeaders))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling HTTP connection manager object")
 		return nil, err
@@ -296,7 +296,7 @@ func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.
 
 func (lb *listenerBuilder) getOutboundHTTPFilterChainForService(upstream service.MeshService, port uint32) (*xds_listener.FilterChain, error) {
 	// Get HTTP filter for service
-	filter, err := lb.getOutboundHTTPFilter()
+	filter, err := lb.getOutboundHTTPFilter(route.OutboundRouteConfigName)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting HTTP filter for upstream service %s", upstream)
 		return nil, err

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/featureflags"
 )
 
 const (
@@ -40,11 +41,20 @@ func (lb *listenerBuilder) newOutboundListener() (*xds_listener.Listener, error)
 		},
 	}
 
-	// Create filter chain for egress if egress is enabled
-	// This filter chain matches any traffic not filtered by allow rules, it will be treated as egress
-	// traffic when enabled
+	// Create filter chains for egress based on policies
+	if egressTrafficPolicy, err := lb.meshCatalog.GetEgressTrafficPolicy(lb.serviceIdentity); err != nil {
+		log.Error().Err(err).Msgf("Error retrieving egress policies for proxy with identity %s, skipping egress filters", lb.serviceIdentity)
+	} else if egressTrafficPolicy != nil {
+		egressFilterChains := lb.getEgressFilterChainsForMatches(egressTrafficPolicy.TrafficMatches)
+		listener.FilterChains = append(listener.FilterChains, egressFilterChains...)
+	}
+
+	// Create a default passthrough filter chain when global egress is enabled.
+	// This filter chain matches any traffic not matching any of the filter chains built from
+	// mesh (SMI or permissive mode) or egress traffic policies. Traffic matching this default
+	// passthrough filter chain will be allowed to passthrough to its original destination.
 	if lb.cfg.IsEgressEnabled() {
-		egressFilterChain, err := buildEgressFilterChain()
+		egressFilterChain, err := getDefaultPassthroughFilterChain()
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting filter chain for Egress")
 			return nil, err
@@ -58,6 +68,27 @@ func (lb *listenerBuilder) newOutboundListener() (*xds_listener.Listener, error)
 		// there are no allowed upstreams for this proxy and egress is disabled.
 		// In this case, return a nil filter chain so that it doesn't get programmed.
 		return nil, nil
+	}
+
+	if featureflags.IsEgressPolicyEnabled() {
+		additionalListenerFilters := []*xds_listener.ListenerFilter{
+			{
+				// To inspect TLS metadata, such as the transport protocol and SNI
+				Name: wellknown.TlsInspector,
+			},
+			{
+				// To inspect if the application protocol is HTTP based
+				Name: wellknown.HttpInspector,
+				// TODO(#3045): configure match predicate for ports serving server-first protocols (ex. mySQL, postgreSQL etc.)
+				// Ports corresponding to server-first protocols, where the server initiates the first byte of a connection, will
+				// cause the HttpInspector ListenerFilter to timeout because it waits for data from the client to inspect the protocol.
+			},
+		}
+		listener.ListenerFilters = append(listener.ListenerFilters, additionalListenerFilters...)
+
+		// ListenerFilter can timeout for server-first protocols. In such cases, continue the processing of the connection
+		// and fallback to the default filter chain.
+		listener.ContinueOnListenerFiltersTimeout = true
 	}
 
 	return listener, nil
@@ -109,7 +140,9 @@ func buildPrometheusListener(connManager *xds_hcm.HttpConnectionManager) (*xds_l
 	}, nil
 }
 
-func buildEgressFilterChain() (*xds_listener.FilterChain, error) {
+// getDefaultPassthroughFilterChain returns a filter chain that matches any traffic, allowing such
+// traffic to be proxied to its original destination via the OutboundPassthroughCluster.
+func getDefaultPassthroughFilterChain() (*xds_listener.FilterChain, error) {
 	tcpProxy := &xds_tcp_proxy.TcpProxy{
 		StatPrefix:       fmt.Sprintf("%s.%s", egressTCPProxyStatPrefix, envoy.OutboundPassthroughCluster),
 		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: envoy.OutboundPassthroughCluster},

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -36,7 +36,7 @@ func TestGetFilterForService(t *testing.T) {
 	mockConfigurator.EXPECT().GetTracingEndpoint().Return("test-endpoint")
 
 	// Check we get HTTP connection manager filter without Permissive mode
-	filter, err := lb.getOutboundHTTPFilter()
+	filter, err := lb.getOutboundHTTPFilter(route.OutboundRouteConfigName)
 
 	assert.NoError(err)
 	assert.Equal(filter.Name, wellknown.HTTPConnectionManager)
@@ -46,7 +46,7 @@ func TestGetFilterForService(t *testing.T) {
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(true)
 	mockConfigurator.EXPECT().GetTracingEndpoint().Return("test-endpoint")
 
-	filter, err = lb.getOutboundHTTPFilter()
+	filter, err = lb.getOutboundHTTPFilter(route.OutboundRouteConfigName)
 	assert.NoError(err)
 	assert.Equal(filter.Name, wellknown.HTTPConnectionManager)
 }

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -53,7 +53,7 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 	return proxy, nil
 }
 
-func TestListenerConfiguration(t *testing.T) {
+func TestNewResponse(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
@@ -85,7 +85,7 @@ func TestListenerConfiguration(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(listener.Name, outboundListenerName)
 	assert.Equal(listener.TrafficDirection, xds_core.TrafficDirection_OUTBOUND)
-	assert.Len(listener.ListenerFilters, 1)
+	assert.Len(listener.ListenerFilters, 3) // Test has egress policy feature enabled, so 3 filters are expected: OriginalDst, TlsInspector, HttpInspector
 	assert.Equal(listener.ListenerFilters[0].Name, wellknown.OriginalDestination)
 	assert.NotNil(listener.FilterChains)
 	// There are 3 filter chains configured on the outbound-listner based on the configuration:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds capability to build LDS filter configs
for egress traffic policies.

Additionally, modifies existing code by renaming
and updating helpers to reuse code where applicable.

Part of #3045

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [X]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`