### PR TITLE
Improves Access Logger names

### DIFF
--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 // BuildFromConfig builds and returns an Envoy Bootstrap object from the given config
@@ -87,7 +88,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 		Admin: &xds_bootstrap.Admin{
 			AccessLog: []*xds_accesslog_config.AccessLog{
 				{
-					Name: "envoy.access_loggers.stdout",
+					Name: envoy.AccessLoggerName,
 					ConfigType: &xds_accesslog_config.AccessLog_TypedConfig{
 						TypedConfig: pbAccessLog,
 					},

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -33,7 +33,7 @@ func TestBuildFromConfig(t *testing.T) {
 
 	expectedYAML := `admin:
   access_log:
-  - name: envoy.access_loggers.stdout
+  - name: envoy.access_loggers.stream
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   address:

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -9,7 +9,6 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -49,6 +48,9 @@ const (
 
 	// OutboundPassthroughCluster is the outbound passthrough cluster name
 	OutboundPassthroughCluster = "passthrough-outbound"
+
+	// AccessLoggerName is name used for the envoy access loggers.
+	AccessLoggerName = "envoy.access_loggers.stream"
 )
 
 // ALPNInMesh indicates that the proxy is connecting to an in-mesh destination.
@@ -86,7 +88,7 @@ func GetAccessLog() []*xds_accesslog_filter.AccessLog {
 		return nil
 	}
 	return []*xds_accesslog_filter.AccessLog{{
-		Name: wellknown.FileAccessLog,
+		Name: AccessLoggerName,
 		ConfigType: &xds_accesslog_filter.AccessLog_TypedConfig{
 			TypedConfig: accessLog,
 		}},

--- a/pkg/injector/envoy_config_health_probes.go
+++ b/pkg/injector/envoy_config_health_probes.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/openservicemesh/osm/pkg/envoy"
+
 	xds_accesslog_filter "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -232,7 +234,7 @@ func getHTTPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
 		return nil, err
 	}
 	return &xds_accesslog_filter.AccessLog{
-		Name: wellknown.FileAccessLog,
+		Name: envoy.AccessLoggerName,
 		ConfigType: &xds_accesslog_filter.AccessLog_TypedConfig{
 			TypedConfig: accessLog,
 		},
@@ -247,7 +249,7 @@ func getTCPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
 		return nil, err
 	}
 	return &xds_accesslog_filter.AccessLog{
-		Name: wellknown.FileAccessLog,
+		Name: envoy.AccessLoggerName,
 		ConfigType: &xds_accesslog_filter.AccessLog_TypedConfig{
 			TypedConfig: accessLog,
 		},

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -1,6 +1,6 @@
 admin:
   access_log:
-  - name: envoy.access_loggers.stdout
+  - name: envoy.access_loggers.stream
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   address:
@@ -107,7 +107,7 @@ static_resources:
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
-          - name: envoy.access_loggers.file
+          - name: envoy.access_loggers.stream
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               log_format:
@@ -157,7 +157,7 @@ static_resources:
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
-          - name: envoy.access_loggers.file
+          - name: envoy.access_loggers.stream
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               log_format:
@@ -207,7 +207,7 @@ static_resources:
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
-          - name: envoy.access_loggers.file
+          - name: envoy.access_loggers.stream
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               log_format:

--- a/tests/envoy_xds_expectations/expected_output_getHTTPAccessLog.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getHTTPAccessLog.yaml
@@ -1,4 +1,4 @@
-name: envoy.access_loggers.file
+name: envoy.access_loggers.stream
 typed_config:
   '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   log_format:

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
@@ -8,7 +8,7 @@ filter_chains:
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
       access_log:
-      - name: envoy.access_loggers.file
+      - name: envoy.access_loggers.stream
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
@@ -8,7 +8,7 @@ filter_chains:
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
       access_log:
-      - name: envoy.access_loggers.file
+      - name: envoy.access_loggers.stream
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:

--- a/tests/envoy_xds_expectations/expected_output_getProbeListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getProbeListener.yaml
@@ -8,7 +8,7 @@ filter_chains:
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
       access_log:
-      - name: envoy.access_loggers.file
+      - name: envoy.access_loggers.stream
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:

--- a/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
@@ -8,7 +8,7 @@ filter_chains:
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
       access_log:
-      - name: envoy.access_loggers.file
+      - name: envoy.access_loggers.stream
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:

--- a/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
@@ -8,7 +8,7 @@ filter_chains:
     typed_config:
       '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
       access_log:
-      - name: envoy.access_loggers.file
+      - name: envoy.access_loggers.stream
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           log_format:

--- a/tests/envoy_xds_expectations/expected_output_getTCPAccessLog.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getTCPAccessLog.yaml
@@ -1,4 +1,4 @@
-name: envoy.access_loggers.file
+name: envoy.access_loggers.stream
 typed_config:
   '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
   log_format:


### PR DESCRIPTION
Access loggers were using incosistent names accross the project.
Consolidate all of them into a single one named `envoy.access_loggers.stream`

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [x] |
| Egress                     | [x] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
