### PR TITLE
cli/test: add unit test for command initialization

### DIFF
--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -54,7 +54,7 @@ func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args 
 	return cmd
 }
 
-func main() {
+func initCommands() *cobra.Command {
 	actionConfig := new(action.Configuration)
 	cmd := newRootCmd(actionConfig, os.Stdin, os.Stdout, os.Args[1:])
 	_ = actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), "secret", debug)
@@ -66,6 +66,11 @@ func main() {
 		}
 	})
 
+	return cmd
+}
+
+func main() {
+	cmd := initCommands()
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/cli/osm_test.go
+++ b/cmd/cli/osm_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+// TestCommandEntryPoint tests that all CLI subcommands can be
+// added under the root CLI command.
+func TestCommandEntryPoint(t *testing.T) {
+	assert := tassert.New(t)
+
+	cmd := initCommands()
+	assert.NotNil(cmd)
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a generic unit test for command initialization.
This is the simplest way to verify that the cobra commands
are created correctly for each subcommand.

It improves the coverage under `cmd/cli` from 49.75% to
64.52%. 

Resolves #3417

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`

---
Previously:
![image](https://user-images.githubusercontent.com/21697719/124640655-92617380-de42-11eb-8d72-1cd55a8f9259.png)

Now:
![image](https://user-images.githubusercontent.com/21697719/124640703-a3aa8000-de42-11eb-980f-d60605ee2214.png)
