### PR TITLE
test(e2e): Configure e2e ports for OpenShift

### DIFF
--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -1,0 +1,6 @@
+package e2e
+
+const (
+	// appPort is the port to be used for server and client applications
+	appPort = 14001
+)

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -80,8 +80,8 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Namespace:    serverNamespace,
 							ReplicaCount: int32(serverReplicaSet),
 							Image:        "simonkowallik/httpbin",
-							Ports:        []int{14001},
-							Command:      []string{"gunicorn", "-b", "0.0.0.0:14001", "httpbin:app", "-k", "gevent"},
+							Ports:        []int{appPort},
+							Command:      []string{"gunicorn", "-b", fmt.Sprintf("0.0.0.0:%d", appPort), "httpbin:app", "-k", "gevent"},
 						})
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -122,7 +122,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Command:      []string{"/bin/bash", "-c", "--"},
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
-							Ports:        []int{14001},
+							Ports:        []int{appPort},
 						})
 
 					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
@@ -165,7 +165,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
 					Name:      trafficSplitName,
 					Namespace: serverNamespace,
-					Ports:     []int{14001},
+					Ports:     []int{appPort},
 				})
 
 				// Creating trafficsplit service in K8s
@@ -212,7 +212,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							SourceContainer: ns, // container_name == NS for this test
 
 							// Targeting the trafficsplit FQDN
-							Destination: fmt.Sprintf("%s.%s:14001", trafficSplitName, serverNamespace),
+							Destination: fmt.Sprintf("%s.%s:%d", trafficSplitName, serverNamespace, appPort),
 						})
 					}
 				}

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -80,7 +80,8 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Namespace:    serverNamespace,
 							ReplicaCount: int32(serverReplicaSet),
 							Image:        "simonkowallik/httpbin",
-							Ports:        []int{80},
+							Ports:        []int{14001},
+							Command:      []string{"gunicorn", "-b", "0.0.0.0:14001", "httpbin:app", "-k", "gevent"},
 						})
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -121,7 +122,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Command:      []string{"/bin/bash", "-c", "--"},
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
-							Ports:        []int{80},
+							Ports:        []int{14001},
 						})
 
 					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
@@ -164,7 +165,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
 					Name:      trafficSplitName,
 					Namespace: serverNamespace,
-					Ports:     []int{80},
+					Ports:     []int{14001},
 				})
 
 				// Creating trafficsplit service in K8s
@@ -211,7 +212,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							SourceContainer: ns, // container_name == NS for this test
 
 							// Targeting the trafficsplit FQDN
-							Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
+							Destination: fmt.Sprintf("%s.%s:14001", trafficSplitName, serverNamespace),
 						})
 					}
 				}


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Use port 14001 for e2e traffic split test so that server/client communication works on OpenShift which reserves port 80.

Partially addresses #3097

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No