### PR TITLE
feat(metrics): proxy reconnect count

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -301,6 +301,7 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.K8sMeshPodCount,
 		metricsstore.DefaultMetricsStore.K8sMeshServiceCount,
 		metricsstore.DefaultMetricsStore.ProxyConnectCount,
+		metricsstore.DefaultMetricsStore.ProxyReconnectCount,
 		metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime,
 		metricsstore.DefaultMetricsStore.CertIssuedCount,
 		metricsstore.DefaultMetricsStore.CertIssuedTime,

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -235,6 +235,7 @@ func respondToRequest(proxy *envoy.Proxy, discoveryRequest *xds_discovery.Discov
 			proxy.String(), typeURL.Short(), requestNonce, requestVersion)
 		proxy.SetLastSentVersion(typeURL, requestVersion)
 		proxy.SetLastAppliedVersion(typeURL, requestVersion)
+		metricsstore.DefaultMetricsStore.ProxyReconnectCount.Inc()
 		return true
 	}
 

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -37,6 +37,9 @@ type MetricsStore struct {
 	// ProxyConnectCount is the metric for the total number of proxies connected to the controller
 	ProxyConnectCount prometheus.Gauge
 
+	// ProxyReconnectCount is the metric for the total reconnects from known proxies to the controller
+	ProxyReconnectCount prometheus.Counter
+
 	// ProxyConfigUpdateTime is the histogram to track time spent for proxy configuration and its occurrences
 	ProxyConfigUpdateTime *prometheus.HistogramVec
 
@@ -109,6 +112,13 @@ func init() {
 		Subsystem: "proxy",
 		Name:      "connect_count",
 		Help:      "represents the number of proxies connected to OSM controller",
+	})
+
+	defaultMetricsStore.ProxyReconnectCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "reconnect_count",
+		Help:      "represents the number of reconnects from known proxies to OSM controller",
 	})
 
 	defaultMetricsStore.ProxyConfigUpdateTime = prometheus.NewHistogramVec(


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add metric for number of reconnects from known proxies to OSM controller

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
