### PR TITLE
ref(install): Log namespace for existing mesh

### DIFF
--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -193,7 +193,7 @@ func (i *installCmd) validateOptions() error {
 		return err
 	}
 	if len(osmControllerDeployments.Items) != 0 {
-		return errMeshAlreadyExists(i.meshName)
+		return errMeshAlreadyExists(i.meshName, osmControllerDeployments.Items[0].Namespace)
 	}
 
 	// ensure no osm-controller is running in the same namespace
@@ -268,12 +268,12 @@ func isValidMeshName(meshName string) error {
 	return nil
 }
 
-func errMeshAlreadyExists(name string) error {
-	return errors.Errorf("Mesh %s already exists in cluster. Please specify a new mesh name using --mesh-name", name)
+func errMeshAlreadyExists(name string, namespace string) error {
+	return errors.Errorf("Mesh %s already exists in namespace %s. Please specify a new mesh name using --mesh-name and install the mesh in a different namespace using --osm-namespace", name, namespace)
 }
 
 func errNamespaceAlreadyHasController(namespace string) error {
-	return annotateErrorMessageWithOsmNamespace("Namespace [%s] already has an osm controller.", namespace)
+	return annotateErrorMessageWithOsmNamespace("Namespace [%s] already has an osm controller. Please specify a different namespace using --osm-namespace", namespace)
 }
 
 // parses Helm strvals line and merges into a map

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -407,7 +407,7 @@ var _ = Describe("Running the install command", func() {
 
 		It("should error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal(errMeshAlreadyExists(installCmd.meshName).Error()))
+			Expect(err.Error()).To(Equal(errMeshAlreadyExists(installCmd.meshName, settings.Namespace()).Error()))
 		})
 	})
 


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Makes error messages more clear about existing meshes when there is an existing mesh that conflicts with the new install.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No