### PR TITLE
envoy/eds: only respond to requested clusters

### DIFF
--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -1,33 +1,24 @@
 package eds
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"testing"
 
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
-	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	tassert "github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/service"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/identity"
-	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
-	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -76,7 +67,10 @@ func TestEndpointConfiguration(t *testing.T) {
 	assert.NotNil(meshCatalog)
 	assert.NotNil(proxy)
 
-	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil, nil)
+	request := &xds_discovery.DiscoveryRequest{
+		ResourceNames: []string{"default/bookstore-v1"},
+	}
+	resources, err := NewResponse(meshCatalog, proxy, request, mockConfigurator, nil, nil)
 	assert.Nil(err)
 	assert.NotNil(resources)
 
@@ -84,7 +78,7 @@ func TestEndpointConfiguration(t *testing.T) {
 	// 1. Bookstore
 	// 2. Bookstore-v1
 	// 3. Bookstore-v2
-	assert.Len(resources, 3)
+	assert.Len(resources, 1)
 
 	loadAssignment, ok := resources[0].(*xds_endpoint.ClusterLoadAssignment)
 
@@ -93,180 +87,40 @@ func TestEndpointConfiguration(t *testing.T) {
 	assert.Len(loadAssignment.Endpoints, 1)
 }
 
-func TestGetEndpointsForProxy(t *testing.T) {
+func TestClusterToMeshSvc(t *testing.T) {
 	assert := tassert.New(t)
 
 	testCases := []struct {
-		name                            string
-		proxyIdentity                   identity.ServiceIdentity
-		trafficTargets                  []*access.TrafficTarget
-		allowedServiceIdentities        []identity.ServiceIdentity
-		services                        []service.MeshService
-		outboundServices                map[identity.ServiceIdentity][]service.MeshService
-		outboundServiceEndpoints        map[service.MeshService][]endpoint.Endpoint
-		outboundServiceAccountEndpoints map[identity.ServiceIdentity]map[service.MeshService][]endpoint.Endpoint
-		expectedEndpoints               map[service.MeshService][]endpoint.Endpoint
+		name            string
+		cluster         string
+		expectedMeshSvc service.MeshService
+		expectError     bool
 	}{
 		{
-			name: `Traffic target defined for bookstore ServiceAccount.
-			This service account has bookstore-v1 service which has one endpoint.
-			Hence one endpoint for bookstore-v1 should be in the expected list`,
-			proxyIdentity:            tests.BookbuyerServiceIdentity,
-			trafficTargets:           []*access.TrafficTarget{&tests.TrafficTarget},
-			allowedServiceIdentities: []identity.ServiceIdentity{tests.BookstoreServiceIdentity},
-			services:                 []service.MeshService{tests.BookstoreV1Service},
-			outboundServices: map[identity.ServiceIdentity][]service.MeshService{
-				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service},
-			},
-			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreV1Service: {tests.Endpoint},
-			},
-			outboundServiceAccountEndpoints: map[identity.ServiceIdentity]map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service: {tests.Endpoint}},
-			},
-			expectedEndpoints: map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreV1Service: {tests.Endpoint},
-			},
+			name:            "valid cluster name",
+			cluster:         "foo/bar",
+			expectedMeshSvc: service.MeshService{Namespace: "foo", Name: "bar"},
+			expectError:     false,
 		},
 		{
-			name: `Traffic target defined for bookstore ServiceAccount.
-			This service account has bookstore-v1 service which has two endpoints,
-			but endpoint 9.9.9.9 is associated with a pod having service account bookstore-v2.
-			Hence this endpoint (9.9.9.9) shouldn't be in bookstore-v1's expected list`,
-			proxyIdentity:            tests.BookbuyerServiceIdentity,
-			trafficTargets:           []*access.TrafficTarget{&tests.TrafficTarget},
-			allowedServiceIdentities: []identity.ServiceIdentity{tests.BookstoreServiceIdentity},
-			services:                 []service.MeshService{tests.BookstoreV1Service},
-			outboundServices: map[identity.ServiceIdentity][]service.MeshService{
-				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service},
-			},
-			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreV1Service: {tests.Endpoint, {
-					IP:   net.ParseIP("9.9.9.9"),
-					Port: endpoint.Port(tests.ServicePort),
-				}},
-			},
-			outboundServiceAccountEndpoints: map[identity.ServiceIdentity]map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service: {tests.Endpoint}},
-			},
-			expectedEndpoints: map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreV1Service: {tests.Endpoint},
-			},
+			name:            "invalid cluster name",
+			cluster:         "foobar",
+			expectedMeshSvc: service.MeshService{},
+			expectError:     true,
 		},
 		{
-			name: `Traffic target defined for bookstore and bookstore-v2 ServiceAccount.
-			Hence one endpoint should be in bookstore-v1's and bookstore-v2's expected list`,
-			proxyIdentity:            tests.BookbuyerServiceIdentity,
-			trafficTargets:           []*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget},
-			allowedServiceIdentities: []identity.ServiceIdentity{tests.BookstoreServiceIdentity, tests.BookstoreV2ServiceIdentity},
-			services:                 []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service},
-			outboundServices: map[identity.ServiceIdentity][]service.MeshService{
-				tests.BookstoreServiceIdentity:   {tests.BookstoreV1Service},
-				tests.BookstoreV2ServiceIdentity: {tests.BookstoreV2Service},
-			},
-			outboundServiceEndpoints: map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreV1Service: {tests.Endpoint},
-				tests.BookstoreV2Service: {endpoint.Endpoint{
-					IP:   net.ParseIP("9.9.9.9"),
-					Port: endpoint.Port(tests.ServicePort),
-				}},
-			},
-			outboundServiceAccountEndpoints: map[identity.ServiceIdentity]map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreServiceIdentity: {tests.BookstoreV1Service: {tests.Endpoint}},
-				tests.BookstoreV2ServiceIdentity: {tests.BookstoreV2Service: {endpoint.Endpoint{
-					IP:   net.ParseIP("9.9.9.9"),
-					Port: endpoint.Port(tests.ServicePort),
-				}}},
-			},
-			expectedEndpoints: map[service.MeshService][]endpoint.Endpoint{
-				tests.BookstoreV1Service: {tests.Endpoint},
-				tests.BookstoreV2Service: {endpoint.Endpoint{
-					IP:   net.ParseIP("9.9.9.9"),
-					Port: endpoint.Port(tests.ServicePort),
-				}},
-			},
+			name:            "invalid cluster name",
+			cluster:         "foo/bar/baz",
+			expectedMeshSvc: service.MeshService{},
+			expectError:     true,
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockCtrl := gomock.NewController(t)
-			kubeClient := testclient.NewSimpleClientset()
-			defer mockCtrl.Finish()
-
-			mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
-			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-			mockKubeController := k8s.NewMockController(mockCtrl)
-			meshSpec := smi.NewMockMeshSpec(mockCtrl)
-			mockEndpointProvider := endpoint.NewMockProvider(mockCtrl)
-
-			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
-			meshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).AnyTimes()
-
-			proxy, err := getProxy(kubeClient)
-			assert.Empty(err)
-			assert.NotNil(mockCatalog)
-			assert.NotNil(proxy)
-
-			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
-
-			for sa, services := range tc.outboundServices {
-				for _, svc := range services {
-					k8sService := tests.NewServiceFixture(svc.Name, svc.Namespace, map[string]string{})
-					mockKubeController.EXPECT().GetService(svc).Return(k8sService).AnyTimes()
-				}
-				mockEndpointProvider.EXPECT().GetServicesForServiceAccount(sa).Return(services, nil).AnyTimes()
-			}
-
-			mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tc.proxyIdentity).Return(tc.services).AnyTimes()
-
-			for svc, endpoints := range tc.outboundServiceEndpoints {
-				mockEndpointProvider.EXPECT().ListEndpointsForService(svc).Return(endpoints).AnyTimes()
-			}
-
-			mockCatalog.EXPECT().ListAllowedOutboundServiceIdentities(tc.proxyIdentity).Return(tc.allowedServiceIdentities, nil).AnyTimes()
-
-			var pods []*v1.Pod
-			for serviceIdentity, services := range tc.outboundServices {
-				sa := serviceIdentity.ToK8sServiceAccount()
-				for _, svc := range services {
-					podlabels := map[string]string{
-						tests.SelectorKey:                tests.SelectorValue,
-						constants.EnvoyUniqueIDLabelName: uuid.New().String(),
-					}
-					pod := tests.NewPodFixture(tests.Namespace, svc.Name, sa.Name, podlabels)
-					svcPodEndpoints := tc.outboundServiceAccountEndpoints[serviceIdentity]
-					var podIps []v1.PodIP
-					for _, podEndpoints := range svcPodEndpoints {
-						for _, ep := range podEndpoints {
-							podIps = append(podIps, v1.PodIP{IP: ep.IP.String()})
-						}
-					}
-					pod.Status.PodIPs = podIps
-					pod.Spec.ServiceAccountName = sa.Name
-					_, err = kubeClient.CoreV1().Pods(tests.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
-					assert.Nil(err)
-					pods = append(pods, &pod)
-				}
-			}
-			mockKubeController.EXPECT().ListPods().Return(pods).AnyTimes()
-
-			for sa, svcEndpoints := range tc.outboundServiceAccountEndpoints {
-				for svc, endpoints := range svcEndpoints {
-					mockEndpointProvider.EXPECT().ListEndpointsForIdentity(sa).Return(endpoints).AnyTimes()
-					mockCatalog.EXPECT().ListAllowedEndpointsForService(tc.proxyIdentity, svc).Return(endpoints, nil).AnyTimes()
-				}
-			}
-
-			actual, err := getEndpointsForProxy(mockCatalog, tc.proxyIdentity)
-			assert.Nil(err)
-			assert.NotNil(actual)
-
-			assert.Len(actual, len(tc.expectedEndpoints))
-			for svc, endpoints := range tc.expectedEndpoints {
-				_, ok := actual[svc]
-				assert.True(ok)
-				assert.ElementsMatch(actual[svc], endpoints)
-			}
+			meshSvc, err := clusterToMeshSvc(tc.cluster)
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedMeshSvc, meshSvc)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Optimizes EDS to only respond with the endpoints for
requested clusters. Per the XDS protocol, additional
responses for resources that have not been requested
will be ignored.

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [ X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
