### PR TITLE
fix: cluster ID used in demo application

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -42,10 +42,9 @@ var (
 	bookwarehouseNamespace                 = os.Getenv(BookwarehouseNamespaceEnvVar)
 
 	bookstoreServiceNamespace = fmt.Sprintf("%s.%s", bookstoreServiceName, bookstoreNamespace)
-	bookstoreClusterID        = os.Getenv("BOOKSTORE_CLUSTER_ID")
 
-	bookstoreService = fmt.Sprintf("%s:%d", appendClusterID(bookstoreServiceNamespace, bookstoreClusterID), bookstorePort) // FQDN
-	warehouseService = fmt.Sprintf("%s.%s:%d", warehouseServiceName, bookwarehouseNamespace, bookwarehousePort)            // FQDN
+	bookstoreService = fmt.Sprintf("%s:%d", bookstoreServiceNamespace, bookstorePort)                           // FQDN
+	warehouseService = fmt.Sprintf("%s.%s:%d", warehouseServiceName, bookwarehouseNamespace, bookwarehousePort) // FQDN
 	booksBought      = fmt.Sprintf("http://%s/books-bought", bookstoreService)
 	buyBook          = fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	chargeAccountURL = fmt.Sprintf("http://%s/%s", warehouseService, RestockWarehouseURL)
@@ -312,13 +311,4 @@ func getHTTPEgressExpectedResponseCode() int {
 	}
 
 	return http.StatusNotFound
-}
-
-// appendClusterID is utilized to append extra DNS information to the FQDN if a clusterID is configured in the MeshConfig
-// <svc-name>.<svc-namespace> becomes <svc-name>.<svc-namespace>.svc.cluster.<clusterID>
-func appendClusterID(baseFQDN, clusterID string) string {
-	if clusterID == "" {
-		return baseFQDN
-	}
-	return baseFQDN + fmt.Sprintf(".svc.cluster.%s", clusterID)
 }

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -10,7 +10,6 @@ CI_CLIENT_CONCURRENT_CONNECTIONS="${CI_CLIENT_CONCURRENT_CONNECTIONS:-1}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
 CI_SLEEP_BETWEEN_REQUESTS_SECONDS="${CI_SLEEP_BETWEEN_REQUESTS_SECONDS:-1}"
 DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
-BOOKSTORE_CLUSTER_ID="${BOOKSTORE_CLUSTER_ID:-}"
 
 kubectl delete deployment bookbuyer -n "$BOOKBUYER_NAMESPACE"  --ignore-not-found
 
@@ -63,8 +62,6 @@ spec:
               value: "$BOOKSTORE_NAMESPACE"
             - name: "BOOKSTORE_SVC"
               value: "$BOOKSTORE_SVC"
-            - name: "BOOKSTORE_CLUSTER_ID"
-              value: "$BOOKSTORE_CLUSTER_ID"
             - name: "CI_MAX_ITERATIONS_THRESHOLD"
               value: "$CI_MAX_ITERATIONS_THRESHOLD"
             - name: "ENABLE_EGRESS"

--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -64,9 +64,6 @@ make docker-push
 echo "Kubernetes contexts to be deployed to: $MULTICLUSTER_CONTEXTS"
 
 for CONTEXT in $MULTICLUSTER_CONTEXTS; do
-    # shellcheck disable=SC2034
-    BOOKSTORE_CLUSTER_ID="$CONTEXT" # this is used when deploying bookstore app
-
     kubectl config use-context "$CONTEXT"
 
     # cleanup stale resources from previous runs


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

cluster ID is used in the demo in multicluster mode, which breaks the demo. This is a continuation of #3854 .

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [x] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No 

1. Is this a breaking change?

No
