### PR TITLE
e2e: Add additional check to verify injector and controller readiness

### DIFF
--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -31,7 +31,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 					"OpenServiceMesh.injector.webhookTimeoutSeconds=30",
 				}
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
-				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 5 /* 3 cert-manager pods, 1 controller, 1 injector */)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 5 /* 3 cert-manager pods, 1 controller, 1 injector */, nil)).To(Succeed())
 
 				// Create Test NS
 				for _, n := range ns {
@@ -56,7 +56,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
 				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
@@ -76,7 +76,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Deploy allow rule client->server
 				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(

--- a/tests/e2e/e2e_controller_restart_test.go
+++ b/tests/e2e/e2e_controller_restart_test.go
@@ -53,7 +53,7 @@ func testHTTPTrafficWithControllerRestart() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no service for client */)
 

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -47,7 +47,7 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 				_, err = Td.CreateService(sourceNs, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1, nil)).To(Succeed())
 
 				controllerDest := "osm-controller." + Td.OsmNamespace + ":9092/debug"
 

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -73,7 +73,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				go func(wg *sync.WaitGroup, srcClient string) {
 					defer GinkgoRecover()
 					defer wg.Done()
-					Expect(Td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService)).To(Succeed())
+					Expect(Td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService, nil)).To(Succeed())
 				}(&wg, destApp)
 
 				// Create all client deployments, also with replicaset
@@ -99,7 +99,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 					go func(wg *sync.WaitGroup, srcClient string) {
 						defer GinkgoRecover()
 						defer wg.Done()
-						Expect(Td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService)).To(Succeed())
+						Expect(Td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService, nil)).To(Succeed())
 					}(&wg, srcClient)
 				}
 				wg.Wait()

--- a/tests/e2e/e2e_egress_policy_test.go
+++ b/tests/e2e/e2e_egress_policy_test.go
@@ -83,7 +83,7 @@ func testEgressPolicy(scenario testScenario) {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's namespace
-		Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1, nil)).To(Succeed())
 
 		url, policy, smiHTTPRoute := getTestAttributes(srcSvcAcc, scenario)
 

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -49,7 +49,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				protocols := []string{
 					"http://",

--- a/tests/e2e/e2e_fluentbit_deployment_test.go
+++ b/tests/e2e/e2e_fluentbit_deployment_test.go
@@ -52,7 +52,7 @@ var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 				// Install OSM without Fluentbit (default)
 				installOpts = Td.GetOSMInstallOpts()
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
-				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 2 /* controller, injector */)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 2 /* controller, injector */, nil)).To(Succeed())
 
 				pods, err = Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
 					LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-controller"}).String(),

--- a/tests/e2e/e2e_garbage_collector_test.go
+++ b/tests/e2e/e2e_garbage_collector_test.go
@@ -53,7 +53,7 @@ var _ = OSMDescribe("Test garbage collection for unused envoy bootstrap config s
 				_, err = Td.CreateService(userService, svcDef)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(Td.WaitForPodsRunningReady(userService, 200*time.Second, userReplicaSet)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(userService, 200*time.Second, userReplicaSet, nil)).To(Succeed())
 
 				By("Verifying the secrets have been patched with OwnerReference")
 

--- a/tests/e2e/e2e_grpc_insecure_origination_test.go
+++ b/tests/e2e/e2e_grpc_insecure_origination_test.go
@@ -63,7 +63,7 @@ func testGRPCTraffic() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupGRPCClient(sourceName)
 
@@ -156,7 +156,7 @@ func setupGRPCClient(sourceName string) *corev1.Pod {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Expect it to be up and running in it's receiver namespace
-	Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+	Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1, nil)).To(Succeed())
 
 	return srcPod
 }

--- a/tests/e2e/e2e_grpc_secure_origination_test.go
+++ b/tests/e2e/e2e_grpc_secure_origination_test.go
@@ -62,7 +62,7 @@ func testSecureGRPCTraffic() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupGRPCClient(sourceName)
 

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -55,7 +55,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
 				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
@@ -75,7 +75,7 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Deploy allow rule client->server
 				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(

--- a/tests/e2e/e2e_health_probe_test.go
+++ b/tests/e2e/e2e_health_probe_test.go
@@ -251,7 +251,7 @@ server {
 			}
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(ns, 60*time.Second, len(pods))).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(ns, 60*time.Second, len(pods), nil)).To(Succeed())
 		})
 	},
 )

--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -53,7 +53,7 @@ var _ = OSMDescribe("HTTP ingress",
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 			// Install nginx ingress controller
 			// Install Service as NodePort on kind, LoadBalancer elsewhere

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -57,7 +57,7 @@ func testIPExclusion() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		// The destination IP will be programmed as an IP exclusion
 		destinationIPRange := fmt.Sprintf("%s/32", dstSvc.Spec.ClusterIP)

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -61,7 +61,7 @@ func testK8sVersion(version string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no service for client */)
 

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -67,7 +67,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 			// Get simple Pod definitions for the client
 			svcAccDef, depDef, svcDef = Td.SimpleDeploymentApp(SimpleDeploymentAppDef{
@@ -88,7 +88,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 			Expect(err).NotTo(HaveOccurred())
 
 			// Expect it to be up and running in it's receiver namespace
-			Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1, nil)).To(Succeed())
 
 			// Deploy allow rule client->server
 			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -68,7 +68,7 @@ func testMultipleServicePerPod() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no service for client */)
 

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -65,7 +65,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 		_, err = Td.CreateService(destNs, svcDef)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1, nil)).To(Succeed())
 
 		// Get simple Pod definitions for the client
 		svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
@@ -87,7 +87,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(sourceNs, 90*time.Second, 1, nil)).To(Succeed())
 
 		req := HTTPRequestDef{
 			SourceNs:        srcPod.Namespace,

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -67,7 +67,7 @@ func testTraffic(withSourceKubernetesService bool) {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, withSourceKubernetesService)
 
@@ -162,7 +162,7 @@ func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {
 	}
 
 	// Expect it to be up and running in it's receiver namespace
-	Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+	Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1, nil)).To(Succeed())
 
 	return srcPod
 }

--- a/tests/e2e/e2e_port_exclusion_test.go
+++ b/tests/e2e/e2e_port_exclusion_test.go
@@ -61,7 +61,7 @@ func testGlobalPortExclusion() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		// The destination port will be programmed as an global port exclusion
 		destinationPort := int(dstSvc.Spec.Ports[0].Port)
@@ -137,7 +137,7 @@ func testPodLevelPortExclusion() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		// Set up the source curl client. It will be a part of the mesh
 		svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
@@ -161,7 +161,7 @@ func testPodLevelPortExclusion() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(sourceName, 90*time.Second, 1, nil)).To(Succeed())
 
 		By("Using pod level port exclusion to access destination")
 		// All ready. Expect client to reach server

--- a/tests/e2e/e2e_proxy_resource_limits.go
+++ b/tests/e2e/e2e_proxy_resource_limits.go
@@ -112,5 +112,5 @@ func createSimpleApp(appName string, ns string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Expect it to be up and running in it's receiver namespace
-	Expect(Td.WaitForPodsRunningReady(ns, 90*time.Second, 1)).To(Succeed())
+	Expect(Td.WaitForPodsRunningReady(ns, 90*time.Second, 1, nil)).To(Succeed())
 }

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -80,9 +80,9 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Wait for client and server pods to be ready
-				Expect(Td.WaitForPodsRunningReady(sourceOne, 90*time.Second, 1)).To(Succeed())
-				Expect(Td.WaitForPodsRunningReady(sourceTwo, 90*time.Second, 1)).To(Succeed())
-				Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceOne, 90*time.Second, 1, nil)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceTwo, 90*time.Second, 1, nil)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 				// The test creates 2 policies:
 				// 1. Policy to allow client 'sourceOne' to access server 'destName' on the HTTP path '/anything'

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -72,7 +72,7 @@ func testTCPTraffic(permissiveMode bool) {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no kubernetes service for the client */)
 

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -67,7 +67,7 @@ func testTCPEgressTraffic() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(destName, 120*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no kubernetes service for the client */)
 

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -109,7 +109,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 		go func() {
 			defer GinkgoRecover()
 			defer wg.Done()
-			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet, nil)).To(Succeed())
 		}()
 
 		// Client apps
@@ -136,7 +136,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 			go func(app string) {
 				defer GinkgoRecover()
 				defer wg.Done()
-				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet, nil)).To(Succeed())
 			}(clientApp)
 		}
 

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -109,7 +109,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				wg.Add(1)
 				go func() {
 					defer wg.Done()
-					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet, nil)).To(Succeed())
 				}()
 
 				// Client apps
@@ -135,7 +135,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 					wg.Add(1)
 					go func(app string) {
 						defer wg.Done()
-						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet, nil)).To(Succeed())
 					}(clientApp)
 				}
 

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -114,7 +114,7 @@ func testTrafficSplit(appProtocol string) {
 		go func() {
 			defer GinkgoRecover()
 			defer wg.Done()
-			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet, nil)).To(Succeed())
 		}()
 
 		// Client apps
@@ -141,7 +141,7 @@ func testTrafficSplit(appProtocol string) {
 			go func(app string) {
 				defer GinkgoRecover()
 				defer wg.Done()
-				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet, nil)).To(Succeed())
 			}(clientApp)
 		}
 

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -133,7 +133,7 @@ var _ = OSMDescribe("Upgrade from latest",
 			_, err = Td.CreateService(ns, svcDef)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(Td.WaitForPodsRunningReady(ns, 90*time.Second, 2)).To(Succeed())
+			Expect(Td.WaitForPodsRunningReady(ns, 90*time.Second, 2, nil)).To(Succeed())
 
 			// Deploy allow rule client->server
 			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(

--- a/tests/scale/scale_trafficSplit_test.go
+++ b/tests/scale/scale_trafficSplit_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 				go func() {
 					defer GinkgoRecover()
 					defer wg.Done()
-					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet)).To(Succeed())
+					Expect(Td.WaitForPodsRunningReady(serverNamespace, 200*time.Second, numberOfServerServices*serverReplicaSet, nil)).To(Succeed())
 				}()
 
 				// Create sleeping client services
@@ -152,7 +152,7 @@ var _ = Describe("Scales a setup with client-servers and traffic splits til fail
 					go func(app string) {
 						defer GinkgoRecover()
 						defer wg.Done()
-						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet)).To(Succeed())
+						Expect(Td.WaitForPodsRunningReady(app, 200*time.Second, clientReplicaSet, nil)).To(Succeed())
 					}(clientApp)
 				}
 				// Wait for clients and server pods to be up


### PR DESCRIPTION
There's been some cases where injector was not ready after osm install
in some very specific situations and environments.

To avoid and ensuring it's not a situational timing issue or a `helm --wait`
related problem (see #3665), this commit adds an additional check to make
_sure_ osm-controller and osm-injector apps are marked as ready by
kubernetes before proceeding.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
no
1. Is this a breaking change?
no