### PR TITLE
envoy: error if proxy is not valid

### DIFF
--- a/pkg/envoy/ads/profile_test.go
+++ b/pkg/envoy/ads/profile_test.go
@@ -1,11 +1,13 @@
 package ads
 
 import (
+	"fmt"
 	"testing"
 
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"github.com/google/uuid"
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -15,7 +17,8 @@ import (
 
 func TestValidateResourcesRequestResponse(t *testing.T) {
 	assert := tassert.New(t)
-	proxy := envoy.NewProxy(certificate.CommonName("common-name"), certificate.SerialNumber("123"), tests.NewMockAddress("1.2.3.4"))
+	proxy, err := envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.sidecar.foo.bar", uuid.New())), certificate.SerialNumber("123"), tests.NewMockAddress("1.2.3.4"))
+	assert.Nil(err)
 
 	testCases := []struct {
 		request          *xds_discovery.DiscoveryRequest

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -84,7 +84,12 @@ var _ = Describe("Test ADS response functions", func() {
 
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID, envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	proxy, err := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+
+	Context("Proxy is valid", func() {
+		Expect(proxy).ToNot((BeNil()))
+		Expect(err).ToNot(HaveOccurred())
+	})
 
 	Context("Test makeRequestForAllSecrets()", func() {
 		It("returns service cert", func() {

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -34,7 +34,8 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 	proxySvcAccount := proxyServiceIdentity.ToK8sServiceAccount()
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxyXDSCertCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", uuid.New(), envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace))
-	testProxy := envoy.NewProxy(proxyXDSCertCN, certSerialNumber, nil)
+	testProxy, err := envoy.NewProxy(proxyXDSCertCN, certSerialNumber, nil)
+	assert.Nil(err)
 
 	testCases := []testCase{
 		{

--- a/pkg/envoy/ads/stream_test.go
+++ b/pkg/envoy/ads/stream_test.go
@@ -25,21 +25,21 @@ func TestIsCNForProxy(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:     "workload CN belongs to proxy",
-			cn:       certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc.namespace", uuid.New(), envoy.KindSidecar)), certSerialNumber, nil),
+			name: "workload CN belongs to proxy",
+			cn:   certificate.CommonName("svc-acc.namespace.cluster.local"),
+			proxy: func() *envoy.Proxy {
+				p, _ := envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc.namespace", uuid.New(), envoy.KindSidecar)), certSerialNumber, nil)
+				return p
+			}(),
 			expected: true,
 		},
 		{
-			name:     "workload CN does not belong to proxy",
-			cn:       certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc-foo.namespace", uuid.New(), envoy.KindSidecar)), certSerialNumber, nil),
-			expected: false,
-		},
-		{
-			name:     "not a workload CN",
-			cn:       certificate.CommonName("some-cn.type"),
-			proxy:    envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.svc-acc-foo.namespace", uuid.New())), certSerialNumber, nil),
+			name: "workload CN does not belong to proxy",
+			cn:   certificate.CommonName("svc-acc.namespace.cluster.local"),
+			proxy: func() *envoy.Proxy {
+				p, _ := envoy.NewProxy(certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc-foo.namespace", uuid.New(), envoy.KindSidecar)), certSerialNumber, nil)
+				return p
+			}(),
 			expected: false,
 		},
 	}

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -49,8 +49,7 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-	return proxy, nil
+	return envoy.NewProxy(certCommonName, certSerialNumber, nil)
 }
 
 func TestEndpointConfiguration(t *testing.T) {

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -59,8 +59,7 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-	return proxy, nil
+	return envoy.NewProxy(certCommonName, certSerialNumber, nil)
 }
 
 func TestNewResponse(t *testing.T) {

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -25,16 +25,16 @@ import (
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
-const (
-	svc = "service-name"
-	ns  = "some-namespace"
-)
-
 var _ = Describe("Test proxy methods", func() {
-	certCommonName := certificate.CommonName(fmt.Sprintf("UUID-of-proxy1234566623211353.%s.%s.one.two.three.co.uk", svc, ns))
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.svc-acc.namespace", uuid.New(), KindSidecar))
 	certSerialNumber := certificate.SerialNumber("123456")
 	podUID := uuid.New().String()
-	proxy := NewProxy(certCommonName, certSerialNumber, tests.NewMockAddress("1.2.3.4"))
+	proxy, err := NewProxy(certCommonName, certSerialNumber, tests.NewMockAddress("1.2.3.4"))
+
+	Context("Proxy is valid", func() {
+		Expect(proxy).ToNot((BeNil()))
+		Expect(err).ToNot(HaveOccurred())
+	})
 
 	Context("test GetPodUID() with empty Pod Metadata field", func() {
 		It("returns correct values", func() {

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -415,8 +415,7 @@ func getBookstoreV1Proxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) 
 
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s", tests.ProxyUUID, tests.BookstoreServiceIdentity, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-	return proxy, nil
+	return envoy.NewProxy(certCommonName, certSerialNumber, nil)
 }
 
 func TestNewResponseWithPermissiveMode(t *testing.T) {
@@ -430,7 +429,8 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 	uuid := uuid.New().String()
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.one.two.three.co.uk", uuid, "some-service", "some-namespace"))
 	certSerialNumber := certificate.SerialNumber("123456")
-	testProxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	testProxy, err := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	assert.Nil(err)
 
 	// Empty discovery request
 	discoveryRequest := xds_discovery.DiscoveryRequest{
@@ -582,7 +582,8 @@ func TestResponseRequestCompletion(t *testing.T) {
 	uuid := uuid.New().String()
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.one.two.three.co.uk", uuid, "some-service", "some-namespace"))
 	certSerialNumber := certificate.SerialNumber("123456")
-	testProxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	testProxy, err := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	assert.Nil(err)
 
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return []service.MeshService{tests.BookstoreV1Service}, nil

--- a/pkg/envoy/registry/announcement_handlers_test.go
+++ b/pkg/envoy/registry/announcement_handlers_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -26,8 +27,8 @@ var _ = Describe("Test Announcement Handlers", func() {
 	var proxyRegistry *ProxyRegistry
 	var podUID string
 	var proxy *envoy.Proxy
-	var envoyCN certificate.CommonName
 	var certManager certificate.Manager
+	envoyCN := certificate.CommonName(fmt.Sprintf("%s.sidecar.foo.bar", uuid.New()))
 
 	BeforeEach(func() {
 		proxyRegistry = NewProxyRegistry(nil)
@@ -44,7 +45,9 @@ var _ = Describe("Test Announcement Handlers", func() {
 		_, err := certManager.IssueCertificate(envoyCN, 5*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 
-		proxy = envoy.NewProxy(envoyCN, "-cert-serial-number-", nil)
+		proxy, err = envoy.NewProxy(envoyCN, "-cert-serial-number-", nil)
+		Expect(err).ToNot(HaveOccurred())
+
 		proxy.PodMetadata = &envoy.PodMetadata{
 			UID: podUID,
 		}

--- a/pkg/envoy/registry/debugger_test.go
+++ b/pkg/envoy/registry/debugger_test.go
@@ -1,6 +1,9 @@
 package registry
 
 import (
+	"fmt"
+
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -10,9 +13,14 @@ import (
 
 var _ = Describe("Test catalog proxy register/unregister", func() {
 	proxyRegistry := NewProxyRegistry(nil)
-	certCommonName := certificate.CommonName("foo")
+	certCommonName := certificate.CommonName(fmt.Sprintf("%s.sidecar.foo.bar", uuid.New()))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+	proxy, err := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+
+	Context("Proxy is valid", func() {
+		Expect(proxy).ToNot((BeNil()))
+		Expect(err).ToNot(HaveOccurred())
+	})
 
 	Context("Test register/unregister proxies", func() {
 		It("no proxies connected or disconnected", func() {

--- a/pkg/envoy/registry/services_test.go
+++ b/pkg/envoy/registry/services_test.go
@@ -49,7 +49,8 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 			certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookstoreServiceAccountName, tests.Namespace))
 			certSerialNumber := certificate.SerialNumber("123456")
-			proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+			proxy, err := envoy.NewProxy(certCommonName, certSerialNumber, nil)
+			Expect(err).ToNot(HaveOccurred())
 			meshServices, err := proxyRegistry.ListProxyServices(proxy)
 			Expect(err).ToNot(HaveOccurred())
 			expectedSvc := service.MeshService{
@@ -65,15 +66,6 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 			Expect(meshServices).Should(HaveLen(len(expectedList)))
 			Expect(meshServices).Should(ConsistOf(expectedList))
-		})
-
-		It("returns an error with an invalid CN", func() {
-			certCommonName := certificate.CommonName("getAllowedDirectionalServices")
-			certSerialNumber := certificate.SerialNumber("123456")
-			proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-			service, err := proxyRegistry.ListProxyServices(proxy)
-			Expect(err).To(HaveOccurred())
-			Expect(service).To(BeNil())
 		})
 	})
 
@@ -97,7 +89,8 @@ var _ = Describe("Test Proxy-Service mapping", func() {
 
 			podCN := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID, envoy.KindSidecar, tests.BookstoreServiceAccountName, namespace))
 			certSerialNumber := certificate.SerialNumber("123456")
-			newProxy := envoy.NewProxy(podCN, certSerialNumber, nil)
+			newProxy, err := envoy.NewProxy(podCN, certSerialNumber, nil)
+			Expect(err).ToNot(HaveOccurred())
 			meshServices, err := proxyRegistry.ListProxyServices(newProxy)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -238,6 +238,5 @@ func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
 
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-	return proxy, nil
+	return envoy.NewProxy(certCommonName, certSerialNumber, nil)
 }

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -351,6 +351,5 @@ func getBookstoreV1Proxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) 
 
 	certCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookstoreServiceIdentity, tests.Namespace))
 	certSerialNumber := certificate.SerialNumber("123456")
-	proxy := envoy.NewProxy(certCommonName, certSerialNumber, nil)
-	return proxy, nil
+	return envoy.NewProxy(certCommonName, certSerialNumber, nil)
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Returns an error if the proxy does not have
a valid CN, so the connection can be terminated
much earlier rather than during the XDS request-
response phase.

Also adds a Kind attribute to the Proxy.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
