### PR TITLE
injector/test: remove unused var and change test dir prefix

### DIFF
--- a/pkg/injector/test/test_helpers.go
+++ b/pkg/injector/test/test_helpers.go
@@ -21,14 +21,8 @@ const directoryForExpectationsYAML = "../../tests/envoy_xds_expectations/"
 
 var log = logger.New("sidecar-injector")
 
-var tempDir string
-
 func getTempDir() string {
-	if tempDir != "" {
-		return tempDir
-	}
-
-	dir, err := ioutil.TempDir("", "envoy")
+	dir, err := ioutil.TempDir("", "osm_test_envoy")
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error creating temp directory")
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes an unused pkg variable and changes the prefix
for the output test directory so it can be easily removed.
/tmp might contain other dirs starting with `envoy`, so deleting
by the existing prefix is not desirable.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
