### PR TITLE
feat(pkg/providers) Plumb through config client to the k8s provider

### DIFF
--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/openservicemesh/osm/pkg/config"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -17,13 +18,12 @@ import (
 )
 
 // NewClient returns a client that has all components necessary to connect to and maintain state of a Kubernetes cluster.
-func NewClient(kubeController k8s.Controller, providerIdent string, cfg configurator.Configurator) (*Client, error) {
-	client := Client{
+func NewClient(kubeController k8s.Controller, configClient config.Controller, providerIdent string, cfg configurator.Configurator) *Client {
+	return &Client{
 		providerIdent:  providerIdent,
 		kubeController: kubeController,
+		configClient:   configClient,
 	}
-
-	return &client, nil
 }
 
 // GetID returns a string descriptor / identifier of the compute provider.

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/config"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -35,20 +36,19 @@ var _ = Describe("Test Kube Client Provider (w/o kubecontroller)", func() {
 		mockConfigurator   *configurator.MockConfigurator
 
 		client *Client
-		err    error
 	)
 
 	mockCtrl = gomock.NewController(GinkgoT())
 	mockKubeController = k8s.NewMockController(mockCtrl)
 	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+	mockConfigController := config.NewMockController(mockCtrl)
 
 	providerID := "provider"
 
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 
 	BeforeEach(func() {
-		client, err = NewClient(mockKubeController, providerID, mockConfigurator)
-		Expect(err).ToNot(HaveOccurred())
+		client = NewClient(mockKubeController, mockConfigController, providerID, mockConfigurator)
 	})
 
 	It("tests GetID", func() {
@@ -292,6 +292,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	)
 	mockCtrl = gomock.NewController(GinkgoT())
 	mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
+	mockConfigController := config.NewMockController(mockCtrl)
 
 	providerID := "test-provider"
 	testNamespace := "testNamespace"
@@ -317,7 +318,7 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		}, 3*time.Second).Should(BeTrue())
 
 		Expect(err).ToNot(HaveOccurred())
-		client, err = NewClient(kubeController, providerID, mockConfigurator)
+		client = NewClient(kubeController, mockConfigController, providerID, mockConfigurator)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -719,10 +720,10 @@ func TestListEndpointsForIdentity(t *testing.T) {
 
 			mockKubeController := k8s.NewMockController(mockCtrl)
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+			mockConfigController := config.NewMockController(mockCtrl)
 			providerID := "provider"
 
-			provider, err := NewClient(mockKubeController, providerID, mockConfigurator)
-			assert.Nil(err)
+			provider := NewClient(mockKubeController, mockConfigController, providerID, mockConfigurator)
 
 			var pods []*corev1.Pod
 			for serviceIdentity, endpoints := range tc.outboundServiceAccountEndpoints {

--- a/pkg/providers/kube/types.go
+++ b/pkg/providers/kube/types.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"github.com/openservicemesh/osm/pkg/config"
 	k8s "github.com/openservicemesh/osm/pkg/kubernetes"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -13,4 +14,5 @@ var (
 type Client struct {
 	providerIdent  string
 	kubeController k8s.Controller
+	configClient   config.Controller
 }


### PR DESCRIPTION
The new config client will be used to incorporate the k8s MultiClusterService objects

Issue: #3444 


| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [x ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No

1. Is this a breaking change?
No
