### PR TITLE
smi/client: remove unused announcement channel

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -452,19 +452,16 @@ type MeshSpec interface {
 	GetService(service.MeshService) *corev1.Service
 
 	// ListServices Lists Kubernets Service resources that are part of monitored namespaces
-    ListServices() []*corev1.Service
+	ListServices() []*corev1.Service
 
 	// ListServiceAccounts Lists Kubernets Service Account resources that are part of monitored namespaces
-    ListServiceAccounts() []*corev1.ServiceAccounts
+	ListServiceAccounts() []*corev1.ServiceAccounts
 
 	// ListHTTPTrafficSpecs lists SMI HTTPRouteGroup resources
 	ListHTTPTrafficSpecs() []*spec.HTTPRouteGroup
 
 	// ListTrafficTargets lists SMI TrafficTarget resources
 	ListTrafficTargets() []*target.TrafficTarget
-
-	// GetAnnouncementsChannel returns the channel on which SMI client makes announcements
-	GetAnnouncementsChannel() <-chan interface{}
 }
 ```
 

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -84,11 +84,6 @@ func (c *client) run(stop <-chan struct{}) error {
 	return nil
 }
 
-// GetAnnouncementsChannel returns the announcement channel for the SMI client.
-func (c *client) GetAnnouncementsChannel() <-chan a.Announcement {
-	return c.announcements
-}
-
 // newClient creates a provider based on a Kubernetes client instance.
 func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTrafficSplitClient.Interface, smiTrafficSpecClient smiTrafficSpecClient.Interface, smiAccessClient smiAccessClient.Interface, osmNamespace string, kubeController k8s.Controller, providerIdent string, stop chan struct{}) (*client, error) {
 	smiTrafficSplitInformerFactory := smiTrafficSplitInformers.NewSharedInformerFactory(smiTrafficSplitClient, k8s.DefaultKubeEventResyncInterval)
@@ -113,7 +108,6 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		providerIdent:  providerIdent,
 		informers:      &informerCollection,
 		caches:         &cacheCollection,
-		announcements:  make(chan a.Announcement),
 		osmNamespace:   osmNamespace,
 		kubeController: kubeController,
 	}

--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -6,7 +6,6 @@ import (
 	spec "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
@@ -67,9 +66,4 @@ func (f fakeMeshSpec) GetTCPRoute(_ string) *spec.TCPRoute {
 // ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.
 func (f fakeMeshSpec) ListTrafficTargets() []*access.TrafficTarget {
 	return f.trafficTargets
-}
-
-// GetAnnouncementsChannel returns the channel on which SMI makes announcements for the fake Mesh Spec.
-func (f fakeMeshSpec) GetAnnouncementsChannel() <-chan announcements.Announcement {
-	return make(chan announcements.Announcement)
 }

--- a/pkg/smi/types.go
+++ b/pkg/smi/types.go
@@ -9,7 +9,6 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -40,7 +39,6 @@ type client struct {
 	caches         *cacheCollection
 	providerIdent  string
 	informers      *informerCollection
-	announcements  chan announcements.Announcement
 	osmNamespace   string
 	kubeController k8s.Controller
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes the unused announcement channel which
was deprecated in favor of pubsub event framework.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
