### PR TITLE
feat(pkg/*): Lay some groundwork for multi cluster gateways.

### DIFF
--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -86,7 +86,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 			trafficSplit: split.TrafficSplit{},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.default",
+					Name: "bookstore.default.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.default",
@@ -198,7 +198,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.default",
+					Name: "bookstore.default.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.default",
@@ -241,7 +241,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookstore-apex",
+					Name: "bookstore-apex.default.local",
 					Hostnames: []string{
 						"bookstore-apex",
 						"bookstore-apex.default",
@@ -354,7 +354,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.default",
+					Name: "bookstore.default.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.default",
@@ -384,7 +384,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookstore-apex",
+					Name: "bookstore-apex.default.local",
 					Hostnames: []string{
 						"bookstore-apex",
 						"bookstore-apex.default",
@@ -446,7 +446,7 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 			trafficSplit:        split.TrafficSplit{},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookbuyer.default",
+					Name: "bookbuyer.default.local",
 					Hostnames: []string{
 						"bookbuyer",
 						"bookbuyer.default",
@@ -659,7 +659,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore-apex",
+					Name: "bookstore-apex.default.local",
 					Hostnames: []string{
 						"bookstore-apex",
 						"bookstore-apex.default",
@@ -775,7 +775,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore-apex",
+					Name: "bookstore-apex.default.local",
 					Hostnames: []string{
 						"bookstore-apex",
 						"bookstore-apex.default",
@@ -892,7 +892,7 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore-apex",
+					Name: "bookstore-apex.default.local",
 					Hostnames: []string{
 						"bookstore-apex",
 						"bookstore-apex.default",
@@ -1034,7 +1034,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.bookstore-ns",
+					Name: "bookstore.bookstore-ns.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.bookstore-ns",
@@ -1125,7 +1125,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.default",
+					Name: "bookstore.default.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.default",
@@ -1208,7 +1208,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name:      tests.BookstoreV1Service.Name + "." + tests.BookstoreV1Service.Namespace,
+					Name:      tests.BookstoreV1Service.Name + "." + tests.BookstoreV1Service.Namespace + ".local",
 					Hostnames: tests.BookstoreV1Hostnames,
 					Rules: []*trafficpolicy.Rule{
 						{
@@ -1291,7 +1291,7 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 			name: "inbound traffic policies for permissive mode",
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.bookstore-ns",
+					Name: "bookstore.bookstore-ns.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.bookstore-ns",
@@ -1412,7 +1412,7 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.default",
+					Name: "bookstore.default.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.default",
@@ -1504,7 +1504,7 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore.default",
+					Name: "bookstore.default.local",
 					Hostnames: []string{
 						"bookstore",
 						"bookstore.default",
@@ -1843,40 +1843,4 @@ func TestGetTrafficSpecName(t *testing.T) {
 	actual := mc.getTrafficSpecName("HTTPRouteGroup", tests.Namespace, tests.RouteGroupName)
 	expected := trafficpolicy.TrafficSpecName(fmt.Sprintf("HTTPRouteGroup/%s/%s", tests.Namespace, tests.RouteGroupName))
 	assert.Equal(actual, expected)
-}
-
-func TestBuildPolicyName(t *testing.T) {
-	assert := tassert.New(t)
-
-	svc := service.MeshService{
-		Namespace: "default",
-		Name:      "foo",
-	}
-
-	testCases := []struct {
-		name          string
-		svc           service.MeshService
-		sameNamespace bool
-		expectedName  string
-	}{
-		{
-			name:          "same namespace",
-			svc:           svc,
-			sameNamespace: true,
-			expectedName:  "foo",
-		},
-		{
-			name:          "different namespace",
-			svc:           svc,
-			sameNamespace: false,
-			expectedName:  "foo.default",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := buildPolicyName(tc.svc, tc.sameNamespace)
-			assert.Equal(tc.expectedName, actual)
-		})
-	}
 }

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -112,6 +112,21 @@ func (mr *MockMeshCatalogerMockRecorder) GetResolvableServiceEndpoints(arg0 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvableServiceEndpoints", reflect.TypeOf((*MockMeshCataloger)(nil).GetResolvableServiceEndpoints), arg0)
 }
 
+// GetServiceHostnames mocks base method
+func (m *MockMeshCataloger) GetServiceHostnames(arg0 service.MeshService, arg1 service.Locality) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceHostnames", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetServiceHostnames indicates an expected call of GetServiceHostnames
+func (mr *MockMeshCatalogerMockRecorder) GetServiceHostnames(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostnames", reflect.TypeOf((*MockMeshCataloger)(nil).GetServiceHostnames), arg0, arg1)
+}
+
 // GetTargetPortToProtocolMappingForService mocks base method
 func (m *MockMeshCataloger) GetTargetPortToProtocolMappingForService(arg0 service.MeshService) (map[uint32]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -24,7 +24,7 @@ import (
 
 var expectedBookbuyerOutbound []*trafficpolicy.OutboundTrafficPolicy = []*trafficpolicy.OutboundTrafficPolicy{
 	{
-		Name:      "bookstore-v1",
+		Name:      "bookstore-v1.default.local",
 		Hostnames: tests.BookstoreV1Hostnames,
 		Routes: []*trafficpolicy.RouteWeightedClusters{
 			{
@@ -34,7 +34,7 @@ var expectedBookbuyerOutbound []*trafficpolicy.OutboundTrafficPolicy = []*traffi
 		},
 	},
 	{
-		Name:      "bookstore-v2",
+		Name:      "bookstore-v2.default.local",
 		Hostnames: tests.BookstoreV2Hostnames,
 		Routes: []*trafficpolicy.RouteWeightedClusters{
 			{
@@ -44,7 +44,7 @@ var expectedBookbuyerOutbound []*trafficpolicy.OutboundTrafficPolicy = []*traffi
 		},
 	},
 	{
-		Name:      "bookstore-apex",
+		Name:      "bookstore-apex.default.local",
 		Hostnames: tests.BookstoreApexHostnames,
 		Routes: []*trafficpolicy.RouteWeightedClusters{
 			{
@@ -112,7 +112,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			trafficspecs:        []*spec.HTTPRouteGroup{&tests.HTTPRouteGroup},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-v1",
+					Name:      "bookstore-v1.default.local",
 					Hostnames: tests.BookstoreV1Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -122,7 +122,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name:      "bookstore-v2",
+					Name:      "bookstore-v2.default.local",
 					Hostnames: tests.BookstoreV2Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -132,7 +132,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name:      "bookstore-apex",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -163,7 +163,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			trafficspecs:        []*spec.HTTPRouteGroup{&tests.HTTPRouteGroupWithHost},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-v1",
+					Name:      "bookstore-v1.default.local",
 					Hostnames: tests.BookstoreV1Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -173,7 +173,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name:      "bookstore-v2",
+					Name:      "bookstore-v2.default.local",
 					Hostnames: tests.BookstoreV2Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -183,7 +183,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name:      "bookstore-apex",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: BookstoreApexHostnamesSorted,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -224,7 +224,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			trafficspecs:        []*spec.HTTPRouteGroup{},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-apex",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -262,7 +262,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			trafficspecs:        []*spec.HTTPRouteGroup{},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name: "bookstore-v1.default",
+					Name: "bookstore-v1.default.local",
 					Hostnames: []string{
 						"bookstore-v1.default",
 						"bookstore-v1.default.svc",
@@ -281,7 +281,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookstore-v2.default",
+					Name: "bookstore-v2.default.local",
 					Hostnames: []string{
 						"bookstore-v2.default",
 						"bookstore-v2.default.svc",
@@ -300,7 +300,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookbuyer.default",
+					Name: "bookbuyer.default.local",
 					Hostnames: []string{
 						"bookbuyer.default",
 						"bookbuyer.default.svc",
@@ -498,7 +498,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-apex.default",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexNamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -524,7 +524,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-apex.default",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexNamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -550,7 +550,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-apex",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -580,7 +580,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-apex.default",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexNamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -593,7 +593,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					},
 				},
 				{
-					Name:      "apex-split-1.bar",
+					Name:      "apex-split-1.bar.local",
 					Hostnames: testSplit1NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -619,7 +619,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "apex-split-1.bar",
+					Name:      "apex-split-1.bar.local",
 					Hostnames: testSplit1NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -649,7 +649,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 			},
 			expectedPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "apex-split-1.bar",
+					Name:      "apex-split-1.bar.local",
 					Hostnames: testSplit1NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -662,7 +662,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 					},
 				},
 				{
-					Name:      "apex-split-1.baz",
+					Name:      "apex-split-1.baz.local",
 					Hostnames: testSplit3NamespacedHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -774,7 +774,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 			services: map[string]string{"bookstore-v1": "default", "bookstore-apex": "default", "bookbuyer": "default"},
 			expectedOutboundPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name: "bookstore-apex.default",
+					Name: "bookstore-apex.default.local",
 					Hostnames: []string{
 						"bookstore-apex.default",
 						"bookstore-apex.default.svc",
@@ -793,7 +793,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookstore-v1.default",
+					Name: "bookstore-v1.default.local",
 					Hostnames: []string{
 						"bookstore-v1.default",
 						"bookstore-v1.default.svc",
@@ -812,7 +812,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookbuyer.default",
+					Name: "bookbuyer.default.local",
 					Hostnames: []string{
 						"bookbuyer.default",
 						"bookbuyer.default.svc",
@@ -876,7 +876,7 @@ func TestBuildOutboundPolicies(t *testing.T) {
 			trafficSplit:    split.TrafficSplit{},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      tests.BookstoreV1Service.Name,
+					Name:      tests.BookstoreV1Service.FQDN(),
 					Hostnames: tests.BookstoreV1Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -896,7 +896,7 @@ func TestBuildOutboundPolicies(t *testing.T) {
 			trafficSplit:    split.TrafficSplit{},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      tests.BookstoreV1Service.Name,
+					Name:      tests.BookstoreV1Service.FQDN(),
 					Hostnames: tests.BookstoreV1Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -990,7 +990,7 @@ func TestListOutboundPoliciesForTrafficTargets(t *testing.T) {
 			trafficspecs:     []*spec.HTTPRouteGroup{&tests.HTTPRouteGroupWithHost},
 			expectedOutbound: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      "bookstore-v1",
+					Name:      "bookstore-v1.default.local",
 					Hostnames: tests.BookstoreV1Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -1000,7 +1000,7 @@ func TestListOutboundPoliciesForTrafficTargets(t *testing.T) {
 					},
 				},
 				{
-					Name:      "bookstore-v2",
+					Name:      "bookstore-v2.default.local",
 					Hostnames: tests.BookstoreV2Hostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -1010,7 +1010,7 @@ func TestListOutboundPoliciesForTrafficTargets(t *testing.T) {
 					},
 				},
 				{
-					Name:      "bookstore-apex",
+					Name:      "bookstore-apex.default.local",
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -173,16 +173,16 @@ func (mc *MeshCatalog) listMeshServices() []service.MeshService {
 	return services
 }
 
-// getServiceHostnames returns a list of hostnames corresponding to the service.
+// GetServiceHostnames returns a list of hostnames corresponding to the service.
 // If the service is in the same namespace, it returns the shorthand hostname for the service that does not
 // include its namespace, ex: bookstore, bookstore:80
-func (mc *MeshCatalog) getServiceHostnames(meshService service.MeshService, sameNamespace bool) ([]string, error) {
+func (mc *MeshCatalog) GetServiceHostnames(meshService service.MeshService, locality service.Locality) ([]string, error) {
 	svc := mc.kubeController.GetService(meshService)
 	if svc == nil {
 		return nil, errors.Errorf("Error fetching service %q", meshService)
 	}
 
-	hostnames := kubernetes.GetHostnamesForService(svc, sameNamespace)
+	hostnames := kubernetes.GetHostnamesForService(svc, locality)
 	return hostnames, nil
 }
 

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -552,13 +552,13 @@ func TestGetServiceHostnames(t *testing.T) {
 	mc := newFakeMeshCatalog()
 
 	testCases := []struct {
-		svc           service.MeshService
-		sameNamespace bool
-		expected      []string
+		svc      service.MeshService
+		locality service.Locality
+		expected []string
 	}{
 		{
 			tests.BookstoreV1Service,
-			true,
+			service.LocalNS,
 			[]string{
 				"bookstore-v1",
 				"bookstore-v1.default",
@@ -574,7 +574,7 @@ func TestGetServiceHostnames(t *testing.T) {
 		},
 		{
 			tests.BookstoreV1Service,
-			false,
+			service.LocalCluster,
 			[]string{
 				"bookstore-v1.default",
 				"bookstore-v1.default.svc",
@@ -589,8 +589,8 @@ func TestGetServiceHostnames(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing hostnames for svc %s with sameNamespace=%t", tc.svc, tc.sameNamespace), func(t *testing.T) {
-			actual, err := mc.getServiceHostnames(tc.svc, tc.sameNamespace)
+		t.Run(fmt.Sprintf("Testing hostnames for svc %s with locality=%d", tc.svc, tc.locality), func(t *testing.T) {
+			actual, err := mc.GetServiceHostnames(tc.svc, tc.locality)
 			assert.Nil(err)
 			assert.ElementsMatch(actual, tc.expected)
 		})

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -102,6 +102,9 @@ type MeshCataloger interface {
 
 	// GetKubeController returns the kube controller instance handling the current cluster
 	GetKubeController() k8s.Controller
+
+	// GetServiceHostnames returns the hostnames for this service, based on the locality of the source.
+	GetServiceHostnames(service.MeshService, service.Locality) ([]string, error)
 }
 
 type trafficDirection string

--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -20,7 +21,7 @@ func TestGetHostnamesForService(t *testing.T) {
 	testCases := []struct {
 		name              string
 		service           *corev1.Service
-		isSameNamespace   bool
+		locality          service.Locality
 		expectedHostnames []string
 	}{
 		{
@@ -28,7 +29,7 @@ func TestGetHostnamesForService(t *testing.T) {
 			service: tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, map[string]string{
 				tests.SelectorKey: tests.SelectorValue,
 			}),
-			isSameNamespace: true,
+			locality: service.LocalNS,
 			expectedHostnames: []string{
 				tests.BookbuyerServiceName,
 				fmt.Sprintf("%s:%d", tests.BookbuyerServiceName, tests.ServicePort),
@@ -47,7 +48,7 @@ func TestGetHostnamesForService(t *testing.T) {
 			service: tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, map[string]string{
 				tests.SelectorKey: tests.SelectorValue,
 			}),
-			isSameNamespace: false,
+			locality: service.LocalCluster,
 			expectedHostnames: []string{
 				fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace),
 				fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
@@ -63,7 +64,7 @@ func TestGetHostnamesForService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := GetHostnamesForService(tc.service, tc.isSameNamespace)
+			actual := GetHostnamesForService(tc.service, tc.locality)
 			assert.ElementsMatch(actual, tc.expectedHostnames)
 			assert.Len(actual, len(tc.expectedHostnames))
 		})

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,12 +1,31 @@
 // Package service models an instance of a service managed by OSM controller and utility routines associated with it.
 package service
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
 	// or viceversa
 	namespaceNameSeparator = "/"
+	localCluster           = "local"
+)
+
+// Locality is the relative locality of a service. ie: if a service is being accessed from the same namespace or a
+// remote cluster.
+type Locality int
+
+const (
+	// LocalNS refers to the local namespace within the local cluster.
+	LocalNS Locality = iota
+
+	// LocalCluster refers to access within the cluster, but not within the same namespace.
+	LocalCluster
+
+	// RemoteCluster refers to access from a different cluster.
+	RemoteCluster
 )
 
 // MeshService is the struct defining a service (Kubernetes or otherwise) within a service mesh.
@@ -16,10 +35,26 @@ type MeshService struct {
 
 	// The name of the service
 	Name string
+
+	ClusterDomain string
 }
 
 func (ms MeshService) String() string {
 	return fmt.Sprintf("%s%s%s", ms.Namespace, namespaceNameSeparator, ms.Name)
+}
+
+// FQDN is similar to String(), but uses a dot separator and is in a different order.
+func (ms MeshService) FQDN() string {
+	if ms.ClusterDomain == "" {
+		ms.ClusterDomain = localCluster
+	}
+	return strings.Join([]string{ms.Name, ms.Namespace, ms.ClusterDomain}, ".")
+}
+
+// Local returns whether or not this is service is in the local cluster.
+func (ms MeshService) Local() bool {
+	// TODO(steeling): if it's unset consider it local for now.
+	return ms.ClusterDomain == localCluster || ms.ClusterDomain == ""
 }
 
 // ClusterName is a type for a service name

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -72,9 +72,9 @@ var _ = Describe(``+
 			})
 
 			const (
-				apexName = "outbound_virtual-host|bookstore-apex"
-				v1Name   = "outbound_virtual-host|bookstore-v1"
-				v2Name   = "outbound_virtual-host|bookstore-v2"
+				apexName = "outbound_virtual-host|bookstore-apex.default.local"
+				v1Name   = "outbound_virtual-host|bookstore-v1.default.local"
+				v2Name   = "outbound_virtual-host|bookstore-v2.default.local"
 			)
 			expectedVHostNames := []string{apexName, v1Name, v2Name}
 

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -103,7 +103,7 @@ func TestRDSRespose(t *testing.T) {
 			},
 			expectedInboundPolicies: []*trafficpolicy.InboundTrafficPolicy{
 				{
-					Name: "bookstore-v1.default",
+					Name: "bookstore-v1.default.local",
 					Hostnames: []string{
 						"bookstore-v1",
 						"bookstore-v1.default",
@@ -146,7 +146,7 @@ func TestRDSRespose(t *testing.T) {
 					},
 				},
 				{
-					Name: tests.BookstoreApexServiceName,
+					Name: tests.BookstoreApexServiceName + ".default.local",
 					Hostnames: []string{
 						"bookstore-apex",
 						"bookstore-apex.default",
@@ -191,7 +191,7 @@ func TestRDSRespose(t *testing.T) {
 			},
 			expectedOutboundPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
-					Name:      tests.BookstoreApexServiceName,
+					Name:      tests.BookstoreApexServiceName + ".default.local",
 					Hostnames: tests.BookstoreApexHostnames,
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
@@ -262,7 +262,7 @@ func TestRDSRespose(t *testing.T) {
 			assert.Equal("rds-inbound", routeConfig.Name)
 			assert.Equal(2, len(routeConfig.VirtualHosts))
 
-			assert.Equal("inbound_virtual-host|bookstore-v1.default", routeConfig.VirtualHosts[0].Name)
+			assert.Equal("inbound_virtual-host|bookstore-v1.default.local", routeConfig.VirtualHosts[0].Name)
 			assert.Equal(tests.BookstoreV1Hostnames, routeConfig.VirtualHosts[0].Domains)
 			assert.Equal(2, len(routeConfig.VirtualHosts[0].Routes))
 			assert.Equal(tests.BookstoreBuyHTTPRoute.Path, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)
@@ -272,7 +272,7 @@ func TestRDSRespose(t *testing.T) {
 			assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes[1].GetRoute().GetWeightedClusters().Clusters))
 			assert.Equal(routeConfig.VirtualHosts[0].Routes[1].GetRoute().GetWeightedClusters().TotalWeight, &wrappers.UInt32Value{Value: uint32(100)})
 
-			assert.Equal("inbound_virtual-host|bookstore-apex", routeConfig.VirtualHosts[1].Name)
+			assert.Equal("inbound_virtual-host|bookstore-apex.default.local", routeConfig.VirtualHosts[1].Name)
 			assert.Equal(tests.BookstoreApexHostnames, routeConfig.VirtualHosts[1].Domains)
 			assert.Equal(2, len(routeConfig.VirtualHosts[1].Routes))
 			assert.Equal(tests.BookstoreBuyHTTPRoute.Path, routeConfig.VirtualHosts[1].Routes[0].GetMatch().GetSafeRegex().Regex)
@@ -291,7 +291,7 @@ func TestRDSRespose(t *testing.T) {
 			assert.Equal("rds-outbound", routeConfig.Name)
 			assert.Equal(1, len(routeConfig.VirtualHosts))
 
-			assert.Equal("outbound_virtual-host|bookstore-apex", routeConfig.VirtualHosts[0].Name)
+			assert.Equal("outbound_virtual-host|bookstore-apex.default.local", routeConfig.VirtualHosts[0].Name)
 			assert.Equal(tests.BookstoreApexHostnames, routeConfig.VirtualHosts[0].Domains)
 			assert.Equal(1, len(routeConfig.VirtualHosts[0].Routes))
 			assert.Equal(tests.WildCardRouteMatch.Path, routeConfig.VirtualHosts[0].Routes[0].GetMatch().GetSafeRegex().Regex)


### PR DESCRIPTION
Multi cluster gateway configurations will have multiple routes
with the same service name. This PR introduces a cluster field
to the MeshService, which currently always returns true for local.
We also change TrafficPolicy names to *always* include the cluster id
and the namespace, export a few functions, and introduce a Locality
type to  determine if a service is being reached from which locality.

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

#3456 


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No.

1. Is this a breaking change?
No -- it does change policy names, but that should have no impact.
