### PR TITLE
e2e: Refactoring namespace-related test functions into a new file - namespace.go

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -303,14 +303,6 @@ func (td *OsmTestData) GetTestFilePath(filename string) string {
 	return absPath
 }
 
-// GetTestNamespaceSelectorMap returns a string-based selector used to refer/select all namespace
-// resources for this test
-func (td *OsmTestData) GetTestNamespaceSelectorMap() map[string]string {
-	return map[string]string{
-		osmTest: fmt.Sprintf("%d", GinkgoRandomSeed()),
-	}
-}
-
 // AreRegistryCredsPresent checks if Registry Credentials are present
 // It's usually used to factor if a docker registry secret and ImagePullSecret
 // should be installed when creating namespaces and application templates
@@ -1017,37 +1009,6 @@ func (td *OsmTestData) installCertManager(instOpts InstallOSMOpts) error {
 	return nil
 }
 
-// AddNsToMesh Adds monitored namespaces to the OSM mesh
-func (td *OsmTestData) AddNsToMesh(shouldInjectSidecar bool, ns ...string) error {
-	td.T.Logf("Adding Namespaces [+%s] to the mesh", ns)
-	for _, namespace := range ns {
-		args := []string{"namespace", "add", namespace}
-		if !shouldInjectSidecar {
-			args = append(args, "--disable-sidecar-injection")
-		}
-
-		stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args)
-		if err != nil {
-			td.T.Logf("error running osm namespace add")
-			td.T.Logf("stdout:\n%s", stdout)
-			td.T.Logf("stderr:\n%s", stderr)
-			return errors.Wrap(err, "failed to run osm namespace add")
-		}
-
-		if Td.EnableNsMetricTag {
-			args = []string{"metrics", "enable", "--namespace", namespace}
-			stdout, stderr, err = td.RunLocal(filepath.FromSlash("../../bin/osm"), args)
-			if err != nil {
-				td.T.Logf("error running osm namespace add")
-				td.T.Logf("stdout:\n%s", stdout)
-				td.T.Logf("stderr:\n%s", stderr)
-				return errors.Wrap(err, "failed to run osm namespace add")
-			}
-		}
-	}
-	return nil
-}
-
 // UpdateOSMConfig updates OSM MeshConfig
 func (td *OsmTestData) UpdateOSMConfig(meshConfig *v1alpha1.MeshConfig) (*v1alpha1.MeshConfig, error) {
 	updated, err := td.ConfigClient.ConfigV1alpha1().MeshConfigs(td.OsmNamespace).Update(context.TODO(), meshConfig, metav1.UpdateOptions{})
@@ -1131,30 +1092,6 @@ func (td *OsmTestData) DeleteNs(nsName string) error {
 		return errors.Wrap(err, "failed to delete namespace "+nsName)
 	}
 	return nil
-}
-
-// WaitForNamespacesDeleted waits for the namespaces to be deleted.
-// Reference impl taken from https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/util.go#L258
-func (td *OsmTestData) WaitForNamespacesDeleted(namespaces []string, timeout time.Duration) error {
-	By(fmt.Sprintf("Waiting for namespaces %v to vanish", namespaces))
-	nsMap := map[string]bool{}
-	for _, ns := range namespaces {
-		nsMap[ns] = true
-	}
-	//Now POLL until all namespaces have been eradicated.
-	return wait.Poll(2*time.Second, timeout,
-		func() (bool, error) {
-			nsList, err := td.Client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
-			if err != nil {
-				return false, err
-			}
-			for _, item := range nsList.Items {
-				if _, ok := nsMap[item.Name]; ok {
-					return false, nil
-				}
-			}
-			return true, nil
-		})
 }
 
 // WaitForPodsDeleted waits for the pods to be deleted.

--- a/tests/framework/namespace.go
+++ b/tests/framework/namespace.go
@@ -1,0 +1,77 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/pkg/errors"
+)
+
+// AddNsToMesh Adds monitored namespaces to the OSM mesh
+func (td *OsmTestData) AddNsToMesh(shouldInjectSidecar bool, ns ...string) error {
+	td.T.Logf("Adding Namespaces [+%s] to the mesh", ns)
+	for _, namespace := range ns {
+		args := []string{"namespace", "add", namespace}
+		if !shouldInjectSidecar {
+			args = append(args, "--disable-sidecar-injection")
+		}
+
+		stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args)
+		if err != nil {
+			td.T.Logf("error running osm namespace add")
+			td.T.Logf("stdout:\n%s", stdout)
+			td.T.Logf("stderr:\n%s", stderr)
+			return errors.Wrap(err, "failed to run osm namespace add")
+		}
+
+		if Td.EnableNsMetricTag {
+			args = []string{"metrics", "enable", "--namespace", namespace}
+			stdout, stderr, err = td.RunLocal(filepath.FromSlash("../../bin/osm"), args)
+			if err != nil {
+				td.T.Logf("error running osm namespace add")
+				td.T.Logf("stdout:\n%s", stdout)
+				td.T.Logf("stderr:\n%s", stderr)
+				return errors.Wrap(err, "failed to run osm namespace add")
+			}
+		}
+	}
+	return nil
+}
+
+// WaitForNamespacesDeleted waits for the namespaces to be deleted.
+// Reference impl taken from https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/util.go#L258
+func (td *OsmTestData) WaitForNamespacesDeleted(namespaces []string, timeout time.Duration) error {
+	ginkgo.By(fmt.Sprintf("Waiting for namespaces %v to vanish", namespaces))
+	nsMap := map[string]bool{}
+	for _, ns := range namespaces {
+		nsMap[ns] = true
+	}
+	//Now POLL until all namespaces have been eradicated.
+	return wait.Poll(2*time.Second, timeout,
+		func() (bool, error) {
+			nsList, err := td.Client.CoreV1().Namespaces().List(context.TODO(), v1.ListOptions{})
+			if err != nil {
+				return false, err
+			}
+			for _, item := range nsList.Items {
+				if _, ok := nsMap[item.Name]; ok {
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+}
+
+// GetTestNamespaceSelectorMap returns a string-based selector used to refer/select all namespace
+// resources for this test
+func (td *OsmTestData) GetTestNamespaceSelectorMap() map[string]string {
+	return map[string]string{
+		osmTest: fmt.Sprintf("%d", ginkgo.GinkgoRandomSeed()),
+	}
+}


### PR DESCRIPTION
This PR moves, without changing, the following functions from `common.go` to `namespace.go`:

  - `AddNsToMesh(shouldInjectSidecar bool, ns ...string)`
  - `WaitForNamespacesDeleted(namespaces []string, timeout time.Duration)`
  - `GetTestNamespaceSelectorMap()`

No functional code changes!

The goal of this PR is to make `common.go` smaller and easier to navigate.  As of this writing it has over 1600 lines of code.
