### PR TITLE
tests(pkg/certificate/providers/tresor): add missing tests for ca.go

### DIFF
--- a/pkg/certificate/providers/tresor/ca_test.go
+++ b/pkg/certificate/providers/tresor/ca_test.go
@@ -1,7 +1,11 @@
 package tresor
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -24,6 +28,69 @@ var _ = Describe("Test creation of a new CA", func() {
 			Expect(x509Cert.NotAfter.Sub(x509Cert.NotBefore)).To(Equal(2 * time.Second))
 			Expect(x509Cert.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
 			Expect(x509Cert.IsCA).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("Test creation from pem", func() {
+	Context("valid pem cert and pem key", func() {
+		ca := certificate.CommonName("Test CA")
+		rootCertCountry := "US"
+		rootCertLocality := "CA"
+		rootCertOrganization := "Root Cert Organization"
+
+		notBefore := time.Now()
+		notAfter := notBefore.Add(1 * time.Hour)
+		serialNumber := big.NewInt(1)
+
+		template := &x509.Certificate{
+			SerialNumber: serialNumber,
+			Subject: pkix.Name{
+				CommonName:   ca.String(),
+				Country:      []string{rootCertCountry},
+				Locality:     []string{rootCertLocality},
+				Organization: []string{rootCertOrganization},
+			},
+			NotBefore:             notBefore,
+			NotAfter:              notAfter,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+
+		rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		Expect(err).ToNot(HaveOccurred())
+
+		derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &rsaKey.PublicKey, rsaKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		pemCert, err := certificate.EncodeCertDERtoPEM(derBytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		pemKey, err := certificate.EncodeKeyDERtoPEM(rsaKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		expiration := time.Now().Add(1 * time.Hour)
+
+		c, err := NewCertificateFromPEM(pemCert, pemKey, expiration)
+		It("should create a new CA", func() {
+			Expect(err).ToNot(HaveOccurred())
+
+			x509Cert, err := certificate.DecodePEMCertificate(c.GetCertificateChain())
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(x509Cert.NotAfter.Sub(x509Cert.NotBefore)).To(Equal(1 * time.Hour))
+			Expect(x509Cert.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
+			Expect(x509Cert.IsCA).To(BeTrue())
+		})
+	})
+
+	Context("invalid pem cert and pem key", func() {
+		expiration := time.Now().Add(1 * time.Hour)
+
+		_, err := NewCertificateFromPEM([]byte(""), []byte(""), expiration)
+		It("should returns en error", func() {
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: shuheiktgw <shuheiktgw@users.noreply.github.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Closes https://github.com/openservicemesh/osm/issues/3445

Added missing tests for pkg/certificate/providers/tresor/ca.go - NewCertificateFromPEM(). Thank you for your review!

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [x] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

No