### PR TITLE
feat(metrics): proxy broadcast event count

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -301,6 +301,7 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.ProxyConnectCount,
 		metricsstore.DefaultMetricsStore.ProxyReconnectCount,
 		metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime,
+		metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount,
 		metricsstore.DefaultMetricsStore.CertIssuedCount,
 		metricsstore.DefaultMetricsStore.CertIssuedTime,
 	)

--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -7,6 +7,7 @@ import (
 
 	a "github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/k8s/events"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
 const (
@@ -101,6 +102,7 @@ func (mc *MeshCatalog) dispatcher() {
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
+			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
 
 			// broadcast done, reset timer channels
 			broadcastScheduled = false
@@ -112,6 +114,7 @@ func (mc *MeshCatalog) dispatcher() {
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
+			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
 
 			// broadcast done, reset timer channels
 			broadcastScheduled = false

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -43,6 +43,9 @@ type MetricsStore struct {
 	// ProxyConfigUpdateTime is the histogram to track time spent for proxy configuration and its occurrences
 	ProxyConfigUpdateTime *prometheus.HistogramVec
 
+	// ProxyBroadcastEventCounter is the metric for the total number of ProxyBroadcast events published
+	ProxyBroadcastEventCount prometheus.Counter
+
 	/*
 	 * Injector metrics
 	 */
@@ -133,6 +136,13 @@ func init() {
 			"resource_type", // identifies a typeURI resource
 			"success",       // further labels if the operation succeeded or not
 		})
+
+	defaultMetricsStore.ProxyBroadcastEventCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "broadcast_event_count",
+		Help:      "Represents the number of ProxyBroadcast events published by the OSM controller",
+	})
 
 	/*
 	 * Injector metrics


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds metrics for the number of ProxyBroadcast events published by
the OSM controller.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
