### PR TITLE
feat(meshConfigCRD): Retain install configurability

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager"` | cert-manager issuer group |
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` | cert-manager issuer kind |
 | OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` | cert-manager issuer namecert-manager issuer name |
+| OpenServiceMesh.configResyncInterval | string | `"0s"` | Sets the resync interval for regular proxy broadcast updates, set to 0s to not enforce any resync |
 | OpenServiceMesh.controllerLogLevel | string | `"info"` | Controller log verbosity |
 | OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana |
 | OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger in the OSM namespace |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -84,6 +84,10 @@ spec:
                           description: "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/"
                           type: object
                           additionalProperties: true
+                    configResyncInterval:
+                      description: Resync interval for regular proxy broadcast updates
+                      type: string
+                      default: "0s"
                 traffic:
                   description: Configuration for traffic management
                   type: object

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -1,0 +1,30 @@
+apiVersion: config.openservicemesh.io/v1alpha1
+kind: MeshConfig
+metadata:
+  name: preset-mesh-config
+spec:
+  sidecar:
+    enablePrivilegedInitContainer: {{.Values.OpenServiceMesh.enablePrivilegedInitContainer}}
+    logLevel: {{.Values.OpenServiceMesh.envoyLogLevel}}
+    maxDataPlaneConnections: {{.Values.OpenServiceMesh.maxDataPlaneConnections}}
+    envoyImage: {{.Values.OpenServiceMesh.sidecarImage}}
+    initContainerImage: "{{ .Values.OpenServiceMesh.image.registry }}/init:{{ .Values.OpenServiceMesh.image.tag }}"
+    configResyncInterval: {{.Values.OpenServiceMesh.configResyncInterval}}
+  traffic:
+    enableEgress: {{.Values.OpenServiceMesh.enableEgress}}
+    useHTTPSIngress: {{.Values.OpenServiceMesh.useHTTPSIngress}}
+    enablePermissiveTrafficPolicyMode: {{.Values.OpenServiceMesh.enablePermissiveTrafficPolicy}}
+    outboundPortExclusionList: {{.Values.OpenServiceMesh.outboundPortExclusionList}}
+    outboundIPRangeExclusionList: {{.Values.OpenServiceMesh.outboundIPRangeExclusionList}}
+  observability:
+    enableDebugServer: {{.Values.OpenServiceMesh.enableDebugServer}}
+    prometheusScraping: {{.Values.OpenServiceMesh.enablePrometheusScraping}}
+    tracing:
+      enable: {{.Values.OpenServiceMesh.tracing.enable}}
+      {{- if .Values.OpenServiceMesh.tracing.enable }}
+      port: {{.Values.OpenServiceMesh.tracing.port}}
+      address: {{.Values.OpenServiceMesh.tracing.address | quote}}
+      endpoint: {{.Values.OpenServiceMesh.tracing.endpoint  | quote}}
+      {{- end }}
+  certificate:
+    serviceCertValidityDuration: {{.Values.OpenServiceMesh.serviceCertValidityDuration}}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -404,6 +404,15 @@
                         "1000"
                     ]
                 },
+                "configResyncInterval": {
+                    "$id": "#/properties/OpenServiceMesh/properties/configResyncInterval",
+                    "type": "string",
+                    "title": "The configResyncInterval schema",
+                    "description": "Sets the resync interval for regular proxy broadcast updates",
+                    "examples": [
+                        "30s"
+                    ]
+                },
                 "envoyLogLevel": {
                     "$id": "#/properties/OpenServiceMesh/properties/envoyLogLevel",
                     "type": "string",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -109,6 +109,8 @@ OpenServiceMesh:
   envoyLogLevel: error
   # -- Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits
   maxDataPlaneConnections: 0
+   # -- Sets the resync interval for regular proxy broadcast updates, set to 0s to not enforce any resync
+  configResyncInterval: "0s"
   # -- Controller log verbosity
   controllerLogLevel: info
   # -- Enforce only deploying one mesh in the cluster

--- a/cmd/init-osm-controller/init-osm-controller_test.go
+++ b/cmd/init-osm-controller/init-osm-controller_test.go
@@ -4,18 +4,58 @@ import (
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 )
 
 func TestCreateDefaultMeshConfig(t *testing.T) {
 	assert := tassert.New(t)
 
-	meshConfig := createDefaultMeshConfig()
-	assert.Equal(meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode, false)
-	assert.Equal(meshConfig.Spec.Traffic.EnableEgress, false)
+	presetMeshConfig := &v1alpha1.MeshConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MeshConfig",
+			APIVersion: "config.openservicemesh.io/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: presetMeshConfigName,
+		},
+		Spec: v1alpha1.MeshConfigSpec{
+			Sidecar: v1alpha1.SidecarSpec{
+				LogLevel:                      "error",
+				EnvoyImage:                    "envoyproxy/envoy-alpine:v1.17.2",
+				InitContainerImage:            "openservicemesh/init:v0.8.3",
+				EnablePrivilegedInitContainer: false,
+				MaxDataPlaneConnections:       0,
+				ConfigResyncInterval:          "2s",
+			},
+			Traffic: v1alpha1.TrafficSpec{
+				EnableEgress:                      true,
+				UseHTTPSIngress:                   false,
+				EnablePermissiveTrafficPolicyMode: true,
+			},
+			Observability: v1alpha1.ObservabilitySpec{
+				EnableDebugServer:  false,
+				PrometheusScraping: true,
+				Tracing: v1alpha1.TracingSpec{
+					Enable: false,
+				},
+			},
+			Certificate: v1alpha1.CertificateSpec{
+				ServiceCertValidityDuration: "24h",
+			},
+		},
+	}
+
+	meshConfig := createDefaultMeshConfig(presetMeshConfig)
+	assert.Equal(meshConfig.Name, meshConfigName)
 	assert.Equal(meshConfig.Spec.Sidecar.LogLevel, "error")
-	assert.Equal(meshConfig.Spec.Sidecar.LogLevel, "error")
+	assert.Equal(meshConfig.Spec.Sidecar.ConfigResyncInterval, "2s")
+	assert.Equal(meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer, false)
+	assert.Equal(meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode, true)
+	assert.Equal(meshConfig.Spec.Traffic.EnableEgress, true)
+	assert.Equal(meshConfig.Spec.Traffic.UseHTTPSIngress, false)
 	assert.Equal(meshConfig.Spec.Observability.PrometheusScraping, true)
 	assert.Equal(meshConfig.Spec.Observability.EnableDebugServer, false)
-	assert.Equal(meshConfig.Spec.Traffic.UseHTTPSIngress, false)
 	assert.Equal(meshConfig.Spec.Certificate.ServiceCertValidityDuration, "24h")
 }

--- a/docs/example/manifests/mesh-config.yaml
+++ b/docs/example/manifests/mesh-config.yaml
@@ -9,6 +9,7 @@ spec:
     maxDataPlaneConnections: 0
     envoyImage: "envoyproxy/envoy-alpine:v1.17.2"
     initContainerImage: "openservicemesh/init:v0.8.3"
+    configResyncInterval: "0s"
   traffic:
     enableEgress: false
     useHTTPSIngress: false
@@ -16,6 +17,8 @@ spec:
   observability:
     enableDebugServer: true
     prometheusScraping: true
+    outboundPortExclusionList: []
+    outboundIPRangeExclusionList: []
     tracing:
       enable: false
   certificate:

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -23,6 +23,7 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 			It("Starts debug server only when enableDebugServer flag is enabled", func() {
 				// Install OSM
 				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnableDebugServer = false
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 				meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
 

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -22,13 +22,10 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 			It("Allows egress traffic when enabled", func() {
 				// Install OSM
 				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EgressEnabled = true
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-				var err error
 				meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
-				meshConfig.Spec.Traffic.EnableEgress = true
-				meshConfig, err = Td.UpdateOSMConfig(meshConfig)
-				Expect(err).NotTo(HaveOccurred())
 
 				// Create Test NS
 				Expect(Td.CreateNs(sourceNs, nil)).To(Succeed())
@@ -44,7 +41,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 					Ports:     []int{80},
 				})
 
-				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err := Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_init_controller_test.go
+++ b/tests/e2e/e2e_init_controller_test.go
@@ -25,9 +25,9 @@ var _ = OSMDescribe("Test init-osm-controller functionalities",
 				// validate osm MeshConfig
 				Expect(meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode).Should(BeFalse())
 				Expect(meshConfig.Spec.Traffic.EnableEgress).Should(BeFalse())
-				Expect(meshConfig.Spec.Sidecar.LogLevel).Should(Equal("error"))
+				Expect(meshConfig.Spec.Sidecar.LogLevel).Should(Equal("debug"))
 				Expect(meshConfig.Spec.Observability.PrometheusScraping).Should(BeTrue())
-				Expect(meshConfig.Spec.Observability.EnableDebugServer).Should(BeFalse())
+				Expect(meshConfig.Spec.Observability.EnableDebugServer).Should(BeTrue())
 				Expect(meshConfig.Spec.Observability.Tracing.Enable).Should(BeFalse())
 				Expect(meshConfig.Spec.Traffic.UseHTTPSIngress).Should(BeFalse())
 				Expect(meshConfig.Spec.Certificate.ServiceCertValidityDuration).Should(Equal("24h"))

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -29,6 +29,7 @@ func testIPExclusion() {
 	It("Tests HTTP traffic to external server via IP exclusion", func() {
 		// Install OSM
 		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = false // explicitly set to false to demonstrate IP exclusion
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
 

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -39,11 +39,9 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 	It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
 		// Install OSM
 		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = true
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
-		meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode = true
-		meshConfig, err := Td.UpdateOSMConfig(meshConfig)
-		Expect(err).NotTo(HaveOccurred())
 
 		// Create Test NS
 		for _, n := range ns {
@@ -60,7 +58,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 				Ports:     []int{80},
 			})
 
-		_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
+		_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		dstPod, err := Td.CreatePod(destNs, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -38,13 +38,8 @@ func testTCPTraffic(permissiveMode bool) {
 	It("Tests TCP traffic for client pod -> server pod", func() {
 		// Install OSM
 		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EnablePermissiveMode = permissiveMode
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
-
-		var err error
-		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
-		meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode = permissiveMode
-		_, err = Td.UpdateOSMConfig(meshConfig)
-		Expect(err).NotTo(HaveOccurred())
 
 		// Load TCP server image
 		Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
@@ -69,7 +64,7 @@ func testTCPTraffic(permissiveMode bool) {
 				AppProtocol: constants.ProtocolTCP,
 			})
 
-		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -30,12 +30,10 @@ func testTCPEgressTraffic() {
 	It("Tests TCP traffic for client pod -> server pod", func() {
 		// Install OSM
 		installOpts := Td.GetOSMInstallOpts()
+		installOpts.EgressEnabled = true
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
-		meshConfig.Spec.Traffic.EnableEgress = true
-		meshConfig, err := Td.UpdateOSMConfig(meshConfig)
-		Expect(err).NotTo(HaveOccurred())
 
 		// Load TCP server image
 		Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
@@ -61,7 +59,7 @@ func testTCPEgressTraffic() {
 				AppProtocol: constants.ProtocolTCP,
 			})
 
-		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -537,6 +537,23 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		// Store current restart values for CTL processes
 		td.InitialRestartValues = td.GetOsmCtlComponentRestarts()
 
+		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
+
+		// This resets supported dynamic configs expected by the caller
+		meshConfig.Spec.Traffic.EnableEgress = instOpts.EgressEnabled
+		meshConfig, err := Td.UpdateOSMConfig(meshConfig)
+		if err != nil {
+			return err
+		}
+		meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode = instOpts.EnablePermissiveMode
+		meshConfig, err = Td.UpdateOSMConfig(meshConfig)
+		if err != nil {
+			return err
+		}
+		meshConfig.Spec.Observability.EnableDebugServer = instOpts.EnableDebugServer
+		if _, err = Td.UpdateOSMConfig(meshConfig); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -677,7 +694,6 @@ func (td *OsmTestData) GetMeshConfig(namespace string) (*v1alpha1.MeshConfig, er
 	if err != nil {
 		return nil, err
 	}
-	td.T.Logf("GetMeshConfig(): %v", meshConfig)
 	return meshConfig, nil
 }
 


### PR DESCRIPTION
**Description**:

This PR creates a MeshConfig resource `preset-mesh-config` using Helm. The init-osm-controller container will check for this resource and create the `osm-mesh-config` MeshConfig if it does not exist.

This change is necessary as we need to support setting mesh configurations from CLI during installation, which was removed when migrating from osm-config configmap to MeshConfig CRD  PR #3276 

As there is logic that ensures MeshConfig is updated from the preset only if it doesn't exit, the config values that a user applies will persist through upgrades. There will be no custom logic needed to retain them in upgrades, there will be a follow up PR to delete upgrade code that depends on configmap (redundant now) .

Fixes #3301
Part of #3039 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution? `no`
