### PR TITLE
injector/iptables: resolve unnecessary TODO comment

### DIFF
--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -34,8 +34,6 @@ var iptablesOutboundStaticRules = []string{
 	// For outbound TCP traffic jump from OUTPUT chain to PROXY_OUTPUT chain
 	"iptables -t nat -A OUTPUT -p tcp -j PROXY_OUTPUT",
 
-	// TODO(#1266): Redirect app back calls to itself using PROXY_UID
-
 	// Don't redirect Envoy traffic back to itself, return it to the next chain for processing
 	fmt.Sprintf("iptables -t nat -A PROXY_OUTPUT -m owner --uid-owner %d -j RETURN", constants.EnvoyUID),
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes an unnecessary TODO comment carried
over from the initial init-iptables.sh script.
This TODO was meant to address a case where
a client sends traffic to itself using the
service IP, which would get routed back to
itself, and if such traffic needed to be
bypassed then an additional iptables rule
would be necessary. Since we do not have
any requirement to bypass additional traffic,
this change removes the ambiguous TODO comment.

Resolves #1266

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Networking                 | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
