### PR TITLE
feat(upgrade): Add a conversion webhook server to OSM control plane

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
         with:
           go-version: 1.16
       - name: Build test dependencies
-        run: make docker-build-init-osm-controller docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-init build-osm docker-build-tcp-echo-server
+        run: make docker-build-init-osm-controller docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-crd-converter docker-build-init build-osm docker-build-tcp-echo-server
       # PR Tests
       - name: Run PR tests
         id: pr_test

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,12 @@ clean-osm-injector:
 clean-osm-crds:
 	@rm -rf bin/osm-crds
 
+.PHONY: clean-osm-crd-converter
+clean-osm-crd-converter:
+	@rm -rf bin/osm-crd-converter
+
 .PHONY: build
-build: build-init-osm-controller build-osm-controller build-osm-injector build-osm-crds
+build: build-init-osm-controller build-osm-controller build-osm-injector build-osm-crds build-osm-crd-converter
 
 .PHONY: build-init-osm-controller
 build-init-osm-controller: clean-init-osm-controller
@@ -79,6 +83,10 @@ build-osm-injector: clean-osm-injector
 .PHONY: build-osm-crds
 build-osm-crds: clean-osm-crds
 	cp -R ./charts/osm/crds ./bin/osm-crds
+
+.PHONY: build-osm-crd-converter
+build-osm-crd-converter: clean-osm-crd-converter
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-crd-converter/osm-crd-converter -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w" ./cmd/osm-crd-converter
 
 .PHONY: build-osm
 build-osm: cmd/cli/chart.tgz
@@ -151,7 +159,7 @@ kind-reset:
 	kind delete cluster --name osm
 
 .PHONY: test-e2e
-test-e2e: docker-build-init-osm-controller docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-init build-osm docker-build-tcp-echo-server
+test-e2e: docker-build-init-osm-controller docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-crd-converter docker-build-init build-osm docker-build-tcp-echo-server
 	go test ./tests/e2e $(E2E_FLAGS_DEFAULT) $(E2E_FLAGS)
 
 .env:
@@ -172,7 +180,7 @@ $(DEMO_BUILD_TARGETS):
 	@if [ -f demo/$(NAME).html.template ]; then cp demo/$(NAME).html.template demo/bin/$(NAME); fi
 
 .PHONY: demo-build
-demo-build: $(DEMO_BUILD_TARGETS) build-init-osm-controller build-osm-controller build-osm-injector build-osm-crds
+demo-build: $(DEMO_BUILD_TARGETS) build-init-osm-controller build-osm-controller build-osm-injector build-osm-crds build-osm-crd-converter
 
 # docker-build-bookbuyer, etc
 DOCKER_DEMO_TARGETS = $(addprefix docker-build-, $(DEMO_TARGETS))
@@ -197,11 +205,15 @@ docker-build-osm-injector: build-osm-injector
 docker-build-osm-crds: build-osm-crds
 	docker build -t $(CTR_REGISTRY)/osm-crds:$(CTR_TAG) -f dockerfiles/Dockerfile.osm-crds bin/osm-crds
 
+docker-build-osm-crd-converter: build-osm-crd-converter
+	docker build -t $(CTR_REGISTRY)/osm-crd-converter:$(CTR_TAG) -f dockerfiles/Dockerfile.osm-crd-converter bin/osm-crd-converter
+
 pkg/envoy/lds/stats.wasm: wasm/stats.cc wasm/Makefile
 	docker run --rm -v $(PWD)/wasm:/work -w /work openservicemesh/proxy-wasm-cpp-sdk:956f0d500c380cc1656a2d861b7ee12c2515a664 /build_wasm.sh
 	@mv wasm/stats.wasm $@
+
 .PHONY: docker-build
-docker-build: $(DOCKER_DEMO_TARGETS) docker-build-init docker-build-init-osm-controller  docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds
+docker-build: $(DOCKER_DEMO_TARGETS) docker-build-init docker-build-init-osm-controller  docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-crd-converter 
 
 .PHONY: embed-files
 embed-files: cmd/cli/chart.tgz pkg/envoy/lds/stats.wasm
@@ -215,7 +227,7 @@ build-ci: embed-files
 	go build -v ./...
 
 # docker-push-bookbuyer, etc
-DOCKER_PUSH_TARGETS = $(addprefix docker-push-, $(DEMO_TARGETS) init init-osm-controller osm-controller osm-injector osm-crds)
+DOCKER_PUSH_TARGETS = $(addprefix docker-push-, $(DEMO_TARGETS) init init-osm-controller osm-controller osm-injector osm-crds osm-crd-converter)
 VERIFY_TAGS = 0
 .PHONY: $(DOCKER_PUSH_TARGETS)
 $(DOCKER_PUSH_TARGETS): NAME=$(@:docker-push-%=%)

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -67,6 +67,9 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.configResyncInterval | string | `"0s"` | Sets the resync interval for regular proxy broadcast updates, set to 0s to not enforce any resync |
 | OpenServiceMesh.controlPlaneTolerations | list | `[]` | Node tolerations applied to control plane pods. The specified tolerations allow pods to schedule onto nodes with matching taints. |
 | OpenServiceMesh.controllerLogLevel | string | `"info"` | Controller log verbosity |
+| OpenServiceMesh.crdConverter.podLabels | object | `{}` | CRD converter's pod labels |
+| OpenServiceMesh.crdConverter.replicaCount | int | `1` | CRD converter's replica count |
+| OpenServiceMesh.crdConverter.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | CRD converter's container resource parameters |
 | OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana with OSM installation |
 | OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger during OSM installation |
 | OpenServiceMesh.deployPrometheus | bool | `false` | Deploy Prometheus with OSM installation |
@@ -78,6 +81,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.enforceSingleMesh | bool | `false` | Enforce only deploying one mesh in the cluster |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar |
 | OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |
+| OpenServiceMesh.featureFlags.enableCRDConverter | bool | `false` | If specified, a conversion webhook for OSM's CRD's will be enabled |
 | OpenServiceMesh.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API If specified, fine grained control over Egress (external) traffic is enforced |
 | OpenServiceMesh.featureFlags.enableMulticlusterMode | bool | `false` | Enable Multicluster mode If specified, multicluster mode will be enabled in OSM |
 | OpenServiceMesh.featureFlags.enableOSMGateway | bool | `false` | Enable OSM gateway for ingress or multicluster |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -227,3 +227,4 @@ spec:
                     enableValidatingWebhook:
                       type: boolean
                       default: false
+

--- a/charts/osm/templates/osm-crd-converter-deployment.yaml
+++ b/charts/osm/templates/osm-crd-converter-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.OpenServiceMesh.featureFlags.enableCRDConverter }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: osm-crd-converter
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: osm-crd-converter
+    meshName: {{ .Values.OpenServiceMesh.meshName }}
+spec:
+  replicas: {{ .Values.OpenServiceMesh.crdConverter.replicaCount }}
+  selector:
+    matchLabels:
+      app: osm-crd-converter
+  template:
+    metadata:
+      labels:
+        {{- include "osm.labels" . | nindent 8 }}
+        app: osm-crd-converter
+  {{- if .Values.OpenServiceMesh.crdConverter.podLabels }}
+  {{- toYaml .Values.OpenServiceMesh.crdConverter.podLabels | nindent 8 }}
+  {{- end }}
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9091'
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- include "restricted.securityContext" . | nindent 6 }}
+      {{- end }}
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - name: osm-crd-converter
+          image: "{{ .Values.OpenServiceMesh.image.registry }}/osm-crd-converter:{{ .Values.OpenServiceMesh.image.tag }}"
+          imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}
+          ports:
+            - name: "tls"
+              containerPort: 443
+            - name: "metrics"
+              containerPort: 9091
+          command: ['/osm-crd-converter']
+          args: [
+            "--verbosity", "{{.Values.OpenServiceMesh.controllerLogLevel}}",
+            "--osm-namespace", "{{ include "osm.namespace" . }}",
+            "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
+            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
+            {{ if eq .Values.OpenServiceMesh.certificateManager "vault" }}
+            "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
+            "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
+            "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",
+            {{- end }}
+            "--cert-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
+            "--cert-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
+            "--cert-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
+          ]
+          resources:
+            limits:
+              cpu: "{{.Values.OpenServiceMesh.crdConverter.resource.limits.cpu}}"
+              memory: "{{.Values.OpenServiceMesh.crdConverter.resource.limits.memory}}"
+            requests:
+              cpu: "{{.Values.OpenServiceMesh.crdConverter.resource.requests.cpu}}"
+              memory: "{{.Values.OpenServiceMesh.crdConverter.resource.requests.memory}}"
+          readinessProbe:
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: 443
+          livenessProbe:
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: 443
+          env:
+            # The CRD_CONVERTER_POD_NAME env variable sets pod name dynamically, used by osm-crd-converter to register events
+            - name: CRD_CONVERTER_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+    {{- if .Values.OpenServiceMesh.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.OpenServiceMesh.imagePullSecrets | indent 8 }}
+    {{- end }}
+    {{- if .Values.OpenServiceMesh.controlPlaneTolerations }}
+      tolerations:
+{{ toYaml .Values.OpenServiceMesh.controlPlaneTolerations | indent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/osm/templates/osm-crd-converter-service.yaml
+++ b/charts/osm/templates/osm-crd-converter-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.OpenServiceMesh.featureFlags.enableCRDConverter }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: osm-crd-converter
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: osm-crd-converter
+spec:
+  ports:
+    - name: tls
+      port: 443
+      targetPort: tls
+  selector:
+    app: osm-crd-converter
+{{- end }}
+

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -153,6 +153,7 @@
                 "osmController",
                 "enablePrivilegedInitContainer",
                 "injector",
+                "crdConverter",
                 "featureFlags"
             ],
             "properties": {
@@ -669,6 +670,38 @@
                     },
                     "additionalProperties": false
                 },
+                "crdConverter": {
+                    "$id": "#/properties/OpenServiceMesh/properties/crdConverter",
+                    "type": "object",
+                    "title": "The CRD converter schema",
+                    "description": "CRD converter's configurations",
+                    "required": [
+                        "replicaCount",
+                        "resource"
+                    ],
+                    "properties": {
+                        "replicaCount": {
+                            "$id": "#/properties/OpenServiceMesh/properties/crdConverter/properties/replicaCount",
+                            "type": "integer",
+                            "title": "The replicaCount schema",
+                            "description": "The number of replicas of the CRD converter pod.",
+                            "examples": [
+                                1
+                            ]
+                        },
+                        "resource": {
+                            "$ref": "#/definitions/containerResources"
+                        },
+                        "podLabels": {
+                            "$id": "#/properties/OpenServiceMesh/properties/crdConverter/properties/podLabels",
+                            "type": "object",
+                            "title": "The podLabels schema",
+                            "description": "Labels for the CRD converter pod.",
+                            "default": {}
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "featureFlags": {
                     "$id": "#/properties/OpenServiceMesh/properties/featureFlags",
                     "type": "object",
@@ -686,7 +719,8 @@
                         "enableMulticlusterMode",
                         "enableOSMGateway",
                         "enableAsyncProxyServiceMapping",
-                        "enableValidatingWebhook"
+                        "enableValidatingWebhook",
+                        "enableCRDConverter"
                     ],
                     "properties": {
                         "enableWASMStats": {
@@ -739,6 +773,15 @@
                             "type": "boolean",
                             "title": "Enable kubernetes validating webhook",
                             "description": "Enable kubernetes validating webhook",
+                            "examples": [
+                                true
+                            ]
+                        },
+                        "enableCRDConverter": {
+                            "$id": "#/properties/OpenServiceMesh/properties/featureFlags/properties/enableCRDConverter",
+                            "type": "boolean",
+                            "title": "Enable CRD Conversion Webhook",
+                            "description": "Enable CRD Conversion Webhook in OSM",
                             "examples": [
                                 true
                             ]

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -254,6 +254,8 @@ OpenServiceMesh:
     enableAsyncProxyServiceMapping: false
     # -- Enable kubernetes validating webhook
     enableValidatingWebhook: false
+    # -- If specified, a conversion webhook for OSM's CRD's will be enabled
+    enableCRDConverter: false
 
 
   # -- Run OSM with PodSecurityPolicy configured
@@ -262,3 +264,20 @@ OpenServiceMesh:
   # -- Node tolerations applied to control plane pods.
   # The specified tolerations allow pods to schedule onto nodes with matching taints.
   controlPlaneTolerations: []
+
+  #
+  # -- OSM's CRD converter parameters
+  crdConverter:
+    # -- CRD converter's replica count
+    replicaCount: 1
+    # -- CRD converter's container resource parameters
+    resource:
+      limits:
+        cpu: "0.5"
+        memory: "64M"
+      requests:
+        cpu: "0.3"
+        memory: "64M"
+    # -- CRD converter's pod labels
+    podLabels: {}
+

--- a/cmd/osm-crd-converter/osm-crd-converter.go
+++ b/cmd/osm-crd-converter/osm-crd-converter.go
@@ -1,0 +1,192 @@
+// Package main implements the main entrypoint for osm-crd-converter and utility routines to
+// bootstrap the various internal components of osm-crd-converter.
+// osm-crd-converter provides crd conversion capability in OSM.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openservicemesh/osm/pkg/certificate/providers"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/crdconversion"
+	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	"github.com/openservicemesh/osm/pkg/httpserver"
+	"github.com/openservicemesh/osm/pkg/k8s/events"
+	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
+	"github.com/openservicemesh/osm/pkg/signals"
+	"github.com/openservicemesh/osm/pkg/version"
+)
+
+var (
+	verbosity          string
+	osmNamespace       string
+	caBundleSecretName string
+	osmMeshConfigName  string
+
+	crdConverterConfig crdconversion.Config
+
+	certProviderKind string
+
+	tresorOptions      providers.TresorOptions
+	vaultOptions       providers.VaultOptions
+	certManagerOptions providers.CertManagerOptions
+
+	scheme = runtime.NewScheme()
+)
+
+var (
+	flags = pflag.NewFlagSet(`osm-crd-converter`, pflag.ExitOnError)
+	log   = logger.New("osm-crd-converter/main")
+)
+
+func init() {
+	flags.StringVarP(&verbosity, "verbosity", "v", "info", "Set log verbosity level")
+	flags.StringVar(&osmNamespace, "osm-namespace", "", "Namespace to which OSM belongs to.")
+	flags.StringVar(&osmMeshConfigName, "osm-config-name", "osm-mesh-config", "Name of the OSM MeshConfig")
+
+	// Generic certificate manager/provider options
+	flags.StringVar(&certProviderKind, "certificate-manager", providers.TresorKind.String(), fmt.Sprintf("Certificate manager, one of [%v]", providers.ValidCertificateProviders))
+	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
+
+	// Vault certificate manager/provider options
+	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")
+	flags.StringVar(&vaultOptions.VaultHost, "vault-host", "vault.default.svc.cluster.local", "Host name of the Hashi Vault")
+	flags.StringVar(&vaultOptions.VaultToken, "vault-token", "", "Secret token for the the Hashi Vault")
+	flags.StringVar(&vaultOptions.VaultRole, "vault-role", "openservicemesh", "Name of the Vault role dedicated to Open Service Mesh")
+	flags.IntVar(&vaultOptions.VaultPort, "vault-port", 8200, "Port of the Hashi Vault")
+
+	// Cert-manager certificate manager/provider options
+	flags.StringVar(&certManagerOptions.IssuerName, "cert-manager-issuer-name", "osm-ca", "cert-manager issuer name")
+	flags.StringVar(&certManagerOptions.IssuerKind, "cert-manager-issuer-kind", "Issuer", "cert-manager issuer kind")
+	flags.StringVar(&certManagerOptions.IssuerGroup, "cert-manager-issuer-group", "cert-manager.io", "cert-manager issuer group")
+
+	_ = clientgoscheme.AddToScheme(scheme)
+	_ = admissionv1.AddToScheme(scheme)
+}
+
+func main() {
+	log.Info().Msgf("Starting osm-crd-converter %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
+	if err := parseFlags(); err != nil {
+		log.Fatal().Err(err).Msg("Error parsing cmd line arguments")
+	}
+	if err := logger.SetLogLevel(verbosity); err != nil {
+		log.Fatal().Err(err).Msg("Error setting log level")
+	}
+
+	// Initialize kube config and client
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error creating kube configs using in-cluster config")
+	}
+	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
+	crdClient := apiclient.NewForConfigOrDie(kubeConfig)
+
+	// Initialize the generic Kubernetes event recorder and associate it with the osm-crd-converter pod resource
+	crdConverterPod, err := getCrdConverterPod(kubeClient)
+	if err != nil {
+		log.Fatal().Msg("Error fetching osm-crd-converter pod")
+	}
+	eventRecorder := events.GenericEventRecorder()
+	if err := eventRecorder.Initialize(crdConverterPod, kubeClient, osmNamespace); err != nil {
+		log.Fatal().Msg("Error initializing generic event recorder")
+	}
+
+	// This ensures CLI parameters (and dependent values) are correct.
+	if err := validateCLIParams(); err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InvalidCLIParameters, "Error validating CLI parameters")
+	}
+
+	stop := signals.RegisterExitHandlers()
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Initialize Configurator to retrieve mesh specific config
+	cfg := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName)
+
+	// Intitialize certificate manager/provider
+	certProviderConfig := providers.NewCertificateProviderConfig(kubeClient, kubeConfig, cfg, providers.Kind(certProviderKind), osmNamespace,
+		caBundleSecretName, tresorOptions, vaultOptions, certManagerOptions)
+
+	certManager, _, err := certProviderConfig.GetCertificateManager()
+	if err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
+			"Error initializing certificate manager of kind %s", certProviderKind)
+	}
+
+	// Initialize the crd conversion webhook
+	crdConverterConfig.ListenPort = 443
+	if err := crdconversion.NewConversionWebhook(crdConverterConfig, kubeClient, crdClient, certManager, osmNamespace, stop); err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating crd conversion webhook")
+	}
+
+	/*
+	 * Initialize osm-crd-converter's HTTP server
+	 */
+	httpServer := httpserver.NewHTTPServer(constants.OSMHTTPServerPort)
+	// Metrics
+	httpServer.AddHandler("/metrics", metricsstore.DefaultMetricsStore.Handler())
+	// Version
+	httpServer.AddHandler("/version", version.GetVersionHandler())
+	// Start HTTP server
+	err = httpServer.Start()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Failed to start OSM metrics/probes HTTP server")
+	}
+
+	<-stop
+	log.Info().Msgf("Stopping osm-crd-converter %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
+}
+
+func parseFlags() error {
+	if err := flags.Parse(os.Args); err != nil {
+		return err
+	}
+	_ = flag.CommandLine.Parse([]string{})
+	return nil
+}
+
+// getCrdConverterPod returns the osm-crd-converter pod spec.
+// The pod name is inferred from the 'CRD_CONVERTER_POD_NAME' env variable which is set during deployment.
+func getCrdConverterPod(kubeClient kubernetes.Interface) (*corev1.Pod, error) {
+	podName := os.Getenv("CRD_CONVERTER_POD_NAME")
+	if podName == "" {
+		return nil, errors.New("CRD_CONVERTER_POD_NAME env variable cannot be empty")
+	}
+
+	pod, err := kubeClient.CoreV1().Pods(osmNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		log.Error().Err(err).Msgf("Error retrieving osm-crd-converter pod %s", podName)
+		return nil, err
+	}
+
+	return pod, nil
+}
+
+// validateCLIParams contains all checks necessary that various permutations of the CLI flags are consistent
+func validateCLIParams() error {
+	if osmNamespace == "" {
+		return errors.New("Please specify the OSM namespace using --osm-namespace")
+	}
+
+	if caBundleSecretName == "" {
+		return errors.Errorf("Please specify the CA bundle secret name using --ca-bundle-secret-name")
+	}
+
+	return nil
+}

--- a/dockerfiles/Dockerfile.osm-crd-converter
+++ b/dockerfiles/Dockerfile.osm-crd-converter
@@ -1,0 +1,2 @@
+FROM gcr.io/distroless/static
+COPY osm-crd-converter /

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -97,6 +97,9 @@ const (
 	// WebhookCertificateSecretName is the default value for webhook secret name
 	WebhookCertificateSecretName = "mutating-webhook-cert-secret"
 
+	// CrdConverterCertificateSecretName is the default value for webhook secret name
+	CrdConverterCertificateSecretName = "crd-converter-cert-secret" // #nosec G101: Potential hardcoded credentials
+
 	// RegexMatchAll is a regex pattern match for all
 	RegexMatchAll = ".*"
 

--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -1,0 +1,166 @@
+package crdconversion
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/providers"
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const (
+	// webhookHealthPath is the HTTP path at which the health of the conversion webhook can be queried
+	webhookHealthPath = "/healthz"
+
+	// crdConverterServiceName is the name of the OSM crd converter webhook service
+	crdConverterServiceName = "osm-crd-converter"
+)
+
+var crdConversionWebhookConfiguration = map[string]string{
+	"traffictargets.access.smi-spec.io":              "/trafficaccessconversion",
+	"httproutegroups.specs.smi-spec.io":              "/httproutegroupconversion",
+	"meshconfigs.config.openservicemesh.io":          "/meshconfigconversion",
+	"multiclusterservices.config.openservicemesh.io": "/multiclusterserviceconversion",
+	"egresses.policy.openservicemesh.io":             "/egresspolicyconversion",
+	"trafficsplits.split.smi-spec.io":                "/trafficsplitconversion",
+	"tcproutes.specs.smi-spec.io":                    "/tcproutesconversion",
+}
+
+var conversionReviewVersions = []string{"v1beta1", "v1"}
+
+// NewConversionWebhook starts a new web server handling requests from the CRD's
+func NewConversionWebhook(config Config, kubeClient kubernetes.Interface, crdClient apiclient.ApiextensionsV1Interface, certManager certificate.Manager, osmNamespace string, stop <-chan struct{}) error {
+	// This is a certificate issued for the crd-converter webhook handler
+	// This cert does not have to be related to the Envoy certs, but it does have to match
+	// the cert provisioned with the ConversionWebhook on the CRD's
+	crdConversionWebhookHandlerCert, err := certManager.IssueCertificate(
+		certificate.CommonName(fmt.Sprintf("%s.%s.svc", crdConverterServiceName, osmNamespace)),
+		constants.XDSCertificateValidityPeriod)
+	if err != nil {
+		return errors.Errorf("Error issuing certificate for the crd-converter: %+v", err)
+	}
+
+	// The following function ensures to atomically create or get the certificate from Kubernetes
+	// secret API store. Multiple instances should end up with the same crdConversionwebhookHandlerCert after this function executed.
+	crdConversionWebhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.CrdConverterCertificateSecretName, crdConversionWebhookHandlerCert, kubeClient)
+	if err != nil {
+		return errors.Errorf("Error fetching crd-converter certificate from k8s secret: %s", err)
+	}
+
+	crdWh := crdConversionWebhook{
+		config: config,
+		cert:   crdConversionWebhookHandlerCert,
+	}
+
+	// Start the ConversionWebhook web server
+	go crdWh.run(stop)
+
+	if err = patchCrdsWithConversionWehook(crdConversionWebhookHandlerCert, crdClient, osmNamespace); err != nil {
+		return errors.Errorf("Error patching crds with conversion webhook %v", err)
+	}
+
+	return nil
+}
+
+func (crdWh *crdConversionWebhook) run(stop <-chan struct{}) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(webhookHealthPath, healthHandler)
+
+	// TODO (snchh): add handler and logic for conversion stratergy of each CRD in OSM
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", crdWh.config.ListenPort),
+		Handler: mux,
+	}
+
+	log.Info().Msgf("Starting conversion webhook server on port: %v", crdWh.config.ListenPort)
+	go func() {
+		// Generate a key pair from your pem-encoded cert and key ([]byte).
+		cert, err := tls.X509KeyPair(crdWh.cert.GetCertificateChain(), crdWh.cert.GetPrivateKey())
+		if err != nil {
+			log.Error().Err(err).Msg("Error parsing crd-converter webhook certificate")
+			return
+		}
+
+		// #nosec G402
+		server.TLSConfig = &tls.Config{
+			Certificates: []tls.Certificate{cert},
+		}
+
+		if err := server.ListenAndServeTLS("", ""); err != nil {
+			log.Error().Err(err).Msg("crd-converter webhook HTTP server failed to start")
+			return
+		}
+	}()
+
+	// Wait on exit signals
+	<-stop
+
+	// Stop the server
+	if err := server.Shutdown(ctx); err != nil {
+		log.Error().Err(err).Msg("Error shutting down crd-conversion webhook HTTP server")
+	} else {
+		log.Info().Msg("Done shutting down crd-conversion webhook HTTP server")
+	}
+}
+
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte("Health OK")); err != nil {
+		log.Error().Err(err).Msg("Error writing bytes for crd-conversion webhook health check handler")
+	}
+}
+
+func patchCrdsWithConversionWehook(cert certificate.Certificater, crdClient apiclient.ApiextensionsV1Interface, osmNamespace string) error {
+	for crdName, crdConversionPath := range crdConversionWebhookConfiguration {
+		if err := updateCrdConversionWebhookConfiguration(cert, crdClient, osmNamespace, crdName, crdConversionPath); err != nil {
+			log.Error().Err(err).Msgf("Error updating conversion webhook configuration for crd : %s", crdName)
+			return err
+		}
+	}
+	return nil
+}
+
+// updateCrdConversionWebhookConfiguration updates the Conversion section of the CRD that needs to be updated.
+func updateCrdConversionWebhookConfiguration(cert certificate.Certificater, crdClient apiclient.ApiextensionsV1Interface, osmNamespace, crdName, crdConversionPath string) error {
+	crd, err := crdClient.CustomResourceDefinitions().Get(context.Background(), crdName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	crd.Spec.Conversion = &apiv1.CustomResourceConversion{
+		Strategy: apiv1.WebhookConverter,
+		Webhook: &apiv1.WebhookConversion{
+			ClientConfig: &apiv1.WebhookClientConfig{
+				Service: &apiv1.ServiceReference{
+					Namespace: osmNamespace,
+					Name:      crdConverterServiceName,
+					Path:      &crdConversionPath,
+				},
+				CABundle: cert.GetCertificateChain(),
+			},
+			ConversionReviewVersions: conversionReviewVersions,
+		},
+	}
+
+	if _, err = crdClient.CustomResourceDefinitions().Update(context.Background(), crd, metav1.UpdateOptions{}); err != nil {
+		log.Error().Err(err).Msgf("Error updating conversion webhook configuration for crd : %s", crdName)
+		return err
+	}
+
+	log.Info().Msgf("successfully updated conversion webhook configuration for crd : %s", crdName)
+	return nil
+}

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -1,0 +1,94 @@
+package crdconversion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	tassert "github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+type mockCertificate struct{}
+
+func (mc mockCertificate) GetCommonName() certificate.CommonName     { return "" }
+func (mc mockCertificate) GetCertificateChain() []byte               { return []byte("chain") }
+func (mc mockCertificate) GetPrivateKey() []byte                     { return []byte("key") }
+func (mc mockCertificate) GetIssuingCA() []byte                      { return []byte("ca") }
+func (mc mockCertificate) GetExpiration() time.Time                  { return time.Now() }
+func (mc mockCertificate) GetSerialNumber() certificate.SerialNumber { return "serial_number" }
+
+func TestUpdateCrdConversionWebhookConfiguration(t *testing.T) {
+	assert := tassert.New(t)
+	cert := mockCertificate{}
+
+	crdClient := fake.NewSimpleClientset(&apiv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tests.test.openservicemesh.io",
+		},
+		Spec: apiv1.CustomResourceDefinitionSpec{
+			Group: "test.openservicemesh.io",
+			Names: apiv1.CustomResourceDefinitionNames{
+				Plural:   "tests",
+				Singular: "test",
+				Kind:     "test",
+				ListKind: "testList",
+			},
+			Scope: apiv1.NamespaceScoped,
+			Versions: []apiv1.CustomResourceDefinitionVersion{{
+				Name:    "v1alpha1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+						Type:       "object",
+						Properties: make(map[string]apiv1.JSONSchemaProps),
+					},
+				},
+			}},
+		},
+	})
+
+	err := updateCrdConversionWebhookConfiguration(cert, crdClient.ApiextensionsV1(), tests.Namespace, "tests.test.openservicemesh.io", "/testconversion")
+	assert.Nil(err)
+
+	crds, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err)
+
+	crd := crds.Items[0]
+	assert.Equal(crd.Spec.Conversion.Strategy, apiv1.WebhookConverter)
+	assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, []byte("chain"))
+	assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace, tests.Namespace)
+	assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Name, crdConverterServiceName)
+	assert.Equal(crd.Spec.Conversion.Webhook.ConversionReviewVersions, conversionReviewVersions)
+}
+
+func TestNewConversionWebhook(t *testing.T) {
+	assert := tassert.New(t)
+	crdConversionConfig := Config{}
+	crdClient := fake.NewSimpleClientset()
+	kubeClient := k8sfake.NewSimpleClientset()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	fakeCertManager := tresor.NewFakeCertManager(mockConfigurator)
+	osmNamespace := "-osm-namespace-"
+	stop := make(<-chan struct{})
+
+	actualErr := NewConversionWebhook(crdConversionConfig, kubeClient, crdClient.ApiextensionsV1(), fakeCertManager, osmNamespace, stop)
+	assert.NotNil(actualErr)
+}

--- a/pkg/crdconversion/types.go
+++ b/pkg/crdconversion/types.go
@@ -1,0 +1,22 @@
+// Package crdconversion implements OSM's CRD conversion facility. The crd-converter webhook
+// server intercepts crd get/list/create/update requests to apply the required conversion logic.
+package crdconversion
+
+import (
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var log = logger.New("crd-conversion")
+
+// crdConversionWebhook is the type used to represent the webhook for the crd converter
+type crdConversionWebhook struct {
+	config Config
+	cert   certificate.Certificater
+}
+
+// Config is the type used to represent the config options for the crd-conversion webhook
+type Config struct {
+	// ListenPort defines the port on which the crd-conversion webhook listens
+	ListenPort int
+}

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -533,6 +533,7 @@ func (td *OsmTestData) LoadOSMImagesIntoKind() error {
 		"osm-injector",
 		"init",
 		"osm-crds",
+		"osm-crd-converter",
 	}
 
 	return td.LoadImagesToKind(imageNames)

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -33,6 +33,8 @@ const (
 	OsmPrometheusAppLabel = "osm-prometheus"
 	// OsmInjectorAppLabel is the OSM injector deployment app label
 	OsmInjectorAppLabel = "osm-injector"
+	// OsmCrdConverterAppLabel is the OSM crd converter deployment app label
+	OsmCrdConverterAppLabel = "osm-crd-converter"
 
 	// OSM Grafana Dashboard specifics
 
@@ -48,7 +50,7 @@ const (
 
 var (
 	// OsmCtlLabels is the list of app labels for OSM CTL
-	OsmCtlLabels = []string{OsmControllerAppLabel, OsmGrafanaAppLabel, OsmPrometheusAppLabel, OsmInjectorAppLabel}
+	OsmCtlLabels = []string{OsmControllerAppLabel, OsmGrafanaAppLabel, OsmPrometheusAppLabel, OsmInjectorAppLabel, OsmCrdConverterAppLabel}
 )
 
 // CreateServiceAccount is a wrapper to create a service account


### PR DESCRIPTION
**Description**:

This commit add a conversion webhook server to OSM's control plane. The
purpose to this server is to patch all the CRD's that OSM manages with
the required conversion webhook configuration and to serve the
conversion requests.

The handler for each of the CRD's conversion requests will be in a follow up pr.

Part of #3396

**Note:** The deployment of the conversion webhook is currently controlled by a feature flag, which will be removed once issue https://github.com/openservicemesh/osm/issues/3716 is resolved 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [X] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
