### PR TITLE
charts/crds: allow object references as matches

### DIFF
--- a/charts/osm/crds/policy.yaml
+++ b/charts/osm/crds/policy.yaml
@@ -91,3 +91,19 @@ spec:
                       protocol:
                         description: Protocol served by this port.
                         type: string
+                matches:
+                  description: The resource references an Egress policy should match on.
+                  type: array
+                  items:
+                    type: object
+                    required: ['apiGroup', 'kind', 'name']
+                    properties:
+                      apiGroup:
+                        description: API group for the resource being referenced.
+                        type: string
+                      kind:
+                        description: Type of resource being referenced.
+                        type: string
+                      name:
+                        description: Name of resource being referenced.
+                        type: string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The Egress policy API allows specifying object
references as matches, enable this in the CRD
definition since the code supports it.

Part of #3045

<!--

Please mark with X for applicable areas.

-->
**Affected area**:

- New Functionality      [ ]
- Documentation          [ ]
- Install                [ ]
- Control Plane          [ ]
- CLI Tool               [ ]
- Certificate Management [ ]
- Networking             [ ]
- Metrics                [ ]
- SMI Policy             [ ]
- Security               [ ]
- Tests                  [ ]
- CI System              [ ]
- Demo                   [ ]
- Performance            [ ]
- Other                  [X]


Please answer the following questions with yes/no.

- Does this change contain code from or inspired by another project? If so, did you notify the maintainers and provide attribution?
`No`