### PR TITLE
errcode: introduce error code management

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/envoy/ads"
 	"github.com/openservicemesh/osm/pkg/envoy/registry"
+	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	"github.com/openservicemesh/osm/pkg/health"
 	"github.com/openservicemesh/osm/pkg/httpserver"
@@ -109,7 +110,7 @@ func init() {
 func main() {
 	log.Info().Msgf("Starting osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 	if err := parseFlags(); err != nil {
-		log.Fatal().Err(err).Msg("Error parsing cmd line arguments")
+		log.Fatal().Err(err).Str(errcode.Kind, errcode.ErrInvalidCLIArgument.String()).Msg("Error parsing cmd line arguments")
 	}
 
 	if err := logger.SetLogLevel(verbosity); err != nil {

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -1,0 +1,32 @@
+// Package errcode defines the error codes for error messages and an explanation
+// of what the error signifies.
+package errcode
+
+import (
+	"fmt"
+)
+
+type errCode int
+
+const (
+	// Kind defines the kind for the error code constants
+	Kind = "error_code"
+)
+
+// Range 1000-1050 is reserved for errors related to application startup
+const (
+	// ErrInvalidCLIArgument refers to an invalid CLI argument being specified
+	ErrInvalidCLIArgument errCode = iota + 1000
+)
+
+// String returns the error code as a string, ex. E1000
+func (e errCode) String() string {
+	return fmt.Sprintf("E%d", e)
+}
+
+//nolint: deadcode,varcheck,unused
+var errCodeMap = map[errCode]string{
+	ErrInvalidCLIArgument: `
+An invalid comment line argument was passed to the application.
+`,
+}

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -1,0 +1,12 @@
+package errcode
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestString(t *testing.T) {
+	assert := tassert.New(t)
+	assert.Equal(ErrInvalidCLIArgument.String(), "E1000")
+}


### PR DESCRIPTION
Introduces a pkg to manage error codes. Documentation
and tooling to inspect errors will be built around
the error code and description mapping provided by
this pkg.

Sample error log with error code:
```
{"level":"error","component":"errcode","error":"some error","error_code":"E1000","time":"2021-06-30T12:52:14-07:00","file":"errcode_test.go:14","message":"some error was seen"}
```

Part of #2866

Signed-off-by: Shashank Ram <shashr2204@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
