### PR TITLE
feat(*): add Envoy active health checks

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -83,6 +83,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |
 | OpenServiceMesh.featureFlags.enableCRDConverter | bool | `true` | Enable CRD conversion webhook. When enabled, a conversion webhook will be deployed to perform API version conversions for custom resources. |
 | OpenServiceMesh.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API. When enabled, fine grained control over Egress (external) traffic is enforced |
+| OpenServiceMesh.featureFlags.enableEnvoyActiveHealthChecks | bool | `false` | Enable Envoy active health checks |
 | OpenServiceMesh.featureFlags.enableIngressBackendPolicy | bool | `false` | Enables OSM's IngressBackend policy API. When enabled, OSM will use the IngressBackend API allow ingress traffic to mesh backends |
 | OpenServiceMesh.featureFlags.enableMulticlusterMode | bool | `false` | Enable Multicluster mode. When enabled, multicluster mode will be enabled in OSM |
 | OpenServiceMesh.featureFlags.enableOSMGateway | bool | `false` | Enable OSM gateway for ingress or multicluster |

--- a/charts/osm/crds/config_meshconfig.yaml
+++ b/charts/osm/crds/config_meshconfig.yaml
@@ -230,4 +230,7 @@ spec:
                     enableIngressBackendPolicy:
                       type: boolean
                       default: false
+                    enableEnvoyActiveHealthChecks:
+                      type: boolean
+                      default: false
 

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -43,6 +43,7 @@ data:
         "enableOSMGateway": {{.Values.OpenServiceMesh.featureFlags.enableOSMGateway}},
         "enableAsyncProxyServiceMapping": {{.Values.OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping}},
         "enableValidatingWebhook": {{.Values.OpenServiceMesh.featureFlags.enableValidatingWebhook}},
-        "enableIngressBackendPolicy": {{.Values.OpenServiceMesh.featureFlags.enableIngressBackendPolicy}}
+        "enableIngressBackendPolicy": {{.Values.OpenServiceMesh.featureFlags.enableIngressBackendPolicy}},
+        "enableEnvoyActiveHealthChecks": {{.Values.OpenServiceMesh.featureFlags.enableEnvoyActiveHealthChecks}}
       }
     }

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -55,7 +55,7 @@ data:
         - role: pod
         metric_relabel_configs:
         - source_labels: [__name__]
-          regex: '(envoy_server_live|envoy_cluster_upstream_rq_xx|envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_tx_bytes_total|envoy_cluster_upstream_cx_rx_bytes_total|envoy_cluster_upstream_cx_destroy_remote_with_active_rq|envoy_cluster_upstream_cx_connect_timeout|envoy_cluster_upstream_cx_destroy_local_with_active_rq|envoy_cluster_upstream_rq_pending_failure_eject|envoy_cluster_upstream_rq_pending_overflow|envoy_cluster_upstream_rq_timeout|envoy_cluster_upstream_rq_rx_reset|^osm.*)'
+          regex: '(envoy_server_live|envoy_cluster_health_check_.*|envoy_cluster_upstream_rq_xx|envoy_cluster_upstream_cx_active|envoy_cluster_upstream_cx_tx_bytes_total|envoy_cluster_upstream_cx_rx_bytes_total|envoy_cluster_upstream_cx_destroy_remote_with_active_rq|envoy_cluster_upstream_cx_connect_timeout|envoy_cluster_upstream_cx_destroy_local_with_active_rq|envoy_cluster_upstream_rq_pending_failure_eject|envoy_cluster_upstream_rq_pending_overflow|envoy_cluster_upstream_rq_timeout|envoy_cluster_upstream_rq_rx_reset|^osm.*)'
           action: keep
         relabel_configs: 
         - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -741,7 +741,8 @@
                         "enableAsyncProxyServiceMapping",
                         "enableValidatingWebhook",
                         "enableCRDConverter",
-                        "enableIngressBackendPolicy"
+                        "enableIngressBackendPolicy",
+                        "enableEnvoyActiveHealthChecks"
                     ],
                     "properties": {
                         "enableWASMStats": {
@@ -812,6 +813,15 @@
                             "type": "boolean",
                             "title": "Enable OSM to use the IngressBackend API",
                             "description": "Enable OSM to use the IngressBackend API for allowing ingress to mesh backends",
+                            "examples": [
+                                true
+                            ]
+                        },
+                        "enableEnvoyActiveHealthChecks": {
+                            "$id": "#/properties/OpenServiceMesh/properties/featureFlags/properties/enableEnvoyActiveHealthChecks",
+                            "type": "boolean",
+                            "title": "Enable Envoy active health checks",
+                            "description": "EnableEnvoyActiveHealthChecks defines if OSM will Envoy active health checks between services allowed to communicate",
                             "examples": [
                                 true
                             ]

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -260,6 +260,8 @@ OpenServiceMesh:
     # -- Enables OSM's IngressBackend policy API.
     # When enabled, OSM will use the IngressBackend API allow ingress traffic to mesh backends
     enableIngressBackendPolicy: false
+    # -- Enable Envoy active health checks
+    enableEnvoyActiveHealthChecks: false
 
   #
   # -- OSM multicluster feature configuration

--- a/cmd/init-osm-controller/init-osm-controller_test.go
+++ b/cmd/init-osm-controller/init-osm-controller_test.go
@@ -54,7 +54,8 @@ func TestCreateDefaultMeshConfig(t *testing.T) {
 	"enableOSMGateway": false,
 	"enableAsyncProxyServiceMapping": false,
 	"enableValidatingWebhook": false,
-	"enableIngressBackendPolicy": true
+	"enableIngressBackendPolicy": true,
+	"enableEnvoyActiveHealthChecks": true
 	}
 }`,
 		},
@@ -71,6 +72,7 @@ func TestCreateDefaultMeshConfig(t *testing.T) {
 	assert.False(meshConfig.Spec.Observability.EnableDebugServer)
 	assert.Equal(meshConfig.Spec.Certificate.ServiceCertValidityDuration, "24h")
 	assert.True(meshConfig.Spec.FeatureFlags.EnableIngressBackendPolicy)
+	assert.True(meshConfig.Spec.FeatureFlags.EnableEnvoyActiveHealthChecks)
 }
 
 func TestValidateCLIParams(t *testing.T) {

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -195,4 +195,8 @@ type FeatureFlags struct {
 	// EnableIngressBackendPolicy defines if OSM will use the IngressBackend API to allow ingress traffic to
 	// service mesh backends.
 	EnableIngressBackendPolicy bool `json:"enableIngressBackendPolicy,omitempty"`
+
+	// EnableEnvoyActiveHealthChecks defines if OSM will Envoy active health
+	// checks between services allowed to communicate.
+	EnableEnvoyActiveHealthChecks bool `json:"enableEnvoyActiveHealthChecks,omitempty"`
 }

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -63,6 +63,20 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 			assert.Equal(tc.expectedLbPolicy, remoteCluster.LbPolicy)
 		})
 	}
+
+	t.Run("adds health checks when configured", func(t *testing.T) {
+		assert := tassert.New(t)
+		remoteCluster, err := getUpstreamServiceCluster(downstreamSvcAccount, upstreamSvc, mockConfigurator, withActiveHealthChecks)
+		assert.NoError(err)
+		assert.NotNil(remoteCluster.HealthChecks)
+	})
+
+	t.Run("does not add health checks when not configured", func(t *testing.T) {
+		assert := tassert.New(t)
+		remoteCluster, err := getUpstreamServiceCluster(downstreamSvcAccount, upstreamSvc, mockConfigurator)
+		assert.NoError(err)
+		assert.Nil(remoteCluster.HealthChecks)
+	})
 }
 
 func TestGetLocalServiceCluster(t *testing.T) {

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -47,6 +47,9 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		if cfg.IsPermissiveTrafficPolicyMode() {
 			opts = append(opts, permissive)
 		}
+		if cfg.GetFeatureFlags().EnableEnvoyActiveHealthChecks {
+			opts = append(opts, withActiveHealthChecks)
+		}
 		cluster, err := getUpstreamServiceCluster(proxyIdentity, dstService, cfg, opts...)
 		if err != nil {
 			log.Error().Err(err).Str(errcode.Kind, errcode.ErrObtainingUpstreamServiceCluster.String()).

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -69,6 +70,7 @@ func TestNewResponse(t *testing.T) {
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(true).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingHost().Return(constants.DefaultTracingHost).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingPort().Return(constants.DefaultTracingPort).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{}).AnyTimes()
 	mockCatalog.EXPECT().GetKubeController().Return(mockKubeController).AnyTimes()
 
 	podlabels := map[string]string{

--- a/pkg/envoy/lds/healthcheck.go
+++ b/pkg/envoy/lds/healthcheck.go
@@ -1,0 +1,45 @@
+package lds
+
+import (
+	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xds_health_check "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
+	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+func getHealthCheckFilter() (*xds_hcm.HttpFilter, error) {
+	hc := &xds_health_check.HealthCheck{
+		PassThroughMode: wrapperspb.Bool(false),
+		Headers: []*xds_route.HeaderMatcher{
+			{
+				Name: ":path",
+				HeaderMatchSpecifier: &xds_route.HeaderMatcher_ExactMatch{
+					ExactMatch: envoy.EnvoyActiveHealthCheckPath,
+				},
+			},
+			{
+				Name: envoy.EnvoyActiveHealthCheckHeaderKey,
+				HeaderMatchSpecifier: &xds_route.HeaderMatcher_PresentMatch{
+					PresentMatch: true,
+				},
+			},
+		},
+	}
+
+	hcAny, err := ptypes.MarshalAny(hc)
+	if err != nil {
+		return nil, errors.Wrap(err, "error marshaling health check filter")
+	}
+
+	return &xds_hcm.HttpFilter{
+		Name: wellknown.HealthCheck,
+		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
+			TypedConfig: hcAny,
+		},
+	}, nil
+}

--- a/pkg/envoy/lds/http_connection_test.go
+++ b/pkg/envoy/lds/http_connection_test.go
@@ -111,6 +111,24 @@ func TestHTTPConnbuild(t *testing.T) {
 				a.True(notContains(connManager.HttpFilters, wellknown.HTTPExternalAuthorization))
 			},
 		},
+		{
+			name: "health check config present when enabled",
+			option: httpConnManagerOptions{
+				enableActiveHealthChecks: true,
+			},
+			assertFunc: func(a *assert.Assertions, connManager *xds_hcm.HttpConnectionManager) {
+				a.True(contains(connManager.HttpFilters, wellknown.HealthCheck))
+			},
+		},
+		{
+			name: "health check config absent when disabled",
+			option: httpConnManagerOptions{
+				enableActiveHealthChecks: false,
+			},
+			assertFunc: func(a *assert.Assertions, connManager *xds_hcm.HttpConnectionManager) {
+				a.True(notContains(connManager.HttpFilters, wellknown.HealthCheck))
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -90,8 +90,9 @@ func (lb *listenerBuilder) getInboundHTTPFilters(proxyService service.MeshServic
 		rdsRoutConfigName: route.InboundRouteConfigName,
 
 		// Additional filters
-		wasmStatsHeaders: lb.getWASMStatsHeaders(),
-		extAuthConfig:    lb.getExtAuthConfig(),
+		wasmStatsHeaders:         lb.getWASMStatsHeaders(),
+		extAuthConfig:            lb.getExtAuthConfig(),
+		enableActiveHealthChecks: lb.cfg.GetFeatureFlags().EnableEnvoyActiveHealthChecks,
 
 		// Tracing options
 		enableTracing:      lb.cfg.IsTracingEnabled(),

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -82,6 +82,14 @@ const (
 	// localClusterSuffix is the tag to append to the local cluster name corresponding to a service cluster.
 	// The local cluster refers to the cluster corresponding to the service the proxy is fronting, accessible over localhost by the proxy.
 	localClusterSuffix = "-local"
+
+	// EnvoyActiveHealthCheckPath is the HTTP endpoint to be used to receive
+	// active health checks.
+	EnvoyActiveHealthCheckPath = "/healthz/osm"
+
+	// EnvoyActiveHealthCheckHeaderKey is the HTTP header key used to identify
+	// active health check traffic.
+	EnvoyActiveHealthCheckHeaderKey = "x-osm-envoy-healthcheck"
 )
 
 // ProxyKind is the type used to define the proxy's kind


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a new `enableEnvoyActiveHealthChecks` feature flag that
enables OSM to program upstream clusters with health checks. When
enabled, it will also add the health check HTTP filter to upstream
proxies which will respond to health check requests.

The actual health check configuration is not currently parameterized, so
all health checks will have this configuration:

    {
      "health_checks": [
        {
          "timeout": "1s",
          "interval": "10s",
          "unhealthy_threshold": 3,
          "healthy_threshold": 1,
          "http_health_check": {
            "host": "<upstream cluster>",
            "path": "/healthz/osm",
            "request_headers_to_add": [
              {
                "header": {
                  "key": "x-osm-envoy-healthcheck",
                  "value": "1"
                }
              }
            ]
          }
        }
      ]
    }

Fixes #3042

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
