### PR TITLE
multicluster: Adding GetMulticlusterGatewaySubjectCommonName()

### DIFF
--- a/cmd/osm-controller/gateway.go
+++ b/cmd/osm-controller/gateway.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,9 +14,9 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/bootstrap"
 	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/multicluster"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
@@ -41,7 +40,7 @@ func bootstrapOSMGateway(kubeClient kubernetes.Interface, certManager certificat
 		return nil
 	}
 
-	gatewayCN := envoy.NewXDSCertCommonName(uuid.New(), envoy.KindGateway, osmServiceAccount, osmNamespace)
+	gatewayCN := multicluster.GetMulticlusterGatewaySubjectCommonName(osmServiceAccount, osmNamespace)
 	bootstrapCert, err := certManager.IssueCertificate(gatewayCN, constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing bootstrap certificate for OSM gateway: %s", err)

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -409,3 +409,13 @@ func GetServiceIdentityFromProxyCertificate(cn certificate.CommonName) (identity
 
 	return cnMeta.ServiceIdentity, nil
 }
+
+// GetKindFromProxyCertificate returns the proxy kind, which is encoded in the Common Name of the XDS certificate.
+func GetKindFromProxyCertificate(cn certificate.CommonName) (ProxyKind, error) {
+	cnMeta, err := getCertificateCommonNameMeta(cn)
+	if err != nil {
+		return "", err
+	}
+
+	return cnMeta.ProxyKind, nil
+}

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -1,7 +1,10 @@
 package envoy
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -364,3 +367,12 @@ var _ = Describe("Test Envoy tools", func() {
 		})
 	})
 })
+
+func TestGetKindFromProxyCertificate(t *testing.T) {
+	assert := tassert.New(t)
+	cn := certificate.CommonName("fcbd7396-2e8c-49dc-91ff-7267d81287ba.gateway.2.3.4.5.6.7.8")
+	actualProxyKind, err := GetKindFromProxyCertificate(cn)
+	assert.Nil(err, fmt.Sprintf("Expected err to be nil; Actually it was %+v", err))
+	expectedProxyKind := KindGateway
+	assert.Equal(expectedProxyKind, actualProxyKind)
+}

--- a/pkg/multicluster/gateway.go
+++ b/pkg/multicluster/gateway.go
@@ -1,0 +1,17 @@
+package multicluster
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/envoy"
+)
+
+// GetMulticlusterGatewaySubjectCommonName creates a unique certificate.CommonName
+// specifically for a Multicluster Gateway. Each gateway will have its own unique
+// cert. The kind of Envoy (gateway) is encoded in the cert CN by convention.
+func GetMulticlusterGatewaySubjectCommonName(serviceAccount, namespace string) certificate.CommonName {
+	gatewayUID := uuid.New()
+	envoyType := envoy.KindGateway
+	return envoy.NewXDSCertCommonName(gatewayUID, envoyType, serviceAccount, namespace)
+}

--- a/pkg/multicluster/gateway_test.go
+++ b/pkg/multicluster/gateway_test.go
@@ -1,0 +1,27 @@
+package multicluster
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openservicemesh/osm/pkg/envoy"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestMulticlusterHelpers(t *testing.T) {
+	assert := tassert.New(t)
+	serviceAccount := "-svc-account-"
+	namespace := "-namespace-"
+
+	actualCN := GetMulticlusterGatewaySubjectCommonName(serviceAccount, namespace)
+	expectedSuffix := ".gateway.-svc-account-.-namespace-.cluster.local"
+	assert.True(strings.HasSuffix(actualCN.String(), expectedSuffix), fmt.Sprintf("Expected the Proxy Cert's Common Name to end with %s", expectedSuffix))
+
+	// Is the kind of proxy properly encoded in this certificate?
+	actualProxyKind, err := envoy.GetKindFromProxyCertificate(actualCN)
+	assert.Nil(err, fmt.Sprintf("Expected error to be nil; It was %+v", err))
+	expectedProxyKind := envoy.KindGateway
+	assert.Equal(expectedProxyKind, actualProxyKind, fmt.Sprintf("Expected proxy kind to be %s; it was actually %s", expectedProxyKind, actualProxyKind))
+}


### PR DESCRIPTION
This PR creates `GetMulticlusterGatewaySubjectCommonName()` to centralize the creation of Common Names for certificates for Multicluster Gateways.

In this PR - adding `GetKindFromProxyCertificate()` to get the proxy kind from said certificate.