### PR TITLE
feat(multicluster): add weight to RemoteCluster

### DIFF
--- a/charts/osm/crds/config_multicluster_service.yaml
+++ b/charts/osm/crds/config_multicluster_service.yaml
@@ -81,6 +81,11 @@ spec:
                       name:
                         description: Name of the remote cluster
                         type: string
+                      weight:
+                        description: Load balancing weight of the remote cluster
+                        type: integer
+                        minimum: 0
+                        default: 0
                       certificate:
                         description: mTLS certificates (optional)
                         type: string

--- a/pkg/apis/config/v1alpha1/multi_cluster_service.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service.go
@@ -47,6 +47,9 @@ type ClusterSpec struct {
 
 	// Name defines the name of the remote cluster.
 	Name string `json:"name,omitempty"`
+
+	// Weight defines the load balancing weight of the remote cluster
+	Weight int `json:"weight,omitempty"`
 }
 
 // PortSpec contains information on service's port.


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Add `weight` attribute to remote cluster spec. This PR prepares for implementing locality based routing. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | X |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?
No
