### PR TITLE
e2e: run all tests before merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        bucket: [1, 2, 3, 4]
+        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     env:
       CTR_TAG: ${{ github.sha }}
       CTR_REGISTRY: "localhost:5000" # unused for kind, but currently required in framework
@@ -193,7 +193,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           K8S_NAMESPACE: "osm-system"
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Tier 1\]\[Bucket ${{ matrix.bucket }}\]' -ginkgo.skip='Upgrade'
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\]' -ginkgo.skip='Upgrade'
         continue-on-error: true
       - name: Upload PR test logs
         if: ${{ steps.pr_test.conclusion != 'skipped' }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -17,45 +17,9 @@ The tests are written using Ginkgo and Gomega so they may also be directly invok
 OSM's framework, helpers and related files are located under `tests/framework`.
 Once imported, it automatically sets up an init mechanism which will automatically initialize and parse flags and variables from both `env` and `go test flags` if any are passed to the test. The hooks for initialization and cleanup are set at Ginkgo's `BeforeEach` at the top level of test execution (between Ginkgo `Describes`); we henceforth recommend keeping every test in its own `Describe` section, as well as on a separate file for clarity. You can refer to [common.go](tests/framework/common.go) for more details about the init, setup and cleanup processes.
 
-Tests are organized by top-level `Describe` blocks into tiers based on priority. A tier's tests will also be run as a part of all the tiers below it.
-
-- Tier 1: run against every PR and should pass before being merged
-- Tier 2: run against every merge into the main branch
-
-Independent of tiers, tests are also organized into buckets. Each bucket runs in parallel, and individual tests in the bucket run sequentially.
-
 ### Test organization
 
-| Test  | Tier | Bucket |
-|--|--|--|
-| e2e_smi_traffic_target_test.go | 1 | 1
-| e2e_trafficsplit_test.go | 1 | 1
-| e2e_permissive_test.go | 1 | 1
-| e2e_deployment_client_server_test.go | 1 | 2
-| e2e_tcp_client_server_test.go | 1 | 2
-| e2e_grpc_insecure_origination_test.go | 1 | 2
-| e2e_http_ingress_test.go | 1 | 3
-| e2e_egress_test.go | 1 | 3
-| e2e_tcp_egress_test.go | 1 | 3
-| e2e_trafficsplit_same_sa_test.go | 1 | 4
-| e2e_pod_client_server_test.go | 1 | 4
-| e2e_helm_install_test.go | 2 | 1
-| e2e_init_controller_test.go | 2 | 1
-| e2e_controller_restart_test.go | 2 | 1
-| e2e_k8s_version_test.go | 2 | 1
-| e2e_hashivault_test.go| 2 | 2
-| e2e_certmanager_test.go | 2 | 2
-| e2e_ip_exclusion_test.go | 2 | 3
-| e2e_port_exclusion_test.go | 2 | 3
-| e2e_grpc_secure_origination_test.go | 2 | 3
-| e2e_multiple_services_per_pod_test.go | 2 | 3
-| e2e_metrics_test.go | 2 | 4
-| e2e_debug_server_test.go | 2 | 4
-| e2e_fluentbit_deployment_test.go | 2 | 4
-| e2e_fluentbit_output_test.go | 2 | 4
-| e2e_upgrade_test.go | 2 | 4
-
-**Note**: These tiers and buckets and which tests fall into each are likely to change as the test suite grows.
+Tests are organized by top-level `Describe` blocks into buckets. Each bucket runs in parallel, and individual tests in the bucket run sequentially.
 
 To help organize the tests, a custom `Describe` block named `OSMDescribe` is provided which accepts an additional struct parameter which contains fields for test metadata like tier and bucket. `OSMDescribe` will construct a well-formatted name including the test metadata which can be used in CI to run tests accordingly. Ginkgo's original `Describe` should not be used directly at the top-level and `OSMDescribe` should be used instead.
 

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 1,
 	},
 	func() {
 		Context("CertManagerSimpleClientServer", func() {

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -14,7 +14,7 @@ import (
 var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 4,
+		Bucket: 1,
 	},
 	func() {
 		Context("DebugServer", func() {

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("HTTP and HTTPS Egress",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 3,
+		Bucket: 2,
 	},
 	func() {
 		Context("Egress", func() {

--- a/tests/e2e/e2e_fluentbit_deployment_test.go
+++ b/tests/e2e/e2e_fluentbit_deployment_test.go
@@ -16,7 +16,7 @@ import (
 var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 4,
+		Bucket: 2,
 	},
 	func() {
 		Context("Fluent Bit deployment", func() {

--- a/tests/e2e/e2e_fluentbit_output_test.go
+++ b/tests/e2e/e2e_fluentbit_output_test.go
@@ -19,7 +19,7 @@ import (
 var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 3,
 	},
 	func() {
 		Context("Fluent Bit output", func() {

--- a/tests/e2e/e2e_grpc_insecure_origination_test.go
+++ b/tests/e2e/e2e_grpc_insecure_origination_test.go
@@ -22,7 +22,7 @@ const grpcbinInsecurePort = 9000
 var _ = OSMDescribe("gRPC insecure traffic origination for client pod -> server pod usint HTTP routes",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 3,
 	},
 	func() {
 		Context("gRPC insecure traffic origination over HTTP2 with SMI HTTP routes", func() {

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 2,
+		Bucket: 4,
 	},
 	func() {
 		Context("HashivaultSimpleClientServer", func() {

--- a/tests/e2e/e2e_health_probe_test.go
+++ b/tests/e2e/e2e_health_probe_test.go
@@ -17,7 +17,7 @@ import (
 var _ = OSMDescribe("Test health probes can succeed",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 3,
+		Bucket: 4,
 	},
 	func() {
 		It("Configures Pods' probes so they work as expected", func() {

--- a/tests/e2e/e2e_helm_install_test.go
+++ b/tests/e2e/e2e_helm_install_test.go
@@ -10,7 +10,7 @@ import (
 var _ = OSMDescribe("Test osm control plane installation with Helm",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 4,
 	},
 	func() {
 		Context("Helm install using default values", func() {

--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -23,7 +23,7 @@ import (
 var _ = OSMDescribe("HTTP ingress",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 3,
+		Bucket: 5,
 	},
 	func() {
 		const destNs = "server"

--- a/tests/e2e/e2e_init_controller_test.go
+++ b/tests/e2e/e2e_init_controller_test.go
@@ -10,7 +10,7 @@ import (
 var _ = OSMDescribe("Test init-osm-controller functionalities",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 5,
 	},
 	func() {
 		Context("When osm-controller starts in fresh environment", func() {

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("Tests traffic via IP range exclusion",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 3,
+		Bucket: 5,
 	},
 	func() {
 		Context("Test IP range exclusion", func() {

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -15,7 +15,7 @@ import (
 var _ = OSMDescribe("Test HTTP traffic for different k8s versions",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 1,
+		Bucket: 6,
 	},
 	func() {
 		Context("Version v1.19.7", func() {

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -16,8 +16,8 @@ import (
 
 var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 	OSMDescribeInfo{
-		Tier:   2,  // experimental feature
-		Bucket: 14, // disabled due to #3199
+		Tier:   2, // experimental feature
+		Bucket: 6,
 	},
 	func() {
 		const sourceNs = "clientns"

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("Test access via multiple services matching the same pod",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 3,
+		Bucket: 6,
 	},
 	func() {
 		Context("Multiple services matching same pod", func() {

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -14,7 +14,7 @@ import (
 var _ = OSMDescribe("Permissive Traffic Policy Mode",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 7,
 	},
 	func() {
 		Context("Permissive mode HTTP test with a Kubernetes Service for the Source", func() {

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -18,7 +18,7 @@ import (
 var _ = OSMDescribe("Test HTTP traffic from 1 pod client -> 1 pod server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 4,
+		Bucket: 7,
 	},
 	func() {
 		Context("Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP", func() {

--- a/tests/e2e/e2e_port_exclusion_test.go
+++ b/tests/e2e/e2e_port_exclusion_test.go
@@ -13,7 +13,7 @@ import (
 var _ = OSMDescribe("Tests traffic via port exclusion",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 3,
+		Bucket: 7,
 	},
 	func() {
 		Context("Test global port exclusion", func() {

--- a/tests/e2e/e2e_proxy_resource_limits.go
+++ b/tests/e2e/e2e_proxy_resource_limits.go
@@ -17,7 +17,7 @@ import (
 var _ = OSMDescribe("Test proxy resource setting",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 4,
+		Bucket: 8,
 	},
 	func() {
 		Context("proxy resources", func() {

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -19,7 +19,7 @@ import (
 var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 8,
 	},
 	func() {
 		Context("SMI TrafficTarget", func() {

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -18,7 +18,7 @@ import (
 var _ = OSMDescribe("Test TCP traffic from 1 pod client -> 1 pod server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 8,
 	},
 	func() {
 		Context("SimpleClientServer TCP with SMI policies", func() {

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -15,7 +15,7 @@ import (
 var _ = OSMDescribe("Test TCP traffic from 1 pod client -> egress server",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 3,
+		Bucket: 9,
 	},
 	func() {
 		Context("SimpleClientServer egress TCP", func() {

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -19,7 +19,7 @@ import (
 var _ = OSMDescribe("Test traffic split where root service is same as backend service",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 2,
+		Bucket: 9,
 	},
 	func() {
 		Context("HTTP traffic splitting with SMI", func() {

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -18,7 +18,7 @@ import (
 var _ = OSMDescribe("Test TrafficSplit where each backend shares the same ServiceAccount",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 4,
+		Bucket: 9,
 	},
 	func() {
 		Context("ClientServerTrafficSplitSameSA", func() {

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -19,7 +19,7 @@ import (
 var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 1,
+		Bucket: 10,
 	},
 	func() {
 		Context("HTTP traffic splitting with SMI", func() {

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -20,7 +20,7 @@ import (
 var _ = OSMDescribe("Upgrade from latest",
 	OSMDescribeInfo{
 		Tier:   2,
-		Bucket: 4,
+		Bucket: 10,
 	},
 	func() {
 		const ns = "upgrade-test"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Runs the entire suite of e2e tests pre-merge. Increases
the number of buckets to keep the suite duration reasonable.

Also removes the test table from the readme since this gets 
stale pretty fast. Tests can be easily found by inspecting
the test directory.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |
| CI System                  | [X] |



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
