### PR TITLE
multicluster: Dedicated Service Account for the Multicluster Gateway

### DIFF
--- a/charts/osm/templates/osm-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-gateway-deployment.yaml
@@ -17,6 +17,7 @@ spec:
         app: osm-gateway
       name: osm-gateway
     spec:
+      serviceAccountName: multicluster-gateway
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
@@ -54,4 +55,15 @@ spec:
         - name: envoy-bootstrap-config-volume
           secret:
             secretName: osm-gateway-bootstrap-config
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: osm-multicluster-gateway
+  name: multicluster-gateway
+  namespace: {{ include "osm.namespace" . }}
 {{- end }}

--- a/charts/osm/templates/osm-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-gateway-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         app: osm-gateway
       name: osm-gateway
     spec:
-      serviceAccountName: multicluster-gateway
+      serviceAccountName: osm-multicluster-gateway
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux
@@ -64,6 +64,6 @@ metadata:
   labels:
     {{- include "osm.labels" . | nindent 4 }}
     app: osm-multicluster-gateway
-  name: multicluster-gateway
+  name: osm-multicluster-gateway
   namespace: {{ include "osm.namespace" . }}
 {{- end }}


### PR DESCRIPTION
This PR moves the OSM Multicluster Gateway Pods to a Service Account `osm-system/osm-multicluster-gateway`

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>