### PR TITLE
ref(pkg/*): make UnmarshsalMeshService a method on SDSCert

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/registry"
+	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -89,20 +90,20 @@ var _ = Describe("Test ADS response functions", func() {
 			expected := &xds_discovery.DiscoveryRequest{
 				TypeUrl: string(envoy.TypeSDS),
 				ResourceNames: []string{
-					envoy.SDSCert{
+					secrets.SDSCert{
 						// Proxy's own cert to present to peer during mTLS/TLS handshake
 						Name:     proxySvcAccount.String(),
-						CertType: envoy.ServiceCertType,
+						CertType: secrets.ServiceCertType,
 					}.String(),
-					envoy.SDSCert{
+					secrets.SDSCert{
 						// Validation certificate for mTLS when this proxy is an upstream
 						Name:     proxySvcAccount.String(),
-						CertType: envoy.RootCertTypeForMTLSInbound,
+						CertType: secrets.RootCertTypeForMTLSInbound,
 					}.String(),
-					envoy.SDSCert{
+					secrets.SDSCert{
 						// Validation ceritificate for TLS when this proxy is an upstream
 						Name:     proxySvcAccount.String(),
-						CertType: envoy.RootCertTypeForHTTPS,
+						CertType: secrets.RootCertTypeForHTTPS,
 					}.String(),
 				},
 			}
@@ -166,27 +167,27 @@ var _ = Describe("Test ADS response functions", func() {
 			tmpResource = (*actualResponses)[4].Resources[0]
 			err = ptypes.UnmarshalAny(tmpResource, &proxyServiceCert)
 			Expect(err).To(BeNil())
-			Expect(proxyServiceCert.Name).To(Equal(envoy.SDSCert{
+			Expect(proxyServiceCert.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: envoy.ServiceCertType,
+				CertType: secrets.ServiceCertType,
 			}.String()))
 
 			serverRootCertTypeForMTLSInbound := xds_auth.Secret{}
 			tmpResource = (*actualResponses)[4].Resources[1]
 			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForMTLSInbound)
 			Expect(err).To(BeNil())
-			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(envoy.SDSCert{
+			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: secrets.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			serverRootCertTypeForHTTPS := xds_auth.Secret{}
 			tmpResource = (*actualResponses)[4].Resources[2]
 			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForHTTPS)
 			Expect(err).To(BeNil())
-			Expect(serverRootCertTypeForHTTPS.Name).To(Equal(envoy.SDSCert{
+			Expect(serverRootCertTypeForHTTPS.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: secrets.RootCertTypeForHTTPS,
 			}.String()))
 		})
 	})
@@ -238,27 +239,27 @@ var _ = Describe("Test ADS response functions", func() {
 			tmpResource = sdsResponse.Resources[0]
 			err = ptypes.UnmarshalAny(tmpResource, &proxyServiceCert)
 			Expect(err).To(BeNil())
-			Expect(proxyServiceCert.Name).To(Equal(envoy.SDSCert{
+			Expect(proxyServiceCert.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: envoy.ServiceCertType,
+				CertType: secrets.ServiceCertType,
 			}.String()))
 
 			serverRootCertTypeForMTLSInbound := xds_auth.Secret{}
 			tmpResource = sdsResponse.Resources[1]
 			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForMTLSInbound)
 			Expect(err).To(BeNil())
-			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(envoy.SDSCert{
+			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: secrets.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			serverRootCertTypeForHTTPS := xds_auth.Secret{}
 			tmpResource = sdsResponse.Resources[2]
 			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForHTTPS)
 			Expect(err).To(BeNil())
-			Expect(serverRootCertTypeForHTTPS.Name).To(Equal(envoy.SDSCert{
+			Expect(serverRootCertTypeForHTTPS.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: secrets.RootCertTypeForHTTPS,
 			}.String()))
 		})
 	})

--- a/pkg/envoy/ads/secrets.go
+++ b/pkg/envoy/ads/secrets.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 )
 
 // makeRequestForAllSecrets constructs an SDS DiscoveryRequest as if an Envoy proxy sent it.
@@ -36,9 +37,9 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 			// It is referenced in the upstream cluster's UpstreamTlsContext and in the inbound
 			// listener's DownstreamTlsContext.
 			// The secret name is of the form <namespace>/<service-account>
-			envoy.SDSCert{
+			secrets.SDSCert{
 				Name:     serviceAccount.String(),
-				CertType: envoy.ServiceCertType,
+				CertType: secrets.ServiceCertType,
 			}.String(),
 
 			// For each root validation cert referenced in the inbound filter chain's DownstreamTlsContext for this proxy,
@@ -50,17 +51,17 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 			// This cert is the upstream service's validation certificate used to validate certificates presented
 			// by downstream clients during mTLS handshake.
 			// The secret name is of the form <namespace>/<upstream-service>
-			envoy.SDSCert{
+			secrets.SDSCert{
 				Name:     serviceAccount.String(),
-				CertType: envoy.RootCertTypeForMTLSInbound,
+				CertType: secrets.RootCertTypeForMTLSInbound,
 			}.String(),
 
 			// This cert is the upstream service's validation certificate used to validate certificates presented
 			// by downstream clients during TLS handshake.
 			// The secret name is of the form <namespace>/<upstream-service>
-			envoy.SDSCert{
+			secrets.SDSCert{
 				Name:     serviceAccount.String(),
-				CertType: envoy.RootCertTypeForHTTPS,
+				CertType: secrets.RootCertTypeForHTTPS,
 			}.String(),
 		},
 		TypeUrl: string(envoy.TypeSDS),
@@ -70,9 +71,9 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 	// Each cert is used to validate the certificate presented by the corresponding upstream service.
 	upstreamServices := meshCatalog.ListAllowedOutboundServicesForIdentity(serviceAccount.ToServiceIdentity())
 	for _, upstream := range upstreamServices {
-		upstreamRootCertResource := envoy.SDSCert{
+		upstreamRootCertResource := secrets.SDSCert{
 			Name:     upstream.String(),
-			CertType: envoy.RootCertTypeForMTLSOutbound,
+			CertType: secrets.RootCertTypeForMTLSOutbound,
 		}.String()
 		discoveryRequest.ResourceNames = append(discoveryRequest.ResourceNames, upstreamRootCertResource)
 	}

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -193,7 +194,7 @@ func TestNewResponse(t *testing.T) {
 			}},
 			ValidationContextType: &xds_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &xds_auth.SdsSecretConfig{
-					Name: fmt.Sprintf("%s%s%s", envoy.RootCertTypeForMTLSOutbound, envoy.Separator, "default/bookstore-v1"),
+					Name: fmt.Sprintf("%s%s%s", secrets.RootCertTypeForMTLSOutbound, secrets.Separator, "default/bookstore-v1"),
 					SdsConfig: &xds_core.ConfigSource{
 						ConfigSourceSpecifier: &xds_core.ConfigSource_Ads{
 							Ads: &xds_core.AggregatedConfigSource{},
@@ -224,7 +225,7 @@ func TestNewResponse(t *testing.T) {
 			}},
 			ValidationContextType: &xds_auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 				ValidationContextSdsSecretConfig: &xds_auth.SdsSecretConfig{
-					Name: fmt.Sprintf("%s%s%s", envoy.RootCertTypeForMTLSOutbound, envoy.Separator, "default/bookstore-v2"),
+					Name: fmt.Sprintf("%s%s%s", secrets.RootCertTypeForMTLSOutbound, secrets.Separator, "default/bookstore-v2"),
 					SdsConfig: &xds_core.ConfigSource{
 						ConfigSourceSpecifier: &xds_core.ConfigSource_Ads{
 							Ads: &xds_core.AggregatedConfigSource{},

--- a/pkg/envoy/secrets/errors.go
+++ b/pkg/envoy/secrets/errors.go
@@ -1,4 +1,4 @@
-package envoy
+package secrets
 
 import (
 	"errors"

--- a/pkg/envoy/secrets/secrets.go
+++ b/pkg/envoy/secrets/secrets.go
@@ -1,0 +1,65 @@
+package secrets
+
+import (
+	"strings"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+const (
+	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
+	// or viceversa
+	namespaceNameSeparator = "/"
+)
+
+// UnmarshalSDSCert parses the SDS resource name and returns an SDSCert object and an error if any
+// Examples:
+// 1. Unmarshalling 'service-cert:foo/bar' returns SDSCert{CertType: service-cert, Name: foo/bar}, nil
+// 2. Unmarshalling 'root-cert-for-mtls-inbound:foo/bar' returns SDSCert{CertType: root-cert-for-mtls-inbound, Name: foo/bar}, nil
+// 3. Unmarshalling 'invalid-cert' returns nil, error
+func UnmarshalSDSCert(str string) (*SDSCert, error) {
+	var ret SDSCert
+
+	// Check separators, ignore empty string fields
+	slices := strings.Split(str, Separator)
+	if len(slices) != 2 {
+		return nil, errInvalidCertFormat
+	}
+
+	// Make sure the slices are not empty. Split might actually leave empty slices.
+	for _, sep := range slices {
+		if len(sep) == 0 {
+			return nil, errInvalidCertFormat
+		}
+	}
+
+	// Check valid certType
+	ret.CertType = SDSCertType(slices[0])
+	if _, ok := validCertTypes[ret.CertType]; !ok {
+		return nil, errInvalidCertFormat
+	}
+
+	ret.Name = slices[1]
+
+	return &ret, nil
+}
+
+// GetMeshService unmarshals a NamespaceService type from a SDSCert name
+func (sdsc *SDSCert) GetMeshService() (*service.MeshService, error) {
+	slices := strings.Split(sdsc.Name, namespaceNameSeparator)
+	if len(slices) != 2 {
+		return nil, service.ErrInvalidMeshServiceFormat
+	}
+
+	// Make sure the slices are not empty. Split might actually leave empty slices.
+	for _, sep := range slices {
+		if len(sep) == 0 {
+			return nil, service.ErrInvalidMeshServiceFormat
+		}
+	}
+
+	return &service.MeshService{
+		Namespace: slices[0],
+		Name:      slices[1],
+	}, nil
+}

--- a/pkg/envoy/secrets/secrets_test.go
+++ b/pkg/envoy/secrets/secrets_test.go
@@ -1,0 +1,167 @@
+package secrets
+
+import (
+	"fmt"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	trequire "github.com/stretchr/testify/require"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+var _ = Describe("Test secert tools", func() {
+	Context("Test UnmarshalSDSCert()", func() {
+		It("Interface marshals and unmarshals preserving the exact same data", func() {
+			InitialObj := SDSCert{
+				CertType: ServiceCertType,
+				Name:     "test-namespace/test-service",
+			}
+
+			// Marshal/stringify it
+			marshaledStr := InitialObj.String()
+
+			// Unmarshal it back from the string
+			finalObj, _ := UnmarshalSDSCert(marshaledStr)
+
+			// First and final object must be equal
+			Expect(*finalObj).To(Equal(InitialObj))
+		})
+
+		It("returns service cert", func() {
+			actual, err := UnmarshalSDSCert("service-cert:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(ServiceCertType))
+			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
+		})
+		It("returns root cert for mTLS", func() {
+			actual, err := UnmarshalSDSCert("root-cert-for-mtls-outbound:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(RootCertTypeForMTLSOutbound))
+			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
+
+		})
+
+		It("returns root cert for non-mTLS", func() {
+			actual, err := UnmarshalSDSCert("root-cert-https:namespace-test/blahBlahBlahCert")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual.CertType).To(Equal(RootCertTypeForHTTPS))
+			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
+		})
+
+		It("returns an error (invalid formatting)", func() {
+			_, err := UnmarshalSDSCert("blahBlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid formatting)", func() {
+			_, err := UnmarshalSDSCert("blahBlahBlahCert:moreblabla/amazingservice:bla")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (missing cert type)", func() {
+			_, err := UnmarshalSDSCert("blahBlahBlahCert/service")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid serv type)", func() {
+			_, err := UnmarshalSDSCert("revoked-cert:blah/BlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (invalid mtls cert type)", func() {
+			_, err := UnmarshalSDSCert("oot-cert-for-mtls-diagonalstream:blah/BlahBlahCert")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error (empty slice)", func() {
+			_, err := UnmarshalSDSCert(":")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+func TestUnmarshalMeshService(t *testing.T) {
+	assert := tassert.New(t)
+	require := trequire.New(t)
+
+	namespace := "randomNamespace"
+	serviceName := "randomServiceName"
+	meshService := &service.MeshService{
+		Namespace: namespace,
+		Name:      serviceName,
+	}
+	str := meshService.String()
+	fmt.Println(str)
+
+	testCases := []struct {
+		name        string
+		expectedErr bool
+		sdsCert     SDSCert
+	}{
+		{
+			name:        "successfully unmarshal service",
+			expectedErr: false,
+			sdsCert: SDSCert{
+				Name: "randomNamespace/randomServiceName",
+			},
+		},
+		{
+			name:        "incomplete namespaced service name 1",
+			expectedErr: true,
+			sdsCert: SDSCert{
+				Name: "/svnc",
+			},
+		},
+		{
+			name:        "incomplete namespaced service name 2",
+			expectedErr: true,
+			sdsCert: SDSCert{
+				Name: "svnc/",
+			},
+		},
+		{
+			name:        "incomplete namespaced service name 3",
+			expectedErr: true,
+			sdsCert: SDSCert{
+				Name: "/svnc/",
+			},
+		},
+		{
+			name:        "incomplete namespaced service name 3",
+			expectedErr: true,
+			sdsCert: SDSCert{
+				Name: "/",
+			},
+		},
+		{
+			name:        "incomplete namespaced service name 3",
+			expectedErr: true,
+			sdsCert: SDSCert{
+				Name: "",
+			},
+		},
+		{
+			name:        "incomplete namespaced service name 3",
+			expectedErr: true,
+			sdsCert: SDSCert{
+				Name: "test",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.sdsCert.GetMeshService()
+			if tc.expectedErr {
+				assert.NotNil(err)
+			} else {
+				require.Nil(err)
+				assert.Equal(meshService, actual)
+			}
+		})
+	}
+}

--- a/pkg/envoy/secrets/types.go
+++ b/pkg/envoy/secrets/types.go
@@ -1,0 +1,57 @@
+package secrets
+
+import "fmt"
+
+const (
+	// Separator is the separator between the prefix and the name of the certificate.
+	Separator = ":"
+)
+
+// SDSCertType is a type of a certificate requested by an Envoy proxy via SDS.
+type SDSCertType string
+
+// SDSCert is only used to interface the naming and related functions to Marshal/Unmarshal a resource name,
+// this avoids having sprintf/parsing logic all over the place
+type SDSCert struct {
+	// Name is the name of the SDS secret for the certificate
+	Name string
+
+	// CertType is the certificate type
+	CertType SDSCertType
+}
+
+// String is a common facility/interface to generate a string resource name out of a SDSCert
+// This is to keep the sprintf logic and/or separators used agnostic to other modules
+func (sdsc SDSCert) String() string {
+	return fmt.Sprintf("%s%s%s",
+		sdsc.CertType.String(),
+		Separator,
+		sdsc.Name)
+}
+
+func (ct SDSCertType) String() string {
+	return string(ct)
+}
+
+// SDSCertType enums
+const (
+	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:webservice"
+	ServiceCertType SDSCertType = "service-cert"
+
+	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate resource name for upstream connectivity. Example: "root-cert-for-mtls-outbound:webservice"
+	RootCertTypeForMTLSOutbound SDSCertType = "root-cert-for-mtls-outbound"
+
+	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate resource name for downstream connectivity. Example: "root-cert-for-mtls-inbound:webservice"
+	RootCertTypeForMTLSInbound SDSCertType = "root-cert-for-mtls-inbound"
+
+	// RootCertTypeForHTTPS is the prefix for the HTTPS root certificate resource name. Example: "root-cert-https:webservice"
+	RootCertTypeForHTTPS SDSCertType = "root-cert-https"
+)
+
+// Defines valid cert types
+var validCertTypes = map[SDSCertType]struct{}{
+	ServiceCertType:             {},
+	RootCertTypeForMTLSOutbound: {},
+	RootCertTypeForMTLSInbound:  {},
+	RootCertTypeForHTTPS:        {},
+}

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -104,75 +105,6 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 	})
 
-	Context("Test UnmarshalSDSCert()", func() {
-		It("Interface marshals and unmarshals preserving the exact same data", func() {
-			InitialObj := SDSCert{
-				CertType: ServiceCertType,
-				Name:     "test-namespace/test-service",
-			}
-
-			// Marshal/stringify it
-			marshaledStr := InitialObj.String()
-
-			// Unmarshal it back from the string
-			finalObj, _ := UnmarshalSDSCert(marshaledStr)
-
-			// First and final object must be equal
-			Expect(*finalObj).To(Equal(InitialObj))
-		})
-
-		It("returns service cert", func() {
-			actual, err := UnmarshalSDSCert("service-cert:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(ServiceCertType))
-			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
-		})
-		It("returns root cert for mTLS", func() {
-			actual, err := UnmarshalSDSCert("root-cert-for-mtls-outbound:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(RootCertTypeForMTLSOutbound))
-			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
-
-		})
-
-		It("returns root cert for non-mTLS", func() {
-			actual, err := UnmarshalSDSCert("root-cert-https:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(RootCertTypeForHTTPS))
-			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
-		})
-
-		It("returns an error (invalid formatting)", func() {
-			_, err := UnmarshalSDSCert("blahBlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid formatting)", func() {
-			_, err := UnmarshalSDSCert("blahBlahBlahCert:moreblabla/amazingservice:bla")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (missing cert type)", func() {
-			_, err := UnmarshalSDSCert("blahBlahBlahCert/service")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid serv type)", func() {
-			_, err := UnmarshalSDSCert("revoked-cert:blah/BlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (invalid mtls cert type)", func() {
-			_, err := UnmarshalSDSCert("oot-cert-for-mtls-diagonalstream:blah/BlahBlahCert")
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("returns an error (empty slice)", func() {
-			_, err := UnmarshalSDSCert(":")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
 	Context("Test GetDownstreamTLSContext()", func() {
 		It("should return TLS context", func() {
 			svcAccount := identity.K8sServiceAccount{Name: "foo", Namespace: "test"}
@@ -196,9 +128,9 @@ var _ = Describe("Test Envoy tools", func() {
 					}},
 					ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
 						ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-							Name: SDSCert{
+							Name: secrets.SDSCert{
 								Name:     "test/foo",
-								CertType: RootCertTypeForMTLSInbound,
+								CertType: secrets.RootCertTypeForMTLSInbound,
 							}.String(),
 							SdsConfig: &core.ConfigSource{
 								ConfigSourceSpecifier: &core.ConfigSource_Ads{
@@ -306,13 +238,13 @@ var _ = Describe("Test Envoy tools", func() {
 
 	Context("Test getCommonTLSContext()", func() {
 		It("returns proper auth.CommonTlsContext for outbound mTLS", func() {
-			tlsSDSCert := SDSCert{
+			tlsSDSCert := secrets.SDSCert{
 				Name:     "default/bookbuyer",
-				CertType: ServiceCertType,
+				CertType: secrets.ServiceCertType,
 			}
-			peerValidationSDSCert := SDSCert{
+			peerValidationSDSCert := secrets.SDSCert{
 				Name:     "default/bookstore-v1",
-				CertType: RootCertTypeForMTLSOutbound,
+				CertType: secrets.RootCertTypeForMTLSOutbound,
 			}
 
 			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)
@@ -336,13 +268,13 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 
 		It("returns proper auth.CommonTlsContext for inbound mTLS", func() {
-			tlsSDSCert := SDSCert{
+			tlsSDSCert := secrets.SDSCert{
 				Name:     "default/bookstore-v1",
-				CertType: ServiceCertType,
+				CertType: secrets.ServiceCertType,
 			}
-			peerValidationSDSCert := SDSCert{
+			peerValidationSDSCert := secrets.SDSCert{
 				Name:     "default/bookstore-v1",
-				CertType: RootCertTypeForMTLSInbound,
+				CertType: secrets.RootCertTypeForMTLSInbound,
 			}
 
 			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)
@@ -366,13 +298,13 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 
 		It("returns proper auth.CommonTlsContext for non-mTLS (HTTPS)", func() {
-			tlsSDSCert := SDSCert{
+			tlsSDSCert := secrets.SDSCert{
 				Name:     "default/bookstore-v1",
-				CertType: ServiceCertType,
+				CertType: secrets.ServiceCertType,
 			}
-			peerValidationSDSCert := SDSCert{
+			peerValidationSDSCert := secrets.SDSCert{
 				Name:     "default/bookstore-v1",
-				CertType: RootCertTypeForHTTPS,
+				CertType: secrets.RootCertTypeForHTTPS,
 			}
 
 			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -5,5 +5,7 @@ import (
 )
 
 var (
-	errInvalidMeshServiceFormat = errors.New("invalid namespaced service string format")
+	// ErrInvalidMeshServiceFormat indicates the format of the information used to populate
+	// the MeshService is invalid
+	ErrInvalidMeshServiceFormat = errors.New("invalid namespaced service string format")
 )

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -14,23 +14,3 @@ func (ms MeshService) Equals(service MeshService) bool {
 func (ms MeshService) ServerName() string {
 	return strings.Join([]string{ms.Name, ms.Namespace, "svc", "cluster", "local"}, ".")
 }
-
-// UnmarshalMeshService unmarshals a NamespaceService type from a string
-func UnmarshalMeshService(str string) (*MeshService, error) {
-	slices := strings.Split(str, namespaceNameSeparator)
-	if len(slices) != 2 {
-		return nil, errInvalidMeshServiceFormat
-	}
-
-	// Make sure the slices are not empty. Split might actually leave empty slices.
-	for _, sep := range slices {
-		if len(sep) == 0 {
-			return nil, errInvalidMeshServiceFormat
-		}
-	}
-
-	return &MeshService{
-		Namespace: slices[0],
-		Name:      slices[1],
-	}, nil
-}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1,80 +1,10 @@
 package service
 
 import (
-	"fmt"
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
-	trequire "github.com/stretchr/testify/require"
 )
-
-func TestUnmarshalMeshService(t *testing.T) {
-	assert := tassert.New(t)
-	require := trequire.New(t)
-
-	namespace := "randomNamespace"
-	serviceName := "randomServiceName"
-	meshService := &MeshService{
-		Namespace: namespace,
-		Name:      serviceName,
-	}
-	str := meshService.String()
-	fmt.Println(str)
-
-	testCases := []struct {
-		name          string
-		expectedErr   bool
-		serviceString string
-	}{
-		{
-			name:          "successfully unmarshal service",
-			expectedErr:   false,
-			serviceString: "randomNamespace/randomServiceName",
-		},
-		{
-			name:          "incomplete namespaced service name 1",
-			expectedErr:   true,
-			serviceString: "/svnc",
-		},
-		{
-			name:          "incomplete namespaced service name 2",
-			expectedErr:   true,
-			serviceString: "svnc/",
-		},
-		{
-			name:          "incomplete namespaced service name 3",
-			expectedErr:   true,
-			serviceString: "/svnc/",
-		},
-		{
-			name:          "incomplete namespaced service name 3",
-			expectedErr:   true,
-			serviceString: "/",
-		},
-		{
-			name:          "incomplete namespaced service name 3",
-			expectedErr:   true,
-			serviceString: "",
-		},
-		{
-			name:          "incomplete namespaced service name 3",
-			expectedErr:   true,
-			serviceString: "test",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := UnmarshalMeshService(tc.serviceString)
-			if tc.expectedErr {
-				assert.NotNil(err)
-			} else {
-				require.Nil(err)
-				assert.Equal(meshService, actual)
-			}
-		})
-	}
-}
 
 func TestServerName(t *testing.T) {
 	assert := tassert.New(t)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Reduces complexity and potential errors caused by passing a non
SDSCert name to the method. UnmarshalMeshService is only used to
parse SDS secrets. This PR makes UnmarshalMeshService a method
on SDSCert and refactors SDSCert types and methods into a new
package.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [  X ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
    no
1. Is this a breaking change?
    no
