### PR TITLE
feat(windows): Adds node selector to pods deployed by tests

### DIFF
--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -40,15 +40,17 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 				}
 
 				// Get simple pod definitions for the HTTP server
-				svcAccDef, podDef, svcDef := Td.SimplePodApp(
+				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 					SimplePodAppDef{
 						Name:      "server",
 						Namespace: destNs,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
+						OS:        Td.ClusterOS,
 					})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				dstPod, err := Td.CreatePod(destNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -59,14 +61,16 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
 					Name:      "client",
 					Namespace: sourceNs,
 					Command:   []string{"/bin/bash", "-c", "--"},
 					Args:      []string{"while true; do sleep 30; done;"},
 					Image:     "songrgg/alpine-debug",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
 
 				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_controller_restart_test.go
+++ b/tests/e2e/e2e_controller_restart_test.go
@@ -37,15 +37,17 @@ func testHTTPTrafficWithControllerRestart() {
 		}
 
 		// Get simple pod definitions for the HTTP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -31,16 +31,18 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 				Expect(Td.CreateNs(sourceNs, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(SimplePodAppDef{
 					Name:      "client",
 					Namespace: sourceNs,
 					Command:   []string{"/bin/bash", "-c", "--"},
 					Args:      []string{"while true; do sleep 30; done;"},
 					Image:     "songrgg/alpine-debug",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -52,7 +52,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				}
 
 				// Use a deployment with multiple replicaset at serverside
-				svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+				svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
 						Name:         "server",
 						Namespace:    destApp,
@@ -60,9 +60,11 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 						Image:        "kennethreitz/httpbin",
 						Ports:        []int{DefaultUpstreamServicePort},
 						Command:      HttpbinCmd,
+						OS:           Td.ClusterOS,
 					})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(destApp, &svcAccDef)
+				_, err = Td.CreateServiceAccount(destApp, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = Td.CreateDeployment(destApp, deploymentDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -78,7 +80,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 
 				// Create all client deployments, also with replicaset
 				for _, srcClient := range sourceNamespaces {
-					svcAccDef, deploymentDef, svcDef = Td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef, err = Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
 							Name:         srcClient,
 							Namespace:    srcClient,
@@ -87,7 +89,10 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
 							Ports:        []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
+							OS:           Td.ClusterOS,
 						})
+					Expect(err).NotTo(HaveOccurred())
+
 					_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
 					_, err = Td.CreateDeployment(srcClient, deploymentDef)

--- a/tests/e2e/e2e_egress_policy_test.go
+++ b/tests/e2e/e2e_egress_policy_test.go
@@ -68,16 +68,18 @@ func testEgressPolicy(scenario testScenario) {
 		Expect(Td.AddNsToMesh(true, sourceNs)).To(Succeed())
 
 		// Create simple pod definitions for the source
-		srcSvcAcc, srcPodDef, _ := Td.SimplePodApp(SimplePodAppDef{
+		srcSvcAcc, srcPodDef, _, err := Td.SimplePodApp(SimplePodAppDef{
 			Name:      sourceName,
 			Namespace: sourceNs,
 			Command:   []string{"/bin/bash", "-c", "--"},
 			Args:      []string{"while true; do sleep 30; done;"},
 			Image:     "songrgg/alpine-debug",
 			Ports:     []int{80},
+			OS:        Td.ClusterOS,
 		})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(sourceNs, &srcSvcAcc)
+		_, err = Td.CreateServiceAccount(sourceNs, &srcSvcAcc)
 		Expect(err).NotTo(HaveOccurred())
 		srcPod, err := Td.CreatePod(sourceNs, srcPodDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -32,16 +32,18 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 				Expect(Td.AddNsToMesh(true, sourceNs)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(SimplePodAppDef{
 					Name:      "client",
 					Namespace: sourceNs,
 					Command:   []string{"/bin/bash", "-c", "--"},
 					Args:      []string{"while true; do sleep 30; done;"},
 					Image:     "songrgg/alpine-debug",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				srcPod, err := Td.CreatePod(sourceNs, podDef)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_garbage_collector_test.go
+++ b/tests/e2e/e2e_garbage_collector_test.go
@@ -35,7 +35,7 @@ var _ = OSMDescribe("Test garbage collection for unused envoy bootstrap config s
 				Expect(Td.AddNsToMesh(true, userService)).To(Succeed())
 
 				// User app
-				svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+				svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
 						Name:         userService,
 						Namespace:    userService,
@@ -44,9 +44,11 @@ var _ = OSMDescribe("Test garbage collection for unused envoy bootstrap config s
 						Args:         []string{"while true; do sleep 30; done;"},
 						Image:        "songrgg/alpine-debug",
 						Ports:        []int{80},
+						OS:           Td.ClusterOS,
 					})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(userService, &svcAccDef)
+				_, err = Td.CreateServiceAccount(userService, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = Td.CreateDeployment(userService, deploymentDef)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_grpc_insecure_origination_test.go
+++ b/tests/e2e/e2e_grpc_insecure_origination_test.go
@@ -46,16 +46,18 @@ func testGRPCTraffic() {
 		}
 
 		// Get simple pod definitions for the gRPC server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:        destName,
 				Namespace:   destName,
 				Image:       "moul/grpcbin",
 				Ports:       []int{grpcbinInsecurePort},
 				AppProtocol: "grpc",
+				OS:          Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -142,14 +144,16 @@ func testGRPCTraffic() {
 
 func setupGRPCClient(sourceName string) *corev1.Pod {
 	// Get simple Pod definitions for the client
-	svcAccDef, podDef, _ := Td.SimplePodApp(SimplePodAppDef{
+	svcAccDef, podDef, _, err := Td.SimplePodApp(SimplePodAppDef{
 		Name:      sourceName,
 		Namespace: sourceName,
 		Command:   []string{"sleep", "365d"},
 		Image:     "networld/grpcurl",
+		OS:        Td.ClusterOS,
 	})
+	Expect(err).NotTo(HaveOccurred())
 
-	_, err := Td.CreateServiceAccount(sourceName, &svcAccDef)
+	_, err = Td.CreateServiceAccount(sourceName, &svcAccDef)
 	Expect(err).NotTo(HaveOccurred())
 
 	srcPod, err := Td.CreatePod(sourceName, podDef)

--- a/tests/e2e/e2e_grpc_secure_origination_test.go
+++ b/tests/e2e/e2e_grpc_secure_origination_test.go
@@ -45,16 +45,18 @@ func testSecureGRPCTraffic() {
 		}
 
 		// Get simple pod definitions for the gRPC server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:        destName,
 				Namespace:   destName,
 				Image:       "moul/grpcbin",
 				Ports:       []int{grpcbinSecurePort},
 				AppProtocol: "tcp",
+				OS:          Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -39,15 +39,17 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 				}
 
 				// Get simple pod definitions for the HTTP server
-				svcAccDef, podDef, svcDef := Td.SimplePodApp(
+				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 					SimplePodAppDef{
 						Name:      "server",
 						Namespace: destNs,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
+						OS:        Td.ClusterOS,
 					})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				dstPod, err := Td.CreatePod(destNs, podDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -58,14 +60,16 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
 					Name:      "client",
 					Namespace: sourceNs,
 					Command:   []string{"/bin/bash", "-c", "--"},
 					Args:      []string{"while true; do sleep 30; done;"},
 					Image:     "songrgg/alpine-debug",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
 
 				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_ingressbackend.go
+++ b/tests/e2e/e2e_ingressbackend.go
@@ -45,15 +45,17 @@ func testIngressBackend() {
 		Expect(Td.AddNsToMesh(true, destNs)).To(Succeed())
 
 		// Get simple pod definitions for the HTTP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      "server",
 				Namespace: destNs,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{serverPort},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destNs, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -41,15 +41,17 @@ func testIPExclusion() {
 		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
 
 		// Set up the destination HTTP server. It is not part of the mesh
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_k8s_ingress_http_test.go
+++ b/tests/e2e/e2e_k8s_ingress_http_test.go
@@ -32,15 +32,17 @@ var _ = OSMDescribe("HTTP ingress using k8s Ingress API",
 			Expect(Td.AddNsToMesh(true, destNs)).To(Succeed())
 
 			// Get simple pod definitions for the HTTP server
-			svcAccDef, podDef, svcDef := Td.SimplePodApp(
+			svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 				SimplePodAppDef{
 					Name:      "server",
 					Namespace: destNs,
 					Image:     "kennethreitz/httpbin",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+			Expect(err).NotTo(HaveOccurred())
 
-			_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+			_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = Td.CreatePod(destNs, podDef)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -45,15 +45,17 @@ func testK8sVersion(version string) {
 		}
 
 		// Get simple pod definitions for the HTTP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -49,7 +49,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get simple pod definitions for the HTTP server
-			svcAccDef, depDef, svcDef := Td.SimpleDeploymentApp(
+			svcAccDef, depDef, svcDef, err := Td.SimpleDeploymentApp(
 				SimpleDeploymentAppDef{
 					ReplicaCount: 1,
 					Name:         "server",
@@ -57,7 +57,9 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 					Image:        "kennethreitz/httpbin",
 					Ports:        []int{DefaultUpstreamServicePort},
 					Command:      HttpbinCmd,
+					OS:           Td.ClusterOS,
 				})
+			Expect(err).NotTo(HaveOccurred())
 
 			_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())
@@ -70,7 +72,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 			Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
 
 			// Get simple Pod definitions for the client
-			svcAccDef, depDef, svcDef = Td.SimpleDeploymentApp(SimpleDeploymentAppDef{
+			svcAccDef, depDef, svcDef, err = Td.SimpleDeploymentApp(SimpleDeploymentAppDef{
 				ReplicaCount: 1,
 				Name:         "client",
 				Namespace:    sourceNs,
@@ -78,7 +80,9 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 				Args:         []string{"while true; do sleep 30; done;"},
 				Image:        "songrgg/alpine-debug",
 				Ports:        []int{DefaultUpstreamServicePort},
+				OS:           Td.ClusterOS,
 			})
+			Expect(err).NotTo(HaveOccurred())
 
 			_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -44,15 +44,17 @@ func testMultipleServicePerPod() {
 		}
 
 		// Create an HTTP server that clients will send requests to
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_permissive_smi_switching.go
+++ b/tests/e2e/e2e_permissive_smi_switching.go
@@ -52,7 +52,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				}
 
 				// Use a deployment with multiple replicaset at serverside
-				svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+				svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
 						Name:         "server",
 						Namespace:    destApp,
@@ -60,9 +60,11 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 						Image:        "kennethreitz/httpbin",
 						Ports:        []int{DefaultUpstreamServicePort},
 						Command:      HttpbinCmd,
+						OS:           Td.ClusterOS,
 					})
+				Expect(err).NotTo(HaveOccurred())
 
-				_, err := Td.CreateServiceAccount(destApp, &svcAccDef)
+				_, err = Td.CreateServiceAccount(destApp, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = Td.CreateDeployment(destApp, deploymentDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -78,7 +80,7 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 
 				// Create all client deployments, also with replicaset
 				for _, srcClient := range sourceNamespaces {
-					svcAccDef, deploymentDef, svcDef = Td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef, err = Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
 							Name:         srcClient,
 							Namespace:    srcClient,
@@ -87,7 +89,10 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
 							Ports:        []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
+							OS:           Td.ClusterOS,
 						})
+					Expect(err).NotTo(HaveOccurred())
+
 					_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
 					_, err = Td.CreateDeployment(srcClient, deploymentDef)

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -50,15 +50,17 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 		}
 
 		// Get simple pod definitions for the HTTP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      "server",
 				Namespace: destNs,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destNs, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		dstPod, err := Td.CreatePod(destNs, podDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -68,14 +70,16 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 		Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1, nil)).To(Succeed())
 
 		// Get simple Pod definitions for the client
-		svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+		svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
 			Name:      "client",
 			Namespace: sourceNs,
 			Command:   []string{"/bin/bash", "-c", "--"},
 			Args:      []string{"while true; do sleep 30; done;"},
 			Image:     "songrgg/alpine-debug",
 			Ports:     []int{80},
+			OS:        Td.ClusterOS,
 		})
+		Expect(err).NotTo(HaveOccurred())
 
 		_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -51,15 +51,17 @@ func testTraffic(withSourceKubernetesService bool) {
 		}
 
 		// Get simple pod definitions for the HTTP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -141,15 +143,17 @@ func testTraffic(withSourceKubernetesService bool) {
 
 func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {
 	// Get simple Pod definitions for the client
-	svcAccDef, podDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+	svcAccDef, podDef, svcDef, err := Td.SimplePodApp(SimplePodAppDef{
 		Name:      sourceName,
 		Namespace: sourceName,
 		Command:   []string{"sleep", "365d"},
 		Image:     "curlimages/curl",
 		Ports:     []int{80},
+		OS:        Td.ClusterOS,
 	})
+	Expect(err).NotTo(HaveOccurred())
 
-	_, err := Td.CreateServiceAccount(sourceName, &svcAccDef)
+	_, err = Td.CreateServiceAccount(sourceName, &svcAccDef)
 	Expect(err).NotTo(HaveOccurred())
 
 	srcPod, err := Td.CreatePod(sourceName, podDef)

--- a/tests/e2e/e2e_port_exclusion_test.go
+++ b/tests/e2e/e2e_port_exclusion_test.go
@@ -45,15 +45,17 @@ func testGlobalPortExclusion() {
 		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
 
 		// Set up the destination HTTP server. It is not part of the mesh
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -121,15 +123,17 @@ func testPodLevelPortExclusion() {
 		Expect(Td.AddNsToMesh(true, sourceName)).To(Succeed())
 
 		// Set up the destination HTTP server. It is not part of the mesh
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:      destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -140,13 +144,15 @@ func testPodLevelPortExclusion() {
 		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
 
 		// Set up the source curl client. It will be a part of the mesh
-		svcAccDef, podDef, svcDef = Td.SimplePodApp(SimplePodAppDef{
+		svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
 			Name:      sourceName,
 			Namespace: sourceName,
 			Command:   []string{"sleep", "365d"},
 			Image:     "curlimages/curl",
 			Ports:     []int{80},
+			OS:        Td.ClusterOS,
 		})
+		Expect(err).NotTo(HaveOccurred())
 
 		_, err = Td.CreateServiceAccount(sourceName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_proxy_resource_limits.go
+++ b/tests/e2e/e2e_proxy_resource_limits.go
@@ -94,7 +94,7 @@ var _ = OSMDescribe("Test proxy resource setting",
 
 func createSimpleApp(appName string, ns string) {
 	// Get simple pod definitions for the HTTP server
-	svcAccDef, podDef, svcDef := Td.SimplePodApp(
+	svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 		SimplePodAppDef{
 			Name:      appName,
 			Namespace: ns,
@@ -102,9 +102,11 @@ func createSimpleApp(appName string, ns string) {
 			Args:      []string{"while true; do sleep 30; done;"},
 			Image:     "songrgg/alpine-debug",
 			Ports:     []int{80},
+			OS:        Td.ClusterOS,
 		})
+	Expect(err).NotTo(HaveOccurred())
 
-	_, err := Td.CreateServiceAccount(ns, &svcAccDef)
+	_, err = Td.CreateServiceAccount(ns, &svcAccDef)
 	Expect(err).NotTo(HaveOccurred())
 	_, err = Td.CreatePod(ns, podDef)
 	Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -39,14 +39,17 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 				}
 
 				// Set up the destination HTTP server
-				svcAccDef, podDef, svcDef := Td.SimplePodApp(
+				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 					SimplePodAppDef{
 						Name:      destName,
 						Namespace: destName,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
+						OS:        Td.ClusterOS,
 					})
-				_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				_, err = Td.CreatePod(destName, podDef)
 				Expect(err).NotTo(HaveOccurred())
@@ -54,26 +57,32 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Set up the HTTP client that is allowed access to the destination
-				allowedSvcAccDef, allowedSrcPodDef, _ := Td.SimplePodApp(SimplePodAppDef{
+				allowedSvcAccDef, allowedSrcPodDef, _, err := Td.SimplePodApp(SimplePodAppDef{
 					Name:      sourceOne,
 					Namespace: sourceOne,
 					Command:   []string{"sleep", "365d"},
 					Image:     "curlimages/curl",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
+
 				_, err = Td.CreateServiceAccount(sourceOne, &allowedSvcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				allowedSrcPod, err := Td.CreatePod(sourceOne, allowedSrcPodDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Set up the HTTP client that is denied access to the destination
-				deniedSvcAccDef, deniedSrcPodDef, _ := Td.SimplePodApp(SimplePodAppDef{
+				deniedSvcAccDef, deniedSrcPodDef, _, err := Td.SimplePodApp(SimplePodAppDef{
 					Name:      sourceTwo,
 					Namespace: sourceTwo,
 					Command:   []string{"sleep", "365d"},
 					Image:     "curlimages/curl",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
+
 				_, err = Td.CreateServiceAccount(sourceTwo, &deniedSvcAccDef)
 				Expect(err).NotTo(HaveOccurred())
 				deniedSrcPod, err := Td.CreatePod(sourceTwo, deniedSrcPodDef)

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -53,7 +53,7 @@ func testTCPTraffic(permissiveMode bool) {
 		destinationPort := 80
 
 		// Get simple pod definitions for the TCP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:        destName,
 				Namespace:   destName,
@@ -62,9 +62,11 @@ func testTCPTraffic(permissiveMode bool) {
 				Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
 				Ports:       []int{destinationPort},
 				AppProtocol: constants.ProtocolTCP,
+				OS:          Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -48,7 +48,7 @@ func testTCPEgressTraffic() {
 		destinationPort := 80
 
 		// Get simple pod definitions for the TCP server
-		svcAccDef, podDef, svcDef := Td.SimplePodApp(
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
 				Name:        destName,
 				Namespace:   destName,
@@ -57,9 +57,11 @@ func testTCPEgressTraffic() {
 				Args:        []string{"--port", fmt.Sprintf("%d", destinationPort)},
 				Ports:       []int{destinationPort},
 				AppProtocol: constants.ProtocolTCP,
+				OS:          Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
-		_, err := Td.CreateServiceAccount(destName, &svcAccDef)
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreatePod(destName, podDef)
 		Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -72,7 +72,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 		Expect(Td.AddNsToMesh(true, allNamespaces...)).To(Succeed())
 
 		// Create server app
-		svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+		svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 			SimpleDeploymentAppDef{
 				Name:         trafficSplitName,
 				Namespace:    serverNamespace,
@@ -81,7 +81,9 @@ func testRecursiveTrafficSplit(appProtocol string) {
 				Ports:        []int{DefaultUpstreamServicePort},
 				AppProtocol:  appProtocol,
 				Command:      HttpbinCmd,
+				OS:           Td.ClusterOS,
 			})
+		Expect(err).NotTo(HaveOccurred())
 
 		// Expose an env variable such as XHTTPBIN_X_POD_NAME:
 		// This httpbin fork will pick certain env variable formats and reply the values as headers.
@@ -98,7 +100,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 			},
 		}
 
-		_, err := Td.CreateServiceAccount(serverNamespace, &svcAccDef)
+		_, err = Td.CreateServiceAccount(serverNamespace, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = Td.CreateDeployment(serverNamespace, deploymentDef)
 		Expect(err).NotTo(HaveOccurred())
@@ -114,7 +116,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 
 		// Client apps
 		for _, clientApp := range clientServices {
-			svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+			svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 				SimpleDeploymentAppDef{
 					Name:         clientApp,
 					Namespace:    clientApp,
@@ -123,9 +125,11 @@ func testRecursiveTrafficSplit(appProtocol string) {
 					Args:         []string{"while true; do sleep 30; done;"},
 					Image:        "songrgg/alpine-debug",
 					Ports:        []int{DefaultUpstreamServicePort},
+					OS:           Td.ClusterOS,
 				})
+			Expect(err).NotTo(HaveOccurred())
 
-			_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
+			_, err = Td.CreateServiceAccount(clientApp, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = Td.CreateDeployment(clientApp, deploymentDef)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_trafficsplit_same_sa_test.go
+++ b/tests/e2e/e2e_trafficsplit_same_sa_test.go
@@ -74,7 +74,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				Expect(err).NotTo(HaveOccurred())
 
 				for _, serverApp := range serverServices {
-					_, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+					_, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
 							Name:         serverApp,
 							Namespace:    serverNamespace,
@@ -82,7 +82,9 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Image:        "simonkowallik/httpbin",
 							Ports:        []int{DefaultUpstreamServicePort},
 							Command:      HttpbinCmd,
+							OS:           Td.ClusterOS,
 						})
+					Expect(err).NotTo(HaveOccurred())
 
 					// Expose an env variable such as XHTTPBIN_X_POD_NAME:
 					// This httpbin fork will pick certain env variable formats and reply the values as headers.
@@ -114,7 +116,7 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 
 				// Client apps
 				for _, clientApp := range clientServices {
-					svcAccDef, deploymentDef, svcDef := Td.SimpleDeploymentApp(
+					svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
 							Name:         clientApp,
 							Namespace:    clientApp,
@@ -123,9 +125,11 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 							Args:         []string{"while true; do sleep 30; done;"},
 							Image:        "songrgg/alpine-debug",
 							Ports:        []int{DefaultUpstreamServicePort},
+							OS:           Td.ClusterOS,
 						})
+					Expect(err).NotTo(HaveOccurred())
 
-					_, err := Td.CreateServiceAccount(clientApp, &svcAccDef)
+					_, err = Td.CreateServiceAccount(clientApp, &svcAccDef)
 					Expect(err).NotTo(HaveOccurred())
 					_, err = Td.CreateDeployment(clientApp, deploymentDef)
 					Expect(err).NotTo(HaveOccurred())
@@ -162,11 +166,13 @@ var _ = OSMDescribe("Test TrafficSplit where each backend shares the same Servic
 				}
 
 				// Create traffic split service. Use simple Pod to create a simple service definition
-				_, _, trafficSplitService := Td.SimplePodApp(SimplePodAppDef{
+				_, _, trafficSplitService, err := Td.SimplePodApp(SimplePodAppDef{
 					Name:      trafficSplitName,
 					Namespace: serverNamespace,
 					Ports:     []int{DefaultUpstreamServicePort},
+					OS:        Td.ClusterOS,
 				})
+				Expect(err).NotTo(HaveOccurred())
 
 				// Creating trafficsplit service in K8s
 				_, err = Td.CreateService(serverNamespace, trafficSplitService)

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -104,13 +104,15 @@ var _ = OSMDescribe("Upgrade from latest",
 			Expect(Td.AddNsToMesh(true, ns)).To(Succeed())
 
 			// Get simple pod definitions for the HTTP server
-			svcAccDef, dstPodDef, svcDef := Td.SimplePodApp(
+			svcAccDef, dstPodDef, svcDef, err := Td.SimplePodApp(
 				SimplePodAppDef{
 					Name:      "server",
 					Namespace: ns,
 					Image:     "kennethreitz/httpbin",
 					Ports:     []int{80},
+					OS:        Td.ClusterOS,
 				})
+			Expect(err).NotTo(HaveOccurred())
 
 			_, err = Td.CreateServiceAccount(ns, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())
@@ -120,14 +122,16 @@ var _ = OSMDescribe("Upgrade from latest",
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get simple Pod definitions for the client
-			svcAccDef, srcPodDef, svcDef := Td.SimplePodApp(SimplePodAppDef{
+			svcAccDef, srcPodDef, svcDef, err := Td.SimplePodApp(SimplePodAppDef{
 				Name:      "client",
 				Namespace: ns,
 				Command:   []string{"/bin/bash", "-c", "--"},
 				Args:      []string{"while true; do sleep 30; done;"},
 				Image:     "songrgg/alpine-debug",
 				Ports:     []int{80},
+				OS:        Td.ClusterOS,
 			})
+			Expect(err).NotTo(HaveOccurred())
 
 			_, err = Td.CreateServiceAccount(ns, &svcAccDef)
 			Expect(err).NotTo(HaveOccurred())

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -133,6 +133,7 @@ func registerFlags(td *OsmTestData) {
 	flag.StringVar((*string)(&td.CollectLogs), "collectLogs", string(CollectLogsIfErrorOnly), "Defines if/when to collect logs.")
 
 	flag.StringVar(&td.ClusterName, "kindClusterName", "osm-e2e", "Name of the Kind cluster to be created")
+
 	flag.BoolVar(&td.CleanupKindCluster, "cleanupKindCluster", true, "Cleanup kind cluster upon exit")
 	flag.BoolVar(&td.CleanupKindClusterBetweenTests, "cleanupKindClusterBetweenTests", false, "Cleanup kind cluster between tests")
 	flag.StringVar(&td.ClusterVersion, "kindClusterVersion", "", "Kind cluster version, ex. v.1.20.2")
@@ -209,6 +210,8 @@ func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 	td.TestID = r.Uint64()
 	td.TestDirName = fmt.Sprintf("test-%d", td.TestID)
 	td.T.Log(color.HiGreenString("> ID for test: %d, Test dir (abs): %s", td.TestID, td.GetTestDirPath()))
+
+	td.ClusterOS = constants.OSLinux
 
 	// String parameter validation
 	err = td.ValidateStringParams()

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -57,6 +57,8 @@ type OsmTestData struct {
 	CleanupKindCluster             bool   // Cleanup kind cluster upon test finish
 	ClusterVersion                 string // Kind cluster version, ex. v1.20.2
 
+	ClusterOS string // The operating system of the working nodes in the cluster. Mixed OS traffic is not supported.
+
 	// Cluster handles and rest config
 	Env        *cli.EnvSettings
 	RestConfig *rest.Config


### PR DESCRIPTION
Adds node selector to the spec of all pods deployed in e2e tests.
Also adds a new flag in the test cli to be able to configure the OS in preparation for
Windows testing.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>