### PR TITLE
charts/crds: use min-max port range validation instead of regex

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -103,7 +103,8 @@ spec:
                       type: array
                       items:
                         type: integer
-                        pattern: ^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$ # 1 to 65535
+                        minimum: 1
+                        maximum: 65535
                     useHTTPSIngress:
                       description: Enable HTTPS ingress on the mesh
                       type: boolean

--- a/charts/osm/crds/policy.yaml
+++ b/charts/osm/crds/policy.yaml
@@ -86,7 +86,8 @@ spec:
                       number:
                         description: Port number of this port.
                         type: integer
-                        pattern: ^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$ # 1 to 65535
+                        minimum: 1
+                        maximum: 65535
                       protocol:
                         description: Protocol served by this port.
                         type: string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Uses a min-max validation for port ranges instead of regex.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [X]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`