### PR TITLE
tests(e2e): fix port issues for remaining e2es on OpenShift

### DIFF
--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -1,6 +1,0 @@
-package e2e
-
-const (
-	// appPort is the port to be used for server and client applications
-	appPort = 14001
-)

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -58,7 +58,8 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 						Namespace:    destApp,
 						ReplicaCount: int32(replicaSetPerService),
 						Image:        "kennethreitz/httpbin",
-						Ports:        []int{80},
+						Ports:        []int{DefaultUpstreamServicePort},
+						Command:      HttpbinCmd,
 					})
 
 				_, err := Td.CreateServiceAccount(destApp, &svcAccDef)
@@ -85,7 +86,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 							Command:      []string{"/bin/bash", "-c", "--"},
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
-							Ports:        []int{80}, // Can't deploy services with empty/no ports
+							Ports:        []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
 						})
 					_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
@@ -139,7 +140,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 							SourcePod:       pod.Name,
 							SourceContainer: ns, // container_name == NS for this test
 
-							Destination: fmt.Sprintf("%s.%s", destApp, destApp),
+							Destination: fmt.Sprintf("%s.%s:%d", destApp, destApp, DefaultUpstreamServicePort),
 						})
 					}
 				}

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -55,7 +55,8 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 					Name:         "server",
 					Namespace:    destNs,
 					Image:        "kennethreitz/httpbin",
-					Ports:        []int{80},
+					Ports:        []int{DefaultUpstreamServicePort},
+					Command:      HttpbinCmd,
 				})
 
 			_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
@@ -76,7 +77,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 				Command:      []string{"/bin/bash", "-c", "--"},
 				Args:         []string{"while true; do sleep 30; done;"},
 				Image:        "songrgg/alpine-debug",
-				Ports:        []int{80},
+				Ports:        []int{DefaultUpstreamServicePort},
 			})
 
 			_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
@@ -120,7 +121,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 						SourcePod:       srcPod.Name,
 						SourceContainer: "client",
 
-						Destination: fmt.Sprintf("%s.%s/status/200", dstSvc.Name, dstSvc.Namespace),
+						Destination: fmt.Sprintf("%s.%s:%d/status/200", dstSvc.Name, dstSvc.Namespace, DefaultUpstreamServicePort),
 					})
 
 				if result.Err != nil || result.StatusCode != 200 {

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -35,8 +35,6 @@ func testRecursiveTrafficSplit(appProtocol string) {
 	const (
 		// to name the header we will use to identify the server that replies
 		HTTPHeaderName = "podname"
-
-		serverPort = 80
 	)
 
 	clientAppBaseName := "client"
@@ -80,8 +78,9 @@ func testRecursiveTrafficSplit(appProtocol string) {
 				Namespace:    serverNamespace,
 				ReplicaCount: int32(serverReplicaSet),
 				Image:        "simonkowallik/httpbin",
-				Ports:        []int{serverPort},
+				Ports:        []int{DefaultUpstreamServicePort},
 				AppProtocol:  appProtocol,
+				Command:      HttpbinCmd,
 			})
 
 		// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -123,7 +122,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 					Command:      []string{"/bin/bash", "-c", "--"},
 					Args:         []string{"while true; do sleep 30; done;"},
 					Image:        "songrgg/alpine-debug",
-					Ports:        []int{80},
+					Ports:        []int{DefaultUpstreamServicePort},
 				})
 
 			_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
@@ -201,7 +200,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 							DestinationNamespace:      serverNamespace,
 							DestinationSvcAccountName: dstServer,
 						},
-						serverPort,
+						DefaultUpstreamServicePort,
 					)
 
 					// Configs have to be put into same NS as server/destination
@@ -234,7 +233,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 					SourceContainer: ns, // container_name == NS for this test
 
 					// Targeting the trafficsplit FQDN
-					Destination: fmt.Sprintf("%s.%s", trafficSplitName, serverNamespace),
+					Destination: fmt.Sprintf("%s.%s:%d", trafficSplitName, serverNamespace, DefaultUpstreamServicePort),
 				})
 			}
 		}
@@ -295,7 +294,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 						SourceContainer: pod.Namespace, // We generally code it like so for test purposes
 
 						// direct traffic target against the specific server service in the server namespace
-						Destination: fmt.Sprintf("%s.%s", svcNs, serverNamespace),
+						Destination: fmt.Sprintf("%s.%s:%d", svcNs, serverNamespace, DefaultUpstreamServicePort),
 					})
 				}
 			}

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -80,8 +80,8 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Namespace:    serverNamespace,
 							ReplicaCount: int32(serverReplicaSet),
 							Image:        "simonkowallik/httpbin",
-							Ports:        []int{appPort},
-							Command:      []string{"gunicorn", "-b", fmt.Sprintf("0.0.0.0:%d", appPort), "httpbin:app", "-k", "gevent"},
+							Ports:        []int{DefaultUpstreamServicePort},
+							Command:      HttpbinCmd,
 						})
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
@@ -122,7 +122,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Command:      []string{"/bin/bash", "-c", "--"},
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
-							Ports:        []int{appPort},
+							Ports:        []int{DefaultUpstreamServicePort},
 						})
 
 					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
@@ -165,7 +165,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
 					Name:      trafficSplitName,
 					Namespace: serverNamespace,
-					Ports:     []int{appPort},
+					Ports:     []int{DefaultUpstreamServicePort},
 				})
 
 				// Creating trafficsplit service in K8s
@@ -212,7 +212,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							SourceContainer: ns, // container_name == NS for this test
 
 							// Targeting the trafficsplit FQDN
-							Destination: fmt.Sprintf("%s.%s:%d", trafficSplitName, serverNamespace, appPort),
+							Destination: fmt.Sprintf("%s.%s:%d", trafficSplitName, serverNamespace, DefaultUpstreamServicePort),
 						})
 					}
 				}

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -88,6 +88,15 @@ func OSMDescribe(name string, opts OSMDescribeInfo, body func()) bool {
 	return Describe(fmt.Sprintf("%s %s", opts, name), body)
 }
 
+const (
+	// DefaultUpstreamServicePort is the default port on which the server apps listen for connections from client apps.
+	// Note: Port 80 should not be used because it does not work on OpenShift.
+	DefaultUpstreamServicePort = 14001
+)
+
+// HttpbinCmd is the command to be used for httpbin applications in e2es
+var HttpbinCmd = []string{"gunicorn", "-b", fmt.Sprintf("0.0.0.0:%d", DefaultUpstreamServicePort), "httpbin:app", "-k", "gevent"}
+
 // Verifies the instType string flag option is a valid enum type
 func verifyValidInstallType(t InstallType) error {
 	switch t {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Changes port used in tests to 14001 since OpenShift uses port 80 itself

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [x] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? no
