### PR TITLE
test(e2e/port_exclusion): change ns name

### DIFF
--- a/tests/e2e/e2e_port_exclusion_test.go
+++ b/tests/e2e/e2e_port_exclusion_test.go
@@ -102,8 +102,9 @@ func testGlobalPortExclusion() {
 }
 
 func testPodLevelPortExclusion() {
-	const sourceName = "client"
-	const destName = "server"
+	// XXX(3755): use a different namespace due to test pollution
+	const sourceName = "client1"
+	const destName = "server1"
 	var ns = []string{sourceName, destName}
 
 	It("Tests HTTP traffic to external server via pod level port exclusion", func() {


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: There appears to be an issue in the port exclusion test where the pod level port exclusion test fails when run immediately after the global port exclusion test with the "noInstall" flag on kind clusters. From testing locally, changing the namespace names in the pod level port exclusion test addresses this issue, perhaps due to a problem with how the namespaces are being cleaned up. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
