### PR TITLE
bugreport: use tar.gz archive and expand help text

### DIFF
--- a/cmd/cli/support_bugreport.go
+++ b/cmd/cli/support_bugreport.go
@@ -17,10 +17,39 @@ import (
 const bugReportDescription = `
 Generate a bug report.
 
+# Specifying the archive format:
+
+If '--out-file' or '-o' is not specified, the bug report will be generated as a
+compressed tar file in the tar.gz format. To generate the bug report using
+a different archive format, specify the output file along with its extension
+type.
+
+The format of the archive is determined by its
+file extension. Supported extensions:
+  .zip
+  .tar
+  .tar.gz
+  .tgz
+  .tar.bz2
+  .tbz2
+  .tar.xz
+  .txz
+  .tar.lz4
+  .tlz4
+  .tar.sz
+  .tsz
+  .rar (open only)
+  .bz2
+  .gz
+  .lz4
+  .sz
+  .xz
+
 *Note:
 - Both 'osm' and 'kubectl' CLI must reside in the evironment's lookup path.
 - If the environment includes sensitive information that should not be collected,
-  please do not specify the associated resources.
+  please do not specify the associated resources. Before sharing the bug report,
+  please audit and redact any sensitive information that should not be shared.
 `
 
 const bugReportExample = `
@@ -68,8 +97,8 @@ func newSupportBugReportCmd(config *action.Configuration, stdout io.Writer, stde
 	f := cmd.Flags()
 	f.StringSliceVar(&bugReportCmd.appNamespaces, "app-namespaces", nil, "Application namespaces")
 	f.StringSliceVar(&bugReportCmd.appDeployments, "app-deployments", nil, "Application deployments: <namespace>/<deployment>")
-	f.StringSliceVar(&bugReportCmd.appPods, "app-pods", nil, "Application pods: <namespace>/pod")
-	f.StringVarP(&bugReportCmd.outFile, "out-file", "o", "", "Output file path")
+	f.StringSliceVar(&bugReportCmd.appPods, "app-pods", nil, "Application pods: <namespace>/<pod>")
+	f.StringVarP(&bugReportCmd.outFile, "out-file", "o", "", "Output file with archive format extension")
 
 	return cmd
 }

--- a/pkg/bugreport/archive.go
+++ b/pkg/bugreport/archive.go
@@ -1,22 +1,20 @@
 package bugreport
 
 import (
-	"compress/flate"
+	"os"
 
 	"github.com/mholt/archiver/v3"
 	"github.com/pkg/errors"
 )
 
 func (c *Config) archive(sourcePath string, destinationPath string) error {
-	z := archiver.Zip{
-		CompressionLevel:       flate.DefaultCompression,
-		MkdirAll:               true,
-		SelectiveCompression:   true,
-		ContinueOnError:        true,
-		OverwriteExisting:      true,
-		ImplicitTopLevelFolder: false,
+	if _, err := os.Stat(destinationPath); err == nil {
+		if err := os.Remove(destinationPath); err != nil {
+			c.completionFailure("Error removing existing bug report file %s", destinationPath)
+			return errors.Wrap(err, "Error generating bug report")
+		}
 	}
-	if err := z.Archive([]string{sourcePath}, destinationPath); err != nil {
+	if err := archiver.Archive([]string{sourcePath}, destinationPath); err != nil {
 		c.completionFailure("Error archiving files for bug report")
 		return errors.Wrap(err, "Error generating bug report")
 	}

--- a/pkg/bugreport/run.go
+++ b/pkg/bugreport/run.go
@@ -56,7 +56,7 @@ func (c *Config) Run() error {
 
 	// Generate output file if not provided
 	if c.OutFile == "" {
-		outFd, err := ioutil.TempFile("", "*_osm-bug-report.zip")
+		outFd, err := ioutil.TempFile("", "*_osm-bug-report.tar.gz")
 		if err != nil {
 			c.completionFailure("Error creating temp file for bug report")
 			return errors.Wrap(err, "Error creating bug report")


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Uses tar.gz as the archive format and adds to the existing
help text regarding sensitive information in the bug report.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
