### PR TITLE
Deprecate support for k8s 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Read more about [OSM's high level goals, design, and architecture](DESIGN.md).
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.18.0 or greater
+- Kubernetes cluster running Kubernetes v1.19.0 or greater
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -20,5 +20,5 @@ version: 0.9.0
 # incremented each time you make changes to the application.
 appVersion: v0.9.0
 
-# This specifies a particular range of k8s versions that the application is compatible with. 
-kubeVersion: ">= 1.18.0"
+# This specifies the minimum Kubernetes version OSM is compatible with.
+kubeVersion: ">= 1.19.0"

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -1,12 +1,12 @@
 # Open Service Mesh Helm Chart
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
 
 A Helm chart to install the [OSM](https://github.com/openservicemesh/osm) control plane on Kubernetes.
 
 ## Prerequisites
 
-- Kubernetes v1.15+
+- Kubernetes >= v1.19.0
 
 ## Get Repo Info
 

--- a/charts/osm/README.md.gotmpl
+++ b/charts/osm/README.md.gotmpl
@@ -1,12 +1,12 @@
 # Open Service Mesh Helm Chart
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.1](https://img.shields.io/badge/AppVersion-v0.6.1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.9.0](https://img.shields.io/badge/AppVersion-v0.9.0-informational?style=flat-square)
 
 A Helm chart to install the [OSM](https://github.com/openservicemesh/osm) control plane on Kubernetes.
 
 ## Prerequisites
 
-- Kubernetes v1.15+
+- Kubernetes >= v1.19.0
 
 ## Get Repo Info
 

--- a/docs/demos/first_steps.md
+++ b/docs/demos/first_steps.md
@@ -22,7 +22,7 @@ This document will walk you through the steps to:
 
 ## Prerequisites
 This demo of OSM v0.8.0 requires:
-  - a cluster running Kubernetes v1.18.0 or greater
+  - a cluster running Kubernetes v1.19.0 or greater
   - a workstation capable of executing [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) scripts
   - [The Kubernetes command-line tool](https://kubernetes.io/docs/tasks/tools/#kubectl) - `kubectl`
 

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -21,9 +21,6 @@ var _ = OSMDescribe("Test HTTP traffic for different k8s versions",
 		Context("Version v1.19.7", func() {
 			testK8sVersion("v1.19.7")
 		})
-		Context("Version v1.18.0", func() {
-			testK8sVersion("v1.18.0")
-		})
 	})
 
 func testK8sVersion(version string) {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
<!--

Deprecates support for k8s 1.18 which is no longer
supported upstream.

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Documentation              | [X] |
| Install                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
