### PR TITLE
charts: allow deploying Contour ingress gateway

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ build-osm: cmd/cli/chart.tgz
 	CGO_ENABLED=0  go build -v -o ./bin/osm -ldflags ${LDFLAGS} ./cmd/cli
 
 cmd/cli/chart.tgz: scripts/generate_chart/generate_chart.go $(shell find charts/osm)
+	helm dependency update charts/osm
 	go run $< > $@
 
 .PHONY: clean-osm

--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -22,3 +22,9 @@ appVersion: v0.9.1
 
 # This specifies the minimum Kubernetes version OSM is compatible with.
 kubeVersion: ">= 1.19.0"
+
+dependencies:
+- name: contour
+  version: 5.1.0
+  repository: https://charts.bitnami.com/bitnami
+  condition: contour.enabled

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -151,6 +151,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
 | OpenServiceMesh.vault.token | string | `""` | token that should be used to connect to Vault |
 | OpenServiceMesh.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
+| contour.enabled | bool | `false` | Enables deployment of Contour control plane and gateway |
 
 <!-- markdownlint-enable MD013 MD034 -->
 <!-- markdownlint-restore -->

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -35,6 +35,16 @@ data:
       },
       "certificate": {
         "serviceCertValidityDuration": "{{.Values.OpenServiceMesh.certificateProvider.serviceCertValidityDuration}}",
+        {{- if .Values.contour.enabled }}
+        "ingressGateway": {
+          "subjectAltNames": ["osm-contour-envoy.{{include "osm.namespace" .}}.cluster.local"],
+          "validityDuration": "24h",
+          "secret": {
+            "name": "osm-contour-envoy-client-cert",
+            "namespace": "{{include "osm.namespace" .}}"
+          }
+        },
+        {{- end }}
         "certKeyBitSize": {{.Values.OpenServiceMesh.certificateProvider.certKeyBitSize}}
       },
       "featureFlags": {

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -3,7 +3,8 @@
     "type": "object",
     "title": "The OSM Helm chart values schema",
     "required": [
-        "OpenServiceMesh"
+        "OpenServiceMesh",
+        "contour"
     ],
     "definitions": {
         "containerResources": {
@@ -203,11 +204,13 @@
                     "type": "object",
                     "title": "The image schema",
                     "description": "The details of the images to run.",
-                    "examples": [{
-                        "registry": "openservicemesh",
-                        "pullPolicy": "IfNotPresent",
-                        "tag": "v0.4.2"
-                    }],
+                    "examples": [
+                        {
+                            "registry": "openservicemesh",
+                            "pullPolicy": "IfNotPresent",
+                            "tag": "v0.4.2"
+                        }
+                    ],
                     "required": [
                         "registry",
                         "pullPolicy",
@@ -364,16 +367,18 @@
                     "type": "object",
                     "title": "The Fluent Bit schema",
                     "description": "The default details of the Fluent Bit sidecar if enabled.",
-                    "examples": [{
-                        "name": "fluentbit-logger",
-                        "registry": "fluent",
-                        "tag": "1.6.4",
-                        "pullPolicy": "IfNotPresent",
-                        "outputPlugin": "stdout",
-                        "enableProxySupport": "false",
-                        "httpProxy": "",
-                        "httpsProxy": ""
-                    }],
+                    "examples": [
+                        {
+                            "name": "fluentbit-logger",
+                            "registry": "fluent",
+                            "tag": "1.6.4",
+                            "pullPolicy": "IfNotPresent",
+                            "outputPlugin": "stdout",
+                            "enableProxySupport": "false",
+                            "httpProxy": "",
+                            "httpsProxy": ""
+                        }
+                    ],
                     "required": [
                         "name",
                         "registry",
@@ -554,9 +559,11 @@
                     "type": "object",
                     "title": "The tracing schema",
                     "description": "An explanation about the purpose of this instance.",
-                    "examples": [{
-                        "enable": true
-                    }],
+                    "examples": [
+                        {
+                            "enable": true
+                        }
+                    ],
                     "required": [
                         "enable",
                         "address",
@@ -742,10 +749,12 @@
                     "type": "object",
                     "title": "Feature flags",
                     "description": "Feature flags",
-                    "examples": [{
-                        "enableWASMStats": true,
-                        "enableEgressPolicy": true
-                    }],
+                    "examples": [
+                        {
+                            "enableWASMStats": true,
+                            "enableEgressPolicy": true
+                        }
+                    ],
                     "required": [
                         "enableWASMStats",
                         "enableEgressPolicy",
@@ -870,12 +879,14 @@
                         "type": "object"
                     },
                     "examples": [
-                        [{
-                            "key": "key1",
-                            "operator": "Equal",
-                            "value": "value1",
-                            "effect": "NoSchedule"
-                        }]
+                        [
+                            {
+                                "key": "key1",
+                                "operator": "Equal",
+                                "value": "value1",
+                                "effect": "NoSchedule"
+                            }
+                        ]
                     ]
                 },
                 "outboundIPRangeExclusionList": {
@@ -959,10 +970,12 @@
                             ]
                         }
                     },
-                    "examples": [{
-                        "port": 3000,
-                        "enableRemoteRendering": true
-                    }],
+                    "examples": [
+                        {
+                            "port": 3000,
+                            "enableRemoteRendering": true
+                        }
+                    ],
                     "additionalProperties": false
                 },
                 "certmanager": {
@@ -1004,11 +1017,13 @@
                             ]
                         }
                     },
-                    "examples": [{
-                        "issuerName": "osm-ca",
-                        "issuerKind": "Issuer",
-                        "issuerGroup": "cert-manager"
-                    }],
+                    "examples": [
+                        {
+                            "issuerName": "osm-ca",
+                            "issuerKind": "Issuer",
+                            "issuerGroup": "cert-manager"
+                        }
+                    ],
                     "additionalProperties": false
                 },
                 "vault": {
@@ -1042,12 +1057,14 @@
                             "type": "string"
                         }
                     },
-                    "examples": [{
-                        "host": "vault.default.svc.cluster.local",
-                        "protocol": "http",
-                        "token": "some-token",
-                        "role": "openservicemesh"
-                    }],
+                    "examples": [
+                        {
+                            "host": "vault.default.svc.cluster.local",
+                            "protocol": "http",
+                            "token": "some-token",
+                            "role": "openservicemesh"
+                        }
+                    ],
                     "additionalProperties": false
                 },
                 "prometheus": {
@@ -1107,9 +1124,11 @@
                         "type": "object"
                     },
                     "examples": [
-                        [{
-                            "name": "secret-name"
-                        }]
+                        [
+                            {
+                                "name": "secret-name"
+                            }
+                        ]
                     ]
                 },
                 "validatorWebhook": {
@@ -1129,6 +1148,20 @@
                 }
             },
             "additionalProperties": false
+        },
+        "contour": {
+            "$id": "#/properties/contour",
+            "type": "object",
+            "title": "Contour Ingress",
+            "description": "Contour Ingress configuration",
+            "properties": {
+                "enabled": {
+                    "$id": "#/properties/contour/enabled",
+                    "title": "Enable Contour",
+                    "description": "Enables Contour control plane and gateway",
+                    "type": "boolean"
+                }
+            }
         }
     }
 }

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -301,3 +301,9 @@ OpenServiceMesh:
   validatorWebhook:
     # -- Name of the ValidatingWebhookConfiguration
     webhookConfigurationName: ""
+
+#
+# -- Contour configuration
+contour:
+  # -- Enables deployment of Contour control plane and gateway
+  enabled: false


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Allows Contour's ingress gateway and control plane
to be deployed.

Part of #3501 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Ingress                    | [X] |

<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:
Tested end-to-end HTTP and HTTPS ingress with Contour using:
```bash
osm install --set OpenServiceMesh.image.tag=$CTR_TAG --set OpenServiceMesh.image.registry=$CTR_REGISTRY --set OpenServiceMesh.image.pullPolicy=Always --set OpenServiceMesh.featureFlags.enableIngressBackendPolicy=true --set contour.enabled=true --set contour.configInline.tls.envoy-client-certificate.name=osm-contour-envoy-client-cert --set contour.configInline.tls.envoy-client-certificate.namespace=osm-system
```


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
