### PR TITLE
chore(injector): Reduce tech debt in osm `/pkg/injector`

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -225,3 +225,12 @@ const (
 	// byte in a TCP connection.
 	ProtocolTCPServerFirst = "tcp-server-first"
 )
+
+// Operating systems.
+const (
+	// OSWindows is the name for Windows operating system.
+	OSWindows string = "windows"
+
+	// OSLinux is the name for Linux operating system.
+	OSLinux string = "linux"
+)

--- a/pkg/envoy/proxy_test.go
+++ b/pkg/envoy/proxy_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Test proxy methods", func() {
 			firstNonce := proxy.GetLastSentNonce(TypeCDS)
 			Expect(firstNonce).ToNot(Equal(uint64(0)))
 			// Platform(Windows): Sleep to accommodate `time.Now()` lower accuracy.
-			if runtime.GOOS == "windows" {
+			if runtime.GOOS == constants.OSWindows {
 				time.Sleep(1 * time.Millisecond)
 			}
 			proxy.SetNewNonce(TypeCDS)

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				// Test unset Requests
 				Requests: nil,
 			}).Times(1)
-			actual := getEnvoySidecarContainerSpec(pod, mockConfigurator, originalHealthProbes, "linux")
+			actual := getEnvoySidecarContainerSpec(pod, mockConfigurator, originalHealthProbes, constants.OSLinux)
 
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,
@@ -373,7 +373,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				// Test unset Requests
 				Requests: nil,
 			}).Times(1)
-			actual := getEnvoySidecarContainerSpec(pod, mockConfigurator, originalHealthProbes, "windows")
+			actual := getEnvoySidecarContainerSpec(pod, mockConfigurator, originalHealthProbes, constants.OSWindows)
 
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -59,7 +59,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	// As a result we assume that the HNS redirection policies are already programmed via a CNI plugin.
 	// Skip adding the init container and only patch the pod spec with sidecar container.
 	podOS := pod.Spec.NodeSelector["kubernetes.io/os"]
-	if !strings.EqualFold(podOS, "windows") {
+	if !strings.EqualFold(podOS, constants.OSWindows) {
 		// Build outbound port exclusion list
 		podOutboundPortExclusionList, _ := wh.getPortExclusionListForPod(pod, namespace, outboundPortExclusionListAnnotation)
 		globalOutboundPortExclusionList := wh.configurator.GetOutboundPortExclusionList()

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -41,7 +41,7 @@ func TestCreatePatch(t *testing.T) {
 	}{
 		{
 			name: "creates a patch for a unix worker",
-			os:   "linux",
+			os:   constants.OSLinux,
 			namespace: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
@@ -64,7 +64,7 @@ func TestCreatePatch(t *testing.T) {
 		},
 		{
 			name: "creates a patch for a windows worker",
-			os:   "windows",
+			os:   constants.OSWindows,
 			namespace: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
@@ -84,7 +84,7 @@ func TestCreatePatch(t *testing.T) {
 		},
 		{
 			name: "metrics enabled",
-			os:   "linux",
+			os:   constants.OSLinux,
 			namespace: &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        namespace,

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -557,7 +557,7 @@ var (
 
 // NewPodFixture creates a new Pod struct for testing.
 func NewPodFixture(namespace string, podName string, serviceAccountName string, labels map[string]string) corev1.Pod {
-	return NewOsSpecificPodFixture(namespace, podName, serviceAccountName, labels, "linux")
+	return NewOsSpecificPodFixture(namespace, podName, serviceAccountName, labels, constants.OSLinux)
 }
 
 // NewOsSpecificPodFixture creates a new Pod struct for testing.


### PR DESCRIPTION
Addressing PR comments from #3861 we have the two follow ups:

1. Make literal strings "windows" and "linux" into a constant
2. Make the return variables of `getPlatformSpecificSpecComponents` named to
improve readability.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
