### PR TITLE
fix(demo): remove host headers in SMI policies

### DIFF
--- a/demo/deploy-traffic-specs.sh
+++ b/demo/deploy-traffic-specs.sh
@@ -44,6 +44,4 @@ spec:
     - name: restock-books
       methods:
       - POST
-      headers:
-      - host: "bookwarehouse.$BOOKWAREHOUSE_NAMESPACE"
 EOF

--- a/docs/example/manifests/access/traffic-access-v1-allow-bookthief.yaml
+++ b/docs/example/manifests/access/traffic-access-v1-allow-bookthief.yaml
@@ -34,12 +34,9 @@ spec:
     methods:
     - GET
     headers:
-    - host: "bookstore.bookstore"
     - "user-agent": ".*-http-client/*.*"
     - "client-app": "bookbuyer"
   - name: buy-a-book
     pathRegex: ".*a-book.*new"
     methods:
     - GET
-    headers:
-    - host: "bookstore.bookstore"

--- a/docs/example/manifests/access/traffic-access-v1.yaml
+++ b/docs/example/manifests/access/traffic-access-v1.yaml
@@ -34,12 +34,9 @@ spec:
     methods:
     - GET
     headers:
-    - host: "bookstore.bookstore"
     - "user-agent": ".*-http-client/*.*"
     - "client-app": "bookbuyer"
   - name: buy-a-book
     pathRegex: ".*a-book.*new"
     methods:
     - GET
-    headers:
-    - host: "bookstore.bookstore"


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
fix(demo): remove host headers in SMI policies

The `:authority` header sent by the bookbuyer to the bookstore is
actually `bookstore.bookstore:14001` where the bookstore's
HTTPRouteGroup used in the manual demo specified a `host` header match
of `bookstore.bookstore`, resulting in

    "response_code_details": "route_not_found"

in the bookstore's logs for requests from the bookbuyer.

This change removes the `host` header matches all of the demo manifests.

Fixes #3616
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [X] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
