### PR TITLE
certificate/tresor: fix root CA cert CN

### DIFF
--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -67,7 +67,7 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 	}
 
 	rootCertificate := Certificate{
-		commonName:   rootCertificateName,
+		commonName:   certificate.CommonName(template.Subject.CommonName),
 		serialNumber: certificate.SerialNumber(serialNumber.String()),
 		certChain:    pemCert,
 		privateKey:   pemKey,
@@ -88,7 +88,7 @@ func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expir
 		return nil, err
 	}
 	rootCertificate := Certificate{
-		commonName:   rootCertificateName,
+		commonName:   certificate.CommonName(x509Cert.Subject.CommonName),
 		serialNumber: certificate.SerialNumber(x509Cert.SerialNumber.String()),
 		certChain:    pemCert,
 		privateKey:   pemKey,

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -13,9 +13,6 @@ import (
 )
 
 const (
-	// String constant used for the commonName of the root certificate
-	rootCertificateName = "root-certificate"
-
 	// How many bits to use for the RSA key
 	rsaBits = 2048
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -97,7 +97,7 @@ const (
 	PrometheusScrapePath = "/stats/prometheus"
 
 	// CertificationAuthorityCommonName is the CN used for the root certificate for OSM.
-	CertificationAuthorityCommonName = "Open Service Mesh Certification Authority"
+	CertificationAuthorityCommonName = "osm-ca.openservicemesh.io"
 
 	// CertificationAuthorityRootValidityPeriod is when the root certificate expires
 	CertificationAuthorityRootValidityPeriod = 87600 * time.Hour // a decade


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change addresses 2 things:
1. Encodes the correct CN used for the root CA cert
   when creating a `Certificate` for it.
2. Uses a fully qualified domain name for the root
   cert CN instead of an arbitrary string.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Certificate Management     | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change? `no`
