### PR TITLE
fix(e2e): Add default meshconfig

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -545,6 +545,25 @@ func (td *OsmTestData) LoadImagesToKind(imageNames []string) error {
 	return nil
 }
 
+func setMeshConfigToDefault(instOpts InstallOSMOpts, meshConfig *v1alpha1.MeshConfig) (defaultConfig *v1alpha1.MeshConfig) {
+	meshConfig.Spec.Traffic.EnableEgress = instOpts.EgressEnabled
+	meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode = instOpts.EnablePermissiveMode
+	meshConfig.Spec.Traffic.OutboundPortExclusionList = []int{}
+	meshConfig.Spec.Traffic.OutboundIPRangeExclusionList = []string{}
+
+	meshConfig.Spec.Observability.EnableDebugServer = instOpts.EnableDebugServer
+
+	meshConfig.Spec.Sidecar.Resources = corev1.ResourceRequirements{}
+	meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer = instOpts.EnablePrivilegedInitContainer
+	meshConfig.Spec.Sidecar.LogLevel = instOpts.EnvoyLogLevel
+	meshConfig.Spec.Sidecar.MaxDataPlaneConnections = 0
+	meshConfig.Spec.Sidecar.ConfigResyncInterval = "0s"
+
+	meshConfig.Spec.Certificate.ServiceCertValidityDuration = "24h"
+
+	return meshConfig
+}
+
 // InstallOSM installs OSM. The behavior of this function is dependant on
 // installType and instOpts
 func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
@@ -562,21 +581,12 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 
 		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
 
-		// This resets supported dynamic configs expected by the caller
-		meshConfig.Spec.Traffic.EnableEgress = instOpts.EgressEnabled
-		meshConfig, err := Td.UpdateOSMConfig(meshConfig)
-		if err != nil {
+		meshConfig = setMeshConfigToDefault(instOpts, meshConfig)
+
+		if _, err := Td.UpdateOSMConfig(meshConfig); err != nil {
 			return err
 		}
-		meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode = instOpts.EnablePermissiveMode
-		meshConfig, err = Td.UpdateOSMConfig(meshConfig)
-		if err != nil {
-			return err
-		}
-		meshConfig.Spec.Observability.EnableDebugServer = instOpts.EnableDebugServer
-		if _, err = Td.UpdateOSMConfig(meshConfig); err != nil {
-			return err
-		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add default meshconfig, and update the meshconfig with default for the noInstall option in e2e tests. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
