### PR TITLE
Make the certificate key size configurable

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -60,6 +60,7 @@ The following table lists the configurable parameters of the osm chart and their
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | OpenServiceMesh.caBundleSecretName | string | `"osm-ca-bundle"` | The Kubernetes secret name to store CA bundle for the root CA used in OSM |
+| OpenServiceMesh.certKeyBitSize | int | `2048` | Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS |
 | OpenServiceMesh.certificateManager | string | `"tresor"` | The Certificate manager type: `tresor`, `vault` or `cert-manager` |
 | OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager.io"` | cert-manager issuer group |
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` | cert-manager issuer kind |
@@ -136,7 +137,6 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Service certificate validity duration for certificate issued to workloads to communicate over mTLS |
-| OpenServiceMesh.certKeyBitSize | int | `2048` | Certificate key size for Envoy certificates |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.18.3"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -60,8 +60,9 @@ The following table lists the configurable parameters of the osm chart and their
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | OpenServiceMesh.caBundleSecretName | string | `"osm-ca-bundle"` | The Kubernetes secret name to store CA bundle for the root CA used in OSM |
-| OpenServiceMesh.certKeyBitSize | int | `2048` | Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS |
-| OpenServiceMesh.certificateManager | string | `"tresor"` | The Certificate manager type: `tresor`, `vault` or `cert-manager` |
+| OpenServiceMesh.certificateProvider.certKeyBitSize | int | `2048` | Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS |
+| OpenServiceMesh.certificateProvider.kind | string | `"tresor"` | The Certificate manager type: `tresor`, `vault` or `cert-manager` |
+| OpenServiceMesh.certificateProvider.serviceCertValidityDuration | string | `"24h"` | Service certificate validity duration for certificate issued to workloads to communicate over mTLS |
 | OpenServiceMesh.certmanager.issuerGroup | string | `"cert-manager.io"` | cert-manager issuer group |
 | OpenServiceMesh.certmanager.issuerKind | string | `"Issuer"` | cert-manager issuer kind |
 | OpenServiceMesh.certmanager.issuerName | string | `"osm-ca"` | cert-manager issuer namecert-manager issuer name |
@@ -136,7 +137,6 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
-| OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Service certificate validity duration for certificate issued to workloads to communicate over mTLS |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.18.3"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -136,6 +136,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.serviceCertValidityDuration | string | `"24h"` | Service certificate validity duration for certificate issued to workloads to communicate over mTLS |
+| OpenServiceMesh.certKeyBitSize | int | `2048` | Certificate key size for Envoy certificates |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.18.3"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |

--- a/charts/osm/crds/config_meshconfig.yaml
+++ b/charts/osm/crds/config_meshconfig.yaml
@@ -191,6 +191,10 @@ spec:
                       description: Sets the service certificate validity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix.
                       type: string
                       default: "24h"
+                    certKeyBitSize:
+                      description: Sets the certificate key bit size for data plane certificates.
+                      type: integer
+                      default: 2048
                 experimental:
                   description: Experimental configurations
                   type: object

--- a/charts/osm/templates/osm-crd-converter-deployment.yaml
+++ b/charts/osm/templates/osm-crd-converter-deployment.yaml
@@ -48,8 +48,8 @@ spec:
             "--verbosity", "{{.Values.OpenServiceMesh.controllerLogLevel}}",
             "--osm-namespace", "{{ include "osm.namespace" . }}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
-            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
-            {{ if eq .Values.OpenServiceMesh.certificateManager "vault" }}
+            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateProvider.kind}}",
+            {{ if eq .Values.OpenServiceMesh.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
             "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -73,8 +73,8 @@ spec:
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--webhook-config-name", "{{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
-            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
-            {{ if eq .Values.OpenServiceMesh.certificateManager "vault" }}
+            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateProvider.kind}}",
+            {{ if eq .Values.OpenServiceMesh.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
             "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -49,8 +49,8 @@ spec:
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--webhook-config-name", "{{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
-            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
-            {{ if eq .Values.OpenServiceMesh.certificateManager "vault" }}
+            "--certificate-manager", "{{.Values.OpenServiceMesh.certificateProvider.kind}}",
+            {{ if eq .Values.OpenServiceMesh.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.OpenServiceMesh.vault.host}}",
             "--vault-protocol", "{{.Values.OpenServiceMesh.vault.protocol}}",
             "--vault-token", "{{.Values.OpenServiceMesh.vault.token}}",

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -34,7 +34,8 @@ data:
         }
       },
       "certificate": {
-        "serviceCertValidityDuration": "{{.Values.OpenServiceMesh.serviceCertValidityDuration}}"
+        "serviceCertValidityDuration": "{{.Values.OpenServiceMesh.serviceCertValidityDuration}}",
+        "certKeyBitSize": {{.Values.OpenServiceMesh.certKeyBitSize}}
       },
       "featureFlags": {
         "enableWASMStats": {{.Values.OpenServiceMesh.featureFlags.enableWASMStats}},

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -34,8 +34,8 @@ data:
         }
       },
       "certificate": {
-        "serviceCertValidityDuration": "{{.Values.OpenServiceMesh.serviceCertValidityDuration}}",
-        "certKeyBitSize": {{.Values.OpenServiceMesh.certKeyBitSize}}
+        "serviceCertValidityDuration": "{{.Values.OpenServiceMesh.certificateProvider.serviceCertValidityDuration}}",
+        "certKeyBitSize": {{.Values.OpenServiceMesh.certificateProvider.certKeyBitSize}}
       },
       "featureFlags": {
         "enableWASMStats": {{.Values.OpenServiceMesh.featureFlags.enableWASMStats}},

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -133,6 +133,7 @@
                 "sidecarImage",
                 "certificateManager",
                 "serviceCertValidityDuration",
+                "certKeyBitSize",
                 "caBundleSecretName",
                 "enableDebugServer",
                 "enablePermissiveTrafficPolicy",
@@ -275,6 +276,15 @@
                     "description": "The service certificate validity duration.",
                     "examples": [
                         "24h"
+                    ]
+                },
+                "certKeyBitSize": {
+                    "$id": "#/properties/OpenServiceMesh/properties/certKeyBitSize",
+                    "type": "integer",
+                    "title": "The certKeyBitSize schema",
+                    "description": "The key size for data plane certificates.",
+                    "examples": [
+                        2048
                     ]
                 },
                 "caBundleSecretName": {

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -131,9 +131,6 @@
             "required": [
                 "image",
                 "sidecarImage",
-                "certificateManager",
-                "serviceCertValidityDuration",
-                "certKeyBitSize",
                 "caBundleSecretName",
                 "enableDebugServer",
                 "enablePermissiveTrafficPolicy",
@@ -259,33 +256,46 @@
                         "envoyproxy/envoy-alpine:v1.18.3"
                     ]
                 },
-                "certificateManager": {
-                    "$id": "#/properties/OpenServiceMesh/properties/certificateManager",
-                    "type": "string",
-                    "title": "The certificateManager schema",
-                    "description": "The certificate manager osm-controller should use.",
-                    "pattern": "^(tresor|vault|cert-manager)$",
-                    "examples": [
-                        "tresor"
-                    ]
-                },
-                "serviceCertValidityDuration": {
-                    "$id": "#/properties/OpenServiceMesh/properties/serviceCertValidityDuration",
-                    "type": "string",
-                    "title": "The serviceCertValidityDuration schema",
-                    "description": "The service certificate validity duration.",
-                    "examples": [
-                        "24h"
-                    ]
-                },
-                "certKeyBitSize": {
-                    "$id": "#/properties/OpenServiceMesh/properties/certKeyBitSize",
-                    "type": "integer",
-                    "title": "The certKeyBitSize schema",
-                    "description": "The key size for data plane certificates.",
-                    "examples": [
-                        2048
-                    ]
+                "certficateProvider": {
+                    "$id": "#/properties/OpenServiceMesh/properties/certificateProvider",
+                    "type": "object",
+                    "title": "The certificate provider schema",
+                    "description": "Certificate provider configuration parameters",
+                    "required": [
+                        "kind",
+                        "issuerKind",
+                        "issuerGroup"
+                    ],
+                    "properties": {
+                        "kind": {
+                            "$id": "#/properties/OpenServiceMesh/properties/certificateProvider/properties/kind",
+                            "type": "string",
+                            "title": "The certificate provider kind schema",
+                            "description": "The certificate manager osm-controller should use.",
+                            "pattern": "^(tresor|vault|cert-manager)$",
+                            "examples": [
+                                "tresor"
+                            ]
+                        },
+                        "serviceCertValidityDuration": {
+                            "$id": "#/properties/OpenServiceMesh/properties/certificateProvider/serviceCertValidityDuration",
+                            "type": "string",
+                            "title": "The serviceCertValidityDuration schema",
+                            "description": "The service certificate validity duration.",
+                            "examples": [
+                                "24h"
+                            ]
+                        },
+                        "certKeyBitSize": {
+                            "$id": "#/properties/OpenServiceMesh/properties/certificateProvider/properties/certKeyBitSize",
+                            "type": "integer",
+                            "title": "The certKeyBitSize schema",
+                            "description": "The key size for data plane certificates.",
+                            "examples": [
+                                2048
+                            ]
+                        }
+                    }
                 },
                 "caBundleSecretName": {
                     "$id": "#/properties/OpenServiceMesh/properties/caBundleSecretName",

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -266,6 +266,7 @@
                         "serviceCertValidityDuration",
                         "certKeyBitSize"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                         "kind": {
                             "$id": "#/properties/OpenServiceMesh/properties/certificateProvider/properties/kind",

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -278,7 +278,7 @@
                             ]
                         },
                         "serviceCertValidityDuration": {
-                            "$id": "#/properties/OpenServiceMesh/properties/certificateProvider/serviceCertValidityDuration",
+                            "$id": "#/properties/OpenServiceMesh/properties/certificateProvider/properties/serviceCertValidityDuration",
                             "type": "string",
                             "title": "The serviceCertValidityDuration schema",
                             "description": "The service certificate validity duration.",

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -263,8 +263,8 @@
                     "description": "Certificate provider configuration parameters",
                     "required": [
                         "kind",
-                        "issuerKind",
-                        "issuerGroup"
+                        "serviceCertValidityDuration",
+                        "certKeyBitSize"
                     ],
                     "properties": {
                         "kind": {

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -256,7 +256,7 @@
                         "envoyproxy/envoy-alpine:v1.18.3"
                     ]
                 },
-                "certficateProvider": {
+                "certificateProvider": {
                     "$id": "#/properties/OpenServiceMesh/properties/certificateProvider",
                     "type": "object",
                     "title": "The certificate provider schema",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -65,8 +65,13 @@ OpenServiceMesh:
       # -- Prometheus data retention time
       time: 15d
 
-  # -- The Certificate manager type: `tresor`, `vault` or `cert-manager`
-  certificateManager: tresor
+  certificateProvider:
+    # -- The Certificate manager type: `tresor`, `vault` or `cert-manager`
+    kind: tresor
+    # -- Service certificate validity duration for certificate issued to workloads to communicate over mTLS
+    serviceCertValidityDuration: 24h
+    # -- Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS
+    certKeyBitSize: 2048
 
   #
   # -- Hashicorp Vault configuration
@@ -89,12 +94,6 @@ OpenServiceMesh:
     issuerKind: Issuer
     # -- cert-manager issuer group
     issuerGroup: cert-manager.io
-
-  # -- Service certificate validity duration for certificate issued to workloads to communicate over mTLS
-  serviceCertValidityDuration: 24h
-
-  # -- Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS
-  certKeyBitSize: 2048
 
   # -- The Kubernetes secret name to store CA bundle for the root CA used in OSM
   caBundleSecretName: osm-ca-bundle

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -93,6 +93,9 @@ OpenServiceMesh:
   # -- Service certificate validity duration for certificate issued to workloads to communicate over mTLS
   serviceCertValidityDuration: 24h
 
+  # -- Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS
+  certKeyBitSize: 2048
+
   # -- The Kubernetes secret name to store CA bundle for the root CA used in OSM
   caBundleSecretName: osm-ca-bundle
 

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -236,7 +236,7 @@ func (i *installCmd) validateOptions() error {
 	}
 
 	if setOptions, ok := s["OpenServiceMesh"].(map[string]interface{}); ok {
-		// if the certificate manager is vault, ensure all relevant information (vault-host, vault-token) is available
+		// if the certificate provider kind is vault, ensure all relevant information (vault-host, vault-token) is available
 		if certProvider, ok := setOptions["certificateProvider"].(map[string]interface{}); ok && certProvider["kind"] == "vault" {
 			var missingFields []string
 			vaultOptions, ok := setOptions["vault"].(map[string]interface{})

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -236,8 +236,8 @@ func (i *installCmd) validateOptions() error {
 	}
 
 	if setOptions, ok := s["OpenServiceMesh"].(map[string]interface{}); ok {
-		// if certificateManager is vault, ensure all relevant information (vault-host, vault-token) is available
-		if setOptions["certificateManager"] == "vault" {
+		// if the certificate manager is vault, ensure all relevant information (vault-host, vault-token) is available
+		if certProvider, ok := setOptions["certificateProvider"].(map[string]interface{}); ok && certProvider["kind"] == "vault" {
 			var missingFields []string
 			vaultOptions, ok := setOptions["vault"].(map[string]interface{})
 			if !ok {

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Running the install command", func() {
 			installCmd := getDefaultInstallCmd(out)
 
 			installCmd.setOptions = []string{
-				"OpenServiceMesh.certificateManager=vault",
+				"OpenServiceMesh.certificateProvider.kind=vault",
 				fmt.Sprintf("OpenServiceMesh.vault.host=%s", testVaultHost),
 				fmt.Sprintf("OpenServiceMesh.vault.token=%s", testVaultToken),
 			}
@@ -225,7 +225,7 @@ var _ = Describe("Running the install command", func() {
 			It("should have the correct values", func() {
 				expectedValues := getDefaultValues()
 				valuesConfig := []string{
-					fmt.Sprintf("OpenServiceMesh.certificateManager=%s", "vault"),
+					fmt.Sprintf("OpenServiceMesh.certificateProvider.kind=%s", "vault"),
 					fmt.Sprintf("OpenServiceMesh.vault.host=%s", testVaultHost),
 					fmt.Sprintf("OpenServiceMesh.vault.token=%s", testVaultToken),
 				}
@@ -269,7 +269,7 @@ var _ = Describe("Running the install command", func() {
 
 			installCmd := getDefaultInstallCmd(out)
 			installCmd.setOptions = []string{
-				"OpenServiceMesh.certificateManager=vault",
+				"OpenServiceMesh.certificateProvider.kind=vault",
 			}
 			err = installCmd.run(config)
 		})
@@ -304,7 +304,7 @@ var _ = Describe("Running the install command", func() {
 
 			installCmd := getDefaultInstallCmd(out)
 			installCmd.setOptions = []string{
-				"OpenServiceMesh.certificateManager=cert-manager",
+				"OpenServiceMesh.certificateProvider.kind=cert-manager",
 			}
 			err = installCmd.run(config)
 		})
@@ -334,7 +334,7 @@ var _ = Describe("Running the install command", func() {
 			It("should have the correct values", func() {
 				expectedValues := getDefaultValues()
 				valuesConfig := []string{
-					fmt.Sprintf("OpenServiceMesh.certificateManager=%s", "cert-manager"),
+					fmt.Sprintf("OpenServiceMesh.certificateProvider.kind=%s", "cert-manager"),
 				}
 				for _, val := range valuesConfig {
 					// parses Helm strvals line and merges into a map
@@ -663,10 +663,10 @@ func TestEnforceSingleMesh(t *testing.T) {
 			fmt.Sprintf("OpenServiceMesh.envoyLogLevel=%s", testEnvoyLogLevel),
 			fmt.Sprintf("OpenServiceMesh.controllerLogLevel=%s", testControllerLogLevel),
 			fmt.Sprintf("OpenServiceMesh.prometheus.retention.time=%s", testRetentionTime),
-			"OpenServiceMesh.serviceCertValidityDuration=24h",
+			"OpenServiceMesh.certificateProvider.serviceCertValidityDuration=24h",
 			"OpenServiceMesh.deployGrafana=false",
 			"OpenServiceMesh.enableIngress=true",
-			"OpenServiceMesh.certificateManager=tresor",
+			"OpenServiceMesh.certificateProvider.kind=tresor",
 		},
 	}
 
@@ -722,11 +722,11 @@ func TestEnforceSingleMeshRejectsNewMesh(t *testing.T) {
 			fmt.Sprintf("OpenServiceMesh.envoyLogLevel=%s", testEnvoyLogLevel),
 			fmt.Sprintf("OpenServiceMesh.controllerLogLevel=%s", testControllerLogLevel),
 			fmt.Sprintf("OpenServiceMesh.prometheus.retention.time=%s", testRetentionTime),
-			"OpenServiceMesh.serviceCertValidityDuration=24h",
+			"OpenServiceMesh.certificateProvider.serviceCertValidityDuration=24h",
 			"OpenServiceMesh.deployGrafana=false",
 			"OpenServiceMesh.deployPrometheus=false",
 			"OpenServiceMesh.enableIngress=true",
-			"OpenServiceMesh.certificateManager=tresor",
+			"OpenServiceMesh.certificateProvider.kind=tresor",
 		},
 	}
 
@@ -772,11 +772,11 @@ func TestEnforceSingleMeshWithExistingMesh(t *testing.T) {
 			fmt.Sprintf("OpenServiceMesh.envoyLogLevel=%s", testEnvoyLogLevel),
 			fmt.Sprintf("OpenServiceMesh.controllerLogLevel=%s", testControllerLogLevel),
 			fmt.Sprintf("OpenServiceMesh.prometheus.retention.time=%s", testRetentionTime),
-			"OpenServiceMesh.serviceCertValidityDuration=24h",
+			"OpenServiceMesh.certificateProvider.serviceCertValidityDuration=24h",
 			"OpenServiceMesh.deployPrometheus=true",
 			"OpenServiceMesh.deployGrafana=false",
 			"OpenServiceMesh.enableIngress=true",
-			"OpenServiceMesh.certificateManager=tresor",
+			"OpenServiceMesh.certificateProvider.kind=tresor",
 		},
 	}
 

--- a/cmd/osm-controller/gateway_test.go
+++ b/cmd/osm-controller/gateway_test.go
@@ -22,6 +22,7 @@ func TestBootstrapOSMGateway(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	fakeCertManager := tresor.NewFakeCertManager(mockConfigurator)
 	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(15 * time.Second).AnyTimes()
+	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 	testCases := []struct {
 		name            string

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -92,7 +92,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
   bin/osm install \
       --osm-namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
-      --set=OpenServiceMesh.certificateManager="$CERT_MANAGER" \
+      --set=OpenServiceMesh.certificateProvider.kind="$CERT_MANAGER" \
       --set=OpenServiceMesh.vault.host="$VAULT_HOST" \
       --set=OpenServiceMesh.vault.token="$VAULT_TOKEN" \
       --set=OpenServiceMesh.vault.protocol="$VAULT_PROTOCOL" \
@@ -115,7 +115,7 @@ else
   bin/osm install \
       --osm-namespace "$K8S_NAMESPACE" \
       --mesh-name "$MESH_NAME" \
-      --set=OpenServiceMesh.certificateManager="$CERT_MANAGER" \
+      --set=OpenServiceMesh.certificateProvider.kind="$CERT_MANAGER" \
       --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
       --set=OpenServiceMesh.imagePullSecrets[0].name="$CTR_REGISTRY_CREDS_NAME" \
       --set=OpenServiceMesh.image.tag="$CTR_TAG" \

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -146,6 +146,9 @@ type ExternalAuthzSpec struct {
 type CertificateSpec struct {
 	// ServiceCertValidityDuration defines the service certificate validity duration.
 	ServiceCertValidityDuration string `json:"serviceCertValidityDuration,omitempty"`
+
+	// CertKeyBitSize defines the certicate key bit size.
+	CertKeyBitSize int `json:"certKeyBitSize,omitempty"`
 }
 
 // MulticlusterSpec represents multicluster configurations.

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -82,10 +82,10 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
 	start := time.Now()
 
-	if cm.validityPeriod == 0 {
-		cm.validityPeriod = cm.cfg.GetServiceCertValidityPeriod()
+	if cm.serviceCertValidityDuration == 0 {
+		cm.serviceCertValidityDuration = cm.cfg.GetServiceCertValidityPeriod()
 	}
-	newCert, err := cm.issue(cn, cm.validityPeriod)
+	newCert, err := cm.issue(cn, cm.serviceCertValidityDuration)
 	if err != nil {
 		return newCert, err
 	}
@@ -245,7 +245,7 @@ func NewCertManager(
 	namespace string,
 	issuerRef cmmeta.ObjectReference,
 	cfg configurator.Configurator,
-	validityPeriod time.Duration,
+	serviceCertValidityDuration time.Duration,
 	keySize int,
 ) (*CertManager, error) {
 	informerFactory := cminformers.NewSharedInformerFactory(client, time.Second*30)
@@ -255,15 +255,15 @@ func NewCertManager(
 	informerFactory.Start(make(chan struct{}))
 
 	cm := &CertManager{
-		ca:             ca,
-		cache:          make(map[certificate.CommonName]certificate.Certificater),
-		namespace:      namespace,
-		client:         client.CertmanagerV1().CertificateRequests(namespace),
-		issuerRef:      issuerRef,
-		crLister:       crLister,
-		cfg:            cfg,
-		validityPeriod: validityPeriod,
-		keySize:        keySize,
+		ca:                          ca,
+		cache:                       make(map[certificate.CommonName]certificate.Certificater),
+		namespace:                   namespace,
+		client:                      client.CertmanagerV1().CertificateRequests(namespace),
+		issuerRef:                   issuerRef,
+		crLister:                    crLister,
+		cfg:                         cfg,
+		serviceCertValidityDuration: serviceCertValidityDuration,
+		keySize:                     keySize,
 	}
 
 	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -82,6 +82,10 @@ func (cm *CertManager) getFromCache(cn certificate.CommonName) certificate.Certi
 func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate.Certificater, error) {
 	start := time.Now()
 
+	// We want the validity duration of the CertManager to remain static during the lifetime
+	// of the CertManager. This tests to see if this value is set, and if it isn't then it
+	// should make the infrequent call to configuration to get this value and cache it for
+	// future certificate operations.
 	if cm.serviceCertValidityDuration == 0 {
 		cm.serviceCertValidityDuration = cm.cfg.GetServiceCertValidityPeriod()
 	}
@@ -151,6 +155,9 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 		Duration: validityPeriod,
 	}
 
+	// Key bit size should remain static during the lifetime of the CertManager. In the event that this
+	// is a zero value, we make the call to config to get the setting and then cache it for future
+	// certificate operations.
 	if cm.keySize == 0 {
 		cm.keySize = cm.cfg.GetCertKeyBitSize()
 	}

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -148,7 +148,8 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 		Duration: validityPeriod,
 	}
 
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, rsaBits)
+	certKeyBitSize := cm.cfg.GetCertKeyBitSize()
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, certKeyBitSize)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingPrivateKey.String()).
 			Msgf("Error generating private key for certificate with CN=%s", cn)

--- a/pkg/certificate/providers/certmanager/certificate_manager_test.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Test cert-manager Certificate Manager", func() {
 
 	Context("Test Getting a certificate from the cache", func() {
 		validity := 1 * time.Hour
+		keySize := 2048
 
 		rootCertPEM, err := tests.GetPEMCert()
 		if err != nil {
@@ -110,6 +111,8 @@ var _ = Describe("Test cert-manager Certificate Manager", func() {
 
 		cm, newCertError := NewCertManager(rootCertificator, fakeClient, "osm-system", cmmeta.ObjectReference{Name: "osm-ca"}, mockConfigurator)
 		It("should get an issued certificate from the cache", func() {
+			mockConfigurator.EXPECT().GetCertKeyBitSize().Return(keySize).AnyTimes()
+
 			Expect(newCertError).ToNot(HaveOccurred())
 			cert, issueCertificateError := cm.IssueCertificate(cn, validity)
 			Expect(issueCertificateError).ToNot(HaveOccurred())
@@ -122,6 +125,7 @@ var _ = Describe("Test cert-manager Certificate Manager", func() {
 
 		It("should rotate the certificate", func() {
 			mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+			mockConfigurator.EXPECT().GetCertKeyBitSize().Return(keySize).AnyTimes()
 
 			cert, err := cm.RotateCertificate(cn)
 			Expect(err).Should(BeNil())

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -16,9 +16,6 @@ import (
 )
 
 const (
-	// How many bits to use for the RSA key
-	rsaBits = 4096
-
 	// checkCertificateExpirationInterval is the interval to check whether a
 	// certificate is close to expiration and needs renewal.
 	checkCertificateExpirationInterval = 5 * time.Second

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -51,8 +51,8 @@ type CertManager struct {
 	cfg configurator.Configurator
 
 	// Issuing certificate properties.
-	validityPeriod time.Duration
-	keySize        int
+	serviceCertValidityDuration time.Duration
+	keySize                     int
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/certmanager/types.go
+++ b/pkg/certificate/providers/certmanager/types.go
@@ -49,6 +49,10 @@ type CertManager struct {
 	crLister cmlisters.CertificateRequestNamespaceLister
 
 	cfg configurator.Configurator
+
+	// Issuing certificate properties.
+	validityPeriod time.Duration
+	keySize        int
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -229,7 +229,13 @@ func (c *Config) getTresorOSMCertificateManager() (certificate.Manager, debugger
 		return nil, nil, errors.Errorf("Failed to synchronize certificate on Secrets API : %v", err)
 	}
 
-	certManager, err := tresor.NewCertManager(rootCert, rootCertOrganization, c.cfg)
+	certManager, err := tresor.NewCertManager(
+		rootCert,
+		rootCertOrganization,
+		c.cfg,
+		c.cfg.GetServiceCertValidityPeriod(),
+		c.cfg.GetCertKeyBitSize(),
+	)
 	if err != nil {
 		return nil, nil, errors.Errorf("Failed to instantiate Tresor as a Certificate Manager")
 	}
@@ -292,7 +298,13 @@ func (c *Config) getHashiVaultOSMCertificateManager(options VaultOptions) (certi
 
 	// A Vault address would have the following shape: "http://vault.default.svc.cluster.local:8200"
 	vaultAddr := fmt.Sprintf("%s://%s:%d", options.VaultProtocol, options.VaultHost, options.VaultPort)
-	vaultCertManager, err := vault.NewCertManager(vaultAddr, options.VaultToken, options.VaultRole, c.cfg)
+	vaultCertManager, err := vault.NewCertManager(
+		vaultAddr,
+		options.VaultToken,
+		options.VaultRole,
+		c.cfg,
+		c.cfg.GetServiceCertValidityPeriod(),
+	)
 	if err != nil {
 		return nil, nil, errors.Errorf("Error instantiating Hashicorp Vault as a Certificate Manager: %+v", err)
 	}
@@ -322,11 +334,19 @@ func (c *Config) getCertManagerOSMCertificateManager(options CertManagerOptions)
 		return nil, nil, fmt.Errorf("Failed to build cert-manager client set: %s", err)
 	}
 
-	certmanagerCertManager, err := certmanager.NewCertManager(rootCert, client, c.providerNamespace, cmmeta.ObjectReference{
-		Name:  options.IssuerName,
-		Kind:  options.IssuerKind,
-		Group: options.IssuerGroup,
-	}, c.cfg)
+	certmanagerCertManager, err := certmanager.NewCertManager(
+		rootCert,
+		client,
+		c.providerNamespace,
+		cmmeta.ObjectReference{
+			Name:  options.IssuerName,
+			Kind:  options.IssuerKind,
+			Group: options.IssuerGroup,
+		},
+		c.cfg,
+		c.cfg.GetServiceCertValidityPeriod(),
+		c.cfg.GetCertKeyBitSize(),
+	)
 	if err != nil {
 		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager as a Certificate Manager: %+v", err)
 	}

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -26,6 +26,8 @@ func TestGetCertificateManager(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
 	mockConfigurator.EXPECT().IsDebugServerEnabled().Return(false).AnyTimes()
+	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
+	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
 
 	testCases := []struct {
 		name string

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -43,18 +43,23 @@ func (c Certificate) GetSerialNumber() certificate.SerialNumber {
 }
 
 // NewCertManager creates a new CertManager with the passed CA and CA Private Key
-func NewCertManager(ca certificate.Certificater, certificatesOrganization string, cfg configurator.Configurator) (*CertManager, error) {
+func NewCertManager(
+	ca certificate.Certificater,
+	certificatesOrganization string,
+	cfg configurator.Configurator,
+	validityPeriod time.Duration,
+	keySize int) (*CertManager, error) {
 	if ca == nil {
 		return nil, errNoIssuingCA
 	}
 
 	certManager := CertManager{
 		// The root certificate signing all newly issued certificates
-		ca: ca,
-
+		ca:                       ca,
 		certificatesOrganization: certificatesOrganization,
-
-		cfg: cfg,
+		cfg:                      cfg,
+		validityPeriod:           validityPeriod,
+		keySize:                  keySize,
 	}
 
 	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.

--- a/pkg/certificate/providers/tresor/certificate.go
+++ b/pkg/certificate/providers/tresor/certificate.go
@@ -47,7 +47,7 @@ func NewCertManager(
 	ca certificate.Certificater,
 	certificatesOrganization string,
 	cfg configurator.Configurator,
-	validityPeriod time.Duration,
+	serviceCertValidityDuration time.Duration,
 	keySize int) (*CertManager, error) {
 	if ca == nil {
 		return nil, errNoIssuingCA
@@ -55,11 +55,11 @@ func NewCertManager(
 
 	certManager := CertManager{
 		// The root certificate signing all newly issued certificates
-		ca:                       ca,
-		certificatesOrganization: certificatesOrganization,
-		cfg:                      cfg,
-		validityPeriod:           validityPeriod,
-		keySize:                  keySize,
+		ca:                          ca,
+		certificatesOrganization:    certificatesOrganization,
+		cfg:                         cfg,
+		serviceCertValidityDuration: serviceCertValidityDuration,
+		keySize:                     keySize,
 	}
 
 	// Instantiating a new certificate rotation mechanism will start a goroutine for certificate rotation.

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -22,7 +22,10 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 		return nil, errNoIssuingCA
 	}
 
-	certKeyBitSize := cm.cfg.GetCertKeyBitSize()
+	certKeyBitSize := rsaBits
+	if cm.cfg != nil {
+		certKeyBitSize = cm.cfg.GetCertKeyBitSize()
+	}
 	certPrivKey, err := rsa.GenerateKey(rand.Reader, certKeyBitSize)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingPrivateKey.String()).

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -162,10 +162,10 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 		return nil, errors.Errorf("Old certificate does not exist for CN=%s", cn)
 	}
 
-	if cm.validityPeriod == 0 {
-		cm.validityPeriod = cm.cfg.GetServiceCertValidityPeriod()
+	if cm.serviceCertValidityDuration == 0 {
+		cm.serviceCertValidityDuration = cm.cfg.GetServiceCertValidityPeriod()
 	}
-	newCert, err := cm.issue(cn, cm.validityPeriod)
+	newCert, err := cm.issue(cn, cm.serviceCertValidityDuration)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -22,6 +22,9 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 		return nil, errNoIssuingCA
 	}
 
+	// Key bit size should remain static during the lifetime of the CertManager. In the event that this
+	// is a zero value, we make the call to config to get the setting and then cache it for future
+	// certificate operations.
 	if cm.keySize == 0 {
 		cm.keySize = cm.cfg.GetCertKeyBitSize()
 	}
@@ -162,6 +165,10 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 		return nil, errors.Errorf("Old certificate does not exist for CN=%s", cn)
 	}
 
+	// We want the validity duration of the CertManager to remain static during the lifetime
+	// of the CertManager. This tests to see if this value is set, and if it isn't then it
+	// should make the infrequent call to configuration to get this value and cache it for
+	// future certificate operations.
 	if cm.serviceCertValidityDuration == 0 {
 		cm.serviceCertValidityDuration = cm.cfg.GetServiceCertValidityPeriod()
 	}

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -22,7 +22,8 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 		return nil, errNoIssuingCA
 	}
 
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, rsaBits)
+	certKeyBitSize := cm.cfg.GetCertKeyBitSize()
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, certKeyBitSize)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingPrivateKey.String()).
 			Msgf("Error generating private key for certificate with CN=%s", cn)

--- a/pkg/certificate/providers/tresor/certificate_manager_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Test Certificate Manager", func() {
 
 		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+		mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 		rootCert, err := NewCA(cn, 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
 		if err != nil {
@@ -78,6 +79,7 @@ var _ = Describe("Test Certificate Manager", func() {
 
 		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+		mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 		rootCert, err := NewCA(cn, validity, rootCertCountry, rootCertLocality, rootCertOrganization)
 		if err != nil {
@@ -202,6 +204,7 @@ func TestGetCertificate(t *testing.T) {
 
 func TestRotateCertificate(t *testing.T) {
 	validity := 1 * time.Hour
+	keySize := 2048
 
 	ca := certificate.CommonName("Test CA")
 	rootCertCountry := "US"
@@ -223,6 +226,7 @@ func TestRotateCertificate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validity).AnyTimes()
+	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(keySize).AnyTimes()
 
 	manager := &CertManager{ca: rootCert, cfg: mockConfigurator}
 	manager.cache.Store(cn, oldCert)

--- a/pkg/certificate/providers/tresor/certificate_manager_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_test.go
@@ -44,7 +44,13 @@ var _ = Describe("Test Certificate Manager", func() {
 		if err != nil {
 			GinkgoT().Fatalf("Error loading CA from files %s and %s: %s", rootCertPem, rootKeyPem, err.Error())
 		}
-		m, newCertError := NewCertManager(rootCert, "org", mockConfigurator)
+		m, newCertError := NewCertManager(
+			rootCert,
+			"org",
+			mockConfigurator,
+			mockConfigurator.GetServiceCertValidityPeriod(),
+			mockConfigurator.GetCertKeyBitSize(),
+		)
 		It("should issue a certificate", func() {
 			Expect(newCertError).ToNot(HaveOccurred())
 			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)
@@ -85,7 +91,13 @@ var _ = Describe("Test Certificate Manager", func() {
 		if err != nil {
 			GinkgoT().Fatalf("Error loading CA from files %s and %s: %s", rootCertPem, rootKeyPem, err.Error())
 		}
-		m, newCertError := NewCertManager(rootCert, "org", mockConfigurator)
+		m, newCertError := NewCertManager(
+			rootCert,
+			"org",
+			mockConfigurator,
+			mockConfigurator.GetServiceCertValidityPeriod(),
+			mockConfigurator.GetCertKeyBitSize(),
+		)
 		It("should get an issued certificate from the cache", func() {
 			Expect(newCertError).ToNot(HaveOccurred())
 			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -40,6 +40,9 @@ type CertManager struct {
 	certificatesOrganization string
 
 	cfg configurator.Configurator
+
+	validityPeriod time.Duration
+	keySize        int
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -41,8 +41,8 @@ type CertManager struct {
 
 	cfg configurator.Configurator
 
-	validityPeriod time.Duration
-	keySize        int
+	serviceCertValidityDuration time.Duration
+	keySize                     int
 }
 
 // Certificate implements certificate.Certificater

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -176,6 +176,10 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 		return nil, errors.Errorf("Old certificate does not exist for CN=%s", cn)
 	}
 
+	// We want the validity duration of the CertManager to remain static during the lifetime
+	// of the CertManager. This tests to see if this value is set, and if it isn't then it
+	// should make the infrequent call to configuration to get this value and cache it for
+	// future certificate operations.
 	if cm.serviceCertValidityDuration == 0 {
 		cm.serviceCertValidityDuration = cm.cfg.GetServiceCertValidityPeriod()
 	}

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -39,11 +39,11 @@ func NewCertManager(
 	token string,
 	role string,
 	cfg configurator.Configurator,
-	validityPeriod time.Duration) (*CertManager, error) {
+	serviceCertValidityDuration time.Duration) (*CertManager, error) {
 	c := &CertManager{
-		role:           vaultRole(role),
-		cfg:            cfg,
-		validityPeriod: validityPeriod,
+		role:                        vaultRole(role),
+		cfg:                         cfg,
+		serviceCertValidityDuration: serviceCertValidityDuration,
 	}
 	config := api.DefaultConfig()
 	config.Address = vaultAddr
@@ -176,10 +176,10 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 		return nil, errors.Errorf("Old certificate does not exist for CN=%s", cn)
 	}
 
-	if cm.validityPeriod == 0 {
-		cm.validityPeriod = cm.cfg.GetServiceCertValidityPeriod()
+	if cm.serviceCertValidityDuration == 0 {
+		cm.serviceCertValidityDuration = cm.cfg.GetServiceCertValidityPeriod()
 	}
-	newCert, err := cm.issue(cn, cm.validityPeriod)
+	newCert, err := cm.issue(cn, cm.serviceCertValidityDuration)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -69,7 +69,13 @@ var _ = Describe("Test client helpers", func() {
 			mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 			mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(validityPeriod).AnyTimes()
 
-			_, err := NewCertManager(vaultAddr, vaultToken, vaultRole, mockConfigurator)
+			_, err := NewCertManager(
+				vaultAddr,
+				vaultToken,
+				vaultRole,
+				mockConfigurator,
+				mockConfigurator.GetServiceCertValidityPeriod(),
+			)
 			Expect(err).To(HaveOccurred())
 			vaultError := err.(*url.Error)
 			expected := `unsupported protocol scheme "foo"`

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -3,6 +3,7 @@ package vault
 
 import (
 	"sync"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 
@@ -26,6 +27,8 @@ type CertManager struct {
 	role vaultRole
 
 	cfg configurator.Configurator
+
+	validityPeriod time.Duration
 }
 
 type vaultRole string

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -28,7 +28,7 @@ type CertManager struct {
 
 	cfg configurator.Configurator
 
-	validityPeriod time.Duration
+	serviceCertValidityDuration time.Duration
 }
 
 type vaultRole string

--- a/pkg/certificate/rotor/rotor_test.go
+++ b/pkg/certificate/rotor/rotor_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Test Rotor", func() {
 		validityPeriod := 1 * time.Hour
 		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Times(0)
+		mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 		certManager := tresor.NewFakeCertManager(mockConfigurator)
 
@@ -49,6 +50,7 @@ var _ = Describe("Test Rotor", func() {
 
 		mockConfigurator = configurator.NewMockConfigurator(mockCtrl)
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
+		mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 		certManager := tresor.NewFakeCertManager(mockConfigurator)
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -16,6 +16,15 @@ import (
 const (
 	// defaultServiceCertValidityDuration is the default validity duration for service certificates
 	defaultServiceCertValidityDuration = 24 * time.Hour
+
+	// defaultCertKeyBitSize is the default certificate key bit size
+	defaultCertKeyBitSize = 2048
+
+	// minCertKeyBitSize is the minimum certificate key bit size
+	minCertKeyBitSize = 512
+
+	// maxCertKeyBitSize is the maximum certificate key bit size
+	maxCertKeyBitSize = 4096
 )
 
 // The functions in this file implement the configurator.Configurator interface
@@ -140,6 +149,17 @@ func (c *Client) GetServiceCertValidityPeriod() time.Duration {
 	}
 
 	return validityDuration
+}
+
+// GetCertKeyBitSize returns the certificate key bit size to be used
+func (c *Client) GetCertKeyBitSize() int {
+	bitSize := c.getMeshConfig().Spec.Certificate.CertKeyBitSize
+	if bitSize < minCertKeyBitSize || bitSize > maxCertKeyBitSize {
+		log.Error().Msgf("Invalid key bit size: %d", bitSize)
+		return defaultCertKeyBitSize
+	}
+
+	return bitSize
 }
 
 // GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -21,7 +21,7 @@ const (
 	defaultCertKeyBitSize = 2048
 
 	// minCertKeyBitSize is the minimum certificate key bit size
-	minCertKeyBitSize = 512
+	minCertKeyBitSize = 2048
 
 	// maxCertKeyBitSize is the maximum certificate key bit size
 	maxCertKeyBitSize = 4096

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -279,6 +279,25 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "GetCertKeyBitSize",
+			initialMeshConfigData: &v1alpha1.MeshConfigSpec{
+				Certificate: v1alpha1.CertificateSpec{
+					CertKeyBitSize: 4096,
+				},
+			},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal(4096, cfg.GetCertKeyBitSize())
+			},
+			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
+				Certificate: v1alpha1.CertificateSpec{
+					CertKeyBitSize: -10,
+				},
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal(defaultCertKeyBitSize, cfg.GetCertKeyBitSize())
+			},
+		},
+		{
 			name:                  "GetOutboundIPRangeExclusionList",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -37,6 +37,20 @@ func (m *MockConfigurator) EXPECT() *MockConfiguratorMockRecorder {
 	return m.recorder
 }
 
+// GetCertKeyBitSize mocks base method
+func (m *MockConfigurator) GetCertKeyBitSize() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCertKeyBitSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// GetCertKeyBitSize indicates an expected call of GetCertKeyBitSize
+func (mr *MockConfiguratorMockRecorder) GetCertKeyBitSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertKeyBitSize", reflect.TypeOf((*MockConfigurator)(nil).GetCertKeyBitSize))
+}
+
 // GetClusterDomain mocks base method
 func (m *MockConfigurator) GetClusterDomain() string {
 	m.ctrl.T.Helper()

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -75,6 +75,9 @@ type Configurator interface {
 	// GetServiceCertValidityPeriod returns the validity duration for service certificates
 	GetServiceCertValidityPeriod() time.Duration
 
+	// GetCertKeyBitSize returns the certificate key bit size
+	GetCertKeyBitSize() int
+
 	// GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
 	GetOutboundIPRangeExclusionList() []string
 

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -85,6 +85,8 @@ func TestNewConversionWebhook(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	keySize := 2048
+	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(keySize).AnyTimes()
 	fakeCertManager := tresor.NewFakeCertManager(mockConfigurator)
 	osmNamespace := "-osm-namespace-"
 	stop := make(<-chan struct{})

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -60,6 +60,8 @@ var _ = Describe("Test ADS response functions", func() {
 	}
 	proxySvcAccount := tests.BookstoreServiceAccount
 
+	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
+
 	labels := map[string]string{constants.EnvoyUniqueIDLabelName: proxyUUID.String()}
 	mc := catalog.NewFakeMeshCatalog(kubeClient, configClient)
 	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
@@ -134,6 +136,7 @@ var _ = Describe("Test ADS response functions", func() {
 		mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 		mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(certDuration).AnyTimes()
+		mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 		mockConfigurator.EXPECT().IsDebugServerEnabled().Return(true).AnyTimes()
 		mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{
 			EnableWASMStats:    false,

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -114,6 +114,7 @@ func TestCreatePatch(t *testing.T) {
 			mockConfigurator.EXPECT().GetOutboundPortExclusionList().Return(nil).Times(1)
 			mockConfigurator.EXPECT().GetInboundPortExclusionList().Return(nil).Times(1)
 			mockConfigurator.EXPECT().GetProxyResources().Return(corev1.ResourceRequirements{}).Times(1)
+			mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 			pod := tests.NewPodFixture(namespace, podName, tests.BookstoreServiceAccountName, nil)
 

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -509,6 +509,8 @@ var _ = Describe("Testing Injector Functions", func() {
 		cfg := configurator.NewMockConfigurator(mockController)
 		certManager := tresor.NewFakeCertManager(cfg)
 
+		cfg.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
+
 		actualErr := NewMutatingWebhook(injectorConfig, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, stop, cfg)
 		expectedErrorMessage := "Error configuring MutatingWebhookConfiguration -webhook-name-: mutatingwebhookconfigurations.admissionregistration.k8s.io \"-webhook-name-\" not found"
 		Expect(actualErr.Error()).To(Equal(expectedErrorMessage))

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -491,10 +491,6 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 		)
 	}
 
-	instOpts.SetOverrides = append(instOpts.SetOverrides,
-		fmt.Sprintf("OpenServiceMesh.certKeyBitSize=%d", instOpts.CertBitSize),
-	)
-
 	td.T.Logf("Setting log OSM's log level through overrides to %s", instOpts.OSMLogLevel)
 	instOpts.SetOverrides = append(instOpts.SetOverrides,
 		fmt.Sprintf("OpenServiceMesh.controllerLogLevel=%s", instOpts.OSMLogLevel))

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -443,7 +443,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	instOpts.SetOverrides = append(instOpts.SetOverrides,
 		fmt.Sprintf("OpenServiceMesh.image.registry=%s", instOpts.ContainerRegistryLoc),
 		fmt.Sprintf("OpenServiceMesh.image.tag=%s", instOpts.OsmImagetag),
-		fmt.Sprintf("OpenServiceMesh.certificateManager=%s", instOpts.CertManager),
+		fmt.Sprintf("OpenServiceMesh.certificateProvider.kind=%s", instOpts.CertManager),
 		fmt.Sprintf("OpenServiceMesh.enableEgress=%v", instOpts.EgressEnabled),
 		fmt.Sprintf("OpenServiceMesh.enablePermissiveTrafficPolicy=%v", instOpts.EnablePermissiveMode),
 		fmt.Sprintf("OpenServiceMesh.enableDebugServer=%v", instOpts.EnableDebugServer),

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -325,6 +325,7 @@ func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 		CertmanagerIssuerGroup: "cert-manager.io",
 		CertmanagerIssuerKind:  "Issuer",
 		CertmanagerIssuerName:  "osm-ca",
+		CertBitSize:            2048,
 		EnvoyLogLevel:          defaultEnvoyLogLevel,
 		OSMLogLevel:            defaultOSMLogLevel,
 		EnableDebugServer:      true,
@@ -396,6 +397,7 @@ func setMeshConfigToDefault(instOpts InstallOSMOpts, meshConfig *v1alpha1.MeshCo
 	meshConfig.Spec.Sidecar.ConfigResyncInterval = "0s"
 
 	meshConfig.Spec.Certificate.ServiceCertValidityDuration = "24h"
+	meshConfig.Spec.Certificate.CertKeyBitSize = instOpts.CertBitSize
 
 	return meshConfig
 }
@@ -488,6 +490,10 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 			fmt.Sprintf("OpenServiceMesh.imagePullSecrets[0].name=%s", RegistrySecretName),
 		)
 	}
+
+	instOpts.SetOverrides = append(instOpts.SetOverrides,
+		fmt.Sprintf("OpenServiceMesh.certKeyBitSize=%d", instOpts.CertBitSize),
+	)
 
 	td.T.Logf("Setting log OSM's log level through overrides to %s", instOpts.OSMLogLevel)
 	instOpts.SetOverrides = append(instOpts.SetOverrides,

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -325,7 +325,7 @@ func (td *OsmTestData) GetOSMInstallOpts() InstallOSMOpts {
 		CertmanagerIssuerGroup: "cert-manager.io",
 		CertmanagerIssuerKind:  "Issuer",
 		CertmanagerIssuerName:  "osm-ca",
-		CertBitSize:            2048,
+		CertKeyBitSize:         2048,
 		EnvoyLogLevel:          defaultEnvoyLogLevel,
 		OSMLogLevel:            defaultOSMLogLevel,
 		EnableDebugServer:      true,
@@ -397,7 +397,7 @@ func setMeshConfigToDefault(instOpts InstallOSMOpts, meshConfig *v1alpha1.MeshCo
 	meshConfig.Spec.Sidecar.ConfigResyncInterval = "0s"
 
 	meshConfig.Spec.Certificate.ServiceCertValidityDuration = "24h"
-	meshConfig.Spec.Certificate.CertKeyBitSize = instOpts.CertBitSize
+	meshConfig.Spec.Certificate.CertKeyBitSize = instOpts.CertKeyBitSize
 
 	return meshConfig
 }

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -93,7 +93,7 @@ type InstallOSMOpts struct {
 	CertmanagerIssuerGroup string
 	CertmanagerIssuerKind  string
 	CertmanagerIssuerName  string
-	CertBitSize            int
+	CertKeyBitSize         int
 
 	EgressEnabled        bool
 	EnablePermissiveMode bool

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -93,6 +93,7 @@ type InstallOSMOpts struct {
 	CertmanagerIssuerGroup string
 	CertmanagerIssuerKind  string
 	CertmanagerIssuerName  string
+	CertBitSize            int
 
 	EgressEnabled        bool
 	EnablePermissiveMode bool

--- a/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
+++ b/tests/scenarios/scenario_mutatingwebhook_reconcile_test.go
@@ -52,6 +52,7 @@ var _ = OSMDescribe("Reconcile MutatingWebhookConfiguration",
 
 				mockController := gomock.NewController(GinkgoT())
 				cfgMock := configurator.NewMockConfigurator(mockController)
+				cfgMock.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
 				certManager := tresor.NewFakeCertManager(cfgMock)
 				cn := certificate.CommonName(fmt.Sprintf("%s.%s.svc", constants.OSMControllerName, testWebhookServiceNamespace))


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This PR addresses #1933. With this PR, the certificate key size is now configurable through mesh config as `certKeyBitSize`. Prior to this PR, it was hard coded.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |
| Certificate Management     | [x] |
| Security                   | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?

No.

1. Is this a breaking change?

No.
