### PR TITLE
feat(pkg/validators): add the main body for the validators libraries

### DIFF
--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -1,0 +1,144 @@
+// Package validator implements utility routines related to Kubernetes' admission webhooks.
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	admissionv1 "k8s.io/api/admission/v1"
+
+	"github.com/openservicemesh/osm/pkg/webhook"
+)
+
+var (
+	defaultValidators = map[string]Validator{}
+)
+
+// RegisterValidator registers all validators. It is not thread safe.
+// It assumes one validator per GVK. If multiple validations need to happen it should all happen in the single validator
+func RegisterValidator(gvk string, v Validator) {
+	defaultValidators[gvk] = v
+}
+
+/*
+There are a few ways to utilize the Validator function:
+
+1. return resp, nil
+
+	In this case we simply return the raw resp. This allows for the most customization.
+
+2. return nil, err
+
+	In this case we convert the error to an AdmissionResponse.  If the error type is an AdmissionError, we
+	convert accordingly, which allows for some customization of the AdmissionResponse. Otherwise, we set Allow to
+	false and the status to the error message.
+
+3. return nil, nil
+
+	In this case we create a simple AdmissionResponse, with Allow set to true.
+
+4. Note that resp, err will ignore the error. It assumes that you are returning nil for resp if there is an error
+
+In all of the above cases we always populate the UID of the response from the request.
+
+An example of a validator:
+
+func FakeValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	o, n := &FakeObj{}, &FakeObj{}
+	// If you need to compare against the old object
+	if err := json.NewDecoder(bytes.NewBuffer(req.OldObject.Raw)).Decode(o); err != nil {
+		return nil, err
+	}
+
+	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(n); err != nil {
+		returrn nil, err
+	}
+
+	// validate the objects, potentially returning an error, or a more detailed AdmissionResponse.
+
+	// This will set allow to true
+	return nil, nil
+}
+*/
+
+// Validator is a function that accepts an AdmissionRequest and returns an AdmissionResponse.
+type Validator func(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
+
+// ValidatingWebhookServer implements the K8s Validating Webhook API, and runs the associated validator func.
+type ValidatingWebhookServer struct {
+	// Map of Resource (GroupVersionKind), to validator
+	Validators map[string]Validator
+}
+
+// New returns a ValidatingWebhookServer with the defaultValidators that were previously registered.
+func New() *ValidatingWebhookServer {
+	vCopy := make(map[string]Validator, len(defaultValidators))
+	for k, v := range defaultValidators {
+		vCopy[k] = v
+	}
+	return &ValidatingWebhookServer{
+		Validators: vCopy,
+	}
+}
+
+// HandleValidation implements the HTTP API for the Validating Webhook.
+func (s *ValidatingWebhookServer) HandleValidation(w http.ResponseWriter, req *http.Request) {
+	defer dclose(req.Body)
+	adReq := new(admissionv1.AdmissionRequest)
+	if err := json.NewDecoder(req.Body).Decode(adReq); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Error().Err(err).Msgf("Error reading admission request body; Responded to admission request with HTTP %v", http.StatusInternalServerError)
+		return
+	}
+
+	data, err := json.Marshal(s.handleValidation(adReq))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Error().Err(err).Msgf("Error marshaling admission response body; Responded to admission request with HTTP %v", http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Error().Err(err).Msgf("Truncated response; error writing output to http writer; Responsed to admission request with HTTP %v", http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *ValidatingWebhookServer) handleValidation(req *admissionv1.AdmissionRequest) (resp *admissionv1.AdmissionResponse) {
+	var err error
+	defer func() {
+		if resp == nil {
+			resp = &admissionv1.AdmissionResponse{Allowed: true}
+		}
+		resp.UID = req.UID // ensure this is always set
+	}()
+	gvk := req.Kind.String()
+	v, ok := s.Validators[gvk]
+	if !ok {
+		return webhook.AdmissionError(fmt.Errorf("unknown gvk: %s", gvk))
+	}
+
+	// We don't explicitly do an if err != nil, since we will set it from
+	resp, err = v(req)
+	if resp != nil {
+		if err != nil {
+			log.Warn().Msgf("Warning! validator for gvk: %s returned both an AdmissionResponse *and* an error. Please return one or the other", gvk)
+		}
+		return
+	}
+	// No response, but got an error.
+	if err != nil {
+		resp = webhook.AdmissionError(err)
+	}
+	return
+}
+
+// defer closer
+func dclose(c io.Closer) {
+	if err := c.Close(); err != nil {
+		log.Error().Err(err).Msgf("Error closing HTTP request body. Potential memory leak.")
+	}
+}

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -1,0 +1,125 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	tassert "github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type fakeObj struct {
+	Allow        bool
+	Error        bool
+	ExplicitResp bool
+}
+
+func TestHandleValidation(t *testing.T) {
+	gvk := metav1.GroupVersionKind{
+		Kind:    "Fake",
+		Group:   "fake.osm.io",
+		Version: "v1alpha1",
+	}
+	s := ValidatingWebhookServer{
+		Validators: map[string]Validator{
+			gvk.String(): func(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+				f := fakeObj{}
+				if err := json.Unmarshal(req.Object.Raw, &f); err != nil {
+					return nil, err
+				}
+				if f.ExplicitResp {
+					return &admissionv1.AdmissionResponse{
+						Allowed: f.Allow,
+						Result:  &metav1.Status{Message: "explicit response"},
+					}, nil
+				}
+				if f.Error {
+					return nil, errors.New("explicit error")
+				}
+				return nil, nil
+			},
+		},
+	}
+	badGvk := metav1.GroupVersionKind{
+		Kind:    "Fake",
+		Group:   "fake.osm.io",
+		Version: "badVersion",
+	}
+	testCases := []struct {
+		testName string
+		req      *admissionv1.AdmissionRequest
+		expResp  *admissionv1.AdmissionResponse
+	}{
+		{
+			testName: "unknown gvk",
+			req: &admissionv1.AdmissionRequest{
+				UID:  "1",
+				Kind: badGvk,
+				Object: runtime.RawExtension{
+					Raw: []byte(`{}`),
+				},
+			},
+			expResp: &admissionv1.AdmissionResponse{
+				UID:    "1",
+				Result: &metav1.Status{Message: fmt.Errorf("unknown gvk: %s", badGvk).Error()},
+			},
+		},
+		{
+			testName: "invalid obj returned explicit error",
+			req: &admissionv1.AdmissionRequest{
+				UID:  "2",
+				Kind: gvk,
+				Object: runtime.RawExtension{
+					Raw: []byte(`{"Error": true}`),
+				},
+			},
+			expResp: &admissionv1.AdmissionResponse{
+				UID:    "2",
+				Result: &metav1.Status{Message: "explicit error"},
+			},
+		},
+		{
+			testName: "valid obj explicit response obj",
+			req: &admissionv1.AdmissionRequest{
+				UID:  "3",
+				Kind: gvk,
+				Object: runtime.RawExtension{
+					Raw: []byte(`{"Allow": true, "ExplicitResp": true}`),
+				},
+			},
+			expResp: &admissionv1.AdmissionResponse{
+				UID:     "3",
+				Allowed: true,
+				Result:  &metav1.Status{Message: "explicit response"},
+			},
+		},
+		{
+			testName: "valid obj implicit response obj",
+			req: &admissionv1.AdmissionRequest{
+				UID:  "4",
+				Kind: gvk,
+				Object: runtime.RawExtension{
+					Raw: []byte(`{}`),
+				},
+			},
+			expResp: &admissionv1.AdmissionResponse{
+				UID:     "4",
+				Allowed: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			resp := s.handleValidation(tc.req)
+			assert := tassert.New(t)
+
+			assert.NotNil(resp)
+			assert.Equal(tc.expResp, resp)
+		})
+	}
+}

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -1,0 +1,71 @@
+package validator
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cv1alpha1 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+	pv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+)
+
+// MinDuration is the minimum duration for a MeshConfig's certificate validity.
+const MinDuration = time.Second
+
+func init() {
+	egressGvk := metav1.GroupVersionKind{
+		Kind:    "Egress",
+		Group:   "policy.openservicemesh.io",
+		Version: "v1alpha1",
+	}
+	meshConfigGvk := metav1.GroupVersionKind{
+		Kind:    "MeshConfig",
+		Group:   "config.openservicemesh.io",
+		Version: "v1alpha1",
+	}
+	RegisterValidator(egressGvk.String(), EgressValidator)
+	RegisterValidator(meshConfigGvk.String(), MeshConfigValidator)
+}
+
+// EgressValidator validates the Egress CRD.
+func EgressValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	egress := &pv1alpha1.Egress{}
+	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(egress); err != nil {
+		return nil, err
+	}
+
+	for _, m := range egress.Spec.Matches {
+		if m.Kind != "HTTPRouteGroup" {
+			return nil, fmt.Errorf("Expected Matches.Kind to be 'HTTPRouteGroup', got: %s", m.Kind)
+		}
+
+		if *m.APIGroup != "specs.smi-spec.io/v1alpha4" {
+			return nil, fmt.Errorf("Expected Matches.APIGroup to be 'specs.smi-spec.io/v1alpha4', got: %s", *m.APIGroup)
+		}
+	}
+
+	return nil, nil
+}
+
+// MeshConfigValidator validates the MeshConfig CRD.
+func MeshConfigValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	config := &cv1alpha1.MeshConfig{}
+	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(config); err != nil {
+		return nil, err
+	}
+
+	d, err := time.ParseDuration(config.Spec.Certificate.ServiceCertValidityDuration)
+	if err != nil {
+		return nil, fmt.Errorf("Certificate.ServiceCertValidityDuration %s is not valid", config.Spec.Certificate.ServiceCertValidityDuration)
+	}
+
+	if d < MinDuration {
+		return nil, fmt.Errorf("Certificate.ServiceCertValidityDuration %d is lower than %d", d, MinDuration)
+	}
+
+	return nil, nil
+}

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -1,0 +1,219 @@
+package validator
+
+import (
+	"errors"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestEgressValidator(t *testing.T) {
+	assert := tassert.New(t)
+	testCases := []struct {
+		name    string
+		input   *admissionv1.AdmissionRequest
+		expResp *admissionv1.AdmissionResponse
+		expErr  error
+	}{
+		{
+			name: "Egress with bad http route fails",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "Egress",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"matches": [
+								{
+								"apiGroup": "v1alpha1",
+								"kind": "BadHttpRoute",
+								"name": "Name"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+
+			expResp: nil,
+			expErr:  errors.New("Expected Matches.Kind to be 'HTTPRouteGroup', got: BadHttpRoute"),
+		},
+		{
+			name: "Egress with bad API group fails",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "Egress",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"matches": [
+								{
+								"apiGroup": "test",
+								"kind": "HTTPRouteGroup",
+								"name": "Name"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+
+			expResp: nil,
+			expErr:  errors.New("Expected Matches.APIGroup to be 'specs.smi-spec.io/v1alpha4', got: test"),
+		},
+		{
+			name: "Egress with valid http route and API group passes",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "Egress",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"matches": [
+								{
+								"apiGroup": "specs.smi-spec.io/v1alpha4",
+								"kind": "HTTPRouteGroup",
+								"name": "Name"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+
+			expResp: nil,
+			expErr:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := EgressValidator(tc.input)
+			t.Log(tc.input.Kind.Kind)
+			assert.Equal(tc.expResp, resp)
+			assert.Equal(tc.expErr, err)
+		})
+	}
+}
+
+func TestMeshConfigValidator(t *testing.T) {
+	assert := tassert.New(t)
+	testCases := []struct {
+		name    string
+		input   *admissionv1.AdmissionRequest
+		expResp *admissionv1.AdmissionResponse
+		expErr  error
+	}{
+		{
+			name: "MeshConfig with invalid duration fails",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "config.openservicemesh.io",
+					Kind:    "MeshConfig",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"certificate": {
+								"serviceCertValidityDuration": "abc"
+							}
+						}
+					}
+					`),
+				},
+			},
+
+			expResp: nil,
+			expErr:  errors.New("Certificate.ServiceCertValidityDuration abc is not valid"),
+		},
+		{
+			name: "MeshConfig with duration lower than minimum duration fails",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "config.openservicemesh.io",
+					Kind:    "MeshConfig",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"certificate": {
+								"serviceCertValidityDuration": "0.5s"
+							}
+						}
+					}
+					`),
+				},
+			},
+
+			expResp: nil,
+			expErr:  errors.New("Certificate.ServiceCertValidityDuration 500000000 is lower than 1000000000"),
+		},
+		{
+			name: "MeshConfig with valid duration passes",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "config.openservicemesh.io",
+					Kind:    "MeshConfig",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"certificate": {
+								"serviceCertValidityDuration": "1h"
+							}
+						}
+					}
+					`),
+				},
+			},
+
+			expResp: nil,
+			expErr:  nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := MeshConfigValidator(tc.input)
+			t.Log(tc.input.Kind.Kind)
+			assert.Equal(tc.expResp, resp)
+			assert.Equal(tc.expErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Add a validating webhook library to the code base. This is an extensible API to allow for registering future validations as well.

It contains a validator for the egress and the MeshConfig CRD's

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ x] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    No

1. Is this a breaking change?

No
