### PR TITLE
envoy: encode proxy identity in XDS cert

### DIFF
--- a/cmd/osm-controller/gateway.go
+++ b/cmd/osm-controller/gateway.go
@@ -41,7 +41,7 @@ func bootstrapOSMGateway(kubeClient kubernetes.Interface, certManager certificat
 		return nil
 	}
 
-	gatewayCN := envoy.NewCertCommonName(uuid.New(), envoy.KindGateway, osmServiceAccount, osmNamespace)
+	gatewayCN := envoy.NewXDSCertCommonName(uuid.New(), envoy.KindGateway, osmServiceAccount, osmNamespace)
 	bootstrapCert, err := certManager.IssueCertificate(gatewayCN, constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing bootstrap certificate for OSM gateway: %s", err)

--- a/pkg/envoy/ads/cache_stream.go
+++ b/pkg/envoy/ads/cache_stream.go
@@ -73,7 +73,7 @@ func GetProxyFromPod(pod *v1.Pod) (*envoy.Proxy, error) {
 
 	// construct CN for this pod/proxy
 	// TODO: Infer proxy type from Pod
-	commonName := envoy.NewCertCommonName(proxyUUID, envoy.KindSidecar, serviceAccount, namespace)
+	commonName := envoy.NewXDSCertCommonName(proxyUUID, envoy.KindSidecar, serviceAccount, namespace)
 	tempProxy, err := envoy.NewProxy(certificate.CommonName(commonName), "NoSerial", &net.IPAddr{IP: net.IPv4zero})
 
 	return tempProxy, err

--- a/pkg/envoy/ads/cache_test.go
+++ b/pkg/envoy/ads/cache_test.go
@@ -22,7 +22,7 @@ func TestGetProxyFromPod(t *testing.T) {
 		namespace       = "namespace"
 		serviceAccount  = "serviceAccount"
 		validUUID       = uuid.New()
-		validCommonName = envoy.NewCertCommonName(validUUID, envoy.KindSidecar, serviceAccount, namespace)
+		validCommonName = envoy.NewXDSCertCommonName(validUUID, envoy.KindSidecar, serviceAccount, namespace)
 	)
 
 	testCases := []struct {

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -52,7 +52,7 @@ func TestNewResponse(t *testing.T) {
 
 	proxyUUID := uuid.New()
 	// The format of the CN matters
-	xdsCertificate := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
+	xdsCertificate := envoy.NewXDSCertCommonName(proxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace)
 	certSerialNumber := certificate.SerialNumber("123456")
 	proxy, err := envoy.NewProxy(xdsCertificate, certSerialNumber, nil)
 	assert.Nil(err)
@@ -384,12 +384,12 @@ func TestNewResponseListServicesError(t *testing.T) {
 	proxy, err := envoy.NewProxy(cn, "", nil)
 	tassert.Nil(t, err)
 
-	proxyIdentity, err := envoy.GetServiceAccountFromProxyCertificate(cn)
+	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(cn)
 	tassert.NoError(t, err)
 
 	ctrl := gomock.NewController(t)
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
-	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity.ToServiceIdentity()).Return(nil).AnyTimes()
+	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity).Return(nil).AnyTimes()
 
 	resp, err := NewResponse(meshCatalog, proxy, nil, nil, nil, proxyRegistry)
 	tassert.Error(t, err)
@@ -412,7 +412,7 @@ func TestNewResponseGetLocalServiceClusterError(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return []service.MeshService{svc}, nil
 	}))
-	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
+	cn := envoy.NewXDSCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
 	proxy, err := envoy.NewProxy(cn, "", nil)
 	tassert.Nil(t, err)
 
@@ -432,7 +432,7 @@ func TestNewResponseGetEgressTrafficPolicyError(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return nil, nil
 	}))
-	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
+	cn := envoy.NewXDSCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
 	proxy, err := envoy.NewProxy(cn, "", nil)
 	tassert.Nil(t, err)
 
@@ -458,7 +458,7 @@ func TestNewResponseGetEgressTrafficPolicyNotEmpty(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return nil, nil
 	}))
-	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
+	cn := envoy.NewXDSCertCommonName(uuid.New(), envoy.KindSidecar, "svcacc", "ns")
 	proxy, err := envoy.NewProxy(cn, "", nil)
 	tassert.Nil(t, err)
 
@@ -489,7 +489,7 @@ func TestNewResponseForGateway(t *testing.T) {
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
 		return nil, nil
 	}))
-	cn := envoy.NewCertCommonName(uuid.New(), envoy.KindGateway, "gateway", "osm-system")
+	cn := envoy.NewXDSCertCommonName(uuid.New(), envoy.KindGateway, "gateway", "osm-system")
 	proxy, err := envoy.NewProxy(cn, "", nil)
 	tassert.Nil(t, err)
 

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -18,7 +18,7 @@ import (
 // 2. Outbound listener to handle outgoing traffic
 // 3. Prometheus listener for metrics
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, proxyRegistry *registry.ProxyRegistry) ([]types.Resource, error) {
-	svcAccount, err := envoy.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
+	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error retrieving ServiceAccount for proxy %s", proxy.String())
 		return nil, err
@@ -31,7 +31,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		statsHeaders = proxy.StatsHeaders()
 	}
 
-	lb := newListenerBuilder(meshCatalog, svcAccount.ToServiceIdentity(), cfg, statsHeaders)
+	lb := newListenerBuilder(meshCatalog, proxyIdentity, cfg, statsHeaders)
 
 	if proxy.Kind() == envoy.KindGateway {
 		return lb.buildGatewayListeners(), nil

--- a/pkg/envoy/proxy.go
+++ b/pkg/envoy/proxy.go
@@ -243,7 +243,7 @@ func NewProxy(certCommonName certificate.CommonName, certSerialNumber certificat
 	}, nil
 }
 
-// NewCertCommonName returns a newly generated CommonName for a certificate of the form: <ProxyUUID>.<kind>.<serviceAccount>.<namespace>
-func NewCertCommonName(proxyUUID uuid.UUID, kind ProxyKind, serviceAccount, namespace string) certificate.CommonName {
-	return certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", proxyUUID.String(), kind, serviceAccount, namespace))
+// NewXDSCertCommonName returns a newly generated CommonName for a certificate of the form: <ProxyUUID>.<kind>.<serviceAccount>.<namespace>
+func NewXDSCertCommonName(proxyUUID uuid.UUID, kind ProxyKind, serviceAccount, namespace string) certificate.CommonName {
+	return certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s.%s", proxyUUID.String(), kind, serviceAccount, namespace, identity.ClusterLocalTrustDomain))
 }

--- a/pkg/envoy/registry/services.go
+++ b/pkg/envoy/registry/services.go
@@ -321,6 +321,6 @@ func getCertCommonNameForPod(pod v1.Pod) (certificate.CommonName, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "invalid UID value for %s label", constants.EnvoyUniqueIDLabelName)
 	}
-	cn := envoy.NewCertCommonName(proxyUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, pod.Namespace)
+	cn := envoy.NewXDSCertCommonName(proxyUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, pod.Namespace)
 	return cn, nil
 }

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -21,7 +21,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request 
 	log.Info().Msgf("Composing SDS Discovery Response for proxy %s", proxy.String())
 
 	// OSM currently relies on kubernetes ServiceAccount for service identity
-	svcAccount, err := envoy.GetServiceAccountFromProxyCertificate(proxy.GetCertificateCommonName())
+	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
 		log.Error().Err(err).Msgf("Error retrieving ServiceAccount for proxy %s", proxy.String())
 		return nil, err
@@ -31,7 +31,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, request 
 		meshCatalog:     meshCatalog,
 		certManager:     certManager,
 		cfg:             cfg,
-		serviceIdentity: svcAccount.ToServiceIdentity(),
+		serviceIdentity: proxyIdentity,
 	}
 
 	var sdsResources []types.Resource

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -22,7 +22,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	namespace := req.Namespace
 
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
-	cn := envoy.NewCertCommonName(proxyUUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, namespace)
+	cn := envoy.NewXDSCertCommonName(proxyUUID, envoy.KindSidecar, pod.Spec.ServiceAccountName, namespace)
 	log.Debug().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN=%s", pod.Spec.ServiceAccountName, namespace, cn)
 	startTime := time.Now()
 	bootstrapCertificate, err := wh.certManager.IssueCertificate(cn, constants.XDSCertificateValidityPeriod)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change refactors the code to encode the
proxy's identity in its XDS cert, which
can be used to derive its service identity
that is encoded in certs for proxy->proxy
communication.

The goal of this change is to avoid leaking
k8s service account across the XDS code, which
abstracts the proxy identity using the identity
pkg. As a part of this, unnecessary conversions
from CN -> service-account -> service-identity
are avoided when invoking APIs on the MeshCataloger
interface. Within XDS, service-identity ->
service-account conversions are only needed in
situations where k8s code has already leaked, such
as when inspecting the associated pod's spec.

Also renames some functions for clarity.

Part of #3168

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no. `no`

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
