### PR TITLE
tests(*): scope assert handles to subtests

### DIFF
--- a/cmd/cli/metrics_test.go
+++ b/cmd/cli/metrics_test.go
@@ -215,8 +215,6 @@ func TestRun_MetricsDisable(t *testing.T) {
 }
 
 func TestIsMonitoredNamespace(t *testing.T) {
-	assert := tassert.New(t)
-
 	meshList := mapset.NewSet(testMesh)
 
 	nsMonitored := corev1.Namespace{
@@ -259,6 +257,8 @@ func TestIsMonitoredNamespace(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing if %s exists is monitored", tc.ns.Name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			monitored, err := isMonitoredNamespace(tc.ns, meshList)
 			assert.Equal(monitored, tc.exists)
 			assert.Equal(err != nil, tc.expectErr)

--- a/cmd/cli/proxy_get_test.go
+++ b/cmd/cli/proxy_get_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestIsMeshedPod(t *testing.T) {
-	assert := tassert.New(t)
-
 	type test struct {
 		pod      corev1.Pod
 		isMeshed bool
@@ -41,6 +39,8 @@ func TestIsMeshedPod(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing if pod %s is meshed", tc.pod.Name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			isMeshed := isMeshedPod(tc.pod)
 			assert.Equal(isMeshed, tc.isMeshed)
 		})
@@ -48,8 +48,6 @@ func TestIsMeshedPod(t *testing.T) {
 }
 
 func TestAnnotateErrMsgWithPodNamespaceMsg(t *testing.T) {
-	assert := tassert.New(t)
-
 	type test struct {
 		errorMsg     string
 		podName      string
@@ -70,6 +68,8 @@ func TestAnnotateErrMsgWithPodNamespaceMsg(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing annotated error message for pod name [%s] in pod namespace [%s]", tc.podName, tc.podNamespace), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			assert.Equal(
 				tc.annotatedMsg,
 				annotateErrMsgWithPodNamespaceMsg(tc.errorMsg, tc.podName, tc.podNamespace).Error())

--- a/cmd/cli/support_err_test.go
+++ b/cmd/cli/support_err_test.go
@@ -10,8 +10,6 @@ import (
 // TestErrInfoRun tests errInfoCmd.run()
 
 func TestErrInfoRun(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name      string
 		errCode   string
@@ -41,6 +39,8 @@ func TestErrInfoRun(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			var out bytes.Buffer
 			cmd := &errInfoCmd{out: &out}
 			err := cmd.run(tc.errCode)

--- a/cmd/cli/trafficpolicy_check_test.go
+++ b/cmd/cli/trafficpolicy_check_test.go
@@ -20,8 +20,6 @@ import (
 )
 
 func TestUnmarshalNamespacedPod(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		namespacedPod     string
 		expectedNamespace string
@@ -36,6 +34,8 @@ func TestUnmarshalNamespacedPod(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing if %s", tc.namespacedPod), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actualNamespace, actualPodName, err := unmarshalNamespacedPod(tc.namespacedPod)
 			assert.Equal(actualNamespace, tc.expectedNamespace)
 			assert.Equal(actualPodName, tc.expectedPodName)
@@ -104,6 +104,8 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing testcase %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// create the MeshConfig
 			_, err := fakeConfigClient.ConfigV1alpha1().MeshConfigs(osmNamespace.Name).Create(context.TODO(), &tc.meshConfig, metav1.CreateOptions{})
 			assert.Nil(err)
@@ -283,6 +285,8 @@ func TestRun(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing testcase %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			cmd.sourcePod = tc.srcNamespacedPod
 			cmd.destinationPod = tc.dstNamespacedPod
 
@@ -541,6 +545,8 @@ func TestCheckTrafficPolicy(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing testcase %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// create MeshConfig
 			_, err := fakeConfigClient.ConfigV1alpha1().MeshConfigs(osmNamespace.Name).Create(context.TODO(), &tc.meshConfig, metav1.CreateOptions{})
 			assert.Nil(err)

--- a/cmd/cli/util_test.go
+++ b/cmd/cli/util_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestAnnotateErrorMessageWithActionableMessage(t *testing.T) {
-	assert := tassert.New(t)
-
 	type test struct {
 		errorMsg     string
 		name         string
@@ -40,6 +38,8 @@ func TestAnnotateErrorMessageWithActionableMessage(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Testing annotated error message", func(t *testing.T) {
+			assert := tassert.New(t)
+
 			assert.Equal(
 				tc.annotatedMsg,
 				annotateErrorMessageWithActionableMessage(actionableMsg, tc.errorMsg, tc.name, tc.namespace, tc.exceptionMsg).Error())
@@ -48,8 +48,6 @@ func TestAnnotateErrorMessageWithActionableMessage(t *testing.T) {
 }
 
 func TestAnnotateErrorMessageWithOsmNamespace(t *testing.T) {
-	assert := tassert.New(t)
-
 	type test struct {
 		errorMsg     string
 		name         string
@@ -75,6 +73,8 @@ func TestAnnotateErrorMessageWithOsmNamespace(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("Testing annotated error message", func(t *testing.T) {
+			assert := tassert.New(t)
+
 			assert.Equal(
 				tc.annotatedMsg,
 				annotateErrorMessageWithOsmNamespace(tc.errorMsg, tc.name, tc.namespace, tc.exceptionMsg).Error())

--- a/cmd/osm-controller/gateway_test.go
+++ b/cmd/osm-controller/gateway_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestBootstrapOSMGateway(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -126,6 +125,8 @@ static_resources:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			fakeClient := fake.NewSimpleClientset()
 
 			testNs := "test"
@@ -150,8 +151,6 @@ static_resources:
 }
 
 func TestIsValidBootstrapData(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name         string
 		boostrapYAML string
@@ -258,6 +257,8 @@ node:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := isValidBootstrapData([]byte(tc.boostrapYAML))
 			assert.Equal(tc.expected, actual)
 		})

--- a/pkg/certificate/providers/certmanager/certificate_manager_test.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager_test.go
@@ -240,6 +240,8 @@ func TestCertificaterFromCertificateRequest(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			cert, err := cm.certificaterFromCertificateRequest(&tc.cr, emptyArr)
 
 			assert.Equal(tc.expectedCertIsNil, cert == nil)

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestGetCertificateManager(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
@@ -49,6 +48,8 @@ func TestGetCertificateManager(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			manager, _, err := tc.util.GetCertificateManager()
 			assert.NotNil(manager)
 			assert.Equal(tc.expectError, err != nil)

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -128,6 +128,8 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCatalog.EXPECT().ListAllowedOutboundServicesForIdentity(tc.proxyIdentity).Return(tc.allowedOutboundServices).Times(1)
 
 			actual := makeRequestForAllSecrets(testProxy, mockCatalog)

--- a/pkg/envoy/ads/stream_test.go
+++ b/pkg/envoy/ads/stream_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestIsCNForProxy(t *testing.T) {
-	assert := tassert.New(t)
-
 	type testCase struct {
 		name     string
 		cn       certificate.CommonName
@@ -46,6 +44,8 @@ func TestIsCNForProxy(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := isCNforProxy(tc.proxy, tc.cn)
 			assert.Equal(tc.expected, actual)
 		})

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestGetUpstreamServiceCluster(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
@@ -53,6 +51,8 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			opts := []clusterOption{withTLS}
 			if tc.permissiveMode {
 				opts = append(opts, permissive)
@@ -66,8 +66,6 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 }
 
 func TestGetLocalServiceCluster(t *testing.T) {
-	assert := tassert.New(t)
-
 	clusterName := "default/bookbuyer/local-local"
 	proxyService := service.MeshService{
 		Name:          "bookbuyer",
@@ -124,6 +122,8 @@ func TestGetLocalServiceCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			if tc.expectedPortToProtocolMappingErr {
 				mockCatalog.EXPECT().GetTargetPortToProtocolMappingForService(tc.proxyService).Return(tc.portToProtocolMapping, errors.New("error")).Times(1)
 			} else {
@@ -238,6 +238,8 @@ func TestGetOriginalDestinationEgressCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := getOriginalDestinationEgressCluster(tc.clusterName)
 			assert.Nil(err)
 			assert.Equal(tc.expected, actual)
@@ -246,8 +248,6 @@ func TestGetOriginalDestinationEgressCluster(t *testing.T) {
 }
 
 func TestGetEgressClusters(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                 string
 		clusterConfigs       []*trafficpolicy.EgressClusterConfig
@@ -293,6 +293,8 @@ func TestGetEgressClusters(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := getEgressClusters(tc.clusterConfigs)
 			assert.Len(actual, tc.expectedClusterCount)
 		})
@@ -300,8 +302,6 @@ func TestGetEgressClusters(t *testing.T) {
 }
 
 func TestGetDNSResolvableEgressCluster(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name            string
 		clusterConfig   *trafficpolicy.EgressClusterConfig
@@ -380,6 +380,8 @@ func TestGetDNSResolvableEgressCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := getDNSResolvableEgressCluster(tc.clusterConfig)
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedCluster, actual)
@@ -388,8 +390,6 @@ func TestGetDNSResolvableEgressCluster(t *testing.T) {
 }
 
 func TestFormatAltStatNameForPrometheus(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                string
 		clusterName         string
@@ -414,6 +414,8 @@ func TestFormatAltStatNameForPrometheus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := formatAltStatNameForPrometheus(tc.clusterName)
 			assert.Equal(tc.expectedAltStatName, actual)
 		})

--- a/pkg/envoy/eds/response_test.go
+++ b/pkg/envoy/eds/response_test.go
@@ -87,8 +87,6 @@ func TestEndpointConfiguration(t *testing.T) {
 }
 
 func TestClusterToMeshSvc(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name            string
 		cluster         string
@@ -121,6 +119,8 @@ func TestClusterToMeshSvc(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			meshSvc, err := clusterToMeshSvc(tc.cluster)
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedMeshSvc, meshSvc)

--- a/pkg/envoy/lds/egress_test.go
+++ b/pkg/envoy/lds/egress_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestGetEgressHTTPFilterChain(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -51,6 +49,8 @@ func TestGetEgressHTTPFilterChain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			lb := &listenerBuilder{
 				cfg: mockConfigurator,
 			}
@@ -69,8 +69,6 @@ func TestGetEgressHTTPFilterChain(t *testing.T) {
 }
 
 func TestGetEgressTCPFilterChain(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -151,6 +149,8 @@ func TestGetEgressTCPFilterChain(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{
 				EnableEgressPolicy: true,
 				EnableWASMStats:    false,
@@ -169,8 +169,6 @@ func TestGetEgressTCPFilterChain(t *testing.T) {
 }
 
 func TestGetEgressFilterChainsForMatches(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -222,6 +220,8 @@ func TestGetEgressFilterChainsForMatches(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			lb := &listenerBuilder{
 				cfg: mockConfigurator,
 			}

--- a/pkg/envoy/lds/gateway_test.go
+++ b/pkg/envoy/lds/gateway_test.go
@@ -98,6 +98,8 @@ func TestNewMultiClusterGatewayListener(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			assert.Equal(listener.FilterChains[i].FilterChainMatch.ServerNames, tc.expectedFilterChainMatch.ServerNames)
 			assert.Equal(listener.FilterChains[i].FilterChainMatch.ApplicationProtocols, tc.expectedFilterChainMatch.ApplicationProtocols)
 			assert.Equal(listener.FilterChains[i].FilterChainMatch.TransportProtocol, tc.expectedFilterChainMatch.TransportProtocol)

--- a/pkg/envoy/lds/ingress_test.go
+++ b/pkg/envoy/lds/ingress_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 func TestGetIngressFilterChains(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -90,6 +89,8 @@ func TestGetIngressFilterChains(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
@@ -132,8 +133,6 @@ func TestGetIngressFilterChains(t *testing.T) {
 }
 
 func TestGetIngressTransportProtocol(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                      string
 		forHTTPS                  bool
@@ -153,6 +152,8 @@ func TestGetIngressTransportProtocol(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := getIngressTransportProtocol(tc.forHTTPS)
 			assert.Equal(tc.expectedTransportProtocol, actual)
 		})

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestGetOutboundHTTPFilterChainForService(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -95,6 +94,8 @@ func TestGetOutboundHTTPFilterChainForService(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCatalog.EXPECT().GetResolvableServiceEndpoints(tests.BookstoreApexService).Return(tc.expectedEndpoints, nil)
 			httpFilterChain, err := lb.getOutboundHTTPFilterChainForService(tests.BookstoreApexService, tc.servicePort)
 
@@ -115,7 +116,6 @@ func TestGetOutboundHTTPFilterChainForService(t *testing.T) {
 }
 
 func TestGetOutboundTCPFilterChainForService(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -173,6 +173,8 @@ func TestGetOutboundTCPFilterChainForService(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCatalog.EXPECT().GetResolvableServiceEndpoints(tests.BookstoreApexService).Return(tc.expectedEndpoints, nil)
 			mockCatalog.EXPECT().GetWeightedClustersForUpstream(tests.BookstoreApexService).Times(1)
 
@@ -195,7 +197,6 @@ func TestGetOutboundTCPFilterChainForService(t *testing.T) {
 }
 
 func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -274,6 +275,8 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
 			if !tc.permissiveMode {
 				// mock catalog calls used to build the RBAC filter
@@ -293,7 +296,6 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 }
 
 func TestGetInboundMeshTCPFilterChain(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -372,6 +374,8 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).Times(1)
 			if !tc.permissiveMode {
 				// mock catalog calls used to build the RBAC filter
@@ -392,7 +396,6 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 
 // Tests getOutboundFilterChainMatchForService and ensures the filter chain match returned is as expected
 func TestGetOutboundFilterChainMatchForService(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
@@ -521,6 +524,8 @@ func TestGetOutboundFilterChainMatchForService(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// mock endpoints returned
 			mockCatalog.EXPECT().GetResolvableServiceEndpoints(tests.BookstoreApexService).Return(tc.endpoints, nil)
 

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -261,8 +261,6 @@ var _ = Describe("Test getHTTPConnectionManager", func() {
 })
 
 func TestGetFilterMatchPredicateForPorts(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		ports         []int
@@ -317,6 +315,8 @@ func TestGetFilterMatchPredicateForPorts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := getFilterMatchPredicateForPorts(tc.ports)
 			assert.Equal(tc.expectedMatch, actual)
 		})
@@ -324,8 +324,6 @@ func TestGetFilterMatchPredicateForPorts(t *testing.T) {
 }
 
 func TestGetFilterMatchPredicateForTrafficMatches(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		matches       []*trafficpolicy.TrafficMatch
@@ -366,6 +364,8 @@ func TestGetFilterMatchPredicateForTrafficMatches(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := getFilterMatchPredicateForTrafficMatches(tc.matches)
 			assert.Equal(tc.expectedMatch, actual)
 		})

--- a/pkg/envoy/lds/rbac_test.go
+++ b/pkg/envoy/lds/rbac_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		trafficTarget trafficpolicy.TrafficTargetWithRoutes
@@ -139,6 +137,8 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// Test the RBAC policies
 			policy, err := buildRBACPolicyFromTrafficTarget(tc.trafficTarget)
 
@@ -149,7 +149,6 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 }
 
 func TestBuildInboundRBACPolicies(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -216,6 +215,8 @@ func TestBuildInboundRBACPolicies(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// Mock catalog calls
 			mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(proxySvcAccount.ToServiceIdentity()).Return(tc.trafficTargets, nil).Times(1)
 
@@ -236,7 +237,6 @@ func TestBuildInboundRBACPolicies(t *testing.T) {
 }
 
 func TestBuildRBACFilter(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -299,6 +299,8 @@ func TestBuildRBACFilter(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// Mock catalog calls
 			mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(proxySvcAccount).Return(tc.trafficTargets, nil).Times(1)
 

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -444,8 +444,6 @@ var _ = Describe("Test XDS certificate tooling", func() {
 })
 
 func TestPodMetadataString(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name     string
 		proxy    *Proxy
@@ -474,6 +472,8 @@ func TestPodMetadataString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := tc.proxy.PodMetadataString()
 			assert.Equal(tc.expected, actual)
 		})

--- a/pkg/envoy/rbac/policy_test.go
+++ b/pkg/envoy/rbac/policy_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                string
 		p                   *Policy
@@ -277,6 +275,8 @@ func TestGenerate(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			policy, err := tc.p.Generate()
 
 			assert.Equal(err != nil, tc.expectError)

--- a/pkg/envoy/rds/route/rbac_test.go
+++ b/pkg/envoy/rds/route/rbac_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestBuildInboundRBACFilterForRule(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name               string
 		rule               *trafficpolicy.Rule
@@ -108,6 +106,8 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			rbacFilter, err := buildInboundRBACFilterForRule(tc.rule)
 
 			assert.Equal(tc.expectError, err != nil)

--- a/pkg/envoy/rds/route/route_config_test.go
+++ b/pkg/envoy/rds/route/route_config_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestBuildRouteConfiguration(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	mockCfg := configurator.NewMockConfigurator(mockCtrl)
 
@@ -96,6 +94,8 @@ func TestBuildRouteConfiguration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCfg.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{
 				EnableWASMStats: false,
 			}).Times(1)
@@ -134,8 +134,6 @@ func TestBuildRouteConfiguration(t *testing.T) {
 }
 
 func TestBuildIngressRouteConfiguration(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	mockCfg := configurator.NewMockConfigurator(mockCtrl)
 
@@ -215,6 +213,8 @@ func TestBuildIngressRouteConfiguration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCfg.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{
 				EnableWASMStats: false,
 			}).AnyTimes()
@@ -237,8 +237,6 @@ func TestBuildIngressRouteConfiguration(t *testing.T) {
 }
 
 func TestBuildVirtualHostStub(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name         string
 		namePrefix   string
@@ -264,6 +262,8 @@ func TestBuildVirtualHostStub(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := buildVirtualHostStub(tc.namePrefix, tc.host, tc.domains)
 			assert.Equal(tc.expectedName, actual.Name)
 			assert.Equal(tc.domains, actual.Domains)
@@ -271,8 +271,6 @@ func TestBuildVirtualHostStub(t *testing.T) {
 	}
 }
 func TestBuildInboundRoutes(t *testing.T) {
-	assert := tassert.New(t)
-
 	testWeightedCluster := service.WeightedCluster{
 		ClusterName: "default/testCluster/local",
 		Weight:      100,
@@ -281,7 +279,7 @@ func TestBuildInboundRoutes(t *testing.T) {
 	testCases := []struct {
 		name       string
 		inputRules []*trafficpolicy.Rule
-		expectFunc func(actual []*xds_route.Route)
+		expectFunc func(assert *tassert.Assertions, actual []*xds_route.Route)
 	}{
 		{
 			name: "valid route rule",
@@ -301,7 +299,7 @@ func TestBuildInboundRoutes(t *testing.T) {
 					),
 				},
 			},
-			expectFunc: func(actual []*xds_route.Route) {
+			expectFunc: func(assert *tassert.Assertions, actual []*xds_route.Route) {
 				assert.Equal(1, len(actual))
 				assert.Equal("/hello", actual[0].GetMatch().GetSafeRegex().Regex)
 				assert.Equal("GET", actual[0].GetMatch().GetHeaders()[0].GetSafeRegexMatch().Regex)
@@ -328,7 +326,7 @@ func TestBuildInboundRoutes(t *testing.T) {
 					AllowedServiceAccounts: nil,
 				},
 			},
-			expectFunc: func(actual []*xds_route.Route) {
+			expectFunc: func(assert *tassert.Assertions, actual []*xds_route.Route) {
 				assert.Equal(0, len(actual))
 			},
 		},
@@ -337,7 +335,7 @@ func TestBuildInboundRoutes(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
 			actual := buildInboundRoutes(tc.inputRules)
-			tc.expectFunc(actual)
+			tc.expectFunc(tassert.New(t), actual)
 		})
 	}
 }
@@ -371,8 +369,6 @@ func TestBuildOutboundRoutes(t *testing.T) {
 }
 
 func TestBuildRoute(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name             string
 		weightedClusters mapset.Set
@@ -619,6 +615,8 @@ func TestBuildRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := buildRoute(tc.pathMatchType, tc.path, tc.method, tc.headersMap, tc.weightedClusters, tc.totalWeight, tc.direction)
 
 			// Assert route.Match
@@ -632,8 +630,6 @@ func TestBuildRoute(t *testing.T) {
 }
 
 func TestBuildWeightedCluster(t *testing.T) {
-	assert := tassert.New(t)
-
 	weightedClusters := mapset.NewSetFromSlice([]interface{}{
 		service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-1/local"), Weight: 30},
 		service.WeightedCluster{ClusterName: service.ClusterName("osm/bookstore-2/local"), Weight: 70},
@@ -661,6 +657,8 @@ func TestBuildWeightedCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := buildWeightedCluster(tc.weightedClusters, tc.totalWeight, tc.direction)
 			assert.Len(actual.Clusters, 2)
 			assert.EqualValues(uint32(tc.totalWeight), actual.TotalWeight.GetValue())
@@ -669,8 +667,6 @@ func TestBuildWeightedCluster(t *testing.T) {
 }
 
 func TestSanitizeHTTPMethods(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                   string
 		allowedMethods         []string
@@ -691,6 +687,8 @@ func TestSanitizeHTTPMethods(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := sanitizeHTTPMethods(tc.allowedMethods)
 			assert.Equal(tc.expectedAllowedMethods, actual)
 		})
@@ -709,8 +707,6 @@ func TestNewRouteConfigurationStub(t *testing.T) {
 }
 
 func TestGetRegexForMethod(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name     string
 		input    string
@@ -730,6 +726,8 @@ func TestGetRegexForMethod(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := getRegexForMethod(tc.input)
 			assert.Equal(tc.expected, actual)
 		})
@@ -869,8 +867,6 @@ func TestLess(t *testing.T) {
 }
 
 func TestBuildEgressRoute(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name           string
 		routingRules   []*trafficpolicy.EgressHTTPRoutingRule
@@ -988,6 +984,8 @@ func TestBuildEgressRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := buildEgressRoutes(tc.routingRules)
 			assert.ElementsMatch(tc.expectedRoutes, actual)
 		})
@@ -995,8 +993,6 @@ func TestBuildEgressRoute(t *testing.T) {
 }
 
 func TestBuildEgressRouteConfiguration(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                     string
 		portSpecificRouteConfigs map[int][]*trafficpolicy.EgressHTTPRouteConfig
@@ -1220,6 +1216,8 @@ func TestBuildEgressRouteConfiguration(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := BuildEgressRouteConfiguration(tc.portSpecificRouteConfigs)
 			assert.ElementsMatch(tc.expectedRouteConfigs, actual)
 		})
@@ -1227,8 +1225,6 @@ func TestBuildEgressRouteConfiguration(t *testing.T) {
 }
 
 func TestGetEgressRouteConfigNameForPort(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name         string
 		port         int
@@ -1248,6 +1244,8 @@ func TestGetEgressRouteConfigNameForPort(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := GetEgressRouteConfigNameForPort(tc.port)
 			assert.Equal(tc.expectedName, actual)
 		})

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -240,7 +240,6 @@ func TestGetRootCert(t *testing.T) {
 }
 
 func TestGetServiceCert(t *testing.T) {
-	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -260,6 +259,8 @@ func TestGetServiceCert(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			// Mock cert
 			mockCertificater.EXPECT().GetCertificateChain().Return(tc.certChain).Times(1)
 			mockCertificater.EXPECT().GetPrivateKey().Return(tc.privKey).Times(1)
@@ -479,8 +480,6 @@ func TestGetSDSSecrets(t *testing.T) {
 }
 
 func TestGetSubjectAltNamesFromSvcAccount(t *testing.T) {
-	assert := tassert.New(t)
-
 	type testCase struct {
 		serviceIdentities   []identity.ServiceIdentity
 		expectedSANMatchers []*xds_matcher.StringMatcher
@@ -509,6 +508,8 @@ func TestGetSubjectAltNamesFromSvcAccount(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := getSubjectAltNamesFromSvcIdentities(tc.serviceIdentities)
 			assert.ElementsMatch(actual, tc.expectedSANMatchers)
 		})
@@ -516,8 +517,6 @@ func TestGetSubjectAltNamesFromSvcAccount(t *testing.T) {
 }
 
 func TestSubjectAltNamesToStr(t *testing.T) {
-	assert := tassert.New(t)
-
 	type testCase struct {
 		sanMatchers []*xds_matcher.StringMatcher
 		strSANs     []string
@@ -546,6 +545,8 @@ func TestSubjectAltNamesToStr(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := subjectAltNamesToStr(tc.sanMatchers)
 			assert.ElementsMatch(actual, tc.strSANs)
 		})

--- a/pkg/envoy/secrets/secrets_test.go
+++ b/pkg/envoy/secrets/secrets_test.go
@@ -87,7 +87,6 @@ var _ = Describe("Test secert tools", func() {
 })
 
 func TestUnmarshalMeshService(t *testing.T) {
-	assert := tassert.New(t)
 	require := trequire.New(t)
 
 	namespace := "randomNamespace"
@@ -159,6 +158,8 @@ func TestUnmarshalMeshService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := tc.sdsCert.GetMeshService()
 			if tc.expectedErr {
 				assert.NotNil(err)
@@ -171,7 +172,6 @@ func TestUnmarshalMeshService(t *testing.T) {
 }
 
 func TestUnmarshalK8sServiceAccount(t *testing.T) {
-	assert := tassert.New(t)
 	require := trequire.New(t)
 
 	namespace := "randomNamespace"
@@ -241,6 +241,8 @@ func TestUnmarshalK8sServiceAccount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := tc.sdsCert.GetK8sServiceAccount()
 			if tc.expectedErr {
 				assert.NotNil(err)
@@ -253,8 +255,6 @@ func TestUnmarshalK8sServiceAccount(t *testing.T) {
 }
 
 func TestGetSecretNameForIdentity(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		si       identity.ServiceIdentity
 		expected string
@@ -271,6 +271,8 @@ func TestGetSecretNameForIdentity(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Test case %d", i), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := GetSecretNameForIdentity(tc.si)
 			assert.Equal(tc.expected, actual)
 		})

--- a/pkg/errcode/errcode_test.go
+++ b/pkg/errcode/errcode_test.go
@@ -12,8 +12,6 @@ func TestString(t *testing.T) {
 }
 
 func TestFromStr(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name            string
 		str             string
@@ -36,6 +34,8 @@ func TestFromStr(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := FromStr(tc.str)
 
 			assert.Equal(tc.expectError, err != nil)

--- a/pkg/identity/kubernetes_test.go
+++ b/pkg/identity/kubernetes_test.go
@@ -29,6 +29,8 @@ func TestGetKubernetesServiceIdentity(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing GetKubernetesServiceIdentity for test case: %v", tc), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			si := GetKubernetesServiceIdentity(tc.svcAccount, tc.trustDomain)
 			assert.Equal(si, tc.expectedServiceIdentity)
 		})

--- a/pkg/ingress/client_test.go
+++ b/pkg/ingress/client_test.go
@@ -36,8 +36,6 @@ func (f *fakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string
 }
 
 func TestGetSupportedIngressVersions(t *testing.T) {
-	assert := tassert.New(t)
-
 	type testCase struct {
 		name             string
 		discoveryClient  discovery.ServerResourcesInterface
@@ -117,6 +115,8 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			versions, err := getSupportedIngressVersions(tc.discoveryClient)
 
 			assert.Equal(tc.exepectError, err != nil)
@@ -128,7 +128,6 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 func TestGetIngressNetworkingV1AndVebeta1(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockKubeController := k8s.NewMockController(mockCtrl)
-	assert := tassert.New(t)
 
 	mockKubeController.EXPECT().IsMonitoredNamespace(gomock.Any()).Return(true).AnyTimes()
 	meshSvc := service.MeshService{Name: "foo", Namespace: "test"}
@@ -303,6 +302,8 @@ func TestGetIngressNetworkingV1AndVebeta1(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			fakeClient := fake.NewSimpleClientset(tc.ingressResource)
 			fakeClient.Discovery().(*fakeDiscovery.FakeDiscovery).Resources = []*metav1.APIResourceList{
 				{

--- a/pkg/injector/metrics_test.go
+++ b/pkg/injector/metrics_test.go
@@ -80,6 +80,8 @@ func TestIsMetricsEnabled(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Namespace %s", tc.namespace), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			enabled, err := wh.isMetricsEnabled(tc.namespace)
 			assert.Equal(enabled, tc.expectMetricsToBeEnabled)
 			assert.Equal(err != nil, tc.expectedErr)

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -135,8 +135,6 @@ func TestCreatePatch(t *testing.T) {
 }
 
 func TestMergePortExclusionLists(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                              string
 		podOutboundPortExclusionList      []int
@@ -177,6 +175,8 @@ func TestMergePortExclusionLists(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := mergePortExclusionLists(tc.podOutboundPortExclusionList, tc.globalOutboundPortExclusionList)
 			assert.ElementsMatch(tc.expectedOutboundPortExclusionList, actual)
 		})

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -106,8 +106,6 @@ func (mc mockCertificate) GetExpiration() time.Time                  { return ti
 func (mc mockCertificate) GetSerialNumber() certificate.SerialNumber { return "serial_number" }
 
 func TestIsAnnotatedForInjection(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name        string
 		annotations map[string]string
@@ -175,6 +173,8 @@ func TestIsAnnotatedForInjection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actualExists, actualEnabled, actualErr := isAnnotatedForInjection(tc.annotations, "-kind-", "-name-")
 			assert.Equal(tc.exists, actualExists)
 			assert.Equal(tc.enabled, actualEnabled)
@@ -664,8 +664,6 @@ var _ = Describe("Testing Injector Functions", func() {
 })
 
 func TestIsAnnotatedForPortExclusion(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		annotations   map[string]string
@@ -712,6 +710,8 @@ func TestIsAnnotatedForPortExclusion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			ports, err := isAnnotatedForPortExclusion(tc.annotations, tc.forAnnotation, "-kind-", "-name-")
 			if err != nil {
 				assert.EqualError(tc.expectedError, err.Error())
@@ -724,8 +724,6 @@ func TestIsAnnotatedForPortExclusion(t *testing.T) {
 }
 
 func TestGetPodOutboundPortExclusionList(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		podAnnotation map[string]string
@@ -772,6 +770,8 @@ func TestGetPodOutboundPortExclusionList(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			mockCtrl := gomock.NewController(GinkgoT())
 			mockKubeController := k8s.NewMockController(mockCtrl)
 			fakeClientSet := fake.NewSimpleClientset()

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -623,8 +623,6 @@ func TestGetEndpoint(t *testing.T) {
 }
 
 func TestIsMetricsEnabled(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                    string
 		addPrometheusAnnotation bool
@@ -659,6 +657,8 @@ func TestIsMetricsEnabled(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			kubeClient := testclient.NewSimpleClientset()
 			stop := make(chan struct{})
 			kubeController, err := NewKubernetesController(kubeClient, testMeshName, stop)

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestGetHostnamesForService(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name              string
 		service           *corev1.Service
@@ -64,6 +62,8 @@ func TestGetHostnamesForService(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := GetHostnamesForService(tc.service, tc.locality)
 			assert.ElementsMatch(actual, tc.expectedHostnames)
 			assert.Len(actual, len(tc.expectedHostnames))
@@ -72,8 +72,6 @@ func TestGetHostnamesForService(t *testing.T) {
 }
 
 func TestGetServiceFromHostname(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name            string
 		hostnames       []string
@@ -99,6 +97,8 @@ func TestGetServiceFromHostname(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			for _, hostname := range tc.hostnames {
 				actual := GetServiceFromHostname(hostname)
 				assert.Equal(actual, tc.expectedService)
@@ -108,8 +108,6 @@ func TestGetServiceFromHostname(t *testing.T) {
 }
 
 func TestGetAppProtocolFromPortName(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name             string
 		portName         string
@@ -139,6 +137,8 @@ func TestGetAppProtocolFromPortName(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := GetAppProtocolFromPortName(tc.portName)
 			assert.Equal(tc.expectedProtocal, actual)
 		})
@@ -146,8 +146,6 @@ func TestGetAppProtocolFromPortName(t *testing.T) {
 }
 
 func TestGetKubernetesServerVersionNumber(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name            string
 		kubeClient      kubernetes.Interface
@@ -179,6 +177,8 @@ func TestGetKubernetesServerVersionNumber(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			if tc.kubeClient != nil {
 				tc.kubeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
 					GitVersion: tc.version,

--- a/pkg/policy/client_test.go
+++ b/pkg/policy/client_test.go
@@ -26,8 +26,6 @@ func TestNewPolicyClient(t *testing.T) {
 }
 
 func TestListEgressPoliciesForSourceIdentity(t *testing.T) {
-	assert := tassert.New(t)
-
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -142,6 +140,8 @@ func TestListEgressPoliciesForSourceIdentity(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
+			assert := tassert.New(t)
+
 			fakepolicyClientSet := fakePolicyClient.NewSimpleClientset()
 
 			// Create fake egress policies

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -27,8 +27,6 @@ func TestServerName(t *testing.T) {
 }
 
 func TestEquals(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name           string
 		service        MeshService
@@ -67,6 +65,8 @@ func TestEquals(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := tc.service.Equals(tc.anotherService)
 			assert.Equal(actual, tc.isEqual)
 		})
@@ -74,8 +74,6 @@ func TestEquals(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		service       MeshService
@@ -103,6 +101,8 @@ func TestString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := tc.service.String()
 			assert.Equal(actual, tc.serviceString)
 		})

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -60,8 +60,6 @@ var (
 )
 
 func TestAddRule(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                  string
 		existingRules         []*Rule
@@ -119,6 +117,8 @@ func TestAddRule(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			inboundPolicy := newTestInboundPolicy(tc.name, tc.existingRules)
 			inboundPolicy.AddRule(tc.route, tc.allowedServiceAccount)
 			assert.Equal(tc.expectedRules, inboundPolicy.Rules)
@@ -127,8 +127,6 @@ func TestAddRule(t *testing.T) {
 }
 
 func TestAddRoute(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                  string
 		existingRoutes        []*RouteWeightedClusters
@@ -234,6 +232,8 @@ func TestAddRoute(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			outboundPolicy := newTestOutboundPolicy(tc.name, tc.existingRoutes)
 			err := outboundPolicy.AddRoute(tc.givenRouteMatch, tc.givenWeightedClusters...)
 			if tc.expectedErr {
@@ -247,8 +247,6 @@ func TestAddRoute(t *testing.T) {
 }
 
 func TestMergeInboundPolicies(t *testing.T) {
-	assert := tassert.New(t)
-
 	testRule1 := Rule{
 		Route:                  testRoute,
 		AllowedServiceAccounts: mapset.NewSet(testServiceAccount1),
@@ -344,6 +342,8 @@ func TestMergeInboundPolicies(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := MergeInboundPolicies(false, tc.originalInbound, tc.newInbound...)
 			assert.ElementsMatch(tc.expectedInbound, actual)
 		})
@@ -351,8 +351,6 @@ func TestMergeInboundPolicies(t *testing.T) {
 }
 
 func TestMergeInboundPoliciesWithPartialHostnames(t *testing.T) {
-	assert := tassert.New(t)
-
 	testRule1 := Rule{
 		Route:                  testRoute,
 		AllowedServiceAccounts: mapset.NewSet(testServiceAccount1),
@@ -423,6 +421,8 @@ func TestMergeInboundPoliciesWithPartialHostnames(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := MergeInboundPolicies(true, tc.originalInbound, tc.newInbound...)
 			assert.ElementsMatch(actual, tc.expectedInbound)
 		})
@@ -430,8 +430,6 @@ func TestMergeInboundPoliciesWithPartialHostnames(t *testing.T) {
 }
 
 func TestMergeRules(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name          string
 		originalRules []*Rule
@@ -509,6 +507,8 @@ func TestMergeRules(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := mergeRules(tc.originalRules, tc.newRules)
 			assert.ElementsMatch(tc.expectedRules, actual)
 		})
@@ -516,8 +516,6 @@ func TestMergeRules(t *testing.T) {
 }
 
 func TestMergeOutboundPolicies(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                                               string
 		originalPolicies, latestPolicies, expectedPolicies []*OutboundTrafficPolicy
@@ -643,6 +641,8 @@ func TestMergeOutboundPolicies(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := MergeOutboundPolicies(tc.allowPartialHostnamesMatch, tc.originalPolicies, tc.latestPolicies...)
 			assert.ElementsMatch(actual, tc.expectedPolicies)
 		})
@@ -650,8 +650,6 @@ func TestMergeOutboundPolicies(t *testing.T) {
 }
 
 func TestMergeRouteWeightedClusters(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name                                         string
 		originalRoutes, latestRoutes, expectedRoutes []*RouteWeightedClusters
@@ -683,6 +681,8 @@ func TestMergeRouteWeightedClusters(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := mergeRoutesWeightedClusters(tc.originalRoutes, tc.latestRoutes)
 			assert.Equal(tc.expectedRoutes, actual)
 		})
@@ -700,8 +700,6 @@ func TestNewInboundTrafficPolicy(t *testing.T) {
 }
 
 func TestNewRouteWeightedCluster(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name             string
 		route            HTTPRouteMatch
@@ -718,6 +716,8 @@ func TestNewRouteWeightedCluster(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := NewRouteWeightedCluster(tc.route, tc.weightedClusters)
 			assert.Equal(tc.expected, actual)
 		})
@@ -736,8 +736,6 @@ func TestNewOutboundPolicy(t *testing.T) {
 }
 
 func TestTotalClustersWeight(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name           string
 		route          RouteWeightedClusters
@@ -760,6 +758,8 @@ func TestTotalClustersWeight(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual := tc.route.TotalClustersWeight()
 			assert.Equal(tc.expectedWeight, actual)
 		})
@@ -814,8 +814,6 @@ func TestSlicesUnionIfSubset(t *testing.T) {
 }
 
 func TestDeduplicateTrafficMatches(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name     string
 		input    []*TrafficMatch
@@ -939,6 +937,8 @@ func TestDeduplicateTrafficMatches(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := DeduplicateTrafficMatches(tc.input)
 			assert.Nil(err)
 			assert.Len(actual, len(tc.expected))
@@ -947,8 +947,6 @@ func TestDeduplicateTrafficMatches(t *testing.T) {
 }
 
 func TestDeduplicateClusterConfigs(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name     string
 		input    []*EgressClusterConfig
@@ -1026,6 +1024,8 @@ func TestDeduplicateClusterConfigs(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := DeduplicateClusterConfigs(tc.input)
 			assert.Nil(err)
 			assert.Len(actual, len(tc.expected))

--- a/pkg/utils/proto_test.go
+++ b/pkg/utils/proto_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestProtoToYAML(t *testing.T) {
-	assert := tassert.New(t)
-
 	testCases := []struct {
 		name         string
 		proto        protoreflect.ProtoMessage
@@ -90,6 +88,8 @@ tls_minimum_protocol_version: TLSv1_2
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			actual, err := ProtoToYAML(tc.proto)
 			assert.Nil(err)
 			assert.Equal(tc.expectedYAML, string(actual))

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -18,7 +18,6 @@ var (
 )
 
 func TestGetAdmissionRequestBody(t *testing.T) {
-	assert := tassert.New(t)
 	w := httptest.NewRecorder()
 
 	testCases := []struct {
@@ -55,6 +54,8 @@ func TestGetAdmissionRequestBody(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
+			assert := tassert.New(t)
+
 			b, err := GetAdmissionRequestBody(w, tc.req)
 			assert.Equal(tc.expErr, err)
 			assert.Equal(tc.expBody, b)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
These changes move Testify `assert` handles from "parent" tests into
subtests so Testify's error messages can refer to a particular test case
in a table of tests vs. the whole table which is more ambiguous.

Previously, if a test case fails:

    % go test ./cmd/cli -run TestIsMonitoredNamespace
    --- FAIL: TestIsMonitoredNamespace (0.00s)
        metrics_test.go:264:
                    Error Trace:    metrics_test.go:264
                    Error:          Not equal:
                                    expected: false
                                    actual  : true
                    Test:           TestIsMonitoredNamespace
    FAIL
    FAIL    github.com/openservicemesh/osm/cmd/cli  0.419s
    FAIL

With these changes:

    % go test ./cmd/cli -run TestIsMonitoredNamespace
    --- FAIL: TestIsMonitoredNamespace (0.00s)
        --- FAIL: TestIsMonitoredNamespace/Testing_if_ns-2_exists_is_monitored (0.00s)
            metrics_test.go:264:
                    Error Trace:    metrics_test.go:264
                    Error:          Not equal:
                                    expected: false
                                    actual  : true
                    Test:           TestIsMonitoredNamespace/Testing_if_ns-2_exists_is_monitored
    FAIL
    FAIL    github.com/openservicemesh/osm/cmd/cli  0.396s
    FAIL

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
