### PR TITLE
service: Simplify and test MeshService.FQDN()

### DIFF
--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -3,7 +3,6 @@ package service
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -13,6 +12,8 @@ const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
 	// or viceversa
 	namespaceNameSeparator = "/"
+
+	fqdnSeparator = "."
 )
 
 // Locality is the relative locality of a service. ie: if a service is being accessed from the same namespace or a
@@ -56,7 +57,7 @@ func (ms MeshService) FQDN() string {
 	if ms.ClusterDomain == "" {
 		ms.ClusterDomain = constants.LocalDomain
 	}
-	return strings.Join([]string{ms.Name, ms.Namespace, ms.ClusterDomain.String()}, ".")
+	return fmt.Sprintf("%s%s%s%s%s", ms.Name, fqdnSeparator, ms.Namespace, fqdnSeparator, ms.ClusterDomain)
 }
 
 // Local returns whether or not this is service is in the local cluster.

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -12,8 +12,6 @@ const (
 	// namespaceNameSeparator used upon marshalling/unmarshalling MeshService to a string
 	// or viceversa
 	namespaceNameSeparator = "/"
-
-	fqdnSeparator = "."
 )
 
 // Locality is the relative locality of a service. ie: if a service is being accessed from the same namespace or a

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -57,7 +57,7 @@ func (ms MeshService) FQDN() string {
 	if ms.ClusterDomain == "" {
 		ms.ClusterDomain = constants.LocalDomain
 	}
-	return fmt.Sprintf("%s%s%s%s%s", ms.Name, fqdnSeparator, ms.Namespace, fqdnSeparator, ms.ClusterDomain)
+	return fmt.Sprintf("%s.%s.%s", ms.Name, ms.Namespace, ms.ClusterDomain)
 }
 
 // Local returns whether or not this is service is in the local cluster.

--- a/pkg/service/types_test.go
+++ b/pkg/service/types_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Test pkg/service functions", func() {
 		})
 	})
 
-	Context("Test MeshService's String method", func() {
+	Context("Test MeshService's String and FQDN methods", func() {
 		namespace := uuid.New().String()
 		name := uuid.New().String()
 		ms := MeshService{
@@ -32,8 +32,12 @@ var _ = Describe("Test pkg/service functions", func() {
 			ClusterDomain: constants.LocalDomain,
 		}
 
-		It("implements stringer correctly", func() {
+		It("implements String() correctly", func() {
 			Expect(ms.String()).To(Equal(fmt.Sprintf("%s/%s/%s", namespace, name, constants.LocalDomain)))
+		})
+
+		It("implements FQDN() correctly", func() {
+			Expect(ms.FQDN()).To(Equal(fmt.Sprintf("%s.%s.%s", name, namespace, constants.LocalDomain)))
 		})
 	})
 


### PR DESCRIPTION
This PR is an attempt to improve the readability of FQDN().  But most importantly - test it and show what it produces.

Signed-off-by: Delyan Raychev <delyan.raychev@microsoft.com>
