### PR TITLE
cli: add support command to list error code description mapping

### DIFF
--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -46,6 +46,7 @@ func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args 
 		newProxyCmd(config, out),
 		newTrafficPolicyCmd(out),
 		newUninstallCmd(config, in, out),
+		newSupportCmd(out),
 	)
 
 	_ = flags.Parse(args)

--- a/cmd/cli/support.go
+++ b/cmd/cli/support.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const supportCmdDescription = `
+This command consists of subcommands related supportability and
+associated tooling, such as examining error codes.
+`
+
+func newSupportCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "support",
+		Short: "supportability tooling",
+		Long:  supportCmdDescription,
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newSupportErrInfoCmd(out))
+
+	return cmd
+}

--- a/cmd/cli/support_err.go
+++ b/cmd/cli/support_err.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/openservicemesh/osm/pkg/errcode"
+)
+
+const errInfoDescription = `
+This command lists the mapping of one or all error codes to their description.`
+
+const errInfoExample = `
+Get the description for the error code E1000
+# osm support error-info E1000
+
+Get the description for all error codes
+# osm support error-info
+`
+
+type errInfoCmd struct {
+	out io.Writer
+}
+
+func newSupportErrInfoCmd(out io.Writer) *cobra.Command {
+	errInfoCmd := &errInfoCmd{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "error-info",
+		Short: "lists mapping of error code to its description",
+		Long:  errInfoDescription,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			var errCode string
+			if len(args) != 0 {
+				errCode = args[0]
+			}
+			return errInfoCmd.run(errCode)
+		},
+		Example: errInfoExample,
+	}
+
+	return cmd
+}
+
+func (cmd *errInfoCmd) run(errCode string) error {
+	table := tablewriter.NewWriter(cmd.out)
+	table.SetHeader([]string{"Error code", "Description"})
+	table.SetRowLine(true)
+	table.SetColWidth(80)
+
+	if errCode != "" {
+		// Print the error code description mapping only for the given error code
+		e, err := errcode.FromStr(errCode)
+		if err != nil {
+			return errors.Errorf("Error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", errCode)
+		}
+		description, ok := errcode.ErrCodeMap[e]
+		if !ok {
+			return errors.Errorf("Error code '%s' is not a valid error code recognized by OSM", errCode)
+		}
+		table.Append([]string{errCode, description})
+	} else {
+		// Print the error code description mapping for all error codes
+		var sortedErrKeys []errcode.ErrCode
+		for err := range errcode.ErrCodeMap {
+			sortedErrKeys = append(sortedErrKeys, err)
+		}
+		sort.Slice(sortedErrKeys, func(i, j int) bool {
+			return sortedErrKeys[i] < sortedErrKeys[j]
+		})
+
+		for _, key := range sortedErrKeys {
+			desc := errcode.ErrCodeMap[key]
+			desc = strings.Trim(desc, "\n") // Trim leading and trailing newlines for consistent formatting
+			table.Append([]string{key.String(), desc})
+		}
+	}
+
+	table.Render()
+
+	return nil
+}

--- a/cmd/cli/support_err_test.go
+++ b/cmd/cli/support_err_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+// TestErrInfoRun tests errInfoCmd.run()
+
+func TestErrInfoRun(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name      string
+		errCode   string
+		expectErr bool
+	}{
+		{
+			name:      "valid error code as input",
+			errCode:   "E1000",
+			expectErr: false,
+		},
+		{
+			name:      "invalid error code format as input",
+			errCode:   "Foo",
+			expectErr: true,
+		},
+		{
+			name:      "valid error code format but unrecognized code as input",
+			errCode:   "E10000",
+			expectErr: true,
+		},
+		{
+			name:      "list all error codes",
+			errCode:   "",
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var out bytes.Buffer
+			cmd := &errInfoCmd{out: &out}
+			err := cmd.run(tc.errCode)
+
+			assert.Equal(tc.expectErr, err != nil)
+		})
+	}
+}

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -4,9 +4,14 @@ package errcode
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
 )
 
-type errCode int
+// ErrCode defines the type to represent error codes
+type ErrCode int
 
 const (
 	// Kind defines the kind for the error code constants
@@ -16,7 +21,7 @@ const (
 // Range 1000-1050 is reserved for errors related to application startup or bootstrapping
 const (
 	// ErrInvalidCLIArgument indicates an invalid CLI argument
-	ErrInvalidCLIArgument errCode = iota + 1000
+	ErrInvalidCLIArgument ErrCode = iota + 1000
 
 	// ErrSettingLogLevel indicates the specified log level could not be set
 	ErrSettingLogLevel
@@ -37,7 +42,7 @@ const (
 // Range 2000-2500 is reserved for errors related to traffic policies
 const (
 	// ErrDedupEgressTrafficMatches indicates an error related to deduplicating egress traffic matches
-	ErrDedupEgressTrafficMatches errCode = iota + 2000
+	ErrDedupEgressTrafficMatches ErrCode = iota + 2000
 
 	// ErrDedupEgressClusterConfigs indicates an error related to deduplicating egress cluster configs
 	ErrDedupEgressClusterConfigs
@@ -71,27 +76,38 @@ const (
 // Range 3000-3500 is reserved for errors related to k8s constructs (service accounts, namespaces, etc.)
 const (
 	// ErrServiceHostnames indicates the hostnames associated with a service could not be computed
-	ErrServiceHostnames errCode = iota + 3000
+	ErrServiceHostnames ErrCode = iota + 3000
 
 	// ErrNoMatchingServiceForServiceAccount indicates there are no services associated with the service account
 	ErrNoMatchingServiceForServiceAccount
 )
 
 // String returns the error code as a string, ex. E1000
-func (e errCode) String() string {
+func (e ErrCode) String() string {
 	return fmt.Sprintf("E%d", e)
 }
 
+// FromStr returns the ErrCode representation for the given error code string
+// Ex. E1000 is converted to ErrInvalidCLIArgument
+func FromStr(e string) (ErrCode, error) {
+	errStr := strings.TrimLeft(e, "E")
+	errInt, err := strconv.Atoi(errStr)
+	if err != nil {
+		return ErrCode(0), errors.Errorf("Error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", e)
+	}
+	return ErrCode(errInt), nil
+}
+
+// ErrCodeMap defines the mapping of error codes to their description.
 // Note: error code description mappings must be defined in the same order
 // as they appear in the error code definitions - from lowest to highest
 // ranges in the order they appear within the range.
-//nolint: deadcode,varcheck,unused
-var errCodeMap = map[errCode]string{
+var ErrCodeMap = map[ErrCode]string{
 	//
 	// Range 1000-1050
 	//
 	ErrInvalidCLIArgument: `
-An invalid comment line argument was passed to the application.
+An invalid command line argument was passed to the application.
 `,
 
 	ErrSettingLogLevel: `

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -10,3 +10,36 @@ func TestString(t *testing.T) {
 	assert := tassert.New(t)
 	assert.Equal(ErrInvalidCLIArgument.String(), "E1000")
 }
+
+func TestFromStr(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		name            string
+		str             string
+		expectedErrCode ErrCode
+		expectError     bool
+	}{
+		{
+			name:            "valid error code",
+			str:             "E1000",
+			expectedErrCode: ErrInvalidCLIArgument,
+			expectError:     false,
+		},
+		{
+			name:            "invalid err code",
+			str:             "invalid",
+			expectedErrCode: ErrCode(0),
+			expectError:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := FromStr(tc.str)
+
+			assert.Equal(tc.expectError, err != nil)
+			assert.Equal(tc.expectedErrCode, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a new command `osm support error-info` that lists
the mapping of one or all error codes to their description.

The mapping will be used for troubleshooting as well
as documentation that will be a part of the osm-docs
repo.

Part of #2866 

Sample output:

```console
$ osm support error-info E1000
+------------+-----------------------------------------------------------------+
| ERROR CODE |                           DESCRIPTION                           |
+------------+-----------------------------------------------------------------+
| E1000      |  An invalid command line argument was passed to the             |
|            | application.                                                    |
+------------+-----------------------------------------------------------------+

```

```console
$ osm support error-info fooo
Error: Error code 'fooo' is not a valid error code format. Should be of the form Exxxx, ex. E1000.
```

```console
$ osm support error-info E10000
Error: Error code 'E10000' is not a valid error code recognized by OSM
```

```console
$ osm support error-info 
+------------+----------------------------------------------------------------------------------+
| ERROR CODE |                                   DESCRIPTION                                    |
+------------+----------------------------------------------------------------------------------+
| E1000      | An invalid command line argument was passed to the application.                  |
+------------+----------------------------------------------------------------------------------+
| E1001      | The specified log level could not be set in the system.                          |
+------------+----------------------------------------------------------------------------------+
| E1002      | The 'osm-mesh-config' MeshConfig custom resource could not be parsed.            |
+------------+----------------------------------------------------------------------------------+
| E1003      | The osm-controller k8s pod resource was not able to be retrieved by the system.  |
+------------+----------------------------------------------------------------------------------+
| E1004      | The osm-injector k8s pod resource was not able to be retrieved by the system.    |
+------------+----------------------------------------------------------------------------------+
| E1005      | The controller-runtime manager to manage the controller used to reconcile the    |
|            | sidecar injector's MutatingWebhookConfiguration resource failed to start.        |
+------------+----------------------------------------------------------------------------------+
...
...
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Documentation              | [ ] |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
