### PR TITLE
catalog: add GetKubecontroller interface

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -36,3 +36,8 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 
 	return &mc
 }
+
+// GetKubecontroller returns the kubecontroller instance handling the current cluster
+func (mc *MeshCatalog) GetKubecontroller() k8s.Controller {
+	return mc.kubeController
+}

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	endpoint "github.com/openservicemesh/osm/pkg/endpoint"
 	identity "github.com/openservicemesh/osm/pkg/identity"
+	kubernetes "github.com/openservicemesh/osm/pkg/kubernetes"
 	service "github.com/openservicemesh/osm/pkg/service"
 	trafficpolicy "github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -65,6 +66,20 @@ func (m *MockMeshCataloger) GetIngressPoliciesForService(arg0 service.MeshServic
 func (mr *MockMeshCatalogerMockRecorder) GetIngressPoliciesForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressPoliciesForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressPoliciesForService), arg0)
+}
+
+// GetKubecontroller mocks base method
+func (m *MockMeshCataloger) GetKubecontroller() kubernetes.Controller {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKubecontroller")
+	ret0, _ := ret[0].(kubernetes.Controller)
+	return ret0
+}
+
+// GetKubecontroller indicates an expected call of GetKubecontroller
+func (mr *MockMeshCatalogerMockRecorder) GetKubecontroller() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKubecontroller", reflect.TypeOf((*MockMeshCataloger)(nil).GetKubecontroller))
 }
 
 // GetPortToProtocolMappingForService mocks base method

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -99,6 +99,9 @@ type MeshCataloger interface {
 
 	// GetEgressTrafficPolicy returns the Egress traffic policy associated with the given service identity
 	GetEgressTrafficPolicy(identity.ServiceIdentity) (*trafficpolicy.EgressTrafficPolicy, error)
+
+	// GetKubecontroller returns the kubecontroller instance handling the current cluster
+	GetKubecontroller() k8s.Controller
 }
 
 type trafficDirection string


### PR DESCRIPTION
XDS verticals have no way to call some of the existing functions
or helpers for XDS (namely, GetPodFromCertificate).

To avoid creating an API everytime we have a use-case that needs
special massaging of data, this commit allows packages to get
visibility on the kubecontroller instance to allow verticals see
kubernetes resources directly if they need to.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

| Control Plane              | [x] |

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No