### PR TITLE
multicluster: Implement Stringer interface on MultiClusterService struct

### DIFF
--- a/pkg/apis/config/v1alpha1/multi_cluster_service.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,6 +22,10 @@ type MultiClusterService struct {
 	// Spec is the MultiClusterService specification.
 	// +optional
 	Spec MultiClusterServiceSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
+}
+
+func (mcs MultiClusterService) String() string {
+	return fmt.Sprintf("%s/%s with SA=%s", mcs.Namespace, mcs.Name, mcs.Spec.ServiceAccount)
 }
 
 // MultiClusterServiceSpec is the type used to represent the multicluster service specification.

--- a/pkg/apis/config/v1alpha1/multi_cluster_service_test.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service_test.go
@@ -1,0 +1,37 @@
+package v1alpha1
+
+import (
+	"fmt"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestMultiClusterServiceStringer tests MultiClusterService Stringer interface implementation.
+func TestMultiClusterServiceStringer(t *testing.T) {
+	assert := tassert.New(t)
+
+	multiclusterService := MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      "name",
+		},
+
+		Spec: MultiClusterServiceSpec{
+			Cluster: []ClusterSpec{
+				{
+					Address: "1.2.3.4:8080",
+					Name:    "remote-cluster-1",
+				},
+				{
+					Address: "5.6.7.8:8080",
+					Name:    "remote-cluster-2",
+				},
+			},
+			ServiceAccount: "sa",
+		},
+	}
+
+	assert.Equal(fmt.Sprintf("MCS=%s", multiclusterService), "MCS=namespace/name with SA=sa")
+}


### PR DESCRIPTION
This PR implements and tests `.String()` on `MultiClusterService` struct.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
