### PR TITLE
chore(pkg/metricsstore): make Help string formatted consistently

### DIFF
--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -81,7 +81,7 @@ func init() {
 			Namespace: metricsRootNamespace,
 			Subsystem: "k8s",
 			Name:      "api_event_count",
-			Help:      "represents the number of events received from the Kubernetes API Server",
+			Help:      "Represents the number of events received from the Kubernetes API Server",
 		},
 		[]string{"type", "namespace"},
 	)
@@ -89,19 +89,19 @@ func init() {
 		Namespace: metricsRootNamespace,
 		Subsystem: "k8s",
 		Name:      "monitored_namespace_count",
-		Help:      "represents the number of namespaces monitored by OSM controller",
+		Help:      "Represents the number of namespaces monitored by OSM controller",
 	})
 	defaultMetricsStore.K8sMeshPodCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metricsRootNamespace,
 		Subsystem: "k8s",
 		Name:      "mesh_pod_count",
-		Help:      "represents the number of pods part of the mesh managed by OSM controller",
+		Help:      "Represents the number of pods part of the mesh managed by OSM controller",
 	})
 	defaultMetricsStore.K8sMeshServiceCount = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: metricsRootNamespace,
 		Subsystem: "k8s",
 		Name:      "mesh_service_count",
-		Help:      "represents the number of services part of the mesh managed by OSM controller",
+		Help:      "Represents the number of services part of the mesh managed by OSM controller",
 	})
 
 	/*
@@ -111,14 +111,14 @@ func init() {
 		Namespace: metricsRootNamespace,
 		Subsystem: "proxy",
 		Name:      "connect_count",
-		Help:      "represents the number of proxies connected to OSM controller",
+		Help:      "Represents the number of proxies connected to OSM controller",
 	})
 
 	defaultMetricsStore.ProxyReconnectCount = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: metricsRootNamespace,
 		Subsystem: "proxy",
 		Name:      "reconnect_count",
-		Help:      "represents the number of reconnects from known proxies to OSM controller",
+		Help:      "Represents the number of reconnects from known proxies to OSM controller",
 	})
 
 	defaultMetricsStore.ProxyConfigUpdateTime = prometheus.NewHistogramVec(
@@ -163,7 +163,7 @@ func init() {
 		Namespace: metricsRootNamespace,
 		Subsystem: "cert",
 		Name:      "issued_count",
-		Help:      "represents the total number of XDS certificates issued to proxies",
+		Help:      "Represents the total number of XDS certificates issued to proxies",
 	})
 
 	defaultMetricsStore.CertIssuedTime = prometheus.NewHistogramVec(

--- a/pkg/metricsstore/metricsstore_test.go
+++ b/pkg/metricsstore/metricsstore_test.go
@@ -45,7 +45,7 @@ func TestMetricsStore(t *testing.T) {
 
 			assert.Equal(http.StatusOK, rr.Code)
 
-			expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count represents the number of events received from the Kubernetes API Server
+			expectedResp := fmt.Sprintf(`# HELP osm_k8s_api_event_count Represents the number of events received from the Kubernetes API Server
 # TYPE osm_k8s_api_event_count counter
 osm_k8s_api_event_count{namespace="foo",type="add"} %d
 `, i /* api event count */)
@@ -76,7 +76,7 @@ osm_k8s_api_event_count{namespace="foo",type="add"} %d
 
 		assert.Equal(http.StatusOK, rr.Code)
 
-		expectedResp := fmt.Sprintf(`# HELP osm_proxy_connect_count represents the number of proxies connected to OSM controller
+		expectedResp := fmt.Sprintf(`# HELP osm_proxy_connect_count Represents the number of proxies connected to OSM controller
 # TYPE osm_proxy_connect_count gauge
 osm_proxy_connect_count %d
 `, proxiesConnected-proxiesDisconnected)


### PR DESCRIPTION
Have Help strings start with a capital letter to match with Prometheus default metric Help strings.

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? no
