### PR TITLE
charts/osm: add pod disruption budgets for control plane

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -97,11 +97,13 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` | Container image registry |
 | OpenServiceMesh.image.tag | string | `"v0.8.4"` | Container image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
-| OpenServiceMesh.injector.podLabels | object | `{}` |  |
+| OpenServiceMesh.injector.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
+| OpenServiceMesh.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
 | OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
+| OpenServiceMesh.osmController.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.osmController.podLabels | object | `{}` | OSM controller's pod labels |
 | OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count |
 | OpenServiceMesh.osmController.resource | object | `{"limits":{"cpu":"1.5","memory":"512M"},"requests":{"cpu":"0.5","memory":"128M"}}` | OSM controller's container resource parameters |

--- a/charts/osm/templates/osm-controller-pod-disruption-budget.yaml
+++ b/charts/osm/templates/osm-controller-pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.OpenServiceMesh.osmController.enablePodDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: osm-controller-pdb
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    app: osm-controller
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: osm-controller
+{{- end }}

--- a/charts/osm/templates/osm-injector-pod-disruption-budget.yaml
+++ b/charts/osm/templates/osm-injector-pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.OpenServiceMesh.injector.enablePodDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: osm-injector-pdb
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    app: osm-injector
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: osm-injector
+{{- end }}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -130,6 +130,15 @@
                             "title": "The podLabels schema",
                             "description": "Labels for the osmController pod.",
                             "default": {}
+                        },
+                        "enablePodDisruptionBudget": {
+                            "$id": "#/properties/OpenServiceMesh/properties/osmController/properties/enablePodDisruptionBudget",
+                            "type": "boolean",
+                            "title": "The enablePodDisruptionBudget schema",
+                            "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
+                            "examples": [
+                                false
+                            ]
                         }
                     },
                     "additionalProperties": false
@@ -588,6 +597,15 @@
                             "title": "The podLabels schema",
                             "description": "Labels for the osm-injector pod.",
                             "default": {}
+                        },
+                        "enablePodDisruptionBudget": {
+                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/enablePodDisruptionBudget",
+                            "type": "boolean",
+                            "title": "The enablePodDisruptionBudget schema",
+                            "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
+                            "examples": [
+                                false
+                            ]
                         }
                     },
                     "additionalProperties": false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -34,6 +34,8 @@ OpenServiceMesh:
         memory: "128M"
     # -- OSM controller's pod labels
     podLabels: {}
+    # -- Enable Pod Disruption Budget
+    enablePodDisruptionBudget: false
 
   #
   # -- Prometheus parameters
@@ -204,7 +206,10 @@ OpenServiceMesh:
       requests:
         cpu: "0.3"
         memory: "64M"
+    # -- Sidecar injector's pod labels
     podLabels: {}
+    # -- Enable Pod Disruption Budget
+    enablePodDisruptionBudget: false
 
   # -- Run init container in privileged mode
   enablePrivilegedInitContainer: false


### PR DESCRIPTION
Adds pod disruption budgets for osm-controller and osm-injector
that can be optionally enabled. This is an HA feature that
ensures replicated control plane apps always maintain a certain
number of healthy replicas at any given time, to account for
voluntary outages such as a node being drained.

Refer to the [HA doc](https://docs.google.com/document/d/1gpNbsghOTmKx0rVh4TL1kzpH6UnlWL3Hkw7lce7WlYM/edit#heading=h.ap5u1c8i7rvb) for more reference.
Part of #3390

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
