### PR TITLE
multicluster: Populate MulticlusterService

### DIFF
--- a/demo/populate-MulticlusterService.sh
+++ b/demo/populate-MulticlusterService.sh
@@ -18,7 +18,7 @@ kubectl patch MulticlusterService \
         --namespace bookstore \
         bookstore \
         --type merge \
-        --patch '{"spec":{"clusters":[{"name":"beta","address":"'${BETA_OSM_GATEWAY_IP}':9876"}]}}'
+        --patch '{"spec":{"clusters":[{"name":"beta","address":"'"${BETA_OSM_GATEWAY_IP}"':9876"}]}}'
 
 kubectl get MulticlusterService \
         --namespace bookstore bookstore \
@@ -32,7 +32,7 @@ kubectl patch MulticlusterService \
         --namespace bookstore \
         bookstore \
         --type merge \
-        --patch '{"spec":{"clusters":[{"name":"alpha","address":"'${ALPHA_OSM_GATEWAY_IP}':9876"}]}}'
+        --patch '{"spec":{"clusters":[{"name":"alpha","address":"'"${ALPHA_OSM_GATEWAY_IP}"':9876"}]}}'
 
 kubectl get MulticlusterService \
         --namespace bookstore bookstore \

--- a/demo/populate-MulticlusterService.sh
+++ b/demo/populate-MulticlusterService.sh
@@ -2,6 +2,9 @@
 
 set -auexo pipefail
 
+# TODO: Parameterize this value: https://github.com/openservicemesh/osm/issues/3804
+GATEWAY_PORT=14080
+
 # Populate the IP of the Multicluster Gateway from the OTHER cluster
 ##########################
 # Get IP addresses of OSM Multicluster Gateways
@@ -18,7 +21,7 @@ kubectl patch MulticlusterService \
         --namespace bookstore \
         bookstore \
         --type merge \
-        --patch '{"spec":{"clusters":[{"name":"beta","address":"'"${BETA_OSM_GATEWAY_IP}"':9876"}]}}'
+        --patch '{"spec":{"clusters":[{"name":"beta","address":"'"${BETA_OSM_GATEWAY_IP}"':'"${GATEWAY_PORT}"'"}]}}'
 
 kubectl get MulticlusterService \
         --namespace bookstore bookstore \
@@ -32,7 +35,7 @@ kubectl patch MulticlusterService \
         --namespace bookstore \
         bookstore \
         --type merge \
-        --patch '{"spec":{"clusters":[{"name":"alpha","address":"'"${ALPHA_OSM_GATEWAY_IP}"':9876"}]}}'
+        --patch '{"spec":{"clusters":[{"name":"alpha","address":"'"${ALPHA_OSM_GATEWAY_IP}"':'"${GATEWAY_PORT}"'"}]}}'
 
 kubectl get MulticlusterService \
         --namespace bookstore bookstore \

--- a/demo/populate-MulticlusterService.sh
+++ b/demo/populate-MulticlusterService.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -auexo pipefail
+
+# Populate the IP of the Multicluster Gateway from the OTHER cluster
+##########################
+# Get IP addresses of OSM Multicluster Gateways
+kubectl config use-context 'alpha'
+ALPHA_OSM_GATEWAY_IP=$(kubectl get pods -n 'osm-system' --selector app=osm-gateway -o json | jq -r '.items[].status.podIP')
+
+kubectl config use-context 'beta'
+BETA_OSM_GATEWAY_IP=$(kubectl get pods -n 'osm-system' --selector app=osm-gateway -o json | jq -r '.items[].status.podIP')
+
+##########################
+# Populate Alpha w/ Beta's IP
+kubectl config use-context 'alpha'
+kubectl patch MulticlusterService \
+        --namespace bookstore \
+        bookstore \
+        --type merge \
+        --patch '{"spec":{"clusters":[{"name":"beta","address":"'${BETA_OSM_GATEWAY_IP}':9876"}]}}'
+
+kubectl get MulticlusterService \
+        --namespace bookstore bookstore \
+        -o json | jq '.spec.clusters'
+
+
+##########################
+# Populate Beta w/ Alpha's IP
+kubectl config use-context 'beta'
+kubectl patch MulticlusterService \
+        --namespace bookstore \
+        bookstore \
+        --type merge \
+        --patch '{"spec":{"clusters":[{"name":"alpha","address":"'${ALPHA_OSM_GATEWAY_IP}':9876"}]}}'
+
+kubectl get MulticlusterService \
+        --namespace bookstore bookstore \
+        -o json | jq '.spec.clusters'

--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -133,3 +133,5 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
     # Create the MultiClusterService object.
     ./demo/deploy-MultiClusterService.sh
 done
+
+./demo/populate-MulticlusterService.sh


### PR DESCRIPTION
This PR adds a script to automate the population of the `other` cluster's IP address and name in the MulticlusterService CRO.