### PR TITLE
osm-validator: enable webhook to validate resources

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -143,6 +143,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |
 | OpenServiceMesh.tracing.port | int | `9411` | Port of the tracing collector service |
 | OpenServiceMesh.useHTTPSIngress | bool | `false` | Enable mesh-wide HTTPS ingress capability (HTTP ingress is the default) |
+| OpenServiceMesh.validatorWebhook.webhookConfigurationName | string | `""` | Name of the ValidatingWebhookConfiguration |
 | OpenServiceMesh.vault.host | string | `""` | Hashicorp Vault host/service - where Vault is installed |
 | OpenServiceMesh.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
 | OpenServiceMesh.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |

--- a/charts/osm/templates/_helpers.tpl
+++ b/charts/osm/templates/_helpers.tpl
@@ -1,12 +1,12 @@
 {{/* Determine osm namespace */}}
-{{- define "osm.namespace" -}} 
-{{ default .Release.Namespace .Values.OpenServiceMesh.osmNamespace}} 
+{{- define "osm.namespace" -}}
+{{ default .Release.Namespace .Values.OpenServiceMesh.osmNamespace}}
 {{- end -}}
 
 {{/* Default tracing address */}}
 {{- define "osm.tracingAddress" -}}
 {{- $address := printf "jaeger.%s.svc.cluster.local" (include "osm.namespace" .) -}}
-{{ default $address .Values.OpenServiceMesh.tracing.address}} 
+{{ default $address .Values.OpenServiceMesh.tracing.address}}
 {{- end -}}
 
 {{/* Labels to be added to all resources */}}
@@ -32,4 +32,10 @@ securityContext:
     capabilities:
         drop:
             - ALL
+{{- end -}}
+
+{{/* Resource validator webhook name */}}
+{{- define "osm.validatorWebhookConfigName" -}}
+{{- $validatorWebhookConfigName := printf "osm-validator-mesh-%s" .Values.OpenServiceMesh.meshName -}}
+{{ default $validatorWebhookConfigName .Values.OpenServiceMesh.validatorWebhook.webhookConfigurationName}}
 {{- end -}}

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -71,7 +71,7 @@ spec:
             "--osm-namespace", "{{ include "osm.namespace" . }}",
             "--osm-service-account", "{{ .Release.Name }}",
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
-            "--webhook-config-name", "{{.Values.OpenServiceMesh.webhookConfigNamePrefix}}-{{.Values.OpenServiceMesh.meshName}}",
+            "--validator-webhook-config", "{{ include "osm.validatorWebhookConfigName" . }}",
             "--ca-bundle-secret-name", "{{.Values.OpenServiceMesh.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.OpenServiceMesh.certificateManager}}",
             {{ if eq .Values.OpenServiceMesh.certificateManager "vault" }}

--- a/charts/osm/templates/osm-validator-service.yaml
+++ b/charts/osm/templates/osm-validator-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: osm-validator
+  namespace: {{ include "osm.namespace" . }}
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: osm-controller
+spec:
+  ports:
+    - name: validator
+      port: 9093
+      targetPort: 9093
+  selector:
+    app: osm-controller

--- a/charts/osm/templates/osm-validator-webhook.yaml
+++ b/charts/osm/templates/osm-validator-webhook.yaml
@@ -1,0 +1,43 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "osm.labels" . | nindent 4 }}
+    app: osm-controller
+  name: {{ include "osm.validatorWebhookConfigName" . }}
+webhooks:
+- name: osm-validator.k8s.io
+  clientConfig:
+    service:
+      name: osm-validator
+      namespace: {{ include "osm.namespace" . }}
+      path: /validate
+      port: 9093
+  failurePolicy: Fail
+  matchPolicy: Exact
+  namespaceSelector:
+    matchLabels:
+      openservicemesh.io/monitored-by: {{.Values.OpenServiceMesh.meshName}}
+    matchExpressions:
+      # This label is explicitly set to ignore a namespace
+      - key: "openservicemesh.io/ignore"
+        operator: DoesNotExist
+      # This label is set by Helm when it creates a namespace (https://github.com/helm/helm/blob/release-3.2/pkg/action/install.go#L292)
+      # It ensures that pods in the control plane namespace are never injected with a sidecar
+      - key: "name"
+        operator: NotIn
+        values:
+        - {{ include "osm.namespace" . }}
+  rules:
+    - apiGroups:
+        - policy.openservicemesh.io
+      apiVersions:
+        - v1alpha1
+      operations:
+        - CREATE
+        - UPDATE
+      resources:
+        - ingressbackends
+        - egresses
+  sideEffects: NoneOnDryRun
+  admissionReviewVersions: ["v1"]

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1098,6 +1098,21 @@
                             }
                         ]
                     ]
+                },
+                "validatorWebhook": {
+                    "$id": "#/properties/OpenServiceMesh/properties/validatorWebhook",
+                    "type": "object",
+                    "title": "The validatorWebhook schema",
+                    "description": "Resource validator webhook configuration",
+                    "properties": {
+                        "webhookConfigurationName": {
+                            "$id": "#/properties/OpenServiceMesh/properties/validatorWebhook/properties/webhookConfigurationName",
+                            "title": "Validator webhook configuration schema",
+                            "description": "Validator's ValidatingWebhookConfigurationName",
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -292,3 +292,8 @@ OpenServiceMesh:
     # -- CRD converter's pod labels
     podLabels: {}
 
+  #
+  # -- OSM resource validator webhook configuration
+  validatorWebhook:
+    # -- Name of the ValidatingWebhookConfiguration
+    webhookConfigurationName: ""

--- a/cmd/osm-controller/validate.go
+++ b/cmd/osm-controller/validate.go
@@ -20,8 +20,8 @@ func validateCLIParams() error {
 		return errors.New("Please specify the OSM namespace using --osm-namespace")
 	}
 
-	if webhookConfigName == "" {
-		return errors.Errorf("Please specify the webhook configuration name using --webhook-config-name")
+	if validatorWebhookConfigName == "" {
+		return errors.Errorf("Please specify the webhook configuration name using --validator-webhook-config")
 	}
 
 	if caBundleSecretName == "" {

--- a/cmd/osm-controller/validate_test.go
+++ b/cmd/osm-controller/validate_test.go
@@ -89,17 +89,17 @@ var _ = Describe("Test validateCertificateManagerOptions", func() {
 
 var _ = Describe("Test validateCLIParams", func() {
 	var (
-		testMeshName           = "test-mesh-name"
-		testOsmNamespace       = "test-namespace"
-		testwebhookConfigName  = "test-webhook-name"
-		testCABundleSecretName = "test-ca-bundle"
+		testMeshName                   = "test-mesh-name"
+		testOsmNamespace               = "test-namespace"
+		testvalidatorWebhookConfigName = "test-webhook-name"
+		testCABundleSecretName         = "test-ca-bundle"
 	)
 
 	Context("none of the necessary CLI params are empty", func() {
 		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
-		webhookConfigName = testwebhookConfigName
+		validatorWebhookConfigName = testvalidatorWebhookConfigName
 		caBundleSecretName = testCABundleSecretName
 
 		err := validateCLIParams()
@@ -112,7 +112,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		certProviderKind = providers.TresorKind.String()
 		meshName = ""
 		osmNamespace = testOsmNamespace
-		webhookConfigName = testwebhookConfigName
+		validatorWebhookConfigName = testvalidatorWebhookConfigName
 
 		err := validateCLIParams()
 
@@ -124,7 +124,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = ""
-		webhookConfigName = testwebhookConfigName
+		validatorWebhookConfigName = testvalidatorWebhookConfigName
 
 		err := validateCLIParams()
 
@@ -132,11 +132,11 @@ var _ = Describe("Test validateCLIParams", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
-	Context("webhookConfigName is empty", func() {
+	Context("validatorWebhookConfigName is empty", func() {
 		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
-		webhookConfigName = ""
+		validatorWebhookConfigName = ""
 
 		err := validateCLIParams()
 
@@ -148,7 +148,7 @@ var _ = Describe("Test validateCLIParams", func() {
 		certProviderKind = providers.TresorKind.String()
 		meshName = testMeshName
 		osmNamespace = testOsmNamespace
-		webhookConfigName = testwebhookConfigName
+		validatorWebhookConfigName = testvalidatorWebhookConfigName
 		caBundleSecretName = ""
 
 		err := validateCLIParams()

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,8 +73,11 @@ const (
 	// OSMHTTPServerPort is the port on which osm-controller and osm-injector serve HTTP requests for metrics, health probes etc.
 	OSMHTTPServerPort = 9091
 
-	//DebugPort is the port on which OSM exposes its debug server
+	// DebugPort is the port on which OSM exposes its debug server
 	DebugPort = 9092
+
+	// ValidatorWebhookPort is the port on which the resource validator webhook listens
+	ValidatorWebhookPort = 9093
 
 	// OSMControllerName is the name of the OSM Controller (formerly ADS service).
 	OSMControllerName = "osm-controller"

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -88,7 +88,8 @@ func ReadinessHandler(probes []Probes, urlProbes []HTTPProbe) http.Handler {
 		for _, urlProbe := range urlProbes {
 			responseCode, err := urlProbe.Probe()
 			if err != nil || responseCode != http.StatusOK {
-				msg := fmt.Sprintf("Readiness probe failed for URL %s", urlProbe.URL)
+				msg := fmt.Sprintf("Readiness probe failed for URL %s: %s", urlProbe.URL, err)
+				log.Warn().Msgf(msg)
 				setProbeResponse(w, responseCode, msg)
 				return
 			}
@@ -115,7 +116,8 @@ func LivenessHandler(probes []Probes, urlProbes []HTTPProbe) http.Handler {
 		for _, urlProbe := range urlProbes {
 			responseCode, err := urlProbe.Probe()
 			if err != nil || responseCode != http.StatusOK {
-				msg := fmt.Sprintf("Liveness probe failed for URL %s", urlProbe.URL)
+				msg := fmt.Sprintf("Liveness probe failed for URL %s: %s", urlProbe.URL, err)
+				log.Warn().Msgf(msg)
 				setProbeResponse(w, responseCode, msg)
 				return
 			}

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/rs/zerolog/log"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,8 +13,8 @@ import (
 )
 
 const (
-	// ValidatingWebhookName is the name of the validating webhook.
-	ValidatingWebhookName = "osm-validate.k8s.io"
+	// validatingWebhookName is the name of the validating webhook.
+	validatingWebhookName = "osm-validator.k8s.io"
 )
 
 // getPartialValidatingWebhookConfiguration returns only the portion of the ValidatingWebhookConfiguration that needs
@@ -27,7 +26,7 @@ func getPartialValidatingWebhookConfiguration(name string, cert certificate.Cert
 		},
 		Webhooks: []admissionregv1.ValidatingWebhook{
 			{
-				Name: ValidatingWebhookName,
+				Name: validatingWebhookName,
 				ClientConfig: admissionregv1.WebhookClientConfig{
 					CABundle: cert.GetCertificateChain(),
 				},

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -1,0 +1,7 @@
+package validator
+
+import (
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var log = logger.New("osm-validator")

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -3,23 +3,29 @@ package validator
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	cv1alpha1 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	pv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-// MinDuration is the minimum duration for a MeshConfig's certificate validity.
-const MinDuration = time.Second
+// minCertValidityDuration is the minimum duration for a MeshConfig's certificate validity.
+const minCertValidityDuration = 2 * time.Minute
 
 func init() {
+	ingressBackendGvk := metav1.GroupVersionKind{
+		Kind:    "IngressBackend",
+		Group:   "policy.openservicemesh.io",
+		Version: "v1alpha1",
+	}
 	egressGvk := metav1.GroupVersionKind{
 		Kind:    "Egress",
 		Group:   "policy.openservicemesh.io",
@@ -30,17 +36,49 @@ func init() {
 		Group:   "config.openservicemesh.io",
 		Version: "v1alpha1",
 	}
-	multiClusterServiceGvk := metav1.GroupVersionKind{
-		Kind:    "MultiClusterService",
-		Group:   "config.openservicemesh.io",
-		Version: "v1alpha1",
-	}
+
+	RegisterValidator(ingressBackendGvk.String(), IngressBackendValidator)
 	RegisterValidator(egressGvk.String(), EgressValidator)
 	RegisterValidator(meshConfigGvk.String(), MeshConfigValidator)
-	RegisterValidator(multiClusterServiceGvk.String(), MeshConfigValidator)
 }
 
-// EgressValidator validates the Egress CRD.
+// IngressBackendValidator validates the IngressBackend custom resource
+func IngressBackendValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	ingressBackend := &pv1alpha1.IngressBackend{}
+	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(ingressBackend); err != nil {
+		return nil, err
+	}
+
+	for _, backend := range ingressBackend.Spec.Backends {
+		// Validate port
+		switch strings.ToLower(backend.Port.Protocol) {
+		case constants.ProtocolHTTP:
+			// Valid
+
+		case constants.ProtocolHTTPS:
+			// Valid
+			// If mTLS is enabled, verify there is an AuthenticatedPrincipal specified
+			authenticatedSourceFound := false
+			for _, source := range ingressBackend.Spec.Sources {
+				if source.Kind == pv1alpha1.KindAuthenticatedPrincipal {
+					authenticatedSourceFound = true
+					break
+				}
+			}
+
+			if backend.TLS.SkipClientCertValidation && !authenticatedSourceFound {
+				return nil, errors.Errorf("HTTPS ingress with client certificate validation enabled must specify at least one 'AuthenticatedPrincipal` source")
+			}
+
+		default:
+			return nil, errors.Errorf("Expected 'port.protocol' to be 'http' or 'https', got: %s", backend.Port.Protocol)
+		}
+	}
+
+	return nil, nil
+}
+
+// EgressValidator validates the Egress custom resource
 func EgressValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
 	egress := &pv1alpha1.Egress{}
 	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(egress); err != nil {
@@ -49,18 +87,18 @@ func EgressValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionR
 
 	for _, m := range egress.Spec.Matches {
 		if m.Kind != "HTTPRouteGroup" {
-			return nil, fmt.Errorf("Expected Matches.Kind to be 'HTTPRouteGroup', got: %s", m.Kind)
+			return nil, errors.Errorf("Expected 'Matches.Kind' to be 'HTTPRouteGroup', got: %s", m.Kind)
 		}
 
 		if *m.APIGroup != "specs.smi-spec.io/v1alpha4" {
-			return nil, fmt.Errorf("Expected Matches.APIGroup to be 'specs.smi-spec.io/v1alpha4', got: %s", *m.APIGroup)
+			return nil, errors.Errorf("Expected 'Matches.APIGroup' to be 'specs.smi-spec.io/v1alpha4', got: %s", *m.APIGroup)
 		}
 	}
 
 	return nil, nil
 }
 
-// MeshConfigValidator validates the MeshConfig CRD.
+// MeshConfigValidator validates the MeshConfig custom resource
 func MeshConfigValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
 	config := &cv1alpha1.MeshConfig{}
 	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(config); err != nil {
@@ -69,11 +107,11 @@ func MeshConfigValidator(req *admissionv1.AdmissionRequest) (*admissionv1.Admiss
 
 	d, err := time.ParseDuration(config.Spec.Certificate.ServiceCertValidityDuration)
 	if err != nil {
-		return nil, fmt.Errorf("Certificate.ServiceCertValidityDuration %s is not valid", config.Spec.Certificate.ServiceCertValidityDuration)
+		return nil, errors.Errorf("'Certificate.ServiceCertValidityDuration' %s is not valid", config.Spec.Certificate.ServiceCertValidityDuration)
 	}
 
-	if d < MinDuration {
-		return nil, fmt.Errorf("Certificate.ServiceCertValidityDuration %d is lower than %d", d, MinDuration)
+	if d < minCertValidityDuration {
+		return nil, errors.Errorf("'Certificate.ServiceCertValidityDuration' %d is lower than %d", d, minCertValidityDuration)
 	}
 
 	return nil, nil
@@ -90,21 +128,21 @@ func MultiClusterServiceValidator(req *admissionv1.AdmissionRequest) (*admission
 
 	for _, cluster := range config.Spec.Clusters {
 		if len(strings.TrimSpace(cluster.Name)) == 0 {
-			return nil, fmt.Errorf("Cluster name is not valid")
+			return nil, errors.New("Cluster name is not valid")
 		}
 		if _, ok := clusterNames[cluster.Name]; ok {
-			return nil, fmt.Errorf("Cluster named %s already exists", cluster.Name)
+			return nil, errors.Errorf("Cluster named %s already exists", cluster.Name)
 		}
 		if len(strings.TrimSpace(cluster.Address)) == 0 {
-			return nil, fmt.Errorf("Cluster address %s is not valid", cluster.Address)
+			return nil, errors.Errorf("Cluster address %s is not valid", cluster.Address)
 		}
 		clusterAddress := strings.Split(cluster.Address, ":")
 		if net.ParseIP(clusterAddress[0]) == nil {
-			return nil, fmt.Errorf("Error parsing IP address %s", cluster.Address)
+			return nil, errors.Errorf("Error parsing IP address %s", cluster.Address)
 		}
 		_, err := strconv.ParseUint(clusterAddress[1], 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing port value %s", cluster.Address)
+			return nil, errors.Errorf("Error parsing port value %s", cluster.Address)
 		}
 		clusterNames[cluster.Name] = true
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -5,9 +5,28 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/rs/zerolog/log"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var (
+	log = logger.New("webhook")
+
+	// ContentTypeJSON is the supported content type for HTTP requests
+	ContentTypeJSON = "application/json"
+
+	// HTTPHeaderContentType is the Content-Type HTTP header key
+	HTTPHeaderContentType = "Content-Type"
+
+	// codecs is the codec factory used by the deserialzer
+	codecs = serializer.NewCodecFactory(runtime.NewScheme())
+
+	// Deserializer is used to decode the admission request body
+	Deserializer = codecs.UniversalDeserializer()
 )
 
 // GetAdmissionRequestBody returns the body of the admission request


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change enables osm-validator, a validating webhook
to validate k8s resources. It addresses existing issues
with the webhook being broken, and updates the name of
the validating webhook and associated flag for clarity
and correctness.
It also updates the min service cert validity duration
to 2 minutes which takes into account the noise added
while performing certificate rotation.

The validations are only enabled for features that have
been tested to work with the validator.

Part of #3281

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
