### PR TITLE
test(openshift): Add demo to OpenShift nightly job

### DIFF
--- a/.github/workflows/openshift-nightly.yml
+++ b/.github/workflows/openshift-nightly.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+env:
+  CTR_REGISTRY: openservicemesh
+  CTR_TAG: ${{ github.sha }}
+
 jobs:
   test:
     name: OpenShift Nightly Job
@@ -26,6 +30,22 @@ jobs:
         run: |
           make build-osm
           go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.skip="\bHTTP ingress\b" -ginkgo.skip="\bUpgrade\b" -test.timeout 180m -deployOnOpenShift=true
-        env: 
-          CTR_REGISTRY: openservicemesh
-          CTR_TAG: ${{ github.sha }}
+      - name: Run Simulation w/ Tresor, SMI policies, and egress disabled
+        env:
+          CERT_MANAGER: "tresor"
+          BOOKSTORE_SVC: "bookstore"
+          BOOKTHIEF_EXPECTED_RESPONSE_CODE: "0"
+          ENABLE_EGRESS: "false"
+          DEPLOY_TRAFFIC_SPLIT: "true"
+          DEPLOY_ON_OPENSHIFT: "true"
+          TIMEOUT: 150s
+          CI_WAIT_FOR_OK_SECONDS: 60
+          CI_MAX_ITERATIONS_THRESHOLD: 60
+          CI_CLIENT_CONCURRENT_CONNECTIONS: 1
+          CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 150
+          CI_MIN_SUCCESS_THRESHOLD: 1
+          OSM_HUMAN_DEBUG_LOG: true
+        run: |
+          touch .env
+          ./demo/run-osm-demo.sh
+          go run ./ci/cmd/maestro.go


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes #3805

Adds the demo to the OSM OpenShift nightly job.

After verifying that this passes for a few days, I will create a follow up PR to use Github Actions [templates](https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization) so that the nightly job stays in sync with the PR gates.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No