### PR TITLE
docs(e2e): Add installType section

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -88,19 +88,6 @@ export CTR_TAG=mytag               # Optional, 'latest' used by default
 make docker-push-init docker-push-osm-controller.    # Use docker-build-* targets instead when using kind
 ```
 
-#### Use Kind for testing
-Testing implements support for Kind. If `kindCluster` is enabled, a new Kind cluster will be provisioned and it will be automatically used for the test.
-```
--kindCluster
-		Creates kind cluster
--kindClusterName string
-		Name of the Kind cluster to be created (default "osm-e2e")
--cleanupKindCluster
-		Cleanup kind cluster upon exit (default true)
--cleanupKindClusterBetweenTests
-		Cleanup kind cluster between tests (default true)
-```
-
 #### Test specific flags
 
 Worth mentioning `cleanupTest` is especially useful for debugging or leaving the test in a certain state at test-exit.
@@ -122,6 +109,41 @@ The `ginkgo.focus` flag can be used to run individual tests. The flag should spe
 
 ```console
 go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.focus="\bSimpleClientServer TCP with SMI policies\b"
+```
+
+#### Setting installType:
+
+The `installType` flag can be used to specify whether the tests should install OSM themselves, or if they will be run on a cluster which already has OSM installed. 
+
+```console
+go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=NoInstall
+```
+
+The different values of installType are as follows:
+
+1. `installType=NoInstall`
+   
+    The e2es will run on the cluster currently in the user's kubeconfig, which is already expected to have OSM installed prior to the test run. The tests will not install OSM before, or uninstall OSM after any of the tests run. The cluster can be of any CNCF certified distribution (though the k8s version cannot be an outdated version).
+
+1. `installType=KindCluster`
+
+	Each test in the e2e suite will spin up a kind cluster, and run that specific test on that kind cluster. Each test will install OSM via the OSM cli, and then uninstall OSM after the test finishes running. The user is not expected to have created any cluster beforehand. 
+
+1. `installType=SelfInstall` (default)
+
+	By default, the e2es will run on the cluster currently in the user's kubeconfig. Each test will install OSM via the OSM cli, and then uninstall OSM after the test finishes running. The cluster can be of any CNCF certified distribution (though the k8s version cannot be an outdated version). The user is should not have OSM installed beforehand. 
+
+
+#### Use Kind for testing
+Testing implements support for Kind. If `installType=KindCluster` is enabled, a new Kind cluster will be provisioned and it will be automatically used for the test.
+
+```
+-kindClusterName string
+		Name of the Kind cluster to be created (default "osm-e2e")
+-cleanupKindCluster
+		Cleanup kind cluster upon exit (default true)
+-cleanupKindClusterBetweenTests
+		Cleanup kind cluster between tests (default true)
 ```
 
 #### Setting test timeout:


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add section to e2e readme detailing the different installType values. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [X] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
