### PR TITLE
feat(pkg/providers/kube): implement the remaining kube provider funcionality

### DIFF
--- a/charts/osm/crds/multiclusterservice.yaml
+++ b/charts/osm/crds/multiclusterservice.yaml
@@ -58,13 +58,13 @@ spec:
                         minimum: 1
                         maximum: 65535
                       protocol:
-                        description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                        description: The protocol for this port. Supports "tcp", "http", and "grpc". Default is tcp.
                         type: string
-                        default: "TCP"
+                        default: "tcp"
                         enum:
-                          - TCP
-                          - UDP
-                          - SCTP
+                          - tcp
+                          - http
+                          - grpc
                   type: string
                 clusters:
                   description: The clusters the service accounts are hosted on.

--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -64,7 +64,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: ["config.openservicemesh.io"]
-    resources: ["meshconfigs"]
+    resources: ["meshconfigs", "multiclusterservices"]
     verbs: ["delete"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
@@ -133,6 +133,7 @@ spec:
         - >
          kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
          kubectl delete crd meshconfigs.config.openservicemesh.io --ignore-not-found;
+         kubectl delete crd multiclusterservices.config.openservicemesh.io --ignore-not-found;
          kubectl delete crd traffictargets.access.smi-spec.io --ignore-not-found;
          kubectl delete crd httproutegroups.specs.smi-spec.io --ignore-not-found;
          kubectl delete crd multiclusterservices.config.openservicemesh.io --ignore-not-found;

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -110,7 +110,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["config.openservicemesh.io"]
-    resources: ["meshconfigs"]
+    resources: ["meshconfigs", "multiclusterservices"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["split.smi-spec.io"]
     resources: ["trafficsplits"]

--- a/pkg/apis/config/v1alpha1/multi_cluster_service.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service.go
@@ -24,6 +24,9 @@ type MultiClusterService struct {
 
 // MultiClusterServiceSpec is the type used to represent the multicluster service specification.
 type MultiClusterServiceSpec struct {
+	// GlobalIP defines the IP Address for the implicit global service.
+	GlobalIP string `json:"globalIP,omitempty" protobuf:"bytes,3,opt,name=globalIP"`
+
 	// ClusterSpec defines the configuration of other clusters
 	Cluster []ClusterSpec `json:"cluster,omitempty"`
 
@@ -48,7 +51,7 @@ type ClusterSpec struct {
 type PortSpec struct {
 	// The port that will be exposed by this service.
 	Port uint32
-	// Protocol is The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+	// Protocol is The IP protocol for this port. Supports "grpc", "http", and "tcp". Default is tcp.
 	Protocol string
 }
 

--- a/pkg/catalog/endpoint.go
+++ b/pkg/catalog/endpoint.go
@@ -61,7 +61,7 @@ func (mc *MeshCatalog) ListEndpointsForServiceIdentity(downstreamIdentity identi
 	}
 
 	// allowedEndpoints comprises of only those endpoints from outboundEndpoints that matches the endpoints from listEndpointsForServiceIdentity
-	// i.e. only those interseting endpoints are taken into cosideration
+	// i.e. only those intersecting endpoints are taken into cosideration
 	var allowedEndpoints []endpoint.Endpoint
 	for _, destSvcIdentity := range destSvcIdentities {
 		log.Info().Msgf("ups svc endpoints: %v, %v", destSvcIdentity, mc.listEndpointsForServiceIdentity(destSvcIdentity))

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -112,9 +112,9 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient versio
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookstoreV2Service.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookwarehouseService.Namespace).Return(true).AnyTimes()
-	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookstoreV1Service).Return([]identity.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookstoreV2Service).Return([]identity.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookbuyerService).Return([]identity.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV1Service).Return([]identity.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookstoreV2Service).Return([]identity.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
+	mockKubeController.EXPECT().ListServiceAccountsForService(tests.BookbuyerService).Return([]identity.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
 	mockKubeController.EXPECT().IsMetricsEnabled(gomock.Any()).Return(true).AnyTimes()
 
 	mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -531,10 +531,10 @@ func TestListInboundTrafficPolicies(t *testing.T) {
 				locality := service.LocalCluster
 				if ms.Namespace == tc.downstreamSA.ToK8sServiceAccount().Namespace {
 					locality = service.LocalNS
-					mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames[ms.Name], nil).AnyTimes()
+					mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames[ms.Name]).AnyTimes()
 				} else {
 					if ms.Name == tests.BookstoreApexServiceName {
-						mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames["BookstoreApexServiceName"], nil).AnyTimes()
+						mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames["BookstoreApexServiceName"]).AnyTimes()
 					}
 				}
 			}
@@ -1011,10 +1011,10 @@ func TestListInboundPoliciesForTrafficSplits(t *testing.T) {
 				locality := service.LocalCluster
 				if ms.Namespace == tc.downstreamSA.ToK8sServiceAccount().Namespace {
 					locality = service.LocalNS
-					mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames[ms.Name], nil).AnyTimes()
+					mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames[ms.Name]).AnyTimes()
 				} else {
 					if ms.Name == tests.BookstoreApexServiceName {
-						mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames["BookstoreApexServiceName"], nil).AnyTimes()
+						mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return(tests.ExpectedHostnames["BookstoreApexServiceName"]).AnyTimes()
 					}
 				}
 			}
@@ -1336,7 +1336,7 @@ func TestBuildInboundPolicies(t *testing.T) {
 				fmt.Sprintf("%s.%s.svc:8888", tc.inboundService.Name, tc.inboundService.Namespace),
 				fmt.Sprintf("%s.%s.svc.cluster:8888", tc.inboundService.Name, tc.inboundService.Namespace),
 				fmt.Sprintf("%s.%s.svc.cluster.local:8888", tc.inboundService.Name, tc.inboundService.Namespace),
-			}, nil).AnyTimes()
+			}).AnyTimes()
 
 			actual := mc.buildInboundPolicies(&trafficTarget, tc.inboundService)
 			assert.ElementsMatch(tc.expectedInboundPolicies, actual)
@@ -1413,7 +1413,7 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 			k8sService := tests.NewServiceFixture(tc.meshService.Name, tc.meshService.Namespace, map[string]string{})
 
 			mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
-			mockKubeController.EXPECT().GetService(tc.meshService).Return(k8sService)
+			mockKubeController.EXPECT().GetService(tc.meshService).Return(k8sService).AnyTimes()
 			mockServiceProvider.EXPECT().GetHostnamesForService(tc.meshService, service.LocalNS).Return([]string{
 				tc.meshService.Name,
 				fmt.Sprintf("%s.%s", tc.meshService.Name, tc.meshService.Namespace),
@@ -1425,7 +1425,7 @@ func TestBuildInboundPermissiveModePolicies(t *testing.T) {
 				fmt.Sprintf("%s.%s.svc:8888", tc.meshService.Name, tc.meshService.Namespace),
 				fmt.Sprintf("%s.%s.svc.cluster:8888", tc.meshService.Name, tc.meshService.Namespace),
 				fmt.Sprintf("%s.%s.svc.cluster.local:8888", tc.meshService.Name, tc.meshService.Namespace),
-			}, nil).AnyTimes()
+			}).AnyTimes()
 
 			actual := mc.buildInboundPermissiveModePolicies(tc.meshService)
 			assert.Len(actual, len(tc.expectedInboundPolicies))
@@ -1691,7 +1691,7 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 						fmt.Sprintf("%s.%s.svc:8888", ms.Name, ms.Namespace),
 						fmt.Sprintf("%s.%s.svc.cluster:8888", ms.Name, ms.Namespace),
 						fmt.Sprintf("%s.%s.svc.cluster.%s:8888", ms.Name, ms.Namespace, ms.ClusterDomain),
-					}, nil).AnyTimes()
+					}).AnyTimes()
 				} else {
 					mockServiceProvider.EXPECT().GetHostnamesForService(ms, locality).Return([]string{
 						fmt.Sprintf("%s.%s", ms.Name, ms.Namespace),
@@ -1702,7 +1702,7 @@ func TestListInboundPoliciesFromTrafficTargets(t *testing.T) {
 						fmt.Sprintf("%s.%s.svc:8888", ms.Name, ms.Namespace),
 						fmt.Sprintf("%s.%s.svc.cluster:8888", ms.Name, ms.Namespace),
 						fmt.Sprintf("%s.%s.svc.cluster.%s:8888", ms.Name, ms.Namespace, ms.ClusterDomain),
-					}, nil).AnyTimes()
+					}).AnyTimes()
 				}
 			}
 

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -160,7 +160,6 @@ func (mc *MeshCatalog) buildOutboundPermissiveModePolicies(sourceNamespace strin
 	var outPolicies []*trafficpolicy.OutboundTrafficPolicy
 
 	destServices := mc.listMeshServices()
-
 	for _, destService := range destServices {
 		locality := service.LocalCluster
 		if destService.Namespace == sourceNamespace {

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -605,7 +605,7 @@ func TestGetServiceHostnames(t *testing.T) {
 		t.Run(fmt.Sprintf("Testing hostnames for svc %s with locality=%d", tc.svc, tc.locality), func(t *testing.T) {
 			k8sService := tests.NewServiceFixture(tc.svc.Name, tc.svc.Namespace, map[string]string{})
 			mockKubeController.EXPECT().GetService(tc.svc).Return(k8sService).Times(1)
-			mockServiceProvider.EXPECT().GetHostnamesForService(tc.svc, tc.locality).Return(tc.expected, nil).Times(1)
+			mockServiceProvider.EXPECT().GetHostnamesForService(tc.svc, tc.locality).Return(tc.expected).Times(1)
 			actual, err := mc.GetServiceHostnames(tc.svc, tc.locality)
 			assert.Nil(err)
 			assert.ElementsMatch(actual, tc.expected)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -266,8 +266,8 @@ func (c Client) GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error)
 	return nil, nil
 }
 
-// ListServiceIdentitiesForService lists ServiceAccounts associated with the given service
-func (c Client) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
+// ListServiceAccountsForService lists ServiceAccounts associated with the given service
+func (c Client) ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error) {
 	var svcAccounts []identity.K8sServiceAccount
 
 	k8sSvc := c.GetService(svc)

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -348,7 +348,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 		})
 	})
 
-	Context("Test ListServiceIdentitiesForService()", func() {
+	Context("Test ListServiceAccountsForService()", func() {
 		var kubeClient *testclient.Clientset
 		var kubeController Controller
 		var err error
@@ -452,7 +452,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 				ClusterDomain: constants.LocalDomain,
 			}
 
-			svcAccounts, err := kubeController.ListServiceIdentitiesForService(meshSvc)
+			svcAccounts, err := kubeController.ListServiceAccountsForService(meshSvc)
 
 			Expect(err).ToNot(HaveOccurred())
 
@@ -552,7 +552,7 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 				ClusterDomain: constants.LocalDomain,
 			}
 
-			svcAccounts, err := kubeController.ListServiceIdentitiesForService(meshSvc)
+			svcAccounts, err := kubeController.ListServiceAccountsForService(meshSvc)
 
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -150,19 +150,19 @@ func (mr *MockControllerMockRecorder) ListServiceAccounts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccounts", reflect.TypeOf((*MockController)(nil).ListServiceAccounts))
 }
 
-// ListServiceIdentitiesForService mocks base method
-func (m *MockController) ListServiceIdentitiesForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
+// ListServiceAccountsForService mocks base method
+func (m *MockController) ListServiceAccountsForService(arg0 service.MeshService) ([]identity.K8sServiceAccount, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServiceIdentitiesForService", arg0)
+	ret := m.ctrl.Call(m, "ListServiceAccountsForService", arg0)
 	ret0, _ := ret[0].([]identity.K8sServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListServiceIdentitiesForService indicates an expected call of ListServiceIdentitiesForService
-func (mr *MockControllerMockRecorder) ListServiceIdentitiesForService(arg0 interface{}) *gomock.Call {
+// ListServiceAccountsForService indicates an expected call of ListServiceAccountsForService
+func (mr *MockControllerMockRecorder) ListServiceAccountsForService(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceIdentitiesForService", reflect.TypeOf((*MockController)(nil).ListServiceIdentitiesForService), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountsForService", reflect.TypeOf((*MockController)(nil).ListServiceAccountsForService), arg0)
 }
 
 // ListServices mocks base method

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -95,7 +95,7 @@ type Controller interface {
 	ListPods() []*corev1.Pod
 
 	// ListServiceIdentitiesForService lists ServiceAccounts associated with the given service
-	ListServiceIdentitiesForService(svc service.MeshService) ([]identity.K8sServiceAccount, error)
+	ListServiceAccountsForService(svc service.MeshService) ([]identity.K8sServiceAccount, error)
 
 	// GetEndpoints returns the endpoints for a given service, if found
 	GetEndpoints(svc service.MeshService) (*corev1.Endpoints, error)

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -1,57 +1,14 @@
 package k8s
 
 import (
-	"fmt"
 	"strings"
 
 	goversion "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/service"
 )
-
-const (
-	clusterDomain = "cluster.local"
-)
-
-// GetHostnamesForService returns a list of hostnames over which the service can be accessed within the local cluster.
-// If 'sameNamespace' is set to true, then the shorthand hostnames service and service:port are also returned.
-func GetHostnamesForService(svc *corev1.Service, locality service.Locality) []string {
-	var domains []string
-	if svc == nil {
-		return domains
-	}
-
-	serviceName := svc.Name
-	namespace := svc.Namespace
-
-	if locality == service.LocalNS {
-		// Within the same namespace, service name is resolvable to its address
-		domains = append(domains, serviceName) // service
-	}
-
-	domains = append(domains, fmt.Sprintf("%s.%s", serviceName, namespace))                       // service.namespace
-	domains = append(domains, fmt.Sprintf("%s.%s.svc", serviceName, namespace))                   // service.namespace.svc
-	domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster", serviceName, namespace))           // service.namespace.svc.cluster
-	domains = append(domains, fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, clusterDomain)) // service.namespace.svc.cluster.local
-	for _, portSpec := range svc.Spec.Ports {
-		port := portSpec.Port
-
-		if locality == service.LocalNS {
-			// Within the same namespace, service name is resolvable to its address
-			domains = append(domains, fmt.Sprintf("%s:%d", serviceName, port)) // service:port
-		}
-
-		domains = append(domains, fmt.Sprintf("%s.%s:%d", serviceName, namespace, port))                       // service.namespace:port
-		domains = append(domains, fmt.Sprintf("%s.%s.svc:%d", serviceName, namespace, port))                   // service.namespace.svc:port
-		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster:%d", serviceName, namespace, port))           // service.namespace.svc.cluster:port
-		domains = append(domains, fmt.Sprintf("%s.%s.svc.%s:%d", serviceName, namespace, clusterDomain, port)) // service.namespace.svc.cluster.local:port
-	}
-	return domains
-}
 
 // GetServiceFromHostname returns the service name from its hostname
 func GetServiceFromHostname(host string) string {

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -5,71 +5,13 @@ import (
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 
-	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
-
-func TestGetHostnamesForService(t *testing.T) {
-	assert := tassert.New(t)
-
-	testCases := []struct {
-		name              string
-		service           *corev1.Service
-		locality          service.Locality
-		expectedHostnames []string
-	}{
-		{
-			name: "hostnames corresponding to a service in the same namespace",
-			service: tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, map[string]string{
-				tests.SelectorKey: tests.SelectorValue,
-			}),
-			locality: service.LocalNS,
-			expectedHostnames: []string{
-				tests.BookbuyerServiceName,
-				fmt.Sprintf("%s:%d", tests.BookbuyerServiceName, tests.ServicePort),
-				fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-				fmt.Sprintf("%s.%s.svc", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s.svc:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-				fmt.Sprintf("%s.%s.svc.cluster", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-				fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-			},
-		},
-		{
-			name: "hostnames corresponding to a service NOT in the same namespace",
-			service: tests.NewServiceFixture(tests.BookbuyerServiceName, tests.Namespace, map[string]string{
-				tests.SelectorKey: tests.SelectorValue,
-			}),
-			locality: service.LocalCluster,
-			expectedHostnames: []string{
-				fmt.Sprintf("%s.%s", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-				fmt.Sprintf("%s.%s.svc", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s.svc:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-				fmt.Sprintf("%s.%s.svc.cluster", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s.svc.cluster:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-				fmt.Sprintf("%s.%s.svc.cluster.local", tests.BookbuyerServiceName, tests.Namespace),
-				fmt.Sprintf("%s.%s.svc.cluster.local:%d", tests.BookbuyerServiceName, tests.Namespace, tests.ServicePort),
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := GetHostnamesForService(tc.service, tc.locality)
-			assert.ElementsMatch(actual, tc.expectedHostnames)
-			assert.Len(actual, len(tc.expectedHostnames))
-		})
-	}
-}
 
 func TestGetServiceFromHostname(t *testing.T) {
 	assert := tassert.New(t)

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -1,13 +1,17 @@
 package kube
 
 import (
+	"fmt"
 	"net"
+	"strconv"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/config"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -24,6 +28,7 @@ func NewClient(kubeController k8s.Controller, configClient config.Controller, pr
 		providerIdent:  providerIdent,
 		kubeController: kubeController,
 		configClient:   configClient,
+		configurator:   cfg,
 	}
 }
 
@@ -37,35 +42,89 @@ func (c *Client) GetID() string {
 func (c *Client) ListEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
 	log.Trace().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
 	var endpoints []endpoint.Endpoint
-
-	kubernetesEndpoints, err := c.kubeController.GetEndpoints(svc)
-	if err != nil || kubernetesEndpoints == nil {
-		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache for service %s", c.providerIdent, svc)
-		return endpoints
+	var mcs *v1alpha1.MultiClusterService
+	if !c.kubeController.IsMonitoredNamespace(svc.Namespace) {
+		return nil
 	}
 
-	if !c.kubeController.IsMonitoredNamespace(kubernetesEndpoints.Namespace) {
-		// Doesn't belong to namespaces we are observing
+	if svc.Local() {
+		kubernetesEndpoints, err := c.kubeController.GetEndpoints(svc)
+		if err != nil || kubernetesEndpoints == nil {
+			log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache for service %s", c.providerIdent, svc)
+		} else {
+			for _, kubernetesEndpoint := range kubernetesEndpoints.Subsets {
+				for _, address := range kubernetesEndpoint.Addresses {
+					for _, port := range kubernetesEndpoint.Ports {
+						ip := net.ParseIP(address.IP)
+						if ip == nil {
+							log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, address.IP)
+							break
+						}
+						ept := endpoint.Endpoint{
+							IP:   ip,
+							Port: endpoint.Port(port.Port),
+						}
+						endpoints = append(endpoints, ept)
+					}
+				}
+			}
+		}
 		return endpoints
 	}
+	if c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		mcs = c.configClient.GetMultiClusterService(svc.Name, svc.Namespace)
+		if mcs == nil {
+			return endpoints
+		}
 
-	for _, kubernetesEndpoint := range kubernetesEndpoints.Subsets {
-		for _, address := range kubernetesEndpoint.Addresses {
-			for _, port := range kubernetesEndpoint.Ports {
-				ip := net.ParseIP(address.IP)
-				if ip == nil {
-					log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, address.IP)
-					break
+		if svc.SingleRemoteCluster() {
+			for _, cluster := range mcs.Spec.Cluster {
+				if cluster.Name == svc.ClusterDomain.String() {
+					ep, err := epFromCluster(cluster.Address)
+					if err == nil {
+						return []endpoint.Endpoint{ep}
+					}
 				}
-				ept := endpoint.Endpoint{
-					IP:   ip,
-					Port: endpoint.Port(port.Port),
+			}
+			// Explicitly return nil for single remote cluster that couldn't get the cluster's address.
+			return nil
+		}
+
+		if svc.Global() {
+			for _, cluster := range mcs.Spec.Cluster {
+				ep, err := epFromCluster(cluster.Address)
+				if err != nil {
+					log.Error().Err(err).Msgf("error parsing endpoint from %s", cluster.Address)
+					continue
 				}
-				endpoints = append(endpoints, ept)
+				endpoints = append(endpoints, ep)
 			}
 		}
 	}
+
+	// Return the collected set of endpoints.
 	return endpoints
+}
+
+func epFromCluster(addr string) (endpoint.Endpoint, error) {
+	parts := strings.Split(addr, ":")
+	if len(parts) != 2 {
+		return endpoint.Endpoint{}, fmt.Errorf("expected an ip Address of format ip:port, got %s", addr)
+	}
+	ip := net.ParseIP(parts[0])
+	if ip == nil {
+		return endpoint.Endpoint{}, fmt.Errorf("error parsing ip from %s, %v", addr, parts)
+	}
+
+	port, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return endpoint.Endpoint{}, err
+	}
+
+	return endpoint.Endpoint{
+		IP:   ip,
+		Port: endpoint.Port(port),
+	}, nil
 }
 
 // ListEndpointsForIdentity retrieves the list of IP addresses for the given service account
@@ -94,6 +153,24 @@ func (c *Client) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdenti
 			endpoints = append(endpoints, ept)
 		}
 	}
+	if c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		for _, mcs := range c.configClient.ListMultiClusterServices() {
+			if mcs.Namespace != sa.Namespace {
+				continue
+			}
+			if mcs.Spec.ServiceAccount != sa.Name {
+				continue
+			}
+			for _, cluster := range mcs.Spec.Cluster {
+				ep, err := epFromCluster(cluster.Address)
+				if err != nil {
+					log.Error().Err(err).Msgf("[%s] Error parsing IP address from MultiClusterService %s", c.providerIdent, cluster.Address)
+					continue
+				}
+				endpoints = append(endpoints, ep)
+			}
+		}
+	}
 	return endpoints
 }
 
@@ -114,18 +191,31 @@ func (c *Client) GetServicesForServiceIdentity(svcIdentity identity.ServiceIdent
 
 		podLabels := pod.ObjectMeta.Labels
 
-		k8sServices, err := c.getServicesByLabels(podLabels, pod.Namespace)
-		if err != nil {
-			log.Error().Err(err).Msgf("[%s] Error retrieving service matching labels %v in namespace %s", c.providerIdent, podLabels, pod.Namespace)
-			return nil, err
-		}
-
-		for _, svc := range k8sServices {
+		for _, svc := range c.getServicesByLabels(podLabels, pod.Namespace) {
 			services.Add(service.MeshService{
 				Namespace:     pod.Namespace,
 				Name:          svc.Name,
 				ClusterDomain: constants.LocalDomain,
 			})
+		}
+	}
+
+	if c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		mcservices := c.configClient.ListMultiClusterServices()
+		for _, mcs := range mcservices {
+			if mcs.Namespace != svcAccount.Namespace {
+				continue
+			}
+			if mcs.Spec.ServiceAccount != svcAccount.Name {
+				continue
+			}
+			for _, cluster := range mcs.Spec.Cluster {
+				services.Add(service.MeshService{
+					Namespace:     mcs.Namespace,
+					Name:          mcs.Name,
+					ClusterDomain: constants.ClusterDomain(cluster.Name),
+				})
+			}
 		}
 	}
 
@@ -145,8 +235,10 @@ func (c *Client) GetServicesForServiceIdentity(svcIdentity identity.ServiceIdent
 
 // GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol
 func (c *Client) GetTargetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
+	if !svc.Local() {
+		return nil, fmt.Errorf("cannot get target ports for remote service %s", svc)
+	}
 	portToProtocolMap := make(map[uint32]string)
-
 	endpoints, err := c.kubeController.GetEndpoints(svc)
 	if err != nil || endpoints == nil {
 		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache", c.providerIdent)
@@ -175,12 +267,11 @@ func (c *Client) GetTargetPortToProtocolMappingForService(svc service.MeshServic
 			portToProtocolMap[uint32(port.Port)] = appProtocol
 		}
 	}
-
 	return portToProtocolMap, nil
 }
 
 // getServicesByLabels gets Kubernetes services whose selectors match the given labels
-func (c *Client) getServicesByLabels(podLabels map[string]string, namespace string) ([]service.MeshService, error) {
+func (c *Client) getServicesByLabels(podLabels map[string]string, namespace string) []service.MeshService {
 	var finalList []service.MeshService
 	serviceList := c.kubeController.ListServices()
 
@@ -202,42 +293,84 @@ func (c *Client) getServicesByLabels(podLabels map[string]string, namespace stri
 		}
 	}
 
-	return finalList, nil
+	return finalList
 }
 
 // GetResolvableEndpointsForService returns the expected endpoints that are to be reached when the service
-// FQDN is resolved
+// FQDN is resolved. This is used after DNS lookup in the filterchain match to match the IP address to an upstream
+// service.
 func (c *Client) GetResolvableEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {
 	var endpoints []endpoint.Endpoint
 	var err error
 
-	// Check if the service has been given Cluster IP
-	kubeService := c.kubeController.GetService(svc)
-	if kubeService == nil {
-		log.Error().Msgf("[%s] Could not find service %s", c.providerIdent, svc)
-		return nil, errServiceNotFound
+	if svc.Local() {
+		// Check if the service has been given Cluster IP
+		kubeService := c.kubeController.GetService(svc)
+		if kubeService == nil {
+			log.Error().Msgf("[%s] Could not find service %s", c.providerIdent, svc)
+			return nil, errServiceNotFound
+		}
+
+		// TODO(steeling): This is not how statefulsets work within kubernetes, and should be removed.
+		if len(kubeService.Spec.ClusterIP) == 0 || kubeService.Spec.ClusterIP == corev1.ClusterIPNone {
+			// If service has no cluster IP or cluster IP is <none>, use final endpoint as resolvable destinations
+			return c.ListEndpointsForService(svc), nil
+		}
+
+		// Cluster IP is present
+		ip := net.ParseIP(kubeService.Spec.ClusterIP)
+		if ip == nil {
+			log.Error().Msgf("[%s] Could not parse Cluster IP %s", c.providerIdent, kubeService.Spec.ClusterIP)
+			return nil, errParseClusterIP
+		}
+
+		for _, svcPort := range kubeService.Spec.Ports {
+			endpoints = append(endpoints, endpoint.Endpoint{
+				IP:   ip,
+				Port: endpoint.Port(svcPort.Port),
+			})
+		}
+		return endpoints, err
 	}
 
-	if len(kubeService.Spec.ClusterIP) == 0 || kubeService.Spec.ClusterIP == corev1.ClusterIPNone {
-		// If service has no cluster IP or cluster IP is <none>, use final endpoint as resolvable destinations
-		return c.ListEndpointsForService(svc), nil
+	if c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		mcs := c.configClient.GetMultiClusterService(svc.Name, svc.Namespace)
+		if mcs == nil {
+			return nil, errServiceNotFound
+		}
+
+		var ipStr string
+		if svc.Global() {
+			ipStr = mcs.Spec.GlobalIP
+		} else {
+			// Refers to a specific cluster
+			for _, cluster := range mcs.Spec.Cluster {
+				if cluster.Name == svc.ClusterDomain.String() {
+					parts := strings.Split(cluster.Address, ":")
+					if len(parts) != 2 {
+						return nil, fmt.Errorf("expected address in format ip:port, got %s", cluster.Address)
+					}
+					ipStr = parts[0]
+					break
+				}
+			}
+		}
+
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			log.Error().Msgf("[%s] Could not parse Cluster IP %s for service %s", c.providerIdent, ipStr, svc)
+			return nil, errParseClusterIP
+		}
+
+		for _, port := range mcs.Spec.Ports {
+			endpoints = append(endpoints, endpoint.Endpoint{
+				IP:   ip,
+				Port: endpoint.Port(port.Port),
+			})
+		}
 	}
 
-	// Cluster IP is present
-	ip := net.ParseIP(kubeService.Spec.ClusterIP)
-	if ip == nil {
-		log.Error().Msgf("[%s] Could not parse Cluster IP %s", c.providerIdent, kubeService.Spec.ClusterIP)
-		return nil, errParseClusterIP
-	}
-
-	for _, svcPort := range kubeService.Spec.Ports {
-		endpoints = append(endpoints, endpoint.Endpoint{
-			IP:   ip,
-			Port: endpoint.Port(svcPort.Port),
-		})
-	}
-
-	return endpoints, err
+	return endpoints, nil
 }
 
 // ListServices returns a list of services that are part of monitored namespaces
@@ -246,24 +379,49 @@ func (c *Client) ListServices() ([]service.MeshService, error) {
 	for _, svc := range c.kubeController.ListServices() {
 		services = append(services, utils.K8sSvcToMeshSvc(svc))
 	}
+
+	if c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		for _, mcs := range c.configClient.ListMultiClusterServices() {
+			for _, cluster := range mcs.Spec.Cluster {
+				services = append(services, service.MeshService{
+					Namespace:     mcs.Namespace,
+					Name:          mcs.Name,
+					ClusterDomain: constants.ClusterDomain(cluster.Name),
+				})
+			}
+		}
+	}
+
 	return services, nil
 }
 
 // ListServiceIdentitiesForService lists the service identities associated with the given mesh service.
 func (c *Client) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.ServiceIdentity, error) {
-	serviceAccounts, err := c.kubeController.ListServiceIdentitiesForService(svc)
-	if err != nil {
-		log.Err(err).Msgf("Error getting ServiceAccounts for Service %s", svc)
+	if svc.Local() {
+		serviceAccounts, err := c.kubeController.ListServiceAccountsForService(svc)
+		if err != nil {
+			log.Err(err).Msgf("Error getting ServiceAccounts for Service %s", svc)
+			return nil, err
+		}
+
+		var serviceIdentities []identity.ServiceIdentity
+		for _, svcAccount := range serviceAccounts {
+			serviceIdentity := svcAccount.ToServiceIdentity()
+			serviceIdentities = append(serviceIdentities, serviceIdentity)
+		}
+
+		return serviceIdentities, nil
+	}
+
+	mcs := c.configClient.GetMultiClusterService(svc.Name, svc.Namespace)
+	if mcs == nil {
+		err := fmt.Errorf("Error getting ServiceAccounts for Service %s", svc)
+		log.Err(err)
 		return nil, err
 	}
-
-	var serviceIdentities []identity.ServiceIdentity
-	for _, svcAccount := range serviceAccounts {
-		serviceIdentity := svcAccount.ToServiceIdentity()
-		serviceIdentities = append(serviceIdentities, serviceIdentity)
-	}
-
-	return serviceIdentities, nil
+	return []identity.ServiceIdentity{
+		identity.K8sServiceAccount{Name: mcs.Spec.ServiceAccount, Namespace: mcs.Namespace}.ToServiceIdentity(),
+	}, nil
 }
 
 // GetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol,
@@ -272,31 +430,86 @@ func (c *Client) ListServiceIdentitiesForService(svc service.MeshService) ([]ide
 func (c *Client) GetPortToProtocolMappingForService(svc service.MeshService) (map[uint32]string, error) {
 	portToProtocolMap := make(map[uint32]string)
 
-	k8sSvc := c.kubeController.GetService(svc)
-	if k8sSvc == nil {
-		return nil, errors.Wrapf(errServiceNotFound, "Error retrieving k8s service %s", svc)
-	}
-
-	for _, portSpec := range k8sSvc.Spec.Ports {
-		var appProtocol string
-		if portSpec.AppProtocol != nil {
-			appProtocol = *portSpec.AppProtocol
-		} else {
-			appProtocol = k8s.GetAppProtocolFromPortName(portSpec.Name)
+	if svc.Local() {
+		k8sSvc := c.kubeController.GetService(svc)
+		if k8sSvc == nil {
+			return nil, errors.Wrapf(errServiceNotFound, "Error retrieving k8s service %s", svc)
 		}
-		portToProtocolMap[uint32(portSpec.Port)] = appProtocol
+
+		for _, portSpec := range k8sSvc.Spec.Ports {
+			var appProtocol string
+			if portSpec.AppProtocol != nil {
+				appProtocol = *portSpec.AppProtocol
+			} else {
+				appProtocol = k8s.GetAppProtocolFromPortName(portSpec.Name)
+			}
+			portToProtocolMap[uint32(portSpec.Port)] = appProtocol
+		}
+		return portToProtocolMap, nil
 	}
 
+	if c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		mcs := c.configClient.GetMultiClusterService(svc.Name, svc.Namespace)
+		if mcs == nil {
+			return nil, fmt.Errorf("Error getting MultiClusterService for Service %s", svc)
+		}
+
+		for _, port := range mcs.Spec.Ports {
+			if protocol, ok := portToProtocolMap[port.Port]; ok && protocol != port.Protocol {
+				log.Error().Msgf("received conflicting port to protocol mapping for service %s", svc)
+			}
+			portToProtocolMap[port.Port] = port.Protocol
+		}
+	}
 	return portToProtocolMap, nil
 }
 
 // GetHostnamesForService returns a list of hostnames over which the service can be accessed within the local cluster.
-func (c *Client) GetHostnamesForService(svc service.MeshService, locality service.Locality) ([]string, error) {
-	k8svc := c.kubeController.GetService(svc)
-	if k8svc == nil {
-		return nil, errors.Errorf("Error fetching service %q", svc)
+func (c *Client) GetHostnamesForService(svc service.MeshService, locality service.Locality) []string {
+	var domains []string
+
+	serviceName := svc.Name
+	namespace := svc.Namespace
+
+	// Referencing a local service in the local namespace
+	if locality == service.LocalNS && svc.Local() {
+		// Within the same namespace, service name is resolvable to its address
+		domains = append(domains, serviceName) // service
 	}
 
-	hostnames := k8s.GetHostnamesForService(k8svc, locality)
-	return hostnames, nil
+	// Referencing a local service in the local cluster
+	if svc.Local() && locality != service.RemoteCluster {
+		domains = append(domains, fmt.Sprintf("%s.%s", serviceName, namespace))             // service.namespace
+		domains = append(domains, fmt.Sprintf("%s.%s.svc", serviceName, namespace))         // service.namespace.svc
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster", serviceName, namespace)) // service.namespace.svc.cluster
+		// Always add the name of the service. This can be local, global, or the remote specific remote cluster.
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster.%s", serviceName, namespace, constants.LocalDomain)) // service.namespace.svc.cluster.local
+	}
+
+	// Allow the local cluster name for all local services
+	if svc.Local() && c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		fmt.Println("||||||||||||| allowed multicluster mode")
+		// Allow reference to the self cluster id.
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster.%s", serviceName, namespace, c.configurator.GetClusterDomain()))
+	}
+
+	if !svc.Local() && c.configurator.GetFeatureFlags().EnableMulticlusterMode {
+		// Always add the name of the service for remote services. This can be local, global, or the specific remote cluster.
+		domains = append(domains, fmt.Sprintf("%s.%s.svc.cluster.%s", serviceName, namespace, svc.ClusterDomain.String())) // service.namespace.svc.cluster.local
+	}
+
+	cp := make([]string, len(domains))
+	copy(cp, domains)
+
+	// Only used to get the ports...
+	ports, err := c.GetPortToProtocolMappingForService(svc)
+	if err != nil {
+		log.Err(err).Msgf("Error getting ports for service %s", svc)
+	}
+	for _, domain := range cp {
+		for port := range ports {
+			domains = append(domains, fmt.Sprintf("%s:%d", domain, port)) // Add the port
+		}
+	}
+	return domains
 }

--- a/pkg/providers/kube/types.go
+++ b/pkg/providers/kube/types.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"github.com/openservicemesh/osm/pkg/config"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -15,4 +16,5 @@ type Client struct {
 	providerIdent  string
 	kubeController k8s.Controller
 	configClient   config.Controller
+	configurator   configurator.Configurator
 }

--- a/pkg/service/mock_service_provider_generated.go
+++ b/pkg/service/mock_service_provider_generated.go
@@ -35,12 +35,11 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // GetHostnamesForService mocks base method
-func (m *MockProvider) GetHostnamesForService(arg0 MeshService, arg1 Locality) ([]string, error) {
+func (m *MockProvider) GetHostnamesForService(arg0 MeshService, arg1 Locality) []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostnamesForService", arg0, arg1)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetHostnamesForService indicates an expected call of GetHostnamesForService

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -65,10 +65,16 @@ func (ms MeshService) Local() bool {
 	return ms.ClusterDomain == constants.LocalDomain || ms.ClusterDomain == ""
 }
 
-// Global returns whether or not this is service points to the global clusterset.
+// Global returns whether or not this service points to the global clusterset.
 func (ms MeshService) Global() bool {
 	// TODO(steeling): if it's unset consider it local for now.
 	return ms.ClusterDomain == constants.GlobalDomain
+}
+
+// SingleRemoteCluster returns whether or not this service points a specific remote cluster.
+func (ms MeshService) SingleRemoteCluster() bool {
+	// TODO(steeling): if it's unset consider it local for now.
+	return ms.ClusterDomain != constants.GlobalDomain && ms.ClusterDomain != constants.LocalDomain
 }
 
 // ClusterName is a type for a service name
@@ -107,7 +113,7 @@ type Provider interface {
 	GetTargetPortToProtocolMappingForService(MeshService) (map[uint32]string, error)
 
 	// GetHostnamesForService returns a list of hostnames over which the service can be accessed within the local cluster.
-	GetHostnamesForService(MeshService, Locality) ([]string, error)
+	GetHostnamesForService(MeshService, Locality) []string
 
 	// GetID returns the unique identifier of the ServiceProvider.
 	GetID() string

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	tresorPem "github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -126,6 +127,48 @@ var (
 		Namespace:     Namespace,
 		Name:          BookbuyerServiceName,
 		ClusterDomain: constants.LocalDomain,
+	}
+
+	// BookbuyerClusterXService is the bookbuyer service in cluster-x.
+	BookbuyerClusterXService = service.MeshService{
+		Namespace:     Namespace,
+		Name:          BookbuyerServiceName,
+		ClusterDomain: constants.ClusterDomain("cluster-x"),
+	}
+
+	// BookbuyerClusterYService is the bookbuyer service in cluster-y.
+	BookbuyerClusterYService = service.MeshService{
+		Namespace:     Namespace,
+		Name:          BookbuyerServiceName,
+		ClusterDomain: constants.ClusterDomain("cluster-y"),
+	}
+
+	// BookbuyerGlobalService is the bookbuyer global service.
+	BookbuyerGlobalService = service.MeshService{
+		Namespace:     Namespace,
+		Name:          BookbuyerServiceName,
+		ClusterDomain: constants.ClusterDomain(constants.GlobalDomain),
+	}
+
+	// BookstoreClusterXService is the bookstore service in cluster-x.
+	BookstoreClusterXService = service.MeshService{
+		Namespace:     Namespace,
+		Name:          "bookstore",
+		ClusterDomain: constants.ClusterDomain("cluster-x"),
+	}
+
+	// BookstoreClusterYService is the bookstore service in cluster-y.
+	BookstoreClusterYService = service.MeshService{
+		Namespace:     Namespace,
+		Name:          "bookstore",
+		ClusterDomain: constants.ClusterDomain("cluster-y"),
+	}
+
+	// BookstoreGlobalService is the bookstore global service.
+	BookstoreGlobalService = service.MeshService{
+		Namespace:     Namespace,
+		Name:          "bookstore",
+		ClusterDomain: constants.ClusterDomain(constants.GlobalDomain),
 	}
 
 	// BookstoreApexService is the bookstore-apex service
@@ -560,6 +603,73 @@ var (
 	}
 )
 
+// MultiClusterService objects
+var (
+	// BookstoreMCS is the bookstore multi cluster service object.
+	BookstoreMCS = &v1alpha1.MultiClusterService{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "bookstore",
+			Namespace: Namespace,
+		},
+		Spec: v1alpha1.MultiClusterServiceSpec{
+			ServiceAccount: BookstoreServiceAccountName,
+			GlobalIP:       "10.10.10.20",
+			Ports: []v1alpha1.PortSpec{
+				{
+					Port:     8081,
+					Protocol: "TCP",
+				},
+				{
+					Port:     9090,
+					Protocol: "TCP",
+				},
+			},
+			Cluster: []v1alpha1.ClusterSpec{
+				{
+					Name:    "cluster-x",
+					Address: "10.10.10.15:80",
+				},
+				{
+					Name:    "cluster-y",
+					Address: "10.10.10.16:90",
+				},
+			},
+		},
+	}
+
+	// BookbuyerMCS is the bookstore multi cluster service object.
+	BookbuyerMCS = &v1alpha1.MultiClusterService{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      BookbuyerServiceName,
+			Namespace: Namespace,
+		},
+		Spec: v1alpha1.MultiClusterServiceSpec{
+			ServiceAccount: BookbuyerServiceAccountName,
+			GlobalIP:       "10.10.10.30",
+			Ports: []v1alpha1.PortSpec{
+				{
+					Port:     8082,
+					Protocol: "TCP",
+				},
+				{
+					Port:     9091,
+					Protocol: "TCP",
+				},
+			},
+			Cluster: []v1alpha1.ClusterSpec{
+				{
+					Name:    "cluster-x",
+					Address: "10.10.10.11:80",
+				},
+				{
+					Name:    "cluster-y",
+					Address: "10.10.10.12:90",
+				},
+			},
+		},
+	}
+)
+
 // NewPodFixture creates a new Pod struct for testing.
 func NewPodFixture(namespace string, podName string, serviceAccountName string, labels map[string]string) corev1.Pod {
 	return corev1.Pod{
@@ -591,6 +701,39 @@ func NewServiceFixture(serviceName, namespace string, selectors map[string]strin
 				Protocol: corev1.ProtocolTCP,
 				Port:     ServicePort,
 			}},
+			Selector: selectors,
+		},
+	}
+}
+
+// NewServiceFixtureWithMultiplePorts creates a new Kubernetes service with 2 ports
+func NewServiceFixtureWithMultiplePorts(serviceName, namespace string, selectors map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name: "servicePort1",
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "backendName",
+					},
+					Protocol: corev1.ProtocolTCP,
+					Port:     8082,
+				},
+				{
+					Name: "servicePort2",
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "backendName",
+					},
+					Protocol: corev1.ProtocolTCP,
+					Port:     9091,
+				},
+			},
 			Selector: selectors,
 		},
 	}


### PR DESCRIPTION
The kube provider needs to take into account the MultiClusterService object
for all calls. This finishes that out, and makes a small change to account
for the port calls, by switching the gateway listener

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

#3444 

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ x] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No

1. Is this a breaking change?
No
