### PR TITLE
feat(pkg/apis): add a global ip address for the multiclusterservice

### DIFF
--- a/charts/osm/crds/multiclusterservice.yaml
+++ b/charts/osm/crds/multiclusterservice.yaml
@@ -41,6 +41,9 @@ spec:
                 - serviceAccount
                 - clusters
               properties:
+                globalIP:
+                  type: string
+                  description: globalIP is the IP address for the implicit global service which references every defined cluster. It is usually assigned at random by OSM.
                 serviceAccount:
                   type: string
                 ports:

--- a/pkg/apis/config/v1alpha1/multi_cluster_service.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service.go
@@ -24,6 +24,9 @@ type MultiClusterService struct {
 
 // MultiClusterServiceSpec is the type used to represent the multicluster service specification.
 type MultiClusterServiceSpec struct {
+	// GlobalIP defines the IP Address for the implicit global service.
+	GlobalIP string `json:"globalIP,omitempty" protobuf:"bytes,3,opt,name=globalIP"`
+
 	// ClusterSpec defines the configuration of other clusters
 	Cluster []ClusterSpec `json:"cluster,omitempty"`
 


### PR DESCRIPTION
The global IP address is used by the listener to determine which service is chosen, and will be assigned by a mutating webhook.

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>


Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No

1. Is this a breaking change?
No