### PR TITLE
chore(cli): Remove verbose osm mesh list output

### DIFF
--- a/cmd/cli/mesh_list_test.go
+++ b/cmd/cli/mesh_list_test.go
@@ -7,8 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	v1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
@@ -70,20 +68,6 @@ var _ = Describe("Running the mesh list command", func() {
 					}),
 				}),
 			}))
-		})
-
-		It("Should return map with pods and joined namespaces", func() {
-			fakeClientSet := fake.NewSimpleClientset(&corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "osm-controller-pod",
-					Namespace: "osm-system",
-					Labels: map[string]string{
-						"app": constants.OSMControllerName,
-					},
-				},
-			},
-			)
-			Expect(getNamespacePods(fakeClientSet, "osm", "osm-system")).To(Equal(map[string][]string{"Pods": {"osm-controller-pod"}}))
 		})
 	})
 

--- a/cmd/cli/uninstall.go
+++ b/cmd/cli/uninstall.go
@@ -93,7 +93,6 @@ func (d *uninstallCmd) run() error {
 			out:       d.out,
 			config:    d.config,
 			clientSet: d.clientSet,
-			localPort: d.localPort,
 		}
 
 		_ = listCmd.run()

--- a/cmd/cli/uninstall_test.go
+++ b/cmd/cli/uninstall_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Running the uninstall command", func() {
 			err = cmd.run()
 
 			It("should output list of meshes in the cluster", func() {
-				Expect(out.String()).To(ContainSubstring("\nList of meshes present in the cluster:\n\nMESH NAME   MESH NAMESPACE   CONTROLLER PODS   VERSION            SMI SUPPORTED   ADDED NAMESPACES\ntesting     osm-system"))
+				Expect(out.String()).To(ContainSubstring("\nList of meshes present in the cluster:\n\nMESH NAME   MESH NAMESPACE   VERSION            ADDED NAMESPACES\ntesting     osm-system"))
 			})
 			It("should prompt for confirmation", func() {
 				Expect(out.String()).To(ContainSubstring("Uninstall OSM [mesh name: testing] in namespace [" + settings.Namespace() + "] ? [y/n]: "))
@@ -282,7 +282,7 @@ var _ = Describe("Running the uninstall command", func() {
 			err = cmd.run()
 
 			It("should output list of meshes in the cluster", func() {
-				Expect(out.String()).To(ContainSubstring("\nList of meshes present in the cluster:\n\nMESH NAME   MESH NAMESPACE   CONTROLLER PODS   VERSION            SMI SUPPORTED   ADDED NAMESPACES\ntesting     osm-system"))
+				Expect(out.String()).To(ContainSubstring("\nList of meshes present in the cluster:\n\nMESH NAME   MESH NAMESPACE   VERSION            ADDED NAMESPACES\ntesting     osm-system"))
 			})
 			It("should prompt for confirmation", func() {
 				Expect(out.String()).To(ContainSubstring("Uninstall OSM [mesh name: testing] in namespace [" + settings.Namespace() + "] ? [y/n]: "))

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
@@ -54,19 +55,16 @@ func confirm(stdin io.Reader, stdout io.Writer, s string, tries int) (bool, erro
 	return false, nil
 }
 
-// getPrettyPrintedMeshInfoList a pretty printed list of meshes.
-// If showIndex is true, then a 1-indexed number is prepended before each mesh.
+// getPrettyPrintedMeshInfoList returns a pretty printed list of meshes.
 func getPrettyPrintedMeshInfoList(meshInfoList []meshInfo) string {
-	s := "\nMESH NAME\tMESH NAMESPACE\tCONTROLLER PODS\tVERSION\tSMI SUPPORTED\tADDED NAMESPACES\n"
+	s := "\nMESH NAME\tMESH NAMESPACE\tVERSION\tADDED NAMESPACES\n"
 
 	for _, meshInfo := range meshInfoList {
 		m := fmt.Sprintf(
-			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\n",
 			meshInfo.name,
 			meshInfo.namespace,
-			strings.Join(meshInfo.controllerPods, ","),
 			meshInfo.version,
-			strings.Join(meshInfo.smiSupportedVersions, ","),
 			strings.Join(meshInfo.monitoredNamespaces, ","),
 		)
 		s += m
@@ -76,7 +74,7 @@ func getPrettyPrintedMeshInfoList(meshInfoList []meshInfo) string {
 }
 
 // getMeshInfoList returns a list of meshes (including the info of each mesh) within the cluster
-func getMeshInfoList(restConfig *rest.Config, clientSet kubernetes.Interface, localPort uint16) ([]meshInfo, error) {
+func getMeshInfoList(restConfig *rest.Config, clientSet kubernetes.Interface) ([]meshInfo, error) {
 	var meshInfoList []meshInfo
 
 	osmControllerDeployments, err := getControllerDeployments(clientSet)
@@ -90,22 +88,10 @@ func getMeshInfoList(restConfig *rest.Config, clientSet kubernetes.Interface, lo
 	for _, osmControllerDeployment := range osmControllerDeployments.Items {
 		meshName := osmControllerDeployment.ObjectMeta.Labels["meshName"]
 		meshNamespace := osmControllerDeployment.ObjectMeta.Namespace
-		meshControllerPods := getNamespacePods(clientSet, meshName, meshNamespace)
 
 		meshVersion := osmControllerDeployment.ObjectMeta.Labels[constants.OSMAppVersionLabelKey]
 		if meshVersion == "" {
 			meshVersion = "Unknown"
-		}
-
-		meshSmiSupportedVersions := []string{"Unknown"}
-		if pods, ok := meshControllerPods["Pods"]; ok && len(pods) > 0 {
-			smiMap, err := getSupportedSmiForControllerPod(meshControllerPods["Pods"][0], meshNamespace, restConfig, clientSet, localPort)
-			if err == nil {
-				meshSmiSupportedVersions = []string{}
-				for smi, version := range smiMap {
-					meshSmiSupportedVersions = append(meshSmiSupportedVersions, fmt.Sprintf("%s:%s", smi, version))
-				}
-			}
 		}
 
 		meshMonitoredNamespaces := []string{}
@@ -117,12 +103,10 @@ func getMeshInfoList(restConfig *rest.Config, clientSet kubernetes.Interface, lo
 		}
 
 		meshInfoList = append(meshInfoList, meshInfo{
-			name:                 meshName,
-			namespace:            meshNamespace,
-			controllerPods:       meshControllerPods["Pods"],
-			version:              meshVersion,
-			smiSupportedVersions: meshSmiSupportedVersions,
-			monitoredNamespaces:  meshMonitoredNamespaces,
+			name:                meshName,
+			namespace:           meshNamespace,
+			version:             meshVersion,
+			monitoredNamespaces: meshMonitoredNamespaces,
 		})
 	}
 
@@ -168,6 +152,56 @@ func getMeshNames(clientSet kubernetes.Interface) mapset.Set {
 	return meshList
 }
 
+// getPrettyPrintedMeshSmiInfoList returns a pretty printed list
+// of meshes with supported smi versions
+func getPrettyPrintedMeshSmiInfoList(meshSmiInfoList []meshSmiInfo) string {
+	s := "\nMESH NAME\tMESH NAMESPACE\tSMI SUPPORTED\n"
+
+	for _, mesh := range meshSmiInfoList {
+		m := fmt.Sprintf(
+			"%s\t%s\t%s\n",
+			mesh.name,
+			mesh.namespace,
+			strings.Join(mesh.smiSupportedVersions, ","),
+		)
+		s += m
+	}
+
+	return s
+}
+
+// getSupportedSmiInfoForMeshList returns a meshSmiInfo list showing
+// the supported smi versions for each osm mesh in the mesh list
+func getSupportedSmiInfoForMeshList(meshInfoList []meshInfo, clientSet kubernetes.Interface, config *rest.Config, localPort uint16) []meshSmiInfo {
+	var meshSmiInfoList []meshSmiInfo
+
+	for _, mesh := range meshInfoList {
+		meshControllerPods := getNamespacePods(clientSet, mesh.name, mesh.namespace)
+
+		meshSmiSupportedVersions := []string{"Unknown"}
+		if pods, ok := meshControllerPods["Pods"]; ok && len(pods) > 0 {
+			smiMap, err := getSupportedSmiForControllerPod(meshControllerPods["Pods"][0], mesh.namespace, config, clientSet, localPort)
+			if err == nil {
+				meshSmiSupportedVersions = []string{}
+				for smi, version := range smiMap {
+					meshSmiSupportedVersions = append(meshSmiSupportedVersions, fmt.Sprintf("%s:%s", smi, version))
+				}
+			}
+		}
+		sort.Strings(meshSmiSupportedVersions)
+
+		meshSmiInfoList = append(meshSmiInfoList, meshSmiInfo{
+			name:                 mesh.name,
+			namespace:            mesh.namespace,
+			smiSupportedVersions: meshSmiSupportedVersions,
+		})
+	}
+
+	return meshSmiInfoList
+}
+
+// getSupportedSmiForControllerPod returns the supported smi versions
+// for a given osm controller pod in a namespace
 func getSupportedSmiForControllerPod(pod string, namespace string, restConfig *rest.Config, clientSet kubernetes.Interface, localPort uint16) (map[string]string, error) {
 	dialer, err := k8s.DialerToPod(restConfig, clientSet, pod, namespace)
 	if err != nil {
@@ -198,6 +232,16 @@ func getSupportedSmiForControllerPod(pod string, namespace string, restConfig *r
 	})
 	if err != nil {
 		return nil, errors.Errorf("Error retrieving supported SMI versions for pod %s in namespace %s: %s", pod, namespace, err)
+	}
+
+	for smiAPI, smiAPIVersion := range smiSupported {
+		// smiApi looks like HTTPRouteGroup
+		// smiApiVersion looks like specs.smi-spec.io/v1alpha4
+		// leave out the API group and only keep the version after "/"
+		splitVersionInfo := strings.SplitN(smiAPIVersion, "/", 2)
+		if len(splitVersionInfo) >= 2 {
+			smiSupported[smiAPI] = splitVersionInfo[1]
+		}
 	}
 
 	return smiSupported, nil

--- a/cmd/cli/util_test.go
+++ b/cmd/cli/util_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Test getting pretty printed output of a list of meshes", func(
 		pp := getPrettyPrintedMeshInfoList(meshInfoList)
 
 		It("should have correct output", func() {
-			Expect(pp).To(Equal("\nMESH NAME\tMESH NAMESPACE\tCONTROLLER PODS\tVERSION\tSMI SUPPORTED\tADDED NAMESPACES\n"))
+			Expect(pp).To(Equal("\nMESH NAME\tMESH NAMESPACE\tVERSION\tADDED NAMESPACES\n"))
 		})
 	})
 
@@ -101,27 +101,59 @@ var _ = Describe("Test getting pretty printed output of a list of meshes", func(
 
 		meshInfoList = []meshInfo{
 			{
-				name:                 "m1",
-				namespace:            "ns1",
-				controllerPods:       []string{"p1", "p2", "p3"},
-				version:              "v1",
-				smiSupportedVersions: []string{"s1", "s2", "s3"},
-				monitoredNamespaces:  []string{"mn1", "mn2", "mn3"},
+				name:                "m1",
+				namespace:           "ns1",
+				version:             "v1",
+				monitoredNamespaces: []string{"mn1", "mn2", "mn3"},
 			},
 			{
-				name:                 "m2",
-				namespace:            "ns2",
-				controllerPods:       []string{"p4", "p5", "p6"},
-				version:              "v2",
-				smiSupportedVersions: []string{"s4", "s5", "s6"},
-				monitoredNamespaces:  []string{"mn4", "mn5", "mn6"},
+				name:                "m2",
+				namespace:           "ns2",
+				version:             "v2",
+				monitoredNamespaces: []string{"mn4", "mn5", "mn6"},
 			},
 		}
 
 		It("should have correct output", func() {
-			Expect(getPrettyPrintedMeshInfoList(meshInfoList)).To(Equal("\nMESH NAME\tMESH NAMESPACE\tCONTROLLER PODS\tVERSION\tSMI SUPPORTED\tADDED NAMESPACES\nm1\tns1\tp1,p2,p3\tv1\ts1,s2,s3\tmn1,mn2,mn3\nm2\tns2\tp4,p5,p6\tv2\ts4,s5,s6\tmn4,mn5,mn6\n"))
+			Expect(getPrettyPrintedMeshInfoList(meshInfoList)).To(Equal("\nMESH NAME\tMESH NAMESPACE\tVERSION\tADDED NAMESPACES\nm1\tns1\tv1\tmn1,mn2,mn3\nm2\tns2\tv2\tmn4,mn5,mn6\n"))
 		})
 
+	})
+})
+
+var _ = Describe("Test getting pretty printed output of smi info of a list of meshes", func() {
+	var (
+		meshSmiInfoList []meshSmiInfo
+	)
+
+	Context("empty mesh list", func() {
+		meshSmiInfoList = []meshSmiInfo{}
+		pp := getPrettyPrintedMeshSmiInfoList(meshSmiInfoList)
+
+		It("should have correct output", func() {
+			Expect(pp).To(Equal("\nMESH NAME\tMESH NAMESPACE\tSMI SUPPORTED\n"))
+		})
+	})
+
+	Context("non-empty mesh list", func() {
+		meshSmiInfoList = []meshSmiInfo{
+			{
+				name:                 "m1",
+				namespace:            "ns1",
+				smiSupportedVersions: []string{"smi1", "smi2", "smi3"},
+			},
+			{
+				name:                 "m2",
+				namespace:            "ns2",
+				smiSupportedVersions: []string{"smi4", "smi5", "smi6"},
+			},
+		}
+
+		pp := getPrettyPrintedMeshSmiInfoList(meshSmiInfoList)
+
+		It("should have correct output", func() {
+			Expect(pp).To(Equal("\nMESH NAME\tMESH NAMESPACE\tSMI SUPPORTED\nm1\tns1\tsmi1,smi2,smi3\nm2\tns2\tsmi4,smi5,smi6\n"))
+		})
 	})
 })
 


### PR DESCRIPTION
This removes verbose output from the osm mesh list
command. The removed output includes osm mesh controller
pod output and supported smi versions.

In lieu of printing verbose output, the command
instead prints out instructions for the user
to obtain supported smi versions through cli commands.

Resolves #3648.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? N
    -   Did you notify the maintainers and provide attribution? NA

1. Is this a breaking change? N
