### PR TITLE
multicluster: Test LDS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,7 @@ jobs:
         run: |
           touch .env
           make kind-up
+          make pkg/envoy/lds/stats.wasm
           go test -v ./tests/scenarios/...
 
   e2etest:

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/openservicemesh/osm/pkg/certificate"
-
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
@@ -17,6 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"

--- a/pkg/multicluster/gateway_test.go
+++ b/pkg/multicluster/gateway_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/openservicemesh/osm/pkg/envoy"
-
 	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 func TestMulticlusterHelpers(t *testing.T) {

--- a/tests/scenarios/helpers.go
+++ b/tests/scenarios/helpers.go
@@ -1,0 +1,110 @@
+package scenarios
+
+import (
+	"fmt"
+
+	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/google/uuid"
+	"k8s.io/client-go/kubernetes"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/multicluster"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+func toInt(val uint32) *wrappers.UInt32Value {
+	return &wrappers.UInt32Value{
+		Value: val,
+	}
+}
+
+func weightedCluster(serviceName string, weight uint32) *xds_route.WeightedCluster_ClusterWeight {
+	return &xds_route.WeightedCluster_ClusterWeight{
+		Name:   fmt.Sprintf("default/%s", serviceName),
+		Weight: toInt(weight),
+	}
+}
+
+func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {
+	bookbuyerPodLabels := map[string]string{
+		tests.SelectorKey:                tests.BookbuyerService.Name,
+		constants.EnvoyUniqueIDLabelName: tests.ProxyUUID,
+	}
+	if _, err := tests.MakePod(kubeClient, tests.Namespace, tests.BookbuyerServiceName, tests.BookbuyerServiceAccountName, bookbuyerPodLabels); err != nil {
+		return nil, err
+	}
+
+	bookstorePodLabels := map[string]string{
+		tests.SelectorKey:                "bookstore",
+		constants.EnvoyUniqueIDLabelName: uuid.New().String(),
+	}
+	if _, err := tests.MakePod(kubeClient, tests.Namespace, "bookstore", tests.BookstoreServiceAccountName, bookstorePodLabels); err != nil {
+		return nil, err
+	}
+
+	selectors := map[string]string{
+		tests.SelectorKey: tests.BookbuyerServiceName,
+	}
+	if _, err := tests.MakeService(kubeClient, tests.BookbuyerServiceName, selectors); err != nil {
+		return nil, err
+	}
+
+	for _, svcName := range []string{tests.BookstoreApexServiceName, tests.BookstoreV1ServiceName, tests.BookstoreV2ServiceName} {
+		selectors := map[string]string{
+			tests.SelectorKey: "bookstore",
+		}
+		if _, err := tests.MakeService(kubeClient, svcName, selectors); err != nil {
+			return nil, err
+		}
+	}
+
+	osmServiceAccount := "osm"
+	osmNamespace := "osm-system"
+	certCommonName := multicluster.GetMulticlusterGatewaySubjectCommonName(osmServiceAccount, osmNamespace)
+	certSerialNumber := certificate.SerialNumber("123456")
+	return envoy.NewProxy(certCommonName, certSerialNumber, nil)
+}
+
+func setupMulticlusterGatewayTest(mockCtrl *gomock.Controller) (catalog.MeshCataloger, *envoy.Proxy, *registry.ProxyRegistry, configurator.Configurator, error) {
+	// ---[  Setup the test context  ]---------
+	kubeClient := testclient.NewSimpleClientset()
+	configClient := configFake.NewSimpleClientset()
+	meshCatalog := catalog.NewFakeMeshCatalog(kubeClient, configClient)
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	proxy, err := getProxy(kubeClient)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
+		return nil, nil
+	}))
+
+	// ---[  Get the config from rds.NewResponse()  ]-------
+	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
+	mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
+	mockConfigurator.EXPECT().GetTracingEndpoint().Return("").AnyTimes()
+
+	// mockConfigurator.EXPECT()..Return().AnyTimes()
+	mockConfigurator.EXPECT().IsEgressEnabled().Return(false).AnyTimes()
+
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{
+		EnableWASMStats:        false,
+		EnableEgressPolicy:     false,
+		EnableMulticlusterMode: true, // ENABLE MULTICLUSTER
+		EnableOSMGateway:       true, // ENABLE MULTICLUSTER GATEWAY
+	}).AnyTimes()
+
+	return meshCatalog, proxy, proxyRegistry, mockConfigurator, err
+}

--- a/tests/scenarios/multicluster_gateway__lds__test.go
+++ b/tests/scenarios/multicluster_gateway__lds__test.go
@@ -1,0 +1,57 @@
+package scenarios
+
+import (
+	"fmt"
+	"testing"
+
+	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/golang/mock/gomock"
+	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/envoy/lds"
+)
+
+func TestMulticlusterGatewayListenerDiscoveryService(t *testing.T) {
+	assert := tassert.New(t)
+
+	// -------------------  SETUP  -------------------
+	meshCatalog, proxy, proxyRegistry, mockConfigurator, err := setupMulticlusterGatewayTest(gomock.NewController(t))
+	assert.Nil(err, fmt.Sprintf("Error setting up the test: %+v", err))
+
+	// -------------------  TEST lds.NewResponse()  -------------------
+	resources, err := lds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, nil, proxyRegistry)
+	assert.Nil(err, fmt.Sprintf("lds.NewResponse return unexpected error: %+v", err))
+	assert.NotNil(resources, "No LDS resources!")
+	assert.Len(resources, 1)
+
+	listener, ok := resources[0].(*xds_listener.Listener)
+	assert.True(ok)
+	assert.Equal("multicluster-listener", listener.Name)
+
+	expectedGatewayListenerAddress := "0.0.0.0"
+	expectedGatewayListenerPort := uint32(15003)
+	assert.Equal(expectedGatewayListenerAddress, listener.Address.GetSocketAddress().Address)
+	assert.Equal(expectedGatewayListenerPort, listener.Address.GetSocketAddress().GetPortValue())
+
+	assert.Len(listener.FilterChains, 1)
+	assert.Len(listener.FilterChains[0].Filters, 2)
+
+	assert.Equal("inbound-multicluster-gateway-filter-chain", listener.FilterChains[0].Name)
+
+	assert.Equal("tls", listener.FilterChains[0].FilterChainMatch.TransportProtocol)
+	assert.Equal([]string{"osm"}, listener.FilterChains[0].FilterChainMatch.ApplicationProtocols)
+	assert.Equal([]string{"*.local"}, listener.FilterChains[0].FilterChainMatch.ServerNames)
+
+	assert.Equal("envoy.filters.network.sni_cluster", listener.FilterChains[0].Filters[0].Name)
+	assert.Equal("envoy.filters.network.tcp_proxy", listener.FilterChains[0].Filters[1].Name)
+
+	assert.Equal("envoy.transport_sockets.tls", listener.FilterChains[0].TransportSocket.Name)
+
+	dTLS := envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{}
+	err = listener.FilterChains[0].TransportSocket.GetTypedConfig().UnmarshalTo(&dTLS)
+	assert.Nil(err)
+
+	assert.Equal("service-cert:osm-system/osm", dTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs[0].Name)
+	assert.Equal("root-cert-for-mtls-inbound:osm-system/osm", dTLS.CommonTlsContext.GetValidationContextSdsSecretConfig().Name)
+}

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -3,6 +3,9 @@ package scenarios
 import (
 	"fmt"
 
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/tests"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -36,7 +39,10 @@ var _ = Describe(``+
 			configClient := configFake.NewSimpleClientset()
 			meshCatalog := catalog.NewFakeMeshCatalog(kubeClient, configClient)
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-			proxy, err := getProxy(kubeClient)
+
+			proxyCertCommonName := certificate.CommonName(fmt.Sprintf("%s.%s.%s.%s", tests.ProxyUUID, envoy.KindSidecar, tests.BookbuyerServiceAccountName, tests.Namespace))
+			proxyCertSerialNumber := certificate.SerialNumber("123456")
+			proxy, err := getProxy(kubeClient, proxyCertCommonName, proxyCertSerialNumber)
 			It("sets up test context - SMI policies, Services, Pods etc.", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(meshCatalog).ToNot(BeNil())


### PR DESCRIPTION
This PR adds a test for the LDS portion of OSM's Multicluster implementation.

This PR is stacked on #3857 (`GetMulticlusterGatewaySubjectCommonName`)

This PR also moves the following functions out `tests/scenarios/traffic_split_with_apex_service_test.go` of and into the new `tests/scenarios/helpers.go`:
-  `func toInt(val uint32) *wrappers.UInt32Value {`
- `func weightedCluster(serviceName string, weight uint32) *xds_route.WeightedCluster_ClusterWeight {`
- `func getProxy(kubeClient kubernetes.Interface) (*envoy.Proxy, error) {`
