### PR TITLE
multicluster: Script to easily capture Envoy configs for multicluster development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ docs/public/*
 node_modules/
 vendor/
 rootfs/
+
+
+# Envoy config captured during development
+envoy_*.json

--- a/demo/get-multicluster-envoy-configs.sh
+++ b/demo/get-multicluster-envoy-configs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script automates the collection of Envoy config during Multicluster demo/development.
+# The configs are collected from Envoys in the ALPHA kube context (cluster).
+
+kubectl config use-context alpha > /dev/null
+for NAMESPACE in bookbuyer bookstore; do
+    for POD in $(kubectl get pod -n "${NAMESPACE}" --no-headers | awk '{print $1}'); do
+      ./osm proxy get config_dump "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
+    done
+done


### PR DESCRIPTION
This PR adds a script, which attempts to automate the collection of __Envoy configuration__ during Multicluster development and demo/troubleshooting.