### PR TITLE
chore(*/*): Remove unused references to kubeclient.

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -187,7 +187,7 @@ func main() {
 			"Error fetching certificate manager of kind %s", certProviderKind)
 	}
 
-	kubeProvider, err := kube.NewProvider(kubeClient, kubernetesClient, constants.KubeProviderName, cfg)
+	kubeProvider, err := kube.NewProvider(kubernetesClient, constants.KubeProviderName, cfg)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Kubernetes endpoints provider")
 	}
@@ -206,7 +206,6 @@ func main() {
 
 	meshCatalog := catalog.NewMeshCatalog(
 		kubernetesClient,
-		kubeClient,
 		meshSpec,
 		certManager,
 		ingressClient,

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,8 +1,6 @@
 package catalog
 
 import (
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -14,7 +12,7 @@ import (
 )
 
 // NewMeshCatalog creates a new service catalog
-func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interface, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, policyController policy.Controller, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
+func NewMeshCatalog(kubeController k8s.Controller, meshSpec smi.MeshSpec, certManager certificate.Manager, ingressMonitor ingress.Monitor, policyController policy.Controller, stop <-chan struct{}, cfg configurator.Configurator, endpointsProviders ...endpoint.Provider) *MeshCatalog {
 	log.Info().Msg("Create a new Service MeshCatalog.")
 	mc := MeshCatalog{
 		endpointsProviders: endpointsProviders,
@@ -24,10 +22,6 @@ func NewMeshCatalog(kubeController k8s.Controller, kubeClient kubernetes.Interfa
 		policyController:   policyController,
 		configurator:       cfg,
 
-		// Kubernetes needed to determine what Services a pod that connects to XDS belongs to.
-		// In multicluster scenarios this would be a map of cluster ID to Kubernetes client.
-		// The certificate itself would contain the cluster ID making it easy to lookup the client in this map.
-		kubeClient:     kubeClient,
 		kubeController: kubeController,
 	}
 

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -113,7 +113,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient versio
 
 	mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(nil).AnyTimes()
 
-	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
+	return NewMeshCatalog(mockKubeController, meshSpec, certManager,
 		mockIngressMonitor, mockPolicyController, stop, cfg, endpointProviders...)
 }
 
@@ -223,6 +223,6 @@ func newFakeMeshCatalog() *MeshCatalog {
 
 	mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(nil).AnyTimes()
 
-	return NewMeshCatalog(mockKubeController, kubeClient, meshSpec, certManager,
+	return NewMeshCatalog(mockKubeController, meshSpec, certManager,
 		mockIngressMonitor, mockPolicyController, stop, cfg, endpointProviders...)
 }

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -132,6 +132,6 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 	mockMeshSpec.EXPECT().ListHTTPTrafficSpecs().Return([]*specs.HTTPRouteGroup{&tests.HTTPRouteGroup}).AnyTimes()
 	mockMeshSpec.EXPECT().ListTrafficSplits().Return([]*split.TrafficSplit{}).AnyTimes()
 
-	return NewMeshCatalog(mockKubeController, kubeClient, mockMeshSpec, certManager,
+	return NewMeshCatalog(mockKubeController, mockMeshSpec, certManager,
 		mockIngressMonitor, mockPolicyController, stop, mockConfigurator, endpointProviders...)
 }

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -5,8 +5,6 @@
 package catalog
 
 import (
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -31,10 +29,6 @@ type MeshCatalog struct {
 	certManager        certificate.Manager
 	ingressMonitor     ingress.Monitor
 	configurator       configurator.Configurator
-
-	// Current assumption is that OSM is working with a single Kubernetes cluster.
-	// This is the API/REST interface to the cluster
-	kubeClient kubernetes.Interface
 
 	// This is the kubernetes client that operates async caches to avoid issuing synchronous
 	// calls through kubeClient and instead relies on background cache synchronization and local

--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -17,10 +16,9 @@ import (
 )
 
 // NewProvider implements mesh.EndpointsProvider, which creates a new Kubernetes cluster/compute provider.
-func NewProvider(kubeClient kubernetes.Interface, kubeController k8s.Controller, providerIdent string, cfg configurator.Configurator) (endpoint.Provider, error) {
+func NewProvider(kubeController k8s.Controller, providerIdent string, cfg configurator.Configurator) (endpoint.Provider, error) {
 	client := Client{
 		providerIdent:  providerIdent,
-		kubeClient:     kubeClient,
 		kubeController: kubeController,
 	}
 

--- a/pkg/endpoint/providers/kube/client_test.go
+++ b/pkg/endpoint/providers/kube/client_test.go
@@ -34,9 +34,8 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 		mockKubeController *k8s.MockController
 		mockConfigurator   *configurator.MockConfigurator
 
-		fakeClientSet *testclient.Clientset
-		provider      endpoint.Provider
-		err           error
+		provider endpoint.Provider
+		err      error
 	)
 
 	mockCtrl = gomock.NewController(GinkgoT())
@@ -48,8 +47,7 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 
 	BeforeEach(func() {
-		fakeClientSet = testclient.NewSimpleClientset()
-		provider, err = NewProvider(fakeClientSet, mockKubeController, providerID, mockConfigurator)
+		provider, err = NewProvider(mockKubeController, providerID, mockConfigurator)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -319,7 +317,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		}, 3*time.Second).Should(BeTrue())
 
 		Expect(err).ToNot(HaveOccurred())
-		provider, err = NewProvider(fakeClientSet, kubeController, providerID, mockConfigurator)
+		provider, err = NewProvider(kubeController, providerID, mockConfigurator)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -723,7 +721,7 @@ func TestListEndpointsForIdentity(t *testing.T) {
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 			providerID := "provider"
 
-			provider, err := NewProvider(kubeClient, mockKubeController, providerID, mockConfigurator)
+			provider, err := NewProvider(mockKubeController, providerID, mockConfigurator)
 			assert.Nil(err)
 
 			var pods []*corev1.Pod

--- a/pkg/endpoint/providers/kube/types.go
+++ b/pkg/endpoint/providers/kube/types.go
@@ -1,8 +1,6 @@
 package kube
 
 import (
-	"k8s.io/client-go/kubernetes"
-
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -14,6 +12,5 @@ var (
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
 	providerIdent  string
-	kubeClient     kubernetes.Interface
 	kubeController k8s.Controller
 }


### PR DESCRIPTION
the kubeclient object is passed around in many
places its never used, this PR removes it.

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

Small refactor.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ x] |

Refactoring/cleanup

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
No.

1. Is this a breaking change?
No.
