### PR TITLE
charts/osm: allow specifying tolerations for control plane pods

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` | cert-manager issuer kind |
 | OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` | cert-manager issuer namecert-manager issuer name |
 | OpenServiceMesh.configResyncInterval | string | `"0s"` | Sets the resync interval for regular proxy broadcast updates, set to 0s to not enforce any resync |
+| OpenServiceMesh.controlPlaneTolerations | list | `[]` | Node tolerations applied to control plane pods. The specified tolerations allow pods to schedule onto nodes with matching taints. |
 | OpenServiceMesh.controllerLogLevel | string | `"info"` | Controller log verbosity |
 | OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana |
 | OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger in the OSM namespace |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -156,3 +156,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.OpenServiceMesh.imagePullSecrets | indent 8 }}
     {{- end }}
+    {{- if .Values.OpenServiceMesh.controlPlaneTolerations }}
+      tolerations:
+{{ toYaml .Values.OpenServiceMesh.controlPlaneTolerations | indent 8 }}
+    {{- end }}

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -88,3 +88,7 @@ spec:
       imagePullSecrets:
 {{ toYaml .Values.OpenServiceMesh.imagePullSecrets | indent 8 }}
     {{- end }}
+    {{- if .Values.OpenServiceMesh.controlPlaneTolerations }}
+      tolerations:
+{{ toYaml .Values.OpenServiceMesh.controlPlaneTolerations | indent 8 }}
+    {{- end }}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -133,11 +133,13 @@
                     "type": "object",
                     "title": "The image schema",
                     "description": "The details of the images to run.",
-                    "examples": [{
-                        "registry": "openservicemesh",
-                        "pullPolicy": "IfNotPresent",
-                        "tag": "v0.4.2"
-                    }],
+                    "examples": [
+                        {
+                            "registry": "openservicemesh",
+                            "pullPolicy": "IfNotPresent",
+                            "tag": "v0.4.2"
+                        }
+                    ],
                     "required": [
                         "registry",
                         "pullPolicy",
@@ -280,16 +282,18 @@
                     "type": "object",
                     "title": "The Fluent Bit schema",
                     "description": "The default details of the Fluent Bit sidecar if enabled.",
-                    "examples": [{
-                        "name": "fluentbit-logger",
-                        "registry": "fluent",
-                        "tag": "1.6.4",
-                        "pullPolicy": "IfNotPresent",
-                        "outputPlugin": "stdout",
-                        "enableProxySupport": "false",
-                        "httpProxy": "",
-                        "httpsProxy": ""
-                    }],
+                    "examples": [
+                        {
+                            "name": "fluentbit-logger",
+                            "registry": "fluent",
+                            "tag": "1.6.4",
+                            "pullPolicy": "IfNotPresent",
+                            "outputPlugin": "stdout",
+                            "enableProxySupport": "false",
+                            "httpProxy": "",
+                            "httpsProxy": ""
+                        }
+                    ],
                     "required": [
                         "name",
                         "registry",
@@ -456,9 +460,11 @@
                     "type": "object",
                     "title": "The tracing schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "examples": [{
-                        "enable": true
-                    }],
+                    "examples": [
+                        {
+                            "enable": true
+                        }
+                    ],
                     "required": [
                         "enable"
                     ],
@@ -596,10 +602,12 @@
                     "type": "object",
                     "title": "Feature flags",
                     "description": "Feature flags",
-                    "examples": [{
-                        "enableWASMStats": true,
-                        "enableEgressPolicy": true
-                    }],
+                    "examples": [
+                        {
+                            "enableWASMStats": true,
+                            "enableEgressPolicy": true
+                        }
+                    ],
                     "required": [
                         "enableWASMStats",
                         "enableEgressPolicy"
@@ -633,6 +641,23 @@
                     "description": "Indicates whether OSM should run with PodSecurityPolicies",
                     "examples": [
                         false
+                    ]
+                },
+                "controlPlaneTolerations": {
+                    "$id": "#/properties/OpenServiceMesh/properties/controlPlaneTolerations",
+                    "type": "array",
+                    "title": "The controlPlaneTolerations schema",
+                    "description": "Node tolerations applied to control plane pods to schedule onto nodes with matching taints",
+                    "items": {
+                        "type": "object"
+                    },
+                    "examples": [
+                        {
+                            "key": "key1",
+                            "operator": "Equal",
+                            "value": "value1",
+                            "effect": "NoSchedule"
+                        }
                     ]
                 }
             },

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -175,3 +175,7 @@ OpenServiceMesh:
 
   # -- Run OSM with PodSecurityPolicy configured
   pspEnabled: false
+
+  # -- Node tolerations applied to control plane pods.
+  # The specified tolerations allow pods to schedule onto nodes with matching taints.
+  controlPlaneTolerations: []


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Allows specifying pod tolerations for control plane pods so
that they are allowed to be scheduled onto nodes with
matching taints.

Can be set using `helm install --set` or `osm install --set`
by passing toleration params such as:
```
--set=OpenServiceMesh.controlPlaneTolerations[0].key=foo \
    --set=OpenServiceMesh.controlPlaneTolerations[0].operator=Equal \
    --set=OpenServiceMesh.controlPlaneTolerations[0].value=bar \
    --set=OpenServiceMesh.controlPlaneTolerations[0].effect=NoSchedule
```

Also indents the schema properties for consistency.

Part of #3253

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Install                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
