### PR TITLE
Refactor: GetMeshConfigJSON returns string

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -167,7 +167,7 @@ func main() {
 	if err != nil {
 		log.Error().Err(err).Msgf("Error parsing MeshConfig %s", osmMeshConfigName)
 	}
-	log.Info().Msgf("Initial MeshConfig %s: %v", osmMeshConfigName, string(meshConfig))
+	log.Info().Msgf("Initial MeshConfig %s: %s", osmMeshConfigName, meshConfig)
 
 	kubernetesClient, err := k8s.NewKubernetesController(kubeClient, meshName, stop)
 	if err != nil {

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -24,16 +24,20 @@ func (c *Client) GetOSMNamespace() string {
 	return c.osmNamespace
 }
 
-func marshalConfigToJSON(config *v1alpha1.MeshConfigSpec) ([]byte, error) {
-	return json.MarshalIndent(config, "", "    ")
+func marshalConfigToJSON(config *v1alpha1.MeshConfigSpec) (string, error) {
+	bytes, err := json.MarshalIndent(config, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
 }
 
 // GetMeshConfigJSON returns the MeshConfig in pretty JSON.
-func (c *Client) GetMeshConfigJSON() ([]byte, error) {
+func (c *Client) GetMeshConfigJSON() (string, error) {
 	cm, err := marshalConfigToJSON(&c.getMeshConfig().Spec)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshaling MeshConfig %s: %+v", c.getMeshConfigCacheKey(), c.getMeshConfig())
-		return nil, err
+		return "", err
 	}
 	return cm, nil
 }

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -98,12 +98,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 						ServiceCertValidityDuration: "24h",
 					},
 				}
-				expectedConfigBytes, err := marshalConfigToJSON(expectedConfig)
+				expectedConfigJSON, err := marshalConfigToJSON(expectedConfig)
 				assert.Nil(err)
 
-				configBytes, err := cfg.GetMeshConfigJSON()
+				configJSON, err := cfg.GetMeshConfigJSON()
 				assert.Nil(err)
-				assert.Equal(string(expectedConfigBytes), string(configBytes))
+				assert.Equal(expectedConfigJSON, configJSON)
 			},
 		},
 		{

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -121,10 +121,10 @@ func (mr *MockConfiguratorMockRecorder) GetMaxDataPlaneConnections() *gomock.Cal
 }
 
 // GetMeshConfigJSON mocks base method
-func (m *MockConfigurator) GetMeshConfigJSON() ([]byte, error) {
+func (m *MockConfigurator) GetMeshConfigJSON() (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMeshConfigJSON")
-	ret0, _ := ret[0].([]byte)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -31,7 +31,7 @@ type Configurator interface {
 	GetOSMNamespace() string
 
 	// GetMeshConfigJSON returns the MeshConfig in pretty JSON (human readable)
-	GetMeshConfigJSON() ([]byte, error)
+	GetMeshConfigJSON() (string, error)
 
 	// IsPermissiveTrafficPolicyMode determines whether we are in "allow-all" mode or SMI policy (block by default) mode
 	IsPermissiveTrafficPolicyMode() bool

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -26,7 +26,7 @@ func (ds DebugConfig) getOSMConfigHandler() http.Handler {
 			log.Error().Err(err)
 			return
 		}
-		_, _ = fmt.Fprint(w, string(confJSON))
+		_, _ = fmt.Fprint(w, confJSON)
 	})
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This PR changes the return value of method `GetMeshConfigJSON()` to `string` rather than `[]byte`.

All usages of `GetMeshConfigJSON()` converts the byte array to string after receiving the return value. To make it more convenient, the method should return string value directly.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

No