### PR TITLE
feat(multicluster): kube provider support multicluster

### DIFF
--- a/charts/osm/crds/multiclusterservice.yaml
+++ b/charts/osm/crds/multiclusterservice.yaml
@@ -52,7 +52,7 @@ spec:
                       - port
                       - protocol
                     properties:
-                      port: 
+                      port:
                         description: The port that will be exposed by this service.
                         type: integer
                         minimum: 1
@@ -65,7 +65,6 @@ spec:
                           - TCP
                           - UDP
                           - SCTP
-                  type: string
                 clusters:
                   description: The clusters the service accounts are hosted on.
                   type: array
@@ -78,6 +77,7 @@ spec:
                       address:
                         description: a routable IP + port
                         type: string
+                        pattern: ^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3}):[0-9]+$
                       name:
                         description: Name of the remote cluster
                         type: string

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -48,7 +48,6 @@ func NewConfigController(kubeConfig *rest.Config, kubeController k8s.Controller,
 	if err != nil {
 		return client, errors.Errorf("Could not start %s client: %s", apiGroup, err)
 	}
-
 	return client, err
 }
 
@@ -79,6 +78,22 @@ func (c client) ListMultiClusterServices() []*v1alpha1.MultiClusterService {
 			services = append(services, mcs)
 		}
 	}
+	return services
+}
+
+func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []*v1alpha1.MultiClusterService {
+	if !c.kubeController.IsMonitoredNamespace(namespace) {
+		return nil
+	}
+
+	var services []*v1alpha1.MultiClusterService
+
+	for _, mcs := range c.ListMultiClusterServices() {
+		if mcs.Spec.ServiceAccount == serviceAccount && mcs.Namespace == namespace {
+			services = append(services, mcs)
+		}
+	}
+
 	return services
 }
 

--- a/pkg/config/mock_client_generated.go
+++ b/pkg/config/mock_client_generated.go
@@ -48,6 +48,20 @@ func (mr *MockControllerMockRecorder) GetMultiClusterService(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultiClusterService", reflect.TypeOf((*MockController)(nil).GetMultiClusterService), arg0, arg1)
 }
 
+// GetMultiClusterServiceByServiceAccount mocks base method
+func (m *MockController) GetMultiClusterServiceByServiceAccount(arg0, arg1 string) []*v1alpha1.MultiClusterService {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultiClusterServiceByServiceAccount", arg0, arg1)
+	ret0, _ := ret[0].([]*v1alpha1.MultiClusterService)
+	return ret0
+}
+
+// GetMultiClusterServiceByServiceAccount indicates an expected call of GetMultiClusterServiceByServiceAccount
+func (mr *MockControllerMockRecorder) GetMultiClusterServiceByServiceAccount(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultiClusterServiceByServiceAccount", reflect.TypeOf((*MockController)(nil).GetMultiClusterServiceByServiceAccount), arg0, arg1)
+}
+
 // ListMultiClusterServices mocks base method
 func (m *MockController) ListMultiClusterServices() []*v1alpha1.MultiClusterService {
 	m.ctrl.T.Helper()

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -23,4 +23,5 @@ type Controller interface {
 	// TODO: specify required functions
 	ListMultiClusterServices() []*v1alpha1.MultiClusterService
 	GetMultiClusterService(name, namespace string) *v1alpha1.MultiClusterService
+	GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []*v1alpha1.MultiClusterService
 }

--- a/pkg/providers/kube/types.go
+++ b/pkg/providers/kube/types.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"github.com/openservicemesh/osm/pkg/config"
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
@@ -12,7 +13,8 @@ var (
 
 // Client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster.
 type Client struct {
-	providerIdent  string
-	kubeController k8s.Controller
-	configClient   config.Controller
+	providerIdent    string
+	kubeController   k8s.Controller
+	configClient     config.Controller
+	meshConfigurator configurator.Configurator
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

kube provider includes remote gateway addresses in service endpoints
list.

TODO after this PR:

* Assign different weight to remote gateways

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

NO