### PR TITLE
feat(multicluster): customize multicluster gateway port

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -117,6 +117,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.injector.webhookTimeoutSeconds | int | `20` | Mutating webhook timeout |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
+| OpenServiceMesh.multicluster.gatewayPort | int | `14080` | The port number of the multicluster gateway service |
 | OpenServiceMesh.osmController.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |
 | OpenServiceMesh.osmController.autoScale.enable | bool | `false` | Enable Autoscale |
 | OpenServiceMesh.osmController.autoScale.maxReplicas | int | `5` | Maximum replicas for autoscale |

--- a/charts/osm/templates/osm-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-gateway-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             "--service-cluster", "osm-gateway",
           ]
           ports:
-            - containerPort: 14080
+            - containerPort: {{ .Values.OpenServiceMesh.multicluster.gatewayPort }}
               name: http2
               protocol: TCP
           volumeMounts:

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -702,6 +702,26 @@
                     },
                     "additionalProperties": false
                 },
+                "multicluster": {
+                    "$id": "#/properties/OpenServiceMesh/properties/multicluster",
+                    "type": "object",
+                    "title": "Multicluster",
+                    "description": "Configuration for multicluster features",
+                    "required": [
+                        "gatewayPort"
+                    ],
+                    "properties": {
+                        "gatewayPort": {
+                            "$id": "#/properties/OpenServiceMesh/properties/multicluster/properties/gatewayPort",
+                            "type": "integer",
+                            "title": "Gateway port",
+                            "description": "Port number of multicluster gateway",
+                            "examples": [
+                                12345
+                            ]
+                        }
+                    }
+                },
                 "featureFlags": {
                     "$id": "#/properties/OpenServiceMesh/properties/featureFlags",
                     "type": "object",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -261,6 +261,11 @@ OpenServiceMesh:
     # When enabled, OSM will use the IngressBackend API allow ingress traffic to mesh backends
     enableIngressBackendPolicy: false
 
+  #
+  # -- OSM multicluster feature configuration
+  multicluster:
+    # -- The port number of the multicluster gateway service
+    gatewayPort: 14080
 
   # -- Run OSM with PodSecurityPolicy configured
   pspEnabled: false


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Add support to customize the multicluster gateway port number.

Issue #3804 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |

### Testing

Manual testing: deployed to local cluster by hacking the demo multicluster script, adding `--set=OpenServiceMesh.multicluster.gatewayPort="12345"`. It is expected that gateway uses port 12345.

After the deployment, verified that the port is expected.

![Screen Shot 2021-07-21 at 10 05 24 AM](https://user-images.githubusercontent.com/872876/126531883-3c634332-82eb-478e-93fa-d26879c476e4.png)


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

1. Is this a breaking change?

No