### PR TITLE
codegen: add build target and CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,8 @@ jobs:
           skip-pkg-cache: true
           args: --timeout 5m --skip-dirs pkg/gen --skip-files "zz_generated.deepcopy.go$"
 
-  tidy:
-    name: Tidy
+  codegen:
+    name: Codegen
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -65,6 +65,8 @@ jobs:
           go-version: 1.16
       - name: go mod tidy
         run: make go-mod-tidy
+      - name: Codegen checks
+        run: make check-codegen
 
   mocks:
     name: Mocks

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,13 @@ check-mocks:
 	@go run ./mockspec/generate.go
 	@git diff --exit-code || { echo "----- Please commit the changes made by 'go run ./mockspec/generate.go' -----"; exit 1; }
 
+.PHONY: check-codegen
+check-codegen:
+	@./codegen/gen-crd-client.sh
+	@git diff --exit-code || { echo "----- Please commit the changes made by './codegen/gen-crd-client.sh' -----"; exit 1; }
+
 .PHONY: go-checks
-go-checks: go-lint go-fmt go-mod-tidy check-mocks
+go-checks: go-lint go-fmt go-mod-tidy check-mocks check-codegen
 
 .PHONY: go-vet
 go-vet:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a build target and check in the CI to ensure
autogenerated Go clients for APIs are always up to
date to avoid issues similar to the one fixed in 60fa3075.

Also collapses the check for `go mod tidy` into the
`codegen` job.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CI System                  | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
