### PR TITLE
multicluster: In case of an error buildGatewayListeners() should return nil

### DIFF
--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -25,6 +25,7 @@ func (lb *listenerBuilder) buildGatewayListeners() []types.Resource {
 	filterChain, err := getGatewayFilterChain(lb.serviceIdentity)
 	if err != nil {
 		log.Err(err).Msg("[Multicluster] Error creating Multicluster gateway filter chain")
+		return nil
 	}
 
 	return []types.Resource{


### PR DESCRIPTION
This PR changes the function `buildGatewayListeners()` so that in case of an error it returns nil (empty slice of `[]types.Resource`).

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
