### PR TITLE
fix(crds/meshconfig): change envoy image pattern

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -68,7 +68,7 @@ spec:
                       description: Image for the Envoy sidecar
                       type: string
                       default: "envoyproxy/envoy-alpine:v1.18.3"
-                      pattern: envoyproxy\/envoy-alpine:v\d+\.\d+\.\d+$
+                      pattern: ^envoyproxy\/envoy-alpine:v\d+\.\d+\.\d+$
                     initContainerImage:
                       description: Image for the init container
                       type: string


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Edit the envoy meshconfig pattern so that downstream charts can pull different envoy images.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [X] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
