### PR TITLE
utils/proto: consolidate proto helpers

### DIFF
--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
+	"github.com/openservicemesh/osm/pkg/utils"
 	"github.com/openservicemesh/osm/pkg/version"
 )
 
@@ -189,7 +190,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 			actualXds, err := getXdsCluster(config)
 			Expect(err).To(BeNil())
 
-			actualYAML, err := protoToYAML(actualXds)
+			actualYAML, err := utils.ProtoToYAML(actualXds)
 			Expect(err).To(BeNil())
 			saveActualEnvoyYAML(actualXDSClusterWithoutProbesFileName, actualYAML)
 			// The "marshalAndSaveToFile" function converts the complex struct into a human readable text, which helps us spot the
@@ -206,7 +207,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 			actualXds, err := getXdsCluster(config)
 			Expect(err).To(BeNil())
 
-			actualYAML, err := protoToYAML(actualXds)
+			actualYAML, err := utils.ProtoToYAML(actualXds)
 			Expect(err).To(BeNil())
 			saveActualEnvoyYAML(actualXDSClusterWithProbesFileName, actualYAML)
 			// The "marshalAndSaveToFile" function converts the complex struct into a human readable text, which helps us spot the
@@ -225,7 +226,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 			actualXds, err := getStaticResources(config)
 			Expect(err).To(BeNil())
 
-			actualYAML, err := protoToYAML(actualXds)
+			actualYAML, err := utils.ProtoToYAML(actualXds)
 			Expect(err).To(BeNil())
 			saveActualEnvoyYAML(actualXDSStaticResourcesWithProbesFileName, actualYAML)
 

--- a/pkg/utils/proto.go
+++ b/pkg/utils/proto.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// ProtoToYAML converts a Proto message to it's YAML representation in bytes
+func ProtoToYAML(m protoreflect.ProtoMessage) ([]byte, error) {
+	marshalOptions := protojson.MarshalOptions{
+		UseProtoNames: true,
+	}
+	configJSON, err := marshalOptions.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+
+	configYAML, err := jsonToYAML(configJSON)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshaling xDS struct into YAML")
+		return nil, err
+	}
+	return configYAML, err
+}
+
+// jsonToYAML converts a JSON representation in bytes to the corresponding YAML representation in bytes
+// Reference impl taken from https://github.com/ghodss/yaml/blob/master/yaml.go#L87
+func jsonToYAML(jb []byte) ([]byte, error) {
+	// Convert the JSON to an object.
+	var jsonObj interface{}
+	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
+	// Go JSON library doesn't try to pick the right number type (int, float,
+	// etc.) when unmarshalling to interface{}, it just picks float64
+	// universally. go-yaml does go through the effort of picking the right
+	// number type, so we can preserve number type throughout this process.
+	err := yaml.Unmarshal([]byte(jb), &jsonObj)
+	if err != nil {
+		return nil, err
+	}
+
+	// Marshal this object into YAML.
+	return yaml.Marshal(jsonObj)
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Consolidates helpers into a separate file in the
utils pkg for reusability. The proto marshalling
to YAML will be required in a subsequent change
that builds the envoy bootstrap config in a generic
way for code reuse between the injector and OSM
gateway.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
