### PR TITLE
chore(demo): Only create creds for private registry

### DIFF
--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -41,6 +41,7 @@ DEPLOY_WITH_SAME_SA="${DEPLOY_WITH_SAME_SA:-false}"
 ENVOY_LOG_LEVEL="${ENVOY_LOG_LEVEL:-debug}"
 DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
 MULTICLUSTER_CONTEXTS="${MULTICLUSTER_CONTEXTS:-alpha beta}"
+USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-false}"
 
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*

--- a/scripts/create-container-registry-creds.sh
+++ b/scripts/create-container-registry-creds.sh
@@ -13,7 +13,9 @@ if [[ "${CI:-}" == "true" ]]; then
     CTR_REGISTRY_PASSWORD=${DOCKER_PASS:-}
 fi
 
-[[ -z "$CTR_REGISTRY_PASSWORD" ]] && exit 0
+if [[ "$USE_PRIVATE_REGISTRY" = false ]]; then
+    exit 0
+fi
 
 REGISTRY=$(echo "$CTR_REGISTRY" | awk -F'.' '{print $1}')
 REGISTRY_URL=$(echo "$CTR_REGISTRY" | awk -F'.' '{print $1 "." $2 "." $3}')


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Use PRIVATE_REGISTRY flag to skip credential creation step in demo if images are being pulled from a public registry. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [X] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
