### PR TITLE
ref(pkg/injector): use XDS structs for envoy bootstrap config

### DIFF
--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -1,12 +1,12 @@
 admin:
   access_log:
-    name: envoy.access_loggers.stdout
+  - name: envoy.access_loggers.stdout
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   address:
     socket_address:
       address: 127.0.0.1
-      port_value: "15000"
+      port_value: 15000
 dynamic_resources:
   ads_config:
     api_type: GRPC
@@ -25,7 +25,7 @@ node:
   id: foo.bar.co.uk
 static_resources:
   clusters:
-  - connect_timeout: 0.25s
+  - connect_timeout: 0.250s
     load_assignment:
       cluster_name: osm-controller
       endpoints:
@@ -61,7 +61,6 @@ static_resources:
         explicit_http_config:
           http2_protocol_options: {}
   - connect_timeout: 1s
-    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: liveness_cluster
       endpoints:
@@ -74,7 +73,6 @@ static_resources:
     name: liveness_cluster
     type: STATIC
   - connect_timeout: 1s
-    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: readiness_cluster
       endpoints:
@@ -87,7 +85,6 @@ static_resources:
     name: readiness_cluster
     type: STATIC
   - connect_timeout: 1s
-    lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: startup_cluster
       endpoints:
@@ -134,7 +131,6 @@ static_resources:
                   upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          codec_type: AUTO
           http_filters:
           - name: envoy.filters.http.router
           route_config:
@@ -185,7 +181,6 @@ static_resources:
                   upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          codec_type: AUTO
           http_filters:
           - name: envoy.filters.http.router
           route_config:
@@ -236,7 +231,6 @@ static_resources:
                   upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-          codec_type: AUTO
           http_filters:
           - name: envoy.filters.http.router
           route_config:

--- a/pkg/injector/test_fixtures/expected_xds_cluster_with_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_cluster_with_probes.yaml
@@ -1,4 +1,4 @@
-connect_timeout: 0.25s
+connect_timeout: 0.250s
 load_assignment:
   cluster_name: osm-controller
   endpoints:

--- a/pkg/injector/test_fixtures/expected_xds_cluster_without_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_cluster_without_probes.yaml
@@ -1,4 +1,4 @@
-connect_timeout: 0.25s
+connect_timeout: 0.250s
 load_assignment:
   cluster_name: osm-controller
   endpoints:

--- a/pkg/injector/test_fixtures/expected_xds_static_resources_with_probes.yaml
+++ b/pkg/injector/test_fixtures/expected_xds_static_resources_with_probes.yaml
@@ -1,5 +1,5 @@
 clusters:
-- connect_timeout: 0.25s
+- connect_timeout: 0.250s
   load_assignment:
     cluster_name: osm-controller
     endpoints:

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -40,16 +40,16 @@ type Config struct {
 
 // Context needed to compose the Envoy bootstrap YAML.
 type envoyBootstrapConfigMeta struct {
-	EnvoyAdminPort int
+	EnvoyAdminPort uint32
 	XDSClusterName string
 	NodeID         string
-	RootCert       string
-	Cert           string
-	Key            string
+	RootCert       []byte
+	Cert           []byte
+	Key            []byte
 
 	// Host and port of the Envoy xDS server
 	XDSHost string
-	XDSPort int
+	XDSPort uint32
 
 	// The bootstrap Envoy config will be affected by the liveness, readiness, startup probes set on
 	// the pod this Envoy is fronting.

--- a/tests/envoy_xds_expectations/expected_output_getHTTPAccessLog.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getHTTPAccessLog.yaml
@@ -1,24 +1,24 @@
-- name: envoy.access_loggers.file
-  typed_config:
-    '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-    log_format:
-      json_format:
-        authority: '%REQ(:AUTHORITY)%'
-        bytes_received: '%BYTES_RECEIVED%'
-        bytes_sent: '%BYTES_SENT%'
-        duration: '%DURATION%'
-        method: '%REQ(:METHOD)%'
-        path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
-        protocol: '%PROTOCOL%'
-        request_id: '%REQ(X-REQUEST-ID)%'
-        requested_server_name: '%REQUESTED_SERVER_NAME%'
-        response_code: '%RESPONSE_CODE%'
-        response_code_details: '%RESPONSE_CODE_DETAILS%'
-        response_flags: '%RESPONSE_FLAGS%'
-        start_time: '%START_TIME%'
-        time_to_first_byte: '%RESPONSE_DURATION%'
-        upstream_cluster: '%UPSTREAM_CLUSTER%'
-        upstream_host: '%UPSTREAM_HOST%'
-        upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
-        user_agent: '%REQ(USER-AGENT)%'
-        x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
+name: envoy.access_loggers.file
+typed_config:
+  '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  log_format:
+    json_format:
+      authority: '%REQ(:AUTHORITY)%'
+      bytes_received: '%BYTES_RECEIVED%'
+      bytes_sent: '%BYTES_SENT%'
+      duration: '%DURATION%'
+      method: '%REQ(:METHOD)%'
+      path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+      protocol: '%PROTOCOL%'
+      request_id: '%REQ(X-REQUEST-ID)%'
+      requested_server_name: '%REQUESTED_SERVER_NAME%'
+      response_code: '%RESPONSE_CODE%'
+      response_code_details: '%RESPONSE_CODE_DETAILS%'
+      response_flags: '%RESPONSE_FLAGS%'
+      start_time: '%START_TIME%'
+      time_to_first_byte: '%RESPONSE_DURATION%'
+      upstream_cluster: '%UPSTREAM_CLUSTER%'
+      upstream_host: '%UPSTREAM_HOST%'
+      upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
+      user_agent: '%REQ(USER-AGENT)%'
+      x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'

--- a/tests/envoy_xds_expectations/expected_output_getLivenessCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessCluster.yaml
@@ -1,5 +1,4 @@
 connect_timeout: 1s
-lb_policy: ROUND_ROBIN
 load_assignment:
   cluster_name: liveness_cluster
   endpoints:

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-      codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router
       route_config:

--- a/tests/envoy_xds_expectations/expected_output_getProbeCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getProbeCluster.yaml
@@ -1,5 +1,4 @@
 connect_timeout: 1s
-lb_policy: ROUND_ROBIN
 load_assignment:
   cluster_name: cluster-name
   endpoints:

--- a/tests/envoy_xds_expectations/expected_output_getProbeListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getProbeListener.yaml
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-      codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router
       route_config:

--- a/tests/envoy_xds_expectations/expected_output_getReadinessCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessCluster.yaml
@@ -1,5 +1,4 @@
 connect_timeout: 1s
-lb_policy: ROUND_ROBIN
 load_assignment:
   cluster_name: readiness_cluster
   endpoints:

--- a/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-      codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router
       route_config:

--- a/tests/envoy_xds_expectations/expected_output_getStartupCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupCluster.yaml
@@ -1,5 +1,4 @@
 connect_timeout: 1s
-lb_policy: ROUND_ROBIN
 load_assignment:
   cluster_name: startup_cluster
   endpoints:

--- a/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
@@ -32,7 +32,6 @@ filter_chains:
               upstream_service_time: '%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%'
               user_agent: '%REQ(USER-AGENT)%'
               x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
-      codec_type: AUTO
       http_filters:
       - name: envoy.filters.http.router
       route_config:

--- a/tests/envoy_xds_expectations/expected_output_getTCPAccessLog.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getTCPAccessLog.yaml
@@ -1,13 +1,13 @@
-- name: envoy.access_loggers.file
-  typed_config:
-    '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-    log_format:
-      json_format:
-        bytes_received: '%BYTES_RECEIVED%'
-        bytes_sent: '%BYTES_SENT%'
-        duration: '%DURATION%'
-        requested_server_name: '%REQUESTED_SERVER_NAME%'
-        response_flags: '%RESPONSE_FLAGS%'
-        start_time: '%START_TIME%'
-        upstream_cluster: '%UPSTREAM_CLUSTER%'
-        upstream_host: '%UPSTREAM_HOST%'
+name: envoy.access_loggers.file
+typed_config:
+  '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  log_format:
+    json_format:
+      bytes_received: '%BYTES_RECEIVED%'
+      bytes_sent: '%BYTES_SENT%'
+      duration: '%DURATION%'
+      requested_server_name: '%REQUESTED_SERVER_NAME%'
+      response_flags: '%RESPONSE_FLAGS%'
+      start_time: '%START_TIME%'
+      upstream_cluster: '%UPSTREAM_CLUSTER%'
+      upstream_host: '%UPSTREAM_HOST%'

--- a/tests/envoy_xds_expectations/expected_output_getVirtualHosts.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getVirtualHosts.yaml
@@ -1,9 +1,9 @@
-- domains:
-  - '*'
-  name: local_service
-  routes:
-  - match:
-      prefix: /some/path
-    route:
-      cluster: -cluster-name-
-      prefix_rewrite: /original/probe/path
+domains:
+- '*'
+name: local_service
+routes:
+- match:
+    prefix: /some/path
+  route:
+    cluster: -cluster-name-
+    prefix_rewrite: /original/probe/path


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updates the envoy bootstrap config to be constructed using XDS
structs directly instead of maps. The XDS objects are marshaled
to JSON and then to YAML. Using the XDS structs directly will help
ensure the objects are configured correctly and all required
fields are set. Additionally, this change will make it easier to
enforce the use of the same API version across the injector and
controller.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ X ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
