### PR TITLE
feat(windows): Make local clusters use localhostIP instead of wildcardIP

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -175,7 +175,7 @@ func getLocalServiceCluster(catalog catalog.MeshCataloger, proxyServiceName serv
 			LbEndpoints: []*xds_endpoint.LbEndpoint{{
 				HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
 					Endpoint: &xds_endpoint.Endpoint{
-						Address: envoy.GetAddress(constants.WildcardIPAddr, port),
+						Address: envoy.GetAddress(constants.LocalhostIPAddress, port),
 					},
 				},
 				LoadBalancingWeight: &wrappers.UInt32Value{

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -111,7 +111,7 @@ func TestGetLocalServiceCluster(t *testing.T) {
 					LbEndpoints: []*xds_endpoint.LbEndpoint{{
 						HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
 							Endpoint: &xds_endpoint.Endpoint{
-								Address: envoy.GetAddress(constants.WildcardIPAddr, uint32(8080)),
+								Address: envoy.GetAddress(constants.LocalhostIPAddress, uint32(8080)),
 							},
 						},
 						LoadBalancingWeight: &wrappers.UInt32Value{

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -134,7 +134,7 @@ func TestNewResponse(t *testing.T) {
 									Address: &xds_core.Address_SocketAddress{
 										SocketAddress: &xds_core.SocketAddress{
 											Protocol: xds_core.SocketAddress_TCP,
-											Address:  constants.WildcardIPAddr,
+											Address:  constants.LocalhostIPAddress,
 											PortSpecifier: &xds_core.SocketAddress_PortValue{
 												PortValue: uint32(80),
 											},

--- a/pkg/injector/envoy_config_health_probes.go
+++ b/pkg/injector/envoy_config_health_probes.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
 
 	xds_accesslog_filter "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -71,7 +72,7 @@ func getProbeCluster(clusterName string, port int32) *xds_cluster.Cluster {
 									Address: &xds_core.Address{
 										Address: &xds_core.Address_SocketAddress{
 											SocketAddress: &xds_core.SocketAddress{
-												Address: "0.0.0.0",
+												Address: constants.LocalhostIPAddress,
 												PortSpecifier: &xds_core.SocketAddress_PortValue{
 													PortValue: uint32(port),
 												},

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -68,7 +68,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.1
                 port_value: 81
     name: liveness_cluster
     type: STATIC
@@ -80,7 +80,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.1
                 port_value: 82
     name: readiness_cluster
     type: STATIC
@@ -92,7 +92,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 0.0.0.0
+                address: 127.0.0.1
                 port_value: 83
     name: startup_cluster
     type: STATIC

--- a/tests/envoy_xds_expectations/actual_output_getProbeCluster.yaml
+++ b/tests/envoy_xds_expectations/actual_output_getProbeCluster.yaml
@@ -7,7 +7,7 @@ load_assignment:
     - endpoint:
         address:
           socket_address:
-            address: 0.0.0.0
+            address: 127.0.0.1
             port_value: 12341234
 name: cluster-name
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getLivenessCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessCluster.yaml
@@ -6,7 +6,7 @@ load_assignment:
     - endpoint:
         address:
           socket_address:
-            address: 0.0.0.0
+            address: 127.0.0.1
             port_value: 81
 name: liveness_cluster
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getProbeCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getProbeCluster.yaml
@@ -6,7 +6,7 @@ load_assignment:
     - endpoint:
         address:
           socket_address:
-            address: 0.0.0.0
+            address: 127.0.0.1
             port_value: 12341234
 name: cluster-name
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getReadinessCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessCluster.yaml
@@ -6,7 +6,7 @@ load_assignment:
     - endpoint:
         address:
           socket_address:
-            address: 0.0.0.0
+            address: 127.0.0.1
             port_value: 82
 name: readiness_cluster
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getStartupCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupCluster.yaml
@@ -6,7 +6,7 @@ load_assignment:
     - endpoint:
         address:
           socket_address:
-            address: 0.0.0.0
+            address: 127.0.0.1
             port_value: 83
 name: startup_cluster
 type: STATIC


### PR DESCRIPTION
Windows (unlike linux) does not allow sockets to connect to wildcardIP (0.0.0.0).

So Envoy clusters that use address 0.0.0.0 will fail on Windows workers. With this PR
we change those tests to use localhostIP.

Validated through unit tests and the CI. Fixes #3882

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>