### PR TITLE
feat(extAuthz): Add inbound external authorization

### DIFF
--- a/docs/example/manifests/opa/deploy-opa-envoy.yaml
+++ b/docs/example/manifests/opa/deploy-opa-envoy.yaml
@@ -1,0 +1,99 @@
+####################################################
+# App Deployment with OPA-Envoy and Envoy sidecars.
+####################################################
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: opa
+  namespace: opa
+  labels:
+    app: opa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: opa
+  template:
+    metadata:
+      labels:
+        app: opa
+    spec:
+      containers:
+        - name: opa-envoy
+          image: openpolicyagent/opa:0.28.0-envoy
+          securityContext:
+            runAsUser: 1111
+          volumeMounts:
+            - readOnly: true
+              mountPath: /policy
+              name: opa-policy
+            - readOnly: true
+              mountPath: /config
+              name: opa-envoy-config
+          args:
+            - "run"
+            - "--server"
+            - "--config-file=/config/config.yaml"
+            - "--addr=0.0.0.0:8181"
+            - "--diagnostic-addr=0.0.0.0:8282"
+            - "--ignore=.*"
+            - "/policy/policy.rego"
+      volumes:
+        - name: proxy-config
+          configMap:
+            name: proxy-config
+        - name: opa-policy
+          configMap:
+            name: opa-policy
+        - name: opa-envoy-config
+          configMap:
+            name: opa-envoy-config
+---
+############################################################
+# Example configuration to bootstrap OPA-Envoy sidecars.
+############################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-envoy-config
+  namespace: opa
+data:
+  config.yaml: |
+    plugins:
+      envoy_ext_authz_grpc:
+        addr: :9191
+        path: envoy/authz/allow
+    decision_logs:
+      console: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opa
+  namespace: opa
+  labels:
+    app: opa
+spec:
+  ports:
+  - port: 9191
+    protocol: TCP
+    targetPort: 9191
+  selector:
+    app: opa
+---
+############################################################
+# Example policy to enforce into OPA-Envoy sidecars.
+############################################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: opa-policy
+  namespace: opa
+data:
+  policy.rego: |
+    package envoy.authz
+
+    import input.attributes.request.http as http_request
+
+    default allow = false
+---

--- a/pkg/auth/types.go
+++ b/pkg/auth/types.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"time"
+)
+
+// ExtAuthConfig implements a generic subset of External Authz to configure external authorization through HttpFilters
+type ExtAuthConfig struct {
+	// Enable enables/disables the inbound external authorization policy if present.
+	Enable bool
+
+	// Address is the target destination endpoint that will handle external authorization.
+	Address string
+
+	// Port is the remote destination port for the external authorization endpoint.
+	Port uint16
+
+	// StatPrefix is a prefix for inbound external authorization related metrics.
+	StatPrefix string
+
+	// AuthzTimeout defines the timeout to consider for the remote endpoint to reply in time.
+	AuthzTimeout time.Duration
+
+	// FailureModeAllow allows specifying if traffic should succeed or fail if the external authorization endpoint fails to respond.
+	FailureModeAllow bool
+}

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Test OSM MeshConfig parsing", func() {
 				"ConfigResyncInterval":          configResyncIntervalKey,
 				"MaxDataPlaneConnections":       maxDataPlaneConnectionsKey,
 				"ProxyResources":                proxyResourcesKey,
+				"InboundExternAuthz":            inboundExtAuthz,
 			}
 			t := reflect.TypeOf(osmConfig{})
 
@@ -225,6 +226,12 @@ func TestMeshConfigEventTriggers(t *testing.T) {
 			},
 			expectProxyBroadcast: false,
 		},
+		{
+			deltaMeshConfigContents: map[string]string{
+				inboundExtAuthz: "true",
+			},
+			expectProxyBroadcast: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -266,6 +273,10 @@ func TestMeshConfigEventTriggers(t *testing.T) {
 				meshConfig.Spec.Traffic.OutboundPortExclusionList = portExclusionList
 			case configResyncIntervalKey:
 				meshConfig.Spec.Sidecar.ConfigResyncInterval = mapVal
+			case inboundExtAuthz:
+				meshConfig.Spec.Traffic.InboundExternalAuthorization = v1alpha1.ExternalAuthzSpec{
+					Enable: true,
+				}
 			}
 		}
 

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -9,6 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	auth "github.com/openservicemesh/osm/pkg/auth"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -75,6 +76,20 @@ func (m *MockConfigurator) GetEnvoyLogLevel() string {
 func (mr *MockConfiguratorMockRecorder) GetEnvoyLogLevel() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvoyLogLevel", reflect.TypeOf((*MockConfigurator)(nil).GetEnvoyLogLevel))
+}
+
+// GetInboundExternalAuthConfig mocks base method
+func (m *MockConfigurator) GetInboundExternalAuthConfig() auth.ExtAuthConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInboundExternalAuthConfig")
+	ret0, _ := ret[0].(auth.ExtAuthConfig)
+	return ret0
+}
+
+// GetInboundExternalAuthConfig indicates an expected call of GetInboundExternalAuthConfig
+func (mr *MockConfiguratorMockRecorder) GetInboundExternalAuthConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInboundExternalAuthConfig", reflect.TypeOf((*MockConfigurator)(nil).GetInboundExternalAuthConfig))
 }
 
 // GetInitContainerImage mocks base method

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
+	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -89,4 +90,7 @@ type Configurator interface {
 
 	// GetProxyResources returns the `Resources` configured for proxies, if any
 	GetProxyResources() corev1.ResourceRequirements
+
+	// GetInboundExternalAuthConfig returns the External Authentication configuration for incoming traffic, if any
+	GetInboundExternalAuthConfig() auth.ExtAuthConfig
 }

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -17,6 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/auth"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -205,6 +206,9 @@ var _ = Describe("Test ADS response functions", func() {
 		mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(certDuration).AnyTimes()
 		mockConfigurator.EXPECT().IsDebugServerEnabled().Return(true).AnyTimes()
+		mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
+			Enable: false,
+		}).AnyTimes()
 
 		It("returns Aggregated Discovery Service response", func() {
 			s := NewADSServer(mc, proxyRegistry, true, tests.Namespace, mockConfigurator, mockCertManager)

--- a/pkg/envoy/lds/auth.go
+++ b/pkg/envoy/lds/auth.go
@@ -1,0 +1,50 @@
+package lds
+
+import (
+	"fmt"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	xds_ext_authz "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/openservicemesh/osm/pkg/auth"
+)
+
+// getExtAuthzHTTPFilter returns an envoy HttpFilter given an ExternAuthConfig configuration
+func getExtAuthzHTTPFilter(extAuthConfig auth.ExtAuthConfig) *xds_hcm.HttpFilter {
+	extAuth := &xds_ext_authz.ExtAuthz{
+		Services: &xds_ext_authz.ExtAuthz_GrpcService{
+			GrpcService: &envoy_config_core_v3.GrpcService{
+				TargetSpecifier: &envoy_config_core_v3.GrpcService_GoogleGrpc_{
+					GoogleGrpc: &envoy_config_core_v3.GrpcService_GoogleGrpc{
+						TargetUri: fmt.Sprintf("%s:%d",
+							extAuthConfig.Address,
+							extAuthConfig.Port),
+						StatPrefix: extAuthConfig.StatPrefix,
+					},
+				},
+				Timeout: ptypes.DurationProto(extAuthConfig.AuthzTimeout),
+			},
+		},
+		TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
+		WithRequestBody: &xds_ext_authz.BufferSettings{
+			MaxRequestBytes:     8192,
+			AllowPartialMessage: true,
+		},
+		FailureModeAllow: extAuthConfig.FailureModeAllow,
+	}
+
+	extAuthMarshalled, err := ptypes.MarshalAny(extAuth)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to marshal External Authorization config")
+	}
+
+	return &xds_hcm.HttpFilter{
+		Name: wellknown.HTTPExternalAuthorization,
+		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
+			TypedConfig: extAuthMarshalled,
+		},
+	}
+}

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -39,7 +39,7 @@ func (lb *listenerBuilder) newIngressHTTPFilterChain(cfg configurator.Configurat
 		return nil
 	}
 
-	ingressConnManager := getHTTPConnectionManager(route.IngressRouteConfigName, cfg, nil)
+	ingressConnManager := getHTTPConnectionManager(route.IngressRouteConfigName, cfg, nil, inbound)
 	marshalledIngressConnManager, err := ptypes.MarshalAny(ingressConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling ingress HttpConnectionManager object for proxy %s", svc)

--- a/pkg/envoy/lds/ingress_test.go
+++ b/pkg/envoy/lds/ingress_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -103,6 +104,10 @@ func TestGetIngressFilterChains(t *testing.T) {
 			mockConfigurator.EXPECT().UseHTTPSIngress().Return(tc.httpsIngress).AnyTimes()
 			// Mock calls used to build the HTTP connection manager
 			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
+			// Expect no External Auth config
+			mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
+				Enable: false,
+			}).AnyTimes()
 
 			filterChains := lb.getIngressFilterChains(proxyService)
 

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -83,7 +83,7 @@ func (lb *listenerBuilder) getInboundHTTPFilters(proxyService service.MeshServic
 	}
 
 	// Apply the HTTP Connection Manager Filter
-	inboundConnManager := getHTTPConnectionManager(route.InboundRouteConfigName, lb.cfg, lb.statsHeaders)
+	inboundConnManager := getHTTPConnectionManager(route.InboundRouteConfigName, lb.cfg, lb.statsHeaders, inbound)
 	marshalledInboundConnManager, err := ptypes.MarshalAny(inboundConnManager)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling inbound HttpConnectionManager for proxy  service %s", proxyService)
@@ -234,7 +234,7 @@ func (lb *listenerBuilder) getOutboundHTTPFilter(routeConfigName string) (*xds_l
 	var err error
 
 	marshalledFilter, err = ptypes.MarshalAny(
-		getHTTPConnectionManager(routeConfigName, lb.cfg, lb.statsHeaders))
+		getHTTPConnectionManager(routeConfigName, lb.cfg, lb.statsHeaders, outbound))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling HTTP connection manager object")
 		return nil, err

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -14,6 +14,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -34,6 +35,9 @@ func TestGetOutboundHTTPFilterChainForService(t *testing.T) {
 	// Mock calls used to build the HTTP connection manager
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingEndpoint().Return("test-api").AnyTimes()
+	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
+		Enable: false,
+	}).AnyTimes()
 
 	lb := &listenerBuilder{
 		meshCatalog:     mockCatalog,
@@ -196,6 +200,9 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 	// Mock calls used to build the HTTP connection manager
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingEndpoint().Return("test-api").AnyTimes()
+	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
+		Enable: false,
+	}).AnyTimes()
 
 	lb := &listenerBuilder{
 		meshCatalog:     mockCatalog,
@@ -286,6 +293,9 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 	// Mock calls used to build the HTTP connection manager
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingEndpoint().Return("test-api").AnyTimes()
+	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
+		Enable: false,
+	}).AnyTimes()
 
 	lb := &listenerBuilder{
 		meshCatalog:     mockCatalog,

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/auth"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -70,6 +71,9 @@ func TestNewResponse(t *testing.T) {
 	mockConfigurator.EXPECT().IsPrometheusScrapingEnabled().Return(true).AnyTimes()
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().IsEgressEnabled().Return(true).AnyTimes()
+	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
+		Enable: false,
+	}).AnyTimes()
 
 	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil)
 	assert.Empty(err)


### PR DESCRIPTION
Commit adds external authorization.

Current version of the feature allows configuring external authorization
through MeshConfig's `inboundExternalAuthorization`.

When `enabled`, external authorization is enforced for all inbound and
ingress for all pods in the mesh.

patchset[1]:
    - moved auth-only configuration definition to standalone `auth` package.
    - Moved doc out, will push to osm-docs.
    - s/incoming/inbound s/outgoing/outbound

Signed-off-by: Eduard Serra <eduser25@gmail.com>

| New Functionality          | [x] |

1. Does this change contain code from or inspired by another project?
no

1. Is this a breaking change?
no