### PR TITLE
multicluster: Adding ?include_eds to script getting Envoy configs

### DIFF
--- a/demo/get-multicluster-envoy-configs.sh
+++ b/demo/get-multicluster-envoy-configs.sh
@@ -3,13 +3,10 @@
 # This script automates the collection of Envoy config during Multicluster demo/development.
 # The configs are collected from Envoys in the ALPHA kube context (cluster).
 
-TMP_PID_FILE=$(mktemp)
-
-PORT=15000
 
 kubectl config use-context alpha > /dev/null
 for NAMESPACE in bookbuyer bookstore; do
     for POD in $(kubectl get pod -n "${NAMESPACE}" --no-headers | awk '{print $1}'); do
-./osm proxy get "config_dump?include_eds" "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
+        ./osm proxy get "config_dump?include_eds" "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
     done
 done

--- a/demo/get-multicluster-envoy-configs.sh
+++ b/demo/get-multicluster-envoy-configs.sh
@@ -3,9 +3,18 @@
 # This script automates the collection of Envoy config during Multicluster demo/development.
 # The configs are collected from Envoys in the ALPHA kube context (cluster).
 
+TMP_PID_FILE=$(mktemp)
+
+PORT=15000
+
 kubectl config use-context alpha > /dev/null
 for NAMESPACE in bookbuyer bookstore; do
     for POD in $(kubectl get pod -n "${NAMESPACE}" --no-headers | awk '{print $1}'); do
-      ./osm proxy get config_dump "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
+      ( kubectl port-forward --namespace="${NAMESPACE}" "${POD}" "${PORT}" & echo $! >&3 ) 3> "${TMP_PID_FILE}"
+      sleep 1
+      curl "http://localhost:${PORT}/config_dump?include_eds"  >  "envoy__config___${NAMESPACE}___${POD}.json"
+      kill -9 $(<"${TMP_PID_FILE}")
+      rm -rf "${TMP_PID_FILE}"
+      # ./osm proxy get config_dump "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
     done
 done

--- a/demo/get-multicluster-envoy-configs.sh
+++ b/demo/get-multicluster-envoy-configs.sh
@@ -10,11 +10,6 @@ PORT=15000
 kubectl config use-context alpha > /dev/null
 for NAMESPACE in bookbuyer bookstore; do
     for POD in $(kubectl get pod -n "${NAMESPACE}" --no-headers | awk '{print $1}'); do
-      ( kubectl port-forward --namespace="${NAMESPACE}" "${POD}" "${PORT}" & echo $! >&3 ) 3> "${TMP_PID_FILE}"
-      sleep 1
-      curl "http://localhost:${PORT}/config_dump?include_eds"  >  "envoy__config___${NAMESPACE}___${POD}.json"
-      kill -9 $(<"${TMP_PID_FILE}")
-      rm -rf "${TMP_PID_FILE}"
-      # ./osm proxy get config_dump "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
+./osm proxy get "config_dump?include_eds" "${POD}" --namespace="${NAMESPACE}" > "envoy__config___${NAMESPACE}___${POD}.json"
     done
 done


### PR DESCRIPTION
This PR changes the helper script so it includes Endpoints as well.

Example:

```bash
$ ./demo/get-multicluster-envoy-configs.sh

$ cat envoy__config___bookbuyer___bookbuyer-586dd84d8c-bf2q7.json | grep 10.244
             "address": "10.244.0.71",
             "address": "10.244.2.122",
             "address": "10.244.0.71",
             "address": "10.244.1.87",
             "address": "10.244.1.87",
             "address": "10.244.1.87",
             "address": "10.244.0.71",
             "address": "10.244.2.122",
```

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
