### PR TITLE
osm-gateway: add support for gateway bootstrapping

### DIFF
--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -196,3 +196,6 @@ spec:
                     enableSnapshotCacheMode:
                       type: boolean
                       default: false
+                    enableOSMGateway:
+                      type: boolean
+                      default: false

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -55,6 +55,7 @@ spec:
           args: [
             "--verbosity", "{{.Values.OpenServiceMesh.controllerLogLevel}}",
             "--osm-namespace", "{{ include "osm.namespace" . }}",
+            "--osm-service-account", "{{ .Release.Name }}",
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--webhook-config-name", "{{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",

--- a/charts/osm/templates/osm-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-gateway-deployment.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.OpenServiceMesh.featureFlags.enableOSMGateway }}
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: osm-gateway
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    app: osm-gateway
+spec:
+  selector:
+    matchLabels:
+      app: osm-gateway
+  template:
+    metadata:
+      labels:
+        app: osm-gateway
+      name: osm-gateway
+    spec:
+      initContainers:
+        - name: osm-gateway-init
+          image: curlimages/curl
+          args:
+          - /bin/sh
+          - -c
+          - >
+            set -x;
+            while [ $(curl -sw '%{http_code}' "http://osm-controller.{{ include "osm.namespace" . }}.svc.cluster.local:9091/health/ready" -o /dev/null) -ne 200 ]; do
+              sleep 10;
+            done
+      containers:
+        - name: envoy
+          image: {{ .Values.OpenServiceMesh.sidecarImage }}
+          command:
+            - "envoy"
+          args: [
+            "--config-path", "/etc/envoy/bootstrap.yaml",
+            "--bootstrap-version", "3",
+            "--service-node", "osm-gateway",
+            "--service-cluster", "osm-gateway",
+          ]
+          ports:
+            - containerPort: 14080
+              name: http2
+              protocol: TCP
+          volumeMounts:
+            - name: envoy-bootstrap-config-volume
+              mountPath: /etc/envoy
+              readOnly: true
+      volumes:
+        - name: envoy-bootstrap-config-volume
+          secret:
+            secretName: osm-gateway-bootstrap-config
+{{- end }}

--- a/charts/osm/templates/osm-gateway-secret.yaml
+++ b/charts/osm/templates/osm-gateway-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.OpenServiceMesh.featureFlags.enableOSMGateway }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: osm-gateway-bootstrap-config
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    app: osm-gateway
+type: Opaque
+stringData:
+  bootstrap.yaml: "-- placeholder --"
+{{- end }}

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -99,7 +99,7 @@ rules:
     verbs: ["create", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update", "delete"]
+    verbs: ["create", "update", "delete", "patch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create", "update"]

--- a/charts/osm/templates/osm-service.yaml
+++ b/charts/osm/templates/osm-service.yaml
@@ -14,5 +14,8 @@ spec:
     - name: debug-port
       port: 9092
       targetPort: 9092
+    - name: healthz
+      port: 9091
+      targetPort: 9091
   selector:
     app: osm-controller

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -27,7 +27,8 @@ spec:
       {{- end }}
   certificate:
     serviceCertValidityDuration: {{.Values.OpenServiceMesh.serviceCertValidityDuration}}
-  featureFlags: 
+  featureFlags:
     enableWASMStats: {{.Values.OpenServiceMesh.featureFlags.enableWASMStats}}
     enableEgressPolicy: {{.Values.OpenServiceMesh.featureFlags.enableEgressPolicy}}
     enableMulticlusterMode: {{.Values.OpenServiceMesh.featureFlags.enableMulticlusterMode}}
+    enableOSMGateway: {{.Values.OpenServiceMesh.featureFlags.enableOSMGateway}}

--- a/cmd/osm-controller/gateway.go
+++ b/cmd/osm-controller/gateway.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/bootstrap"
+	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/utils"
+)
+
+const (
+	gatewayBootstrapSecretName = "osm-gateway-bootstrap-config" // #nosec G101: Potential hardcoded credentials
+	bootstrapConfigKey         = "bootstrap.yaml"
+)
+
+func bootstrapOSMGateway(kubeClient kubernetes.Interface, certManager certificate.Manager, osmNamespace string) error {
+	secret, err := kubeClient.CoreV1().Secrets(osmNamespace).Get(context.Background(), gatewayBootstrapSecretName, metav1.GetOptions{})
+	if err != nil {
+		return errors.Errorf("Error fetching OSM gateway's bootstrap config %s/%s", osmNamespace, gatewayBootstrapSecretName)
+	}
+
+	if bootstrapData, ok := secret.Data[bootstrapConfigKey]; !ok {
+		return errors.Errorf("Missing OSM gateway bootstrap config in %s/%s", osmNamespace, gatewayBootstrapSecretName)
+	} else if isValidBootstrapData(bootstrapData) {
+		// If there is a valid bootstrap config, it means we do not need to reconfigure it. It implies
+		// osm-controller restarted after creating the bootstrap config previously.
+		log.Info().Msg("A valid bootstrap config exists for OSM gateway, skipping gateway bootstrapping")
+		return nil
+	}
+
+	gatewayCN := envoy.NewCertCommonName(uuid.New(), envoy.KindGateway, osmServiceAccount, osmNamespace)
+	bootstrapCert, err := certManager.IssueCertificate(gatewayCN, constants.XDSCertificateValidityPeriod)
+	if err != nil {
+		return errors.Errorf("Error issuing bootstrap certificate for OSM gateway: %s", err)
+	}
+
+	bootstrapConfig, err := bootstrap.BuildFromConfig(bootstrap.Config{
+		NodeID:           bootstrapCert.GetCommonName().String(),
+		AdminPort:        constants.EnvoyAdminPort,
+		XDSClusterName:   constants.OSMControllerName,
+		XDSHost:          fmt.Sprintf("%s.%s.svc.%s", constants.OSMControllerName, osmNamespace, identity.ClusterLocalTrustDomain),
+		XDSPort:          constants.ADSServerPort,
+		TrustedCA:        bootstrapCert.GetIssuingCA(),
+		CertificateChain: bootstrapCert.GetCertificateChain(),
+		PrivateKey:       bootstrapCert.GetPrivateKey(),
+	})
+	if err != nil {
+		return errors.Errorf("Error building OSM gateway's bootstrap config from %s/%s", osmNamespace, gatewayBootstrapSecretName)
+	}
+
+	bootstrapData, err := utils.ProtoToYAML(bootstrapConfig)
+	if err != nil {
+		return errors.Errorf("Error marshalling updated OSM gateway's bootstrap config from %s/%s", osmNamespace, gatewayBootstrapSecretName)
+	}
+
+	updatedSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayBootstrapSecretName,
+			Namespace: osmNamespace,
+		},
+		Data: map[string][]byte{
+			bootstrapConfigKey: bootstrapData,
+		},
+	}
+
+	patchJSON, err := json.Marshal(updatedSecret)
+	if err != nil {
+		return err
+	}
+
+	if _, err = kubeClient.CoreV1().Secrets(osmNamespace).Patch(context.Background(), gatewayBootstrapSecretName, types.StrategicMergePatchType, patchJSON, metav1.PatchOptions{}); err != nil {
+		return errors.Errorf("Error patching OSM gateway's bootstrap secret %s/%s: %s", osmNamespace, gatewayBootstrapSecretName, err)
+	}
+
+	return nil
+}
+
+// isValidBootstrapData returns a boolean indicating if the bootstrap config YAML data is valid
+// It determines validity by examining the presence of the minimum set of top level keys that
+// should be present in the bootstrap config YAML. This is enough to determine validity because
+// it means these top level keys were previously encoded as a part of the k8s secret corresponding
+// to the bootstrap config.
+func isValidBootstrapData(bootstrapData []byte) bool {
+	js, err := yaml.YAMLToJSON([]byte(bootstrapData))
+	if err != nil {
+		return false
+	}
+
+	jsonMap := make(map[string]interface{})
+	err = json.Unmarshal(js, &jsonMap)
+	if err != nil {
+		return false
+	}
+
+	requiredKeys := []string{"admin", "node", "static_resources", "dynamic_resources"}
+	for _, key := range requiredKeys {
+		if _, ok := jsonMap[key]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/cmd/osm-controller/gateway_test.go
+++ b/cmd/osm-controller/gateway_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
+)
+
+func TestBootstrapOSMGateway(t *testing.T) {
+	assert := tassert.New(t)
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	fakeCertManager := tresor.NewFakeCertManager(mockConfigurator)
+	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(15 * time.Second).AnyTimes()
+
+	testCases := []struct {
+		name            string
+		bootstrapSecret *corev1.Secret
+		expectError     bool
+	}{
+		{
+			name:            "secret does not exist, it should be created by Helm",
+			bootstrapSecret: nil,
+			expectError:     true,
+		},
+		{
+			name: "Secret with placeholder config exists",
+			bootstrapSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayBootstrapSecretName,
+					Namespace: osmNamespace,
+				},
+				Data: map[string][]byte{
+					bootstrapConfigKey: []byte("-- placeholder --"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Secret with valid config exists",
+			bootstrapSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gatewayBootstrapSecretName,
+					Namespace: osmNamespace,
+				},
+				Data: map[string][]byte{
+					bootstrapConfigKey: []byte(`admin:
+  access_log:
+  - name: envoy.access_loggers.stream
+    typed_config:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 15000
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: osm-controller
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+node:
+  id: ab394bf2-3a1e-4f59-a182-688a732f180f.gateway.osm.osm-system
+static_resources:
+  clusters:
+  - connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: osm-controller
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: osm-controller.osm-system.svc.cluster.local
+                port_value: 15128
+    name: osm-controller
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          alpn_protocols:
+          - h2
+          tls_certificates:
+          - certificate_chain:
+              inline_bytes: --redacted--
+            private_key:
+              inline_bytes: --redacted--
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+            tls_minimum_protocol_version: TLSv1_2
+          validation_context:
+            trusted_ca:
+              inline_bytes: --redacted--
+    type: LOGICAL_DNS
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+`),
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeClient := fake.NewSimpleClientset()
+
+			testNs := "test"
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNs,
+				},
+			}
+
+			_, err := fakeClient.CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+			assert.Nil(err)
+
+			if tc.bootstrapSecret != nil {
+				_, err := fakeClient.CoreV1().Secrets(testNs).Create(context.Background(), tc.bootstrapSecret, metav1.CreateOptions{})
+				assert.Nil(err)
+			}
+
+			actual := bootstrapOSMGateway(fakeClient, fakeCertManager, testNs)
+			assert.Equal(tc.expectError, actual != nil)
+		})
+	}
+}
+
+func TestIsValidBootstrapData(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name         string
+		boostrapYAML string
+		expected     bool
+	}{
+		{
+			name: "valid bootstrap config",
+			boostrapYAML: `admin:
+  access_log:
+  - name: envoy.access_loggers.stream
+    typed_config:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 15000
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: osm-controller
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+node:
+  id: ab394bf2-3a1e-4f59-a182-688a732f180f.gateway.osm.osm-system
+static_resources:
+  clusters:
+  - connect_timeout: 0.250s
+    load_assignment:
+      cluster_name: osm-controller
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: osm-controller.osm-system.svc.cluster.local
+                port_value: 15128
+    name: osm-controller
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          alpn_protocols:
+          - h2
+          tls_certificates:
+          - certificate_chain:
+              inline_bytes: --redacted--
+            private_key:
+              inline_bytes: --redacted--
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+            tls_minimum_protocol_version: TLSv1_2
+          validation_context:
+            trusted_ca:
+              inline_bytes: --redacted--
+    type: LOGICAL_DNS
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http2_protocol_options: {}
+`,
+			expected: true,
+		},
+		{
+			name: "invalid bootstrap config, missing static_resources",
+			boostrapYAML: `admin:
+  access_log:
+  - name: envoy.access_loggers.stream
+    typed_config:
+      '@type': type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 15000
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: osm-controller
+    set_node_on_first_message_only: true
+    transport_api_version: V3
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+node:
+  id: ab394bf2-3a1e-4f59-a182-688a732f180f.gateway.osm.osm-system
+`,
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isValidBootstrapData([]byte(tc.boostrapYAML))
+			assert.Equal(tc.expected, actual)
+		})
+	}
+}

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -309,6 +309,11 @@ func isCNforProxy(proxy *envoy.Proxy, cn certificate.CommonName) bool {
 // recordPodMetadata records pod metadata and verifies the certificate issued for this pod
 // is for the same service account as seen on the pod's service account
 func (s *Server) recordPodMetadata(p *envoy.Proxy) error {
+	if p.Kind() == envoy.KindGateway {
+		log.Debug().Msgf("Proxy with serial no %s is a gateway, skipping recording pod metadata", p.GetCertificateSerialNumber())
+		return nil
+	}
+
 	pod, err := envoy.GetPodFromCertificate(p.GetCertificateCommonName(), s.kubecontroller)
 	if err != nil {
 		log.Warn().Msgf("Could not find pod for connecting proxy %s. No metadata was recorded.", p.GetCertificateSerialNumber())

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -15,6 +15,11 @@ import (
 
 // NewResponse creates a new Cluster Discovery Response.
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, proxyRegistry *registry.ProxyRegistry) ([]types.Resource, error) {
+	if proxy.Kind() == envoy.KindGateway {
+		// TODO: Configure gateway
+		return nil, nil
+	}
+
 	svcList, err := proxyRegistry.ListProxyServices(proxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy with SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -18,6 +18,11 @@ import (
 // 2. Outbound listener to handle outgoing traffic
 // 3. Prometheus listener for metrics
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, proxyRegistry *registry.ProxyRegistry) ([]types.Resource, error) {
+	if proxy.Kind() == envoy.KindGateway {
+		// TODO: Configure gateway
+		return nil, nil
+	}
+
 	svcList, err := proxyRegistry.ListProxyServices(proxy)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error looking up MeshService for Envoy certificate SerialNumber=%s on Pod with UID=%s", proxy.GetCertificateSerialNumber(), proxy.GetPodUID())


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds support to bootstrap osm-gateway.
This change allows osm-gateway to connect to
osm-controller over XDS gRPC while returning nil
LDS and CDS configs so that further processing
of XDS requests are not exercised.

Part of #3501

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Ingress                    | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
