### PR TITLE
multicluster: Small tweaks to pkg/config/client for clarity and better logging

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -15,6 +15,8 @@ import (
 const (
 	// apiGroup is the k8s API group that this package interacts with
 	apiGroup = "config.openservicemesh.io"
+
+	multiclusterInformerName = `MulticlusterService`
 )
 
 // NewConfigController returns a config.Controller struct related to functionality provided by the resources in the config.openservicemesh.io API group
@@ -29,28 +31,24 @@ func NewConfigController(kubeConfig *rest.Config, kubeController k8s.Controller,
 
 	shouldObserve := func(obj interface{}) bool {
 		object, ok := obj.(metav1.Object)
-		if !ok {
-			return false
-		}
-		return kubeController.IsMonitoredNamespace(object.GetNamespace())
+		return ok && kubeController.IsMonitoredNamespace(object.GetNamespace())
 	}
 
-	remoteServiceEventTypes := k8s.EventTypes{
+	multiclusterServiceEventTypes := k8s.EventTypes{
 		Add:    announcements.MultiClusterServiceAdded,
 		Update: announcements.MultiClusterServiceUpdated,
 		Delete: announcements.MultiClusterServiceDeleted,
 	}
-	client.informer.Informer().AddEventHandler(k8s.GetKubernetesEventHandlers("MultiClusterService", "Kube", shouldObserve, remoteServiceEventTypes))
+	client.informer.Informer().AddEventHandler(k8s.GetKubernetesEventHandlers(multiclusterInformerName, "Kube", shouldObserve, multiclusterServiceEventTypes))
 
-	err := client.run(stop)
-	if err != nil {
+	if err := client.run(stop); err != nil {
 		return client, errors.Errorf("Could not start %s client: %s", apiGroup, err)
 	}
-	return client, err
+	return client, nil
 }
 
 func (c client) run(stop <-chan struct{}) error {
-	log.Info().Msgf("%s client started", apiGroup)
+	log.Info().Msgf("Starting informers for %s", apiGroup)
 
 	if c.informer == nil {
 		return errInitInformers
@@ -58,11 +56,11 @@ func (c client) run(stop <-chan struct{}) error {
 
 	go c.informer.Informer().Run(stop)
 
-	log.Info().Msgf("Waiting for %s RemoteService informers' cache to sync", apiGroup)
+	log.Info().Msgf("Waiting for %s %s informers' cache to sync", apiGroup, multiclusterInformerName)
 	if !cache.WaitForCacheSync(stop, c.informer.Informer().HasSynced) {
 		return errSyncingCaches
 	}
 
-	log.Info().Msgf("Cache sync finished for %s RemoteService informers", apiGroup)
+	log.Info().Msgf("Cache sync finished for %s %s informers", apiGroup, multiclusterInformerName)
 	return nil
 }


### PR DESCRIPTION
This PR augments log lines w/ the name of the informers (corrects `RemoteService` w/ `MulticlusterService`).
Simplifies some blocks of code.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>