### PR TITLE
ref: method renaming for cataloger endpoint methods

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -302,11 +302,11 @@ type MeshCataloger interface {
 	// GetSMISpec returns the SMI spec
 	GetSMISpec() smi.MeshSpec
 
-	// ListAllowedInboundServiceIdentities lists the downstream service identities that can connect to the given service account
-	ListAllowedInboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	// ListInboundServiceIdentities lists the downstream service identities that can connect to the given service account
+	ListInboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
-	// ListAllowedOutboundServiceIdentities lists the upstream service identities the given service account can connect to
-	ListAllowedOutboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
+	// ListOutboundServiceIdentities lists the upstream service identities the given service account can connect to
+	ListOutboundServiceIdentities(service.K8sServiceAccount) ([]service.K8sServiceAccount, error)
 
 	// ListServiceIdentitiesForService lists the service identities associated with the given service
 	ListServiceIdentitiesForService(service.MeshService) ([]service.K8sServiceAccount, error)

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -156,50 +156,6 @@ func (mr *MockMeshCatalogerMockRecorder) GetWeightedClustersForUpstream(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWeightedClustersForUpstream", reflect.TypeOf((*MockMeshCataloger)(nil).GetWeightedClustersForUpstream), arg0)
 }
 
-// ListAllowedInboundServiceIdentities mocks base method
-func (m *MockMeshCataloger) ListAllowedInboundServiceIdentities(arg0 identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedInboundServiceIdentities", arg0)
-	ret0, _ := ret[0].([]identity.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAllowedInboundServiceIdentities indicates an expected call of ListAllowedInboundServiceIdentities
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedInboundServiceIdentities(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedInboundServiceIdentities", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedInboundServiceIdentities), arg0)
-}
-
-// ListAllowedOutboundServiceIdentities mocks base method
-func (m *MockMeshCataloger) ListAllowedOutboundServiceIdentities(arg0 identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedOutboundServiceIdentities", arg0)
-	ret0, _ := ret[0].([]identity.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAllowedOutboundServiceIdentities indicates an expected call of ListAllowedOutboundServiceIdentities
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServiceIdentities(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServiceIdentities", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServiceIdentities), arg0)
-}
-
-// ListAllowedOutboundServicesForIdentity mocks base method
-func (m *MockMeshCataloger) ListAllowedOutboundServicesForIdentity(arg0 identity.ServiceIdentity) []service.MeshService {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllowedOutboundServicesForIdentity", arg0)
-	ret0, _ := ret[0].([]service.MeshService)
-	return ret0
-}
-
-// ListAllowedOutboundServicesForIdentity indicates an expected call of ListAllowedOutboundServicesForIdentity
-func (mr *MockMeshCatalogerMockRecorder) ListAllowedOutboundServicesForIdentity(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllowedOutboundServicesForIdentity", reflect.TypeOf((*MockMeshCataloger)(nil).ListAllowedOutboundServicesForIdentity), arg0)
-}
-
 // ListEndpointsForServiceIdentity mocks base method
 func (m *MockMeshCataloger) ListEndpointsForServiceIdentity(arg0 identity.ServiceIdentity, arg1 service.MeshService) ([]endpoint.Endpoint, error) {
 	m.ctrl.T.Helper()
@@ -213,6 +169,21 @@ func (m *MockMeshCataloger) ListEndpointsForServiceIdentity(arg0 identity.Servic
 func (mr *MockMeshCatalogerMockRecorder) ListEndpointsForServiceIdentity(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEndpointsForServiceIdentity", reflect.TypeOf((*MockMeshCataloger)(nil).ListEndpointsForServiceIdentity), arg0, arg1)
+}
+
+// ListInboundServiceIdentities mocks base method
+func (m *MockMeshCataloger) ListInboundServiceIdentities(arg0 identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInboundServiceIdentities", arg0)
+	ret0, _ := ret[0].([]identity.ServiceIdentity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListInboundServiceIdentities indicates an expected call of ListInboundServiceIdentities
+func (mr *MockMeshCatalogerMockRecorder) ListInboundServiceIdentities(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInboundServiceIdentities", reflect.TypeOf((*MockMeshCataloger)(nil).ListInboundServiceIdentities), arg0)
 }
 
 // ListInboundTrafficPolicies mocks base method
@@ -256,6 +227,35 @@ func (m *MockMeshCataloger) ListMeshServicesForIdentity(arg0 identity.ServiceIde
 func (mr *MockMeshCatalogerMockRecorder) ListMeshServicesForIdentity(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMeshServicesForIdentity", reflect.TypeOf((*MockMeshCataloger)(nil).ListMeshServicesForIdentity), arg0)
+}
+
+// ListOutboundServiceIdentities mocks base method
+func (m *MockMeshCataloger) ListOutboundServiceIdentities(arg0 identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOutboundServiceIdentities", arg0)
+	ret0, _ := ret[0].([]identity.ServiceIdentity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOutboundServiceIdentities indicates an expected call of ListOutboundServiceIdentities
+func (mr *MockMeshCatalogerMockRecorder) ListOutboundServiceIdentities(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundServiceIdentities", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundServiceIdentities), arg0)
+}
+
+// ListOutboundServicesForIdentity mocks base method
+func (m *MockMeshCataloger) ListOutboundServicesForIdentity(arg0 identity.ServiceIdentity) []service.MeshService {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOutboundServicesForIdentity", arg0)
+	ret0, _ := ret[0].([]service.MeshService)
+	return ret0
+}
+
+// ListOutboundServicesForIdentity indicates an expected call of ListOutboundServicesForIdentity
+func (mr *MockMeshCatalogerMockRecorder) ListOutboundServicesForIdentity(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutboundServicesForIdentity", reflect.TypeOf((*MockMeshCataloger)(nil).ListOutboundServicesForIdentity), arg0)
 }
 
 // ListOutboundTrafficPolicies mocks base method

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -109,9 +109,9 @@ func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespa
 	return outboundPoliciesFromSplits
 }
 
-// ListAllowedOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
+// ListOutboundServicesForIdentity list the services the given service account is allowed to initiate outbound connections to
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(serviceIdentity identity.ServiceIdentity) []service.MeshService {
+func (mc *MeshCatalog) ListOutboundServicesForIdentity(serviceIdentity identity.ServiceIdentity) []service.MeshService {
 	ident := serviceIdentity.ToK8sServiceAccount()
 	if mc.isOSMGateway(serviceIdentity) {
 		var services []service.MeshService
@@ -312,7 +312,7 @@ func (mc *MeshCatalog) GetWeightedClustersForUpstream(upstream service.MeshServi
 // ListMeshServicesForIdentity returns a list of services the service with the
 // given identity can communicate with, including apex TrafficSplit services.
 func (mc *MeshCatalog) ListMeshServicesForIdentity(identity identity.ServiceIdentity) []service.MeshService {
-	upstreamServices := mc.ListAllowedOutboundServicesForIdentity(identity)
+	upstreamServices := mc.ListOutboundServicesForIdentity(identity)
 	if len(upstreamServices) == 0 {
 		log.Debug().Msgf("Proxy with identity %s does not have any allowed upstream services", identity)
 		return nil

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -753,7 +753,7 @@ func TestListOutboundTrafficPoliciesForTrafficSplits(t *testing.T) {
 	}
 }
 
-func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
+func TestListOutboundServicesForIdentity(t *testing.T) {
 	assert := tassert.New(t)
 
 	testCases := []struct {
@@ -796,7 +796,7 @@ func TestListAllowedOutboundServicesForIdentity(t *testing.T) {
 			mc := newFakeMeshCatalogForRoutes(t, testParams{
 				permissiveMode: tc.permissiveMode,
 			})
-			actualList := mc.ListAllowedOutboundServicesForIdentity(tc.svcIdentity)
+			actualList := mc.ListOutboundServicesForIdentity(tc.svcIdentity)
 			assert.ElementsMatch(actualList, tc.expectedList)
 		})
 	}

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -21,15 +21,15 @@ const (
 	httpRouteGroupKind = "HTTPRouteGroup"
 )
 
-// ListAllowedInboundServiceIdentities lists the downstream service identities that can connect to the given upstream service account
+// ListInboundServiceIdentities lists the downstream service identities that are allowed to connect to the given service identity
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (mc *MeshCatalog) ListAllowedInboundServiceIdentities(upstream identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+func (mc *MeshCatalog) ListInboundServiceIdentities(upstream identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
 	return mc.getAllowedDirectionalServiceAccounts(upstream, inbound)
 }
 
-// ListAllowedOutboundServiceIdentities lists the upstream service identities the given downstream service account can connect to
+// ListOutboundServiceIdentities lists the upstream service identities the given service identity are allowed to connect to
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (mc *MeshCatalog) ListAllowedOutboundServiceIdentities(downstream identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+func (mc *MeshCatalog) ListOutboundServiceIdentities(downstream identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
 	return mc.getAllowedDirectionalServiceAccounts(downstream, outbound)
 }
 

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 
-func TestListAllowedInboundServiceIdentities(t *testing.T) {
+func TestListInboundServiceIdentities(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -189,14 +189,14 @@ func TestListAllowedInboundServiceIdentities(t *testing.T) {
 			// Mock TrafficTargets returned by MeshSpec, should return all TrafficTargets relevant for this test
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).Times(1)
 
-			actual, err := meshCatalog.ListAllowedInboundServiceIdentities(tc.serviceIdentity)
+			actual, err := meshCatalog.ListInboundServiceIdentities(tc.serviceIdentity)
 			assert.Equal(err != nil, tc.expectError)
 			assert.ElementsMatch(actual, tc.expectedInboundServiceIdentities)
 		})
 	}
 }
 
-func TestListAllowedOutboundServiceIdentities(t *testing.T) {
+func TestListOutboundServiceIdentities(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -372,7 +372,7 @@ func TestListAllowedOutboundServiceIdentities(t *testing.T) {
 			// Mock TrafficTargets returned by MeshSpec, should return all TrafficTargets relevant for this test
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).Times(1)
 
-			actual, err := meshCatalog.ListAllowedOutboundServiceIdentities(tc.serviceIdentity)
+			actual, err := meshCatalog.ListOutboundServiceIdentities(tc.serviceIdentity)
 			assert.Equal(err != nil, tc.expectError)
 			assert.ElementsMatch(actual, tc.expectedOutboundServiceIdentities)
 		})

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -49,14 +49,14 @@ type MeshCataloger interface {
 	// ListOutboundTrafficPolicies returns all outbound traffic policies related to the given service identity
 	ListOutboundTrafficPolicies(identity.ServiceIdentity) []*trafficpolicy.OutboundTrafficPolicy
 
-	// ListAllowedOutboundServicesForIdentity list the services the given service identity is allowed to initiate outbound connections to
-	ListAllowedOutboundServicesForIdentity(identity.ServiceIdentity) []service.MeshService
+	// ListOutboundServicesForIdentity list the services the given service identity is allowed to initiate outbound connections to
+	ListOutboundServicesForIdentity(identity.ServiceIdentity) []service.MeshService
 
-	// ListAllowedInboundServiceIdentities lists the downstream service identities that can connect to the given service identity
-	ListAllowedInboundServiceIdentities(identity.ServiceIdentity) ([]identity.ServiceIdentity, error)
+	// ListInboundServiceIdentities lists the downstream service identities that are allowed to connect to the given service identity
+	ListInboundServiceIdentities(identity.ServiceIdentity) ([]identity.ServiceIdentity, error)
 
-	// ListAllowedOutboundServiceIdentities lists the upstream service identities the given service identity can connect to
-	ListAllowedOutboundServiceIdentities(identity.ServiceIdentity) ([]identity.ServiceIdentity, error)
+	// ListOutboundServiceIdentities lists the upstream service identities the given service identity are allowed to connect to
+	ListOutboundServiceIdentities(identity.ServiceIdentity) ([]identity.ServiceIdentity, error)
 
 	// ListServiceIdentitiesForService lists the service identities associated with the given service
 	ListServiceIdentitiesForService(service.MeshService) ([]identity.ServiceIdentity, error)

--- a/pkg/envoy/ads/secrets.go
+++ b/pkg/envoy/ads/secrets.go
@@ -70,7 +70,7 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 
 	// Create an SDS validation cert corresponding to each upstream service that this proxy can connect to.
 	// Each cert is used to validate the certificate presented by the corresponding upstream service.
-	upstreamServices := meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity)
+	upstreamServices := meshCatalog.ListOutboundServicesForIdentity(proxyIdentity)
 	for _, upstream := range upstreamServices {
 		upstreamRootCertResource := secrets.SDSCert{
 			Name:     upstream.NameWithoutCluster(),

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -130,7 +130,7 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
 			assert := tassert.New(t)
 
-			mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tc.proxyIdentity).Return(tc.allowedOutboundServices).Times(1)
+			mockCatalog.EXPECT().ListOutboundServicesForIdentity(tc.proxyIdentity).Return(tc.allowedOutboundServices).Times(1)
 
 			actual := makeRequestForAllSecrets(testProxy, mockCatalog)
 

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -25,7 +25,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	if proxy.Kind() == envoy.KindGateway {
 		// Build remote clusters based on allowed outbound services
-		for _, dstService := range meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity) {
+		for _, dstService := range meshCatalog.ListOutboundServicesForIdentity(proxyIdentity) {
 			cluster, err := getUpstreamServiceCluster(proxyIdentity, dstService, cfg)
 			if err != nil {
 				log.Error().Err(err).Msgf("Failed to construct service cluster for service %s for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
@@ -39,7 +39,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	}
 
 	// Build remote clusters based on allowed outbound services
-	for _, dstService := range meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity) {
+	for _, dstService := range meshCatalog.ListOutboundServicesForIdentity(proxyIdentity) {
 		opts := []clusterOption{withTLS}
 		if cfg.IsPermissiveTrafficPolicyMode() {
 			opts = append(opts, permissive)

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -61,7 +61,7 @@ func TestNewResponse(t *testing.T) {
 		return []service.MeshService{tests.BookbuyerService}, nil
 	}))
 
-	mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tests.BookbuyerServiceIdentity).Return([]service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service}).AnyTimes()
+	mockCatalog.EXPECT().ListOutboundServicesForIdentity(tests.BookbuyerServiceIdentity).Return([]service.MeshService{tests.BookstoreV1Service, tests.BookstoreV2Service}).AnyTimes()
 	mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(tests.BookbuyerService).Return(map[uint32]string{uint32(80): "protocol"}, nil)
 	mockCatalog.EXPECT().GetEgressTrafficPolicy(tests.BookbuyerServiceIdentity).Return(nil, nil).AnyTimes()
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
@@ -389,7 +389,7 @@ func TestNewResponseListServicesError(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
-	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity).Return(nil).AnyTimes()
+	meshCatalog.EXPECT().ListOutboundServicesForIdentity(proxyIdentity).Return(nil).AnyTimes()
 
 	resp, err := NewResponse(meshCatalog, proxy, nil, nil, nil, proxyRegistry)
 	tassert.Error(t, err)
@@ -416,7 +416,7 @@ func TestNewResponseGetLocalServiceClusterError(t *testing.T) {
 	proxy, err := envoy.NewProxy(cn, "", nil)
 	tassert.Nil(t, err)
 
-	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity).Return(nil).Times(1)
+	meshCatalog.EXPECT().ListOutboundServicesForIdentity(proxyIdentity).Return(nil).Times(1)
 	meshCatalog.EXPECT().GetTargetPortToProtocolMappingForService(svc).Return(nil, errors.New("some error")).Times(1)
 	meshCatalog.EXPECT().GetKubeController().Return(mockKubeController).AnyTimes()
 	mockKubeController.EXPECT().ListPods().Return([]*v1.Pod{})
@@ -441,7 +441,7 @@ func TestNewResponseGetEgressTrafficPolicyError(t *testing.T) {
 	mockKubeController := k8s.NewMockController(ctrl)
 	cfg := configurator.NewMockConfigurator(ctrl)
 
-	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity).Return(nil).Times(1)
+	meshCatalog.EXPECT().ListOutboundServicesForIdentity(proxyIdentity).Return(nil).Times(1)
 	meshCatalog.EXPECT().GetEgressTrafficPolicy(proxyIdentity).Return(nil, errors.New("some error")).Times(1)
 	meshCatalog.EXPECT().GetKubeController().Return(mockKubeController).AnyTimes()
 	mockKubeController.EXPECT().ListPods().Return([]*v1.Pod{})
@@ -466,7 +466,7 @@ func TestNewResponseGetEgressTrafficPolicyNotEmpty(t *testing.T) {
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
 	mockKubeController := k8s.NewMockController(ctrl)
 	cfg := configurator.NewMockConfigurator(ctrl)
-	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity).Return(nil).Times(1)
+	meshCatalog.EXPECT().ListOutboundServicesForIdentity(proxyIdentity).Return(nil).Times(1)
 	meshCatalog.EXPECT().GetKubeController().Return(mockKubeController).AnyTimes()
 	mockKubeController.EXPECT().ListPods().Return([]*v1.Pod{})
 	meshCatalog.EXPECT().GetEgressTrafficPolicy(proxyIdentity).Return(&trafficpolicy.EgressTrafficPolicy{
@@ -497,7 +497,7 @@ func TestNewResponseForGateway(t *testing.T) {
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
 	mockKubeController := k8s.NewMockController(ctrl)
 	cfg := configurator.NewMockConfigurator(ctrl)
-	meshCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(proxyIdentity).Return([]service.MeshService{
+	meshCatalog.EXPECT().ListOutboundServicesForIdentity(proxyIdentity).Return([]service.MeshService{
 		tests.BookbuyerService,
 		tests.BookwarehouseService,
 	}).AnyTimes()

--- a/pkg/envoy/eds/response.go
+++ b/pkg/envoy/eds/response.go
@@ -104,7 +104,7 @@ func clusterToMeshSvc(cluster string) (service.MeshService, error) {
 func getEndpointsForProxy(meshCatalog catalog.MeshCataloger, proxyIdentity identity.ServiceIdentity) (map[service.MeshService][]endpoint.Endpoint, error) {
 	allowedServicesEndpoints := make(map[service.MeshService][]endpoint.Endpoint)
 
-	for _, dstSvc := range meshCatalog.ListAllowedOutboundServicesForIdentity(proxyIdentity) {
+	for _, dstSvc := range meshCatalog.ListOutboundServicesForIdentity(proxyIdentity) {
 		endpoints, err := meshCatalog.ListEndpointsForServiceIdentity(proxyIdentity, dstSvc)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed listing allowed endpoints for service %s for proxy identity %s", dstSvc, proxyIdentity)

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -191,7 +191,7 @@ func getServiceIdentitiesFromCert(sdscert secrets.SDSCert, serviceIdentity ident
 		// service identities that are allowed to connect to this upstream identity. This means, if the upstream proxy
 		// identity is 'X', the SANs for this certificate should correspond to all the downstream identities
 		// allowed to access 'X'.
-		svcIdentities, err := meshCatalog.ListAllowedInboundServiceIdentities(serviceIdentity)
+		svcIdentities, err := meshCatalog.ListInboundServiceIdentities(serviceIdentity)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error listing inbound service accounts for proxy with ServiceAccount %s", serviceIdentity)
 			return nil, err

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -120,7 +120,7 @@ func TestGetRootCert(t *testing.T) {
 					identity.K8sServiceAccount{Name: "sa-3", Namespace: "ns-3"}.ToServiceIdentity(),
 				}
 				ident := identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}.ToServiceIdentity()
-				d.mockCatalog.EXPECT().ListAllowedInboundServiceIdentities(ident).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListInboundServiceIdentities(ident).Return(allowedInboundSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 
@@ -321,7 +321,7 @@ func TestGetSDSSecrets(t *testing.T) {
 					identity.K8sServiceAccount{Name: "sa-2", Namespace: "ns-2"}.ToServiceIdentity(),
 					identity.K8sServiceAccount{Name: "sa-3", Namespace: "ns-3"}.ToServiceIdentity(),
 				}
-				d.mockCatalog.EXPECT().ListAllowedInboundServiceIdentities(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}.ToServiceIdentity()).Return(allowedInboundSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListInboundServiceIdentities(identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}.ToServiceIdentity()).Return(allowedInboundSvcAccounts, nil).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This PR aims to resolve issue #3190 .

It mainly drops the word `allowed` from cataloger endpoints methods.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

No
