### PR TITLE
osm-controller: remove unused kubeconfig file dependency

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -58,7 +58,6 @@ const (
 var (
 	verbosity          string
 	meshName           string // An ID that uniquely identifies an OSM instance
-	kubeConfigFile     string
 	osmNamespace       string
 	osmServiceAccount  string
 	webhookConfigName  string
@@ -82,7 +81,6 @@ var (
 func init() {
 	flags.StringVarP(&verbosity, "verbosity", "v", constants.DefaultOSMLogLevel, "Set boot log verbosity level")
 	flags.StringVar(&meshName, "mesh-name", "", "OSM mesh name")
-	flags.StringVar(&kubeConfigFile, "kubeconfig", "", "Path to Kubernetes config file")
 	flags.StringVar(&osmNamespace, "osm-namespace", "", "OSM controller's namespace")
 	flags.StringVar(&osmServiceAccount, "osm-service-account", "", "OSM controller's service account")
 	flags.StringVar(&webhookConfigName, "webhook-config-name", "", "Name of the MutatingWebhookConfiguration to be configured by osm-controller")
@@ -121,9 +119,9 @@ func main() {
 	events.GetPubSubInstance() // Just to generate the interface, single routine context
 
 	// Initialize kube config and client
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigFile)
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {
-		log.Fatal().Err(err).Msgf("Error creating kube config (kubeconfig=%s)", kubeConfigFile)
+		log.Fatal().Err(err).Msg("Error creating kube configs using in-cluster config")
 	}
 	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Since osm-controller builds the kube config using the
in-cluster config and not the kubeconfig file, this
change removes the unused dependency on the kubeconfig
file. The kubeconfig file was used during the initial development
phase.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
