### PR TITLE
chore(clusterIP): replace clusterIPNone constant with k8s constant

### DIFF
--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -2,7 +2,6 @@ package kube
 
 import (
 	"net"
-	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
@@ -15,10 +14,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/service"
-)
-
-const (
-	clusterIPNone = "none"
 )
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
@@ -220,7 +215,7 @@ func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]en
 		return nil, errServiceNotFound
 	}
 
-	if len(kubeService.Spec.ClusterIP) == 0 || strings.ToLower(kubeService.Spec.ClusterIP) == clusterIPNone {
+	if len(kubeService.Spec.ClusterIP) == 0 || kubeService.Spec.ClusterIP == corev1.ClusterIPNone {
 		// If service has no cluster IP or cluster IP is <none>, use final endpoint as resolvable destinations
 		return c.ListEndpointsForService(svc), nil
 	}

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 				Namespace: tests.BookbuyerService.Namespace,
 			},
 			Spec: corev1.ServiceSpec{
-				ClusterIP: clusterIPNone,
+				ClusterIP: corev1.ClusterIPNone,
 				Ports: []corev1.ServicePort{{
 					Name:     "servicePort",
 					Protocol: corev1.ProtocolTCP,


### PR DESCRIPTION
**Description**:

Replaced custom constant for custerIPNone with k8s constant.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no` 
