### PR TITLE
multicluster: Resolve multicluster services via /etc/hosts

### DIFF
--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -74,6 +74,14 @@ spec:
             - name: "CI_SLEEP_BETWEEN_REQUESTS_SECONDS"
               value: "$CI_SLEEP_BETWEEN_REQUESTS_SECONDS"
 
+      # This is used for Multicluster environment demos,
+      # where the bookstore will try to resolve these 2 hosts.
+      hostAliases:
+      - ip: 127.0.0.1
+        hostnames:
+        - "bookstore.bookstore.svc.cluster.alpha"
+        - "bookstore.bookstore.svc.cluster.beta"
+
       imagePullSecrets:
         - name: "$CTR_REGISTRY_CREDS_NAME"
 EOF


### PR DESCRIPTION
This is a _hack_, which allows services not DNS resolvable by Kube DNS to pass the gethostbyname stage of `cURL`, and offload the rest to Envoy, which will know how to handle the call.

The IP address for the hosts `bookstore.bookstore.svc.cluster.alpha` and `bookstore.bookstore.svc.cluster.beta` does not really matter.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
