### PR TITLE
bug-report: implement bug report tool

### DIFF
--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -22,7 +22,7 @@ To install and configure OSM, run:
 
 var settings = cli.New()
 
-func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args []string) *cobra.Command {
+func newRootCmd(config *action.Configuration, stdin io.Reader, stdout io.Writer, stderr io.Writer, args []string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "osm",
 		Short:        "Install and manage Open Service Mesh",
@@ -36,17 +36,17 @@ func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args 
 
 	// Add subcommands here
 	cmd.AddCommand(
-		newMeshCmd(config, in, out),
-		newEnvCmd(out),
-		newInstallCmd(config, out),
-		newDashboardCmd(config, out),
-		newNamespaceCmd(out),
-		newMetricsCmd(out),
-		newVersionCmd(out),
-		newProxyCmd(config, out),
-		newTrafficPolicyCmd(out),
-		newUninstallCmd(config, in, out),
-		newSupportCmd(out),
+		newMeshCmd(config, stdin, stdout),
+		newEnvCmd(stdout),
+		newInstallCmd(config, stdout),
+		newDashboardCmd(config, stdout),
+		newNamespaceCmd(stdout),
+		newMetricsCmd(stdout),
+		newVersionCmd(stdout),
+		newProxyCmd(config, stdout),
+		newTrafficPolicyCmd(stdout),
+		newUninstallCmd(config, stdin, stdout),
+		newSupportCmd(config, stdout, stderr),
 	)
 
 	_ = flags.Parse(args)
@@ -56,7 +56,7 @@ func newRootCmd(config *action.Configuration, in io.Reader, out io.Writer, args 
 
 func initCommands() *cobra.Command {
 	actionConfig := new(action.Configuration)
-	cmd := newRootCmd(actionConfig, os.Stdin, os.Stdout, os.Args[1:])
+	cmd := newRootCmd(actionConfig, os.Stdin, os.Stdout, os.Stderr, os.Args[1:])
 	_ = actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), "secret", debug)
 
 	// run when each command's execute method is called

--- a/cmd/cli/support.go
+++ b/cmd/cli/support.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/action"
 )
 
 const supportCmdDescription = `
@@ -11,14 +12,15 @@ This command consists of subcommands related supportability and
 associated tooling, such as examining error codes.
 `
 
-func newSupportCmd(out io.Writer) *cobra.Command {
+func newSupportCmd(config *action.Configuration, stdout io.Writer, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "support",
 		Short: "supportability tooling",
 		Long:  supportCmdDescription,
 		Args:  cobra.NoArgs,
 	}
-	cmd.AddCommand(newSupportErrInfoCmd(out))
+	cmd.AddCommand(newSupportErrInfoCmd(stdout))
+	cmd.AddCommand(newSupportBugReportCmd(config, stdout, stderr))
 
 	return cmd
 }

--- a/cmd/cli/support_bugreport.go
+++ b/cmd/cli/support_bugreport.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/pkg/action"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/bugreport"
+	"github.com/openservicemesh/osm/pkg/k8s"
+)
+
+const bugReportDescription = `
+Generate a bug report.
+
+*Note:
+- Both 'osm' and 'kubectl' CLI must reside in the evironment's lookup path.
+- If the environment includes sensitive information that should not be collected,
+  please do not specify the associated resources.
+`
+
+const bugReportExample = `
+# Generate a bug report for the given namespaces, deployments, and pods
+osm support bug-report --app-namespaces bookbuyer,bookstore \
+	--app-deployments bookbuyer/bookbuyer,bookstore/bookstore-v1 \
+	--app-pods bookthief/bookthief-7bb7f9b98c-qplq4
+`
+
+type bugReportCmd struct {
+	stdout         io.Writer
+	stderr         io.Writer
+	kubeClient     kubernetes.Interface
+	appNamespaces  []string
+	appDeployments []string
+	appPods        []string
+	outFile        string
+}
+
+func newSupportBugReportCmd(config *action.Configuration, stdout io.Writer, stderr io.Writer) *cobra.Command {
+	bugReportCmd := &bugReportCmd{
+		stdout: stdout,
+		stderr: stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "bug-report",
+		Short: "generate bug report",
+		Long:  bugReportDescription,
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
+			}
+			bugReportCmd.kubeClient, err = kubernetes.NewForConfig(config)
+			if err != nil {
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
+			}
+			return bugReportCmd.run()
+		},
+		Example: bugReportExample,
+	}
+
+	f := cmd.Flags()
+	f.StringSliceVar(&bugReportCmd.appNamespaces, "app-namespaces", nil, "Application namespaces")
+	f.StringSliceVar(&bugReportCmd.appDeployments, "app-deployments", nil, "Application deployments: <namespace>/<deployment>")
+	f.StringSliceVar(&bugReportCmd.appPods, "app-pods", nil, "Application pods: <namespace>/pod")
+	f.StringVarP(&bugReportCmd.outFile, "out-file", "o", "", "Output file path")
+
+	return cmd
+}
+
+func (cmd *bugReportCmd) run() error {
+	var appPods, appDeployments []types.NamespacedName
+
+	for _, pod := range cmd.appPods {
+		p, err := k8s.NamespacedNameFrom(pod)
+		if err != nil {
+			fmt.Fprintf(cmd.stderr, "Pod name %s is not namespaced, skipping it", pod)
+			continue
+		}
+		appPods = append(appPods, p)
+	}
+
+	for _, deployment := range cmd.appDeployments {
+		d, err := k8s.NamespacedNameFrom(deployment)
+		if err != nil {
+			fmt.Fprintf(cmd.stderr, "Deployment name %s is not namespaced, skipping it", deployment)
+			continue
+		}
+		appDeployments = append(appDeployments, d)
+	}
+
+	bugReportCfg := &bugreport.Config{
+		Stdout:               cmd.stdout,
+		Stderr:               cmd.stderr,
+		KubeClient:           cmd.kubeClient,
+		ControlPlaneNamepace: settings.Namespace(),
+		AppNamespaces:        cmd.appNamespaces,
+		AppDeployments:       appDeployments,
+		AppPods:              appPods,
+		OutFile:              cmd.outFile,
+	}
+
+	return bugReportCfg.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/jinzhu/copier v0.2.4
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/matm/gocov-html v0.0.0-20200509184451-71874e2e203b
+	github.com/mholt/archiver/v3 v3.5.0
 	github.com/mitchellh/gox v1.0.1
 	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,7 @@ github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk5
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -260,6 +261,9 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 h1:ZClxb8laGDf5arX
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dsnet/compress v0.0.1 h1:PlZu0n3Tuv04TzpfPbrnI0HW/YwodEXDS+oPKahKF0Q=
+github.com/dsnet/compress v0.0.1/go.mod h1:Aw8dCMJ7RioblQeTqt88akK31OvO8Dhf5JflhBbQEHo=
+github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -684,8 +688,14 @@ github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQL
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.0 h1:wJbzvpYMVGG9iTI9VxpnNZfd4DzMPoCWze3GgSqz8yg=
 github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/pgzip v1.2.4 h1:TQ7CNpYKovDOmqzRHKxJh0BeaBI7UdQZYc6p7pMQh1A=
+github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -761,6 +771,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mbilski/exhaustivestruct v1.1.0 h1:4ykwscnAFeHJruT+EY3M3vdeP8uXMh0VV2E61iR7XD8=
 github.com/mbilski/exhaustivestruct v1.1.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
+github.com/mholt/archiver/v3 v3.5.0 h1:nE8gZIrw66cu4osS/U7UW7YDuGMHssxKutU8IfWxwWE=
+github.com/mholt/archiver/v3 v3.5.0/go.mod h1:qqTTPUK/HZPFgFQ/TJ3BzvTpF/dPtFVJXdQbCmeMxwc=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -835,6 +847,8 @@ github.com/nishanths/exhaustive v0.1.0 h1:kVlMw8h2LHPMGUVqUj6230oQjjTMFjwcZrnkhX
 github.com/nishanths/exhaustive v0.1.0/go.mod h1:S1j9110vxV1ECdCudXRkeMnFQ/DQk9ajLT0Uf2MYZQQ=
 github.com/norwoodj/helm-docs v1.4.0 h1:Vfkp6xpW6kFJNPX1vY0gnGOcCxN8Gi9C7ahqxiXw0Ak=
 github.com/norwoodj/helm-docs v1.4.0/go.mod h1:z8Evt7esakCuqMKuwpVAAp4NyHgQbH3iGWsGmLuBcV0=
+github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
+github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -906,6 +920,8 @@ github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rK
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4/v4 v4.0.3 h1:vNQKSVZNYUEAvRY9FaUXAF1XPbSOHJtDTiP41kzDz2E=
+github.com/pierrec/lz4/v4 v4.0.3/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1089,6 +1105,9 @@ github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa h1:RC4maTWLK
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
+github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ultraware/funlen v0.0.3 h1:5ylVWm8wsNwH5aWo9438pwvsK0QiqVuUrt9bn7S/iLA=
 github.com/ultraware/funlen v0.0.3/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=
 github.com/ultraware/whitespace v0.0.4 h1:If7Va4cM03mpgrNH9k49/VOicWpGoG70XPBFFODYDsg=
@@ -1111,6 +1130,8 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHo
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=

--- a/pkg/bugreport/archive.go
+++ b/pkg/bugreport/archive.go
@@ -1,0 +1,26 @@
+package bugreport
+
+import (
+	"compress/flate"
+
+	"github.com/mholt/archiver/v3"
+	"github.com/pkg/errors"
+)
+
+func (c *Config) archive(sourcePath string, destinationPath string) error {
+	z := archiver.Zip{
+		CompressionLevel:       flate.DefaultCompression,
+		MkdirAll:               true,
+		SelectiveCompression:   true,
+		ContinueOnError:        true,
+		OverwriteExisting:      true,
+		ImplicitTopLevelFolder: false,
+	}
+	if err := z.Archive([]string{sourcePath}, destinationPath); err != nil {
+		c.completionFailure("Error archiving files for bug report")
+		return errors.Wrap(err, "Error generating bug report")
+	}
+
+	c.completionSuccess("Bug report successfully archived to %s", destinationPath)
+	return nil
+}

--- a/pkg/bugreport/namespace.go
+++ b/pkg/bugreport/namespace.go
@@ -1,0 +1,60 @@
+package bugreport
+
+import (
+	"os"
+	"path"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const (
+	rootNamespaceDirName = "namespaces"
+)
+
+var commonNamespaceCmds = [][]string{
+	{"osm", "namespace", "list"},
+}
+
+func (c *Config) initRootNamespaceDir() error {
+	rootNsDir := c.rootNamespaceDirPath()
+	if err := os.Mkdir(rootNsDir, 0700); err != nil {
+		return errors.Wrapf(err, "Error creating root dir %s for namespaces", rootNsDir)
+	}
+	return nil
+}
+
+func (c *Config) collectMeshedNamespaceReport() {
+	for _, nsCmd := range commonNamespaceCmds {
+		outPath := path.Join(c.rootNamespaceDirPath(), commandsDirName, strings.Join(nsCmd, "_"))
+		if err := runCmdAndWriteToFile(nsCmd, outPath); err != nil {
+			c.completionFailure("Error running command: %v", nsCmd)
+		}
+	}
+}
+
+func (c *Config) collectPerNamespaceReport() {
+	for _, ns := range c.AppNamespaces {
+		for _, nsCmd := range getPerNamespaceCommands(ns) {
+			outPath := path.Join(c.rootNamespaceDirPath(), ns, commandsDirName, strings.Join(nsCmd, "_"))
+			if err := runCmdAndWriteToFile(nsCmd, outPath); err != nil {
+				c.completionFailure("Error running cmd: %v", nsCmd)
+			}
+		}
+		c.completionSuccess("Collected report from Namespace %q", ns)
+	}
+}
+
+func (c *Config) rootNamespaceDirPath() string {
+	return path.Join(c.stagingDir, rootNamespaceDirName)
+}
+
+func getPerNamespaceCommands(namespace string) [][]string {
+	return [][]string{
+		{"kubectl", "get", "events", "-n", namespace},
+		{"kubectl", "get", "pods", "-n", namespace, "-l", constants.EnvoyUniqueIDLabelName},
+		{"kubectl", "get", "svc", "-n", namespace},
+	}
+}

--- a/pkg/bugreport/pod.go
+++ b/pkg/bugreport/pod.go
@@ -1,0 +1,78 @@
+package bugreport
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	mapset "github.com/deckarep/golang-set"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	rootPodDirName = "pods"
+)
+
+func (c *Config) collectPerPodReport() {
+	for _, pod := range c.AppPods {
+		for _, podCmd := range getPerPodCommands(pod) {
+			outPath := path.Join(c.rootNamespaceDirPath(), pod.Namespace, rootPodDirName, pod.Name, commandsDirName, strings.Join(podCmd, "_"))
+			if err := runCmdAndWriteToFile(podCmd, outPath); err != nil {
+				c.completionFailure("Error running cmd: %v", podCmd)
+			}
+		}
+		c.completionSuccess("Collected report for Pod %q", pod)
+	}
+}
+
+func (c *Config) getUniquePods() []types.NamespacedName {
+	var pods []types.NamespacedName
+	podSet := mapset.NewSet()
+
+	for _, pod := range c.AppPods {
+		podSet.Add(pod)
+	}
+
+	for _, deployment := range c.AppDeployments {
+		d, err := c.KubeClient.AppsV1().Deployments(deployment.Namespace).Get(context.Background(), deployment.Name, metav1.GetOptions{})
+		if err != nil {
+			c.completionFailure("Deployment %s not found, skipping it", deployment)
+			continue
+		}
+		podLabels := d.Spec.Template.ObjectMeta.Labels
+		options := metav1.ListOptions{
+			LabelSelector: fields.SelectorFromSet(podLabels).String(),
+		}
+		podList, err := c.KubeClient.CoreV1().Pods(deployment.Namespace).List(context.Background(), options)
+		if err != nil {
+			c.completionFailure("Error listing Pods for Deployment %s, err: %s", deployment, err)
+		}
+		if podList == nil {
+			continue
+		}
+		for _, pod := range podList.Items {
+			p := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+			podSet.Add(p)
+		}
+	}
+
+	for p := range podSet.Iter() {
+		pods = append(pods, p.(types.NamespacedName))
+	}
+
+	return pods
+}
+
+func getPerPodCommands(pod types.NamespacedName) [][]string {
+	return [][]string{
+		{"kubectl", "logs", pod.Name, "-n", pod.Namespace, "-c", "envoy"},
+		{"osm", "proxy", "get", "config_dump", pod.Name, "-n", pod.Namespace},
+		{"osm", "proxy", "get", "ready", pod.Name, "-n", pod.Namespace},
+		{"osm", "proxy", "get", "stats", pod.Name, "-n", pod.Namespace},
+		{"osm", "proxy", "get", "clusters", pod.Name, "-n", pod.Namespace},
+		{"osm", "proxy", "get", "listeners", pod.Name, "-n", pod.Namespace},
+		{"osm", "proxy", "get", "certs", pod.Name, "-n", pod.Namespace},
+	}
+}

--- a/pkg/bugreport/run.go
+++ b/pkg/bugreport/run.go
@@ -1,0 +1,131 @@
+package bugreport
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	successIndicator = "\u2713" // check mark, used for success
+	failureIndicator = "x"      // cross mark, used for failure
+	commandsDirName  = "commands"
+)
+
+// Run generates a bug report from the given config
+func (c *Config) Run() error {
+	// Check prerequisites
+	if err := checkPrereq(); err != nil {
+		return err
+	}
+
+	// Create staging directory
+	stagingDir, err := ioutil.TempDir("", "osm_bug_report_")
+	if err != nil {
+		return errors.Wrap(err, "Error creating temp directory needed for creating bug report. Aborting")
+	}
+	c.stagingDir = stagingDir
+	fmt.Fprintf(c.Stdout, "[+] Created staging dir %s to generate bug report\n", stagingDir)
+	c.endSection()
+
+	// Generate report for mesh namespaces
+	fmt.Fprintf(c.Stdout, "[+] Collecting information about meshed namespaces\n")
+	if err := c.initRootNamespaceDir(); err != nil {
+		c.completionFailure("Error initializing root namespaces dir. Aborting")
+	}
+	c.collectMeshedNamespaceReport()
+	c.completionSuccess("Finished generating report for meshed namespaces")
+	c.endSection()
+
+	// Generate report for each app namespace
+	fmt.Fprintf(c.Stdout, "[+] Collecting information from individual app namespaces\n")
+	c.collectPerNamespaceReport()
+	c.completionSuccess("Finished generating report for individual app namespaces")
+	c.endSection()
+
+	// Generate report for each app pod
+	c.AppPods = c.getUniquePods()
+	fmt.Fprintf(c.Stdout, "[+] Collecting information from individual app namespaces\n")
+	c.collectPerPodReport()
+	c.completionSuccess("Finished generating report for individual app pods")
+	c.endSection()
+
+	// Generate output file if not provided
+	if c.OutFile == "" {
+		outFd, err := ioutil.TempFile("", "*_osm-bug-report.zip")
+		if err != nil {
+			c.completionFailure("Error creating temp file for bug report")
+			return errors.Wrap(err, "Error creating bug report")
+		}
+		c.OutFile = outFd.Name()
+	}
+
+	// Archive it
+	fmt.Fprintf(c.Stdout, "[+] Collecting information from individual app namespaces\n")
+	if err := c.archive(stagingDir, c.OutFile); err != nil {
+		c.completionFailure("Error archiving bug report")
+		return errors.Wrap(err, "Error creating bug report")
+	}
+	// Remove staging dir
+	if err := os.RemoveAll(c.stagingDir); err != nil {
+		c.completionFailure("Error removing staging dir %s, err: %s", c.stagingDir, err)
+	}
+	c.endSection()
+
+	return nil
+}
+
+func checkPrereq() error {
+	requiredTools := []string{"osm", "kubectl"}
+	for _, tool := range requiredTools {
+		if !pathExists(tool) {
+			return errors.Errorf("Prerequisite not met: %s not found", tool)
+		}
+	}
+	return nil
+}
+
+func pathExists(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func (c *Config) endSection() {
+	fmt.Fprint(c.Stdout, "\n\n")
+}
+
+func (c *Config) completionSuccess(format string, a ...interface{}) {
+	fmt.Fprintf(c.Stdout, "%s %s\n", successIndicator, fmt.Sprintf(format, a...))
+}
+
+func (c *Config) completionFailure(format string, a ...interface{}) {
+	fmt.Fprintf(c.Stderr, "%s %s\n", failureIndicator, fmt.Sprintf(format, a...))
+}
+
+func runCmdAndWriteToFile(cmdList []string, outFile string) error {
+	if len(cmdList) == 0 {
+		return errors.New("Atleast 1 command must be provided, none provided")
+	}
+
+	// Create parent directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(outFile), 0700); err != nil {
+		return errors.Wrapf(err, "Error creating parent directory for path: %s", outFile)
+	}
+
+	cmd := exec.Command(cmdList[0], cmdList[1:]...) //#nosec G204
+
+	// open the out file for writing
+	outfile, err := os.Create(outFile)
+	if err != nil {
+		return err
+	}
+	defer outfile.Close() //nolint: errcheck, #nosec G307
+	cmd.Stdout = outfile
+	cmd.Stderr = outfile
+
+	return cmd.Run()
+}

--- a/pkg/bugreport/run_test.go
+++ b/pkg/bugreport/run_test.go
@@ -1,0 +1,64 @@
+// +build withEnvPathSet
+
+package bugreport
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func TestRun(t *testing.T) {
+	a := assert.New(t)
+	r := require.New(t)
+
+	fakeClient := fake.NewSimpleClientset()
+
+	outFile, err := ioutil.TempFile("", "*_osm-bug-report.zip")
+	r.Nil(err)
+
+	ns1 := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "ns1",
+			Labels: map[string]string{constants.OSMKubeResourceMonitorAnnotation: "osm"},
+		},
+	}
+	_, err = fakeClient.CoreV1().Namespaces().Create(context.TODO(), ns1, metav1.CreateOptions{})
+	r.Nil(err)
+
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "ns1",
+			Labels:    map[string]string{constants.EnvoyUniqueIDLabelName: "test"},
+		},
+	}
+	_, err = fakeClient.CoreV1().Pods(pod1.Namespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+	r.Nil(err)
+
+	c := &Config{
+		Stdout:        new(bytes.Buffer),
+		Stderr:        new(bytes.Buffer),
+		KubeClient:    fakeClient,
+		AppNamespaces: []string{ns1.Name},
+		AppPods:       []types.NamespacedName{{Name: pod1.Name, Namespace: pod1.Namespace}},
+		OutFile:       outFile.Name(),
+	}
+
+	err = c.Run()
+	a.Nil(err)
+
+	err = os.RemoveAll(outFile.Name())
+	r.Nil(err)
+}

--- a/pkg/bugreport/types.go
+++ b/pkg/bugreport/types.go
@@ -1,0 +1,22 @@
+// Package bugreport implements functionality related to generating bug reports.
+package bugreport
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Config is the type used to hold the bug report configuration
+type Config struct {
+	Stdout               io.Writer
+	Stderr               io.Writer
+	KubeClient           kubernetes.Interface
+	ControlPlaneNamepace string
+	AppNamespaces        []string
+	AppDeployments       []types.NamespacedName
+	AppPods              []types.NamespacedName
+	OutFile              string
+	stagingDir           string
+}

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -7,6 +7,7 @@ import (
 	goversion "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -100,4 +101,19 @@ func GetKubernetesServerVersionNumber(kubeClient kubernetes.Interface) ([]int, e
 	}
 
 	return ver.Segments(), nil
+}
+
+// NamespacedNameFrom returns the namespaced name for the given name if possible, otherwise an error
+func NamespacedNameFrom(name string) (types.NamespacedName, error) {
+	var nsName types.NamespacedName
+
+	chunks := strings.Split(name, "/")
+	if len(chunks) != 2 {
+		return nsName, errors.Errorf("%s is not a namespaced name", name)
+	}
+
+	nsName.Namespace = chunks[0]
+	nsName.Name = chunks[1]
+
+	return nsName, nil
 }

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -6,6 +6,7 @@ import (
 
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes"
@@ -188,6 +189,44 @@ func TestGetKubernetesServerVersionNumber(t *testing.T) {
 			version, err := GetKubernetesServerVersionNumber(tc.kubeClient)
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedVersion, version)
+		})
+	}
+}
+
+func TestNamespacedNameFrom(t *testing.T) {
+	testCases := []struct {
+		name      string
+		in        string
+		out       types.NamespacedName
+		expectErr bool
+	}{
+		{
+			name:      "valid namespaced name",
+			in:        "foo/bar",
+			out:       types.NamespacedName{Namespace: "foo", Name: "bar"},
+			expectErr: false,
+		},
+		{
+			name:      "invalid namespaced name with no separator",
+			in:        "foobar",
+			out:       types.NamespacedName{},
+			expectErr: true,
+		},
+		{
+			name:      "invalid namespaced name with multiple separators",
+			in:        "foo/bar/baz",
+			out:       types.NamespacedName{},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			actual, err := NamespacedNameFrom(tc.in)
+			assert.Equal(tc.out, actual)
+			assert.Equal(tc.expectErr, err != nil)
 		})
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Implements a tool to generate a bug report archive.
The tool collects info about app namespaces, pods,
events etc.

This is an initial implementation to enable users to generate
a bug report, without which it's not possible to debug most
issues.

Example:
```
$ osm support bug-report  --app-deployments bookbuyer/bookbuyer,bookstore/bookstore-v1 --app-pods bookthief/bookthief-7bb7f9b98c-qplq4 --app-namespaces bookbuyer,bookstore 
[+] Created staging dir /tmp/osm_bug_report_059982018 to generate bug report


[+] Collecting information about meshed namespaces
✓ Finished generating report for meshed namespaces


[+] Collecting information from individual app namespaces
✓ Collected report from Namespace "bookbuyer"
✓ Collected report from Namespace "bookstore"
✓ Finished generating report for individual app namespaces


[+] Collecting information from individual app namespaces
✓ Collected report for Pod "bookthief/bookthief-7bb7f9b98c-qplq4"
✓ Collected report for Pod "bookbuyer/bookbuyer-58689d659c-lmm8n"
✓ Collected report for Pod "bookstore/bookstore-v1-74d9cbd7c8-fw8c7"
✓ Finished generating report for individual app pods


[+] Collecting information from individual app namespaces
✓ Bug report successfully archived to /tmp/520720697_osm-bug-report.zip
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
