### PR TITLE
feat(rbac): Add Grafana and Prometheus SecurityContexts by default

### DIFF
--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- include "osm.labels" . | nindent 8 }}
         app: osm-grafana
     spec:
-      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       serviceAccountName: osm-grafana

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "osm.labels" . | nindent 8 }}
         app: osm-prometheus
     spec:
-      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       containers:


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds Grafana and Prometheus SecurityContexts by default (enablePsp not required)
Fixes #3054 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No