### PR TITLE
dispatcher: Add MultiClusterService events to the dispatch system

### DIFF
--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -35,6 +35,7 @@ func (mc *MeshCatalog) dispatcher() {
 		a.PodAdded, a.PodDeleted, a.PodUpdated, // pod
 		a.RouteGroupAdded, a.RouteGroupDeleted, a.RouteGroupUpdated, // routegroup
 		a.ServiceAdded, a.ServiceDeleted, a.ServiceUpdated, // service
+		a.MultiClusterServiceAdded, a.MultiClusterServiceDeleted, a.MultiClusterServiceUpdated, // Multicluster Service
 		a.ServiceAccountAdded, a.ServiceAccountDeleted, a.ServiceAccountUpdated, // serviceaccount
 		a.TrafficSplitAdded, a.TrafficSplitDeleted, a.TrafficSplitUpdated, // traffic split
 		a.TrafficTargetAdded, a.TrafficTargetDeleted, a.TrafficTargetUpdated, // traffic target


### PR DESCRIPTION
This PR adds the `MultiClusterService` events (add, update, delete) to the catalog/dispatch system so these events cause Envoy config refreshes as well.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
