### PR TITLE
envoy/rds: remove colon from egress route config name

### DIFF
--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -375,5 +375,5 @@ func getRegexForMethod(httpMethod string) string {
 
 // GetEgressRouteConfigNameForPort returns the Egress route configuration object's name given the port it is targeted to
 func GetEgressRouteConfigNameForPort(port int) string {
-	return fmt.Sprintf("%s:%d", egressRouteConfigNamePrefix, port)
+	return fmt.Sprintf("%s.%d", egressRouteConfigNamePrefix, port)
 }

--- a/pkg/envoy/rds/route/route_config_test.go
+++ b/pkg/envoy/rds/route/route_config_test.go
@@ -1050,7 +1050,7 @@ func TestBuildEgressRouteConfiguration(t *testing.T) {
 			},
 			expectedRouteConfigs: []*xds_route.RouteConfiguration{
 				{
-					Name:             "rds-egress:80",
+					Name:             "rds-egress.80",
 					ValidateClusters: &wrappers.BoolValue{Value: false},
 					VirtualHosts: []*xds_route.VirtualHost{
 						{
@@ -1146,7 +1146,7 @@ func TestBuildEgressRouteConfiguration(t *testing.T) {
 					},
 				},
 				{
-					Name:             "rds-egress:90",
+					Name:             "rds-egress.90",
 					ValidateClusters: &wrappers.BoolValue{Value: false},
 					VirtualHosts: []*xds_route.VirtualHost{
 						{
@@ -1224,12 +1224,12 @@ func TestGetEgressRouteConfigNameForPort(t *testing.T) {
 		{
 			name:         "test 1",
 			port:         10,
-			expectedName: "rds-egress:10",
+			expectedName: "rds-egress.10",
 		},
 		{
 			name:         "test 2",
 			port:         20,
-			expectedName: "rds-egress:20",
+			expectedName: "rds-egress.20",
 		},
 	}
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The ':' character does not render uniformly in the stats
emitted by envoy because it is used as the delimiter for
the key and its value. As a result, the stats corresponding
to an egress route config is inconsistent:
```
http.mesh-http-conn-manager.rds-egress:80.tracing.service_forced: 0
http.mesh-http-conn-manager.rds-egress_80.rds.rds-egress_80.config_reload: 1
```

With this change, the stats corresponding to a route config are
uniformly rendered:
```
http.mesh-http-conn-manager.rds-egress.80.tracing.service_forced: 0
http.mesh-http-conn-manager.rds-egress.80.rds.rds-egress.80.config_reload: 1
```

Consistent formatting makes it easier to debug issues when
inspecting the stats.

This is similar to the change done in 1f10701f as a part of
issue #2156.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |
| Egress                     | [X] |
| Observability              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
