### PR TITLE
multicluster: Defaulting demo to Tresor certificate issuer

### DIFF
--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -95,7 +95,6 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
     bin/osm install \
         --osm-namespace "$K8S_NAMESPACE" \
         --mesh-name "$MESH_NAME" \
-        --set=OpenServiceMesh.certificateManager="tresor" \
         --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
         --set=OpenServiceMesh.imagePullSecrets[0].name="$CTR_REGISTRY_CREDS_NAME" \
         --set=OpenServiceMesh.image.tag="$CTR_TAG" \


### PR DESCRIPTION
This PR removes optionality of running OSM Multicluster w/ other cert issues.
This PR hard-codes `tresor` as the only Multicluster demo cert issuer.

The goal is to simplify.


Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
