### PR TITLE
multicluster: Augment IDENTITY envirenment variable in demos with current kubectx

### DIFF
--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -6,6 +6,7 @@ set -aueo pipefail
 source .env
 VERSION=${1:-v1}
 SVC="bookstore-$VERSION"
+KUBE_CONTEXT=$(kubectl config current-context)
 
 kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  --ignore-not-found
 
@@ -88,7 +89,7 @@ spec:
           args: ["--path", "./", "--port", "14001"]
           env:
             - name: IDENTITY
-              value: ${SVC}
+              value: ${SVC}.${KUBE_CONTEXT}
             - name: BOOKWAREHOUSE_NAMESPACE
               value: ${BOOKWAREHOUSE_NAMESPACE}
 

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -7,6 +7,7 @@ source .env
 VERSION=${1:-v1}
 SVC="bookstore-$VERSION"
 DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
+KUBE_CONTEXT=$(kubectl config current-context)
 
 kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  --ignore-not-found
 
@@ -94,7 +95,7 @@ spec:
           args: ["--path", "./", "--port", "14001"]
           env:
             - name: IDENTITY
-              value: ${SVC}
+              value: ${SVC}.${KUBE_CONTEXT}
             - name: BOOKWAREHOUSE_NAMESPACE
               value: ${BOOKWAREHOUSE_NAMESPACE}
 

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -5,6 +5,7 @@ set -aueo pipefail
 # shellcheck disable=SC1091
 source .env
 DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
+KUBE_CONTEXT=$(kubectl config current-context)
 
 kubectl delete deployment bookwarehouse -n "$BOOKWAREHOUSE_NAMESPACE"  --ignore-not-found
 
@@ -70,7 +71,7 @@ spec:
           command: ["/bookwarehouse"]
           env:
             - name: IDENTITY
-              value: bookwarehouse
+              value: bookwarehouse.${KUBE_CONTEXT}
 
       imagePullSecrets:
         - name: "$CTR_REGISTRY_CREDS_NAME"


### PR DESCRIPTION
This PR adds the current kube context to the `IDENTITY` environment variable for `bookstore` and `bookwarehouse` pods for **the demo**.

This is going to be very useful in multicluster environments, where we may have `bookstore` in a cluster `alpha` and a cluster `beta` (kubectx).



Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
