### PR TITLE
feat(upgrade): Add new http server to crd converter

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -9,7 +9,7 @@ metadata:
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     helm.sh/hook-weight: "-1"
-    helm.sh/hook: post-delete
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   privileged: false
@@ -60,7 +60,7 @@ metadata:
   labels:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-delete
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 rules:
   - apiGroups: ["config.openservicemesh.io"]
@@ -85,7 +85,7 @@ metadata:
   labels:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-delete
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 subjects:
   - kind: ServiceAccount
@@ -104,7 +104,7 @@ metadata:
   labels:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-delete
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
 apiVersion: v1
@@ -115,7 +115,7 @@ metadata:
   labels:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
-    helm.sh/hook: post-delete
+    helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   serviceAccountName: {{ .Release.Name }}-cleanup

--- a/charts/osm/templates/osm-crd-converter-deployment.yaml
+++ b/charts/osm/templates/osm-crd-converter-deployment.yaml
@@ -41,6 +41,8 @@ spec:
               containerPort: 443
             - name: "metrics"
               containerPort: 9091
+            - name: "health"
+              containerPort: 9095
           command: ['/osm-crd-converter']
           args: [
             "--verbosity", "{{.Values.OpenServiceMesh.controllerLogLevel}}",
@@ -67,16 +69,16 @@ spec:
             initialDelaySeconds: 5
             timeoutSeconds: 5
             httpGet:
-              scheme: HTTPS
+              scheme: HTTP
               path: /healthz
-              port: 443
+              port: 9095
           livenessProbe:
             initialDelaySeconds: 5
             timeoutSeconds: 5
             httpGet:
-              scheme: HTTPS
+              scheme: HTTP
               path: /healthz
-              port: 443
+              port: 9095
           env:
             # The CRD_CONVERTER_POD_NAME env variable sets pod name dynamically, used by osm-crd-converter to register events
             - name: CRD_CONVERTER_POD_NAME

--- a/charts/osm/templates/osm-crd-converter-service.yaml
+++ b/charts/osm/templates/osm-crd-converter-service.yaml
@@ -12,6 +12,8 @@ spec:
     - name: tls
       port: 443
       targetPort: tls
+    - name: health
+      port: 9095
   selector:
     app: osm-crd-converter
 {{- end }}

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -35,6 +35,18 @@ spec:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
       initContainers:
+        {{- if .Values.OpenServiceMesh.featureFlags.enableCRDConverter }}
+        - name: init-osm-controller-crd
+          image: curlimages/curl
+          args:
+          - /bin/sh
+          - -c
+          - >
+            set -x;
+            while [ $(curl -sw '%{http_code}' "http://osm-crd-converter.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
+              sleep 10;
+            done
+        {{- end }}
         - name: init-osm-controller
           image: "{{ .Values.OpenServiceMesh.image.registry }}/init-osm-controller:{{ .Values.OpenServiceMesh.image.tag }}"
           imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}


### PR DESCRIPTION
**Description**:

Add another http server to the crd converter which servers as the health
endpoint which is used to sync the readiness of osm-controller based on this port.

Update the cleanup hook as pre-delete to ensure proper deletion order
of CRD's and services via Helm.

Part of #3396

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [X] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no. `no`

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
