### PR TITLE
MultiClusterServiceSpec in MultiClusterService CRD is not optional

### DIFF
--- a/pkg/apis/config/v1alpha1/multi_cluster_service.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service.go
@@ -20,7 +20,6 @@ type MultiClusterService struct {
 	metav1.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
 	// Spec is the MultiClusterService specification.
-	// +optional
 	Spec MultiClusterServiceSpec `json:"spec,omitempty" yaml:"spec,omitempty"`
 }
 


### PR DESCRIPTION
I believe it is reasonable to make `MultiClusterServiceSpec` a required struct when `MultiClusterService` is created.  Without the `spec` the rest of the CRD would me meaningless.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
