### PR TITLE
feat(*): get annotations for retry policy

### DIFF
--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -179,7 +179,7 @@ func buildInboundRoutes(rules []*trafficpolicy.Rule) []*xds_route.Route {
 
 		// Each HTTP method corresponds to a separate route
 		for _, method := range allowedMethods {
-			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, method, rule.Route.HTTPRouteMatch.Headers, rule.Route.WeightedClusters, 100, inboundRoute)
+			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, method, rule.Route.HTTPRouteMatch.Headers, rule.Route.WeightedClusters, 100, inboundRoute, rule.Route.RetryPolicy)
 			route.TypedPerFilterConfig = rbacPolicyForRoute
 			routes = append(routes, route)
 		}
@@ -191,8 +191,9 @@ func buildOutboundRoutes(outRoutes []*trafficpolicy.RouteWeightedClusters) []*xd
 	var routes []*xds_route.Route
 	for _, outRoute := range outRoutes {
 		emptyHeaders := map[string]string{}
-		routes = append(routes, buildRoute(trafficpolicy.PathMatchRegex, constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), outboundRoute))
+		routes = append(routes, buildRoute(trafficpolicy.PathMatchRegex, constants.RegexMatchAll, constants.WildcardHTTPMethod, emptyHeaders, outRoute.WeightedClusters, outRoute.TotalClustersWeight(), outboundRoute, outRoute.RetryPolicy))
 	}
+
 	return routes
 }
 
@@ -206,14 +207,14 @@ func buildEgressRoutes(routingRules []*trafficpolicy.EgressHTTPRoutingRule) []*x
 		// Build the route for the given egress routing rule and method
 		// Each HTTP method corresponds to a separate route
 		for _, httpMethod := range allowedHTTPMethods {
-			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, httpMethod, nil, rule.Route.WeightedClusters, rule.Route.TotalClustersWeight(), outboundRoute)
+			route := buildRoute(rule.Route.HTTPRouteMatch.PathMatchType, rule.Route.HTTPRouteMatch.Path, httpMethod, nil, rule.Route.WeightedClusters, rule.Route.TotalClustersWeight(), outboundRoute, rule.Route.RetryPolicy)
 			routes = append(routes, route)
 		}
 	}
 	return routes
 }
 
-func buildRoute(pathMatchTypeType trafficpolicy.PathMatchType, path string, method string, headersMap map[string]string, weightedClusters mapset.Set, totalWeight int, direction Direction) *xds_route.Route {
+func buildRoute(pathMatchTypeType trafficpolicy.PathMatchType, path string, method string, headersMap map[string]string, weightedClusters mapset.Set, totalWeight int, direction Direction, retryPolicy trafficpolicy.RetryPolicy) *xds_route.Route {
 	route := xds_route.Route{
 		Match: &xds_route.RouteMatch{
 			Headers: getHeadersForRoute(method, headersMap),
@@ -222,6 +223,11 @@ func buildRoute(pathMatchTypeType trafficpolicy.PathMatchType, path string, meth
 			Route: &xds_route.RouteAction{
 				ClusterSpecifier: &xds_route.RouteAction_WeightedClusters{
 					WeightedClusters: buildWeightedCluster(weightedClusters, totalWeight, direction),
+				},
+				RetryPolicy: &xds_route.RetryPolicy{
+					RetryOn:       retryPolicy.RetryOn,
+					NumRetries:    retryPolicy.NumRetries,
+					PerTryTimeout: retryPolicy.PerTryTimeout,
 				},
 			},
 		},

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -210,6 +210,14 @@ func mergeRoutesWeightedClusters(originalRoutes, latestRoutes []*RouteWeightedCl
 	return originalRoutes
 }
 
+// MergeRoutesRetryPolicy adds the retry policy to the Route
+func MergeRoutesRetryPolicy(routes []*RouteWeightedClusters, retryPolicy RetryPolicy) []*RouteWeightedClusters {
+	for _, route := range routes {
+		route.RetryPolicy = retryPolicy
+	}
+	return routes
+}
+
 // slicesUnionIfSubset returns the union of the two slices if either slices is a subset of the other
 func slicesUnionIfSubset(first, second []string) []string {
 	areSubsets := false

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -4,6 +4,8 @@ package trafficpolicy
 
 import (
 	mapset "github.com/deckarep/golang-set"
+	"github.com/golang/protobuf/ptypes/duration"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/identity"
 )
@@ -45,6 +47,14 @@ type TCPRouteMatch struct {
 type RouteWeightedClusters struct {
 	HTTPRouteMatch   HTTPRouteMatch `json:"http_route_match:omitempty"`
 	WeightedClusters mapset.Set     `json:"weighted_clusters:omitempty"`
+	RetryPolicy      RetryPolicy
+}
+
+// RetryPolicy is a struct of the RetryPolicy
+type RetryPolicy struct {
+	RetryOn       string                  `json:"retry_on,omitempty"`
+	NumRetries    *wrapperspb.UInt32Value `json:"num_retries,omitempty"`
+	PerTryTimeout *duration.Duration      `json:"per_try_timeout,omitempty"`
 }
 
 // InboundTrafficPolicy is a struct that associates incoming traffic on a set of Hostnames with a list of Rules


### PR DESCRIPTION
**Description**:
Gets annotations from TrafficTargets policy to create retry policy
and resolves #3339

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ x] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? no
