### PR TITLE
ingress: support ignoring an ingress resource

### DIFF
--- a/cmd/cli/namespace_ignore.go
+++ b/cmd/cli/namespace_ignore.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const namespaceIgnoreDescription = `
@@ -20,8 +22,6 @@ belonging to the given namespace or set of namespaces will be prevented.
 The command will not remove previously injected sidecars on pods belonging
 to the given namespaces.
 `
-
-const ignoreLabel = "openservicemesh.io/ignore"
 
 type namespaceIgnoreCmd struct {
 	out        io.Writer
@@ -77,7 +77,7 @@ func (cmd *namespaceIgnoreCmd) run() error {
 			"%s": "true"
 		}
 	}
-}`, ignoreLabel)
+}`, constants.IgnoreLabel)
 
 		_, err := cmd.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 		if err != nil {

--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -84,7 +84,7 @@ func (l *namespaceListCmd) run() error {
 		if !ok {
 			sidecarInjectionEnabled = "-" // not set
 		}
-		if _, ignored := ns.Labels[ignoreLabel]; ignored {
+		if _, ignored := ns.Labels[constants.IgnoreLabel]; ignored {
 			sidecarInjectionEnabled = "disabled (ignored)"
 		}
 

--- a/cmd/cli/namespace_list_test.go
+++ b/cmd/cli/namespace_list_test.go
@@ -68,7 +68,7 @@ func TestNamespaceList(t *testing.T) {
 						Name: "ns",
 						Labels: map[string]string{
 							constants.OSMKubeResourceMonitorAnnotation: "my-mesh",
-							ignoreLabel: "any value",
+							constants.IgnoreLabel:                      "any value",
 						},
 						Annotations: map[string]string{
 							constants.SidecarInjectionAnnotation: "enabled",

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -703,7 +703,7 @@ var _ = Describe("Running the namespace ignore command", func() {
 		It("should correctly add an ignore label to the namespace", func() {
 			ns, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns.Labels[ignoreLabel]).To(Equal("true"))
+			Expect(ns.Labels[constants.IgnoreLabel]).To(Equal("true"))
 		})
 	})
 
@@ -738,11 +738,11 @@ var _ = Describe("Running the namespace ignore command", func() {
 		It("should correctly add an ignore label to the namespaces", func() {
 			ns, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns.Labels[ignoreLabel]).To(Equal("true"))
+			Expect(ns.Labels[constants.IgnoreLabel]).To(Equal("true"))
 
 			ns2, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace2, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns2.Labels[ignoreLabel]).To(Equal("true"))
+			Expect(ns2.Labels[constants.IgnoreLabel]).To(Equal("true"))
 		})
 	})
 })

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -149,13 +149,19 @@ const (
 	OSMMeshConfig = "osm-mesh-config"
 )
 
-// Annotations used by the controller
+// Annotations used by the control plane
 const (
 	// SidecarInjectionAnnotation is the annotation used for sidecar injection
 	SidecarInjectionAnnotation = "openservicemesh.io/sidecar-injection"
 
 	// MetricsAnnotation is the annotation used for enabling/disabling metrics
 	MetricsAnnotation = "openservicemesh.io/metrics"
+)
+
+// Labels used by the control plane
+const (
+	// IgnoreLabel is the label used to ignore a resource
+	IgnoreLabel = "openservicemesh.io/ignore"
 )
 
 // Annotations used for Metrics

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -15,8 +15,8 @@ var (
 	log = logger.New("kube-ingress")
 )
 
-// Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
-type Client struct {
+// client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
+type client struct {
 	informerV1      cache.SharedIndexInformer
 	cacheV1         cache.Store
 	informerV1beta1 cache.SharedIndexInformer


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
As a part of #3582, specific ingress resources
need to be ignored. This change adds support
for this using the existing `openservicemesh.io/ignore`
label.

Also addresses an unnecessary type export and makes
unusued variable usage explicit.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
