### PR TITLE
(area/multicluster) adding local checks to service and kubernetes client

### DIFF
--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -178,6 +178,8 @@ func (c Client) GetTargetPortToProtocolMappingForService(svc service.MeshService
 func (c *Client) getServicesByLabels(podLabels map[string]string, namespace string) ([]corev1.Service, error) {
 	var finalList []corev1.Service
 	serviceList := c.kubeController.ListServices()
+	
+	// TODO: Query for the multicluster service object
 
 	for _, svc := range serviceList {
 		// TODO: #1684 Introduce APIs to dynamically allow applying selectors, instead of callers implementing

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -190,6 +190,10 @@ func (c Client) ListMonitoredNamespaces() ([]string, error) {
 // GetService retrieves the Kubernetes Services resource for the given MeshService
 func (c Client) GetService(svc service.MeshService) *corev1.Service {
 	// client-go cache uses <namespace>/<name> as key
+	if !svc.IsLocal() {
+		// TODO: Query for the multicluster service object
+		return nil
+	}
 	svcIf, exists, err := c.informers[Services].GetStore().GetByKey(svc.String())
 	if exists && err == nil {
 		svc := svcIf.(*corev1.Service)
@@ -257,6 +261,12 @@ func (c Client) ListPods() []*corev1.Pod {
 // GetEndpoints returns the endpoint for a given service, otherwise returns nil if not found
 // or error if the API errored out.
 func (c Client) GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error) {
+	
+	if !svc.IsLocal() {
+		// TODO: Query for the multicluster service object
+		return nil, errors.New("not a local service")
+	}
+
 	ep, exists, err := c.informers[Endpoints].GetStore().GetByKey(svc.String())
 	if err != nil {
 		return nil, err

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -22,6 +22,10 @@ func (ms MeshService) String() string {
 	return fmt.Sprintf("%s%s%s", ms.Namespace, namespaceNameSeparator, ms.Name)
 }
 
+func (ms MeshService) IsLocal() bool {
+	return true
+}
+
 // ClusterName is a type for a service name
 type ClusterName string
 


### PR DESCRIPTION
Signed-off-by: timmyreilly <tireilly@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
For #3456, using IsLocal to check where the meshservice is located


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No