### PR TITLE
multicluster: Add (and use) deploy-MulticlusterService.sh

### DIFF
--- a/demo/deploy-MultiClusterService.sh
+++ b/demo/deploy-MultiClusterService.sh
@@ -17,17 +17,16 @@ metadata:
 
 spec:
   clusters:
+
   - name: alpha
-    # certificate
-    address: 1.99.99.1:7777
+
+    # TODO: This address and port number must be updated
+    address: 1.1.1.1:1111
 
   - name: beta
-    # certificate
-    address: 2.2.2.2:5555
 
-#  ports:
-#    - port: 8888
-#      protocol: TCP
+    # TODO: This address and port number must be updated
+    address: 2.2.2.2:2222
 
   serviceAccount: bookstore-v1
 EOF

--- a/demo/deploy-MultiClusterService.sh
+++ b/demo/deploy-MultiClusterService.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -auexo pipefail
+
+NS=bookstore
+NAME=bookstore
+
+kubectl delete MultiClusterService -n $NS $NAME || true
+
+kubectl apply -f - <<EOF
+apiVersion: config.openservicemesh.io/v1alpha1
+kind: MultiClusterService
+
+metadata:
+  namespace: $NS
+  name: $NAME
+
+spec:
+  clusters:
+  - name: alpha
+    # certificate
+    address: 1.99.99.1:7777
+
+  - name: beta
+    # certificate
+    address: 2.2.2.2:5555
+
+#  ports:
+#    - port: 8888
+#      protocol: TCP
+
+  serviceAccount: bookstore-v1
+EOF

--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -127,4 +127,8 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
     else
         ./demo/deploy-traffic-target.sh
     fi
+
+    # Create the MultiClusterService object.
+    ./demo/deploy-MultiClusterService.sh
+
 done

--- a/pkg/apis/config/v1alpha1/multi_cluster_service_test.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service_test.go
@@ -19,7 +19,7 @@ func TestMultiClusterServiceStringer(t *testing.T) {
 		},
 
 		Spec: MultiClusterServiceSpec{
-			Cluster: []ClusterSpec{
+			Clusters: []ClusterSpec{
 				{
 					Address: "1.2.3.4:8080",
 					Name:    "remote-cluster-1",


### PR DESCRIPTION
Adding a small script to create a `MultiClusterService` object for the OSM Multicluster demo.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
