### PR TITLE
GetServiceHostnames: Fix nil pointer dereference

### DIFF
--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -189,8 +189,12 @@ func (mc *MeshCatalog) listMeshServices() []service.MeshService {
 // If the service is in the same namespace, it returns the shorthand hostname for the service that does not
 // include its namespace, ex: bookstore, bookstore:80
 func (mc *MeshCatalog) GetServiceHostnames(meshService service.MeshService, locality service.Locality) ([]string, error) {
-	svc := utils.K8sSvcToMeshSvc(mc.kubeController.GetService(meshService))
+	k8sSvc := mc.kubeController.GetService(meshService)
+	if k8sSvc == nil {
+		return nil, errors.Errorf("Service %s not found", meshService.String())
+	}
 
+	svc := utils.K8sSvcToMeshSvc(k8sSvc)
 	var hostnames []string
 	for _, provider := range mc.serviceProviders {
 		hosts, err := provider.GetHostnamesForService(svc, locality)


### PR DESCRIPTION
Under the condition of the service disappearing (or not being
present yet due to informer latency), there was a condition
that could try to dereference a nil pointer.

Fixes #3902

Signed-off-by: Eduard Serra <eduser25@gmail.com>

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No