### PR TITLE
Backport inbound port exclusion and ingress ignore features

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -97,6 +97,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` | Container image registry |
 | OpenServiceMesh.image.tag | string | `"v0.9.0"` | Container image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
+| OpenServiceMesh.inboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
 | OpenServiceMesh.injector.podLabels | object | `{}` |  |
 | OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -108,6 +108,13 @@ spec:
                         type: integer
                         minimum: 1
                         maximum: 65535
+                    inboundPortExclusionList:
+                      description: Global list of ports to exclude from inbound traffic interception by the sidecar proxy.
+                      type: array
+                      items:
+                        type: integer
+                        minimum: 1
+                        maximum: 65535
                     useHTTPSIngress:
                       description: Enable HTTPS ingress on the mesh
                       type: boolean

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -15,6 +15,7 @@ spec:
     useHTTPSIngress: {{.Values.OpenServiceMesh.useHTTPSIngress}}
     enablePermissiveTrafficPolicyMode: {{.Values.OpenServiceMesh.enablePermissiveTrafficPolicy}}
     outboundPortExclusionList: {{.Values.OpenServiceMesh.outboundPortExclusionList}}
+    inboundPortExclusionList: {{.Values.OpenServiceMesh.inboundPortExclusionList}}
     outboundIPRangeExclusionList: {{.Values.OpenServiceMesh.outboundIPRangeExclusionList}}
   observability:
     enableDebugServer: {{.Values.OpenServiceMesh.enableDebugServer}}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -700,6 +700,23 @@
                         ]
                     ]
                 },
+                "inboundPortExclusionList": {
+                    "$id": "#/properties/OpenServiceMesh/properties/inboundPortExclusionList",
+                    "type": "array",
+                    "title": "The inboundPortExclusionList schema",
+                    "description": "Inbound port exluclusion list for sidecar traffic interception",
+                    "items": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                    },
+                    "examples": [
+                        [
+                            6379,
+                            3315
+                        ]
+                    ]
+                },
                 "grafana": {
                     "$id": "#/properties/OpenServiceMesh/properties/grafana",
                     "type": "object",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -191,6 +191,10 @@ OpenServiceMesh:
   # If specified, must be a list of positive integers.
   outboundPortExclusionList: []
 
+  # -- Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy.
+  # If specified, must be a list of positive integers.
+  inboundPortExclusionList: []
+
   #
   # -- OSM's sidecar injector parameters
   injector:

--- a/cmd/cli/namespace_ignore.go
+++ b/cmd/cli/namespace_ignore.go
@@ -11,6 +11,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const namespaceIgnoreDescription = `
@@ -20,8 +22,6 @@ belonging to the given namespace or set of namespaces will be prevented.
 The command will not remove previously injected sidecars on pods belonging
 to the given namespaces.
 `
-
-const ignoreLabel = "openservicemesh.io/ignore"
 
 type namespaceIgnoreCmd struct {
 	out        io.Writer
@@ -77,7 +77,7 @@ func (cmd *namespaceIgnoreCmd) run() error {
 			"%s": "true"
 		}
 	}
-}`, ignoreLabel)
+}`, constants.IgnoreLabel)
 
 		_, err := cmd.clientSet.CoreV1().Namespaces().Patch(ctx, ns, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}, "")
 		if err != nil {

--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -84,7 +84,7 @@ func (l *namespaceListCmd) run() error {
 		if !ok {
 			sidecarInjectionEnabled = "-" // not set
 		}
-		if _, ignored := ns.Labels[ignoreLabel]; ignored {
+		if _, ignored := ns.Labels[constants.IgnoreLabel]; ignored {
 			sidecarInjectionEnabled = "disabled (ignored)"
 		}
 

--- a/cmd/cli/namespace_list_test.go
+++ b/cmd/cli/namespace_list_test.go
@@ -68,7 +68,7 @@ func TestNamespaceList(t *testing.T) {
 						Name: "ns",
 						Labels: map[string]string{
 							constants.OSMKubeResourceMonitorAnnotation: "my-mesh",
-							ignoreLabel: "any value",
+							constants.IgnoreLabel:                      "any value",
 						},
 						Annotations: map[string]string{
 							constants.SidecarInjectionAnnotation: "enabled",

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -703,7 +703,7 @@ var _ = Describe("Running the namespace ignore command", func() {
 		It("should correctly add an ignore label to the namespace", func() {
 			ns, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns.Labels[ignoreLabel]).To(Equal("true"))
+			Expect(ns.Labels[constants.IgnoreLabel]).To(Equal("true"))
 		})
 	})
 
@@ -738,11 +738,11 @@ var _ = Describe("Running the namespace ignore command", func() {
 		It("should correctly add an ignore label to the namespaces", func() {
 			ns, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns.Labels[ignoreLabel]).To(Equal("true"))
+			Expect(ns.Labels[constants.IgnoreLabel]).To(Equal("true"))
 
 			ns2, err := fakeClientSet.CoreV1().Namespaces().Get(context.TODO(), testNamespace2, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(ns2.Labels[ignoreLabel]).To(Equal("true"))
+			Expect(ns2.Labels[constants.IgnoreLabel]).To(Equal("true"))
 		})
 	})
 })

--- a/docs/example/manifests/meshconfig/mesh-config.yaml
+++ b/docs/example/manifests/meshconfig/mesh-config.yaml
@@ -18,6 +18,7 @@ spec:
     enableDebugServer: true
     prometheusScraping: true
     outboundPortExclusionList: []
+    inboundPortExclusionList: []
     outboundIPRangeExclusionList: []
     tracing:
       enable: false

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -72,6 +72,9 @@ type TrafficSpec struct {
 	// OutboundPortExclusionList defines a global list of ports to exclude from outbound traffic interception by the sidecar proxy.
 	OutboundPortExclusionList []int `json:"outboundPortExclusionList,omitempty"`
 
+	// InboundPortExclusionList defines a global list of ports to exclude from inbound traffic interception by the sidecar proxy.
+	InboundPortExclusionList []int `json:"inboundPortExclusionList,omitempty"`
+
 	// UseHTTPSIngress defines a boolean indicating if HTTPS Ingress is enabled globally in the mesh.
 	UseHTTPSIngress bool `json:"useHTTPSIngress,omitempty"`
 

--- a/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -196,6 +196,11 @@ func (in *TrafficSpec) DeepCopyInto(out *TrafficSpec) {
 		*out = make([]int, len(*in))
 		copy(*out, *in)
 	}
+	if in.InboundPortExclusionList != nil {
+		in, out := &in.InboundPortExclusionList, &out.InboundPortExclusionList
+		*out = make([]int, len(*in))
+		copy(*out, *in)
+	}
 	out.InboundExternalAuthorization = in.InboundExternalAuthorization
 	return
 }

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -156,6 +156,11 @@ func (c *Client) GetOutboundPortExclusionList() []int {
 	return c.getMeshConfig().Spec.Traffic.OutboundPortExclusionList
 }
 
+// GetInboundPortExclusionList returns the list of ports (positive integers) to exclude from inbound sidecar interception
+func (c *Client) GetInboundPortExclusionList() []int {
+	return c.getMeshConfig().Spec.Traffic.InboundPortExclusionList
+}
+
 // IsPrivilegedInitContainer returns whether init containers should be privileged
 func (c *Client) IsPrivilegedInitContainer() bool {
 	return c.getMeshConfig().Spec.Sidecar.EnablePrivilegedInitContainer

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -328,6 +328,21 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 		},
 		{
+			name:                  "GetIboundPortExclusionList",
+			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Nil(cfg.GetInboundPortExclusionList())
+			},
+			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
+				Traffic: v1alpha1.TrafficSpec{
+					InboundPortExclusionList: []int{7070, 6080},
+				},
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal([]int{7070, 6080}, cfg.GetInboundPortExclusionList())
+			},
+		},
+		{
 			name: "IsPrivilegedInitContainer",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -92,6 +92,20 @@ func (mr *MockConfiguratorMockRecorder) GetInboundExternalAuthConfig() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInboundExternalAuthConfig", reflect.TypeOf((*MockConfigurator)(nil).GetInboundExternalAuthConfig))
 }
 
+// GetInboundPortExclusionList mocks base method
+func (m *MockConfigurator) GetInboundPortExclusionList() []int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInboundPortExclusionList")
+	ret0, _ := ret[0].([]int)
+	return ret0
+}
+
+// GetInboundPortExclusionList indicates an expected call of GetInboundPortExclusionList
+func (mr *MockConfiguratorMockRecorder) GetInboundPortExclusionList() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInboundPortExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetInboundPortExclusionList))
+}
+
 // GetInitContainerImage mocks base method
 func (m *MockConfigurator) GetInitContainerImage() string {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -81,6 +81,9 @@ type Configurator interface {
 	// GetOutboundPortExclusionList returns the list of ports to exclude from outbound sidecar interception
 	GetOutboundPortExclusionList() []int
 
+	// GetInboundPortExclusionList returns the list of ports to exclude from inbound sidecar interception
+	GetInboundPortExclusionList() []int
+
 	// IsPrivilegedInitContainer determines whether init containers should be privileged
 	IsPrivilegedInitContainer() bool
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -149,13 +149,19 @@ const (
 	OSMMeshConfig = "osm-mesh-config"
 )
 
-// Annotations used by the controller
+// Annotations used by the control plane
 const (
 	// SidecarInjectionAnnotation is the annotation used for sidecar injection
 	SidecarInjectionAnnotation = "openservicemesh.io/sidecar-injection"
 
 	// MetricsAnnotation is the annotation used for enabling/disabling metrics
 	MetricsAnnotation = "openservicemesh.io/metrics"
+)
+
+// Labels used by the control plane
+const (
+	// IgnoreLabel is the label used to ignore a resource
+	IgnoreLabel = "openservicemesh.io/ignore"
 )
 
 // Annotations used for Metrics

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -15,8 +15,8 @@ var (
 	log = logger.New("kube-ingress")
 )
 
-// Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
-type Client struct {
+// client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
+type client struct {
 	informerV1      cache.SharedIndexInformer
 	cacheV1         cache.Store
 	informerV1beta1 cache.SharedIndexInformer

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -9,8 +9,8 @@ import (
 )
 
 func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string, outboundPortExclusionList []int,
-	enablePrivilegedInitContainer bool) corev1.Container {
-	iptablesInitCommandsList := generateIptablesCommands(outboundIPRangeExclusionList, outboundPortExclusionList)
+	inboundPortExclusionList []int, enablePrivilegedInitContainer bool) corev1.Container {
+	iptablesInitCommandsList := generateIptablesCommands(outboundIPRangeExclusionList, outboundPortExclusionList, inboundPortExclusionList)
 	iptablesInitCommand := strings.Join(iptablesInitCommandsList, " && ")
 
 	return corev1.Container{

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -23,12 +23,10 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
 	Context("test getInitContainerSpec()", func() {
-		It("Creates init container without outbound ip range exclusion list", func() {
+		It("Creates init container without ip range exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
-			var outboundIPRangeExclusionList []string = nil
-			var outboundPortExclusionList []int = nil
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, outboundIPRangeExclusionList, outboundPortExclusionList, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, privileged)
 
 			expected := corev1.Container{
 				Name:    "-container-name-",
@@ -59,9 +57,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		It("Creates init container with outbound exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
 			outboundIPRangeExclusionList := []string{"1.1.1.1/32", "10.0.0.10/24"}
-			var outboundPortExclusionList []int = nil
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, outboundIPRangeExclusionList, outboundPortExclusionList, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, outboundIPRangeExclusionList, nil, nil, privileged)
 
 			expected := corev1.Container{
 				Name:    "-container-name-",
@@ -91,10 +88,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 		It("Creates init container with privileged true", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
-			var outboundIPRangeExclusionList []string = nil
-			var outboundPortExclusionList []int = nil
 			privileged := privilegedTrue
-			actual := getInitContainerSpec(containerName, mockConfigurator, outboundIPRangeExclusionList, outboundPortExclusionList, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, privileged)
 
 			expected := corev1.Container{
 				Name:    "-container-name-",
@@ -124,10 +119,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 		It("Creates init container without outbound port exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
-			var outboundIPRangeExclusionList []string = nil
-			var outboundPortExclusionList []int = nil
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, outboundIPRangeExclusionList, outboundPortExclusionList, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, privileged)
 
 			expected := corev1.Container{
 				Name:    "-container-name-",
@@ -157,10 +150,9 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 		It("init container with outbound port exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
-			var outboundIPRangeExclusionList []string = nil
 			outboundPortExclusionList := []int{6060, 7070}
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, outboundIPRangeExclusionList, outboundPortExclusionList, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, outboundPortExclusionList, nil, privileged)
 
 			expected := corev1.Container{
 				Name:    "-container-name-",

--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -69,7 +69,7 @@ var iptablesInboundStaticRules = []string{
 }
 
 // generateIptablesCommands generates a list of iptables commands to set up sidecar interception and redirection
-func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundPortExclusionList []int) []string {
+func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundPortExclusionList []int, inboundPortExclusionList []int) []string {
 	var cmd []string
 
 	// 1. Create redirection chains
@@ -89,7 +89,7 @@ func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundPor
 		cmd = append(cmd, rule)
 	}
 
-	// 5. Create dynamic outbound ports exclusion rule
+	// 5. Create dynamic outbound ports exclusion rules
 	if len(outboundPortExclusionList) > 0 {
 		var portExclusionListStr []string
 		for _, port := range outboundPortExclusionList {
@@ -97,6 +97,17 @@ func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundPor
 		}
 		outboundPortsToExclude := strings.Join(portExclusionListStr, ",")
 		rule := fmt.Sprintf("iptables -t nat -I PROXY_OUTPUT -p tcp --match multiport --dports %s -j RETURN", outboundPortsToExclude)
+		cmd = append(cmd, rule)
+	}
+
+	// 6. Create dynamic inbound ports exclusion rules
+	if len(inboundPortExclusionList) > 0 {
+		var portExclusionListStr []string
+		for _, port := range inboundPortExclusionList {
+			portExclusionListStr = append(portExclusionListStr, strconv.Itoa(port))
+		}
+		inboundPortsToExclude := strings.Join(portExclusionListStr, ",")
+		rule := fmt.Sprintf("iptables -t nat -I PROXY_INBOUND -p tcp --match multiport --dports %s -j RETURN", inboundPortsToExclude)
 		cmd = append(cmd, rule)
 	}
 

--- a/pkg/injector/iptables_test.go
+++ b/pkg/injector/iptables_test.go
@@ -1,0 +1,43 @@
+package injector
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestGenerateIptablesCommands(t *testing.T) {
+	assert := tassert.New(t)
+
+	outboundIPRangeExclusion := []string{"1.1.1.1/32", "2.2.2.2/32"}
+	outboundPortExclusion := []int{10, 20}
+	inboundPortExclusion := []int{30, 40}
+
+	actual := generateIptablesCommands(outboundIPRangeExclusion, outboundPortExclusion, inboundPortExclusion)
+
+	expected := []string{
+		"iptables -t nat -N PROXY_INBOUND",
+		"iptables -t nat -N PROXY_IN_REDIRECT",
+		"iptables -t nat -N PROXY_OUTPUT",
+		"iptables -t nat -N PROXY_REDIRECT",
+		"iptables -t nat -A PROXY_REDIRECT -p tcp -j REDIRECT --to-port 15001",
+		"iptables -t nat -A PROXY_REDIRECT -p tcp --dport 15000 -j ACCEPT",
+		"iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT",
+		"iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner 1500 -j RETURN",
+		"iptables -t nat -A PROXY_OUTPUT -d 127.0.0.1/32 -j RETURN",
+		"iptables -t nat -A PROXY_OUTPUT -j PROXY_REDIRECT",
+		"iptables -t nat -A PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003",
+		"iptables -t nat -A PREROUTING -p tcp -j PROXY_INBOUND",
+		"iptables -t nat -A PROXY_INBOUND -p tcp --dport 15010 -j RETURN",
+		"iptables -t nat -A PROXY_INBOUND -p tcp --dport 15901 -j RETURN",
+		"iptables -t nat -A PROXY_INBOUND -p tcp --dport 15902 -j RETURN",
+		"iptables -t nat -A PROXY_INBOUND -p tcp --dport 15903 -j RETURN",
+		"iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT",
+		"iptables -t nat -I PROXY_OUTPUT -d 1.1.1.1/32 -j RETURN",
+		"iptables -t nat -I PROXY_OUTPUT -d 2.2.2.2/32 -j RETURN",
+		"iptables -t nat -I PROXY_OUTPUT -p tcp --match multiport --dports 10,20 -j RETURN",
+		"iptables -t nat -I PROXY_INBOUND -p tcp --match multiport --dports 30,40 -j RETURN",
+	}
+
+	assert.ElementsMatch(expected, actual)
+}

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -63,6 +63,7 @@ var _ = Describe("Test all patch operations", func() {
 			mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
 			mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
 			mockConfigurator.EXPECT().GetOutboundPortExclusionList().Return(nil).Times(1)
+			mockConfigurator.EXPECT().GetInboundPortExclusionList().Return(nil).Times(1)
 			mockConfigurator.EXPECT().GetProxyResources().Return(corev1.ResourceRequirements{}).Times(1)
 
 			req := &admissionv1.AdmissionRequest{Namespace: namespace}

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -55,8 +55,11 @@ const (
 	// injectorServiceName is the name of the OSM sidecar injector service
 	injectorServiceName = "osm-injector"
 
-	// outboundPortExclusionListAnnotation is the annotation used for outbound port exclusion
+	// outboundPortExclusionListAnnotation is the annotation used for outbound port exclusions
 	outboundPortExclusionListAnnotation = "openservicemesh.io/outbound-port-exclusion-list"
+
+	// inboundPortExclusionListAnnotation is the annotation used for inbound port exclusions
+	inboundPortExclusionListAnnotation = "openservicemesh.io/inbound-port-exclusion-list"
 )
 
 // NewMutatingWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
@@ -319,18 +322,21 @@ func (wh *mutatingWebhook) mustInject(pod *corev1.Pod, namespace string) (bool, 
 	return false, nil
 }
 
-// getPodOutboundPortExclusionList gets a list of ports to exclude from outbound sidecar interception.
+// getPortExclusionListForPod gets a list of ports to exclude from sidecar traffic interception for the given
+// pod and annotation kind.
 //
-// Outbound Ports are excluded from sidecar interception when:
-// 1. The pod is explicitly annotated with a single or comma separate list of ports
+// Ports are excluded from sidecar interception when the pod is explicitly annotated with a single or
+// comma separate list of ports.
+//
+// The kind of exclusion (inbound vs outbound) is determined by the specified annotation.
 //
 // The function returns an error when it is unable to determine whether ports need to be excluded from outbound sidecar interception.
-func (wh *mutatingWebhook) getPodOutboundPortExclusionList(pod *corev1.Pod, namespace string) ([]int, error) {
+func (wh *mutatingWebhook) getPortExclusionListForPod(pod *corev1.Pod, namespace string, annotation string) ([]int, error) {
 	var ports []int
 	// Check if the pod is annotated for outbound port exclusion
-	ports, err := isAnnotatedForOutboundPortExclusion(pod.Annotations, pod.Kind, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+	ports, err := isAnnotatedForPortExclusion(pod.Annotations, annotation, pod.Kind, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
 	if err != nil {
-		log.Error().Err(err).Msg("Error determining outbound ports for exclusion on pod")
+		log.Error().Err(err).Msgf("Error determining port exclusions for annotation %s on pod %s/%s", annotation, namespace, pod.Name)
 		return ports, err
 	}
 
@@ -354,19 +360,19 @@ func isAnnotatedForInjection(annotations map[string]string, objectKind string, o
 	return
 }
 
-func isAnnotatedForOutboundPortExclusion(annotations map[string]string, objectKind string, objectName string) (ports []int, err error) {
-	outboundPortsToExclude, ok := annotations[outboundPortExclusionListAnnotation]
+func isAnnotatedForPortExclusion(annotations map[string]string, portAnnotation string, objectKind string, objectName string) (ports []int, err error) {
+	portsToExcludeStr, ok := annotations[portAnnotation]
 	if !ok {
 		return ports, err
 	}
 
-	log.Trace().Msgf("%s %s has outbound port exclusion annotation: '%s:%s'", objectKind, objectName, outboundPortExclusionListAnnotation, outboundPortsToExclude)
-	portsToExclude := strings.Split(outboundPortsToExclude, ",")
+	log.Trace().Msgf("%s %s has port exclusion annotation: '%s:%s'", objectKind, objectName, portAnnotation, portsToExcludeStr)
+	portsToExclude := strings.Split(portsToExcludeStr, ",")
 	for _, portStr := range portsToExclude {
 		portStr := strings.TrimSpace(portStr)
 		portInt, ok := strconv.Atoi(portStr)
 		if ok != nil || portInt <= 0 {
-			err = errors.Errorf("Invalid port for key %q: %s", outboundPortExclusionListAnnotation, outboundPortsToExclude)
+			err = errors.Errorf("Invalid port '%s' specified for annotation '%s'", portStr, portAnnotation)
 			ports = nil
 			return ports, err
 		}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Cherry-picks 6664c75e and 9c7a2d9f for v0.9.1,
required to address #3582 with v0.9.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
