### PR TITLE
Makes unit test pass on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.yaml text eol=lf

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -3,7 +3,9 @@ package envoy
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -63,7 +65,10 @@ var _ = Describe("Test proxy methods", func() {
 
 			firstNonce := proxy.GetLastSentNonce(TypeCDS)
 			Expect(firstNonce).ToNot(Equal(uint64(0)))
-
+			// Platform(Windows): Sleep to accommodate `time.Now()` lower accuracy.
+			if runtime.GOOS == "windows" {
+				time.Sleep(1 * time.Millisecond)
+			}
 			proxy.SetNewNonce(TypeCDS)
 
 			secondNonce := proxy.GetLastSentNonce(TypeCDS)


### PR DESCRIPTION
Make checkout of yaml files to be the same on both platforms and adds a small delay to test to accommodate for Windows which has lower accuracy in `time.Now()`

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
