### PR TITLE
Fix broken lint make rule and target the CI golangci-lint version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.30
+          version: v1.41.1
           skip-pkg-cache: true
           args: --timeout 5m --skip-dirs pkg/gen --skip-files "zz_generated.deepcopy.go$"
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,10 @@
 run:
   tests: true
+  timeout: 5m
+  skip-dirs:
+    - pkg/gen
+  skip-files:
+    - "zz_generated.deepcopy.go$"
 
 linters:
   enable:

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,15 @@ go-vet:
 
 .PHONY: go-lint
 go-lint: cmd/cli/chart.tgz pkg/envoy/lds/stats.wasm
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint run --config .golangci.yml
+	@if ! golangci-lint version 2>&1 | grep 1.30; then \
+		echo Installing golangci-lint; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30; \
+	fi; \
+	golangci-lint run \
+		--config .golangci.yml \
+		--timeout 5m \
+		--skip-dirs pkg/gen \
+		--skip-files "zz_generated.deepcopy.go$$"
 
 .PHONY: go-fmt
 go-fmt:

--- a/Makefile
+++ b/Makefile
@@ -137,15 +137,7 @@ go-vet:
 
 .PHONY: go-lint
 go-lint: cmd/cli/chart.tgz pkg/envoy/lds/stats.wasm
-	@if ! golangci-lint version 2>&1 | grep 1.30; then \
-		echo Installing golangci-lint; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.30; \
-	fi; \
-	golangci-lint run \
-		--config .golangci.yml \
-		--timeout 5m \
-		--skip-dirs pkg/gen \
-		--skip-files "zz_generated.deepcopy.go$$"
+	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.41.1 golangci-lint run --config .golangci.yml
 
 .PHONY: go-fmt
 go-fmt:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This rule appeared to have had two issues prior to this PR.

1. It did not run correctly/successfully:

```
$ make go-lint
go run github.com/golangci/golangci-lint/cmd/golangci-lint run --config .golangci.yml
# github.com/golangci/golangci-lint/pkg/golinters
../../go/pkg/mod/github.com/golangci/golangci-lint@v1.32.2/pkg/golinters/unused.go:16:7: undefined: unused.NewChecker
make: *** [Makefile:140: go-lint] Error 2
```

2. The version of golangci-lint that this was using (1.32) was not the same as the version for CI (1.30). These versions should be the same so that the local experience matches the CI pipeline.

This PR fixes both of these points by checking the currently installed golangci-lint bin. If it does not exist or if it is not the CI version (1.30) then it will install it. After that, it will lint with the same options that are used in CI.

I understand that the recommendation from golangci-lint is to use the GitHub Action, but we should consider creating a shell script to handle this logic, so that it can be invoked from the CI pipeline as well as our local dev machines. As it stands now, if the GitHub Action version changes, we will be out of sync again. The same situation applies if we use different args to lint.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?

No.

1. Is this a breaking change?

No.
