### PR TITLE
fix: patch backporting PR for meshconfig changes

### DIFF
--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -320,6 +320,15 @@
                         false
                     ]
                 },
+                "enablePrometheusScraping": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enablePrometheusScraping",
+                    "type": "boolean",
+                    "title": "Deprecated: The enablePrometheusScraping schema",
+                    "description": "Deprecated: Indicates whether Prometheus scraping should be enabled.",
+                    "examples": [
+                        true
+                    ]
+                },
                 "deployGrafana": {
                     "$id": "#/properties/OpenServiceMesh/properties/deployGrafana",
                     "type": "boolean",


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds enablePrometheusScraping back to values.schema.json. Since
osm mesh upgrade reuses values from previous releases, the
enablePrometheusScraping flag must remain in the values schema to
avoid errors on upgrade even though it is no longer used in the
codebase.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [  X ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
