### PR TITLE
test/ads: fix unit test flakyness

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(err).To(BeNil())
 			Expect(proxyServiceCert.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: secrets.ServiceCertType,
+				CertType: secrets.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			serverRootCertTypeForMTLSInbound := xds_auth.Secret{}
@@ -196,7 +196,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(err).To(BeNil())
 			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: secrets.RootCertTypeForMTLSInbound,
+				CertType: secrets.ServiceCertType,
 			}.String()))
 		})
 	})
@@ -253,7 +253,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(err).To(BeNil())
 			Expect(proxyServiceCert.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: secrets.ServiceCertType,
+				CertType: secrets.RootCertTypeForMTLSInbound,
 			}.String()))
 
 			serverRootCertTypeForMTLSInbound := xds_auth.Secret{}
@@ -262,7 +262,7 @@ var _ = Describe("Test ADS response functions", func() {
 			Expect(err).To(BeNil())
 			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
-				CertType: secrets.RootCertTypeForMTLSInbound,
+				CertType: secrets.ServiceCertType,
 			}.String()))
 		})
 	})

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -2,6 +2,7 @@ package ads
 
 import (
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -295,6 +296,7 @@ func getRequestedResourceNamesSet(discoveryRequest *xds_discovery.DiscoveryReque
 }
 
 // getResourceSliceFromMapset is a helper to convert a mapset of resource names to a string slice
+// return slice is alphabetically ordered to ensure output determinism for a given input
 func getResourceSliceFromMapset(resourceMap mapset.Set) []string {
 	resourceSlice := []string{}
 	it := resourceMap.Iterator()
@@ -307,6 +309,7 @@ func getResourceSliceFromMapset(resourceMap mapset.Set) []string {
 		}
 		resourceSlice = append(resourceSlice, resString)
 	}
+	sort.Strings(resourceSlice)
 	return resourceSlice
 }
 


### PR DESCRIPTION
PR #3803 introduced a mapset (backed by golang map) to slice conversion,
which does not guarantee same output ordering for the same input,
thus was making a unit test fail from time to time.

This commit forces output of the slice to be alphabetically ordered,
ensuring determinism of the output slice for the same input mapset.

Signed-off-by: Eduard Serra <eduser25@gmail.com>

| Tests                      | [x] |


1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No