### PR TITLE
fix(e2e): skip e2e_init_controller_test for noInstall

### DIFF
--- a/tests/e2e/e2e_init_controller_test.go
+++ b/tests/e2e/e2e_init_controller_test.go
@@ -15,6 +15,10 @@ var _ = OSMDescribe("Test init-osm-controller functionalities",
 	func() {
 		Context("When osm-controller starts in fresh environment", func() {
 			It("creates default MeshConfig resource", func() {
+
+				if Td.InstType == "NoInstall" {
+					Skip("Skipping test: NoInstall marked on a test that requires fresh installation")
+				}
 				instOpts := Td.GetOSMInstallOpts()
 
 				// Install OSM


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Skip the e2e_init_controller_test if the test suite is run with "NoInstall" 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No

1. Is this a breaking change? No
