### PR TITLE
Create noinstall nightly job

### DIFF
--- a/.github/workflows/nightly-noinstall.yml
+++ b/.github/workflows/nightly-noinstall.yml
@@ -1,0 +1,55 @@
+name: OSM NoInstall Nightly Job
+on: 
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: NoInstall Nightly Job
+    runs-on: ubuntu-latest
+    env: 
+      KUBECONFIG: ./kind-kubeconfig
+    steps:
+      - name: Set random cluster name
+        run: echo "$KIND_CLUSTER_NAME=kind-e2e-$(openssl rand -hex 6)" >> $GITHUB_ENV
+      - name: Setup Kind
+        run: |
+          # config for 1 control plane node and 2 workers (necessary for conformance)
+          cat <<EOF > "kind-config.yaml"
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+          - role: control-plane
+          - role: worker
+          - role: worker
+          EOF
+
+          cat kind-config.yaml
+
+          # use local kindest/node:latest image from kind build node-image
+          kind create cluster --name $KIND_CLUSTER_NAME --image kindest/node:$NODE_IMAGE_TAG -v=3 --wait=1m --config=kind-config.yaml --kubeconfig=kind-kubeconfig
+        env:
+          NODE_IMAGE_TAG: "v1.19.1"
+          KUBECONFIG: ./kind-kubeconfig
+      - name: Get cluster version and nodes
+        run: |
+          kubectl version
+          kubectl get nodes
+      - name: Checkout v2
+        uses: actions/checkout@v2
+      - name: Install OSM via OSM CLI
+        run: |
+          make build-osm
+          ./bin/osm install \
+            --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
+            --set=OpenServiceMesh.image.tag="$CTR_TAG"
+        env: 
+          CTR_REGISTRY: openservicemesh
+          CTR_TAG: ${{ github.sha }}
+      - name: Run e2es
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -test.timeout 60m -installType=NoInstall
+        env: 
+          CTR_REGISTRY: openservicemesh
+          CTR_TAG: ${{ github.sha }}
+      - name: Kind cleanup
+        run: kind delete cluster --name $KIND_CLUSTER_NAME


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add a no-install nightly job that creates a kind cluster, installs OSM via OSM CLI, and runs the e2e suite with the "NoInstall" flag enabled. These will run off of main. 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No
