### PR TITLE
pkg/*: safely filter events for monitored namespaces

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -1,9 +1,8 @@
 package config
 
 import (
-	"reflect"
-
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -51,8 +50,11 @@ func newConfigClient(configClient configV1alpha1Client.Interface, kubeController
 	}
 
 	shouldObserve := func(obj interface{}) bool {
-		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
-		return kubeController.IsMonitoredNamespace(ns)
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+		return kubeController.IsMonitoredNamespace(object.GetNamespace())
 	}
 
 	remoteServiceEventTypes := k8s.EventTypes{

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -1,8 +1,6 @@
 package ingress
 
 import (
-	"reflect"
-
 	networkingV1 "k8s.io/api/networking/v1"
 	networkingV1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,8 +48,11 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 	}
 
 	shouldObserve := func(obj interface{}) bool {
-		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
-		return kubeController.IsMonitoredNamespace(ns)
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+		return kubeController.IsMonitoredNamespace(object.GetNamespace())
 	}
 
 	c := client{

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,7 +1,6 @@
 package k8s
 
 import (
-	"reflect"
 	"strconv"
 
 	mapset "github.com/deckarep/golang-set"
@@ -80,8 +79,11 @@ func (c *Client) initNamespaceMonitor() {
 
 // Function to filter K8s meta Objects by OSM's isMonitoredNamespace
 func (c *Client) shouldObserve(obj interface{}) bool {
-	ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
-	return c.IsMonitoredNamespace(ns)
+	object, ok := obj.(metav1.Object)
+	if !ok {
+		return false
+	}
+	return c.IsMonitoredNamespace(object.GetNamespace())
 }
 
 // Initializes Service monitoring

--- a/pkg/k8s/event_handlers_test.go
+++ b/pkg/k8s/event_handlers_test.go
@@ -1,10 +1,9 @@
 package k8s
 
 import (
-	"reflect"
-
 	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,8 +22,11 @@ const (
 var _ = Describe("Testing event handlers", func() {
 	Context("Test add on a monitored namespace", func() {
 		shouldObserve := func(obj interface{}) bool {
-			ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
-			return ns == testNamespace
+			object, ok := obj.(metav1.Object)
+			if !ok {
+				return false
+			}
+			return testNamespace == object.GetNamespace()
 		}
 
 		It("Should add the event to the announcement channel", func() {

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -1,9 +1,8 @@
 package policy
 
 import (
-	"reflect"
-
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -56,8 +55,11 @@ func newPolicyClient(policyClient policyV1alpha1Client.Interface, kubeController
 	}
 
 	shouldObserve := func(obj interface{}) bool {
-		ns := reflect.ValueOf(obj).Elem().FieldByName("ObjectMeta").FieldByName("Namespace").String()
-		return kubeController.IsMonitoredNamespace(ns)
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+		return kubeController.IsMonitoredNamespace(object.GetNamespace())
 	}
 
 	egressEventTypes := k8s.EventTypes{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The existing check using reflect can panic if the
event object is not as expected. This change
safely converts the interface to an API object
before retrieving its namespace.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
