### PR TITLE
charts/osm: don't set the replicaCount with HPA

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -111,7 +111,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.injector.autoScale.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | OpenServiceMesh.injector.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
-| OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
+| OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count (ignored when autoscale.enable is true) |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
 | OpenServiceMesh.injector.webhookTimeoutSeconds | int | `20` | Mutating webhook timeout |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
@@ -123,7 +123,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.osmController.autoScale.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | OpenServiceMesh.osmController.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.osmController.podLabels | object | `{}` | OSM controller's pod labels |
-| OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count |
+| OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count (ignored when autoscale.enable is true) |
 | OpenServiceMesh.osmController.resource | object | `{"limits":{"cpu":"1.5","memory":"512M"},"requests":{"cpu":"0.5","memory":"128M"}}` | OSM controller's container resource parameters |
 | OpenServiceMesh.osmNamespace | string | `""` | Namespace to deploy OSM in. If not specified, the Helm release namespace is used. |
 | OpenServiceMesh.outboundIPRangeExclusionList | list | `[]` | Specifies a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     meshName: {{ .Values.OpenServiceMesh.meshName }}
     {{ if .Values.OpenServiceMesh.enforceSingleMesh }}enforceSingleMesh: "true"{{ end }}
 spec:
+  {{- if not .Values.OpenServiceMesh.osmController.autoScale.enable }}
   replicas: {{ .Values.OpenServiceMesh.osmController.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: osm-controller

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app: osm-injector
     meshName: {{ .Values.OpenServiceMesh.meshName }}
 spec:
+  {{- if not .Values.OpenServiceMesh.injector.autoScale.enable }}
   replicas: {{ .Values.OpenServiceMesh.injector.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: osm-injector

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -22,7 +22,7 @@ OpenServiceMesh:
   #
   # -- OSM controller parameters
   osmController:
-    # -- OSM controller's replica count
+    # -- OSM controller's replica count (ignored when autoscale.enable is true)
     replicaCount: 1
     # -- OSM controller's container resource parameters
     resource:
@@ -207,7 +207,7 @@ OpenServiceMesh:
   #
   # -- OSM's sidecar injector parameters
   injector:
-    # -- Sidecar injector's replica count
+    # -- Sidecar injector's replica count (ignored when autoscale.enable is true)
     replicaCount: 1
     # -- Sidecar injector's container resource parameters
     resource:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
When HPA is enabled, the deployment will be auto-scaled
based on the configured HPA resource. Updating the deployment
with HPA enabled will invalidate the replicas set by HPA.

Per kubernetes/kubernetes#25238, it is recommended to
not set the replicaCount when HPA is enabled.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Install                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
