### PR TITLE
bug(test): set registry secret when necessary

### DIFF
--- a/tests/e2e/e2e_health_probe_test.go
+++ b/tests/e2e/e2e_health_probe_test.go
@@ -175,7 +175,7 @@ server {
 			}
 
 			makePod := func(name string, probe *corev1.Probe) *corev1.Pod {
-				return &corev1.Pod{
+				podDef := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: name,
 					},
@@ -223,7 +223,18 @@ server {
 						},
 					},
 				}
+
+				if Td.AreRegistryCredsPresent() {
+					podDef.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+						{
+							Name: RegistrySecretName,
+						},
+					}
+				}
+
+				return podDef
 			}
+
 			pods := []*corev1.Pod{
 				makePod("nginx-http", http),
 				makePod("nginx-https", https),

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -81,9 +81,6 @@ var _ = AfterSuite(func() {
 })
 
 const (
-	// default name for the container registry secret
-	registrySecretName = "acr-creds"
-
 	// test tag prefix, for NS labeling
 	osmTest = "osmTest"
 
@@ -149,6 +146,8 @@ const (
 	KindCluster InstallType = "KindCluster"
 	// NoInstall uses current kube cluster, assumes an OSM is present in `OsmNamespace`
 	NoInstall InstallType = "NoInstall"
+	// RegistrySecretName is the default name for the container registry secret
+	RegistrySecretName = "acr-creds"
 )
 
 // Verifies the instType string flag option is a valid enum type
@@ -633,7 +632,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 
 	if len(instOpts.ContainerRegistrySecret) != 0 {
 		instOpts.SetOverrides = append(instOpts.SetOverrides,
-			fmt.Sprintf("OpenServiceMesh.imagePullSecrets[0].name=%s", registrySecretName),
+			fmt.Sprintf("OpenServiceMesh.imagePullSecrets[0].name=%s", RegistrySecretName),
 		)
 	}
 
@@ -1393,11 +1392,11 @@ type DockerConfigEntry struct {
 	Auth     string `json:"auth,omitempty"`
 }
 
-// CreateDockerRegistrySecret creates a secret named `registrySecretName` in namespace <ns>,
+// CreateDockerRegistrySecret creates a secret named `RegistrySecretName` in namespace <ns>,
 // based on ctrRegistry variables
 func (td *OsmTestData) CreateDockerRegistrySecret(ns string) {
 	secret := &corev1.Secret{}
-	secret.Name = registrySecretName
+	secret.Name = RegistrySecretName
 	secret.Type = corev1.SecretTypeDockerConfigJson
 	secret.Data = map[string][]byte{}
 
@@ -1415,7 +1414,7 @@ func (td *OsmTestData) CreateDockerRegistrySecret(ns string) {
 	json, _ := json.Marshal(dockerCfgJSON)
 	secret.Data[corev1.DockerConfigJsonKey] = json
 
-	td.T.Logf("Pushing Registry secret '%s' for namespace %s... ", registrySecretName, ns)
+	td.T.Logf("Pushing Registry secret '%s' for namespace %s... ", RegistrySecretName, ns)
 	_, err := td.Client.CoreV1().Secrets(ns).Create(context.Background(), secret, metav1.CreateOptions{})
 	if err != nil {
 		td.T.Fatalf("Could not add registry secret")

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -190,7 +190,7 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 	if td.AreRegistryCredsPresent() {
 		podDefinition.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 			{
-				Name: registrySecretName,
+				Name: RegistrySecretName,
 			},
 		}
 	}
@@ -327,7 +327,7 @@ func (td *OsmTestData) SimpleDeploymentApp(def SimpleDeploymentAppDef) (corev1.S
 	if td.AreRegistryCredsPresent() {
 		deploymentDefinition.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 			{
-				Name: registrySecretName,
+				Name: RegistrySecretName,
 			},
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This PR resolves issue #3395.

Registry secret is set when using non-default registry for most of the images, such as osm-controller, init, client and server. But for this specific case, setting registry secret process is missing.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

No
