### PR TITLE
multicluster: Carve out multicluster code out into functions and into multicluster.go file

### DIFF
--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -763,6 +763,8 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 	mockKubeController := k8s.NewMockController(mockCtrl)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockConfigController := config.NewMockController(mockCtrl)
+
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 	providerID := "provider"
 	provider := NewClient(mockKubeController, mockConfigController, providerID, mockConfigurator)
 

--- a/pkg/providers/kube/multicluster.go
+++ b/pkg/providers/kube/multicluster.go
@@ -1,0 +1,76 @@
+package kube
+
+import (
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/service"
+)
+
+// getMulticlusterEndpoints returns the endpoints for multicluster services if such exist.
+func (c *Client) getMulticlusterEndpoints(svc service.MeshService) []endpoint.Endpoint {
+	if !c.meshConfigurator.GetFeatureFlags().EnableMulticlusterMode {
+		return nil
+	}
+
+	log.Trace().Msgf("[%s] Getting Multicluster Endpoints for service %s", c.providerIdent, svc)
+
+	serviceIdentities, err := c.kubeController.ListServiceIdentitiesForService(svc)
+	if err != nil {
+		log.Error().Err(err).Msgf("[%s] Error getting Multicluster service identities for service %s", c.providerIdent, svc.Name)
+		return nil
+	}
+
+	var endpoints []endpoint.Endpoint
+	for _, ident := range serviceIdentities {
+		remoteEndpoints := c.getMultiClusterServiceEndpointsForServiceAccount(ident.Name, ident.Namespace)
+		endpoints = append(endpoints, remoteEndpoints...)
+	}
+
+	log.Trace().Msgf("[%s] Multicluster Endpoints for service %s: %+v", c.providerIdent, svc, endpoints)
+
+	return endpoints
+}
+
+// getMultiClusterServiceEndpointsForServiceAccount returns the multicluster services for a service account if such exist.
+func (c *Client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount, namespace string) []endpoint.Endpoint {
+	if !c.meshConfigurator.GetFeatureFlags().EnableMulticlusterMode {
+		return nil
+	}
+
+	services := c.configClient.GetMultiClusterServiceByServiceAccount(serviceAccount, namespace)
+
+	if len(services) <= 0 {
+		return nil
+	}
+
+	var endpoints []endpoint.Endpoint
+	for _, svc := range services {
+		for _, cluster := range svc.Spec.Clusters {
+			tokens := strings.Split(cluster.Address, ":")
+			if len(tokens) != 2 {
+				log.Error().Msgf("Error parsing remote service %s address %s. It should have IP address and port number", svc.Name, cluster.Address)
+				continue
+			}
+
+			ip, portStr := tokens[0], tokens[1]
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				log.Error().Msgf("Remote service %s port number format invalid. Remote cluster address: %s", svc.Name, cluster.Address)
+				continue
+			}
+
+			ept := endpoint.Endpoint{
+				IP:   net.ParseIP(ip),
+				Port: endpoint.Port(port),
+			}
+			endpoints = append(endpoints, ept)
+		}
+	}
+
+	log.Trace().Msgf("[%s] Multicluster Endpoints for service account %s: %+v", c.providerIdent, serviceAccount, endpoints)
+
+	return endpoints
+}

--- a/pkg/providers/kube/multicluster_test.go
+++ b/pkg/providers/kube/multicluster_test.go
@@ -1,0 +1,86 @@
+package kube
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/config"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+var _ = Describe("Test Multicluster functions of the Kubernetes endpoint", func() {
+	defer GinkgoRecover()
+
+	var client *Client
+
+	mockCtrl := gomock.NewController(GinkgoT())
+	mockKubeController := k8s.NewMockController(mockCtrl)
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	mockConfigController := config.NewMockController(mockCtrl)
+
+	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+
+	toReturn := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Namespace: tests.BookbuyerService.Namespace},
+		Subsets: []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: "8.8.8.8",
+			}},
+			Ports: []corev1.EndpointPort{{
+				Port: 88,
+			}},
+		}},
+	}
+	mockKubeController.EXPECT().GetEndpoints(tests.BookbuyerService).Return(toReturn, nil).AnyTimes()
+
+	toReturnIdentities := []identity.K8sServiceAccount{tests.BookbuyerServiceAccount}
+	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookbuyerService).Return(toReturnIdentities, nil).AnyTimes()
+
+	expectedEndpoint := []endpoint.Endpoint{{
+		IP:   net.IPv4(1, 2, 3, 4),
+		Port: 5678,
+	}}
+
+	toReturnServices := []v1alpha1.MultiClusterService{{
+		Spec: v1alpha1.MultiClusterServiceSpec{
+			Clusters: []v1alpha1.ClusterSpec{{
+				Address: fmt.Sprintf("%s:%d", expectedEndpoint[0].IP, expectedEndpoint[0].Port),
+				Name:    "alpha",
+			}},
+			ServiceAccount: tests.BookbuyerServiceAccountName,
+			Ports:          nil,
+		},
+	}}
+	mockConfigController.EXPECT().GetMultiClusterServiceByServiceAccount(tests.BookbuyerServiceName, tests.Namespace).Return(toReturnServices).AnyTimes()
+
+	BeforeEach(func() {
+		client = NewClient(mockKubeController, mockConfigController, "kubernetes-endpoint-provider", mockConfigurator)
+	})
+
+	Context("Test getMulticlusterEndpoints()", func() {
+		It("returns Multicluster endpoints for a service", func() {
+			actual := client.getMulticlusterEndpoints(tests.BookbuyerService)
+			Expect(actual).To(Equal(expectedEndpoint))
+		})
+	})
+
+	Context("Test getMultiClusterServiceEndpointsForServiceAccount()", func() {
+		It("returns Multicluster endpoints for a service account", func() {
+			actual := client.getMultiClusterServiceEndpointsForServiceAccount(tests.BookbuyerServiceAccountName, tests.Namespace)
+			Expect(actual).To(Equal(expectedEndpoint))
+		})
+	})
+})


### PR DESCRIPTION
This PR moves multicluster-related code into new functions and a separate file: `pkg/providers/kube/multicluster.go`

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
