### PR TITLE
test(e2e/http_ingress): Increase time limit

### DIFF
--- a/tests/e2e/e2e_http_ingress_test.go
+++ b/tests/e2e/e2e_http_ingress_test.go
@@ -123,7 +123,7 @@ var _ = OSMDescribe("HTTP ingress",
 				}
 				Td.T.Logf("> REST req failed expectedly: %d", status)
 				return true
-			}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
+			}, 5 /*consecutive success threshold*/, 120*time.Second /*timeout*/)
 			Expect(cond).To(BeTrue())
 
 			ing := &v1beta1.Ingress{
@@ -169,7 +169,7 @@ var _ = OSMDescribe("HTTP ingress",
 				}
 				Td.T.Logf("> REST req succeeded: %d", status)
 				return true
-			}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
+			}, 5 /*consecutive success threshold*/, 120*time.Second /*timeout*/)
 			Expect(cond).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Increase time limit for http ingress test. While testing locally, it sometimes took around 40-50 seconds or so for the request failures to fail expectedly after experiencing a timeout. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
