### PR TITLE
test(*): Adds test to certificate_manager.go

### DIFF
--- a/pkg/certificate/encode.go
+++ b/pkg/certificate/encode.go
@@ -48,7 +48,7 @@ func DecodePEMCertificate(certPEM []byte) (*x509.Certificate, error) {
 		var block *pemEnc.Block
 		block, certPEM = pemEnc.Decode(certPEM)
 		if block == nil {
-			return nil, errNoCertificateInPEM
+			return nil, ErrNoCertificateInPEM
 		}
 		if block.Type != TypeCertificate || len(block.Headers) != 0 {
 			continue
@@ -62,7 +62,7 @@ func DecodePEMCertificate(certPEM []byte) (*x509.Certificate, error) {
 		return cert, nil
 	}
 
-	return nil, errNoCertificateInPEM
+	return nil, ErrNoCertificateInPEM
 }
 
 // DecodePEMPrivateKey converts a certificate from PEM to x509 encoding
@@ -84,7 +84,7 @@ func DecodePEMPrivateKey(keyPEM []byte) (*rsa.PrivateKey, error) {
 		return caKeyInterface.(*rsa.PrivateKey), nil
 	}
 
-	return nil, errNoCertificateInPEM
+	return nil, ErrNoCertificateInPEM
 }
 
 // EncodeCertReqDERtoPEM encodes the certificate request provided in DER format

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -7,5 +7,7 @@ import (
 var errEncodeKey = errors.New("encode key")
 var errEncodeCert = errors.New("encode cert")
 var errMarshalPrivateKey = errors.New("marshal private key")
-var errNoCertificateInPEM = errors.New("no certificate in PEM")
 var errNoPrivateKeyInPEM = errors.New("no private Key in PEM")
+
+// ErrNoCertificateInPEM is the errror for no certificate in PEM
+var ErrNoCertificateInPEM = errors.New("no certificate in PEM")

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -52,7 +52,7 @@ func (cm *CertManager) GetCertificate(cn certificate.CommonName) (certificate.Ce
 	if cert := cm.getFromCache(cn); cert != nil {
 		return cert, nil
 	}
-	return nil, fmt.Errorf("failed to find certificate with CN=%s", cn)
+	return nil, errCertNotFound
 }
 
 func (cm *CertManager) deleteFromCache(cn certificate.CommonName) {

--- a/pkg/certificate/providers/certmanager/errors.go
+++ b/pkg/certificate/providers/certmanager/errors.go
@@ -1,0 +1,7 @@
+package certmanager
+
+import (
+	"errors"
+)
+
+var errCertNotFound = errors.New("failed to find cert")


### PR DESCRIPTION
Adds unit tests to functions in `certificate_manager.go`
and resolves #3435.

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [x ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? no
