### PR TITLE
Backport control plane HPA and PDB changes for v0.9.1

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -98,12 +98,22 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.image.tag | string | `"v0.9.0"` | Container image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.inboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
+| OpenServiceMesh.injector.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |
+| OpenServiceMesh.injector.autoScale.enable | bool | `false` | Enable Autoscale |
+| OpenServiceMesh.injector.autoScale.maxReplicas | int | `5` | Maximum replicas for autoscale |
+| OpenServiceMesh.injector.autoScale.minReplicas | int | `1` | Minimum replicas for autoscale |
+| OpenServiceMesh.injector.autoScale.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | OpenServiceMesh.injector.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
 | OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
+| OpenServiceMesh.osmController.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |
+| OpenServiceMesh.osmController.autoScale.enable | bool | `false` | Enable Autoscale |
+| OpenServiceMesh.osmController.autoScale.maxReplicas | int | `5` | Maximum replicas for autoscale |
+| OpenServiceMesh.osmController.autoScale.minReplicas | int | `1` | Minimum replicas for autoscale |
+| OpenServiceMesh.osmController.autoScale.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | OpenServiceMesh.osmController.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.osmController.podLabels | object | `{}` | OSM controller's pod labels |
 | OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -98,11 +98,13 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.image.tag | string | `"v0.9.0"` | Container image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.inboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
-| OpenServiceMesh.injector.podLabels | object | `{}` |  |
+| OpenServiceMesh.injector.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
+| OpenServiceMesh.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
 | OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
+| OpenServiceMesh.osmController.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.osmController.podLabels | object | `{}` | OSM controller's pod labels |
 | OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count |
 | OpenServiceMesh.osmController.resource | object | `{"limits":{"cpu":"1.5","memory":"512M"},"requests":{"cpu":"0.5","memory":"128M"}}` | OSM controller's container resource parameters |

--- a/charts/osm/templates/osm-controller-hpa.yaml
+++ b/charts/osm/templates/osm-controller-hpa.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.OpenServiceMesh.osmController.autoScale.enable }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: osm-controller-hpa
+  namespace: {{ include "osm.namespace" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: osm-controller
+  minReplicas: {{.Values.OpenServiceMesh.osmController.autoScale.minReplicas}}
+  maxReplicas: {{.Values.OpenServiceMesh.osmController.autoScale.maxReplicas}}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{.Values.OpenServiceMesh.osmController.autoScale.targetAverageUtilization}}
+{{- end }}

--- a/charts/osm/templates/osm-controller-pod-disruption-budget.yaml
+++ b/charts/osm/templates/osm-controller-pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.OpenServiceMesh.osmController.enablePodDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: osm-controller-pdb
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    app: osm-controller
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: osm-controller
+{{- end }}

--- a/charts/osm/templates/osm-injector-hpa.yaml
+++ b/charts/osm/templates/osm-injector-hpa.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.OpenServiceMesh.injector.autoScale.enable }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: osm-injector-hpa
+  namespace: {{ include "osm.namespace" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: osm-injector
+  minReplicas: {{.Values.OpenServiceMesh.injector.autoScale.minReplicas}}
+  maxReplicas: {{.Values.OpenServiceMesh.injector.autoScale.maxReplicas}}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{.Values.OpenServiceMesh.injector.autoScale.targetAverageUtilization}}
+{{- end }}

--- a/charts/osm/templates/osm-injector-pod-disruption-budget.yaml
+++ b/charts/osm/templates/osm-injector-pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.OpenServiceMesh.injector.enablePodDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: osm-injector-pdb
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    app: osm-injector
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: osm-injector
+{{- end }}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -67,6 +67,59 @@
                     "additionalProperties": false
                 }
             }
+        },
+        "autoScale": {
+            "$id": "#/properties/definitions/properties/autoScale",
+            "type": "object",
+            "title": "The autoScale schema",
+            "description": "Autoscale configuration parameters",
+            "required": [
+                "enable"
+            ],
+            "properties": {
+                "enable": {
+                    "$id": "#/properties/definitions/properties/autoScale/properties/enable",
+                    "type": "boolean",
+                    "title": "Autoscale enable",
+                    "description": "Indicates whether autoscale should be enabled or not.",
+                    "examples": [
+                        false
+                    ]
+                },
+                "minReplicas": {
+                    "$id": "#/properties/definitions/properties/autoScale/properties/minReplicas",
+                    "type": "integer",
+                    "title": "Autoscale minimum replicas",
+                    "description": "Indicates the minimum replicas for autoscale.",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "examples": [
+                        1
+                    ]
+                },
+                "maxReplicas": {
+                    "$id": "#/properties/definitions/properties/autoScale/properties/maxReplicas",
+                    "type": "integer",
+                    "title": "Autoscale maximum replicase",
+                    "description": "Indicates the maximum replicas for autoscale.",
+                    "minimum": 1,
+                    "maximum": 10,
+                    "examples": [
+                        5
+                    ]
+                },
+                "targetAverageUtilization": {
+                    "$id": "#/properties/definitions/properties/autoScale/properties/targetAverageUtilization",
+                    "type": "integer",
+                    "title": "Autoscale targetAverageUtilization",
+                    "description": "Indicates average target CPU utilization (percentage) for autoscale.",
+                    "minimum": 0,
+                    "maximum": 100,
+                    "examples": [
+                        80
+                    ]
+                }
+            }
         }
     },
     "properties": {
@@ -139,6 +192,9 @@
                             "examples": [
                                 false
                             ]
+                        },
+                        "autoScale": {
+                            "$ref": "#/definitions/autoScale"
                         }
                     },
                     "additionalProperties": false
@@ -606,6 +662,9 @@
                             "examples": [
                                 false
                             ]
+                        },
+                        "autoScale": {
+                            "$ref": "#/definitions/autoScale"
                         }
                     },
                     "additionalProperties": false

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -130,6 +130,15 @@
                             "title": "The podLabels schema",
                             "description": "Labels for the osmController pod.",
                             "default": {}
+                        },
+                        "enablePodDisruptionBudget": {
+                            "$id": "#/properties/OpenServiceMesh/properties/osmController/properties/enablePodDisruptionBudget",
+                            "type": "boolean",
+                            "title": "The enablePodDisruptionBudget schema",
+                            "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
+                            "examples": [
+                                false
+                            ]
                         }
                     },
                     "additionalProperties": false
@@ -588,6 +597,15 @@
                             "title": "The podLabels schema",
                             "description": "Labels for the osm-injector pod.",
                             "default": {}
+                        },
+                        "enablePodDisruptionBudget": {
+                            "$id": "#/properties/OpenServiceMesh/properties/injector/properties/enablePodDisruptionBudget",
+                            "type": "boolean",
+                            "title": "The enablePodDisruptionBudget schema",
+                            "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
+                            "examples": [
+                                false
+                            ]
                         }
                     },
                     "additionalProperties": false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -34,6 +34,8 @@ OpenServiceMesh:
         memory: "128M"
     # -- OSM controller's pod labels
     podLabels: {}
+    # -- Enable Pod Disruption Budget
+    enablePodDisruptionBudget: false
 
   #
   # -- Prometheus parameters
@@ -208,7 +210,10 @@ OpenServiceMesh:
       requests:
         cpu: "0.3"
         memory: "64M"
+    # -- Sidecar injector's pod labels
     podLabels: {}
+    # -- Enable Pod Disruption Budget
+    enablePodDisruptionBudget: false
 
   # -- Run init container in privileged mode
   enablePrivilegedInitContainer: false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -36,6 +36,16 @@ OpenServiceMesh:
     podLabels: {}
     # -- Enable Pod Disruption Budget
     enablePodDisruptionBudget: false
+    # -- Auto scale configuration
+    autoScale:
+      # -- Enable Autoscale
+      enable: false
+      # -- Minimum replicas for autoscale
+      minReplicas: 1
+      # -- Maximum replicas for autoscale
+      maxReplicas: 5
+      # -- Average target CPU utilization (%)
+      targetAverageUtilization: 80
 
   #
   # -- Prometheus parameters
@@ -214,6 +224,16 @@ OpenServiceMesh:
     podLabels: {}
     # -- Enable Pod Disruption Budget
     enablePodDisruptionBudget: false
+    # -- Auto scale configuration
+    autoScale:
+      # -- Enable Autoscale
+      enable: false
+      # -- Minimum replicas for autoscale
+      minReplicas: 1
+      # -- Maximum replicas for autoscale
+      maxReplicas: 5
+      # -- Average target CPU utilization (%)
+      targetAverageUtilization: 80
 
   # -- Run init container in privileged mode
   enablePrivilegedInitContainer: false


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Backports 30a6ec0b and 3f794156 for HA/scale with v0.9.1.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
