### PR TITLE
update envoy to 1.18.3

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -111,7 +111,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.replicaCount | int | `1` | `osm-controller` replicas |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Sets the service certificatevalidity duration |
-| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.17.2"` | Envoy sidecar image |
+| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.18.3"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `""` | Tracing destination cluster (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the cluster |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Destination's API or collector endpoint where the spans will be sent to |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -67,7 +67,7 @@ spec:
                     envoyImage:
                       description: Image for the Envoy sidecar
                       type: string
-                      default: "envoyproxy/envoy-alpine:v1.17.2"
+                      default: "envoyproxy/envoy-alpine:v1.18.3"
                       pattern: envoyproxy\/envoy-alpine:v\d+\.\d+\.\d+$
                     initContainerImage:
                       description: Image for the init container

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -181,7 +181,7 @@
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
                     "examples": [
-                        "envoyproxy/envoy-alpine:v1.17.2"
+                        "envoyproxy/envoy-alpine:v1.18.3"
                     ]
                 },
                 "certificateManager": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -15,7 +15,7 @@ OpenServiceMesh:
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
   # -- Envoy sidecar image
-  sidecarImage: envoyproxy/envoy-alpine:v1.17.2
+  sidecarImage: envoyproxy/envoy-alpine:v1.18.3
   osmcontroller:
     resource:
       limits:

--- a/cmd/init-osm-controller/init-osm-controller_test.go
+++ b/cmd/init-osm-controller/init-osm-controller_test.go
@@ -23,7 +23,7 @@ func TestCreateDefaultMeshConfig(t *testing.T) {
 		Spec: v1alpha1.MeshConfigSpec{
 			Sidecar: v1alpha1.SidecarSpec{
 				LogLevel:                      "error",
-				EnvoyImage:                    "envoyproxy/envoy-alpine:v1.17.2",
+				EnvoyImage:                    "envoyproxy/envoy-alpine:v1.18.3",
 				InitContainerImage:            "openservicemesh/init:v0.8.3",
 				EnablePrivilegedInitContainer: false,
 				MaxDataPlaneConnections:       0,

--- a/docs/example/manifests/meshconfig/mesh-config.yaml
+++ b/docs/example/manifests/meshconfig/mesh-config.yaml
@@ -7,7 +7,7 @@ spec:
     enablePrivilegedInitContainer: false
     logLevel: error
     maxDataPlaneConnections: 0
-    envoyImage: "envoyproxy/envoy-alpine:v1.17.2"
+    envoyImage: "envoyproxy/envoy-alpine:v1.18.3"
     initContainerImage: "openservicemesh/init:v0.8.3"
     configResyncInterval: "0s"
   traffic:

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -246,7 +246,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			name:                  "GetEnvoyImage",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal("envoyproxy/envoy-alpine:v1.17.2", cfg.GetEnvoyImage())
+				assert.Equal("envoyproxy/envoy-alpine:v1.18.3", cfg.GetEnvoyImage())
 			},
 			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{

--- a/pkg/configurator/validating_webhook_test.go
+++ b/pkg/configurator/validating_webhook_test.go
@@ -464,10 +464,10 @@ func TestCheckEnvoyLogLevels(t *testing.T) {
 func TestCheckEnvoyImage(t *testing.T) {
 	assert := tassert.New(t)
 	tests := map[string]bool{
-		"envoyproxy/envoy-alpine:v1.17.2": true,
+		"envoyproxy/envoy-alpine:v1.18.3": true,
 		"envoyproxy/envoy-alpine:v1.1.1":  true,
 		"envoyproxy/envoy-alpine":         false,
-		"envoyproxy/envoy:v1.17.2":        false,
+		"envoyproxy/envoy:v1.18.3":        false,
 	}
 
 	for image, expRes := range tests {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,7 +56,7 @@ const (
 	DefaultEnvoyLogLevel = "error"
 
 	// DefaultEnvoyImage is the default envoy proxy sidecar image if not defined in the osm MeshConfig
-	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.17.2"
+	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.18.3"
 
 	// DefaultInitContainerImage is the default init container image if not defined in the osm MeshConfig
 	DefaultInitContainerImage = "openservicemesh/init:v0.8.3"


### PR DESCRIPTION
Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

**Description**:

See #3343

Updates OSM to user Envoy version 1.18.3.

I will do a follow up PR to change the generated config to use some newer features.

I validated through `./demo/run-osm-demo.sh` and `./bin/osm proxy get config_dump bookbuyer-85d5c5f4f4-l7bgs -n bookbuyer > envoy-new.json`

```
    "node": {
     "hidden_envoy_deprecated_build_version": "98c1c9e9a40804b93b074badad1cdf284b47d58b/1.18.3/Clean/RELEASE/BoringSSL",
     "user_agent_name": "envoy",
     "user_agent_build_version": {
      "version": {
       "major_number": 1,
       "minor_number": 18,
       "patch": 3
      },
      "metadata": {
       "revision.sha": "98c1c9e9a40804b93b074badad1cdf284b47d58b",
       "build.type": "RELEASE",
       "revision.status": "Clean",
       "ssl.version": "BoringSSL"
      }
 ```


**Affected area**:

- New Functionality      [ ]
- Documentation          []
- Install                []
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [ ]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
