### PR TITLE
fix(pkg/envoy/cds): configure egress Envoy cluster altStatName for prometheus

### DIFF
--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -322,7 +322,7 @@ func TestGetDNSResolvableEgressCluster(t *testing.T) {
 			},
 			expectedCluster: &xds_cluster.Cluster{
 				Name:           "foo.com:80",
-				AltStatName:    "foo.com:80",
+				AltStatName:    "foo_com_80",
 				ConnectTimeout: ptypes.DurationProto(clusterConnectTimeout),
 				ClusterDiscoveryType: &xds_cluster.Cluster_Type{
 					Type: xds_cluster.Cluster_STRICT_DNS,
@@ -382,6 +382,39 @@ func TestGetDNSResolvableEgressCluster(t *testing.T) {
 			actual, err := getDNSResolvableEgressCluster(tc.clusterConfig)
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedCluster, actual)
+		})
+	}
+}
+
+func TestFormatAltStatNameForPrometheus(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name                string
+		clusterName         string
+		expectedAltStatName string
+	}{
+		{
+			name:                "configure cluster name containing '.' and ':'",
+			clusterName:         "foo.com:80",
+			expectedAltStatName: "foo_com_80",
+		},
+		{
+			name:                "configure cluster name containing multiple '.' and :''",
+			clusterName:         "foo.bar.com:80",
+			expectedAltStatName: "foo_bar_com_80",
+		},
+		{
+			name:                "configure cluster name not containing '.' and ':'",
+			clusterName:         "foo",
+			expectedAltStatName: "foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := formatAltStatNameForPrometheus(tc.clusterName)
+			assert.Equal(tc.expectedAltStatName, actual)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This change formats the altStatName of Envoy clusters created based on the applied egress policies so that egress traffic can be observed with Prometheus. The change only applies to egress traffic enabled using egress policies, not globally enabled egress. The AltStatName of the cluster is formatted so that the stats for the cluster are grouped with Envoy metrics we are already scraping for. Prior to this change, the egress cluster name would be interpreted incorrectly due to periods and colons in the name and the stats would be grouped under a unique metric. We were not scraping for this metric and it would be difficult for customers to interpret.

Addresses issue #3164.

This change can be demonstrated using the [egress policy demo](https://docs.openservicemesh.io/docs/tasks/traffic_management/demos/egress_policy_demo/). Metrics can be enabled for the curl namespace using `osm metrics enable --namespace curl`. The stats for egress traffic between the curl pod and httpbin.org  should be visible at stats/prometheus on the envoyAdmin.

```
# TYPE envoy_cluster_upstream_rq counter
envoy_cluster_upstream_rq{envoy_response_code="200",envoy_cluster_name="envoy-metrics-cluster"} 163
envoy_cluster_upstream_rq{envoy_response_code="200",envoy_cluster_name="httpbin_org_80"} 2
envoy_cluster_upstream_rq{envoy_response_code="200",envoy_cluster_name="osm-controller"} 2
envoy_cluster_upstream_rq{envoy_response_code="503",envoy_cluster_name="osm-controller"} 
```

Prior to this change, stats for upstream requests for the httpbin.org:80 cluster would be visible as the following:

```
# TYPE envoy_cluster_upstream_rq counter
envoy_cluster_upstream_rq{envoy_response_code="200",envoy_cluster_name="envoy-metrics-cluster"} 163
envoy_cluster_upstream_rq{envoy_response_code="200",envoy_cluster_name="osm-controller"} 2
envoy_cluster_upstream_rq{envoy_response_code="503",envoy_cluster_name="osm-controller"} 

# TYPE envoy_cluster_org_80_upstream_rq counter
envoy_cluster_upstream_rq{envoy_response_code="200",envoy_cluster_name="httpbin"} 2
```

The metric name `envoy_cluster_org_80_upstream_rq` does not intuitively represent the envoy cluster, httpbin.org:80. By default, the altStatName for an Envoy cluster is the cluster name. In this case, the cluster name includes periods and colon. Envoy interprets colons as underscores and the period as a delimiter when formatting the metrics exposed at stats/prometheus. This causes the naming issues seen above. Additionally, the metric `envoy_cluster_org_80_upstream_rq` is not scaped by prometheus.

With this change, egress traffic stats can be queried as follows:

![MicrosoftTeams-image](https://user-images.githubusercontent.com/64559656/123171571-dad76500-d430-11eb-9e54-37c513de84c3.png)

**Note:**

- An egress prefix could be used to specify that the cluster is an egress cluster.
- There may be more characters in hostnames that could cause the naming issues seen above.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ X ] |
| Networking                 | [ ] |
| Observability              | [ X ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no. 

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
