### PR TITLE
multicluster: Use []v1alpha1.MultiClusterService (not a slice of pointers)

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -69,11 +69,11 @@ func (c client) run(stop <-chan struct{}) error {
 	return nil
 }
 
-func (c client) ListMultiClusterServices() []*v1alpha1.MultiClusterService {
-	var services []*v1alpha1.MultiClusterService
+func (c client) ListMultiClusterServices() []v1alpha1.MultiClusterService {
+	var services []v1alpha1.MultiClusterService
 
 	for _, obj := range c.informer.Informer().GetStore().List() {
-		mcs := obj.(*v1alpha1.MultiClusterService)
+		mcs := obj.(v1alpha1.MultiClusterService)
 		if c.kubeController.IsMonitoredNamespace(mcs.Namespace) {
 			services = append(services, mcs)
 		}
@@ -81,12 +81,12 @@ func (c client) ListMultiClusterServices() []*v1alpha1.MultiClusterService {
 	return services
 }
 
-func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []*v1alpha1.MultiClusterService {
+func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []v1alpha1.MultiClusterService {
 	if !c.kubeController.IsMonitoredNamespace(namespace) {
 		return nil
 	}
 
-	var services []*v1alpha1.MultiClusterService
+	var services []v1alpha1.MultiClusterService
 
 	for _, mcs := range c.ListMultiClusterServices() {
 		if mcs.Spec.ServiceAccount == serviceAccount && mcs.Namespace == namespace {

--- a/pkg/config/mock_client_generated.go
+++ b/pkg/config/mock_client_generated.go
@@ -49,10 +49,10 @@ func (mr *MockControllerMockRecorder) GetMultiClusterService(arg0, arg1 interfac
 }
 
 // GetMultiClusterServiceByServiceAccount mocks base method
-func (m *MockController) GetMultiClusterServiceByServiceAccount(arg0, arg1 string) []*v1alpha1.MultiClusterService {
+func (m *MockController) GetMultiClusterServiceByServiceAccount(arg0, arg1 string) []v1alpha1.MultiClusterService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultiClusterServiceByServiceAccount", arg0, arg1)
-	ret0, _ := ret[0].([]*v1alpha1.MultiClusterService)
+	ret0, _ := ret[0].([]v1alpha1.MultiClusterService)
 	return ret0
 }
 
@@ -63,10 +63,10 @@ func (mr *MockControllerMockRecorder) GetMultiClusterServiceByServiceAccount(arg
 }
 
 // ListMultiClusterServices mocks base method
-func (m *MockController) ListMultiClusterServices() []*v1alpha1.MultiClusterService {
+func (m *MockController) ListMultiClusterServices() []v1alpha1.MultiClusterService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMultiClusterServices")
-	ret0, _ := ret[0].([]*v1alpha1.MultiClusterService)
+	ret0, _ := ret[0].([]v1alpha1.MultiClusterService)
 	return ret0
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -20,8 +20,7 @@ type client struct {
 
 // Controller is the interface for the functionality provided by the resources part of the multiclusterservice.openservicemesh.io API group
 type Controller interface {
-	// TODO: specify required functions
-	ListMultiClusterServices() []*v1alpha1.MultiClusterService
+	ListMultiClusterServices() []v1alpha1.MultiClusterService
 	GetMultiClusterService(name, namespace string) *v1alpha1.MultiClusterService
-	GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []*v1alpha1.MultiClusterService
+	GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []v1alpha1.MultiClusterService
 }

--- a/pkg/gen/client/config/listers/config/v1alpha1/multiclusterservice.go
+++ b/pkg/gen/client/config/listers/config/v1alpha1/multiclusterservice.go
@@ -27,7 +27,7 @@ import (
 type MultiClusterServiceLister interface {
 	// List lists all MultiClusterServices in the indexer.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.MultiClusterService, err error)
+	List(selector labels.Selector) (ret []v1alpha1.MultiClusterService, err error)
 	// MultiClusterServices returns an object that can list and get MultiClusterServices.
 	MultiClusterServices(namespace string) MultiClusterServiceNamespaceLister
 	MultiClusterServiceListerExpansion
@@ -44,9 +44,9 @@ func NewMultiClusterServiceLister(indexer cache.Indexer) MultiClusterServiceList
 }
 
 // List lists all MultiClusterServices in the indexer.
-func (s *multiClusterServiceLister) List(selector labels.Selector) (ret []*v1alpha1.MultiClusterService, err error) {
+func (s *multiClusterServiceLister) List(selector labels.Selector) (ret []v1alpha1.MultiClusterService, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.MultiClusterService))
+		ret = append(ret, m.(v1alpha1.MultiClusterService))
 	})
 	return ret, err
 }
@@ -61,7 +61,7 @@ func (s *multiClusterServiceLister) MultiClusterServices(namespace string) Multi
 type MultiClusterServiceNamespaceLister interface {
 	// List lists all MultiClusterServices in the indexer for a given namespace.
 	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1alpha1.MultiClusterService, err error)
+	List(selector labels.Selector) (ret []v1alpha1.MultiClusterService, err error)
 	// Get retrieves the MultiClusterService from the indexer for a given namespace and name.
 	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha1.MultiClusterService, error)
@@ -76,9 +76,9 @@ type multiClusterServiceNamespaceLister struct {
 }
 
 // List lists all MultiClusterServices in the indexer for a given namespace.
-func (s multiClusterServiceNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.MultiClusterService, err error) {
+func (s multiClusterServiceNamespaceLister) List(selector labels.Selector) (ret []v1alpha1.MultiClusterService, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1alpha1.MultiClusterService))
+		ret = append(ret, m.(v1alpha1.MultiClusterService))
 	})
 	return ret, err
 }

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -327,10 +327,11 @@ func (c *Client) GetHostnamesForService(svc service.MeshService, locality servic
 }
 
 func (c *Client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount, namespace string) []endpoint.Endpoint {
-	return getEndpointsFromMultiClusterServices(c.configClient.GetMultiClusterServiceByServiceAccount(serviceAccount, namespace))
+	services := c.configClient.GetMultiClusterServiceByServiceAccount(serviceAccount, namespace)
+	return getEndpointsFromMultiClusterServices(services)
 }
 
-func getEndpointsFromMultiClusterServices(services []*v1alpha1.MultiClusterService) []endpoint.Endpoint {
+func getEndpointsFromMultiClusterServices(services []v1alpha1.MultiClusterService) []endpoint.Endpoint {
 	var endpoints []endpoint.Endpoint
 	if len(services) > 0 {
 		for _, svc := range services {

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -769,7 +769,7 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 	destServiceIdentity := tests.BookstoreServiceIdentity
 	destSA := destServiceIdentity.ToK8sServiceAccount()
 
-	mcServices := []*v1alpha1.MultiClusterService{
+	mcServices := []v1alpha1.MultiClusterService{
 		{
 			Spec: v1alpha1.MultiClusterServiceSpec{
 				Clusters: []v1alpha1.ClusterSpec{
@@ -789,7 +789,8 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 
 	configClient := fakeConfig.NewSimpleClientset()
 	for _, mcService := range mcServices {
-		_, err := configClient.ConfigV1alpha1().MultiClusterServices(tests.Namespace).Create(context.TODO(), mcService, metav1.CreateOptions{})
+		mcServicePtr := mcService
+		_, err := configClient.ConfigV1alpha1().MultiClusterServices(tests.Namespace).Create(context.TODO(), &mcServicePtr, metav1.CreateOptions{})
 		assert.Nil(err)
 	}
 


### PR DESCRIPTION
This PR changes the multicluster implementation from using `[]*v1alpha1.MultiClusterService` to using `[]v1alpha1.MultiClusterService`. In other words - removes usage of slice of pointers.

A good write-up on why:  https://philpearl.github.io/post/bad_go_slice_of_pointers

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
