### PR TITLE
CI: Updating kind go library to 0.11.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,6 @@ require (
 	google.golang.org/grpc v1.36.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	helm.sh/helm/v3 v3.5.3
 	honnef.co/go/tools v0.1.1 // indirect
 	k8s.io/api v0.20.5
@@ -60,7 +59,7 @@ require (
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	mvdan.cc/gofumpt v0.1.0 // indirect
 	sigs.k8s.io/controller-runtime v0.6.3
-	sigs.k8s.io/kind v0.9.0
+	sigs.k8s.io/kind v0.11.1
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alessio/shellescape v1.2.2 h1:8LnL+ncxhWT2TR00dfJRT25JWWrhkMZXneHVWnetDZg=
-github.com/alessio/shellescape v1.2.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -285,8 +285,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch/v5 v5.1.0 h1:B0aXl1o/1cP8NbviYiBMkcHBtUjIJ1/Ccg6b+SwCLQg=
-github.com/evanphx/json-patch/v5 v5.1.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
+github.com/evanphx/json-patch/v5 v5.2.0 h1:8ozOH5xxoMYDt5/u+yMTsVXydVCbTORFnOOoq2lumco=
+github.com/evanphx/json-patch/v5 v5.2.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d h1:105gxyaGwCFad8crR9dcMQWvV9Hvulu6hwUh4tWPJnM=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
@@ -857,8 +857,8 @@ github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible/go.mod h1:xlUlxe/2It
 github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0/go.mod h1:2ejgys4qY+iNVW1IittZhyRYA6MNv8TgM6VHqojbB9g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pelletier/go-toml v1.8.0 h1:Keo9qb7iRJs2voHvunFtuuYFsbWeOBh8/P9v/kVMFtw=
-github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
+github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1281,7 +1281,6 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1631,8 +1630,8 @@ sigs.k8s.io/controller-runtime v0.6.2/go.mod h1:vhcq/rlnENJ09SIRp3EveTaZ0yqH526h
 sigs.k8s.io/controller-runtime v0.6.3 h1:SBbr+inLPEKhvlJtrvDcwIpm+uhDvp63Bl72xYJtoOE=
 sigs.k8s.io/controller-runtime v0.6.3/go.mod h1:WlZNXcM0++oyaQt4B7C2lEE5JYRs8vJUzRP4N4JpdAY=
 sigs.k8s.io/controller-tools v0.2.9-0.20200414181213-645d44dca7c0/go.mod h1:YKE/iHvcKITCljdnlqHYe+kAt7ZldvtAwUzQff0k1T0=
-sigs.k8s.io/kind v0.9.0 h1:SoDlXq6pEc7dGagHULNRCCBYrLH6xOi7lqXTRXeAlg4=
-sigs.k8s.io/kind v0.9.0/go.mod h1:cxKQWwmbtRDzQ+RNKnR6gZG6fjbeTtItp5cGf+ww+1Y=
+sigs.k8s.io/kind v0.11.1 h1:pVzOkhUwMBrCB0Q/WllQDO3v14Y+o2V0tFgjTqIUjwA=
+sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=


### PR DESCRIPTION
There's a CI breakage due to kube-proxy failing to start on the kind node.
```
2021-06-30T22:05:30.81895558Z stderr F I0630 22:05:30.818289       1 conntrack.go:100] Set sysctl 'net/netfilter/nf_conntrack_max' to 131072
2021-06-30T22:05:30.818968181Z stderr F F0630 22:05:30.818310       1 server.go:495] open /proc/sys/net/netfilter/nf_conntrack_max: permission denied
```
node stays in forever down:
```
Jun 30 22:05:04 osm-e2e-control-plane kubelet[682]: E0630 22:05:04.733414     682 pod_workers.go:191] Error syncing pod a9df50c9-a5cc-4418-a219-cc4b31c3dab6 ("kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"), skipping: failed to "StartContainer" for "kube-proxy" with CrashLoopBackOff: "back-off 20s restarting failed container=kube-proxy pod=kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"
Jun 30 22:05:16 osm-e2e-control-plane kubelet[682]: I0630 22:05:16.638529     682 topology_manager.go:219] [topologymanager] RemoveContainer - Container ID: 6c45038ab249f06a12a574c3a3b274fa20b1d42109ec955129f05554de1629ac
Jun 30 22:05:16 osm-e2e-control-plane kubelet[682]: E0630 22:05:16.638956     682 pod_workers.go:191] Error syncing pod a9df50c9-a5cc-4418-a219-cc4b31c3dab6 ("kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"), skipping: failed to "StartContainer" for "kube-proxy" with CrashLoopBackOff: "back-off 20s restarting failed container=kube-proxy pod=kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"
Jun 30 22:05:30 osm-e2e-control-plane kubelet[682]: I0630 22:05:30.638555     682 topology_manager.go:219] [topologymanager] RemoveContainer - Container ID: 6c45038ab249f06a12a574c3a3b274fa20b1d42109ec955129f05554de1629ac
Jun 30 22:05:31 osm-e2e-control-plane kubelet[682]: E0630 22:05:31.775508     682 pod_workers.go:191] Error syncing pod a9df50c9-a5cc-4418-a219-cc4b31c3dab6 ("kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"), skipping: failed to "StartContainer" for "kube-proxy" with CrashLoopBackOff: "back-off 40s restarting failed container=kube-proxy pod=kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"
Jun 30 22:05:45 osm-e2e-control-plane kubelet[682]: I0630 22:05:45.638567     682 topology_manager.go:219] [topologymanager] RemoveContainer - Container ID: 51a185a75ca8fee17f4f0b4ef90f8db8590fd324cbab4cfdd0912145fcb51746
Jun 30 22:05:45 osm-e2e-control-plane kubelet[682]: E0630 22:05:45.643921     682 pod_workers.go:191] Error syncing pod a9df50c9-a5cc-4418-a219-cc4b31c3dab6 ("kube-proxy-8bshx_kube-system(a9df50c9-a5cc-4418-a219-cc4b31c3dab6)"), skipping: failed to "StartContainer" for "kube-proxy" with CrashLoopBackOff: "back-off 40s restarting failed
```

Fix is actually part of a recent update, which is assumed part of the library (and code) used internally in e2e kind infra bringup:
https://github.com/kubernetes-sigs/kind/pull/2241/files

Co-authored-by: Shashank Ram <shashr2204@gmail.com>
Co-authored-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No