### PR TITLE
feat(*): garbage collector for OSM pod secrets

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -257,6 +257,8 @@ func main() {
 	debugConfig := debugger.NewDebugConfig(certDebugger, xdsServer, meshCatalog, proxyRegistry, kubeConfig, kubeClient, cfg, kubernetesClient)
 	debugConfig.StartDebugServerConfigListener()
 
+	k8s.PatchSecretHandler(kubeClient)
+
 	<-stop
 	log.Info().Msgf("Stopping osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 }

--- a/pkg/kubernetes/announcement_handlers.go
+++ b/pkg/kubernetes/announcement_handlers.go
@@ -1,0 +1,60 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
+)
+
+// PatchSecretHandler patches the envoy bootstrap config secrets based on the PodAdd events
+func PatchSecretHandler(kubeClient kubernetes.Interface) {
+	podAddSubscription := events.GetPubSubInstance().Subscribe(announcements.PodAdded)
+
+	go func() {
+		for {
+			podAddedMsg := <-podAddSubscription
+			psubMessage, castOk := podAddedMsg.(events.PubSubMessage)
+			if !castOk {
+				log.Error().Msgf("Error casting PubSubMessage: %T %v", psubMessage, psubMessage)
+				continue
+			}
+
+			// guaranteed can only be a PodAdded event
+			addedPodObj, castOk := psubMessage.NewObj.(*corev1.Pod)
+			if !castOk {
+				log.Error().Msgf("Failed to cast to *v1.Pod: %T %v", psubMessage.OldObj, psubMessage.OldObj)
+				continue
+			}
+
+			podUID := addedPodObj.GetUID()
+			podUUID := addedPodObj.GetLabels()[constants.EnvoyUniqueIDLabelName]
+			podName := addedPodObj.GetName()
+			namespace := addedPodObj.GetNamespace()
+			secretName := fmt.Sprintf("envoy-bootstrap-config-%s", podUUID)
+
+			if secret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{}); err != nil {
+				log.Error().Err(err).Msgf("Failed to get secret %s/%s mounted to Pod %s/%s", namespace, secretName, namespace, podName)
+			} else {
+				secret.ObjectMeta.OwnerReferences = append(secret.ObjectMeta.OwnerReferences, metav1.OwnerReference{
+					APIVersion: "v1",
+					Kind:       "Pod",
+					Name:       podName,
+					UID:        podUID,
+				})
+
+				if _, err = kubeClient.CoreV1().Secrets(namespace).Update(context.Background(), secret, metav1.UpdateOptions{}); err != nil {
+					log.Error().Err(err).Msgf("Failed to update OwnerReference for Secret %s/%s to reference Pod %s/%s", namespace, secretName, namespace, podName)
+				} else {
+					log.Debug().Msgf("Updated OwnerReference for Secret %s/%s to reference Pod %s/%s", namespace, secretName, namespace, podName)
+				}
+			}
+		}
+	}()
+}

--- a/tests/e2e/e2e_garbage_collector_test.go
+++ b/tests/e2e/e2e_garbage_collector_test.go
@@ -1,0 +1,109 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Test garbage collection for unused envoy bootstrap config secrets",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 2,
+	},
+	func() {
+		Context("Garbage Collection", func() {
+			userService := "app"
+			userReplicaSet := 1
+
+			It("Tests garbage collection", func() {
+				// Install OSM
+				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+
+				// Create NSs
+				Expect(Td.CreateNs(userService, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, userService)).To(Succeed())
+
+				// User app
+				svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+					SimpleDeploymentAppDef{
+						Name:         userService,
+						Namespace:    userService,
+						ReplicaCount: int32(userReplicaSet),
+						Command:      []string{"/bin/bash", "-c", "--"},
+						Args:         []string{"while true; do sleep 30; done;"},
+						Image:        "songrgg/alpine-debug",
+						Ports:        []int{80},
+					})
+
+				_, err := Td.CreateServiceAccount(userService, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateDeployment(userService, deploymentDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(userService, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(userService, 200*time.Second, userReplicaSet)).To(Succeed())
+
+				By("Verifying the secrets have been patched with OwnerReference")
+
+				podSelector := constants.EnvoyUniqueIDLabelName
+
+				pods, err := Td.Client.CoreV1().Pods(userService).List(context.Background(), metav1.ListOptions{LabelSelector: podSelector})
+				Expect(err).To(BeNil())
+
+				for _, pod := range pods.Items {
+					podUUID := pod.GetLabels()[podSelector]
+					secretName := fmt.Sprintf("envoy-bootstrap-config-%s", podUUID)
+					secret, err := Td.Client.CoreV1().Secrets(userService).Get(context.Background(), secretName, metav1.GetOptions{})
+					Expect(err).To(BeNil())
+
+					ownerReferences := secret.GetOwnerReferences()
+					Expect(ownerReferences).ToNot(BeNil())
+
+					expectedOwnerReference := v1.OwnerReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Name:       pod.GetName(),
+						UID:        pod.GetUID(),
+					}
+
+					foundReference := false
+					for _, ownerReference := range ownerReferences {
+						if reflect.DeepEqual(expectedOwnerReference, ownerReference) {
+							foundReference = true
+						}
+					}
+					Expect(foundReference).To(BeTrue())
+				}
+
+				By("Verifying unused secrets are deleted when the referenced owner is deleted")
+
+				pods, err = Td.Client.CoreV1().Pods(userService).List(context.Background(), metav1.ListOptions{LabelSelector: podSelector})
+				Expect(err).To(BeNil())
+
+				policy := metav1.DeletePropagationForeground
+				err = Td.Client.CoreV1().Pods(userService).DeleteCollection(context.Background(), metav1.DeleteOptions{PropagationPolicy: &policy}, metav1.ListOptions{LabelSelector: podSelector})
+				Expect(err).To(BeNil())
+
+				Expect(Td.WaitForPodsDeleted(pods, userService, 200*time.Second)).To(Succeed())
+
+				for _, pod := range pods.Items {
+					podUUID := pod.GetLabels()[podSelector]
+					secretName := fmt.Sprintf("envoy-bootstrap-config-%s", podUUID)
+					_, err := Td.Client.CoreV1().Secrets(userService).Get(context.Background(), secretName, metav1.GetOptions{})
+					Expect(err).ToNot(BeNil())
+				}
+			})
+		})
+	})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Creates a handler that subscribes to the PodAdded announcement.
When a pod is added to a namespace that is observed by the OSM
service mesh, the OwnerReference of the envoy bootstrap config
secret mounted to the pod is set to reference the pod. When the
pod terminates, the Kubernetes garbage collector will delete the
secret since its owner no longer exists. This change will prevent
the persistence of unused Kubernetes secrets.

Resolves #2795 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ X ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ X ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
no