### PR TITLE
envoy: add additional metadata for the proxy's kind

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Test ADS response functions", func() {
 		GinkgoT().Fatalf("Error creating new Bookstire Apex service: %s", err.Error())
 	}
 
-	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", proxyUUID, proxySvcAccount.Name, proxySvcAccount.Namespace))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID, envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 
@@ -118,7 +118,7 @@ var _ = Describe("Test ADS response functions", func() {
 	Context("Test sendAllResponses()", func() {
 
 		certManager := tresor.NewFakeCertManager(mockConfigurator)
-		certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), proxySvcAccount.Name, proxySvcAccount.Namespace))
+		certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", uuid.New(), envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace))
 		certDuration := 1 * time.Hour
 		certPEM, _ := certManager.IssueCertificate(certCommonName, certDuration)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
@@ -199,7 +199,7 @@ var _ = Describe("Test ADS response functions", func() {
 	Context("Test sendSDSResponse()", func() {
 
 		certManager := tresor.NewFakeCertManager(mockConfigurator)
-		certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), proxySvcAccount.Name, proxySvcAccount.Namespace))
+		certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", uuid.New(), envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace))
 		certDuration := 1 * time.Hour
 		certPEM, _ := certManager.IssueCertificate(certCommonName, certDuration)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -33,7 +33,7 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 	proxyServiceIdentity := identity.K8sServiceAccount{Name: "test-sa", Namespace: "ns-1"}.ToServiceIdentity()
 	proxySvcAccount := proxyServiceIdentity.ToK8sServiceAccount()
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxyXDSCertCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", uuid.New(), proxySvcAccount.Name, proxySvcAccount.Namespace))
+	proxyXDSCertCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", uuid.New(), envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace))
 	testProxy := envoy.NewProxy(proxyXDSCertCN, certSerialNumber, nil)
 
 	testCases := []testCase{

--- a/pkg/envoy/ads/stream_test.go
+++ b/pkg/envoy/ads/stream_test.go
@@ -27,13 +27,13 @@ func TestIsCNForProxy(t *testing.T) {
 		{
 			name:     "workload CN belongs to proxy",
 			cn:       certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.svc-acc.namespace", uuid.New())), certSerialNumber, nil),
+			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc.namespace", uuid.New(), envoy.KindSidecar)), certSerialNumber, nil),
 			expected: true,
 		},
 		{
 			name:     "workload CN does not belong to proxy",
 			cn:       certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.svc-acc-foo.namespace", uuid.New())), certSerialNumber, nil),
+			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc-foo.namespace", uuid.New(), envoy.KindSidecar)), certSerialNumber, nil),
 			expected: false,
 		},
 		{

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -44,7 +44,7 @@ func TestNewResponse(t *testing.T) {
 
 	proxyUUID := uuid.New()
 	// The format of the CN matters
-	xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.foo.bar", proxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+	xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(xdsCertificate, certSerialNumber, nil)
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
@@ -381,7 +381,7 @@ func TestNewResponseGetLocalServiceClusterError(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return []service.MeshService{svc}, nil
 	}))
-	cn := envoy.NewCertCommonNameWithProxyID(uuid.New(), "svcacc", "ns")
+	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
 	proxy := envoy.NewProxy(cn, "", nil)
 
 	ctrl := gomock.NewController(t)
@@ -399,7 +399,7 @@ func TestNewResponseGetEgressTrafficPolicyError(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return nil, nil
 	}))
-	cn := envoy.NewCertCommonNameWithProxyID(uuid.New(), "svcacc", "ns")
+	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
 	proxy := envoy.NewProxy(cn, "", nil)
 
 	ctrl := gomock.NewController(t)
@@ -421,7 +421,7 @@ func TestNewResponseGetEgressTrafficPolicyNotEmpty(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return nil, nil
 	}))
-	cn := envoy.NewCertCommonNameWithProxyID(uuid.New(), "svcacc", "ns")
+	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
 	proxy := envoy.NewProxy(cn, "", nil)
 
 	ctrl := gomock.NewController(t)

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -47,7 +47,7 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 		}
 	}
 
-	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 	return proxy, nil

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -50,7 +50,7 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 		}
 	}
 
-	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 	return proxy, nil

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
@@ -224,7 +223,7 @@ func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificat
 	}
 }
 
-// NewCertCommonNameWithProxyID returns a newly generated CommonName for a certificate of the form: <ProxyUUID>.<serviceAccount>.<namespace>
-func NewCertCommonNameWithProxyID(proxyUUID uuid.UUID, serviceAccount, namespace string) certificate.CommonName {
-	return certificate.CommonName(strings.Join([]string{proxyUUID.String(), serviceAccount, namespace}, constants.DomainDelimiter))
+// NewCertCommonName returns a newly generated CommonName for a certificate of the form: <ProxyUUID>.<kind>.<serviceAccount>.<namespace>
+func NewCertCommonName(proxyUUID uuid.UUID, kind ProxyKind, serviceAccount, namespace string) certificate.CommonName {
+	return certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID.String(), kind, serviceAccount, namespace))
 }

--- a/pkg/envoy/registry/services_test.go
+++ b/pkg/envoy/registry/services_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 			svc2 := tests.NewServiceFixture(svcName2, tests.Namespace, selector)
 			mockKubeController.EXPECT().ListServices().Return([]*v1.Service{svc, svc2}).Times(1)
 
-			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookstoreServiceAccountName, tests.Namespace))
+			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookstoreServiceAccountName, tests.Namespace))
 			certSerialNumber := certificate.SerialNumber("123456")
 			proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 			meshServices, err := proxyRegistry.ListProxyServices(proxy)
@@ -95,7 +95,7 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 			svc := tests.NewServiceFixture(svcName, namespace, selector)
 			mockKubeController.EXPECT().ListServices().Return([]*v1.Service{svc}).Times(1)
 
-			podCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s", proxyUUID, tests.BookstoreServiceAccountName, namespace))
+			podCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID, envoy.KindSidecar, tests.BookstoreServiceAccountName, namespace))
 			certSerialNumber := certificate.SerialNumber("123456")
 			newProxy := envoy.NewProxy(podCN, certSerialNumber, nil)
 			meshServices, err := proxyRegistry.ListProxyServices(newProxy)

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -56,7 +56,7 @@ func TestNewResponse(t *testing.T) {
 	// have be prefixed with the ID of the pod. It is the first chunk of a dot-separated string.
 	podID := uuid.New().String()
 
-	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", podID, serviceAccount, namespace))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", podID, envoy.KindSidecar, serviceAccount, namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	goodProxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -83,3 +83,14 @@ const (
 	// The local cluster refers to the cluster corresponding to the service the proxy is fronting, accessible over localhost by the proxy.
 	localClusterSuffix = "-local"
 )
+
+// ProxyKind is the type used to define the proxy's kind
+type ProxyKind string
+
+const (
+	// KindSidecar implies the proxy is a sidecar
+	KindSidecar ProxyKind = "sidecar"
+
+	// KindGateway implies the proxy is a gateway
+	KindGateway ProxyKind = "gateway"
+)

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -302,6 +302,7 @@ func GetLocalClusterNameForServiceCluster(clusterName string) string {
 // certificateCommonNameMeta is the type that stores the metadata present in the CommonName field in a proxy's certificate
 type certificateCommonNameMeta struct {
 	ProxyUUID uuid.UUID
+	ProxyKind ProxyKind
 	// TODO(draychev): Change this to ServiceIdentity type (instead of string)
 	ServiceAccount string
 	Namespace      string
@@ -309,7 +310,7 @@ type certificateCommonNameMeta struct {
 
 func getCertificateCommonNameMeta(cn certificate.CommonName) (*certificateCommonNameMeta, error) {
 	chunks := strings.Split(cn.String(), constants.DomainDelimiter)
-	if len(chunks) < 3 {
+	if len(chunks) < 4 {
 		return nil, ErrInvalidCertificateCN
 	}
 	proxyUUID, err := uuid.Parse(chunks[0])
@@ -320,9 +321,10 @@ func getCertificateCommonNameMeta(cn certificate.CommonName) (*certificateCommon
 
 	return &certificateCommonNameMeta{
 		ProxyUUID: proxyUUID,
+		ProxyKind: ProxyKind(chunks[1]),
 		// TODO(draychev): Use ServiceIdentity vs ServiceAccount
-		ServiceAccount: chunks[1],
-		Namespace:      chunks[2],
+		ServiceAccount: chunks[2],
+		Namespace:      chunks[3],
 	}, nil
 }
 

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -22,7 +22,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	namespace := req.Namespace
 
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
-	cn := envoy.NewCertCommonNameWithProxyID(proxyUUID, pod.Spec.ServiceAccountName, namespace)
+	cn := envoy.NewCertCommonName(proxyUUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, namespace)
 	log.Debug().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN=%s", pod.Spec.ServiceAccountName, namespace, cn)
 	startTime := time.Now()
 	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn, constants.XDSCertificateValidityPeriod)

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -236,7 +236,7 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 		}
 	}
 
-	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookbuyerServiceAccountName, tests.Namespace))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 	return proxy, nil

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -349,7 +349,7 @@ func getBookstoreV1Proxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) 
 		}
 	}
 
-	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookstoreServiceIdentity, tests.Namespace))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookstoreServiceIdentity, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
 	return proxy, nil


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds additional metadata in the proxy's XDS cert
to identify the proxy's kind.

Currently, osm-controller only supports programming proxies
that run as a sidecar on app pods. As a part of the effort
to implement a proxy gateway, osm-controller will also
require to identify and program a proxy gateway. The
config for a gateway proxy will be completely different
compared to that of a sidecar proxy, and this change will
allow identifying the kind of the proxy to do so.

Existing code and tests have been updated to set the
proxy's kind to `sidecar`.

Part of #3501

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
