### PR TITLE
feat(pkg/catalog):  Gateway gets all in-cluster services for ListAllowedOutbound

### DIFF
--- a/pkg/catalog/gateway.go
+++ b/pkg/catalog/gateway.go
@@ -1,0 +1,14 @@
+package catalog
+
+import (
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/identity"
+)
+
+// isOSMGateway checks if the ServiceIdentity belongs to the MultiClusterGateway.
+// Only used if MultiClusterMode is enabled.
+func (mc *MeshCatalog) isOSMGateway(svcIdentity identity.ServiceIdentity) bool {
+	sa := svcIdentity.ToK8sServiceAccount()
+	return mc.configurator.GetFeatureFlags().EnableMulticlusterMode &&
+		envoy.ProxyKind(sa.Name) == envoy.KindGateway && sa.Namespace == mc.configurator.GetOSMNamespace()
+}

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -38,6 +39,8 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 	mockKubeController := k8s.NewMockController(mockCtrl)
 	mockIngressMonitor := ingress.NewMockMonitor(mockCtrl)
 	mockPolicyController := policy.NewMockController(mockCtrl)
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetOSMNamespace().Return("osm-system").AnyTimes()
 
 	endpointProviders := []endpoint.Provider{
 		kube.NewFakeProvider(),

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -104,6 +104,16 @@ func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespa
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
 func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(serviceIdentity identity.ServiceIdentity) []service.MeshService {
 	ident := serviceIdentity.ToK8sServiceAccount()
+	if mc.isOSMGateway(serviceIdentity) {
+		var services []service.MeshService
+		for _, svc := range mc.listMeshServices() {
+			// The gateway can only forward to local services.
+			if svc.Local() {
+				services = append(services, svc)
+			}
+		}
+		return services
+	}
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
 		return mc.listMeshServices()
 	}

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -334,7 +335,7 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
 			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
-
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 			for _, ms := range tc.apexMeshServices {
 				apexK8sService := tests.NewServiceFixture(ms.Name, ms.Namespace, map[string]string{})
 				mockKubeController.EXPECT().GetService(ms).Return(apexK8sService).AnyTimes()
@@ -733,6 +734,12 @@ func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
 		{
 			name:           "permissive mode enabled",
 			svcIdentity:    tests.BookstoreServiceIdentity,
+			expectedList:   []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService, tests.BookbuyerService},
+			permissiveMode: true,
+		},
+		{
+			name:           "gateway",
+			svcIdentity:    "gateway.osm-system.cluster.local",
 			expectedList:   []service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service, tests.BookstoreApexService, tests.BookbuyerService},
 			permissiveMode: true,
 		},
@@ -1314,6 +1321,8 @@ func TestListMeshServicesForIdentity(t *testing.T) {
 	mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockController := k8s.NewMockController(mockCtrl)
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetOSMNamespace().Return("osm-system").AnyTimes()
 
 	mc := MeshCatalog{
 		meshSpec:       mockMeshSpec,


### PR DESCRIPTION
Prep multi cluster gateway, by adding logic to the MeshCatalog
for the gateway

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

part of #3444


Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [x ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No

1. Is this a breaking change?
No
