### PR TITLE
catalog: Refactor buildOutboundPolicies()

### DIFF
--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -241,7 +241,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 				}
 				outboundPolicies = trafficpolicy.MergeOutboundPolicies(AllowPartialHostnamesMatch, outboundPolicies, policyWithHostHeader)
 			} else {
-				needWildCardRoute = true
+				needWildcardRoute = true
 			}
 		}
 		if needWildCardRoute {

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -247,7 +247,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 		if needWildCardRoute {
 			if err := policy.AddRoute(trafficpolicy.WildCardRouteMatch, weightedCluster); err != nil {
 				log.Error().Err(err).Str(errcode.Kind, errcode.ErrAddingRouteToOutboundTrafficPolicy.String()).
-					Msgf("Error adding Route to outbound policy for source %s/%s and destination %s/%s", source.Namespace, source.Name, destService.Namespace, destService.Name)
+					Msgf("Error adding wildcard route to outbound policy for source %s/%s and destination %s/%s", source.Namespace, source.Name, destService.Namespace, destService.Name)
 				continue
 			}
 		}

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -241,7 +241,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 				}
 				outboundPolicies = trafficpolicy.MergeOutboundPolicies(AllowPartialHostnamesMatch, outboundPolicies, policyWithHostHeader)
 			} else {
-				needWildcardRoute = true
+				needWildCardRoute = true
 			}
 		}
 		if needWildCardRoute {


### PR DESCRIPTION
This PR changes
- from `if !mc.isTrafficSplitApexService(destService) {` 
- to `if mc.isTrafficSplitApexService(destService) {` + `continue`

** no functional code changes**

This PR simply removes a level of indentation!