### PR TITLE
egress: add support for server-first TCP protocols

### DIFF
--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -44,7 +44,7 @@ func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceId
 					DestinationProtocol: portSpec.Protocol,
 				})
 
-			case constants.ProtocolTCP:
+			case constants.ProtocolTCP, constants.ProtocolTCPServerFirst:
 				// ---
 				// Build the TCP cluster config for this port
 				clusterConfigs = append(clusterConfigs, &trafficpolicy.EgressClusterConfig{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -196,4 +196,9 @@ const (
 
 	// gRPC protocol
 	ProtocolGRPC = "grpc"
+
+	// ProtocolTCPServerFirst implies TCP based server first protocols
+	// Ex. MySQL, SMTP, PostgreSQL etc. where the server initiates the first
+	// byte in a TCP connection.
+	ProtocolTCPServerFirst = "tcp-server-first"
 )

--- a/pkg/envoy/lds/egress.go
+++ b/pkg/envoy/lds/egress.go
@@ -43,7 +43,7 @@ func (lb *listenerBuilder) getEgressFilterChainsForMatches(matches []*trafficpol
 				filterChains = append(filterChains, filterChain)
 			}
 
-		case constants.ProtocolTCP, constants.ProtocolHTTPS:
+		case constants.ProtocolTCP, constants.ProtocolHTTPS, constants.ProtocolTCPServerFirst:
 			// TCP or HTTPS protocol --> TCPProxy filter
 			if filterChain, err := lb.getEgressTCPFilterChain(*match); err != nil {
 				log.Error().Err(err).Msgf("Error building egress filter chain for match [%v]", *match)

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -3,16 +3,19 @@ package lds
 import (
 	"fmt"
 
+	mapset "github.com/deckarep/golang-set"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	xds_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/featureflags"
+	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
 const (
@@ -41,14 +44,6 @@ func (lb *listenerBuilder) newOutboundListener() (*xds_listener.Listener, error)
 		},
 	}
 
-	// Create filter chains for egress based on policies
-	if egressTrafficPolicy, err := lb.meshCatalog.GetEgressTrafficPolicy(lb.serviceIdentity); err != nil {
-		log.Error().Err(err).Msgf("Error retrieving egress policies for proxy with identity %s, skipping egress filters", lb.serviceIdentity)
-	} else if egressTrafficPolicy != nil {
-		egressFilterChains := lb.getEgressFilterChainsForMatches(egressTrafficPolicy.TrafficMatches)
-		listener.FilterChains = append(listener.FilterChains, egressFilterChains...)
-	}
-
 	// Create a default passthrough filter chain when global egress is enabled.
 	// This filter chain matches any traffic not matching any of the filter chains built from
 	// mesh (SMI or permissive mode) or egress traffic policies. Traffic matching this default
@@ -62,26 +57,31 @@ func (lb *listenerBuilder) newOutboundListener() (*xds_listener.Listener, error)
 		listener.DefaultFilterChain = egressFilterChain
 	}
 
-	if len(listener.FilterChains) == 0 && listener.DefaultFilterChain == nil {
-		// Programming a listener with no filter chains is an error.
-		// It is possible for the outbound listener to have no filter chains if
-		// there are no allowed upstreams for this proxy and egress is disabled.
-		// In this case, return a nil filter chain so that it doesn't get programmed.
-		return nil, nil
-	}
-
 	if featureflags.IsEgressPolicyEnabled() {
+		var filterDisableMatchPredicate *xds_listener.ListenerFilterChainMatchPredicate
+		// Create filter chains for egress based on policies
+		if egressTrafficPolicy, err := lb.meshCatalog.GetEgressTrafficPolicy(lb.serviceIdentity); err != nil {
+			log.Error().Err(err).Msgf("Error retrieving egress policies for proxy with identity %s, skipping egress filters", lb.serviceIdentity)
+		} else if egressTrafficPolicy != nil {
+			egressFilterChains := lb.getEgressFilterChainsForMatches(egressTrafficPolicy.TrafficMatches)
+			listener.FilterChains = append(listener.FilterChains, egressFilterChains...)
+			filterDisableMatchPredicate = getFilterMatchPredicateForTrafficMatches(egressTrafficPolicy.TrafficMatches)
+		}
 		additionalListenerFilters := []*xds_listener.ListenerFilter{
+			// Configure match predicate for ports serving server-first protocols (ex. mySQL, postgreSQL etc.).
+			// Ports corresponding to server-first protocols, where the server initiates the first byte of a connection, will
+			// cause the HttpInspector ListenerFilter to timeout because it waits for data from the client to inspect the protocol.
+			// Such ports will set the protocol to 'tcp-server-first' in an Egress policy.
+			// The 'FilterDisabled' field configures the match predicate.
 			{
 				// To inspect TLS metadata, such as the transport protocol and SNI
-				Name: wellknown.TlsInspector,
+				Name:           wellknown.TlsInspector,
+				FilterDisabled: filterDisableMatchPredicate,
 			},
 			{
 				// To inspect if the application protocol is HTTP based
-				Name: wellknown.HttpInspector,
-				// TODO(#3045): configure match predicate for ports serving server-first protocols (ex. mySQL, postgreSQL etc.)
-				// Ports corresponding to server-first protocols, where the server initiates the first byte of a connection, will
-				// cause the HttpInspector ListenerFilter to timeout because it waits for data from the client to inspect the protocol.
+				Name:           wellknown.HttpInspector,
+				FilterDisabled: filterDisableMatchPredicate,
 			},
 		}
 		listener.ListenerFilters = append(listener.ListenerFilters, additionalListenerFilters...)
@@ -89,6 +89,14 @@ func (lb *listenerBuilder) newOutboundListener() (*xds_listener.Listener, error)
 		// ListenerFilter can timeout for server-first protocols. In such cases, continue the processing of the connection
 		// and fallback to the default filter chain.
 		listener.ContinueOnListenerFiltersTimeout = true
+	}
+
+	if len(listener.FilterChains) == 0 && listener.DefaultFilterChain == nil {
+		// Programming a listener with no filter chains is an error.
+		// It is possible for the outbound listener to have no filter chains if
+		// there are no allowed upstreams for this proxy and egress is disabled.
+		// In this case, return a nil filter chain so that it doesn't get programmed.
+		return nil, nil
 	}
 
 	return listener, nil
@@ -162,4 +170,65 @@ func getDefaultPassthroughFilterChain() (*xds_listener.FilterChain, error) {
 			},
 		},
 	}, nil
+}
+
+// getFilterMatchPredicateForTrafficMatches returns a ListenerFilterChainMatchPredicate corresponding to server-first ports.
+// If there are no server-first ports, a nil object is returned.
+func getFilterMatchPredicateForTrafficMatches(matches []*trafficpolicy.TrafficMatch) *xds_listener.ListenerFilterChainMatchPredicate {
+	var ports []int
+	portSet := mapset.NewSet()
+
+	for _, match := range matches {
+		// Only configure match predicate for server first protocol
+		if match.DestinationProtocol != constants.ProtocolTCPServerFirst {
+			continue
+		}
+
+		newlyAdded := portSet.Add(match.DestinationPort)
+		if newlyAdded {
+			ports = append(ports, match.DestinationPort)
+		}
+	}
+
+	if len(ports) == 0 {
+		return nil
+	}
+
+	return getFilterMatchPredicateForPorts(ports)
+}
+
+// getFilterMatchPredicateForPorts returns a ListenerFilterChainMatchPredicate that matches the given set of ports
+func getFilterMatchPredicateForPorts(ports []int) *xds_listener.ListenerFilterChainMatchPredicate {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	matchPredicates := []*xds_listener.ListenerFilterChainMatchPredicate{}
+
+	// Create a match predicate for each port
+	for _, port := range ports {
+		matchRule := &xds_listener.ListenerFilterChainMatchPredicate{
+			Rule: &xds_listener.ListenerFilterChainMatchPredicate_DestinationPortRange{
+				DestinationPortRange: &xds_type.Int32Range{
+					Start: int32(port),     // Start is inclusive
+					End:   int32(port + 1), // End is exclusive
+				},
+			},
+		}
+		matchPredicates = append(matchPredicates, matchRule)
+	}
+
+	if len(matchPredicates) > 1 {
+		// Proto constraint validation requirers at least 2 items to be able
+		// to use an OR based match set.
+		return &xds_listener.ListenerFilterChainMatchPredicate{
+			Rule: &xds_listener.ListenerFilterChainMatchPredicate_OrMatch{
+				OrMatch: &xds_listener.ListenerFilterChainMatchPredicate_MatchSet{
+					Rules: matchPredicates,
+				},
+			},
+		}
+	}
+
+	return &xds_listener.ListenerFilterChainMatchPredicate{Rule: matchPredicates[0].GetRule()}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds support to enable egress for server-first
protocols such as MySQL, PostgreSQL etc. by bypassing the
listener filters that wait on client data,  which would
otherwise time out for such protocols.
An egress policy for TCP based server-first protocols must
set the protocol to `tcp-server-first` to indicate that
protocol detection must be skipped for such a port.

Verified this change with mySQL based egress and confirmed
that such traffic no longer times out the listener filter
that wait on data from the client.

Part of #3045

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [X]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [X]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`