### PR TITLE
Update Envoy config to comply with 1.18.3 api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce
 	github.com/dustin/go-humanize v1.0.0
-	github.com/envoyproxy/go-control-plane v0.9.8
+	github.com/envoyproxy/go-control-plane v0.9.9
 	github.com/fatih/color v1.10.0
 	github.com/go-logr/logr v0.2.1 // indirect
 	github.com/golang/mock v1.4.1
@@ -44,7 +44,7 @@ require (
 	golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 // indirect
 	golang.org/x/tools v0.1.1-0.20210319172145-bda8f5cee399 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.0.1
-	google.golang.org/grpc v1.27.1
+	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/alessio/shellescape v1.2.2 h1:8LnL+ncxhWT2TR00dfJRT25JWWrhkMZXneHVWne
 github.com/alessio/shellescape v1.2.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -174,8 +175,11 @@ github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmE
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.8.5/go.mod h1:8KhU6K+zHUEWOSU++mEQYf7D9UZOcQcibUoSm6vCUz4=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/containerd/cgroups v0.0.0-20200531161412-0dbf7f05ba59 h1:qWj4qVYZ95vLWwqyNJCQg7rDsG5wPdze0UaPolH7DUk=
@@ -266,8 +270,10 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
-github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9 h1:vQLjymTobffN2R0F8eTqw6q7iozfRO5Z0m+/4Vw+/uA=
+github.com/envoyproxy/go-control-plane v0.9.9/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=
@@ -548,6 +554,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -908,6 +915,7 @@ github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 h1:L8QM9bvf
 github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95/go.mod h1:rlzQ04UMyJXu/aOvhd8qT+hvDrFpiwqp8MRXDY9szc0=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
@@ -1078,6 +1086,7 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3 h1:8sGtKOrtQqkN1bp2AtX+misvLIlOmsEsNd+9NIcPEm8=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
@@ -1417,6 +1426,7 @@ google.golang.org/genproto v0.0.0-20200204135345-fa8e72b47b90/go.mod h1:GmwEX6Z4
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a h1:pOwg4OoaRYScjmR4LlLgdtnyoHYTSAVhhqe5uPdpII8=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1437,6 +1447,9 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
+google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -1480,6 +1493,7 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.0.0/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -63,9 +63,15 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		}
 	}
 
+	outboundPassthroughCluser, err := getOriginalDestinationEgressCluster(envoy.OutboundPassthroughCluster)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to passthrough cluster for egress for proxy %s", envoy.OutboundPassthroughCluster)
+		return nil, err
+	}
+
 	// Add an outbound passthrough cluster for egress if global mesh-wide Egress is enabled
 	if cfg.IsEgressEnabled() {
-		clusters = append(clusters, getOriginalDestinationEgressCluster(envoy.OutboundPassthroughCluster))
+		clusters = append(clusters, outboundPassthroughCluser)
 	}
 
 	// Add an inbound prometheus cluster (from Prometheus to localhost)

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -76,17 +76,20 @@ func TestNewResponse(t *testing.T) {
 		require.True(ok)
 		actualClusters = append(actualClusters, cl)
 	}
+
+	HTTP2ProtocolOptions, err := envoy.GetHTTP2ProtocolOptions()
+	assert.Nil(err)
+
 	expectedLocalCluster := &xds_cluster.Cluster{
-		TransportSocketMatches: nil,
-		Name:                   "default/bookbuyer-local",
-		AltStatName:            "default/bookbuyer-local",
-		ClusterDiscoveryType:   &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STRICT_DNS},
-		EdsClusterConfig:       nil,
-		ConnectTimeout:         ptypes.DurationProto(1 * time.Second),
-		ProtocolSelection:      xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
-		RespectDnsTtl:          true,
-		DnsLookupFamily:        xds_cluster.Cluster_V4_ONLY,
-		Http2ProtocolOptions:   &xds_core.Http2ProtocolOptions{},
+		TransportSocketMatches:        nil,
+		Name:                          "default/bookbuyer-local",
+		AltStatName:                   "default/bookbuyer-local",
+		ClusterDiscoveryType:          &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_STRICT_DNS},
+		EdsClusterConfig:              nil,
+		ConnectTimeout:                ptypes.DurationProto(1 * time.Second),
+		RespectDnsTtl:                 true,
+		DnsLookupFamily:               xds_cluster.Cluster_V4_ONLY,
+		TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
 		LoadAssignment: &xds_endpoint.ClusterLoadAssignment{
 			ClusterName: "default/bookbuyer-local",
 			Endpoints: []*xds_endpoint.LocalityLbEndpoints{
@@ -123,12 +126,11 @@ func TestNewResponse(t *testing.T) {
 	require.Nil(err)
 
 	expectedBookstoreV1Cluster := &xds_cluster.Cluster{
-		TransportSocketMatches: nil,
-		Name:                   "default/bookstore-v1",
-		AltStatName:            "",
-		ClusterDiscoveryType:   &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_EDS},
-		Http2ProtocolOptions:   &xds_core.Http2ProtocolOptions{},
-		ProtocolSelection:      xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		TransportSocketMatches:        nil,
+		Name:                          "default/bookstore-v1",
+		AltStatName:                   "",
+		ClusterDiscoveryType:          &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_EDS},
+		TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
 		EdsClusterConfig: &xds_cluster.Cluster_EdsClusterConfig{
 			EdsConfig: &xds_core.ConfigSource{
 				ConfigSourceSpecifier: &xds_core.ConfigSource_Ads{
@@ -153,12 +155,11 @@ func TestNewResponse(t *testing.T) {
 	upstreamTLSProto, err = ptypes.MarshalAny(envoy.GetUpstreamTLSContext(tests.BookbuyerServiceIdentity, tests.BookstoreV2Service))
 	require.Nil(err)
 	expectedBookstoreV2Cluster := &xds_cluster.Cluster{
-		TransportSocketMatches: nil,
-		Name:                   "default/bookstore-v2",
-		AltStatName:            "",
-		ClusterDiscoveryType:   &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_EDS},
-		Http2ProtocolOptions:   &xds_core.Http2ProtocolOptions{},
-		ProtocolSelection:      xds_cluster.Cluster_USE_DOWNSTREAM_PROTOCOL,
+		TransportSocketMatches:        nil,
+		Name:                          "default/bookstore-v2",
+		AltStatName:                   "",
+		ClusterDiscoveryType:          &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_EDS},
+		TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
 		EdsClusterConfig: &xds_cluster.Cluster_EdsClusterConfig{
 			EdsConfig: &xds_core.ConfigSource{
 				ConfigSourceSpecifier: &xds_core.ConfigSource_Ads{

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -79,8 +79,6 @@ const (
 )
 
 const (
-	accessLogPath = "/dev/stdout"
-
 	// localClusterSuffix is the tag to append to the local cluster name corresponding to a service cluster.
 	// The local cluster refers to the cluster corresponding to the service the proxy is fronting, accessible over localhost by the proxy.
 	localClusterSuffix = "-local"

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -5,7 +5,7 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -33,12 +33,11 @@ func TestGetAccessLog(t *testing.T) {
 	assert.NotNil(res)
 }
 
-func TestGetFileAccessLog(t *testing.T) {
+func TestGetStdoutAccessLog(t *testing.T) {
 	assert := tassert.New(t)
 
-	expAccessLogger := &xds_accesslog.FileAccessLog{
-		Path: accessLogPath,
-		AccessLogFormat: &xds_accesslog.FileAccessLog_LogFormat{
+	expAccessLogger := &xds_accesslog.StdoutAccessLog{
+		AccessLogFormat: &xds_accesslog.StdoutAccessLog_LogFormat{
 			LogFormat: &xds_core.SubstitutionFormatString{
 				Format: &xds_core.SubstitutionFormatString_JsonFormat{
 					JsonFormat: &structpb.Struct{
@@ -68,7 +67,7 @@ func TestGetFileAccessLog(t *testing.T) {
 			},
 		},
 	}
-	resAccessLogger := getFileAccessLog()
+	resAccessLogger := getStdoutAccessLog()
 
 	assert.Equal(resAccessLogger, expAccessLogger)
 }

--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -19,7 +19,12 @@ import (
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Configurator) ([]byte, error) {
 	m := map[interface{}]interface{}{
 		"admin": map[string]interface{}{
-			"access_log_path": "/dev/stdout",
+			"access_log": map[string]interface{}{
+				"name": "envoy.access_loggers.stdout",
+				"typed_config": map[string]interface{}{
+					"@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog",
+				},
+			},
 			"address": map[string]interface{}{
 				"socket_address": map[string]string{
 					"address":    constants.LocalhostIPAddress,
@@ -149,10 +154,17 @@ func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamesp
 
 func getXdsCluster(config envoyBootstrapConfigMeta) map[string]interface{} {
 	return map[string]interface{}{
-		"name":                   config.XDSClusterName,
-		"connect_timeout":        "0.25s",
-		"type":                   "LOGICAL_DNS",
-		"http2_protocol_options": map[string]string{},
+		"name":            config.XDSClusterName,
+		"connect_timeout": "0.25s",
+		"type":            "LOGICAL_DNS",
+		"typed_extension_protocol_options": map[string]interface{}{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": map[string]interface{}{
+				"@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+				"explicit_http_config": map[string]interface{}{
+					"http2_protocol_options": map[string]string{},
+				},
+			},
+		},
 		"transport_socket": map[string]interface{}{
 			"name": "envoy.transport_sockets.tls",
 			"typed_config": map[string]interface{}{

--- a/pkg/injector/envoy_config_health_probes.go
+++ b/pkg/injector/envoy_config_health_probes.go
@@ -162,8 +162,7 @@ func getHTTPAccessLog() []map[string]interface{} {
 		{
 			"name": "envoy.access_loggers.file",
 			"typed_config": map[string]interface{}{
-				"@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-				"path":  "/dev/stdout",
+				"@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog",
 				"log_format": map[string]interface{}{
 					"json_format": map[string]interface{}{
 						"requested_server_name": "%REQUESTED_SERVER_NAME%",
@@ -197,8 +196,7 @@ func getTCPAccessLog() []map[string]interface{} {
 		{
 			"name": "envoy.access_loggers.file",
 			"typed_config": map[string]interface{}{
-				"@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
-				"path":  "/dev/stdout",
+				"@type": "type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog",
 				"log_format": map[string]interface{}{
 					"json_format": map[string]interface{}{
 						"requested_server_name": "%REQUESTED_SERVER_NAME%",

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -1,5 +1,8 @@
 admin:
-  access_log_path: /dev/stdout
+  access_log:
+    name: envoy.access_loggers.stdout
+    typed_config:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   address:
     socket_address:
       address: 127.0.0.1
@@ -21,7 +24,6 @@ dynamic_resources:
 static_resources:
   clusters:
   - connect_timeout: 0.25s
-    http2_protocol_options: {}
     load_assignment:
       cluster_name: osm-controller
       endpoints:
@@ -51,6 +53,11 @@ static_resources:
             trusted_ca:
               inline_bytes: eHg=
     type: LOGICAL_DNS
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
   - connect_timeout: 1s
     lb_policy: ROUND_ROBIN
     load_assignment:
@@ -103,7 +110,7 @@ static_resources:
           access_log:
           - name: envoy.access_loggers.file
             typed_config:
-              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               log_format:
                 json_format:
                   authority: '%REQ(:AUTHORITY)%'
@@ -125,7 +132,6 @@ static_resources:
                   upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-              path: /dev/stdout
           codec_type: AUTO
           http_filters:
           - name: envoy.filters.http.router
@@ -155,7 +161,7 @@ static_resources:
           access_log:
           - name: envoy.access_loggers.file
             typed_config:
-              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               log_format:
                 json_format:
                   authority: '%REQ(:AUTHORITY)%'
@@ -177,7 +183,6 @@ static_resources:
                   upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-              path: /dev/stdout
           codec_type: AUTO
           http_filters:
           - name: envoy.filters.http.router
@@ -207,7 +212,7 @@ static_resources:
           access_log:
           - name: envoy.access_loggers.file
             typed_config:
-              '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+              '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               log_format:
                 json_format:
                   authority: '%REQ(:AUTHORITY)%'
@@ -229,7 +234,6 @@ static_resources:
                   upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-              path: /dev/stdout
           codec_type: AUTO
           http_filters:
           - name: envoy.filters.http.router

--- a/pkg/injector/test_fixtures/expected_xds_cluster_with_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_cluster_with_probes.yaml
@@ -1,5 +1,4 @@
 connect_timeout: 0.25s
-http2_protocol_options: {}
 load_assignment:
   cluster_name: osm-controller
   endpoints:
@@ -29,3 +28,8 @@ transport_socket:
         trusted_ca:
           inline_bytes: eHg=
 type: LOGICAL_DNS
+typed_extension_protocol_options:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    explicit_http_config:
+      http2_protocol_options: {}

--- a/pkg/injector/test_fixtures/expected_xds_cluster_without_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_cluster_without_probes.yaml
@@ -1,5 +1,4 @@
 connect_timeout: 0.25s
-http2_protocol_options: {}
 load_assignment:
   cluster_name: osm-controller
   endpoints:
@@ -29,3 +28,8 @@ transport_socket:
         trusted_ca:
           inline_bytes: eHg=
 type: LOGICAL_DNS
+typed_extension_protocol_options:
+  envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+    '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+    explicit_http_config:
+      http2_protocol_options: {}

--- a/pkg/injector/test_fixtures/expected_xds_static_resources_with_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_static_resources_with_probes.yaml
@@ -1,6 +1,5 @@
 clusters:
 - connect_timeout: 0.25s
-  http2_protocol_options: {}
   load_assignment:
     cluster_name: osm-controller
     endpoints:
@@ -30,3 +29,8 @@ clusters:
           trusted_ca:
             inline_bytes: eHg=
   type: LOGICAL_DNS
+  typed_extension_protocol_options:
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicit_http_config:
+        http2_protocol_options: {}

--- a/tests/envoy_xds_expectations/expected_output_getHTTPAccessLog.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getHTTPAccessLog.yaml
@@ -1,6 +1,6 @@
 - name: envoy.access_loggers.file
   typed_config:
-    '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+    '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
     log_format:
       json_format:
         authority: '%REQ(:AUTHORITY)%'
@@ -22,4 +22,3 @@
         upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
         user_agent: '%REQ(USER-AGENT)%'
         x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-    path: /dev/stdout

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
@@ -10,7 +10,7 @@ filter_chains:
       access_log:
       - name: envoy.access_loggers.file
         typed_config:
-          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:
             json_format:
               authority: '%REQ(:AUTHORITY)%'
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          path: /dev/stdout
       codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
@@ -10,7 +10,7 @@ filter_chains:
       access_log:
       - name: envoy.access_loggers.file
         typed_config:
-          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:
             json_format:
               bytes_received: '%BYTES_RECEIVED%'
@@ -21,7 +21,6 @@ filter_chains:
               start_time: '%START_TIME%'
               upstream_cluster: '%UPSTREAM_CLUSTER%'
               upstream_host: '%UPSTREAM_HOST%'
-          path: /dev/stdout
       cluster: liveness_cluster
       stat_prefix: health_probes
 name: liveness_listener

--- a/tests/envoy_xds_expectations/expected_output_getProbeListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getProbeListener.yaml
@@ -10,7 +10,7 @@ filter_chains:
       access_log:
       - name: envoy.access_loggers.file
         typed_config:
-          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:
             json_format:
               authority: '%REQ(:AUTHORITY)%'
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          path: /dev/stdout
       codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router

--- a/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
@@ -10,7 +10,7 @@ filter_chains:
       access_log:
       - name: envoy.access_loggers.file
         typed_config:
-          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:
             json_format:
               authority: '%REQ(:AUTHORITY)%'
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          path: /dev/stdout
       codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router

--- a/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
@@ -10,7 +10,7 @@ filter_chains:
       access_log:
       - name: envoy.access_loggers.file
         typed_config:
-          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:
             json_format:
               authority: '%REQ(:AUTHORITY)%'
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          path: /dev/stdout
       codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router

--- a/tests/envoy_xds_expectations/expected_output_getTCPAccessLog.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getTCPAccessLog.yaml
@@ -1,6 +1,6 @@
 - name: envoy.access_loggers.file
   typed_config:
-    '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+    '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
     log_format:
       json_format:
         bytes_received: '%BYTES_RECEIVED%'
@@ -11,4 +11,3 @@
         start_time: '%START_TIME%'
         upstream_cluster: '%UPSTREAM_CLUSTER%'
         upstream_host: '%UPSTREAM_HOST%'
-    path: /dev/stdout


### PR DESCRIPTION
This patch makes the following updates:

1. Use `type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog` in admin
2. Use `type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog` in listeners
3. Use explicit http2 config

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>