### PR TITLE
Updating pkg/providers/kube/client.go, client_test.go to support MultiCluster Services.

### DIFF
--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -1,7 +1,10 @@
 package kube
 
 import (
+	"fmt"
 	"net"
+	"strconv"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
@@ -38,63 +41,81 @@ func (c *Client) ListEndpointsForService(svc service.MeshService) []endpoint.End
 	log.Trace().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
 	var endpoints []endpoint.Endpoint
 
-	kubernetesEndpoints, err := c.kubeController.GetEndpoints(svc)
-	if err != nil || kubernetesEndpoints == nil {
-		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache for service %s", c.providerIdent, svc)
-		return endpoints
-	}
+	// 3 scenarios for getting endpoints: (1) multicluster (2) global (3) local
 
-	if !c.kubeController.IsMonitoredNamespace(kubernetesEndpoints.Namespace) {
-		// Doesn't belong to namespaces we are observing
-		return endpoints
-	}
-
-	for _, kubernetesEndpoint := range kubernetesEndpoints.Subsets {
-		for _, address := range kubernetesEndpoint.Addresses {
-			for _, port := range kubernetesEndpoint.Ports {
-				ip := net.ParseIP(address.IP)
-				if ip == nil {
-					log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, address.IP)
-					break
-				}
+	// (1) multicluster
+	if !svc.Local() && !svc.Global() {
+		// Using svc name and namespace, get multiclusterservice object
+		// TODO: What is method to get multicluster service?
+		mcsvc := c.configClient.GetMultiClusterService(svc.Name, svc.Namespace)
+		for _, cluster := range mcsvc.Spec.Cluster {
+			if cluster.Name == string(svc.ClusterDomain) {
+				s := strings.Split(cluster.Address, ":")
+				port, _ := strconv.ParseUint(s[1], 10, 32)
+				fmt.Println(port)
 				ept := endpoint.Endpoint{
-					IP:   ip,
-					Port: endpoint.Port(port.Port),
+					IP:   net.ParseIP(s[0]),
+					Port: endpoint.Port(port),
 				}
 				endpoints = append(endpoints, ept)
+				// Return right away because should be just one endpoint
+				return endpoints
 			}
 		}
+		return nil
 	}
-	return endpoints
-}
-
-// ListEndpointsForIdentity retrieves the list of IP addresses for the given service account
-// Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (c *Client) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdentity) []endpoint.Endpoint {
-	sa := serviceIdentity.ToK8sServiceAccount()
-	log.Trace().Msgf("[%s] Getting Endpoints for service account %s on Kubernetes", c.providerIdent, sa)
-	var endpoints []endpoint.Endpoint
-
-	podList := c.kubeController.ListPods()
-	for _, pod := range podList {
-		if pod.Namespace != sa.Namespace {
-			continue
-		}
-		if pod.Spec.ServiceAccountName != sa.Name {
-			continue
-		}
-
-		for _, podIP := range pod.Status.PodIPs {
-			ip := net.ParseIP(podIP.IP)
-			if ip == nil {
-				log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, podIP.IP)
-				break
+	// (2) global
+	if !svc.Local() && svc.Global() {
+		// Using svc name and namespace, get multiclusterservice object
+		// TODO: What is method to get multicluster service?
+		mcsvc := c.configClient.GetMultiClusterService(svc.Name, svc.Namespace)
+		for _, cluster := range mcsvc.Spec.Cluster {
+			if cluster.Name == string(svc.ClusterDomain) {
+				s := strings.Split(cluster.Address, ":")
+				port, _ := strconv.ParseUint(s[1], 10, 32)
+				fmt.Println(port)
+				ept := endpoint.Endpoint{
+					IP:   net.ParseIP(s[0]),
+					Port: endpoint.Port(port),
+				}
+				endpoints = append(endpoints, ept)
+				// Return right away because should be just one endpoint
 			}
-			ept := endpoint.Endpoint{IP: ip}
-			endpoints = append(endpoints, ept)
 		}
+		return endpoints
 	}
-	return endpoints
+	// (3) local
+	if svc.Local() && !svc.Global() {
+		kubernetesEndpoints, err := c.kubeController.GetEndpoints(svc)
+		if err != nil || kubernetesEndpoints == nil {
+			log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache for service %s", c.providerIdent, svc)
+			return endpoints
+		}
+
+		if !c.kubeController.IsMonitoredNamespace(kubernetesEndpoints.Namespace) {
+			// Doesn't belong to namespaces we are observing
+			return endpoints
+		}
+
+		for _, kubernetesEndpoint := range kubernetesEndpoints.Subsets {
+			for _, address := range kubernetesEndpoint.Addresses {
+				for _, port := range kubernetesEndpoint.Ports {
+					ip := net.ParseIP(address.IP)
+					if ip == nil {
+						log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, address.IP)
+						break
+					}
+					ept := endpoint.Endpoint{
+						IP:   ip,
+						Port: endpoint.Port(port.Port),
+					}
+					endpoints = append(endpoints, ept)
+				}
+			}
+		}
+		return endpoints
+	}
+	return nil
 }
 
 // GetServicesForServiceIdentity retrieves a list of services for the given service identity.

--- a/pkg/providers/kube/types.go
+++ b/pkg/providers/kube/types.go
@@ -2,7 +2,7 @@ package kube
 
 import (
 	"github.com/openservicemesh/osm/pkg/config"
-	"github.com/openservicemesh/osm/pkg/k8s"
+	k8s "github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -44,6 +44,10 @@ const (
 	// BookbuyerServiceName is the name of the bookbuyer service
 	BookbuyerServiceName = "bookbuyer"
 
+	BookbuyerServiceNameGlobal = "bookbuyerglobal"
+
+	BookbuyerServiceNameMultiCluster = "bookbuyermulticluster"
+
 	// BookwarehouseServiceName is the name of the bookwarehouse service
 	BookwarehouseServiceName = "bookwarehouse"
 
@@ -126,6 +130,18 @@ var (
 		Namespace:     Namespace,
 		Name:          BookbuyerServiceName,
 		ClusterDomain: constants.LocalDomain,
+	}
+	// BookbuyerService is the bookbuyer service. Global Version.
+	BookbuyerServiceGlobal = service.MeshService{
+		Namespace:     Namespace,
+		Name:          BookbuyerServiceNameGlobal,
+		ClusterDomain: constants.GlobalDomain,
+	}
+	// BookbuyerService is the bookbuyer service. Global Version.
+	BookbuyerServiceMultiCluster = service.MeshService{
+		Namespace:     Namespace,
+		Name:          BookbuyerServiceNameMultiCluster,
+		ClusterDomain: "clusterX",
 	}
 
 	// BookstoreApexService is the bookstore-apex service


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updating pkg/providers/kube/client.go to support MultiCluster Services.

The kube provider is what discovers services and endpoints. With the new multi cluster service, we will need to edit the kube provider to discover services and endpoints from the MultiClusterService object.

If there is a call that accepts a MeshService, it should query for the MCS if the mesh service is not local, and keep the current functionality if it is local.

Some functions accept a MeshService object, some don't.

Code will loop through "clusters" of a MultiClusterService, grabbing the IPs and Service Name.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ X] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?

**No**

    -   Did you notify the maintainers and provide attribution?
**No**

1. Is this a breaking change?
**Yes**
