### PR TITLE
ref(controller): remove osmConfig struct

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -2,9 +2,7 @@ package configurator
 
 import (
 	"fmt"
-	"strings"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
@@ -27,41 +25,17 @@ const (
 	// PermissiveTrafficPolicyModeKey is the key name used for permissive mode in the MeshConfig
 	PermissiveTrafficPolicyModeKey = "permissive_traffic_policy_mode"
 
-	// egressKey is the key name used for egress in the MeshConfig
-	egressKey = "egress"
-
-	// enableDebugServer is the key name used for the debug server in the MeshConfig
-	enableDebugServer = "enable_debug_server"
-
-	// prometheusScrapingKey is the key name used for prometheus scraping in the MeshConfig
-	prometheusScrapingKey = "prometheus_scraping"
-
-	// useHTTPSIngressKey is the key name used for HTTPS ingress in the MeshConfig
-	useHTTPSIngressKey = "use_https_ingress"
-
 	// maxDataPlaneConnectionsKey is the key name used for max data plane connections in the MeshConfig
 	maxDataPlaneConnectionsKey = "max_data_plane_connections"
 
-	// tracingEnableKey is the key name used for tracing in the MeshConfig
-	tracingEnableKey = "tracing_enable"
-
-	// tracingAddressKey is the key name used to specify the tracing address in the MeshConfig
-	tracingAddressKey = "tracing_address"
-
 	// tracingPortKey is the key name used to specify the tracing port in the MeshConfig
 	tracingPortKey = "tracing_port"
-
-	// tracingEndpointKey is the key name used to specify the tracing endpoint in the MeshConfig
-	tracingEndpointKey = "tracing_endpoint"
 
 	// envoyLogLevel is the key name used to specify the log level of Envoy proxy in the MeshConfig
 	envoyLogLevelKey = "envoy_log_level"
 
 	// envoyImage is the key name used to specify the image of the Envoy proxy in the MeshConfig
 	envoyImageKey = "envoy_image"
-
-	// initContainerImage is the key name used to specify the init container image in the MeshConfig
-	initContainerImage = "init_container_image"
 
 	// serviceCertValidityDurationKey is the key name used to specify the validity duration of service certificates in the MeshConfig
 	serviceCertValidityDurationKey = "service_cert_validity_duration"
@@ -72,17 +46,8 @@ const (
 	// outboundPortExclusionListKey is the key name used to specify the ports to exclude from outbound sidecar interception
 	outboundPortExclusionListKey = "outbound_port_exclusion_list"
 
-	// enablePrivilegedInitContainerKey is the key name used to specify whether init containers should be privileged in the MeshConfig
-	enablePrivilegedInitContainerKey = "enable_privileged_init_container"
-
 	// configResyncInterval is the key name used to configure the resync interval for regular proxy broadcast updates
 	configResyncIntervalKey = "config_resync_interval"
-
-	// proxyResources is the key used to configure proxy resources
-	proxyResourcesKey = "proxy_resources"
-
-	// inboundExtAuthz is the key used to enable the inbound external authorization filter
-	inboundExtAuthz = "inbound_ext_authz"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -172,45 +137,6 @@ func (c *Client) run(stop <-chan struct{}) {
 	log.Debug().Msg("[MeshConfig Client] Cache sync for MeshConfig informer finished")
 }
 
-// Parses a kubernetes config map object into an osm runtime object representing OSM's options/config
-func parseOSMMeshConfig(meshConfig *v1alpha1.MeshConfig) *osmConfig {
-	// Invalid values should be prevented once https://github.com/openservicemesh/osm/issues/1788
-	// is implemented.
-
-	spec := &meshConfig.Spec
-
-	osmConfig := osmConfig{
-		PermissiveTrafficPolicyMode:   spec.Traffic.EnablePermissiveTrafficPolicyMode,
-		Egress:                        spec.Traffic.EnableEgress,
-		EnableDebugServer:             spec.Observability.EnableDebugServer,
-		UseHTTPSIngress:               spec.Traffic.UseHTTPSIngress,
-		EnvoyLogLevel:                 spec.Sidecar.LogLevel,
-		EnvoyImage:                    spec.Sidecar.EnvoyImage,
-		InitContainerImage:            spec.Sidecar.InitContainerImage,
-		ServiceCertValidityDuration:   spec.Certificate.ServiceCertValidityDuration,
-		OutboundIPRangeExclusionList:  strings.Join(spec.Traffic.OutboundIPRangeExclusionList, ","),
-		OutboundPortExclusionList:     spec.Traffic.OutboundPortExclusionList,
-		EnablePrivilegedInitContainer: spec.Sidecar.EnablePrivilegedInitContainer,
-		PrometheusScraping:            spec.Observability.PrometheusScraping,
-		ConfigResyncInterval:          spec.Sidecar.ConfigResyncInterval,
-		MaxDataPlaneConnections:       spec.Sidecar.MaxDataPlaneConnections,
-		TracingEnable:                 spec.Observability.Tracing.Enable,
-		proxyResources:                spec.Sidecar.Resources,
-	}
-
-	if spec.Observability.Tracing.Enable {
-		osmConfig.TracingAddress = spec.Observability.Tracing.Address
-		osmConfig.TracingEndpoint = spec.Observability.Tracing.Endpoint
-		osmConfig.TracingPort = int(spec.Observability.Tracing.Port)
-	}
-
-	if spec.Traffic.InboundExternalAuthorization.Enable {
-		osmConfig.inboundExternalAuth = spec.Traffic.InboundExternalAuthorization
-	}
-
-	return &osmConfig
-}
-
 func meshConfigAddedMessageHandler(psubMsg *events.PubSubMessage) {
 	log.Debug().Msgf("[%s] OSM MeshConfig added event triggered a global proxy broadcast",
 		psubMsg.AnnouncementType)
@@ -234,43 +160,42 @@ func meshConfigDeletedMessageHandler(psubMsg *events.PubSubMessage) {
 
 func meshConfigUpdatedMessageHandler(psubMsg *events.PubSubMessage) {
 	// Get the MeshConfig resource
-	prevMeshConfigObj, okPrevCast := psubMsg.OldObj.(*v1alpha1.MeshConfig)
-	newMeshConfigObj, okNewCast := psubMsg.NewObj.(*v1alpha1.MeshConfig)
+	prevMeshConfig, okPrevCast := psubMsg.OldObj.(*v1alpha1.MeshConfig)
+	newMeshConfig, okNewCast := psubMsg.NewObj.(*v1alpha1.MeshConfig)
 	if !okPrevCast || !okNewCast {
 		log.Error().Msgf("[%s] Error casting old/new MeshConfigs objects (%v %v)",
 			psubMsg.AnnouncementType, okPrevCast, okNewCast)
 		return
 	}
 
-	// Parse old and new configs
-	prevMeshConfig := parseOSMMeshConfig(prevMeshConfigObj)
-	newMeshConfig := parseOSMMeshConfig(newMeshConfigObj)
+	prevSpec := prevMeshConfig.Spec
+	newSpec := newMeshConfig.Spec
 
 	// Determine if we should issue new global config update to all envoys
 	triggerGlobalBroadcast := false
 
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.Egress != newMeshConfig.Egress)
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.PermissiveTrafficPolicyMode != newMeshConfig.PermissiveTrafficPolicyMode)
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.UseHTTPSIngress != newMeshConfig.UseHTTPSIngress)
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingEnable != newMeshConfig.TracingEnable)
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingAddress != newMeshConfig.TracingAddress)
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingEndpoint != newMeshConfig.TracingEndpoint)
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.TracingPort != newMeshConfig.TracingPort)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Traffic.EnableEgress != newSpec.Traffic.EnableEgress)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Traffic.EnablePermissiveTrafficPolicyMode != newSpec.Traffic.EnablePermissiveTrafficPolicyMode)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Traffic.UseHTTPSIngress != newSpec.Traffic.UseHTTPSIngress)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Observability.Tracing.Enable != newSpec.Observability.Tracing.Enable)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Observability.Tracing.Address != newSpec.Observability.Tracing.Address)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Observability.Tracing.Endpoint != newSpec.Observability.Tracing.Endpoint)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Observability.Tracing.Port != newSpec.Observability.Tracing.Port)
+	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevSpec.Traffic.InboundExternalAuthorization.Enable != newSpec.Traffic.InboundExternalAuthorization.Enable)
 
-	triggerGlobalBroadcast = triggerGlobalBroadcast || (prevMeshConfig.inboundExternalAuth.Enable != newMeshConfig.inboundExternalAuth.Enable)
 	// Do not trigger updates on the inner configuration changes of ExtAuthz if disabled,
 	// or otherwise skip checking if the update is to be scheduled anyway
-	if newMeshConfig.inboundExternalAuth.Enable && !triggerGlobalBroadcast {
+	if newSpec.Traffic.InboundExternalAuthorization.Enable && !triggerGlobalBroadcast {
 		triggerGlobalBroadcast = triggerGlobalBroadcast ||
-			(prevMeshConfig.inboundExternalAuth.Address != newMeshConfig.inboundExternalAuth.Address)
+			(prevSpec.Traffic.InboundExternalAuthorization.Address != newSpec.Traffic.InboundExternalAuthorization.Address)
 		triggerGlobalBroadcast = triggerGlobalBroadcast ||
-			(prevMeshConfig.inboundExternalAuth.Port != newMeshConfig.inboundExternalAuth.Port)
+			(prevSpec.Traffic.InboundExternalAuthorization.Port != newSpec.Traffic.InboundExternalAuthorization.Port)
 		triggerGlobalBroadcast = triggerGlobalBroadcast ||
-			(prevMeshConfig.inboundExternalAuth.StatPrefix != newMeshConfig.inboundExternalAuth.StatPrefix)
+			(prevSpec.Traffic.InboundExternalAuthorization.StatPrefix != newSpec.Traffic.InboundExternalAuthorization.StatPrefix)
 		triggerGlobalBroadcast = triggerGlobalBroadcast ||
-			(prevMeshConfig.inboundExternalAuth.Timeout != newMeshConfig.inboundExternalAuth.Timeout)
+			(prevSpec.Traffic.InboundExternalAuthorization.Timeout != newSpec.Traffic.InboundExternalAuthorization.Timeout)
 		triggerGlobalBroadcast = triggerGlobalBroadcast ||
-			(prevMeshConfig.inboundExternalAuth.FailureModeAllow != newMeshConfig.inboundExternalAuth.FailureModeAllow)
+			(prevSpec.Traffic.InboundExternalAuthorization.FailureModeAllow != newSpec.Traffic.InboundExternalAuthorization.FailureModeAllow)
 	}
 
 	if triggerGlobalBroadcast {
@@ -292,12 +217,12 @@ func (c *Client) getMeshConfigCacheKey() string {
 }
 
 // Returns the current MeshConfig
-func (c *Client) getMeshConfig() *osmConfig {
+func (c *Client) getMeshConfig() *v1alpha1.MeshConfig {
 	meshConfigCacheKey := c.getMeshConfigCacheKey()
 	item, exists, err := c.cache.GetByKey(meshConfigCacheKey)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting MeshConfig from cache with key %s", meshConfigCacheKey)
-		return &osmConfig{}
+		return &v1alpha1.MeshConfig{}
 	}
 
 	var meshConfig *v1alpha1.MeshConfig
@@ -308,73 +233,5 @@ func (c *Client) getMeshConfig() *osmConfig {
 		meshConfig = item.(*v1alpha1.MeshConfig)
 	}
 
-	return parseOSMMeshConfig(meshConfig)
-}
-
-// This struct must match the shape of the "osm-mesh-config" MeshConfig
-// which was created in the OSM namespace.
-type osmConfig struct {
-	// PermissiveTrafficPolicyMode is a bool toggle, which when TRUE ignores SMI policies and
-	// allows existing Kubernetes services to communicate with each other uninterrupted.
-	// This is useful whet set TRUE in brownfield configurations, where we first want to observe
-	// existing traffic patterns.
-	PermissiveTrafficPolicyMode bool `yaml:"permissive_traffic_policy_mode"`
-
-	// Egress is a bool toggle used to enable or disable egress globally within the mesh
-	Egress bool `yaml:"egress"`
-
-	// EnableDebugServer is a bool toggle, which enables/disables the debug server within the OSM Controller
-	EnableDebugServer bool `yaml:"enable_debug_server"`
-
-	// PrometheusScraping is a bool toggle used to enable or disable metrics scraping by Prometheus
-	PrometheusScraping bool `yaml:"prometheus_scraping"`
-
-	// UseHTTPSIngress is a bool toggle enabling HTTPS protocol between ingress and backend pods
-	UseHTTPSIngress bool `yaml:"use_https_ingress"`
-
-	// MaxDataPlaneConnections indicates max allowed data plane connections
-	MaxDataPlaneConnections int `yaml:"max_data_plane_connections"`
-
-	// TracingEnabled is a bool toggle used to enable or disable tracing
-	TracingEnable bool `yaml:"tracing_enable"`
-
-	// TracingAddress is the address of the listener cluster
-	TracingAddress string `yaml:"tracing_address"`
-
-	// TracingPort remote port for the listener
-	TracingPort int `yaml:"tracing_port"`
-
-	// TracingEndpoint is the collector endpoint on the listener
-	TracingEndpoint string `yaml:"tracing_endpoint"`
-
-	// EnvoyLogLevel is a string that defines the log level for envoy proxies
-	EnvoyLogLevel string `yaml:"envoy_log_level"`
-
-	// EnvoyImage is the sidecar image
-	EnvoyImage string `yaml:"envoy_image"`
-
-	// InitContainerImage is the init container image
-	InitContainerImage string `yaml:"init_container_image"`
-
-	// ServiceCertValidityDuration is a string that defines the validity duration of service certificates
-	// It is represented as a sequence of decimal numbers each with optional fraction and a unit suffix.
-	// Ex: 1h to represent 1 hour, 30m to represent 30 minutes, 1.5h or 1h30m to represent 1 hour and 30 minutes.
-	ServiceCertValidityDuration string `yaml:"service_cert_validity_duration"`
-
-	// OutboundIPRangeExclusionList is the list of outbound IP ranges to exclude from sidecar interception
-	OutboundIPRangeExclusionList string `yaml:"outbound_ip_range_exclusion_list"`
-
-	// OutboundPortExclusionList is the list of outbound ports to exclude from sidecar interception
-	OutboundPortExclusionList []int `yaml:"outbound_port_exclusion_list"`
-
-	EnablePrivilegedInitContainer bool `yaml:"enable_privileged_init_container"`
-
-	// ConfigResyncInterval is a flag to configure resync interval for regular proxy broadcast updates
-	ConfigResyncInterval string `yaml:"config_resync_interval"`
-
-	// proxyResources are the proxy resources speficied for a proxy, if any
-	proxyResources corev1.ResourceRequirements
-
-	// inboundExternalAuth is the external authorization configuration for inbound and ingress
-	inboundExternalAuth v1alpha1.ExternalAuthzSpec
+	return meshConfig
 }

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -3,11 +3,11 @@ package configurator
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
@@ -24,13 +24,13 @@ func (c *Client) GetOSMNamespace() string {
 	return c.osmNamespace
 }
 
-func marshalConfigToJSON(config *osmConfig) ([]byte, error) {
+func marshalConfigToJSON(config *v1alpha1.MeshConfigSpec) ([]byte, error) {
 	return json.MarshalIndent(config, "", "    ")
 }
 
 // GetMeshConfigJSON returns the MeshConfig in pretty JSON.
 func (c *Client) GetMeshConfigJSON() ([]byte, error) {
-	cm, err := marshalConfigToJSON(c.getMeshConfig())
+	cm, err := marshalConfigToJSON(&c.getMeshConfig().Spec)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshaling MeshConfig %s: %+v", c.getMeshConfigCacheKey(), c.getMeshConfig())
 		return nil, err
@@ -43,32 +43,32 @@ func (c *Client) GetMeshConfigJSON() ([]byte, error) {
 // or it is in SMI Spec mode, in which only traffic between source/destinations
 // referenced in SMI policies is allowed.
 func (c *Client) IsPermissiveTrafficPolicyMode() bool {
-	return c.getMeshConfig().PermissiveTrafficPolicyMode
+	return c.getMeshConfig().Spec.Traffic.EnablePermissiveTrafficPolicyMode
 }
 
 // IsEgressEnabled determines whether egress is globally enabled in the mesh or not.
 func (c *Client) IsEgressEnabled() bool {
-	return c.getMeshConfig().Egress
+	return c.getMeshConfig().Spec.Traffic.EnableEgress
 }
 
 // IsDebugServerEnabled determines whether osm debug HTTP server is enabled
 func (c *Client) IsDebugServerEnabled() bool {
-	return c.getMeshConfig().EnableDebugServer
+	return c.getMeshConfig().Spec.Observability.EnableDebugServer
 }
 
 // IsPrometheusScrapingEnabled determines whether Prometheus is enabled for scraping metrics
 func (c *Client) IsPrometheusScrapingEnabled() bool {
-	return c.getMeshConfig().PrometheusScraping
+	return c.getMeshConfig().Spec.Observability.PrometheusScraping
 }
 
 // IsTracingEnabled returns whether tracing is enabled
 func (c *Client) IsTracingEnabled() bool {
-	return c.getMeshConfig().TracingEnable
+	return c.getMeshConfig().Spec.Observability.Tracing.Enable
 }
 
 // GetTracingHost is the host to which we send tracing spans
 func (c *Client) GetTracingHost() string {
-	tracingAddress := c.getMeshConfig().TracingAddress
+	tracingAddress := c.getMeshConfig().Spec.Observability.Tracing.Address
 	if tracingAddress != "" {
 		return tracingAddress
 	}
@@ -77,7 +77,7 @@ func (c *Client) GetTracingHost() string {
 
 // GetTracingPort returns the tracing listener port
 func (c *Client) GetTracingPort() uint32 {
-	tracingPort := c.getMeshConfig().TracingPort
+	tracingPort := c.getMeshConfig().Spec.Observability.Tracing.Port
 	if tracingPort != 0 {
 		return uint32(tracingPort)
 	}
@@ -86,7 +86,7 @@ func (c *Client) GetTracingPort() uint32 {
 
 // GetTracingEndpoint returns the listener's collector endpoint
 func (c *Client) GetTracingEndpoint() string {
-	tracingEndpoint := c.getMeshConfig().TracingEndpoint
+	tracingEndpoint := c.getMeshConfig().Spec.Observability.Tracing.Endpoint
 	if tracingEndpoint != "" {
 		return tracingEndpoint
 	}
@@ -95,17 +95,17 @@ func (c *Client) GetTracingEndpoint() string {
 
 // UseHTTPSIngress determines whether traffic between ingress and backend pods should use HTTPS protocol
 func (c *Client) UseHTTPSIngress() bool {
-	return c.getMeshConfig().UseHTTPSIngress
+	return c.getMeshConfig().Spec.Traffic.UseHTTPSIngress
 }
 
 // GetMaxDataPlaneConnections returns the max data plane connections allowed, 0 if disabled
 func (c *Client) GetMaxDataPlaneConnections() int {
-	return c.getMeshConfig().MaxDataPlaneConnections
+	return c.getMeshConfig().Spec.Sidecar.MaxDataPlaneConnections
 }
 
 // GetEnvoyLogLevel returns the envoy log level
 func (c *Client) GetEnvoyLogLevel() string {
-	logLevel := c.getMeshConfig().EnvoyLogLevel
+	logLevel := c.getMeshConfig().Spec.Sidecar.LogLevel
 	if logLevel != "" {
 		return logLevel
 	}
@@ -114,7 +114,7 @@ func (c *Client) GetEnvoyLogLevel() string {
 
 // GetEnvoyImage returns the envoy image
 func (c *Client) GetEnvoyImage() string {
-	image := c.getMeshConfig().EnvoyImage
+	image := c.getMeshConfig().Spec.Sidecar.EnvoyImage
 	if image != "" {
 		return image
 	}
@@ -123,7 +123,7 @@ func (c *Client) GetEnvoyImage() string {
 
 // GetInitContainerImage returns the init container image
 func (c *Client) GetInitContainerImage() string {
-	initImage := c.getMeshConfig().InitContainerImage
+	initImage := c.getMeshConfig().Spec.Sidecar.InitContainerImage
 	if initImage != "" {
 		return initImage
 	}
@@ -132,7 +132,7 @@ func (c *Client) GetInitContainerImage() string {
 
 // GetServiceCertValidityPeriod returns the validity duration for service certificates, and a default in case of invalid duration
 func (c *Client) GetServiceCertValidityPeriod() time.Duration {
-	durationStr := c.getMeshConfig().ServiceCertValidityDuration
+	durationStr := c.getMeshConfig().Spec.Certificate.ServiceCertValidityDuration
 	validityDuration, err := time.ParseDuration(durationStr)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error parsing service certificate validity duration %s=%s", serviceCertValidityDurationKey, durationStr)
@@ -144,33 +144,23 @@ func (c *Client) GetServiceCertValidityPeriod() time.Duration {
 
 // GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
 func (c *Client) GetOutboundIPRangeExclusionList() []string {
-	ipRangesStr := c.getMeshConfig().OutboundIPRangeExclusionList
-	if ipRangesStr == "" {
-		return nil
-	}
-
-	exclusionList := strings.Split(ipRangesStr, ",")
-	for i := range exclusionList {
-		exclusionList[i] = strings.TrimSpace(exclusionList[i])
-	}
-
-	return exclusionList
+	return c.getMeshConfig().Spec.Traffic.OutboundIPRangeExclusionList
 }
 
 // GetOutboundPortExclusionList returns the list of ports (positive integers) to exclude from outbound sidecar interception
 func (c *Client) GetOutboundPortExclusionList() []int {
-	return c.getMeshConfig().OutboundPortExclusionList
+	return c.getMeshConfig().Spec.Traffic.OutboundPortExclusionList
 }
 
 // IsPrivilegedInitContainer returns whether init containers should be privileged
 func (c *Client) IsPrivilegedInitContainer() bool {
-	return c.getMeshConfig().EnablePrivilegedInitContainer
+	return c.getMeshConfig().Spec.Sidecar.EnablePrivilegedInitContainer
 }
 
 // GetConfigResyncInterval returns the duration for resync interval.
 // If error or non-parsable value, returns 0 duration
 func (c *Client) GetConfigResyncInterval() time.Duration {
-	resyncDuration := c.getMeshConfig().ConfigResyncInterval
+	resyncDuration := c.getMeshConfig().Spec.Sidecar.ConfigResyncInterval
 	duration, err := time.ParseDuration(resyncDuration)
 	if err != nil {
 		log.Debug().Err(err).Msgf("Error parsing config resync interval: %s", duration)
@@ -181,13 +171,13 @@ func (c *Client) GetConfigResyncInterval() time.Duration {
 
 // GetProxyResources returns the `Resources` configured for proxies, if any
 func (c *Client) GetProxyResources() corev1.ResourceRequirements {
-	return c.getMeshConfig().proxyResources
+	return c.getMeshConfig().Spec.Sidecar.Resources
 }
 
 // GetInboundExternalAuthConfig returns the External Authentication configuration for incoming traffic, if any
 func (c *Client) GetInboundExternalAuthConfig() auth.ExtAuthConfig {
 	extAuthConfig := auth.ExtAuthConfig{}
-	inboundExtAuthzMeshConfig := c.getMeshConfig().inboundExternalAuth
+	inboundExtAuthzMeshConfig := c.getMeshConfig().Spec.Traffic.InboundExternalAuthorization
 
 	extAuthConfig.Enable = inboundExtAuthzMeshConfig.Enable
 	extAuthConfig.Address = inboundExtAuthzMeshConfig.Address


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Remove intermediate struct `osmConfig`. It was previously used to represent the data of osm-config configmap. As OSM migrates to MeshConfig, `osmConfig` is not useful.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [x] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

`No`

1. Is this a breaking change?

`No`