### PR TITLE
multicluster: Create sni_cluster filter for the Multicluster Gateway listener

### DIFF
--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -22,8 +22,7 @@ func (lb *listenerBuilder) buildGatewayListeners() []types.Resource {
 		return nil
 	}
 
-	// TODO(draychev): What should the Service Identity here be?
-	filterChain, err := getGatewayFilterChain("osm-gateway.osm-system")
+	filterChain, err := getGatewayFilterChain(lb.serviceIdentity)
 	if err != nil {
 		log.Err(err).Msg("[Multicluster] Error creating Multicluster gateway filter chain")
 	}

--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -22,12 +22,10 @@ func (lb *listenerBuilder) buildGatewayListeners() []types.Resource {
 		return nil
 	}
 
-	// TODO(draychev): what should this be?
-	svcIdent := identity.ServiceIdentity("osm-gateway.osm-system")
-
-	filterChain, err := getGatewayFilterChain(svcIdent)
+	// TODO(draychev): What should the Service Identity here be?
+	filterChain, err := getGatewayFilterChain("osm-gateway.osm-system")
 	if err != nil {
-		log.Err(err).Msg("Error creating Multicluster gateway filter chain")
+		log.Err(err).Msg("[Multicluster] Error creating Multicluster gateway filter chain")
 	}
 
 	return []types.Resource{
@@ -47,13 +45,13 @@ func getGatewayFilterChain(svcIdent identity.ServiceIdentity) (*xds_listener.Fil
 	}
 	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
-		log.Error().Err(err).Msg("Error marshalling tcpProxy object for gateway filter chain")
+		log.Error().Err(err).Msg("[Multicluster] Error marshalling tcpProxy object for gateway filter chain")
 		return nil, err
 	}
 
 	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(svcIdent, true /* mTLS */))
 	if err != nil {
-		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext object for service identity %s", svcIdent)
+		log.Error().Err(err).Msgf("[Multicluster] Error marshalling DownstreamTLSContext object for service identity %s", svcIdent)
 		return nil, err
 	}
 

--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -51,7 +51,7 @@ func getGatewayFilterChain(svcIdent identity.ServiceIdentity) (*xds_listener.Fil
 		return nil, err
 	}
 
-	marshalledDownstreamTLSContext, err := envoy.MessageToAny(envoy.GetDownstreamTLSContext(svcIdent, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(svcIdent, true /* mTLS */))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext object for service identity %s", svcIdent)
 		return nil, err

--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -1,90 +1,89 @@
 package lds
 
 import (
-	"fmt"
-
+	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"google.golang.org/protobuf/types/known/wrapperspb"
+	"github.com/golang/protobuf/ptypes"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/errcode"
-	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/identity"
+)
+
+const (
+	inboundMulticlusterGatewayFilterChainName = "inbound-multicluster-gateway-filter-chain"
 )
 
 func (lb *listenerBuilder) buildGatewayListeners() []types.Resource {
 	if !lb.cfg.GetFeatureFlags().EnableMulticlusterMode {
 		return nil
 	}
+
+	// TODO(draychev): what should this be?
+	svcIdent := identity.ServiceIdentity("osm-gateway.osm-system")
+
+	filterChain, err := getGatewayFilterChain(svcIdent)
+	if err != nil {
+		log.Err(err).Msg("Error creating Multicluster gateway filter chain")
+	}
+
 	return []types.Resource{
 		&xds_listener.Listener{
 			Name:         multiclusterListenerName,
 			Address:      envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyInboundListenerPort),
-			FilterChains: lb.getMultiClusterGatewayFilterChainPerUpstream(),
-			ListenerFilters: []*xds_listener.ListenerFilter{
-				{
-					// The ProxyProtocol ListenerFilter is used to redirect traffic
-					// to its intended destination.
-					Name: wellknown.ProxyProtocol,
-				},
-			},
+			FilterChains: []*xds_listener.FilterChain{filterChain},
 		},
 	}
 }
 
-func (lb *listenerBuilder) getMultiClusterGatewayFilterChainPerUpstream() []*xds_listener.FilterChain {
-	var filterChains []*xds_listener.FilterChain
-
-	dstServices := lb.meshCatalog.ListMeshServicesForIdentity(lb.serviceIdentity)
-	if len(dstServices) == 0 {
-		log.Debug().Msgf("Proxy with identity %s does not have any allowed upstream services", lb.serviceIdentity)
-		return filterChains
+func getGatewayFilterChain(svcIdent identity.ServiceIdentity) (*xds_listener.FilterChain, error) {
+	tcpProxy := &xds_tcp_proxy.TcpProxy{
+		StatPrefix:       envoy.MulticlusterGatewayCluster,
+		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: envoy.MulticlusterGatewayCluster},
+		AccessLog:        envoy.GetAccessLog(),
+	}
+	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	if err != nil {
+		log.Error().Err(err).Msg("Error marshalling tcpProxy object for gateway filter chain")
+		return nil, err
 	}
 
-	// Iterate all destination services
-	for _, upstream := range dstServices {
-		if !upstream.Local() {
-			continue
-		}
+	marshalledDownstreamTLSContext, err := envoy.MessageToAny(envoy.GetDownstreamTLSContext(svcIdent, true /* mTLS */))
+	if err != nil {
+		log.Error().Err(err).Msgf("Error marshalling DownstreamTLSContext object for service identity %s", svcIdent)
+		return nil, err
+	}
 
-		log.Trace().Msgf("Building outbound filter chain for upstream service %s for proxy with identity %s", upstream, lb.serviceIdentity)
-		protocolToPortMap, err := lb.meshCatalog.GetPortToProtocolMappingForService(upstream)
-		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServicePorts.String()).
-				Msgf("Error retrieving port to protocol mapping for upstream service %s", upstream)
-			continue
-		}
-
-		// Create protocol specific inbound filter chains per port to handle different ports serving different protocols
-		for port := range protocolToPortMap {
-			// The gateway uses SSL passthrough, so simply uses a TCP filter.
-			filter, err := lb.getOutboundTCPFilter(upstream)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error getting tcp filter for upstream service %s", upstream)
-				continue
-			}
-
-			filterChains = append(filterChains, &xds_listener.FilterChain{
-				Name:    fmt.Sprintf("%s:%s", outboundMeshTCPFilterChainPrefix, upstream),
-				Filters: []*xds_listener.Filter{filter},
-				FilterChainMatch: &xds_listener.FilterChainMatch{
-					DestinationPort: &wrapperspb.UInt32Value{
-						Value: port,
-					},
-					ServerNames: []string{
-						service.MeshService{
-							Name:          upstream.Name,
-							Namespace:     upstream.Namespace,
-							ClusterDomain: constants.ClusterDomain(lb.cfg.GetClusterDomain())}.ServerName(),
-					},
-					ApplicationProtocols: envoy.ALPNInMesh,
-					TransportProtocol:    envoy.TransportProtocolTLS,
+	filterChain := &xds_listener.FilterChain{
+		Name: inboundMulticlusterGatewayFilterChainName,
+		FilterChainMatch: &xds_listener.FilterChainMatch{
+			ServerNames: []string{
+				"*.local",
+			},
+			TransportProtocol:    envoy.TransportProtocolTLS,
+			ApplicationProtocols: envoy.ALPNInMesh, // in-mesh proxies will advertise this, set in UpstreamTlsContext
+		},
+		Filters: []*xds_listener.Filter{
+			{
+				// This is of utmost importance to the Multicluster Gateway!
+				Name: "envoy.filters.network.sni_cluster",
+			},
+			{
+				Name: wellknown.TCPProxy,
+				ConfigType: &xds_listener.Filter_TypedConfig{
+					TypedConfig: marshalledTCPProxy,
 				},
-			})
-		}
+			},
+		},
+		TransportSocket: &xds_core.TransportSocket{
+			Name: wellknown.TransportSocketTls,
+			ConfigType: &xds_core.TransportSocket_TypedConfig{
+				TypedConfig: marshalledDownstreamTLSContext,
+			},
+		},
 	}
-
-	return filterChains
+	return filterChain, nil
 }

--- a/pkg/envoy/lds/gateway_test.go
+++ b/pkg/envoy/lds/gateway_test.go
@@ -15,7 +15,14 @@ import (
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
-func TestNewMultiClusterGatewayListener(t *testing.T) {
+func TestGetGatewayFilterChain(t *testing.T) {
+	assert := tassert.New(t)
+	filterChain, err := getGatewayFilterChain("one.two")
+	assert.Nil(err)
+	assert.Equal(len(filterChain.Filters), 2)
+}
+
+func TestBuildGatewayListeners(t *testing.T) {
 	assert := tassert.New(t)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/envoy/lds/gateway_test.go
+++ b/pkg/envoy/lds/gateway_test.go
@@ -1,13 +1,11 @@
 package lds
 
 import (
-	"fmt"
 	"testing"
 
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -32,7 +30,8 @@ func TestNewMultiClusterGatewayListener(t *testing.T) {
 	mockConfigurator.EXPECT().GetTracingEndpoint().Return("test-api").AnyTimes()
 	mockConfigurator.EXPECT().GetClusterDomain().Return("cluster-x").AnyTimes()
 	id := identity.K8sServiceAccount{Name: "gateway", Namespace: "osm-system"}.ToServiceIdentity()
-	mockCatalog.EXPECT().ListMeshServicesForIdentity(id).Return([]service.MeshService{
+
+	returnMeshSvc := []service.MeshService{
 		tests.BookbuyerService,
 		tests.BookwarehouseService,
 		// Non local should get filtered out.
@@ -41,17 +40,17 @@ func TestNewMultiClusterGatewayListener(t *testing.T) {
 			Namespace:     "default",
 			ClusterDomain: "non-local",
 		},
-	})
+	}
+	mockCatalog.EXPECT().ListMeshServicesForIdentity(id).Return(returnMeshSvc).AnyTimes()
 
-	mockCatalog.EXPECT().GetPortToProtocolMappingForService(tests.BookbuyerService).Return(map[uint32]string{
-		80: "",
-	}, nil).AnyTimes()
-	mockCatalog.EXPECT().GetPortToProtocolMappingForService(tests.BookwarehouseService).Return(map[uint32]string{
-		80: "",
-	}, nil).AnyTimes()
+	svcMap := map[uint32]string{80: ""}
+	mockCatalog.EXPECT().GetPortToProtocolMappingForService(tests.BookbuyerService).Return(svcMap, nil).AnyTimes()
+	mockCatalog.EXPECT().GetPortToProtocolMappingForService(tests.BookwarehouseService).Return(svcMap, nil).AnyTimes()
 
 	mockCatalog.EXPECT().GetWeightedClustersForUpstream(tests.BookbuyerService).Return(nil).AnyTimes()
 	mockCatalog.EXPECT().GetWeightedClustersForUpstream(tests.BookwarehouseService).Return(nil).AnyTimes()
+
+	mockCatalog.EXPECT().ListMeshServicesForIdentity("gateway.osm-system.cluster.local").AnyTimes()
 
 	lb := &listenerBuilder{
 		meshCatalog:     mockCatalog,
@@ -59,52 +58,18 @@ func TestNewMultiClusterGatewayListener(t *testing.T) {
 		serviceIdentity: id,
 	}
 
-	testCases := []struct {
-		name string
-		port uint32
-
-		expectedFilterChainMatch *xds_listener.FilterChainMatch
-	}{
-		{
-			name: "bookbuyer gateway filter chain",
-			port: 80,
-			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
-				DestinationPort: &wrapperspb.UInt32Value{Value: 80},
-				ServerNames: []string{
-					"bookbuyer.default.svc.cluster.cluster-x",
-				},
-				TransportProtocol:    "tls",
-				ApplicationProtocols: []string{"osm"},
-			},
-		},
-		{
-			name: "bookwarehouse gateway filter chain",
-			port: 80,
-			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
-				DestinationPort: &wrapperspb.UInt32Value{Value: 80},
-				ServerNames: []string{
-					"bookwarehouse.default.svc.cluster.cluster-x",
-				},
-				TransportProtocol:    "tls",
-				ApplicationProtocols: []string{"osm"},
-			},
-		},
-	}
 	listeners := lb.buildGatewayListeners()
 	assert.Len(listeners, 1)
 	listener, ok := listeners[0].(*xds_listener.Listener)
 	assert.True(ok)
-	assert.Len(listener.FilterChains, 2)
+	assert.Len(listener.FilterChains, 1)
 
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			assert := tassert.New(t)
+	// This filter is of utmost importance to the functioning of the Multicluster Gateway.
+	expectedFilterChain := "envoy.filters.network.sni_cluster"
+	assert.Equal(listener.FilterChains[0].Filters[0].Name, expectedFilterChain)
 
-			assert.Equal(listener.FilterChains[i].FilterChainMatch.ServerNames, tc.expectedFilterChainMatch.ServerNames)
-			assert.Equal(listener.FilterChains[i].FilterChainMatch.ApplicationProtocols, tc.expectedFilterChainMatch.ApplicationProtocols)
-			assert.Equal(listener.FilterChains[i].FilterChainMatch.TransportProtocol, tc.expectedFilterChainMatch.TransportProtocol)
-			assert.Equal(listener.FilterChains[i].FilterChainMatch.DestinationPort.Value, tc.expectedFilterChainMatch.DestinationPort.Value)
-			assert.Len(listener.FilterChains[i].Filters, 1)
-		})
-	}
+	assert.Equal(listener.FilterChains[0].FilterChainMatch.ServerNames, []string{"*.local"})
+	assert.Equal(listener.FilterChains[0].FilterChainMatch.ApplicationProtocols, []string{"osm"})
+	assert.Equal(listener.FilterChains[0].FilterChainMatch.TransportProtocol, "tls")
+	assert.Len(listener.FilterChains[0].Filters, 2)
 }

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -9,7 +9,6 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -410,13 +409,4 @@ func GetServiceIdentityFromProxyCertificate(cn certificate.CommonName) (identity
 	}
 
 	return cnMeta.ServiceIdentity, nil
-}
-
-// MessageToAny converts from proto message to proto Any and returns an error if any
-func MessageToAny(pb proto.Message) (*any.Any, error) {
-	msg, err := ptypes.MarshalAny(pb)
-	if err != nil {
-		return nil, err
-	}
-	return msg, nil
 }

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -9,6 +9,7 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
@@ -52,6 +53,9 @@ const (
 
 	// AccessLoggerName is name used for the envoy access loggers.
 	AccessLoggerName = "envoy.access_loggers.stream"
+
+	// MulticlusterGatewayCluster is the tls passthough cluster name for multicluster gateway
+	MulticlusterGatewayCluster = "passthrough-multicluster-gateway"
 )
 
 // ALPNInMesh indicates that the proxy is connecting to an in-mesh destination.
@@ -406,4 +410,13 @@ func GetServiceIdentityFromProxyCertificate(cn certificate.CommonName) (identity
 	}
 
 	return cnMeta.ServiceIdentity, nil
+}
+
+// MessageToAny converts from proto message to proto Any and returns an error if any
+func MessageToAny(pb proto.Message) (*any.Any, error) {
+	msg, err := ptypes.MarshalAny(pb)
+	if err != nil {
+		return nil, err
+	}
+	return msg, nil
 }


### PR DESCRIPTION
This PR configures a `sni_cluster` filter for the Multicluster Gateway listener.

### Example of this looks like

> Note `envoy.filters.network.sni_cluster`

```json
  {
    "@type": "type.googleapis.com/envoy.admin.v3.ListenersConfigDump",
    "version_info": "1",
    "dynamic_listeners": [
      {
        "name": "multicluster-listener",
        "active_state": {
          "version_info": "1",
          "listener": {
            "@type": "type.googleapis.com/envoy.config.listener.v3.Listener",
            "name": "multicluster-listener",
            "address": {
              "socket_address": {
                "address": "0.0.0.0",
                "port_value": 15003
              }
            },
            "filter_chains": [
              {
                "filter_chain_match": {
                  "transport_protocol": "tls",
                  "application_protocols": [
                    "osm"
                  ],
                  "server_names": [
                    "*.local"
                  ]
                },
                "filters": [
                  {
                    "name": "envoy.filters.network.sni_cluster"
                  },
                  {
                    "name": "envoy.filters.network.tcp_proxy",
                    "typed_config": {
                      "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
                      "stat_prefix": "passthrough-multicluster-gateway",
                      "cluster": "passthrough-multicluster-gateway",
                      "access_log": [
                        {
                          "name": "envoy.access_loggers.stream",
                          "typed_config": {
...
```
Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
