### PR TITLE
feat(demo): add 'publish_images' flag

### DIFF
--- a/.github/workflows/openshift-nightly.yml
+++ b/.github/workflows/openshift-nightly.yml
@@ -45,6 +45,7 @@ jobs:
           CI_MAX_WAIT_FOR_POD_TIME_SECONDS: 150
           CI_MIN_SUCCESS_THRESHOLD: 1
           OSM_HUMAN_DEBUG_LOG: true
+          PUBLISH_IMAGES: "false"
         run: |
           touch .env
           ./demo/run-osm-demo.sh

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -37,6 +37,7 @@ DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
 TIMEOUT="${TIMEOUT:-90s}"
+PUBLISH_IMAGES="${PUBLISH_IMAGES:-true}"
 
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*
@@ -83,8 +84,10 @@ if [ "$DEPLOY_ON_OPENSHIFT" = true ] ; then
     optionalInstallArgs+=" --set=OpenServiceMesh.enablePrivilegedInitContainer=true"
 fi
 
-make docker-push
-./scripts/create-container-registry-creds.sh "$K8S_NAMESPACE"
+if [ "$PUBLISH_IMAGES" = true ]; then
+    make docker-push
+    ./scripts/create-container-registry-creds.sh "$K8S_NAMESPACE"
+fi
 
 # Deploys Xds and Prometheus
 echo "Certificate Manager in use: $CERT_MANAGER"


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add a "PUBLISH_IMAGES" flag for the osm demo, and skip the step to publish images for the OpenShift nightly job. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [X] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
