### PR TITLE
ads: Convert superset logic to equals when computing ACK

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -273,15 +273,9 @@ func respondToRequest(proxy *envoy.Proxy, discoveryRequest *xds_discovery.Discov
 	// Get resources last sent prior to this request
 	resourcesLastSent := proxy.GetLastResourcesSent(typeURL)
 
-	// If what we last sent is a superset of what the
-	// requests resources subscribes to, it's ACK and nothing needs to be done.
-	// Otherwise, envoy might be asking us for additional resources that have to be sent along last time's resources.
-	// Difference returns elemenets of <requested> that are not part of elements of <last sent>
-
-	requestedResourcesDifference := resourcesRequested.Difference(resourcesLastSent)
-	if requestedResourcesDifference.Cardinality() != 0 {
-		log.Debug().Msgf("Proxy %s: request difference in v:%d - requested: %v lastSent: %v (diff: %v), triggering update",
-			proxy.String(), requestVersion, resourcesRequested, resourcesLastSent, requestedResourcesDifference)
+	if !resourcesRequested.Equal(resourcesLastSent) {
+		log.Debug().Msgf("Proxy %s: request difference in v:%d - requested: %v lastSent: %v, triggering update",
+			proxy.String(), requestVersion, resourcesRequested, resourcesLastSent)
 		return true
 	}
 


### PR DESCRIPTION
Unsubscriptions might be requesting less resources from a given number
of resources previously requested:

```
Original logic:
req: [N:-, A, B]
response: [N:1, A, B]
req: [N:1, A, B] (ACK)

envoy unsubscribes from B:
req: [N:1, A]
response: // OSM Never replies as nonce 1 should have already fulfilled this request, as it
          // is a superset (already had 'A') from the new resources being requested
```

This is causing issues as it seems that envoy does expect to be replied to.
Changing superset logic to equals will make OSM reply as long as the requested
resources are different from the last sent.


This fix is sitting on top of #3803, as it is needed to properly account for the subscribed and
sent resources in a proper way, for every proxy.

Related to #3775