### PR TITLE
metricsstore: Small refactor and cleanup

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -146,8 +146,18 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start the default metrics store
-	startMetricsStore()
+	metricsstore.GetMetricsStore().Start(
+		metricsstore.GetMetricsStore().K8sAPIEventCounter,
+		metricsstore.GetMetricsStore().K8sMonitoredNamespaceCount,
+		metricsstore.GetMetricsStore().K8sMeshPodCount,
+		metricsstore.GetMetricsStore().K8sMeshServiceCount,
+		metricsstore.GetMetricsStore().ProxyConnectCount,
+		metricsstore.GetMetricsStore().ProxyReconnectCount,
+		metricsstore.GetMetricsStore().ProxyConfigUpdateTime,
+		metricsstore.GetMetricsStore().ProxyBroadcastEventCount,
+		metricsstore.GetMetricsStore().CertIssuedCount,
+		metricsstore.GetMetricsStore().CertIssuedTime,
+	)
 
 	// This component will be watching the OSM MeshConfig and will make it available
 	// to the rest of the components.
@@ -268,7 +278,7 @@ func main() {
 		"/health/alive": health.LivenessHandler(funcProbes, getHTTPHealthProbes()),
 	})
 	// Metrics
-	httpServer.AddHandler("/metrics", metricsstore.DefaultMetricsStore.Handler())
+	httpServer.AddHandler("/metrics", metricsstore.GetMetricsStore().Handler())
 	// Version
 	httpServer.AddHandler("/version", version.GetVersionHandler())
 	// Supported SMI Versions
@@ -289,22 +299,6 @@ func main() {
 
 	<-stop
 	log.Info().Msgf("Stopping osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
-}
-
-// Start the metric store, register the metrics OSM will expose
-func startMetricsStore() {
-	metricsstore.DefaultMetricsStore.Start(
-		metricsstore.DefaultMetricsStore.K8sAPIEventCounter,
-		metricsstore.DefaultMetricsStore.K8sMonitoredNamespaceCount,
-		metricsstore.DefaultMetricsStore.K8sMeshPodCount,
-		metricsstore.DefaultMetricsStore.K8sMeshServiceCount,
-		metricsstore.DefaultMetricsStore.ProxyConnectCount,
-		metricsstore.DefaultMetricsStore.ProxyReconnectCount,
-		metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime,
-		metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount,
-		metricsstore.DefaultMetricsStore.CertIssuedCount,
-		metricsstore.DefaultMetricsStore.CertIssuedTime,
-	)
 }
 
 // getHTTPHealthProbes returns the HTTP health probes served by OSM controller

--- a/cmd/osm-crd-converter/osm-crd-converter.go
+++ b/cmd/osm-crd-converter/osm-crd-converter.go
@@ -140,7 +140,7 @@ func main() {
 	 */
 	httpServer := httpserver.NewHTTPServer(constants.OSMHTTPServerPort)
 	// Metrics
-	httpServer.AddHandler("/metrics", metricsstore.DefaultMetricsStore.Handler())
+	httpServer.AddHandler("/metrics", metricsstore.GetMetricsStore().Handler())
 	// Version
 	httpServer.AddHandler("/version", version.GetVersionHandler())
 	// Start HTTP server

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -127,12 +127,12 @@ func main() {
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Start the default metrics store
-	metricsstore.DefaultMetricsStore.Start(
-		metricsstore.DefaultMetricsStore.InjectorRqTime,
-		metricsstore.DefaultMetricsStore.InjectorSidecarCount,
-		metricsstore.DefaultMetricsStore.CertIssuedCount,
-		metricsstore.DefaultMetricsStore.CertIssuedTime,
+	// Start the metrics store
+	metricsstore.GetMetricsStore().Start(
+		metricsstore.GetMetricsStore().InjectorRqTime,
+		metricsstore.GetMetricsStore().InjectorSidecarCount,
+		metricsstore.GetMetricsStore().CertIssuedCount,
+		metricsstore.GetMetricsStore().CertIssuedTime,
 	)
 
 	// Initialize Configurator to retrieve mesh specific config
@@ -170,7 +170,7 @@ func main() {
 	 */
 	httpServer := httpserver.NewHTTPServer(constants.OSMHTTPServerPort)
 	// Metrics
-	httpServer.AddHandler("/metrics", metricsstore.DefaultMetricsStore.Handler())
+	httpServer.AddHandler("/metrics", metricsstore.GetMetricsStore().Handler())
 	// Version
 	httpServer.AddHandler("/version", version.GetVersionHandler())
 	// Start HTTP server

--- a/pkg/catalog/dispatcher.go
+++ b/pkg/catalog/dispatcher.go
@@ -102,7 +102,7 @@ func (mc *MeshCatalog) dispatcher() {
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
-			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
+			metricsstore.GetMetricsStore().ProxyBroadcastEventCount.Inc()
 
 			// broadcast done, reset timer channels
 			broadcastScheduled = false
@@ -114,7 +114,7 @@ func (mc *MeshCatalog) dispatcher() {
 			events.GetPubSubInstance().Publish(events.PubSubMessage{
 				AnnouncementType: a.ProxyBroadcast,
 			})
-			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
+			metricsstore.GetMetricsStore().ProxyBroadcastEventCount.Inc()
 
 			// broadcast done, reset timer channels
 			broadcastScheduled = false

--- a/pkg/envoy/ads/profile.go
+++ b/pkg/envoy/ads/profile.go
@@ -25,7 +25,7 @@ func xdsPathTimeTrack(startedAt time.Time, log *zerolog.Event, typeURI envoy.Typ
 
 	log.Msgf("[%s] processing for Proxy with Certificate SerialNumber=%s took %s", typeURI, proxy.GetCertificateSerialNumber(), elapsed)
 
-	metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime.
+	metricsstore.GetMetricsStore().ProxyConfigUpdateTime.
 		WithLabelValues(typeURI.String(), fmt.Sprintf("%t", success)).
 		Observe(elapsed.Seconds())
 }

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -37,7 +37,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	}
 
 	log.Trace().Msgf("Envoy with certificate SerialNumber=%s connected", certSerialNumber)
-	metricsstore.DefaultMetricsStore.ProxyConnectCount.Inc()
+	metricsstore.GetMetricsStore().ProxyConnectCount.Inc()
 
 	// This is the Envoy proxy that just connected to the control plane.
 	// NOTE: This is step 1 of the registration. At this point we do not yet have context on the Pod.
@@ -90,19 +90,19 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	for {
 		select {
 		case <-ctx.Done():
-			metricsstore.DefaultMetricsStore.ProxyConnectCount.Dec()
+			metricsstore.GetMetricsStore().ProxyConnectCount.Dec()
 			return nil
 
 		case <-quit:
 			log.Debug().Msgf("gRPC stream closed for proxy %s!", proxy.String())
-			metricsstore.DefaultMetricsStore.ProxyConnectCount.Dec()
+			metricsstore.GetMetricsStore().ProxyConnectCount.Dec()
 			return nil
 
 		case discoveryRequest, ok := <-requests:
 			if !ok {
 				log.Error().Str(errcode.Kind, errcode.ErrGRPCStreamClosedByProxy.String()).
 					Msgf("gRPC stream closed by proxy %s!", proxy.String())
-				metricsstore.DefaultMetricsStore.ProxyConnectCount.Dec()
+				metricsstore.GetMetricsStore().ProxyConnectCount.Dec()
 				return errGrpcClosed
 			}
 
@@ -238,7 +238,7 @@ func respondToRequest(proxy *envoy.Proxy, discoveryRequest *xds_discovery.Discov
 		proxy.SetLastSentVersion(typeURL, requestVersion)
 		proxy.SetLastAppliedVersion(typeURL, requestVersion)
 		proxy.SetSubscribedResources(typeURL, getRequestedResourceNamesSet(discoveryRequest))
-		metricsstore.DefaultMetricsStore.ProxyReconnectCount.Inc()
+		metricsstore.GetMetricsStore().ProxyReconnectCount.Inc()
 		return true
 	}
 

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -39,7 +39,7 @@ func TestNewHTTPServer(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockProbe := health.NewMockProbes(mockCtrl)
 	testProbes := []health.Probes{mockProbe}
-	metricsStore := metricsstore.DefaultMetricsStore
+	metricsStore := metricsstore.GetMetricsStore()
 
 	httpServ := NewHTTPServer(testPort)
 

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -34,8 +34,8 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	}
 	elapsed := time.Since(startTime)
 
-	metricsstore.DefaultMetricsStore.CertIssuedCount.Inc()
-	metricsstore.DefaultMetricsStore.CertIssuedTime.
+	metricsstore.GetMetricsStore().CertIssuedCount.Inc()
+	metricsstore.GetMetricsStore().CertIssuedTime.
 		WithLabelValues().Observe(elapsed.Seconds())
 	originalHealthProbes := rewriteHealthProbes(pod)
 

--- a/pkg/injector/profiling.go
+++ b/pkg/injector/profiling.go
@@ -37,7 +37,7 @@ func webhookTimeTrack(start time.Time, timeout time.Duration, success *bool) {
 	log.Debug().Msgf("Mutate Webhook took %v to execute (%.2f of it's timeout, %v)",
 		elapsed, percentOfTimeout, timeout)
 
-	metricsstore.DefaultMetricsStore.InjectorSidecarCount.Inc()
-	metricsstore.DefaultMetricsStore.InjectorRqTime.
+	metricsstore.GetMetricsStore().InjectorSidecarCount.Inc()
+	metricsstore.GetMetricsStore().InjectorRqTime.
 		WithLabelValues(fmt.Sprintf("%t", *success)).Observe(elapsed.Seconds())
 }

--- a/pkg/k8s/event_handlers.go
+++ b/pkg/k8s/event_handlers.go
@@ -38,7 +38,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				OldObj:           nil,
 			})
 			ns := getNamespace(obj)
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(eventTypes.Add.String(), ns).Inc()
+			metricsstore.GetMetricsStore().K8sAPIEventCounter.WithLabelValues(eventTypes.Add.String(), ns).Inc()
 			updateEventSpecificMetrics(eventTypes.Add)
 		},
 
@@ -52,7 +52,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				OldObj:           oldObj,
 			})
 			ns := getNamespace(newObj)
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(eventTypes.Update.String(), ns).Inc()
+			metricsstore.GetMetricsStore().K8sAPIEventCounter.WithLabelValues(eventTypes.Update.String(), ns).Inc()
 		},
 
 		DeleteFunc: func(obj interface{}) {
@@ -65,7 +65,7 @@ func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve
 				OldObj:           obj,
 			})
 			ns := getNamespace(obj)
-			metricsstore.DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues(eventTypes.Delete.String(), ns).Inc()
+			metricsstore.GetMetricsStore().K8sAPIEventCounter.WithLabelValues(eventTypes.Delete.String(), ns).Inc()
 			updateEventSpecificMetrics(eventTypes.Delete)
 		},
 	}

--- a/pkg/k8s/metrics.go
+++ b/pkg/k8s/metrics.go
@@ -8,21 +8,21 @@ import (
 func updateEventSpecificMetrics(eventType announcements.AnnouncementType) {
 	switch eventType {
 	case announcements.NamespaceAdded:
-		metricsstore.DefaultMetricsStore.K8sMonitoredNamespaceCount.Inc()
+		metricsstore.GetMetricsStore().K8sMonitoredNamespaceCount.Inc()
 
 	case announcements.NamespaceDeleted:
-		metricsstore.DefaultMetricsStore.K8sMonitoredNamespaceCount.Dec()
+		metricsstore.GetMetricsStore().K8sMonitoredNamespaceCount.Dec()
 
 	case announcements.PodAdded:
-		metricsstore.DefaultMetricsStore.K8sMeshPodCount.Inc()
+		metricsstore.GetMetricsStore().K8sMeshPodCount.Inc()
 
 	case announcements.PodDeleted:
-		metricsstore.DefaultMetricsStore.K8sMeshPodCount.Dec()
+		metricsstore.GetMetricsStore().K8sMeshPodCount.Dec()
 
 	case announcements.ServiceAdded:
-		metricsstore.DefaultMetricsStore.K8sMeshServiceCount.Inc()
+		metricsstore.GetMetricsStore().K8sMeshServiceCount.Inc()
 
 	case announcements.ServiceDeleted:
-		metricsstore.DefaultMetricsStore.K8sMeshServiceCount.Dec()
+		metricsstore.GetMetricsStore().K8sMeshServiceCount.Dec()
 	}
 }

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -12,180 +12,129 @@ import (
 // Ex: osm_<metric-name>
 const metricsRootNamespace = "osm"
 
-// MetricsStore is a type that provides functionality related to metrics
-type MetricsStore struct {
-	// Define metrics by their category below ----------------------
+var metricsStore *MetricsStore
 
-	/*
-	 * K8s metrics
-	 */
-	// K8sAPIEventCounter is the metric counter for the number of K8s API events
-	K8sAPIEventCounter *prometheus.CounterVec
+// GetMetricsStore returns a singleton
+func GetMetricsStore() *MetricsStore {
+	if metricsStore == nil {
+		metricsStore = &MetricsStore{
+			/*
+			 * K8s metrics
+			 */
+			K8sAPIEventCounter: prometheus.NewCounterVec(
+				prometheus.CounterOpts{
+					Namespace: metricsRootNamespace,
+					Subsystem: "k8s",
+					Name:      "api_event_count",
+					Help:      "Number of events received from the Kubernetes API Server",
+				},
+				[]string{"type", "namespace"},
+			),
 
-	// K8sMonitoredNamespaceCount is the metric for the number of monitored namespaces
-	K8sMonitoredNamespaceCount prometheus.Gauge
+			K8sMonitoredNamespaceCount: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "k8s",
+				Name:      "monitored_namespace_count",
+				Help:      "Number of namespaces monitored by OSM controller",
+			}),
 
-	// K8sMeshPodCount is the metric for the number of pods participating in the mesh
-	K8sMeshPodCount prometheus.Gauge
+			K8sMeshPodCount: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "k8s",
+				Name:      "mesh_pod_count",
+				Help:      "Number of pods part of the mesh managed by OSM controller",
+			}),
 
-	// K8sMeshServiceCount is the metric for the number of services in the mesh
-	K8sMeshServiceCount prometheus.Gauge
+			K8sMeshServiceCount: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "k8s",
+				Name:      "mesh_service_count",
+				Help:      "Number of services part of the mesh managed by OSM controller",
+			}),
 
-	/*
-	 * Proxy metrics
-	 */
-	// ProxyConnectCount is the metric for the total number of proxies connected to the controller
-	ProxyConnectCount prometheus.Gauge
+			/*
+			 * Proxy metrics
+			 */
+			ProxyConnectCount: prometheus.NewGauge(prometheus.GaugeOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "proxy",
+				Name:      "connect_count",
+				Help:      "Number of proxies connected to OSM controller",
+			}),
 
-	// ProxyReconnectCount is the metric for the total reconnects from known proxies to the controller
-	ProxyReconnectCount prometheus.Counter
+			ProxyReconnectCount: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "proxy",
+				Name:      "reconnect_count",
+				Help:      "Number of reconnects from known proxies to OSM controller",
+			}),
 
-	// ProxyConfigUpdateTime is the histogram to track time spent for proxy configuration and its occurrences
-	ProxyConfigUpdateTime *prometheus.HistogramVec
+			ProxyConfigUpdateTime: prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Namespace: metricsRootNamespace,
+					Subsystem: "proxy",
+					Name:      "config_update_time",
+					Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90},
+					Help:      "Histogram for time spent for proxy configuration",
+				},
+				[]string{
+					"resource_type", // identifies a typeURI resource
+					"success",       // further labels if the operation succeeded or not
+				}),
 
-	// ProxyBroadcastEventCounter is the metric for the total number of ProxyBroadcast events published
-	ProxyBroadcastEventCount prometheus.Counter
+			ProxyBroadcastEventCount: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "proxy",
+				Name:      "broadcast_event_count",
+				Help:      "Number of ProxyBroadcast events published by the OSM controller",
+			}),
 
-	/*
-	 * Injector metrics
-	 */
-	// InjectorSidecarCount counts the number of injector webhooks dealt with over time
-	InjectorSidecarCount prometheus.Counter
+			/*
+			 * Injector metrics
+			 */
+			InjectorSidecarCount: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "injector",
+				Name:      "injector_sidecar_count",
+				Help:      "Counts the number of injector webhooks dealt with over time",
+			}),
 
-	// InjectorRqTime the histogram to track times for the injector webhook calls
-	InjectorRqTime *prometheus.HistogramVec
+			InjectorRqTime: prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Namespace: metricsRootNamespace,
+					Subsystem: "injector",
+					Name:      "injector_rq_time",
+					Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40},
+					Help:      "Histogram for time taken to perform sidecar injection",
+				},
+				[]string{
+					"success",
+				}),
 
-	/*
-	 * Certificate metrics
-	 */
-	// CertIssuedCount is the metric counter for the number of certificates issued
-	CertIssuedCount prometheus.Counter
+			/*
+			 * Certificate metrics
+			 */
+			CertIssuedCount: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: metricsRootNamespace,
+				Subsystem: "cert",
+				Name:      "issued_count",
+				Help:      "Total number of XDS certificates issued to proxies",
+			}),
 
-	// CertXdsIssuedCounter the histogram to track the time to issue a certificates
-	CertIssuedTime *prometheus.HistogramVec
+			CertIssuedTime: prometheus.NewHistogramVec(
+				prometheus.HistogramOpts{
+					Namespace: metricsRootNamespace,
+					Subsystem: "cert",
+					Name:      "issued_time",
+					Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90},
+					Help:      "Histogram for time spent to issue xds certificate",
+				},
+				[]string{}),
 
-	/*
-	 * MetricsStore internals should be defined below --------------
-	 */
-	registry *prometheus.Registry
-}
-
-var defaultMetricsStore MetricsStore
-
-// DefaultMetricsStore is the default metrics store
-var DefaultMetricsStore = &defaultMetricsStore
-
-func init() {
-	/*
-	 * K8s metrics
-	 */
-	defaultMetricsStore.K8sAPIEventCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: metricsRootNamespace,
-			Subsystem: "k8s",
-			Name:      "api_event_count",
-			Help:      "Represents the number of events received from the Kubernetes API Server",
-		},
-		[]string{"type", "namespace"},
-	)
-	defaultMetricsStore.K8sMonitoredNamespaceCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "k8s",
-		Name:      "monitored_namespace_count",
-		Help:      "Represents the number of namespaces monitored by OSM controller",
-	})
-	defaultMetricsStore.K8sMeshPodCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "k8s",
-		Name:      "mesh_pod_count",
-		Help:      "Represents the number of pods part of the mesh managed by OSM controller",
-	})
-	defaultMetricsStore.K8sMeshServiceCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "k8s",
-		Name:      "mesh_service_count",
-		Help:      "Represents the number of services part of the mesh managed by OSM controller",
-	})
-
-	/*
-	 * Proxy metrics
-	 */
-	defaultMetricsStore.ProxyConnectCount = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "proxy",
-		Name:      "connect_count",
-		Help:      "Represents the number of proxies connected to OSM controller",
-	})
-
-	defaultMetricsStore.ProxyReconnectCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "proxy",
-		Name:      "reconnect_count",
-		Help:      "Represents the number of reconnects from known proxies to OSM controller",
-	})
-
-	defaultMetricsStore.ProxyConfigUpdateTime = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metricsRootNamespace,
-			Subsystem: "proxy",
-			Name:      "config_update_time",
-			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90},
-			Help:      "Histogram to track time spent for proxy configuration",
-		},
-		[]string{
-			"resource_type", // identifies a typeURI resource
-			"success",       // further labels if the operation succeeded or not
-		})
-
-	defaultMetricsStore.ProxyBroadcastEventCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "proxy",
-		Name:      "broadcast_event_count",
-		Help:      "Represents the number of ProxyBroadcast events published by the OSM controller",
-	})
-
-	/*
-	 * Injector metrics
-	 */
-	defaultMetricsStore.InjectorSidecarCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "injector",
-		Name:      "injector_sidecar_count",
-		Help:      "Counts the number of injector webhooks dealt with over time",
-	})
-
-	defaultMetricsStore.InjectorRqTime = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metricsRootNamespace,
-			Subsystem: "injector",
-			Name:      "injector_rq_time",
-			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40},
-			Help:      "Histogram for time taken to perform sidecar injection",
-		},
-		[]string{
-			"success",
-		})
-
-	/*
-	 * Certificate metrics
-	 */
-	defaultMetricsStore.CertIssuedCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metricsRootNamespace,
-		Subsystem: "cert",
-		Name:      "issued_count",
-		Help:      "Represents the total number of XDS certificates issued to proxies",
-	})
-
-	defaultMetricsStore.CertIssuedTime = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metricsRootNamespace,
-			Subsystem: "cert",
-			Name:      "issued_time",
-			Buckets:   []float64{.1, .25, .5, 1, 2.5, 5, 10, 20, 40, 90},
-			Help:      "Histogram to track time spent to issue xds certificate",
-		},
-		[]string{})
-	defaultMetricsStore.registry = prometheus.NewRegistry()
+			registry: prometheus.NewRegistry(),
+		}
+	}
+	return metricsStore
 }
 
 // Start store

--- a/pkg/metricsstore/metricsstore_test.go
+++ b/pkg/metricsstore/metricsstore_test.go
@@ -10,16 +10,16 @@ import (
 )
 
 func setup() {
-	DefaultMetricsStore.Start(
-		DefaultMetricsStore.K8sAPIEventCounter,
-		DefaultMetricsStore.ProxyConnectCount,
+	GetMetricsStore().Start(
+		GetMetricsStore().K8sAPIEventCounter,
+		GetMetricsStore().ProxyConnectCount,
 	)
 }
 
 func teardown() {
-	DefaultMetricsStore.Stop(
-		DefaultMetricsStore.K8sAPIEventCounter,
-		DefaultMetricsStore.ProxyConnectCount,
+	GetMetricsStore().Stop(
+		GetMetricsStore().K8sAPIEventCounter,
+		GetMetricsStore().ProxyConnectCount,
 	)
 }
 
@@ -33,9 +33,9 @@ func TestMetricsStore(t *testing.T) {
 		apiEventCount := 3
 
 		for i := 1; i <= apiEventCount; i++ {
-			DefaultMetricsStore.K8sAPIEventCounter.WithLabelValues("add", "foo").Inc()
+			GetMetricsStore().K8sAPIEventCounter.WithLabelValues("add", "foo").Inc()
 
-			handler := DefaultMetricsStore.Handler()
+			handler := GetMetricsStore().Handler()
 
 			req, err := http.NewRequest("GET", "/metrics", nil)
 			assert.Nil(err)
@@ -60,13 +60,13 @@ osm_k8s_api_event_count{namespace="foo",type="add"} %d
 		proxiesDisconnected := 2
 
 		for i := 1; i <= proxiesConnected; i++ {
-			DefaultMetricsStore.ProxyConnectCount.Inc()
+			GetMetricsStore().ProxyConnectCount.Inc()
 		}
 		for i := 1; i <= proxiesDisconnected; i++ {
-			DefaultMetricsStore.ProxyConnectCount.Dec()
+			GetMetricsStore().ProxyConnectCount.Dec()
 		}
 
-		handler := DefaultMetricsStore.Handler()
+		handler := GetMetricsStore().Handler()
 
 		req, err := http.NewRequest("GET", "/metrics", nil)
 		assert.Nil(err)

--- a/pkg/metricsstore/types.go
+++ b/pkg/metricsstore/types.go
@@ -1,0 +1,61 @@
+package metricsstore
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// MetricsStore is a type that provides functionality related to metrics
+type MetricsStore struct {
+	// Define metrics by their category below ----------------------
+
+	/*
+	 * K8s metrics
+	 */
+	// K8sAPIEventCounter is the metric counter for the number of K8s API events
+	K8sAPIEventCounter *prometheus.CounterVec
+
+	// K8sMonitoredNamespaceCount is the metric for the number of monitored namespaces
+	K8sMonitoredNamespaceCount prometheus.Gauge
+
+	// K8sMeshPodCount is the metric for the number of pods participating in the mesh
+	K8sMeshPodCount prometheus.Gauge
+
+	// K8sMeshServiceCount is the metric for the number of services in the mesh
+	K8sMeshServiceCount prometheus.Gauge
+
+	/*
+	 * Proxy metrics
+	 */
+	// ProxyConnectCount is the metric for the total number of proxies connected to the controller
+	ProxyConnectCount prometheus.Gauge
+
+	// ProxyReconnectCount is the metric for the total reconnects from known proxies to the controller
+	ProxyReconnectCount prometheus.Counter
+
+	// ProxyConfigUpdateTime is the histogram to track time spent for proxy configuration and its occurrences
+	ProxyConfigUpdateTime *prometheus.HistogramVec
+
+	// ProxyBroadcastEventCounter is the metric for the total number of ProxyBroadcast events published
+	ProxyBroadcastEventCount prometheus.Counter
+
+	/*
+	 * Injector metrics
+	 */
+	// InjectorSidecarCount counts the number of injector webhooks dealt with over time
+	InjectorSidecarCount prometheus.Counter
+
+	// InjectorRqTime the histogram to track times for the injector webhook calls
+	InjectorRqTime *prometheus.HistogramVec
+
+	/*
+	 * Certificate metrics
+	 */
+	// CertIssuedCount is the metric counter for the number of certificates issued
+	CertIssuedCount prometheus.Counter
+
+	// CertXdsIssuedCounter the histogram to track the time to issue a certificates
+	CertIssuedTime *prometheus.HistogramVec
+
+	/*
+	 * MetricsStore internals should be defined below --------------
+	 */
+	registry *prometheus.Registry
+}


### PR DESCRIPTION
This is a small refactor to the metrics store.
In this PR:

 - Use `GetMetricsStore()` function to initialize instead of `DefaultMetricsStore` variable with `init()`
 - `MetricsStore` struct moved to pkg/metricsstore/types.go