### PR TITLE
e2e: Simplify file path constructor

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1618,6 +1618,7 @@ func (td *OsmTestData) GrabLogs() error {
 
 		for _, dbgEnvoyPath := range envoyDebugPaths {
 			cmd := "../../bin/osm"
+			filePath := fmt.Sprintf("%s/%s.txt", podEnvoyConfigFilepath, dbgEnvoyPath)
 			args := []string{
 				"proxy",
 				"get",
@@ -1626,7 +1627,7 @@ func (td *OsmTestData) GrabLogs() error {
 				"--namespace",
 				pod.Namespace,
 				"-f",
-				strings.Join([]string{podEnvoyConfigFilepath, fmt.Sprintf("%s.txt", dbgEnvoyPath)}, "/"),
+				filePath,
 			}
 
 			stdout, stderr, err := td.RunLocal(cmd, args)


### PR DESCRIPTION
This PR simplifies the concatenation of a few strings into a file path.  The goal is to make it easier to comprehend at first glance what the file path would be. 

Also - by using the variable name `filePath` we indicate what the string is.

No functional code changes.