### PR TITLE
fix(build): rebuild chart when its root files change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build-osm-injector: clean-osm-injector
 build-osm: cmd/cli/chart.tgz
 	CGO_ENABLED=0  go build -v -o ./bin/osm -ldflags ${LDFLAGS} ./cmd/cli
 
-cmd/cli/chart.tgz: scripts/generate_chart/generate_chart.go $(wildcard charts/osm/**/*)
+cmd/cli/chart.tgz: scripts/generate_chart/generate_chart.go $(shell find charts/osm)
 	go run $< > $@
 
 .PHONY: clean-osm


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The dependencies listed for the cmd/cli/chart.tgz target previously
only included files in a subdirectory of the chart and was missing the
files at its root, like values.yaml. This change includes all files
underneath charts/osm at any depth as a dependency for the generated
chart embedded in the CLI.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
