### PR TITLE
feat(rbac): Add Jaeger SecurityContext and PSP

### DIFF
--- a/charts/osm/templates/jaeger-deployment.yaml
+++ b/charts/osm/templates/jaeger-deployment.yaml
@@ -18,9 +18,10 @@ spec:
         {{- include "osm.labels" . | nindent 8 }}
         app: jaeger
     spec:
-      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
+      serviceAccountName: jaeger
       containers:
       - name: jaeger
         image: jaegertracing/all-in-one

--- a/charts/osm/templates/jaeger-rbac.yaml
+++ b/charts/osm/templates/jaeger-rbac.yaml
@@ -1,0 +1,96 @@
+{{- if .Values.OpenServiceMesh.deployJaeger }}
+{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-jaeger-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # This is redundant with non-root + disallow privilege escalation,
+  # but we can provide it for defense in depth.
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    # Assume that persistentVolumes set up by the cluster admin are safe to use.
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: jaeger
+  name: jaeger
+  namespace: {{ include "osm.namespace" . }}
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: jaeger
+  name: {{.Release.Name}}-jaeger
+rules:
+  {{- if .Values.OpenServiceMesh.pspEnabled }}
+  - apiGroups: ["extensions"]
+    resourceNames: ["{{ .Release.Name }}-jaeger-psp"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+  {{- end }}
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{.Release.Name}}-jaeger
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: jaeger
+subjects:
+  - kind: ServiceAccount
+    name: jaeger
+    namespace: {{ include "osm.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{.Release.Name}}-jaeger
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds SecurityContext and PSP for jaeger deployment.

Tested with both PSP enabled and PSP disabled clusters.

SecurityContext is added regardless of pspEnabled as a best practice.

Partially fixes #1941
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No