### PR TITLE
fix(pkg/endpoint/providers/kube): fix GetResolvableEndpointsForService

### DIFF
--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"net"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
@@ -14,6 +15,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
+)
+
+const (
+	clusterIPNone = "none"
 )
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
@@ -215,8 +220,8 @@ func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]en
 		return nil, errServiceNotFound
 	}
 
-	if len(kubeService.Spec.ClusterIP) == 0 {
-		// If service has no cluster IP, use final endpoint as resolvable destinations
+	if len(kubeService.Spec.ClusterIP) == 0 || strings.ToLower(kubeService.Spec.ClusterIP) == clusterIPNone {
+		// If service has no cluster IP or cluster IP is <none>, use final endpoint as resolvable destinations
 		return c.ListEndpointsForService(svc), nil
 	}
 


### PR DESCRIPTION
**Description**:

This commit fixes a bug in the method GetResolvableEndpointsForService.
It returns the service endpoints when the clusterIP is set to none

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
