### PR TITLE
envoy: changing node ID to CN

### DIFF
--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -18,6 +18,9 @@ import (
 
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Configurator) ([]byte, error) {
 	m := map[interface{}]interface{}{
+		"node": map[string]interface{}{
+			"id": config.NodeID,
+		},
 		"admin": map[string]interface{}{
 			"access_log": map[string]interface{}{
 				"name": "envoy.access_loggers.stdout",
@@ -111,6 +114,7 @@ func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamesp
 	configMeta := envoyBootstrapConfigMeta{
 		EnvoyAdminPort: constants.EnvoyAdminPort,
 		XDSClusterName: constants.OSMControllerName,
+		NodeID:         cert.GetCommonName().String(),
 
 		RootCert: base64.StdEncoding.EncodeToString(cert.GetIssuingCA()),
 		Cert:     base64.StdEncoding.EncodeToString(cert.GetCertificateChain()),

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -30,7 +30,6 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 	const (
 		containerName = "-container-name-"
 		envoyImage    = "-envoy-image-"
-		nodeID        = "-node-id-"
 		clusterID     = "-cluster-id-"
 
 		// This file contains the Bootstrap YAML generated for all of the Envoy proxies in OSM.
@@ -125,6 +124,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 	}
 
 	config := envoyBootstrapConfigMeta{
+		NodeID:   cert.GetCommonName().String(),
 		RootCert: base64.StdEncoding.EncodeToString(cert.GetIssuingCA()),
 		Cert:     base64.StdEncoding.EncodeToString(cert.GetCertificateChain()),
 		Key:      base64.StdEncoding.EncodeToString(cert.GetPrivateKey()),
@@ -291,7 +291,6 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				Args: []string{
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
-					"--service-node", "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/svcacc/$(POD_NAME)/workload-kind/workload-name",
 					"--service-cluster", "svcacc.namespace",
 					"--bootstrap-version 3",
 				},

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -21,6 +21,8 @@ dynamic_resources:
   lds_config:
     ads: {}
     resource_api_version: V3
+node:
+  id: foo.bar.co.uk
 static_resources:
   clusters:
   - connect_timeout: 0.25s

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -42,6 +42,7 @@ type Config struct {
 type envoyBootstrapConfigMeta struct {
 	EnvoyAdminPort int
 	XDSClusterName string
+	NodeID         string
 	RootCert       string
 	Cert           string
 	Key            string


### PR DESCRIPTION
- Node ID was currently used for metadata purposes, this commit
makes Common Name (CN) of an envoy's certificate as its node identifier.
- The change of Node ID is in order to prepare adoption of
go-control-plane's XDS caches mechanisms.
- Node ID can be consolidated as part of envoy's bootstrap config yaml,
which seems a better than envoy cli args.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

| Control Plane              | [ ] |

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No