### PR TITLE
test(pkg/identity): add test to GetCertificateCommonName()

### DIFF
--- a/pkg/identity/types_test.go
+++ b/pkg/identity/types_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -36,12 +38,9 @@ var _ = Describe("Test pkg/service functions", func() {
 			Expect(actual).To(Equal(expected))
 		})
 
-		It("implements K8sServiceAccount{}.ToServiceIdentity() correctly", func() {
-			actual := K8sServiceAccount{
-				Namespace: "ns",
-				Name:      "name",
-			}.ToServiceIdentity()
-			expected := ServiceIdentity("name.ns.cluster.local")
+		It("implements ServiceIdentity{}.GetCertificateCommonName() correctly", func() {
+			actual := ServiceIdentity("name.ns.cluster.local").GetCertificateCommonName()
+			expected := certificate.CommonName("name.ns.cluster.local")
 			Expect(actual).To(Equal(expected))
 		})
 
@@ -51,6 +50,15 @@ var _ = Describe("Test pkg/service functions", func() {
 				Namespace: "ns",
 				Name:      "name",
 			}
+			Expect(actual).To(Equal(expected))
+		})
+
+		It("implements K8sServiceAccount{}.ToServiceIdentity() correctly", func() {
+			actual := K8sServiceAccount{
+				Namespace: "ns",
+				Name:      "name",
+			}.ToServiceIdentity()
+			expected := ServiceIdentity("name.ns.cluster.local")
 			Expect(actual).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
Adds unit test for `GetCertificateCommonName()` and changes the order of tests to parallel functions
and resolves #3448.

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [x ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? no
