### PR TITLE
fix(injector): increase injector webhook timeout

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -109,6 +109,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
 | OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
+| OpenServiceMesh.injector.webhookTimeoutSeconds | int | `20` | Mutating webhook timeout |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
 | OpenServiceMesh.osmController.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |

--- a/charts/osm/templates/mutatingwebhook.yaml
+++ b/charts/osm/templates/mutatingwebhook.yaml
@@ -44,6 +44,6 @@ webhooks:
   # For dry-run requests, this side effect is skipped.
   # Ref: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
   sideEffects: NoneOnDryRun
-  # Default timeout is 10s. Set this to 20s to account for slowness in scale environments
-  timeoutSeconds: 20
+  # Default k8s timeout is 10s if a timeout is not specified. This is set to 20s to account for slowness in scale environments.
+  timeoutSeconds: {{.Values.OpenServiceMesh.injector.webhookTimeoutSeconds}}
   admissionReviewVersions: ["v1"]

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -656,6 +656,15 @@
                         },
                         "autoScale": {
                             "$ref": "#/definitions/autoScale"
+                        },
+                        "webhookTimeoutSeconds": {
+                            "$id": "#/properties/OpenServiceMesh/properties/webhookTimeout",
+                            "type": "integer",
+                            "title": "Webhook Timeout Seconds",
+                            "description": "Timeout for the mutating webhook in seconds",
+                            "examples": [
+                                20
+                            ]
                         }
                     },
                     "additionalProperties": false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -231,6 +231,8 @@ OpenServiceMesh:
       maxReplicas: 5
       # -- Average target CPU utilization (%)
       targetAverageUtilization: 80
+    # -- Mutating webhook timeout
+    webhookTimeoutSeconds: 20
 
   # -- Run init container in privileged mode
   enablePrivilegedInitContainer: false

--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -25,6 +25,11 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 				// Install OSM
 				installOpts := Td.GetOSMInstallOpts()
 				installOpts.CertManager = "cert-manager"
+				installOpts.SetOverrides = []string{
+					// increase timeout when using an external certificate provider due to
+					// potential slowness issuing certs
+					"OpenServiceMesh.injector.webhookTimeoutSeconds=30",
+				}
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 5 /* 3 cert-manager pods, 1 controller, 1 injector */)).To(Succeed())
 

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -25,6 +25,11 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 				// Install OSM
 				installOpts := Td.GetOSMInstallOpts()
 				installOpts.CertManager = "vault"
+				installOpts.SetOverrides = []string{
+					// increase timeout when using an external certificate provider due to
+					// potential slowness issuing certs
+					"OpenServiceMesh.injector.webhookTimeoutSeconds=30",
+				}
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				// Create Test NS


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Allows the timeout for the injector's mutating webhook to be
configured using Helm's set flag. Increases the timeout for tests
using external certificate providers due to the potential for
slowness in issuing certs.

Resolves #3634 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ X ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ X ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ X ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
