### PR TITLE
multicluster: Carve out multicluster-related functions in a separate file

### DIFF
--- a/pkg/config/multicluster.go
+++ b/pkg/config/multicluster.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+)
+
+func (c client) ListMultiClusterServices() []v1alpha1.MultiClusterService {
+	var services []v1alpha1.MultiClusterService
+
+	for _, obj := range c.informer.Informer().GetStore().List() {
+		mcs := obj.(*v1alpha1.MultiClusterService)
+		if c.kubeController.IsMonitoredNamespace(mcs.Namespace) {
+			services = append(services, *mcs)
+		}
+	}
+
+	log.Trace().Msgf("All Multicluster services: %+v", services)
+
+	return services
+}
+
+func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []v1alpha1.MultiClusterService {
+	if !c.kubeController.IsMonitoredNamespace(namespace) {
+		return nil
+	}
+
+	var services []v1alpha1.MultiClusterService
+
+	for _, svc := range c.ListMultiClusterServices() {
+		if svc.Spec.ServiceAccount == serviceAccount && svc.Namespace == namespace {
+			services = append(services, svc)
+		}
+	}
+
+	log.Trace().Msgf("Multicluster services for svc account %s/%s: %+v", namespace, serviceAccount, services)
+
+	return services
+}
+
+func (c client) GetMultiClusterService(name, namespace string) *v1alpha1.MultiClusterService {
+	if !c.kubeController.IsMonitoredNamespace(namespace) {
+		return nil
+	}
+	mcs, ok, err := c.informer.Informer().GetStore().GetByKey(namespace + "/" + name)
+	if err != nil || !ok {
+		log.Error().Err(err).Msgf("Error getting MultiClusterService %s in namespace %s from informer ", name, namespace)
+		return nil
+	}
+	return mcs.(*v1alpha1.MultiClusterService)
+}


### PR DESCRIPTION
This PR moves multicluster-related functions to a new file - `pkg/config/multicluster.go`

I wish I could say "no functional code changes", but I took the liberty to add `log.Trace()....` statements