### PR TITLE
test(openshift/nightly): Always clean up resources

### DIFF
--- a/.github/workflows/openshift-nightly.yml
+++ b/.github/workflows/openshift-nightly.yml
@@ -51,6 +51,7 @@ jobs:
           ./demo/run-osm-demo.sh
           go run ./ci/cmd/maestro.go
       - name: Cleanup resources
+        if: ${{ always }}
         env:
           BOOKWAREHOUSE_NAMESPACE: bookwarehouse
           BOOKBUYER_NAMESPACE: bookbuyer


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Forgot to add this in my previous PR to run the cleanup script, but we want the cleanup step to run even if the e2es or the demos fail for the OpenShift nightly job. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? No
