### PR TITLE
multicluster: Simplify and test

### DIFF
--- a/pkg/providers/kube/multicluster.go
+++ b/pkg/providers/kube/multicluster.go
@@ -5,9 +5,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/service"
 )
+
+const portIPSeparator = `:`
 
 // getMulticlusterEndpoints returns the endpoints for multicluster services if such exist.
 func (c *Client) getMulticlusterEndpoints(svc service.MeshService) []endpoint.Endpoint {
@@ -48,29 +51,42 @@ func (c *Client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount
 
 	var endpoints []endpoint.Endpoint
 	for _, svc := range services {
+		var endpointsForService []endpoint.Endpoint
+		log.Trace().Msgf("Working on service: %s --> spec=%+v", svc, svc.Spec.Clusters)
 		for _, cluster := range svc.Spec.Clusters {
-			tokens := strings.Split(cluster.Address, ":")
-			if len(tokens) != 2 {
-				log.Error().Msgf("Error parsing remote service %s address %s. It should have IP address and port number", svc.Name, cluster.Address)
-				continue
+			log.Trace().Msgf("Looking for IP and Port for cluster=%s for service %s", cluster.Name, svc)
+			if ip, port, err := getIPPort(cluster); err != nil {
+				log.Err(err).Msgf("Error getting IP and Port for cluster=%s for service %s", cluster.Name, svc)
+			} else {
+				endpointsForService = append(endpointsForService, endpoint.Endpoint{
+					IP:   ip,
+					Port: endpoint.Port(port),
+				})
 			}
-
-			ip, portStr := tokens[0], tokens[1]
-			port, err := strconv.Atoi(portStr)
-			if err != nil {
-				log.Error().Msgf("Remote service %s port number format invalid. Remote cluster address: %s", svc.Name, cluster.Address)
-				continue
-			}
-
-			ept := endpoint.Endpoint{
-				IP:   net.ParseIP(ip),
-				Port: endpoint.Port(port),
-			}
-			endpoints = append(endpoints, ept)
 		}
+		log.Trace().Msgf("Multicluster endpoints for service %+v: %+v", services, endpointsForService)
+		endpoints = append(endpoints, endpointsForService...)
 	}
 
 	log.Trace().Msgf("[%s] Multicluster Endpoints for service account %s: %+v", c.providerIdent, serviceAccount, endpoints)
-
 	return endpoints
+}
+
+func getIPPort(cluster v1alpha1.ClusterSpec) (ip net.IP, port int, err error) {
+	tokens := strings.Split(cluster.Address, portIPSeparator)
+	if len(tokens) != 2 {
+		log.Error().Msgf("Invalid address format %s. It should have IP address and port number separated by %s", cluster.Address, portIPSeparator)
+		return nil, 0, err
+	}
+
+	ipStr, portStr := tokens[0], tokens[1]
+	port, err = strconv.Atoi(portStr)
+	if err != nil {
+		log.Error().Msgf("Invalid port number format %s for cluster address: %s", portStr, cluster.Address)
+		return nil, 0, err
+	}
+
+	ip = net.ParseIP(ipStr)
+
+	return ip, port, err
 }

--- a/pkg/providers/kube/multicluster_test.go
+++ b/pkg/providers/kube/multicluster_test.go
@@ -3,13 +3,12 @@ package kube
 import (
 	"fmt"
 	"net"
+	"testing"
 
 	"github.com/golang/mock/gomock"
+	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/config"
@@ -20,12 +19,12 @@ import (
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
-var _ = Describe("Test Multicluster functions of the Kubernetes endpoint", func() {
-	defer GinkgoRecover()
+func TestHelperFunctions(t *testing.T) {
+	assert := tassert.New(t)
 
 	var client *Client
 
-	mockCtrl := gomock.NewController(GinkgoT())
+	mockCtrl := gomock.NewController(t)
 	mockKubeController := k8s.NewMockController(mockCtrl)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockConfigController := config.NewMockController(mockCtrl)
@@ -66,35 +65,27 @@ var _ = Describe("Test Multicluster functions of the Kubernetes endpoint", func(
 	}}
 	mockConfigController.EXPECT().GetMultiClusterServiceByServiceAccount(tests.BookbuyerServiceName, tests.Namespace).Return(toReturnServices).AnyTimes()
 
-	BeforeEach(func() {
-		client = NewClient(mockKubeController, mockConfigController, "kubernetes-endpoint-provider", mockConfigurator)
-	})
+	client = NewClient(mockKubeController, mockConfigController, "kubernetes-endpoint-provider", mockConfigurator)
 
-	Context("Test getMulticlusterEndpoints()", func() {
-		It("returns Multicluster endpoints for a service", func() {
-			actual := client.getMulticlusterEndpoints(tests.BookbuyerService)
-			Expect(actual).To(Equal(expectedEndpoint))
-		})
-	})
+	// Test getMulticlusterEndpoints()
+	// returns Multicluster endpoints for a service
+	actual := client.getMulticlusterEndpoints(tests.BookbuyerService)
+	assert.Equal(actual, expectedEndpoint)
 
-	Context("Test getMultiClusterServiceEndpointsForServiceAccount()", func() {
-		It("returns Multicluster endpoints for a service account", func() {
-			actual := client.getMultiClusterServiceEndpointsForServiceAccount(tests.BookbuyerServiceAccountName, tests.Namespace)
-			Expect(actual).To(Equal(expectedEndpoint))
-		})
-	})
+	// Test getMultiClusterServiceEndpointsForServiceAccount()
+	// returns Multicluster endpoints for a service account
+	actual = client.getMultiClusterServiceEndpointsForServiceAccount(tests.BookbuyerServiceAccountName, tests.Namespace)
+	assert.Equal(actual, expectedEndpoint)
 
-	Context("Test getIPPort()", func() {
-		It("returns the port number specified in a ClusterSpec", func() {
-			clusterSpec := v1alpha1.ClusterSpec{
-				Address: "1.2.3.4:5678",
-			}
-			actualIP, actualPort, err := getIPPort(clusterSpec)
-			Expect(err).ToNot(HaveOccurred())
-			expectedIP := net.ParseIP("1.2.3.4")
-			expectedPort := 5678
-			Expect(actualIP).To(Equal(expectedIP))
-			Expect(actualPort).To(Equal(expectedPort))
-		})
-	})
-})
+	// Test getIPPort()
+	// returns the port number specified in a ClusterSpec
+	clusterSpec := v1alpha1.ClusterSpec{
+		Address: "1.2.3.4:5678",
+	}
+	actualIP, actualPort, err := getIPPort(clusterSpec)
+	assert.Equal(err, nil)
+	expectedIP := net.ParseIP("1.2.3.4")
+	expectedPort := 5678
+	assert.Equal(actualIP, expectedIP)
+	assert.Equal(actualPort, expectedPort)
+}

--- a/pkg/providers/kube/multicluster_test.go
+++ b/pkg/providers/kube/multicluster_test.go
@@ -83,4 +83,18 @@ var _ = Describe("Test Multicluster functions of the Kubernetes endpoint", func(
 			Expect(actual).To(Equal(expectedEndpoint))
 		})
 	})
+
+	Context("Test getIPPort()", func() {
+		It("returns the port number specified in a ClusterSpec", func() {
+			clusterSpec := v1alpha1.ClusterSpec{
+				Address: "1.2.3.4:5678",
+			}
+			actualIP, actualPort, err := getIPPort(clusterSpec)
+			Expect(err).ToNot(HaveOccurred())
+			expectedIP := net.ParseIP("1.2.3.4")
+			expectedPort := 5678
+			Expect(actualIP).To(Equal(expectedIP))
+			Expect(actualPort).To(Equal(expectedPort))
+		})
+	})
 })


### PR DESCRIPTION
This PR simplifies the `getMulticlusterEndpoints()` function. It adds `getIPPort()` to separate concerns, and a test for it.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
