### PR TITLE
tests(e2e): Create ServiceAccount for Vault

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -726,29 +726,39 @@ func (td *OsmTestData) LoadOSMImagesIntoKind() error {
 
 func (td *OsmTestData) installVault(instOpts InstallOSMOpts) error {
 	td.T.Log("Installing Vault")
+
+	appName := "vault"
 	replicas := int32(1)
 	terminationGracePeriodSeconds := int64(10)
+
+	serviceAccountDefinition := Td.SimpleServiceAccount(appName, td.OsmNamespace)
+	svcAccount, err := Td.CreateServiceAccount(serviceAccountDefinition.Namespace, &serviceAccountDefinition)
+	if err != nil {
+		return errors.Wrap(err, "failed to create vault service account")
+	}
+
 	vaultDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "vault",
+			Name: appName,
 			Labels: map[string]string{
-				"app": "vault",
+				"app": appName,
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "vault",
+					"app": appName,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app": "vault",
+						"app": appName,
 					},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            svcAccount.Name,
 					TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 					Containers: []corev1.Container{
 						{
@@ -843,22 +853,22 @@ tail /dev/random;
 			},
 		},
 	}
-	_, err := td.Client.AppsV1().Deployments(instOpts.ControlPlaneNS).Create(context.TODO(), vaultDep, metav1.CreateOptions{})
+	_, err = td.Client.AppsV1().Deployments(instOpts.ControlPlaneNS).Create(context.TODO(), vaultDep, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to create vault deployment")
 	}
 
 	vaultSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "vault",
+			Name: appName,
 			Labels: map[string]string{
-				"app": "vault",
+				"app": appName,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeLoadBalancer,
 			Selector: map[string]string{
-				"app": "vault",
+				"app": appName,
 			},
 			Ports: []corev1.ServicePort{
 				{

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -150,15 +150,10 @@ type SimplePodAppDef struct {
 	AppProtocol string
 }
 
-// SimplePodApp creates returns a set of k8s typed definitions for a pod-based k8s definition.
+// SimplePodApp returns a set of k8s typed definitions for a pod-based k8s definition.
 // Includes Pod, Service and ServiceAccount types
 func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount, corev1.Pod, corev1.Service) {
-	serviceAccountDefinition := corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      def.Name,
-			Namespace: def.Namespace,
-		},
-	}
+	serviceAccountDefinition := Td.SimpleServiceAccount(def.Name, def.Namespace)
 
 	podDefinition := corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -249,6 +244,17 @@ func (td *OsmTestData) SimplePodApp(def SimplePodAppDef) (corev1.ServiceAccount,
 	}
 
 	return serviceAccountDefinition, podDefinition, serviceDefinition
+}
+
+// SimpleServiceAccount returns a k8s typed definition for a service account.
+func (td *OsmTestData) SimpleServiceAccount(name string, namespace string) corev1.ServiceAccount {
+	serviceAccountDefinition := corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return serviceAccountDefinition
 }
 
 // getKubernetesServerVersionNumber returns the version number in chunks, ex. v1.19.3 => [1, 19, 3]


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a ServiceAccount for when vault is deployed in e2es. This allows the vault to be deployed with the privileged SCC on OpenShift which is necessary since it requires the IPC_LOCK capability.

The OpenShift docs recommend the privileged SCC here: https://www.openshift.com/blog/integrating-vault-with-legacy-applications

Related to #3097
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No