### PR TITLE
adding guard clauses to endpoints provider for non-local condition

### DIFF
--- a/pkg/endpoint/providers/kube/client.go
+++ b/pkg/endpoint/providers/kube/client.go
@@ -36,6 +36,11 @@ func (c Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endp
 	log.Trace().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
 	var endpoints []endpoint.Endpoint
 
+	if !svc.IsLocal() {
+		log.Trace().Msg("Not a local service and we can't handle that scenario yet.")
+		return nil
+	}
+
 	kubernetesEndpoints, err := c.kubeController.GetEndpoints(svc)
 	if err != nil || kubernetesEndpoints == nil {
 		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache for service %s", c.providerIdent, svc)
@@ -142,6 +147,11 @@ func (c Client) GetServicesForServiceAccount(svcAccount identity.K8sServiceAccou
 func (c Client) GetTargetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
 	portToProtocolMap := make(map[uint32]string)
 
+	if !svc.IsLocal() {
+		log.Trace().Msg("Not a local service and we can't handle that scenario yet.")
+		return nil, errors.New("Unable to handle non-local port service mappings")
+	}
+
 	endpoints, err := c.kubeController.GetEndpoints(svc)
 	if err != nil || endpoints == nil {
 		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache", c.providerIdent)
@@ -205,6 +215,11 @@ func (c *Client) getServicesByLabels(podLabels map[string]string, namespace stri
 func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {
 	var endpoints []endpoint.Endpoint
 	var err error
+
+	if !svc.IsLocal() {
+		log.Trace().Msg("Not a local service and we can't handle that scenario yet.")
+		return nil, errors.New("Unable to handle non-local resolvable endpoints for non-local services")
+	}
 
 	// Check if the service has been given Cluster IP
 	kubeService := c.kubeController.GetService(svc)

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -18,6 +18,10 @@ type MeshService struct {
 	Name string
 }
 
+func (ms MeshService) IsLocal() bool {
+	return true
+}
+
 func (ms MeshService) String() string {
 	return fmt.Sprintf("%s%s%s", ms.Namespace, namespaceNameSeparator, ms.Name)
 }


### PR DESCRIPTION
Signed-off-by: timmyreilly <tireilly@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
Handling non-local services in endpoints provider with guard clauses. 
#3456 and #3441 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No