### PR TITLE
smi: check SMI CRDs during liveness probe

### DIFF
--- a/pkg/smi/health.go
+++ b/pkg/smi/health.go
@@ -16,7 +16,7 @@ type HealthChecker struct {
 
 // Liveness is the Kubernetes liveness probe handler.
 func (smi HealthChecker) Liveness() bool {
-	return true
+	return checkSMICrdsExist(smi.SMIClientset)
 }
 
 // Readiness is the Kubernetes readiness probe handler.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
SMI client implements the `health.Probes` interface for
readiness and liveness probes. This change checks for
the existence of SMI CRDs as a part of the liveness
probe.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
