### PR TITLE
ingress: refactor code to make it extendable for IngressBackend API

### DIFF
--- a/pkg/apis/policy/v1alpha1/ingress_backend.go
+++ b/pkg/apis/policy/v1alpha1/ingress_backend.go
@@ -50,6 +50,14 @@ type BackendSpec struct {
 	TLS TLSSpec `json:"tls,omitempty"`
 }
 
+const (
+	// KindService is the kind corresponding to a Service resource.
+	KindService = "Service"
+
+	// KindAuthenticatedPrincipal is the kind corresponding to an authenticated principal.
+	KindAuthenticatedPrincipal = "AuthenticatedPrincipal"
+)
+
 // IngressSourceSpec is the type used to represent the Source in the list of Sources specified in an
 // IngressBackend policy specification.
 type IngressSourceSpec struct {

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -53,19 +53,19 @@ func (mr *MockMeshCatalogerMockRecorder) GetEgressTrafficPolicy(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEgressTrafficPolicy", reflect.TypeOf((*MockMeshCataloger)(nil).GetEgressTrafficPolicy), arg0)
 }
 
-// GetIngressPoliciesForService mocks base method
-func (m *MockMeshCataloger) GetIngressPoliciesForService(arg0 service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error) {
+// GetIngressTrafficPolicy mocks base method
+func (m *MockMeshCataloger) GetIngressTrafficPolicy(arg0 service.MeshService) (*trafficpolicy.IngressTrafficPolicy, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIngressPoliciesForService", arg0)
-	ret0, _ := ret[0].([]*trafficpolicy.InboundTrafficPolicy)
+	ret := m.ctrl.Call(m, "GetIngressTrafficPolicy", arg0)
+	ret0, _ := ret[0].(*trafficpolicy.IngressTrafficPolicy)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetIngressPoliciesForService indicates an expected call of GetIngressPoliciesForService
-func (mr *MockMeshCatalogerMockRecorder) GetIngressPoliciesForService(arg0 interface{}) *gomock.Call {
+// GetIngressTrafficPolicy indicates an expected call of GetIngressTrafficPolicy
+func (mr *MockMeshCatalogerMockRecorder) GetIngressTrafficPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressPoliciesForService", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressPoliciesForService), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressTrafficPolicy", reflect.TypeOf((*MockMeshCataloger)(nil).GetIngressTrafficPolicy), arg0)
 }
 
 // GetKubeController mocks base method

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -70,8 +70,8 @@ type MeshCataloger interface {
 	// If no LB/virtual IPs are assigned to the service, GetResolvableServiceEndpoints will return ListEndpointsForService
 	GetResolvableServiceEndpoints(service.MeshService) ([]endpoint.Endpoint, error)
 
-	// GetIngressPoliciesForService returns the inbound traffic policies associated with an ingress service
-	GetIngressPoliciesForService(service.MeshService) ([]*trafficpolicy.InboundTrafficPolicy, error)
+	// GetIngressTrafficPolicy returns the ingress traffic policy for the given mesh service
+	GetIngressTrafficPolicy(service.MeshService) (*trafficpolicy.IngressTrafficPolicy, error)
 
 	// GetTargetPortToProtocolMappingForService returns a mapping of the service's ports to their corresponding application protocol.
 	// The ports returned are the actual ports on which the application exposes the service derived from the service's endpoints,

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -283,7 +283,7 @@ func TestNewResponse(t *testing.T) {
 
 			mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(tc.expectedInboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
-			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(tc.ingressInboundPolicies, nil).AnyTimes()
+			mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(&trafficpolicy.IngressTrafficPolicy{HTTPRoutePolicies: tc.ingressInboundPolicies}, nil).AnyTimes()
 			mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 
 			// Empty discovery request
@@ -530,7 +530,7 @@ func TestNewResponseWithPermissiveMode(t *testing.T) {
 
 	mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(testPermissiveInbound).AnyTimes()
 	mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(testPermissiveOutbound).AnyTimes()
-	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return(testIngressInbound, nil).AnyTimes()
+	mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(&trafficpolicy.IngressTrafficPolicy{HTTPRoutePolicies: testIngressInbound}, nil).AnyTimes()
 	mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).AnyTimes()
@@ -600,7 +600,7 @@ func TestResponseRequestCompletion(t *testing.T) {
 
 	mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}).AnyTimes()
 	mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return([]*trafficpolicy.OutboundTrafficPolicy{}).AnyTimes()
-	mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()
+	mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -255,6 +255,9 @@ const (
 
 	// ErrBuildingRBACPolicy indicates the XDS RBAC policy could not be created from a given traffic target policy
 	ErrBuildingRBACPolicy
+
+	// ErrIngressFilterChain indicates there an error related to an ingress filter chain
+	ErrIngressFilterChain
 )
 
 // String returns the error code as a string, ex. E1000
@@ -633,7 +636,11 @@ traffic. The XDS filter chain for ingress traffic to the port is not created.
 `,
 
 	ErrBuildingRBACPolicy: `
-A XDS RBAC policy could not be generated from the specified traffic target
+An XDS RBAC policy could not be generated from the specified traffic target
 policy.
+`,
+
+	ErrIngressFilterChain: `
+An XDS filter chain could not be constructed for ingress.
 `,
 }

--- a/pkg/trafficpolicy/ingress_types.go
+++ b/pkg/trafficpolicy/ingress_types.go
@@ -1,0 +1,17 @@
+package trafficpolicy
+
+// IngressTrafficPolicy defines the ingress traffic match and routes for a given backend
+type IngressTrafficPolicy struct {
+	TrafficMatches    []*IngressTrafficMatch
+	HTTPRoutePolicies []*InboundTrafficPolicy
+}
+
+// IngressTrafficMatch defines the attributes to match ingress traffic for a given backend
+type IngressTrafficMatch struct {
+	Name                     string
+	Port                     uint32
+	Protocol                 string
+	SourceIPRanges           []string
+	ServerNames              []string
+	SkipClientCertValidation bool
+}

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -245,7 +245,7 @@ func TestRDSRespose(t *testing.T) {
 
 			mockCatalog.EXPECT().ListInboundTrafficPolicies(gomock.Any(), gomock.Any()).Return(tc.expectedInboundPolicies).AnyTimes()
 			mockCatalog.EXPECT().ListOutboundTrafficPolicies(gomock.Any()).Return(tc.expectedOutboundPolicies).AnyTimes()
-			mockCatalog.EXPECT().GetIngressPoliciesForService(gomock.Any()).Return([]*trafficpolicy.InboundTrafficPolicy{}, nil).AnyTimes()
+			mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 
 			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil, proxyRegistry)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change refactors the ingress code in catalog, envoy/lds|rds
to make it generic enough to work with both the k8s Ingress API
as well as the newly introduced IngressBackend API.

The resulting Envoy config before and after this change should
be the same (with the exception of the filter chain name).

Required for #3779 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
