### PR TITLE
smi/health: fix race condition leading to controller crash

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -251,7 +251,7 @@ func main() {
 	clientset := extensionsClientset.NewForConfigOrDie(kubeConfig)
 
 	// Health/Liveness probes
-	funcProbes := []health.Probes{xdsServer, smi.HealthChecker{SMIClientset: clientset}}
+	funcProbes := []health.Probes{xdsServer, smi.HealthChecker{DiscoveryClient: clientset.Discovery()}}
 	httpServer.AddHandlers(map[string]http.Handler{
 		"/health/ready": health.ReadinessHandler(funcProbes, getHTTPHealthProbes()),
 		"/health/alive": health.LivenessHandler(funcProbes, getHTTPHealthProbes()),

--- a/pkg/ingress/client_test.go
+++ b/pkg/ingress/client_test.go
@@ -23,18 +23,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
-type fakeDiscoveryClient struct {
-	discovery.ServerResourcesInterface
-	resources map[string]metav1.APIResourceList
-	err       error
-}
-
-// ServerResourcesForGroupVersion returns the supported resources for a group and version.
-func (f *fakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
-	resp := f.resources[groupVersion]
-	return &resp, f.err
-}
-
 func TestGetSupportedIngressVersions(t *testing.T) {
 	type testCase struct {
 		name             string
@@ -46,8 +34,8 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 	testCases := []testCase{
 		{
 			name: "k8s API server supports both ingress v1 and v1beta",
-			discoveryClient: &fakeDiscoveryClient{
-				resources: map[string]metav1.APIResourceList{
+			discoveryClient: &k8s.FakeDiscoveryClient{
+				Resources: map[string]metav1.APIResourceList{
 					"networking.k8s.io/v1": {APIResources: []metav1.APIResource{
 						{Kind: "Ingress"},
 						{Kind: "NetworkPolicy"},
@@ -56,7 +44,7 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 						{Kind: "Ingress"},
 					}},
 				},
-				err: nil,
+				Err: nil,
 			},
 			expectedVersions: map[string]bool{
 				"networking.k8s.io/v1":      true,
@@ -66,8 +54,8 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 		},
 		{
 			name: "k8s API server supports only ingress v1beta1",
-			discoveryClient: &fakeDiscoveryClient{
-				resources: map[string]metav1.APIResourceList{
+			discoveryClient: &k8s.FakeDiscoveryClient{
+				Resources: map[string]metav1.APIResourceList{
 					"networking.k8s.io/v1": {APIResources: []metav1.APIResource{
 						{Kind: "NetworkPolicy"},
 					}},
@@ -75,7 +63,7 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 						{Kind: "Ingress"},
 					}},
 				},
-				err: nil,
+				Err: nil,
 			},
 			expectedVersions: map[string]bool{
 				"networking.k8s.io/v1":      false,
@@ -85,8 +73,8 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 		},
 		{
 			name: "k8s API server supports only ingress v1",
-			discoveryClient: &fakeDiscoveryClient{
-				resources: map[string]metav1.APIResourceList{
+			discoveryClient: &k8s.FakeDiscoveryClient{
+				Resources: map[string]metav1.APIResourceList{
 					"networking.k8s.io/v1": {APIResources: []metav1.APIResource{
 						{Kind: "Ingress"},
 					}},
@@ -94,7 +82,7 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 						{Kind: "NetworkPolicy"},
 					}},
 				},
-				err: nil,
+				Err: nil,
 			},
 			expectedVersions: map[string]bool{
 				"networking.k8s.io/v1":      true,
@@ -104,9 +92,9 @@ func TestGetSupportedIngressVersions(t *testing.T) {
 		},
 		{
 			name: "k8s API server returns an error",
-			discoveryClient: &fakeDiscoveryClient{
-				resources: map[string]metav1.APIResourceList{},
-				err:       errors.New("fake error"),
+			discoveryClient: &k8s.FakeDiscoveryClient{
+				Resources: map[string]metav1.APIResourceList{},
+				Err:       errors.New("fake error"),
 			},
 			expectedVersions: nil,
 			exepectError:     true,

--- a/pkg/k8s/fake.go
+++ b/pkg/k8s/fake.go
@@ -1,0 +1,19 @@
+package k8s
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+)
+
+// FakeDiscoveryClient is a fake client for k8s API discovery
+type FakeDiscoveryClient struct {
+	discovery.ServerResourcesInterface
+	Resources map[string]metav1.APIResourceList
+	Err       error
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group and version.
+func (f *FakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	resp := f.Resources[groupVersion]
+	return &resp, f.Err
+}

--- a/pkg/smi/health.go
+++ b/pkg/smi/health.go
@@ -4,62 +4,69 @@ import (
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	smiSplit "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
-	extensionsClientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-
-	"github.com/openservicemesh/osm/pkg/version"
+	"k8s.io/client-go/discovery"
 )
 
 var (
 
-	// The key is the API Resource.Kind and the value is the SMI CRD Type
-	reqKinds = map[string]string{
-		"HTTPRouteGroup": "specs",  // Full CRD API Group: specs.smi-spec.io
-		"TCPRoute":       "specs",  // Full CRD API Group: specs.smi-spec.io
-		"TrafficSplit":   "split",  // Full CRD API Group: split.smi-spec.io
-		"TrafficTarget":  "access", // Full CRD API Group: access.smi-spec.io
+	// requiredResourceKindGroupMap is a mapping of the required resource kind to it's API group
+	requiredResourceKindGroupMap = map[string]string{
+		"HTTPRouteGroup": smiSpecs.SchemeGroupVersion.String(),
+		"TCPRoute":       smiSpecs.SchemeGroupVersion.String(),
+		"TrafficSplit":   smiSplit.SchemeGroupVersion.String(),
+		"TrafficTarget":  smiAccess.SchemeGroupVersion.String(),
 	}
-	candidateVersions = []string{smiSpecs.SchemeGroupVersion.String(), smiAccess.SchemeGroupVersion.String(), smiSpecs.SchemeGroupVersion.String(), smiSplit.SchemeGroupVersion.String()}
+	smiAPIGroupVersions = []string{
+		smiSpecs.SchemeGroupVersion.String(),
+		smiAccess.SchemeGroupVersion.String(),
+		smiSpecs.SchemeGroupVersion.String(),
+		smiSplit.SchemeGroupVersion.String(),
+	}
 )
 
 // HealthChecker has SMI clientset interface to access SMI CRDS
 type HealthChecker struct {
-	SMIClientset extensionsClientset.Interface
+	DiscoveryClient discovery.ServerResourcesInterface
 }
 
 // Liveness is the Kubernetes liveness probe handler.
-func (smi HealthChecker) Liveness() bool {
-	return checkSMICrdsExist(smi.SMIClientset, reqKinds, candidateVersions)
+func (c HealthChecker) Liveness() bool {
+	return c.requiredAPIResourcesExist()
 }
 
 // Readiness is the Kubernetes readiness probe handler.
-func (smi HealthChecker) Readiness() bool {
-	return checkSMICrdsExist(smi.SMIClientset, reqKinds, candidateVersions)
+func (c HealthChecker) Readiness() bool {
+	return c.requiredAPIResourcesExist()
 }
 
 // GetID returns the ID of the probe
-func (smi HealthChecker) GetID() string {
+func (c HealthChecker) GetID() string {
 	return "SMI"
 }
 
-func checkSMICrdsExist(clientset extensionsClientset.Interface, reqKinds map[string]string, candidateVersions []string) bool {
-	client := clientset.Discovery()
-	for _, groupVersion := range candidateVersions {
-		list, err := client.ServerResourcesForGroupVersion(groupVersion)
+// requiredAPIResourcesExist returns true if the required API resources are available on the API server
+func (c HealthChecker) requiredAPIResourcesExist() bool {
+	resourceKindAvailable := make(map[string]bool)
+	for resourceKind := range requiredResourceKindGroupMap {
+		resourceKindAvailable[resourceKind] = false
+	}
+	for _, groupVersion := range smiAPIGroupVersions {
+		list, err := c.DiscoveryClient.ServerResourcesForGroupVersion(groupVersion)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting resources for groupVersion %s", groupVersion)
 			return false
 		}
 		for _, resource := range list.APIResources {
-			crdName := resource.Kind
-			delete(reqKinds, crdName)
+			resourceKindAvailable[resource.Kind] = true
 		}
 	}
 
-	if len(reqKinds) != 0 {
-		for missingCRD := range reqKinds {
-			log.Error().Err(errSMICrds).Msgf("Missing SMI CRD: %s. To manually install %s, do `kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm/%s/charts/osm/crds/%s.yaml`", missingCRD, missingCRD, version.Version, reqKinds[missingCRD])
+	for resourceKind, isAvailable := range resourceKindAvailable {
+		if !isAvailable {
+			log.Error().Err(errSMICrds).Msgf("SMI API for Kind=%s, GroupVersion=%s is not available", resourceKind, requiredResourceKindGroupMap[resourceKind])
+			return false
 		}
-		return false
 	}
+
 	return true
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change fixes a bug where a pkg scoped map is being
concurrently modified to check if SMI API resources are
available.
Additionally, it refactors the code for clarity and better
unit testing.

Panic trace:
```
goroutine 295 [running]:
runtime.throw(0x1f7c257, 0x15)
        /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc000c83740 sp=0xc000c83710 pc=0x438272
runtime.mapdelete_faststr(0x1c43520, 0xc0000aa420, 0xc0006ac1e0, 0xe)
        /usr/local/go/src/runtime/map_faststr.go:382 +0x3a8 fp=0xc000c837a8 sp=0xc000c83740 pc=0x414c48
github.com/openservicemesh/osm/pkg/smi.checkSMICrdsExist(0x221cb50, 0xc00094fc98, 0xc0000aa420, 0x30b9a80, 0x4, 0x4, 0x21dc0c0)
        /src/projects/osm/pkg/smi/health.go:54 +0x42e fp=0xc000c839b0 sp=0xc000c837a8 pc=0x17f860e
github.com/openservicemesh/osm/pkg/smi.HealthChecker.Readiness(...)
        /src/projects/osm/pkg/smi/health.go:36
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| SMI Policy                 | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
