### PR TITLE
multicluster: For ease of debugging - log lines related to Multicluster capability should contain 'Multicluster' word

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -313,7 +313,7 @@ func isCNforProxy(proxy *envoy.Proxy, cn certificate.CommonName) bool {
 // is for the same service account as seen on the pod's service account
 func (s *Server) recordPodMetadata(p *envoy.Proxy) error {
 	if p.Kind() == envoy.KindGateway {
-		log.Debug().Msgf("Proxy with serial no %s is a gateway, skipping recording pod metadata", p.GetCertificateSerialNumber())
+		log.Debug().Msgf("Proxy with serial no %s is a Multicluster gateway, skipping recording pod metadata", p.GetCertificateSerialNumber())
 		return nil
 	}
 


### PR DESCRIPTION
This PR adds the word `Multicluster` to a log line.  This makes it easy to grep log lines for Multicluster specific messages -- easier development.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
