### PR TITLE
multicluster: Enable Multicluster Gateway feature flag for multicluster demo

### DIFF
--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -109,6 +109,7 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
         --set=OpenServiceMesh.envoyLogLevel="$ENVOY_LOG_LEVEL" \
         --set=OpenServiceMesh.controllerLogLevel="trace" \
         --set=OpenServiceMesh.featureFlags.enableMulticlusterMode="true" \
+        --set=OpenServiceMesh.featureFlags.enableOSMGateway="true" \
         --timeout="$TIMEOUT" \
         $optionalInstallArgs
 


### PR DESCRIPTION
This PR adds the `enableOSMGateway` feature flag to the Multicluster demo script.
This will ensure that we deploy a multicluster gateway when this demo us ran.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
