### PR TITLE
ref(config): remove osmconfig footprint

### DIFF
--- a/charts/osm/templates/osm-service.yaml
+++ b/charts/osm/templates/osm-service.yaml
@@ -16,19 +16,3 @@ spec:
       targetPort: 9092
   selector:
     app: osm-controller
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: osm-config-validator
-  namespace: {{ include "osm.namespace" . }}
-  labels:
-    {{- include "osm.labels" . | nindent 4 }}
-    app: osm-controller
-spec:
-  ports:
-    - name: config-validator
-      port: 9093
-      targetPort: 9093
-  selector:
-    app: osm-controller

--- a/demo/deploy-smi-policies.sh
+++ b/demo/deploy-smi-policies.sh
@@ -13,13 +13,13 @@ source .env
 echo -e "Enable SMI Spec policies"
 kubectl apply -f - <<EOF
 apiVersion: v1
-kind: ConfigMap
+kind: MeshConfig
 
 metadata:
-  name: osm-config
+  name: osm-mesh-config
   namespace: $K8S_NAMESPACE
-
-data:
-  permissive_traffic_policy_mode: "false"
+spec:
+  traffic:
+    enablePermissiveTrafficPolicyMode: false
 
 EOF

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -145,9 +145,6 @@ const (
 	// Example use: envoy --service-node 52883c80-6e0d-4c64-b901-cbcb75134949/bookstore/10.144.2.91/bookstore-v1/bookstore-v1
 	EnvoyServiceNodeSeparator = "/"
 
-	// OSMConfigMap is the name of the OSM ConfigMap
-	OSMConfigMap = "osm-config"
-
 	// OSMMeshConfig is the name of the OSM MeshConfig
 	OSMMeshConfig = "osm-mesh-config"
 )


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Changes in this PR:

* Remove osm-config-validator service
* Create MeshConfig when deploying SMI policy, rather than osm-config ConfigMap

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [X] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

No