### PR TITLE
Renaming variable colliding with imported package name

### DIFF
--- a/pkg/apis/config/v1alpha1/multi_cluster_service_test.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service_test.go
@@ -19,7 +19,7 @@ func TestMultiClusterServiceStringer(t *testing.T) {
 		},
 
 		Spec: MultiClusterServiceSpec{
-			Cluster: []ClusterSpec{
+			Clusters: []ClusterSpec{
 				{
 					Address: "1.2.3.4:8080",
 					Name:    "remote-cluster-1",

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -333,18 +333,18 @@ func (c *Client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount
 func getEndpointsFromMultiClusterServices(services []*v1alpha1.MultiClusterService) []endpoint.Endpoint {
 	endpoints := []endpoint.Endpoint{}
 	if len(services) > 0 {
-		for _, service := range services {
-			for _, cluster := range service.Spec.Clusters {
+		for _, svc := range services {
+			for _, cluster := range svc.Spec.Clusters {
 				tokens := strings.Split(cluster.Address, ":")
 				if len(tokens) != 2 {
-					log.Error().Msgf("Error parsing remote service %s address %s. It should have IP address and port number", service.Name, cluster.Address)
+					log.Error().Msgf("Error parsing remote service %s address %s. It should have IP address and port number", svc.Name, cluster.Address)
 					continue
 				}
 
 				ip, portStr := tokens[0], tokens[1]
 				port, err := strconv.Atoi(portStr)
 				if err != nil {
-					log.Error().Msgf("Remote service %s port number format invalid. Remote cluster address: %s", service.Name, cluster.Address)
+					log.Error().Msgf("Remote service %s port number format invalid. Remote cluster address: %s", svc.Name, cluster.Address)
 					continue
 				}
 


### PR DESCRIPTION
This PR renames a variable so that it does not collide with an imported package name.