### PR TITLE
osm-controller: use fixed port number for ADS server

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -47,7 +47,7 @@ spec:
           ports:
             - name: "admin-port"
               containerPort: 15000
-            - name: "osm-port"
+            - name: "ads-port"
               containerPort: 15128
             - name: "metrics"
               containerPort: 9091

--- a/charts/osm/templates/osm-service.yaml
+++ b/charts/osm/templates/osm-service.yaml
@@ -8,7 +8,7 @@ metadata:
     app: osm-controller
 spec:
   ports:
-    - name: osm-port
+    - name: ads-port
       port: 15128
       targetPort: 15128
     - name: debug-port

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -76,7 +76,6 @@ var (
 
 var (
 	flags = pflag.NewFlagSet(`osm-controller`, pflag.ExitOnError)
-	port  = flags.Int("port", constants.OSMControllerPort, "Aggregated Discovery Service port number.")
 	log   = logger.New("osm-controller/main")
 )
 
@@ -225,7 +224,7 @@ func main() {
 
 	// Create and start the ADS gRPC service
 	xdsServer := ads.NewADSServer(meshCatalog, proxyRegistry, cfg.IsDebugServerEnabled(), osmNamespace, cfg, certManager)
-	if err := xdsServer.Start(ctx, cancel, *port, adsCert); err != nil {
+	if err := xdsServer.Start(ctx, cancel, constants.ADSServerPort, adsCert); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error initializing ADS server")
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -76,8 +76,8 @@ const (
 	// OSMControllerName is the name of the OSM Controller (formerly ADS service).
 	OSMControllerName = "osm-controller"
 
-	// OSMControllerPort is the port on which XDS listens for new connections.
-	OSMControllerPort = 15128
+	// ADSServerPort is the port on which the Aggregated Discovery Service (ADS) listens for new gRPC connections from Envoy proxies
+	ADSServerPort = 15128
 
 	// PrometheusScrapePath is the path for prometheus to scrap envoy metrics from
 	PrometheusScrapePath = "/stats/prometheus"

--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -112,7 +112,7 @@ func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamesp
 		Key:      base64.StdEncoding.EncodeToString(cert.GetPrivateKey()),
 
 		XDSHost: fmt.Sprintf("%s.%s.svc.cluster.local", constants.OSMControllerName, osmNamespace),
-		XDSPort: constants.OSMControllerPort,
+		XDSPort: constants.ADSServerPort,
 
 		// OriginalHealthProbes stores the path and port for liveness, readiness, and startup health probes as initially
 		// defined on the Pod Spec.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Resolves #2190 by using a constant port number for the
ADS server in osm-controller. The port number was partially
configurable via the controller's command line flags but
this isn't enough to make the port number configurable.
Since there is no use case for this port to be configurable,
use a fixed port number. Also, renames the name of the port
for clarity.

Resolves #2190

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
