### PR TITLE
pkg/cert/providers: add cert provider validators test

### DIFF
--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -210,3 +210,139 @@ func TestGetCertificateFromKubernetes(t *testing.T) {
 		assert.Equal(testElement.expectNilVal, cert == nil)
 	}
 }
+
+func TestValidateCertManagerOptions(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		testName  string
+		options   CertManagerOptions
+		expectErr bool
+	}{
+		{
+			testName: "Empty issuer",
+			options: CertManagerOptions{
+				IssuerName:  "",
+				IssuerKind:  "test-kind",
+				IssuerGroup: "test-group",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty kind",
+			options: CertManagerOptions{
+				IssuerName:  "test-name",
+				IssuerKind:  "",
+				IssuerGroup: "test-group",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty group",
+			options: CertManagerOptions{
+				IssuerName:  "test-name",
+				IssuerKind:  "test-kind",
+				IssuerGroup: "",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Valid cert manager opts",
+			options: CertManagerOptions{
+				IssuerName:  "test-name",
+				IssuerKind:  "test-kind",
+				IssuerGroup: "test-group",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, t := range testCases {
+		err := ValidateCertManagerOptions(t.options)
+		if t.expectErr {
+			assert.Error(err, "test '%s' didn't error as expected", t.testName)
+		} else {
+			assert.NoError(err, "test '%s' didn't succeed as expected", t.testName)
+		}
+	}
+}
+
+func TestValidateVaultOptions(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		testName  string
+		options   VaultOptions
+		expectErr bool
+	}{
+		{
+			testName: "invalid proto",
+			options: VaultOptions{
+				VaultProtocol: "ftp",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "vault-role",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty host",
+			options: VaultOptions{
+				VaultProtocol: "http",
+				VaultHost:     "",
+				VaultToken:    "vault-token",
+				VaultRole:     "vault-role",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty token",
+			options: VaultOptions{
+				VaultProtocol: "https",
+				VaultHost:     "vault-host",
+				VaultToken:    "",
+				VaultRole:     "vault-role",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty role",
+			options: VaultOptions{
+				VaultProtocol: "http",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty role",
+			options: VaultOptions{
+				VaultProtocol: "https",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Valid config",
+			options: VaultOptions{
+				VaultProtocol: "https",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "role",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, t := range testCases {
+		err := ValidateVaultOptions(t.options)
+		if t.expectErr {
+			assert.Error(err, "test '%s' didn't error as expected", t.testName)
+		} else {
+			assert.NoError(err, "test '%s' didn't succeed as expected", t.testName)
+		}
+	}
+}


### PR DESCRIPTION
Unit test for `ValidateCertManagerOptions` and `ValidateVaultOptions`

part of #3425

Signed-off-by: Eduard Serra <eduser25@gmail.com>

| Tests                      | [ ] |

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No