### PR TITLE
ref(proxy registry): track proxy-service relations async

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.enablePrivilegedInitContainer | bool | `false` | Run init container in privileged mode |
 | OpenServiceMesh.enforceSingleMesh | bool | `false` | Enforce only deploying one mesh in the cluster |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar |
+| OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |
 | OpenServiceMesh.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API If specified, fine grained control over Egress (external) traffic is enforced |
 | OpenServiceMesh.featureFlags.enableMulticlusterMode | bool | `false` | Enable Multicluster mode If specified, multicluster mode will be enabled in OSM |
 | OpenServiceMesh.featureFlags.enableOSMGateway | bool | `false` | Enable OSM gateway for ingress or multicluster |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -199,3 +199,6 @@ spec:
                     enableOSMGateway:
                       type: boolean
                       default: false
+                    enableAsyncProxyServiceMapping:
+                      type: boolean
+                      default: false

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -32,3 +32,4 @@ spec:
     enableEgressPolicy: {{.Values.OpenServiceMesh.featureFlags.enableEgressPolicy}}
     enableMulticlusterMode: {{.Values.OpenServiceMesh.featureFlags.enableMulticlusterMode}}
     enableOSMGateway: {{.Values.OpenServiceMesh.featureFlags.enableOSMGateway}}
+    enableAsyncProxyServiceMapping: {{.Values.OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping}}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -675,7 +675,8 @@
                         "enableWASMStats",
                         "enableEgressPolicy",
                         "enableMulticlusterMode",
-                        "enableOSMGateway"
+                        "enableOSMGateway",
+                        "enableAsyncProxyServiceMapping"
                     ],
                     "properties": {
                         "enableWASMStats": {
@@ -710,6 +711,15 @@
                             "type": "boolean",
                             "title": "Enable OSM gateway",
                             "description": "Enable OSM gateway for ingress or multicluster",
+                            "examples": [
+                                true
+                            ]
+                        },
+                        "enableAsyncProxyServiceMapping": {
+                            "$id": "#/properties/OpenServiceMesh/properties/featureFlags/properties/enableAsyncProxyServiceMapping",
+                            "type": "boolean",
+                            "title": "Enable async proxy-service mapping",
+                            "description": "Enable async proxy-service mapping",
                             "examples": [
                                 true
                             ]

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -244,6 +244,8 @@ OpenServiceMesh:
     enableMulticlusterMode: false
     # -- Enable OSM gateway for ingress or multicluster
     enableOSMGateway: false
+    # -- Enable async proxy-service mapping
+    enableAsyncProxyServiceMapping: false
 
   # -- Run OSM with PodSecurityPolicy configured
   pspEnabled: false

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -164,4 +164,7 @@ type FeatureFlags struct {
 
 	// EnableOSMGateway defines if OSM gateway is enabled.
 	EnableOSMGateway bool `json:"enableOSMGateway,omitempty"`
+
+	//EnableAsyncProxyServiceMapping defines if OSM will map proxies to services asynchronously.
+	EnableAsyncProxyServiceMapping bool `json:"enableAsyncProxyServiceMapping,omitempty"`
 }

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -449,6 +449,21 @@ func TestCreateUpdateConfig(t *testing.T) {
 				assert.Equal(true, cfg.GetFeatureFlags().EnableMulticlusterMode)
 			},
 		},
+		{
+			name:                  "IsAsyncProxyServiceMappingEnabled",
+			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal(false, cfg.GetFeatureFlags().EnableAsyncProxyServiceMapping)
+			},
+			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
+				FeatureFlags: v1alpha1.FeatureFlags{
+					EnableAsyncProxyServiceMapping: true,
+				},
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal(true, cfg.GetFeatureFlags().EnableAsyncProxyServiceMapping)
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/envoy/registry/services.go
+++ b/pkg/envoy/registry/services.go
@@ -3,12 +3,19 @@ package registry
 import (
 	"fmt"
 	"strings"
+	"sync"
 
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -39,10 +46,7 @@ func (k *KubeProxyServiceMapper) ListProxyServices(p *envoy.Proxy) ([]service.Me
 		return nil, err
 	}
 
-	services, err := listServicesForPod(pod, k.KubeController)
-	if err != nil {
-		return nil, err
-	}
+	services := listServicesForPod(pod, k.KubeController)
 
 	if len(services) == 0 {
 		return nil, nil
@@ -55,6 +59,190 @@ func (k *KubeProxyServiceMapper) ListProxyServices(p *envoy.Proxy) ([]service.Me
 		pod.ObjectMeta.UID, pod.Namespace, pod.Name, servicesForPod)
 
 	return meshServices, nil
+}
+
+// AsyncKubeProxyServiceMapper maps an Envoy instance to services in a
+// Kubernetes cluster. It maintains a cache of the mapping updated in response
+// to Kubernetes events.
+type AsyncKubeProxyServiceMapper struct {
+	kubeController k8s.Controller
+	kubeEvents     chan interface{}
+	servicesForCN  map[certificate.CommonName][]service.MeshService
+	cnsForService  map[service.MeshService]map[certificate.CommonName]struct{}
+	cacheLock      sync.RWMutex
+}
+
+// NewAsyncKubeProxyServiceMapper initializes a KubeProxyServiceMapper with an empty cache.
+func NewAsyncKubeProxyServiceMapper(controller k8s.Controller) *AsyncKubeProxyServiceMapper {
+	return &AsyncKubeProxyServiceMapper{
+		kubeController: controller,
+		servicesForCN:  make(map[certificate.CommonName][]service.MeshService),
+		cnsForService:  make(map[service.MeshService]map[certificate.CommonName]struct{}),
+		kubeEvents: events.GetPubSubInstance().Subscribe(
+			announcements.PodAdded,
+			announcements.PodUpdated,
+			announcements.PodDeleted,
+			announcements.ServiceAdded,
+			announcements.ServiceUpdated,
+			announcements.ServiceDeleted,
+		),
+	}
+}
+
+// Run starts updating the proxy-to-services cache based on k8s notifications.
+func (k *AsyncKubeProxyServiceMapper) Run(stop <-chan struct{}) {
+	// Populate the cache using the cluster's existing state. Otherwise if
+	// existing resources are not modified, no events will come through to
+	// update the cache.
+	k.cacheLock.Lock()
+	for _, pod := range k.kubeController.ListPods() {
+		k.handlePodUpdate(pod)
+	}
+	k.cacheLock.Unlock()
+
+	go func() {
+		for {
+			select {
+			case <-stop:
+				events.GetPubSubInstance().Unsub(k.kubeEvents)
+				return
+			case ev := <-k.kubeEvents:
+				event, ok := ev.(events.PubSubMessage)
+				if !ok {
+					log.Error().Msgf("ignoring unexpected pubsub message type: %T %v", ev, ev)
+					continue
+				}
+				k.cacheLock.Lock()
+				switch event.AnnouncementType {
+				case announcements.PodAdded, announcements.PodUpdated:
+					pod := event.NewObj.(*v1.Pod)
+					k.handlePodUpdate(pod)
+				case announcements.PodDeleted:
+					pod := event.OldObj.(*v1.Pod)
+					k.handlePodDelete(pod)
+				case announcements.ServiceAdded, announcements.ServiceUpdated:
+					svc := event.NewObj.(*v1.Service)
+					k.handleServiceUpdate(svc)
+				case announcements.ServiceDeleted:
+					svc := event.OldObj.(*v1.Service)
+					k.handleServiceDelete(svc)
+				}
+				k.cacheLock.Unlock()
+				events.GetPubSubInstance().Publish(events.PubSubMessage{
+					AnnouncementType: announcements.ScheduleProxyBroadcast,
+				})
+			}
+		}
+	}()
+}
+
+func (k *AsyncKubeProxyServiceMapper) handlePodUpdate(pod *v1.Pod) {
+	if pod == nil {
+		return
+	}
+	cn, err := getCertCommonNameForPod(*pod)
+	if err != nil {
+		log.Error().Err(err).Msgf("ignoring updated pod %s/%s", pod.Namespace, pod.Name)
+		return
+	}
+
+	services := listServicesForPod(pod, k.kubeController)
+
+	meshServices := kubernetesServicesToMeshServices(services)
+
+	servicesForPod := strings.Join(listServiceNames(meshServices), ",")
+	log.Trace().Msgf("Services associated with Pod with UID=%s Name=%s/%s: %+v",
+		pod.ObjectMeta.UID, pod.Namespace, pod.Name, servicesForPod)
+
+	k.servicesForCN[cn] = meshServices
+
+	for _, svc := range meshServices {
+		if k.cnsForService[svc] == nil {
+			k.cnsForService[svc] = make(map[certificate.CommonName]struct{})
+		}
+		k.cnsForService[svc][cn] = struct{}{}
+	}
+}
+
+func (k *AsyncKubeProxyServiceMapper) handlePodDelete(pod *v1.Pod) {
+	if pod == nil {
+		return
+	}
+	cn, err := getCertCommonNameForPod(*pod)
+	if err != nil {
+		log.Error().Err(err).Msgf("ignoring deleted pod %s/%s", pod.Namespace, pod.Name)
+		return
+	}
+
+	for _, svc := range k.servicesForCN[cn] {
+		delete(k.cnsForService[svc], cn)
+	}
+
+	delete(k.servicesForCN, cn)
+}
+
+func (k *AsyncKubeProxyServiceMapper) handleServiceUpdate(svc *v1.Service) {
+	if svc == nil {
+		return
+	}
+
+	updatedSvc := service.MeshService{
+		Name:      svc.Name,
+		Namespace: svc.Namespace,
+	}
+	if k.cnsForService[updatedSvc] == nil {
+		k.cnsForService[updatedSvc] = make(map[certificate.CommonName]struct{})
+	}
+
+	pods := listPodsForService(svc, k.kubeController)
+	for _, pod := range pods {
+		cn, err := getCertCommonNameForPod(pod)
+		if err != nil {
+			log.Error().Err(err)
+			continue
+		}
+		alreadyCached := false
+		for _, cachedSvc := range k.servicesForCN[cn] {
+			if cachedSvc == updatedSvc {
+				alreadyCached = true
+				break
+			}
+		}
+		if !alreadyCached {
+			k.servicesForCN[cn] = append(k.servicesForCN[cn], updatedSvc)
+		}
+
+		k.cnsForService[updatedSvc][cn] = struct{}{}
+	}
+}
+
+func (k *AsyncKubeProxyServiceMapper) handleServiceDelete(svc *v1.Service) {
+	if svc == nil {
+		return
+	}
+
+	deleted := service.MeshService{
+		Name:      svc.Name,
+		Namespace: svc.Namespace,
+	}
+	for cn := range k.cnsForService[deleted] {
+		var rem []service.MeshService
+		for _, s := range k.servicesForCN[cn] {
+			if s == deleted {
+				continue
+			}
+			rem = append(rem, s)
+		}
+		k.servicesForCN[cn] = rem
+	}
+	delete(k.cnsForService, deleted)
+}
+
+// ListProxyServices maps an Envoy instance to a number of Kubernetes services.
+func (k *AsyncKubeProxyServiceMapper) ListProxyServices(p *envoy.Proxy) ([]service.MeshService, error) {
+	k.cacheLock.RLock()
+	defer k.cacheLock.RUnlock()
+	return k.servicesForCN[p.GetCertificateCommonName()], nil
 }
 
 func kubernetesServicesToMeshServices(kubernetesServices []v1.Service) (meshServices []service.MeshService) {
@@ -75,7 +263,7 @@ func listServiceNames(meshServices []service.MeshService) (serviceNames []string
 }
 
 // listServicesForPod lists Kubernetes services whose selectors match pod labels
-func listServicesForPod(pod *v1.Pod, kubeController k8s.Controller) ([]v1.Service, error) {
+func listServicesForPod(pod *v1.Pod, kubeController k8s.Controller) []v1.Service {
 	var serviceList []v1.Service
 	svcList := kubeController.ListServices()
 
@@ -94,5 +282,41 @@ func listServicesForPod(pod *v1.Pod, kubeController k8s.Controller) ([]v1.Servic
 		}
 	}
 
-	return serviceList, nil
+	return serviceList
+}
+
+func listPodsForService(service *v1.Service, kubeController k8s.Controller) []v1.Pod {
+	svcRawSelector := service.Spec.Selector
+	// service has no selectors, we do not need to match against the pod label
+	if len(svcRawSelector) == 0 {
+		return nil
+	}
+	selector := labels.Set(svcRawSelector).AsSelector()
+
+	allPods := kubeController.ListPods()
+
+	var matchedPods []v1.Pod
+	for _, pod := range allPods {
+		if service.Namespace != pod.Namespace {
+			continue
+		}
+		if selector.Matches(labels.Set(pod.Labels)) {
+			matchedPods = append(matchedPods, *pod)
+		}
+	}
+
+	return matchedPods
+}
+
+func getCertCommonNameForPod(pod v1.Pod) (certificate.CommonName, error) {
+	proxyUIDStr, exists := pod.Labels[constants.EnvoyUniqueIDLabelName]
+	if !exists {
+		return "", errors.Errorf("no %s label", constants.EnvoyUniqueIDLabelName)
+	}
+	proxyUID, err := uuid.Parse(proxyUIDStr)
+	if err != nil {
+		return "", errors.Wrapf(err, "invalid UID value for %s label", constants.EnvoyUniqueIDLabelName)
+	}
+	cn := envoy.NewCertCommonName(proxyUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, pod.Namespace)
+	return cn, nil
 }

--- a/pkg/envoy/registry/services_test.go
+++ b/pkg/envoy/registry/services_test.go
@@ -3,10 +3,12 @@ package registry
 import (
 	"context"
 	"fmt"
+	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/onsi/ginkgo"
+	tassert "github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -14,10 +16,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/kubernetes/events"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -71,7 +75,6 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 	Context("Test getServiceFromCertificate()", func() {
 		It("works as expected", func() {
-
 			// Create the POD
 			proxyUUID := uuid.New()
 			namespace := uuid.New().String()
@@ -133,8 +136,7 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 			pod := tests.NewPodFixture(namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			mockKubeController.EXPECT().ListServices().Return(services)
-			actualSvcs, err := listServicesForPod(&pod, mockKubeController)
-			Expect(err).ToNot(HaveOccurred())
+			actualSvcs := listServicesForPod(&pod, mockKubeController)
 			Expect(len(actualSvcs)).To(Equal(2))
 
 			actualNames := []string{actualSvcs[0].Name, actualSvcs[1].Name}
@@ -153,8 +155,7 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 			mockKubeController.EXPECT().ListServices().Return([]*v1.Service{service})
 			pod := tests.NewPodFixture(namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
-			actualSvcs, err := listServicesForPod(&pod, mockKubeController)
-			Expect(err).ToNot(HaveOccurred())
+			actualSvcs := listServicesForPod(&pod, mockKubeController)
 			Expect(len(actualSvcs)).To(Equal(0))
 		})
 
@@ -177,8 +178,7 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 			mockKubeController.EXPECT().ListServices().Return([]*v1.Service{service})
 			pod := tests.NewPodFixture(namespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
-			actualSvcs, err := listServicesForPod(&pod, mockKubeController)
-			Expect(err).ToNot(HaveOccurred())
+			actualSvcs := listServicesForPod(&pod, mockKubeController)
 			Expect(len(actualSvcs)).To(Equal(0))
 		})
 	})
@@ -243,3 +243,1480 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 		})
 	})
 })
+
+func TestAsyncKubeProxyServiceMapperListServicesForProxy(t *testing.T) {
+	cn1 := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc1", "ns1")
+	cn2 := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc2", "ns2")
+	svc1 := service.MeshService{Namespace: "ns1", Name: "svc1"}
+	mapper := &AsyncKubeProxyServiceMapper{
+		servicesForCN: map[certificate.CommonName][]service.MeshService{
+			cn1: nil,
+			cn2: {svc1},
+		},
+	}
+
+	assert := tassert.New(t)
+
+	proxy, err := envoy.NewProxy(cn1, "", nil)
+	assert.NoError(err)
+	svcs, err := mapper.ListProxyServices(proxy)
+	assert.NoError(err)
+	assert.Nil(svcs)
+
+	proxy, err = envoy.NewProxy(cn2, "", nil)
+	assert.NoError(err)
+	svcs, err = mapper.ListProxyServices(proxy)
+	assert.NoError(err)
+	assert.Equal([]service.MeshService{svc1}, svcs)
+}
+
+func TestAsyncKubeProxyServiceMapperRun(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	kubeController := k8s.NewMockController(mockCtrl)
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	k := NewAsyncKubeProxyServiceMapper(kubeController)
+
+	assert.Empty(k.servicesForCN)
+
+	proxyUID := uuid.New()
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-namespace",
+			Labels: map[string]string{
+				"app":                            "my-app",
+				constants.EnvoyUniqueIDLabelName: proxyUID.String(),
+			},
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: "my-service-acc",
+		},
+	}
+	cn := envoy.NewCertCommonName(proxyUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, pod.Namespace)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "my-namespace",
+		},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "my-app",
+			},
+		},
+	}
+	broadcast := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
+
+	kubeController.EXPECT().ListPods().Return([]*v1.Pod{pod}).Times(1)
+	kubeController.EXPECT().ListServices().Return([]*v1.Service{svc}).Times(1)
+
+	k.Run(stop)
+
+	svcs := k.servicesForCN[cn]
+	assert.NotEmpty(svcs)
+
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.ServiceDeleted,
+		OldObj:           svc,
+	})
+	<-broadcast
+
+	assert.Empty(k.servicesForCN[cn])
+
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.PodDeleted,
+		OldObj:           pod,
+	})
+	<-broadcast
+
+	assert.Empty(k.servicesForCN)
+
+	kubeController.EXPECT().ListServices().Return(nil).Times(1)
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.PodAdded,
+		NewObj:           pod,
+	})
+	<-broadcast
+
+	svcs, ok := k.servicesForCN[cn]
+	assert.True(ok, "expected CN %s to exist in cache, but it doesn't", cn)
+	assert.Empty(svcs)
+
+	kubeController.EXPECT().ListPods().Return([]*v1.Pod{pod}).Times(1)
+	events.GetPubSubInstance().Publish(events.PubSubMessage{
+		AnnouncementType: announcements.ServiceAdded,
+		NewObj:           svc,
+	})
+	<-broadcast
+
+	svcs = k.servicesForCN[cn]
+	assert.NotEmpty(svcs)
+}
+
+func TestKubeHandlePodUpdate(t *testing.T) {
+	uid1 := uuid.New()
+	uid2 := uuid.New()
+
+	tests := []struct {
+		name                  string
+		existingCNsToServices map[certificate.CommonName][]service.MeshService
+		existingServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+		existingSvcs          []*v1.Service
+		pod                   *v1.Pod
+		expectedCNsToServices map[certificate.CommonName][]service.MeshService
+		expectedServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+	}{
+		{
+			name:                  "nil pod",
+			pod:                   nil,
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "first new pod matching no services",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "first new pod matching one service",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+						"app":                            "my-app",
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingSvcs: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+					Spec: v1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "my-app",
+						},
+					},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "first new pod matching two services",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+						"app":                            "my-app",
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingSvcs: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "ns",
+					},
+					Spec: v1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "my-app",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc2",
+						Namespace: "ns",
+					},
+					Spec: v1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "my-app",
+						},
+					},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc1",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc2",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc1", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc2", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "second pod matching no services",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "other-svc1",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "other-svc1", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "other-svc1",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "other-svc1", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "pod without envoy uid label",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels:    map[string]string{},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "second pod matching same service",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid2.String(),
+						"app":                            "my-app",
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingSvcs: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+					Spec: v1.ServiceSpec{
+						Selector: map[string]string{
+							"app": "my-app",
+						},
+					},
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			kubeController := k8s.NewMockController(mockCtrl)
+			kubeController.EXPECT().ListServices().Return(test.existingSvcs)
+
+			k := &AsyncKubeProxyServiceMapper{
+				kubeController: kubeController,
+				servicesForCN:  test.existingCNsToServices,
+				cnsForService:  test.existingServicesToCNs,
+			}
+			if k.servicesForCN == nil {
+				k.servicesForCN = map[certificate.CommonName][]service.MeshService{}
+			}
+			if k.cnsForService == nil {
+				k.cnsForService = map[service.MeshService]map[certificate.CommonName]struct{}{}
+			}
+
+			k.handlePodUpdate(test.pod)
+
+			tassert.Equal(t, test.expectedCNsToServices, k.servicesForCN)
+			tassert.Equal(t, test.expectedServicesToCNs, k.cnsForService)
+		})
+	}
+}
+
+func TestKubeHandlePodDelete(t *testing.T) {
+	uid1 := uuid.New()
+	uid2 := uuid.New()
+
+	tests := []struct {
+		name                  string
+		existingCNsToServices map[certificate.CommonName][]service.MeshService
+		existingServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+		pod                   *v1.Pod
+		expectedCNsToServices map[certificate.CommonName][]service.MeshService
+		expectedServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+	}{
+		{
+			name:                  "empty existing cache",
+			pod:                   nil,
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete nil pod",
+			pod:  nil,
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete pod without proxy uuid",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels:    map[string]string{},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete pod not matching any existing",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete only pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete one of several pods",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete one of several pods matching a service",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uid1.String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{Namespace: "ns", Name: "svc"},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{Namespace: "ns", Name: "svc"},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Namespace: "ns", Name: "svc"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{Namespace: "ns", Name: "svc"},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Namespace: "ns", Name: "svc"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			k := &AsyncKubeProxyServiceMapper{
+				servicesForCN: test.existingCNsToServices,
+				cnsForService: test.existingServicesToCNs,
+			}
+			if k.servicesForCN == nil {
+				k.servicesForCN = map[certificate.CommonName][]service.MeshService{}
+			}
+			if k.cnsForService == nil {
+				k.cnsForService = map[service.MeshService]map[certificate.CommonName]struct{}{}
+			}
+
+			k.handlePodDelete(test.pod)
+
+			tassert.Equal(t, test.expectedCNsToServices, k.servicesForCN)
+			tassert.Equal(t, test.expectedServicesToCNs, k.cnsForService)
+		})
+	}
+}
+
+func TestKubeHandleServiceUpdate(t *testing.T) {
+	uid1 := uuid.New()
+	uid2 := uuid.New()
+
+	tests := []struct {
+		name                  string
+		existingCNsToServices map[certificate.CommonName][]service.MeshService
+		existingServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+		existingPods          []*v1.Pod
+		service               *v1.Service
+		expectedCNsToServices map[certificate.CommonName][]service.MeshService
+		expectedServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+	}{
+		{
+			name:    "add nil service",
+			service: nil,
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "add service backed by no pods",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc",
+					Namespace: "ns",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "ns"}: {},
+			},
+		},
+		{
+			name: "add service backed by one pod to empty cache",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc",
+					Namespace: "ns",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "my-app",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Labels: map[string]string{
+							constants.EnvoyUniqueIDLabelName: uid1.String(),
+							"app":                            "my-app",
+						},
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: "svcacc",
+					},
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "add service backed by one pod with invalid UID",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc",
+					Namespace: "ns",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "my-app",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Labels: map[string]string{
+							constants.EnvoyUniqueIDLabelName: uid1.String() + "-invalid",
+							"app":                            "my-app",
+						},
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: "svcacc",
+					},
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "other-svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "other-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "other-svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "other-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "ns"}: {},
+			},
+		},
+		{
+			name: "add service backed by multiple pods to empty cache",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc",
+					Namespace: "ns",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "my-app",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Labels: map[string]string{
+							constants.EnvoyUniqueIDLabelName: uid1.String(),
+							"app":                            "my-app",
+						},
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: "svcacc",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Labels: map[string]string{
+							constants.EnvoyUniqueIDLabelName: uid2.String(),
+							"app":                            "my-app",
+						},
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: "svcacc",
+					},
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "update service backed by multiple pods already cached",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc",
+					Namespace: "ns",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "my-app",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Labels: map[string]string{
+							constants.EnvoyUniqueIDLabelName: uid1.String(),
+							"app":                            "my-app",
+						},
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: "svcacc",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns",
+						Labels: map[string]string{
+							constants.EnvoyUniqueIDLabelName: uid2.String(),
+							"app":                            "my-app",
+						},
+					},
+					Spec: v1.PodSpec{
+						ServiceAccountName: "svcacc",
+					},
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "not-ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "not-ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "not-ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "not-ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			kubeController := k8s.NewMockController(mockCtrl)
+			kubeController.EXPECT().ListPods().Return(test.existingPods)
+
+			k := &AsyncKubeProxyServiceMapper{
+				kubeController: kubeController,
+				servicesForCN:  test.existingCNsToServices,
+				cnsForService:  test.existingServicesToCNs,
+			}
+			if k.servicesForCN == nil {
+				k.servicesForCN = map[certificate.CommonName][]service.MeshService{}
+			}
+			if k.cnsForService == nil {
+				k.cnsForService = map[service.MeshService]map[certificate.CommonName]struct{}{}
+			}
+
+			k.handleServiceUpdate(test.service)
+
+			tassert.Equal(t, test.expectedCNsToServices, k.servicesForCN)
+			tassert.Equal(t, test.expectedServicesToCNs, k.cnsForService)
+		})
+	}
+}
+
+func TestKubeHandleServiceDelete(t *testing.T) {
+	uid1 := uuid.New()
+	uid2 := uuid.New()
+
+	tests := []struct {
+		name                  string
+		existingCNsToServices map[certificate.CommonName][]service.MeshService
+		existingServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+		service               *v1.Service
+		expectedCnsToServices map[certificate.CommonName][]service.MeshService
+		expectedServicesToCNs map[service.MeshService]map[certificate.CommonName]struct{}
+	}{
+		{
+			name:                  "empty existing cache",
+			service:               nil,
+			expectedCnsToServices: map[certificate.CommonName][]service.MeshService{},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name:    "delete nil service",
+			service: nil,
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCnsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "delete service backed by no proxies",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "not-ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "not-ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCnsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "not-ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "not-ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+		{
+			name: "delete only service from one proxy",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCnsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): nil,
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{},
+		},
+		{
+			name: "delete service from all proxies",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "svc",
+				},
+			},
+			existingCNsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "not-ns",
+					},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+					{
+						Name:      "svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			existingServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "not-ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+			expectedCnsToServices: map[certificate.CommonName][]service.MeshService{
+				envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "svc",
+						Namespace: "not-ns",
+					},
+				},
+				envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {
+					{
+						Name:      "not-svc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expectedServicesToCNs: map[service.MeshService]map[certificate.CommonName]struct{}{
+				{Name: "not-svc", Namespace: "ns"}: {
+					envoy.NewCertCommonName(uid2, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+				{Name: "svc", Namespace: "not-ns"}: {
+					envoy.NewCertCommonName(uid1, envoy.KindSidecar, "svcacc", "ns"): {},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			k := &AsyncKubeProxyServiceMapper{
+				servicesForCN: test.existingCNsToServices,
+				cnsForService: test.existingServicesToCNs,
+			}
+			if k.servicesForCN == nil {
+				k.servicesForCN = map[certificate.CommonName][]service.MeshService{}
+			}
+			if k.cnsForService == nil {
+				k.cnsForService = map[service.MeshService]map[certificate.CommonName]struct{}{}
+			}
+
+			k.handleServiceDelete(test.service)
+
+			tassert.Equal(t, test.expectedCnsToServices, k.servicesForCN)
+			tassert.Equal(t, test.expectedServicesToCNs, k.cnsForService)
+		})
+	}
+}
+
+func TestListPodsForService(t *testing.T) {
+	tests := []struct {
+		name         string
+		service      *v1.Service
+		existingPods []*v1.Pod
+		expected     []v1.Pod
+	}{
+		{
+			name: "no existing pods",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"a": "selector",
+					},
+				},
+			},
+			existingPods: nil,
+			expected:     nil,
+		},
+		{
+			name: "match only pod",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"a": "selector",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod",
+						Labels: map[string]string{
+							"some": "labels",
+							"that": "match",
+							"a":    "selector",
+						},
+					},
+				},
+			},
+			expected: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod",
+						Labels: map[string]string{
+							"some": "labels",
+							"that": "match",
+							"a":    "selector",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "match pod except for namespace",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "svc",
+				},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"a": "selector",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "pod",
+						Namespace: "pod",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "empty service selector",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "match several pods",
+			service: &v1.Service{
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{
+						"a": "selector",
+					},
+				},
+			},
+			existingPods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "pod3",
+						Labels: map[string]string{},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod4",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+			},
+			expected: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod4",
+						Labels: map[string]string{
+							"a": "selector",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			kubeController := k8s.NewMockController(ctrl)
+			kubeController.EXPECT().ListPods().Return(test.existingPods).Times(1)
+
+			actual := listPodsForService(test.service, kubeController)
+			tassert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestGetCertCommonNameForPod(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       v1.Pod
+		shouldErr bool
+	}{
+		{
+			name: "valid CN",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uuid.New().String(),
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			name: "invalid UID",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels: map[string]string{
+						constants.EnvoyUniqueIDLabelName: uuid.New().String() + "-not-valid",
+					},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			shouldErr: true,
+		},
+		{
+			name: "no UID",
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Labels:    map[string]string{},
+				},
+				Spec: v1.PodSpec{
+					ServiceAccountName: "svcacc",
+				},
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			cn, err := getCertCommonNameForPod(test.pod)
+			if test.shouldErr {
+				assert.Empty(cn)
+				assert.Error(err)
+			} else {
+				assert.NotEmpty(cn)
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestAsyncKubeProxyServiceMapperRace(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	kubeController := k8s.NewMockController(mockCtrl)
+
+	k := NewAsyncKubeProxyServiceMapper(kubeController)
+
+	stop := make(chan struct{})
+
+	kubeController.EXPECT().ListPods().Return(nil).Times(1)
+	k.Run(stop)
+
+	proxyUUID := uuid.New()
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constants.EnvoyUniqueIDLabelName: proxyUUID.String(),
+				"app":                            "my-app",
+			},
+		},
+	}
+	svc := &v1.Service{
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "my-app",
+			},
+		},
+	}
+	cn := envoy.NewCertCommonName(proxyUUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, pod.Namespace)
+	proxy, err := envoy.NewProxy(cn, "", nil)
+	tassert.NoError(t, err)
+
+	numWriteLoopIters := 100
+	totalExpectedBroadcasts := numWriteLoopIters * 4 // four Publish() calls per loop
+	doWrites := func() {
+		for i := 0; i < numWriteLoopIters; i++ {
+			kubeController.EXPECT().ListServices().Return(nil).Times(1)
+			events.GetPubSubInstance().Publish(events.PubSubMessage{
+				AnnouncementType: announcements.PodAdded,
+				NewObj:           pod,
+			})
+
+			kubeController.EXPECT().ListPods().Return([]*v1.Pod{pod}).Times(1)
+			events.GetPubSubInstance().Publish(events.PubSubMessage{
+				AnnouncementType: announcements.ServiceAdded,
+				NewObj:           svc,
+			})
+
+			events.GetPubSubInstance().Publish(events.PubSubMessage{
+				AnnouncementType: announcements.ServiceDeleted,
+				OldObj:           svc,
+			})
+			events.GetPubSubInstance().Publish(events.PubSubMessage{
+				AnnouncementType: announcements.PodDeleted,
+				OldObj:           pod,
+			})
+		}
+	}
+
+	doReads := func(stop <-chan struct{}) {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = k.ListProxyServices(proxy)
+			}
+		}
+	}
+
+	// wait ensures all the published events have been handled by the mapper.
+	wait := func() {
+		broadcast := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
+		defer events.GetPubSubInstance().Unsub(broadcast)
+		for i := 0; i < totalExpectedBroadcasts; i++ {
+			<-broadcast
+		}
+		close(stop)
+	}
+
+	go wait()
+	go doWrites()
+	go doReads(stop)
+	go doReads(stop)
+
+	<-stop
+}


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds an `AsyncKubeProxyServiceMapper` used by the proxy
registry to maintain its own cache that maps proxies to which services
they back. It responds to add/update/delete events on k8s pods and
services, updates its cache, then schedules a new proxy update
broadcast. The `AsyncProxyServiceMapper` is disabled by default (with
the existing `KubeProxyServiceMapper` used instead) and can be enabled
with the `enableAsyncProxyServiceMapping` feature flag.

Fixes #3273

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
