### PR TITLE
envoy/eds: fix cluster name to mesh service parsing

### DIFF
--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -89,8 +89,8 @@ func generateEDSConfig(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy) ([
 
 func clusterToMeshSvc(cluster string) (service.MeshService, error) {
 	chunks := strings.Split(cluster, namespacedNameDelimiter)
-	if len(chunks) != 2 {
-		return service.MeshService{}, errors.Errorf("Invalid cluster name. Expected: <namespace>/<name>, Got: %s", cluster)
+	if len(chunks) != 3 {
+		return service.MeshService{}, errors.Errorf("Invalid cluster name. Expected: <namespace>/<name>/<cluster>, Got: %s", cluster)
 	}
 	return service.MeshService{
 		Namespace:     chunks[0],

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -67,7 +67,7 @@ func TestEndpointConfiguration(t *testing.T) {
 	assert.NotNil(proxy)
 
 	request := &xds_discovery.DiscoveryRequest{
-		ResourceNames: []string{"default/bookstore-v1"},
+		ResourceNames: []string{"default/bookstore-v1/local"},
 	}
 	resources, err := NewResponse(meshCatalog, proxy, request, mockConfigurator, nil, nil)
 	assert.Nil(err)
@@ -97,7 +97,7 @@ func TestClusterToMeshSvc(t *testing.T) {
 	}{
 		{
 			name:    "valid cluster name",
-			cluster: "foo/bar",
+			cluster: "foo/bar/local",
 			expectedMeshSvc: service.MeshService{
 				Namespace:     "foo",
 				Name:          "bar",
@@ -113,7 +113,7 @@ func TestClusterToMeshSvc(t *testing.T) {
 		},
 		{
 			name:            "invalid cluster name",
-			cluster:         "foo/bar/baz",
+			cluster:         "foo/barbaz",
 			expectedMeshSvc: service.MeshService{},
 			expectError:     true,
 		},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Change db538a1f8 introduced a regression where the cluster
name is not correctly parsed to retrieve the mesh service.

This causes EDS to error and endpoints to not be
programmed.

Error log:
```
{"level":"error","component":"envoy/eds","error":"Invalid cluster name. Expected: <namespace>/<name>, Got: server/server/local","time":"2021-06-24T19:09:41Z","file":"response.go:52","message":"Error retrieving MeshService from Cluster server/server/local"}
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
