### PR TITLE
charts/osm: allow additional root properties

### DIFF
--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -913,6 +913,5 @@
             },
             "additionalProperties": false
         }
-    },
-    "additionalProperties": false
+    }
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, the schema prevents additional
Helm chart properties other than OpenServiceMesh
which is the root property for all values.

This change enforces strict validation only
for the OpenServiceMesh root property. Other
root properties that might be leveraged by
Helm charts using the OSM chart as a dependency
will not be subjected to schema validations.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Install                    | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
