### PR TITLE
e2e: Move helm related functions into helm.go

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -480,35 +480,6 @@ func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 	}
 }
 
-// HelmInstallOSM installs an osm control plane using the osm chart which lives in charts/osm
-func (td *OsmTestData) HelmInstallOSM(release, namespace string) error {
-	if td.InstType == KindCluster {
-		if err := td.LoadOSMImagesIntoKind(); err != nil {
-			return err
-		}
-	}
-
-	values := fmt.Sprintf("OpenServiceMesh.image.registry=%s,OpenServiceMesh.image.tag=%s,OpenServiceMesh.meshName=%s", td.CtrRegistryServer, td.OsmImageTag, release)
-	args := []string{"install", release, "../../charts/osm", "--set", values, "--namespace", namespace, "--create-namespace", "--wait"}
-	stdout, stderr, err := td.RunLocal("helm", args)
-	if err != nil {
-		td.T.Logf("stdout:\n%s", stdout)
-		return errors.Errorf("failed to run helm install with osm chart: %s", stderr)
-	}
-
-	return nil
-}
-
-// DeleteHelmRelease uninstalls a particular helm release
-func (td *OsmTestData) DeleteHelmRelease(name, namespace string) error {
-	args := []string{"uninstall", name, "--namespace", namespace}
-	_, _, err := td.RunLocal("helm", args)
-	if err != nil {
-		td.T.Fatal(err)
-	}
-	return nil
-}
-
 // LoadImagesToKind loads the list of images to the node for Kind clusters
 func (td *OsmTestData) LoadImagesToKind(imageNames []string) error {
 	if td.InstType != KindCluster {

--- a/tests/framework/helm.go
+++ b/tests/framework/helm.go
@@ -1,0 +1,36 @@
+package framework
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// HelmInstallOSM installs an osm control plane using the osm chart which lives in charts/osm
+func (td *OsmTestData) HelmInstallOSM(release, namespace string) error {
+	if td.InstType == KindCluster {
+		if err := td.LoadOSMImagesIntoKind(); err != nil {
+			return err
+		}
+	}
+
+	values := fmt.Sprintf("OpenServiceMesh.image.registry=%s,OpenServiceMesh.image.tag=%s,OpenServiceMesh.meshName=%s", td.CtrRegistryServer, td.OsmImageTag, release)
+	args := []string{"install", release, "../../charts/osm", "--set", values, "--namespace", namespace, "--create-namespace", "--wait"}
+	stdout, stderr, err := td.RunLocal("helm", args)
+	if err != nil {
+		td.T.Logf("stdout:\n%s", stdout)
+		return errors.Errorf("failed to run helm install with osm chart: %s", stderr)
+	}
+
+	return nil
+}
+
+// DeleteHelmRelease uninstalls a particular helm release
+func (td *OsmTestData) DeleteHelmRelease(name, namespace string) error {
+	args := []string{"uninstall", name, "--namespace", namespace}
+	_, _, err := td.RunLocal("helm", args)
+	if err != nil {
+		td.T.Fatal(err)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR moves a few helm related functions into a new file - 'helm.go'

The goal is to lower the number of lines in `common.go`, which as of this writing is around 1600 lines.

No functional code changes.