### PR TITLE
envoy: remove unnecessary peer validation cert for TLS (non-mTLS)

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -113,11 +113,6 @@ var _ = Describe("Test ADS response functions", func() {
 						Name:     proxySvcAccount.String(),
 						CertType: secrets.RootCertTypeForMTLSInbound,
 					}.String(),
-					secrets.SDSCert{
-						// Validation ceritificate for TLS when this proxy is an upstream
-						Name:     proxySvcAccount.String(),
-						CertType: secrets.RootCertTypeForHTTPS,
-					}.String(),
 				},
 			}
 			Expect(actual).ToNot(BeNil())
@@ -175,8 +170,7 @@ var _ = Describe("Test ADS response functions", func() {
 			// Expect 3 SDS certs:
 			// 1. Proxy's own cert to present to peer during mTLS/TLS handshake
 			// 2. mTLS validation cert when this proxy is an upstream
-			// 3. TLS validation cert when this proxy is an upstream
-			Expect(len((*actualResponses)[4].Resources)).To(Equal(3))
+			Expect(len((*actualResponses)[4].Resources)).To(Equal(2))
 
 			var tmpResource *any.Any
 
@@ -196,15 +190,6 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
 				CertType: secrets.RootCertTypeForMTLSInbound,
-			}.String()))
-
-			serverRootCertTypeForHTTPS := xds_auth.Secret{}
-			tmpResource = (*actualResponses)[4].Resources[2]
-			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForHTTPS)
-			Expect(err).To(BeNil())
-			Expect(serverRootCertTypeForHTTPS.Name).To(Equal(secrets.SDSCert{
-				Name:     proxySvcAccount.String(),
-				CertType: secrets.RootCertTypeForHTTPS,
 			}.String()))
 		})
 	})
@@ -247,8 +232,7 @@ var _ = Describe("Test ADS response functions", func() {
 			// Expect 3 SDS certs:
 			// 1. Proxy's own cert to present to peer during mTLS/TLS handshake
 			// 2. mTLS validation cert when this proxy is an upstream
-			// 3. TLS validation cert when this proxy is an upstream
-			Expect(len(sdsResponse.Resources)).To(Equal(3))
+			Expect(len(sdsResponse.Resources)).To(Equal(2))
 
 			var tmpResource *any.Any
 
@@ -268,15 +252,6 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
 				CertType: secrets.RootCertTypeForMTLSInbound,
-			}.String()))
-
-			serverRootCertTypeForHTTPS := xds_auth.Secret{}
-			tmpResource = sdsResponse.Resources[2]
-			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForHTTPS)
-			Expect(err).To(BeNil())
-			Expect(serverRootCertTypeForHTTPS.Name).To(Equal(secrets.SDSCert{
-				Name:     proxySvcAccount.String(),
-				CertType: secrets.RootCertTypeForHTTPS,
 			}.String()))
 		})
 	})

--- a/pkg/envoy/ads/secrets.go
+++ b/pkg/envoy/ads/secrets.go
@@ -17,7 +17,6 @@ import (
 // 2. Client's root validation certificate to validate upstream services during mTLS handshake: root-cert-for-mtls-outbound:<namespace>/<server-service-name>
 // 3. Server's service certificate when this proxy is an upstream: service-cert:<namespace>/<server-service-name>
 // 4. Server's root validation certificate to validate downstream clients during mTLS handshake: root-cert-for-mtls-inbound:<namespace>/<server-service-name>
-// 5. Server's root validation certificate to validate downstream clients during TLS handshake: root-cert-https:<namespace>/<server-service-name>
 //
 // This request will be sent to SDS which will return certificates encoded in SDS secrets corresponding to the resource names
 // encoded in the DiscoveryRequest this function creates and returns.
@@ -47,7 +46,6 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 			// create an SDS resource with the same name.
 			// The DownstreamTlsContext on the inbound filter chain references the following validation cert types:
 			// 1. root-cert-for-mtls-inbound: root validation cert to validate the downstream's cert during mTLS handshake
-			// 2. root-cert-https: root validation cert to validate the downstream's cert during TLS (non-mTLS) handshake
 
 			// This cert is the upstream service's validation certificate used to validate certificates presented
 			// by downstream clients during mTLS handshake.
@@ -55,14 +53,6 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 			secrets.SDSCert{
 				Name:     proxyIdentity.ToK8sServiceAccount().String(),
 				CertType: secrets.RootCertTypeForMTLSInbound,
-			}.String(),
-
-			// This cert is the upstream service's validation certificate used to validate certificates presented
-			// by downstream clients during TLS handshake.
-			// The secret name is of the form <namespace>/<upstream-service>
-			secrets.SDSCert{
-				Name:     proxyIdentity.ToK8sServiceAccount().String(),
-				CertType: secrets.RootCertTypeForHTTPS,
 			}.String(),
 		},
 		TypeUrl: string(envoy.TypeSDS),

--- a/pkg/envoy/ads/secrets_test.go
+++ b/pkg/envoy/ads/secrets_test.go
@@ -58,7 +58,6 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 					// 3. Inbound validation certs to validate downstreams
 					"root-cert-for-mtls-inbound:ns-1/test-sa",
-					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -81,7 +80,6 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 					// 3. Inbound validation certs to validate downstreams
 					"root-cert-for-mtls-inbound:ns-1/test-sa",
-					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -97,7 +95,6 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 					// 4. Inbound validation certs to validate downstreams
 					"root-cert-for-mtls-inbound:ns-1/test-sa",
-					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},
@@ -120,7 +117,6 @@ func TestMakeRequestForAllSecrets(t *testing.T) {
 
 					// 4. Inbound validation certs to validate downstreams
 					"root-cert-for-mtls-inbound:ns-1/test-sa",
-					"root-cert-https:ns-1/test-sa",
 				},
 			},
 		},

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -62,7 +62,6 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 	// - "service-cert:namespace/service-account"
 	// - "root-cert-for-mtls-outbound:namespace/service"
 	// - "root-cert-for-mtls-inbound:namespace/service-service-account"
-	// - "root-cert-for-https:namespace/service-service-account"
 
 	// The Envoy makes a request for a list of resources (aka certificates), which we will send as a response to the SDS request.
 	for _, requestedCertificate := range requestedCerts {
@@ -85,13 +84,16 @@ func (s *sdsImpl) getSDSSecrets(cert certificate.Certificater, requestedCerts []
 			certs = append(certs, envoySecret)
 
 		// A root certificate used to validate a service certificate is requested
-		case secrets.RootCertTypeForMTLSInbound, secrets.RootCertTypeForMTLSOutbound, secrets.RootCertTypeForHTTPS:
+		case secrets.RootCertTypeForMTLSInbound, secrets.RootCertTypeForMTLSOutbound:
 			envoySecret, err := s.getRootCert(cert, *sdsCert)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error creating cert %s for proxy %s", requestedCertificate, proxy.String())
 				continue
 			}
 			certs = append(certs, envoySecret)
+
+		default:
+			log.Error().Msgf("Unexpected certificate type %s requested for proxy %s", requestedCertificate, proxy)
 		}
 	}
 

--- a/pkg/envoy/secrets/secrets_test.go
+++ b/pkg/envoy/secrets/secrets_test.go
@@ -47,13 +47,6 @@ var _ = Describe("Test secert tools", func() {
 
 		})
 
-		It("returns root cert for non-mTLS", func() {
-			actual, err := UnmarshalSDSCert("root-cert-https:namespace-test/blahBlahBlahCert")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(actual.CertType).To(Equal(RootCertTypeForHTTPS))
-			Expect(actual.Name).To(Equal("namespace-test/blahBlahBlahCert"))
-		})
-
 		It("returns an error (invalid formatting)", func() {
 			_, err := UnmarshalSDSCert("blahBlahBlahCert")
 			Expect(err).To(HaveOccurred())

--- a/pkg/envoy/secrets/types.go
+++ b/pkg/envoy/secrets/types.go
@@ -35,17 +35,14 @@ func (ct SDSCertType) String() string {
 
 // SDSCertType enums
 const (
-	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:webservice"
+	// ServiceCertType is the prefix for the service certificate resource name. Example: "service-cert:ns/name"
 	ServiceCertType SDSCertType = "service-cert"
 
-	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate resource name for upstream connectivity. Example: "root-cert-for-mtls-outbound:webservice"
+	// RootCertTypeForMTLSOutbound is the prefix for the mTLS root certificate resource name for upstream connectivity. Example: "root-cert-for-mtls-outbound:ns/name"
 	RootCertTypeForMTLSOutbound SDSCertType = "root-cert-for-mtls-outbound"
 
-	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate resource name for downstream connectivity. Example: "root-cert-for-mtls-inbound:webservice"
+	// RootCertTypeForMTLSInbound is the prefix for the mTLS root certificate resource name for downstream connectivity. Example: "root-cert-for-mtls-inbound:ns/name"
 	RootCertTypeForMTLSInbound SDSCertType = "root-cert-for-mtls-inbound"
-
-	// RootCertTypeForHTTPS is the prefix for the HTTPS root certificate resource name. Example: "root-cert-https:webservice"
-	RootCertTypeForHTTPS SDSCertType = "root-cert-https"
 )
 
 // Defines valid cert types
@@ -53,5 +50,4 @@ var validCertTypes = map[SDSCertType]struct{}{
 	ServiceCertType:             {},
 	RootCertTypeForMTLSOutbound: {},
 	RootCertTypeForMTLSInbound:  {},
-	RootCertTypeForHTTPS:        {},
 }

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -241,7 +241,7 @@ var _ = Describe("Test Envoy tools", func() {
 				Name:     "default/bookbuyer",
 				CertType: secrets.ServiceCertType,
 			}
-			peerValidationSDSCert := secrets.SDSCert{
+			peerValidationSDSCert := &secrets.SDSCert{
 				Name:     "default/bookstore-v1",
 				CertType: secrets.RootCertTypeForMTLSOutbound,
 			}
@@ -271,7 +271,7 @@ var _ = Describe("Test Envoy tools", func() {
 				Name:     "default/bookstore-v1",
 				CertType: secrets.ServiceCertType,
 			}
-			peerValidationSDSCert := secrets.SDSCert{
+			peerValidationSDSCert := &secrets.SDSCert{
 				Name:     "default/bookstore-v1",
 				CertType: secrets.RootCertTypeForMTLSInbound,
 			}
@@ -296,17 +296,13 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(actual).To(Equal(expected))
 		})
 
-		It("returns proper auth.CommonTlsContext for non-mTLS (HTTPS)", func() {
+		It("returns proper auth.CommonTlsContext for TLS (non-mTLS)", func() {
 			tlsSDSCert := secrets.SDSCert{
 				Name:     "default/bookstore-v1",
 				CertType: secrets.ServiceCertType,
 			}
-			peerValidationSDSCert := secrets.SDSCert{
-				Name:     "default/bookstore-v1",
-				CertType: secrets.RootCertTypeForHTTPS,
-			}
 
-			actual := getCommonTLSContext(tlsSDSCert, peerValidationSDSCert)
+			actual := getCommonTLSContext(tlsSDSCert, nil /* no client cert validation */)
 
 			expected := &auth.CommonTlsContext{
 				TlsParams: GetTLSParams(),
@@ -314,13 +310,7 @@ var _ = Describe("Test Envoy tools", func() {
 					Name:      "service-cert:default/bookstore-v1",
 					SdsConfig: GetADSConfigSource(),
 				}},
-				ValidationContextType: &auth.CommonTlsContext_ValidationContextSdsSecretConfig{
-					ValidationContextSdsSecretConfig: &auth.SdsSecretConfig{
-						Name:      "root-cert-https:default/bookstore-v1",
-						SdsConfig: GetADSConfigSource(),
-					},
-				},
-				AlpnProtocols: nil,
+				ValidationContextType: nil, // TLS cert type should not validate the client certificate
 			}
 
 			Expect(actual).To(Equal(expected))


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change fixes an existing bug where when mTLS is disabled,
the root certificate is still being configured to validate the
client cert. In TLS mode (non-mTLS), the certificate presented
by the client should not be validated and hence there is no
reason to publish this peer cert validation context along with
the server cert.

A non-mTLS root certificate should never be requested by the proxy.

Required by #3779 to enable TLS based ingress to backends.
    
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
