### PR TITLE
Backport nodeSelectors for install and demo

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -17,6 +17,9 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-cleanup
       restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: garbage-collector
           image: bitnami/kubectl

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -24,6 +24,9 @@ spec:
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       serviceAccountName: osm-grafana
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: grafana
           image: "grafana/grafana:7.0.1"

--- a/charts/osm/templates/jaeger-deployment.yaml
+++ b/charts/osm/templates/jaeger-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       serviceAccountName: jaeger
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - name: jaeger
         image: jaegertracing/all-in-one

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - name: prometheus
         ports:

--- a/cmd/cli/testdata/test-chart/templates/deployment.yaml
+++ b/cmd/cli/testdata/test-chart/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
         testing: test
     spec:
       {{- with .Values.OpenServiceMesh.imagePullSecrets }}
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end}}

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -47,7 +47,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookbuyer
-
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         # Main container with APP
         - name: bookbuyer

--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -74,6 +74,9 @@ spec:
         version: $VERSION
     spec:
       serviceAccountName: bookstore
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -80,6 +80,9 @@ spec:
         version: $VERSION
     spec:
       serviceAccountName: "$SVC"
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -65,7 +65,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookthief
-
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         # Main container with APP
         - name: bookthief

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -59,7 +59,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookwarehouse
-
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         # Main container with APP
         - name: bookwarehouse

--- a/demo/deploy-tcp-client.sh
+++ b/demo/deploy-tcp-client.sh
@@ -41,6 +41,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: tcp-client
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - name: tcp-client
         image: "${CTR_REGISTRY}/tcp-client:${CTR_TAG}"

--- a/demo/deploy-tcp-echo-service.sh
+++ b/demo/deploy-tcp-echo-service.sh
@@ -59,6 +59,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: tcp-echo
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - name: tcp-echo-server
         image: "${CTR_REGISTRY}/tcp-echo-server:${CTR_TAG}"

--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -27,6 +27,9 @@ spec:
       labels:
         app: vault
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       terminationGracePeriodSeconds: 10
       containers:
       - name: vault

--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -26,6 +26,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookbuyer
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: bookbuyer
           image: openservicemesh/bookbuyer:v0.9.0

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -41,6 +41,9 @@ spec:
         app: bookstore-v2
     spec:
       serviceAccountName: bookstore-v2
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: bookstore
           image: openservicemesh/bookstore:v0.9.0

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -41,6 +41,9 @@ spec:
         app: bookstore
     spec:
       serviceAccountName: bookstore
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: bookstore
           image: openservicemesh/bookstore:v0.9.0

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -25,6 +25,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookthief
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: bookthief
           image: openservicemesh/bookthief:v0.9.0

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -42,6 +42,9 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookwarehouse
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: bookwarehouse
           image: openservicemesh/bookwarehouse:v0.9.0

--- a/docs/example/manifests/opa/deploy-opa-envoy.yaml
+++ b/docs/example/manifests/opa/deploy-opa-envoy.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app: opa
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
         - name: opa-envoy
           image: openpolicyagent/opa:0.28.0-envoy

--- a/docs/example/manifests/samples/curl/curl.yaml
+++ b/docs/example/manifests/samples/curl/curl.yaml
@@ -18,6 +18,9 @@ spec:
         app: curl
     spec:
       serviceAccountName: curl
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - image: curlimages/curl
         imagePullPolicy: IfNotPresent

--- a/docs/example/manifests/samples/httpbin/httpbin.yaml
+++ b/docs/example/manifests/samples/httpbin/httpbin.yaml
@@ -33,6 +33,9 @@ spec:
         app: httpbin
     spec:
       serviceAccountName: httpbin
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       containers:
       - image: kennethreitz/httpbin
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Cherry-picks f5c66c2 and bdd664c for v0.9.1,
required to address #3509 with v0.9.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [X] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No