### PR TITLE
ref: Simply events sub and pub implementation

### DIFF
--- a/cmd/osm-controller/log_handler.go
+++ b/cmd/osm-controller/log_handler.go
@@ -14,7 +14,7 @@ import (
 // StartGlobalLogLevelHandler registers a listener to meshconfig events and log level changes,
 // and applies new log level at global scope
 func StartGlobalLogLevelHandler(cfg configurator.Configurator, stop <-chan struct{}) {
-	meshConfigChannel := events.GetPubSubInstance().Subscribe(
+	meshConfigChannel := events.Subscribe(
 		announcements.MeshConfigAdded,
 		announcements.MeshConfigDeleted,
 		announcements.MeshConfigUpdated)

--- a/cmd/osm-controller/log_handler_test.go
+++ b/cmd/osm-controller/log_handler_test.go
@@ -26,7 +26,7 @@ func TestGlobalLogLevelHandler(t *testing.T) {
 
 	// Set log level through a meshconfig event
 	mockConfigurator.EXPECT().GetOSMLogLevel().Return("warn").Times(1)
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.MeshConfigUpdated,
 	})
 
@@ -36,7 +36,7 @@ func TestGlobalLogLevelHandler(t *testing.T) {
 
 	// Reset back
 	mockConfigurator.EXPECT().GetOSMLogLevel().Return("trace").Times(1)
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.MeshConfigUpdated,
 	})
 

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -118,8 +118,6 @@ func main() {
 		log.Fatal().Err(err).Msg("Error setting log level")
 	}
 
-	events.GetPubSubInstance() // Just to generate the interface, single routine context
-
 	// Initialize kube config and client
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", "")
 	if err != nil {

--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -29,7 +29,7 @@ func (mc *MeshCatalog) dispatcher() {
 	// This will be finely tuned in near future, we can instrument other modules
 	// to take ownership of certain events, and just notify dispatcher through
 	// ScheduleBroadcastUpdate announcement type
-	subChannel := events.GetPubSubInstance().Subscribe(
+	subChannel := events.Subscribe(
 		a.ScheduleProxyBroadcast,                              // Other modules requesting a global envoy update
 		a.EndpointAdded, a.EndpointDeleted, a.EndpointUpdated, // endpoint
 		a.NamespaceAdded, a.NamespaceDeleted, a.NamespaceUpdated, // namespace
@@ -99,7 +99,7 @@ func (mc *MeshCatalog) dispatcher() {
 		// A select-fallthrough doesn't exist, we are copying some code here
 		case <-chanMovingDeadline:
 			log.Info().Msgf("Moving deadline trigger - Broadcast envoy update")
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
 			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
@@ -111,7 +111,7 @@ func (mc *MeshCatalog) dispatcher() {
 
 		case <-chanMaxDeadline:
 			log.Info().Msgf("Max deadline trigger - Broadcast envoy update")
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
 			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -99,7 +99,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 	cm.cache[cn] = newCert
 	cm.cacheLock.Unlock()
 
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.CertificateRotated,
 		NewObj:           newCert,
 		OldObj:           oldCert,

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -179,7 +179,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 
 	cm.cache.Store(cn, newCert)
 
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.CertificateRotated,
 		NewObj:           newCert,
 		OldObj:           oldCert.(certificate.Certificater),

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -190,7 +190,7 @@ func (cm *CertManager) RotateCertificate(cn certificate.CommonName) (certificate
 
 	cm.cache.Store(cn, newCert)
 
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.CertificateRotated,
 		NewObj:           newCert,
 		OldObj:           oldCert.(certificate.Certificater),

--- a/pkg/certificate/rotor/rotor_test.go
+++ b/pkg/certificate/rotor/rotor_test.go
@@ -58,11 +58,11 @@ var _ = Describe("Test Rotor", func() {
 
 		var certAnnouncement chan interface{}
 		BeforeEach(func() {
-			certAnnouncement = events.GetPubSubInstance().Subscribe(announcements.CertificateRotated)
+			certAnnouncement = events.Subscribe(announcements.CertificateRotated)
 		})
 
 		AfterEach(func() {
-			events.GetPubSubInstance().Unsub(certAnnouncement)
+			events.Unsub(certAnnouncement)
 		})
 
 		It("issued a new certificate", func() {

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -62,14 +62,14 @@ func newConfigurator(meshConfigClientSet versioned.Interface, stop <-chan struct
 // on config seen on the MeshConfig
 func (c *Client) runMeshConfigListener(stop <-chan struct{}) {
 	// Create the subscription channel synchronously
-	cfgSubChannel := events.GetPubSubInstance().Subscribe(
+	cfgSubChannel := events.Subscribe(
 		announcements.MeshConfigAdded,
 		announcements.MeshConfigDeleted,
 		announcements.MeshConfigUpdated,
 	)
 
 	// Defer unsubscription on async routine exit
-	defer events.GetPubSubInstance().Unsub(cfgSubChannel)
+	defer events.Unsub(cfgSubChannel)
 
 	for {
 		select {
@@ -110,7 +110,7 @@ func (c *Client) run(stop <-chan struct{}) {
 func meshConfigAddedMessageHandler(psubMsg *events.PubSubMessage) {
 	log.Debug().Msgf("[%s] OSM MeshConfig added event triggered a global proxy broadcast",
 		psubMsg.AnnouncementType)
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.ScheduleProxyBroadcast,
 		OldObj:           nil,
 		NewObj:           nil,
@@ -121,7 +121,7 @@ func meshConfigDeletedMessageHandler(psubMsg *events.PubSubMessage) {
 	// Ignore deletion. We expect config to be present
 	log.Debug().Msgf("[%s] OSM MeshConfig deleted event triggered a global proxy broadcast",
 		psubMsg.AnnouncementType)
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.ScheduleProxyBroadcast,
 		OldObj:           nil,
 		NewObj:           nil,
@@ -171,7 +171,7 @@ func meshConfigUpdatedMessageHandler(psubMsg *events.PubSubMessage) {
 	if triggerGlobalBroadcast {
 		log.Debug().Msgf("[%s] OSM MeshConfig update triggered global proxy broadcast",
 			psubMsg.AnnouncementType)
-		events.GetPubSubInstance().Publish(events.PubSubMessage{
+		events.Publish(events.PubSubMessage{
 			AnnouncementType: announcements.ScheduleProxyBroadcast,
 			OldObj:           nil,
 			NewObj:           nil,

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -27,14 +27,14 @@ func TestMeshConfigEventTriggers(t *testing.T) {
 	assert := tassert.New(t)
 	meshConfigClientSet := testclient.NewSimpleClientset()
 
-	confChannel := events.GetPubSubInstance().Subscribe(
+	confChannel := events.Subscribe(
 		announcements.MeshConfigAdded,
 		announcements.MeshConfigDeleted,
 		announcements.MeshConfigUpdated)
-	defer events.GetPubSubInstance().Unsub(confChannel)
+	defer events.Unsub(confChannel)
 
-	proxyBroadcastChannel := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
-	defer events.GetPubSubInstance().Unsub(proxyBroadcastChannel)
+	proxyBroadcastChannel := events.Subscribe(announcements.ScheduleProxyBroadcast)
+	defer events.Unsub(proxyBroadcastChannel)
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -527,10 +527,10 @@ func TestCreateUpdateConfig(t *testing.T) {
 			meshConfigClientSet := testclient.NewSimpleClientset()
 
 			// Prepare the pubsub channel
-			confChannel := events.GetPubSubInstance().Subscribe(
+			confChannel := events.Subscribe(
 				announcements.MeshConfigAdded,
 				announcements.MeshConfigUpdated)
-			defer events.GetPubSubInstance().Unsub(confChannel)
+			defer events.Unsub(confChannel)
 
 			// Create configurator
 			stop := make(chan struct{})

--- a/pkg/debugger/debugger_config_listener.go
+++ b/pkg/debugger/debugger_config_listener.go
@@ -10,7 +10,7 @@ import (
 // StartDebugServerConfigListener registers a go routine to listen to configuration and configure debug server as needed
 func (d *DebugConfig) StartDebugServerConfigListener() {
 	// Subscribe to configuration updates
-	ch := events.GetPubSubInstance().Subscribe(
+	ch := events.Subscribe(
 		announcements.MeshConfigAdded,
 		announcements.MeshConfigDeleted,
 		announcements.MeshConfigUpdated)

--- a/pkg/envoy/ads/cache_stream.go
+++ b/pkg/envoy/ads/cache_stream.go
@@ -21,7 +21,7 @@ import (
 // Routine which fulfills listening to proxy broadcasts
 func (s *Server) broadcastListener() {
 	// Register to Envoy global broadcast updates
-	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
+	broadcastUpdate := events.Subscribe(announcements.ProxyBroadcast)
 	for {
 		<-broadcastUpdate
 		s.allPodUpdater()

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -71,10 +71,10 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	go receive(requests, &server, proxy, quit, s.proxyRegistry)
 
 	// Register to Envoy global broadcast updates
-	broadcastUpdate := events.GetPubSubInstance().Subscribe(announcements.ProxyBroadcast)
+	broadcastUpdate := events.Subscribe(announcements.ProxyBroadcast)
 
 	// Register for certificate rotation updates
-	certAnnouncement := events.GetPubSubInstance().Subscribe(announcements.CertificateRotated)
+	certAnnouncement := events.Subscribe(announcements.CertificateRotated)
 
 	newJob := func(typeURIs []envoy.TypeURI, discoveryRequest *xds_discovery.DiscoveryRequest) *proxyResponseJob {
 		return &proxyResponseJob{

--- a/pkg/envoy/registry/announcement_handlers.go
+++ b/pkg/envoy/registry/announcement_handlers.go
@@ -11,7 +11,7 @@ import (
 // ReleaseCertificateHandler releases certificates based on podDelete events
 // returns a stop channel which can be used to stop the inner handler
 func (pr *ProxyRegistry) ReleaseCertificateHandler(certManager certificate.Manager) chan struct{} {
-	podDeleteSubscription := events.GetPubSubInstance().Subscribe(announcements.PodDeleted)
+	podDeleteSubscription := events.Subscribe(announcements.PodDeleted)
 	stop := make(chan struct{})
 
 	go func() {
@@ -41,7 +41,7 @@ func (pr *ProxyRegistry) ReleaseCertificateHandler(certManager certificate.Manag
 
 					// Request a broadcast update, just for security.
 					// Dispatcher code also handles PodDelete, so probably the two will get coalesced.
-					events.GetPubSubInstance().Publish(events.PubSubMessage{
+					events.Publish(events.PubSubMessage{
 						AnnouncementType: announcements.ScheduleProxyBroadcast,
 						NewObj:           nil,
 						OldObj:           nil,

--- a/pkg/envoy/registry/announcement_handlers_test.go
+++ b/pkg/envoy/registry/announcement_handlers_test.go
@@ -75,10 +75,10 @@ var _ = Describe("Test Announcement Handlers", func() {
 
 			// Register to Update proxies event. We should see a schedule broadcast update
 			// requested by the handler when the certificate is released.
-			rcvBroadcastChannel := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
+			rcvBroadcastChannel := events.Subscribe(announcements.ScheduleProxyBroadcast)
 
 			// Publish a podDeleted event
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: announcements.PodDeleted,
 				NewObj:           nil,
 				OldObj: &v1.Pod{
@@ -115,7 +115,7 @@ var _ = Describe("Test Announcement Handlers", func() {
 			Expect(connectedProxies[0]).To(Equal(*proxy))
 
 			// Publish some event unrelated to podDeleted
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: announcements.IngressAdded,
 				NewObj:           nil,
 				OldObj: &v1.Pod{

--- a/pkg/envoy/registry/services.go
+++ b/pkg/envoy/registry/services.go
@@ -78,7 +78,7 @@ func NewAsyncKubeProxyServiceMapper(controller k8s.Controller) *AsyncKubeProxySe
 		kubeController: controller,
 		servicesForCN:  make(map[certificate.CommonName][]service.MeshService),
 		cnsForService:  make(map[service.MeshService]map[certificate.CommonName]struct{}),
-		kubeEvents: events.GetPubSubInstance().Subscribe(
+		kubeEvents: events.Subscribe(
 			announcements.PodAdded,
 			announcements.PodUpdated,
 			announcements.PodDeleted,
@@ -104,7 +104,7 @@ func (k *AsyncKubeProxyServiceMapper) Run(stop <-chan struct{}) {
 		for {
 			select {
 			case <-stop:
-				events.GetPubSubInstance().Unsub(k.kubeEvents)
+				events.Unsub(k.kubeEvents)
 				return
 			case ev := <-k.kubeEvents:
 				event, ok := ev.(events.PubSubMessage)
@@ -128,7 +128,7 @@ func (k *AsyncKubeProxyServiceMapper) Run(stop <-chan struct{}) {
 					k.handleServiceDelete(svc)
 				}
 				k.cacheLock.Unlock()
-				events.GetPubSubInstance().Publish(events.PubSubMessage{
+				events.Publish(events.PubSubMessage{
 					AnnouncementType: announcements.ScheduleProxyBroadcast,
 				})
 			}

--- a/pkg/ingress/gateway.go
+++ b/pkg/ingress/gateway.go
@@ -104,9 +104,9 @@ func (c client) storeCertInSecret(cert certificate.Certificater, secret corev1.S
 // handleCertificateChange updates the gateway certificate and secret when the MeshConfig resource changes or
 // when the corresponding gateway certificate is rotated.
 func (c client) handleCertificateChange(currentCertSpec *configv1alpha1.IngressGatewayCertSpec, stop <-chan struct{}) {
-	meshConfigUpdated := events.GetPubSubInstance().Subscribe(announcements.MeshConfigUpdated)
+	meshConfigUpdated := events.Subscribe(announcements.MeshConfigUpdated)
 
-	certRotated := events.GetPubSubInstance().Subscribe(announcements.CertificateRotated)
+	certRotated := events.Subscribe(announcements.CertificateRotated)
 
 	for {
 		select {

--- a/pkg/ingress/gateway_test.go
+++ b/pkg/ingress/gateway_test.go
@@ -331,7 +331,7 @@ func TestHandleCertificateChange(t *testing.T) {
 			}
 
 			if tc.updatedMeshConfig != nil {
-				events.GetPubSubInstance().Publish(events.PubSubMessage{
+				events.Publish(events.PubSubMessage{
 					AnnouncementType: announcements.MeshConfigUpdated,
 					NewObj:           tc.updatedMeshConfig,
 					OldObj:           tc.previousMeshConfig,

--- a/pkg/k8s/announcement_handlers.go
+++ b/pkg/k8s/announcement_handlers.go
@@ -16,7 +16,7 @@ import (
 // PatchSecretHandler patches the envoy bootstrap config secrets based on the PodAdd events
 // returns a stop channel which can be used to stop the inner handler
 func PatchSecretHandler(kubeClient kubernetes.Interface) chan struct{} {
-	podAddSubscription := events.GetPubSubInstance().Subscribe(announcements.PodAdded)
+	podAddSubscription := events.Subscribe(announcements.PodAdded)
 	stop := make(chan struct{})
 
 	go func() {

--- a/pkg/k8s/announcement_handlers_test.go
+++ b/pkg/k8s/announcement_handlers_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Test Announcement Handlers", func() {
 			Expect(err).To(BeNil())
 
 			// Publish a podAdded event
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: announcements.PodAdded,
 				NewObj:           &pod,
 				OldObj:           nil,

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -143,10 +143,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should create and delete services, and be detected if NS is monitored", func() {
 			meshSvc := tests.BookbuyerService
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
+			serviceChannel := events.Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			defer events.Unsub(serviceChannel)
 
 			// Create monitored namespace for this service
 			testNamespace := &corev1.Namespace{
@@ -192,10 +192,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should return a list of Services", func() {
 			// Define services to test with
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
+			serviceChannel := events.Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			defer events.Unsub(serviceChannel)
 			testSvcs := []service.MeshService{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
@@ -259,10 +259,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should create and delete service accounts, and be detected if NS is monitored", func() {
 			k8sSvcAccount := tests.BookbuyerServiceAccount
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAccountAdded,
+			serviceChannel := events.Subscribe(announcements.ServiceAccountAdded,
 				announcements.ServiceAccountDeleted,
 				announcements.ServiceAccountUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			defer events.Unsub(serviceChannel)
 
 			// Create monitored namespace for this service
 			testNamespace := &corev1.Namespace{
@@ -295,10 +295,10 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 
 		It("should return a list of service accounts", func() {
 			// Define services to test with
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAccountAdded,
+			serviceChannel := events.Subscribe(announcements.ServiceAccountAdded,
 				announcements.ServiceAccountDeleted,
 				announcements.ServiceAccountUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
+			defer events.Unsub(serviceChannel)
 			testSvcAccounts := []identity.K8sServiceAccount{
 				{Name: uuid.New().String(), Namespace: "ns-1"},
 				{Name: uuid.New().String(), Namespace: "ns-2"},
@@ -366,14 +366,14 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			testSvcAccountName1 := "test-service-account-1"
 			testSvcAccountName2 := "test-service-account-2"
 
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
+			serviceChannel := events.Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
-			podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
+			defer events.Unsub(serviceChannel)
+			podsChannel := events.Subscribe(announcements.PodAdded,
 				announcements.PodDeleted,
 				announcements.PodUpdated)
-			defer events.GetPubSubInstance().Unsub(podsChannel)
+			defer events.Unsub(podsChannel)
 
 			// Create a namespace
 			testNamespace := &corev1.Namespace{
@@ -468,14 +468,14 @@ var _ = Describe("Test Namespace KubeController Methods", func() {
 			testSvcAccountName1 := "test-service-account-1"
 			testSvcAccountName2 := "test-service-account-2"
 
-			serviceChannel := events.GetPubSubInstance().Subscribe(announcements.ServiceAdded,
+			serviceChannel := events.Subscribe(announcements.ServiceAdded,
 				announcements.ServiceDeleted,
 				announcements.ServiceUpdated)
-			defer events.GetPubSubInstance().Unsub(serviceChannel)
-			podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
+			defer events.Unsub(serviceChannel)
+			podsChannel := events.Subscribe(announcements.PodAdded,
 				announcements.PodDeleted,
 				announcements.PodUpdated)
-			defer events.GetPubSubInstance().Unsub(podsChannel)
+			defer events.Unsub(podsChannel)
 
 			// Create a namespace
 			testNamespace := &corev1.Namespace{
@@ -573,10 +573,10 @@ func TestGetEndpoint(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(kubeController)
 
-	endpointsChannel := events.GetPubSubInstance().Subscribe(announcements.EndpointAdded,
+	endpointsChannel := events.Subscribe(announcements.EndpointAdded,
 		announcements.EndpointDeleted,
 		announcements.EndpointUpdated)
-	defer events.GetPubSubInstance().Unsub(endpointsChannel)
+	defer events.Unsub(endpointsChannel)
 
 	// Create a namespace
 	testNamespace := &corev1.Namespace{

--- a/pkg/k8s/event_handlers.go
+++ b/pkg/k8s/event_handlers.go
@@ -32,7 +32,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 			if !shouldObserve(obj) {
 				return
 			}
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: eventTypes.Add,
 				NewObj:           obj,
 				OldObj:           nil,
@@ -46,7 +46,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 			if !shouldObserve(newObj) {
 				return
 			}
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: eventTypes.Update,
 				NewObj:           newObj,
 				OldObj:           oldObj,
@@ -59,7 +59,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 			if !shouldObserve(obj) {
 				return
 			}
-			events.GetPubSubInstance().Publish(events.PubSubMessage{
+			events.Publish(events.PubSubMessage{
 				AnnouncementType: eventTypes.Delete,
 				NewObj:           nil,
 				OldObj:           obj,

--- a/pkg/k8s/event_handlers_test.go
+++ b/pkg/k8s/event_handlers_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Testing event handlers", func() {
 		}
 
 		It("Should add the event to the announcement channel", func() {
-			podAddChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded)
-			defer events.GetPubSubInstance().Unsub(podAddChannel)
+			podAddChannel := events.Subscribe(announcements.PodAdded)
+			defer events.Unsub(podAddChannel)
 
 			pod := tests.NewPodFixture(testNamespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)
 			eventTypes := EventTypes{
@@ -60,8 +60,8 @@ var _ = Describe("Testing event handlers", func() {
 		})
 
 		It("Should not add the event to the announcement channel", func() {
-			podAddChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded)
-			defer events.GetPubSubInstance().Unsub(podAddChannel)
+			podAddChannel := events.Subscribe(announcements.PodAdded)
+			defer events.Unsub(podAddChannel)
 
 			var pod corev1.Pod
 			pod.Namespace = "not-a-monitored-namespace"
@@ -84,8 +84,8 @@ var _ = Describe("Testing event handlers", func() {
 func TestUpdateEvent(t *testing.T) {
 	a := assert.New(t)
 
-	updateChan := events.GetPubSubInstance().Subscribe(announcements.PodUpdated)
-	defer events.GetPubSubInstance().Unsub(updateChan)
+	updateChan := events.Subscribe(announcements.PodUpdated)
+	defer events.Unsub(updateChan)
 
 	// Add and update a pod
 	originalPod := tests.NewPodFixture(testNamespace, "pod-name", tests.BookstoreServiceAccountName, tests.PodLabels)

--- a/pkg/k8s/events/event_pubsub_test.go
+++ b/pkg/k8s/events/event_pubsub_test.go
@@ -33,8 +33,8 @@ func TestPubSubEvents(t *testing.T) {
 	}
 
 	for i := range testCases {
-		subscribedChanel := GetPubSubInstance().Subscribe(testCases[i].register)
-		GetPubSubInstance().Publish(testCases[i].publish)
+		subscribedChanel := Subscribe(testCases[i].register)
+		Publish(testCases[i].publish)
 
 		select {
 		case psMesg := <-subscribedChanel:
@@ -57,15 +57,15 @@ func TestPubSubClose(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	subChannel := GetPubSubInstance().Subscribe(announcements.EndpointUpdated)
+	subChannel := Subscribe(announcements.EndpointUpdated)
 
 	// publish something
-	GetPubSubInstance().Publish(PubSubMessage{
+	Publish(PubSubMessage{
 		AnnouncementType: announcements.EndpointUpdated,
 	})
 
 	// make sure channel is drained and closed
-	GetPubSubInstance().Unsub(subChannel)
+	Unsub(subChannel)
 
 	// Channel has to have been already emptied and closed
 	_, ok := <-subChannel

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -358,14 +358,14 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	})
 
 	It("should return a service that matches the ServiceAccount associated with the Pod", func() {
-		podsAndServiceChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
+		podsAndServiceChannel := events.Subscribe(announcements.PodAdded,
 			announcements.PodDeleted,
 			announcements.PodUpdated,
 			announcements.ServiceAdded,
 			announcements.ServiceDeleted,
 			announcements.ServiceUpdated,
 		)
-		defer events.GetPubSubInstance().Unsub(podsAndServiceChannel)
+		defer events.Unsub(podsAndServiceChannel)
 
 		// Create a Service
 		svc := &corev1.Service{
@@ -439,10 +439,10 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	})
 
 	It("should return an error when the Service selector doesn't match the pod", func() {
-		podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
+		podsChannel := events.Subscribe(announcements.PodAdded,
 			announcements.PodDeleted,
 			announcements.PodUpdated)
-		defer events.GetPubSubInstance().Unsub(podsChannel)
+		defer events.Unsub(podsChannel)
 
 		// Create a Service
 		svc := &corev1.Service{
@@ -511,10 +511,10 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 	})
 
 	It("should return an error when the service doesn't have a selector", func() {
-		podsChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
+		podsChannel := events.Subscribe(announcements.PodAdded,
 			announcements.PodDeleted,
 			announcements.PodUpdated)
-		defer events.GetPubSubInstance().Unsub(podsChannel)
+		defer events.Unsub(podsChannel)
 
 		// Create a Service
 		svc := &corev1.Service{
@@ -582,14 +582,14 @@ var _ = Describe("Test Kube Client Provider (/w kubecontroller)", func() {
 		// This test is meant to ensure the
 		// service selector logic works as expected when multiple services
 		// have the same selector match.
-		podsAndServiceChannel := events.GetPubSubInstance().Subscribe(announcements.PodAdded,
+		podsAndServiceChannel := events.Subscribe(announcements.PodAdded,
 			announcements.PodDeleted,
 			announcements.PodUpdated,
 			announcements.ServiceAdded,
 			announcements.ServiceDeleted,
 			announcements.ServiceUpdated,
 		)
-		defer events.GetPubSubInstance().Unsub(podsAndServiceChannel)
+		defer events.Unsub(podsAndServiceChannel)
 
 		// Create a Service
 		svc := &corev1.Service{

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -96,10 +96,10 @@ var _ = Describe("When listing TrafficSplit", func() {
 	})
 
 	It("should return a list of traffic split resources", func() {
-		tsChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficSplitAdded,
+		tsChannel := events.Subscribe(announcements.TrafficSplitAdded,
 			announcements.TrafficSplitDeleted,
 			announcements.TrafficSplitUpdated)
-		defer events.GetPubSubInstance().Unsub(tsChannel)
+		defer events.Unsub(tsChannel)
 
 		split := &smiSplit.TrafficSplit{
 			ObjectMeta: metav1.ObjectMeta{
@@ -147,10 +147,10 @@ var _ = Describe("When listing ServiceAccounts", func() {
 	})
 
 	It("should return a list of service accounts specified in TrafficTarget resources", func() {
-		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
+		ttChannel := events.Subscribe(announcements.TrafficTargetAdded,
 			announcements.TrafficTargetDeleted,
 			announcements.TrafficTargetUpdated)
-		defer events.GetPubSubInstance().Unsub(ttChannel)
+		defer events.Unsub(ttChannel)
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
@@ -207,10 +207,10 @@ var _ = Describe("When listing TrafficTargets", func() {
 	})
 
 	It("Returns a list of TrafficTarget resources", func() {
-		ttChannel := events.GetPubSubInstance().Subscribe(announcements.TrafficTargetAdded,
+		ttChannel := events.Subscribe(announcements.TrafficTargetAdded,
 			announcements.TrafficTargetDeleted,
 			announcements.TrafficTargetUpdated)
-		defer events.GetPubSubInstance().Unsub(ttChannel)
+		defer events.Unsub(ttChannel)
 
 		trafficTarget := &smiAccess.TrafficTarget{
 			TypeMeta: metav1.TypeMeta{
@@ -270,10 +270,10 @@ var _ = Describe("When listing ListHTTPTrafficSpecs", func() {
 	})
 
 	It("should return a list of ListHTTPTrafficSpecs resources", func() {
-		rgChannel := events.GetPubSubInstance().Subscribe(announcements.RouteGroupAdded,
+		rgChannel := events.Subscribe(announcements.RouteGroupAdded,
 			announcements.RouteGroupDeleted,
 			announcements.RouteGroupUpdated)
-		defer events.GetPubSubInstance().Unsub(rgChannel)
+		defer events.Unsub(rgChannel)
 
 		routeSpec := &smiSpecs.HTTPRouteGroup{
 			TypeMeta: metav1.TypeMeta{
@@ -340,10 +340,10 @@ var _ = Describe("When listing TCP routes", func() {
 	})
 
 	It("should return a list of TCPRoute resources", func() {
-		trChannel := events.GetPubSubInstance().Subscribe(announcements.TCPRouteAdded,
+		trChannel := events.Subscribe(announcements.TCPRouteAdded,
 			announcements.TCPRouteDeleted,
 			announcements.TCPRouteUpdated)
-		defer events.GetPubSubInstance().Unsub(trChannel)
+		defer events.Unsub(trChannel)
 		routeSpec := &smiSpecs.TCPRoute{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha4",
@@ -387,10 +387,10 @@ var _ = Describe("When getting a TCP route by its namespaced name", func() {
 	})
 
 	It("should return a non nil TCPRoute when found", func() {
-		trChannel := events.GetPubSubInstance().Subscribe(announcements.TCPRouteAdded,
+		trChannel := events.Subscribe(announcements.TCPRouteAdded,
 			announcements.TCPRouteDeleted,
 			announcements.TCPRouteUpdated)
-		defer events.GetPubSubInstance().Unsub(trChannel)
+		defer events.Unsub(trChannel)
 		routeSpec := &smiSpecs.TCPRoute{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha4",
@@ -430,10 +430,10 @@ var _ = Describe("When getting an HTTP route by its namespaced name", func() {
 	})
 
 	It("should return a non nil HTTPRouteGroup when found", func() {
-		trChannel := events.GetPubSubInstance().Subscribe(announcements.RouteGroupAdded,
+		trChannel := events.Subscribe(announcements.RouteGroupAdded,
 			announcements.RouteGroupDeleted,
 			announcements.RouteGroupUpdated)
-		defer events.GetPubSubInstance().Unsub(trChannel)
+		defer events.Unsub(trChannel)
 		routeSpec := &smiSpecs.HTTPRouteGroup{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "specs.smi-spec.io/v1alpha4",

--- a/pkg/ticker/ticker.go
+++ b/pkg/ticker/ticker.go
@@ -58,7 +58,7 @@ func InitTicker(c configurator.Configurator) *ResyncTicker {
 // Listens to meshconfig events and notifies ticker routine to start/stop
 func tickerConfigListener(cfg configurator.Configurator, ready chan struct{}, stop <-chan struct{}) {
 	// Subscribe to configuration updates
-	meshConfigChannel := events.GetPubSubInstance().Subscribe(
+	meshConfigChannel := events.Subscribe(
 		announcements.MeshConfigAdded,
 		announcements.MeshConfigDeleted,
 		announcements.MeshConfigUpdated)
@@ -69,7 +69,7 @@ func tickerConfigListener(cfg configurator.Configurator, ready chan struct{}, st
 
 	// Initial config
 	if currentDuration >= minimumTickerDuration {
-		events.GetPubSubInstance().Publish(events.PubSubMessage{
+		events.Publish(events.PubSubMessage{
 			AnnouncementType: announcements.TickerStart,
 			NewObj:           currentDuration,
 		})
@@ -89,14 +89,14 @@ func tickerConfigListener(cfg configurator.Configurator, ready chan struct{}, st
 			if newResyncInterval >= minimumTickerDuration {
 				// Notify to re/start ticker
 				log.Warn().Msgf("Interval %s >= %s, issuing start ticker.", newResyncInterval, minimumTickerDuration)
-				events.GetPubSubInstance().Publish(events.PubSubMessage{
+				events.Publish(events.PubSubMessage{
 					AnnouncementType: announcements.TickerStart,
 					NewObj:           newResyncInterval,
 				})
 			} else {
 				// Notify to ticker to stop
 				log.Warn().Msgf("Interval %s < %s, issuing ticker stop.", newResyncInterval, minimumTickerDuration)
-				events.GetPubSubInstance().Publish(events.PubSubMessage{
+				events.Publish(events.PubSubMessage{
 					AnnouncementType: announcements.TickerStop,
 					NewObj:           newResyncInterval,
 				})
@@ -110,9 +110,9 @@ func tickerConfigListener(cfg configurator.Configurator, ready chan struct{}, st
 
 func ticker(ready chan struct{}, stop <-chan struct{}) {
 	ticker := make(<-chan time.Time)
-	tickStart := events.GetPubSubInstance().Subscribe(
+	tickStart := events.Subscribe(
 		announcements.TickerStart)
-	tickStop := events.GetPubSubInstance().Subscribe(
+	tickStop := events.Subscribe(
 		announcements.TickerStop)
 
 	// Notify the calling function we are ready to receive events
@@ -143,7 +143,7 @@ func ticker(ready chan struct{}, stop <-chan struct{}) {
 			ticker = make(<-chan time.Time)
 		case <-ticker:
 			log.Info().Msgf("Ticker requesting broadcast proxy update")
-			events.GetPubSubInstance().Publish(
+			events.Publish(
 				events.PubSubMessage{
 					AnnouncementType: announcements.ScheduleProxyBroadcast,
 				},

--- a/pkg/ticker/ticker_test.go
+++ b/pkg/ticker/ticker_test.go
@@ -23,8 +23,8 @@ func TestInitTicker(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(gomock.NewController(t))
 	mockConfigurator.EXPECT().GetConfigResyncInterval().Return(time.Duration(0))
 
-	events.GetPubSubInstance().Subscribe(announcements.TickerStart)
-	events.GetPubSubInstance().Subscribe(announcements.TickerStop)
+	events.Subscribe(announcements.TickerStart)
+	events.Subscribe(announcements.TickerStop)
 
 	assert.Nil(rTicker)
 	ticker := InitTicker(mockConfigurator)
@@ -41,8 +41,8 @@ func TestInitTicker(t *testing.T) {
 func TestTicker(t *testing.T) {
 	assert := assert.New(t)
 
-	broadcastEvents := events.GetPubSubInstance().Subscribe(announcements.ScheduleProxyBroadcast)
-	defer events.GetPubSubInstance().Unsub(broadcastEvents)
+	broadcastEvents := events.Subscribe(announcements.ScheduleProxyBroadcast)
+	defer events.Unsub(broadcastEvents)
 
 	broadcastsReceived := 0
 	stop := make(chan struct{})
@@ -66,7 +66,7 @@ func TestTicker(t *testing.T) {
 	<-doneInit
 
 	// Start ticker, tick at 100ms rate
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.TickerStart,
 		NewObj:           time.Duration(100 * time.Millisecond),
 	})
@@ -77,7 +77,7 @@ func TestTicker(t *testing.T) {
 	}, 3*time.Second, 500*time.Millisecond)
 
 	// Stop the ticker
-	events.GetPubSubInstance().Publish(events.PubSubMessage{
+	events.Publish(events.PubSubMessage{
 		AnnouncementType: announcements.TickerStop,
 	})
 
@@ -96,8 +96,8 @@ func TestTickerConfigurator(t *testing.T) {
 	assert := assert.New(t)
 	mockConfigurator := configurator.NewMockConfigurator(gomock.NewController(t))
 
-	tickerStartEvents := events.GetPubSubInstance().Subscribe(announcements.TickerStart)
-	tickerStopEvents := events.GetPubSubInstance().Subscribe(announcements.TickerStop)
+	tickerStartEvents := events.Subscribe(announcements.TickerStart)
+	tickerStopEvents := events.Subscribe(announcements.TickerStop)
 
 	// First init will expect defaults to false
 	mockConfigurator.EXPECT().GetConfigResyncInterval().Return(time.Duration(0))
@@ -127,7 +127,7 @@ func TestTickerConfigurator(t *testing.T) {
 	for _, test := range tickerConfTests {
 		// Simulate a meshconfig change, expect the right calls if it is enabled
 		mockConfigurator.EXPECT().GetConfigResyncInterval().Return(test.mockTickerDurationVal)
-		events.GetPubSubInstance().Publish(events.PubSubMessage{
+		events.Publish(events.PubSubMessage{
 			AnnouncementType: announcements.MeshConfigUpdated,
 		})
 


### PR DESCRIPTION
Hide singleton pubsub instance invocation internal of events package

Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Remove method `GetPubSubInstance()` from PubSub interface. Invocation of singleton is hidden inside 
 other functions in `events` package.

Issue #3174 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

1. Is this a breaking change?
