### PR TITLE
catalog/route: fix missing hostnames for permissive mode

### DIFF
--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -265,10 +265,12 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 				{
 					Name: "bookstore-v1.default.local",
 					Hostnames: []string{
+						"bookstore-v1",
 						"bookstore-v1.default",
 						"bookstore-v1.default.svc",
 						"bookstore-v1.default.svc.cluster",
 						"bookstore-v1.default.svc.cluster.local",
+						"bookstore-v1:8888",
 						"bookstore-v1.default:8888",
 						"bookstore-v1.default.svc:8888",
 						"bookstore-v1.default.svc.cluster:8888",
@@ -284,10 +286,12 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 				{
 					Name: "bookstore-v2.default.local",
 					Hostnames: []string{
+						"bookstore-v2",
 						"bookstore-v2.default",
 						"bookstore-v2.default.svc",
 						"bookstore-v2.default.svc.cluster",
 						"bookstore-v2.default.svc.cluster.local",
+						"bookstore-v2:8888",
 						"bookstore-v2.default:8888",
 						"bookstore-v2.default.svc:8888",
 						"bookstore-v2.default.svc.cluster:8888",
@@ -303,10 +307,12 @@ func TestListOutboundTrafficPolicies(t *testing.T) {
 				{
 					Name: "bookbuyer.default.local",
 					Hostnames: []string{
+						"bookbuyer",
 						"bookbuyer.default",
 						"bookbuyer.default.svc",
 						"bookbuyer.default.svc.cluster",
 						"bookbuyer.default.svc.cluster.local",
+						"bookbuyer:8888",
 						"bookbuyer.default:8888",
 						"bookbuyer.default.svc:8888",
 						"bookbuyer.default.svc.cluster:8888",
@@ -773,12 +779,14 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 
 	testCases := []struct {
 		name                     string
+		sourceNamespace          string
 		services                 map[string]string
 		expectedOutboundPolicies []*trafficpolicy.OutboundTrafficPolicy
 	}{
 		{
-			name:     "outbound traffic policies for permissive mode",
-			services: map[string]string{"bookstore-v1": "default", "bookstore-apex": "default", "bookbuyer": "default"},
+			name:            "outbound traffic policies for permissive mode",
+			sourceNamespace: "test",
+			services:        map[string]string{"bookstore-v1": "default", "bookstore-apex": "default", "bookbuyer": "test"},
 			expectedOutboundPolicies: []*trafficpolicy.OutboundTrafficPolicy{
 				{
 					Name: "bookstore-apex.default.local",
@@ -819,21 +827,26 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "bookbuyer.default.local",
+					Name: "bookbuyer.test.local",
 					Hostnames: []string{
-						"bookbuyer.default",
-						"bookbuyer.default.svc",
-						"bookbuyer.default.svc.cluster",
-						"bookbuyer.default.svc.cluster.local",
-						"bookbuyer.default:8888",
-						"bookbuyer.default.svc:8888",
-						"bookbuyer.default.svc.cluster:8888",
-						"bookbuyer.default.svc.cluster.local:8888",
+						"bookbuyer",
+						"bookbuyer.test",
+						"bookbuyer.test.svc",
+						"bookbuyer.test.svc.cluster",
+						"bookbuyer.test.svc.cluster.local",
+						"bookbuyer:8888",
+						"bookbuyer.test:8888",
+						"bookbuyer.test.svc:8888",
+						"bookbuyer.test.svc.cluster:8888",
+						"bookbuyer.test.svc.cluster.local:8888",
 					},
 					Routes: []*trafficpolicy.RouteWeightedClusters{
 						{
-							HTTPRouteMatch:   tests.WildCardRouteMatch,
-							WeightedClusters: mapset.NewSet(tests.BookbuyerDefaultWeightedCluster),
+							HTTPRouteMatch: tests.WildCardRouteMatch,
+							WeightedClusters: mapset.NewSet(service.WeightedCluster{
+								ClusterName: "test/bookbuyer",
+								Weight:      100,
+							}),
 						},
 					},
 				},
@@ -855,7 +868,7 @@ func TestBuildOutboundPermissiveModePolicies(t *testing.T) {
 			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
 			mockKubeController.EXPECT().ListServices().Return(k8sServices)
 
-			actual := mc.buildOutboundPermissiveModePolicies()
+			actual := mc.buildOutboundPermissiveModePolicies(tc.sourceNamespace)
 			assert.Len(actual, len(tc.expectedOutboundPolicies))
 			assert.ElementsMatch(tc.expectedOutboundPolicies, actual)
 		})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
In permissive mode, when client belongs to the same namespace
as the upstream service, the shorthand FQDN <service>,
<service>:<port> should be configured as domains in the
virtual_host for the corresponding service. This change
addresses this bug specific to permissive mode.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
