### PR TITLE
feat(proxyResLimits): Add proxy resource configuration through MeshConfig

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
@@ -76,6 +77,9 @@ const (
 
 	// configResyncInterval is the key name used to configure the resync interval for regular proxy broadcast updates
 	configResyncIntervalKey = "config_resync_interval"
+
+	// proxyResources is the key used to configure proxy resources
+	proxyResourcesKey = "proxy_resources"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -188,6 +192,7 @@ func parseOSMMeshConfig(meshConfig *v1alpha1.MeshConfig) *osmConfig {
 		ConfigResyncInterval:          spec.Sidecar.ConfigResyncInterval,
 		MaxDataPlaneConnections:       spec.Sidecar.MaxDataPlaneConnections,
 		TracingEnable:                 spec.Observability.Tracing.Enable,
+		proxyResources:                spec.Sidecar.Resources,
 	}
 
 	if spec.Observability.Tracing.Enable {
@@ -343,4 +348,7 @@ type osmConfig struct {
 
 	// ConfigResyncInterval is a flag to configure resync interval for regular proxy broadcast updates
 	ConfigResyncInterval string `yaml:"config_resync_interval"`
+
+	// proxyResources are the proxy resources speficied for a proxy, if any
+	proxyResources corev1.ResourceRequirements
 }

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Test OSM MeshConfig parsing", func() {
 				"EnablePrivilegedInitContainer": enablePrivilegedInitContainerKey,
 				"ConfigResyncInterval":          configResyncIntervalKey,
 				"MaxDataPlaneConnections":       maxDataPlaneConnectionsKey,
+				"ProxyResources":                proxyResourcesKey,
 			}
 			t := reflect.TypeOf(osmConfig{})
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -174,4 +176,9 @@ func (c *Client) GetConfigResyncInterval() time.Duration {
 		return time.Duration(0)
 	}
 	return duration
+}
+
+// GetProxyResources returns the `Resources` configured for proxies, if any
+func (c *Client) GetProxyResources() corev1.ResourceRequirements {
+	return c.getMeshConfig().proxyResources
 }

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 )
 
 // MockConfigurator is a mock of Configurator interface
@@ -159,6 +160,20 @@ func (m *MockConfigurator) GetOutboundPortExclusionList() []int {
 func (mr *MockConfiguratorMockRecorder) GetOutboundPortExclusionList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundPortExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundPortExclusionList))
+}
+
+// GetProxyResources mocks base method
+func (m *MockConfigurator) GetProxyResources() v1.ResourceRequirements {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProxyResources")
+	ret0, _ := ret[0].(v1.ResourceRequirements)
+	return ret0
+}
+
+// GetProxyResources indicates an expected call of GetProxyResources
+func (mr *MockConfiguratorMockRecorder) GetProxyResources() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProxyResources", reflect.TypeOf((*MockConfigurator)(nil).GetProxyResources))
 }
 
 // GetServiceCertValidityPeriod mocks base method

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -4,6 +4,7 @@ package configurator
 import (
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -85,4 +86,7 @@ type Configurator interface {
 	// GetConfigResyncInterval returns the duration for resync interval.
 	// If error or non-parsable value, returns 0 duration
 	GetConfigResyncInterval() time.Duration
+
+	// GetProxyResources returns the `Resources` configured for proxies, if any
+	GetProxyResources() corev1.ResourceRequirements
 }

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -48,7 +48,8 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator
 			ReadOnly:  true,
 			MountPath: envoyProxyConfigPath,
 		}},
-		Command: []string{"envoy"},
+		Command:   []string{"envoy"},
+		Resources: cfg.GetProxyResources(),
 		Args: []string{
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -63,6 +63,7 @@ var _ = Describe("Test all patch operations", func() {
 			mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
 			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
 			mockConfigurator.EXPECT().GetOutboundPortExclusionList().Return(nil).Times(1)
+			mockConfigurator.EXPECT().GetProxyResources().Return(corev1.ResourceRequirements{}).Times(1)
 
 			req := &admissionv1.AdmissionRequest{Namespace: namespace}
 			jsonPatches, err := wh.createPatch(&pod, req, proxyUUID)

--- a/tests/e2e/e2e_proxy_resource_limits.go
+++ b/tests/e2e/e2e_proxy_resource_limits.go
@@ -1,0 +1,116 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Test proxy resource setting",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 4,
+	},
+	func() {
+		Context("proxy resources", func() {
+			It("tests default resource values and updated resource values for proxies", func() {
+				// Install OSM
+				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+
+				const testNS = "client"
+				const clientNoResourceLimits = "client1"
+				const clientResLimits = "client2"
+
+				// Create Test NS
+				Expect(Td.CreateNs(testNS, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, testNS)).To(Succeed())
+
+				// Confirm there are no resource limits for proxies by default
+				meshConfig, err := Td.GetMeshConfig(Td.OsmNamespace)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(len(meshConfig.Spec.Sidecar.Resources.Limits)).To(BeZero())
+				Expect(len(meshConfig.Spec.Sidecar.Resources.Requests)).To(BeZero())
+
+				// Create simple app, expect no resources for this proxy
+				createSimpleApp(clientNoResourceLimits, testNS)
+
+				// Validate proxy resources for this pod, expect none set
+				pod, err := Td.Client.CoreV1().Pods(testNS).Get(context.Background(), clientNoResourceLimits, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				found := false
+				for _, cont := range pod.Spec.Containers {
+					if cont.Name == "envoy" {
+						Expect(len(cont.Resources.Limits)).To(BeZero())
+						Expect(len(cont.Resources.Requests)).To(BeZero())
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue())
+
+				// Update meshconfig, update proxy resources
+				meshConfig.Spec.Sidecar.Resources = corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("2"),
+						corev1.ResourceMemory: resource.MustParse("128M"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("64M"),
+					},
+				}
+				_, err = Td.ConfigClient.ConfigV1alpha1().MeshConfigs(Td.OsmNamespace).Update(context.TODO(), meshConfig, v1.UpdateOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+
+				// Create a new app
+				createSimpleApp(clientResLimits, testNS)
+
+				// Verify this pod has now the correct proxy resource limits and requests set
+				pod, err = Td.Client.CoreV1().Pods(testNS).Get(context.Background(), clientResLimits, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				found = false
+				for _, cont := range pod.Spec.Containers {
+					if cont.Name == "envoy" {
+						Expect(cont.Resources.Limits[corev1.ResourceCPU]).To(Equal(resource.MustParse("2")))
+						Expect(cont.Resources.Limits[corev1.ResourceMemory]).To(Equal(resource.MustParse("128M")))
+						Expect(cont.Resources.Requests[corev1.ResourceCPU]).To(Equal(resource.MustParse("1")))
+						Expect(cont.Resources.Requests[corev1.ResourceMemory]).To(Equal(resource.MustParse("64M")))
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
+		})
+	})
+
+func createSimpleApp(appName string, ns string) {
+	// Get simple pod definitions for the HTTP server
+	svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		SimplePodAppDef{
+			Name:      appName,
+			Namespace: ns,
+			Command:   []string{"/bin/bash", "-c", "--"},
+			Args:      []string{"while true; do sleep 30; done;"},
+			Image:     "songrgg/alpine-debug",
+			Ports:     []int{80},
+		})
+
+	_, err := Td.CreateServiceAccount(ns, &svcAccDef)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = Td.CreatePod(ns, podDef)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = Td.CreateService(ns, svcDef)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Expect it to be up and running in it's receiver namespace
+	Expect(Td.WaitForPodsRunningReady(ns, 90*time.Second, 1)).To(Succeed())
+}


### PR DESCRIPTION
Uses the available, recently introduced configuration options in MeshConfig to configure
proxy resources `requests` and `limits`.

- Includes various unit tests on related packages for relevant functions
- Includes an e2e test

Signed-off-by: Eduard Serra <eduser25@gmail.com>


- New Functionality      [x]
- Control Plane          [x]

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
No