### PR TITLE
fix(.mergify.yml)Fixes autorebase label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -124,6 +124,4 @@ pull_request_rules:
       - -draft
     actions:
       rebase:
-        # bot_account is the account the rebase will be done under
-        # if not specified Mergify will use any user in OSM that's logged into Mergify
-        bot_account: OSM-PR-bot
+        # Mergify will use any OSM user that's logged into the Mergify dashboard for the rebasing


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes the `bot_account` field to allow the `autorebase` feature to work. Originally, the feature (to specify the account being used to do the rebasing under) was free, but now it is a subscription-only feature. Now the `autorebase` feature will use any OSM account in the Mergify dashboard to perform the rebasing, which is not an issue because there's only one OSM account in Mergify.
Resolves #3544
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [X ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
No