### PR TITLE
feat(pkg/envoy): incrementing metric for error codes

### DIFF
--- a/cmd/osm-controller/log_handler.go
+++ b/cmd/osm-controller/log_handler.go
@@ -26,7 +26,7 @@ func StartGlobalLogLevelHandler(cfg configurator.Configurator, stop <-chan struc
 	log.Info().Msgf("Setting initial log level from meshconfig: %s", logLevel)
 	err := logger.SetLogLevel(logLevel)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrSettingLogLevel.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrSettingLogLevel)).
 			Msg("Error setting initial log level from meshconfig")
 	} else {
 		currentLogLevel = logLevel
@@ -40,7 +40,7 @@ func StartGlobalLogLevelHandler(cfg configurator.Configurator, stop <-chan struc
 				if logLevel != currentLogLevel {
 					err := logger.SetLogLevel(logLevel)
 					if err != nil {
-						log.Error().Err(err).Str(errcode.Kind, errcode.ErrSettingLogLevel.String()).
+						log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrSettingLogLevel)).
 							Msg("Error setting log level from meshconfig")
 					} else {
 						log.Info().Msgf("Global log level changed to: %s", logLevel)

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -331,7 +331,8 @@ func getOSMControllerPod(kubeClient kubernetes.Interface) (*corev1.Pod, error) {
 
 	pod, err := kubeClient.CoreV1().Pods(osmNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingControllerPod.String()).
+		// TODO: Need to push metric
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingControllerPod)).
 			Msgf("Error retrieving osm-controller pod %s", podName)
 		return nil, err
 	}

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -331,7 +331,7 @@ func getOSMControllerPod(kubeClient kubernetes.Interface) (*corev1.Pod, error) {
 
 	pod, err := kubeClient.CoreV1().Pods(osmNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		// TODO: Need to push metric
+		// TODO: Need to push metric?
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingControllerPod)).
 			Msgf("Error retrieving osm-controller pod %s", podName)
 		return nil, err

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -133,6 +133,7 @@ func main() {
 		metricsstore.DefaultMetricsStore.InjectorSidecarCount,
 		metricsstore.DefaultMetricsStore.CertIssuedCount,
 		metricsstore.DefaultMetricsStore.CertIssuedTime,
+		metricsstore.DefaultMetricsStore.ErrCodeCounter,
 	)
 
 	// Initialize Configurator to retrieve mesh specific config

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -201,7 +201,8 @@ func getInjectorPod(kubeClient kubernetes.Interface) (*corev1.Pod, error) {
 
 	pod, err := kubeClient.CoreV1().Pods(osmNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingInjectorPod.String()).
+		// TODO: Need to push metric
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingInjectorPod)).
 			Msgf("Error retrieving osm-injector pod %s", podName)
 		return nil, err
 	}

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -201,7 +201,7 @@ func getInjectorPod(kubeClient kubernetes.Interface) (*corev1.Pod, error) {
 
 	pod, err := kubeClient.CoreV1().Pods(osmNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		// TODO: Need to push metric
+		// TODO: Need to push metric?
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingInjectorPod)).
 			Msgf("Error retrieving osm-injector pod %s", podName)
 		return nil, err

--- a/cmd/osm-injector/reconcile.go
+++ b/cmd/osm-injector/reconcile.go
@@ -35,7 +35,7 @@ func createReconciler(kubeClient *kubernetes.Clientset) error {
 		// mgr.Start() below will block until stopped
 		// See: https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.6/pkg/manager/internal.go#L507-L514
 		if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrStartingReconcileManager.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrStartingReconcileManager)).
 				Msg("Error starting controller-runtime manager for MutatingWebhookConfigurartion's reconciler")
 		}
 	}()

--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -93,7 +93,7 @@ func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceId
 	// Deduplicate the list of EgressClusterConfig objects
 	clusterConfigs, err = trafficpolicy.DeduplicateClusterConfigs(clusterConfigs)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDedupEgressClusterConfigs.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDedupEgressClusterConfigs)).
 			Msgf("Error deduplicating egress clusters configs for service identity %s", serviceIdentity)
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (mc *MeshCatalog) buildHTTPRouteConfigs(egressPolicy *policyV1alpha1.Egress
 	destIPSet := mapset.NewSet()
 	for _, ipRange := range egressPolicy.Spec.IPAddresses {
 		if _, _, err := net.ParseCIDR(ipRange); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrInvalidEgressIPRange.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidEgressIPRange)).
 				Msgf("Invalid IP range [%s] specified in egress policy %s/%s; will be skipped", ipRange, egressPolicy.Namespace, egressPolicy.Name)
 			continue
 		}
@@ -142,14 +142,14 @@ func (mc *MeshCatalog) buildHTTPRouteConfigs(egressPolicy *policyV1alpha1.Egress
 			// A TypedLocalObjectReference (Spec.Matches) is a reference to another object in the same namespace
 			httpRouteName := fmt.Sprintf("%s/%s", egressPolicy.Namespace, match.Name)
 			if httpRouteGroup := mc.meshSpec.GetHTTPRouteGroup(httpRouteName); httpRouteGroup == nil {
-				log.Error().Str(errcode.Kind, errcode.ErrEgressSMIHTTPRouteGroupNotFound.String()).
+				log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEgressSMIHTTPRouteGroupNotFound)).
 					Msgf("Error fetching HTTPRouteGroup resource %s referenced in Egress policy %s/%s", httpRouteName, egressPolicy.Namespace, egressPolicy.Name)
 			} else {
 				matches := getHTTPRouteMatchesFromHTTPRouteGroup(httpRouteGroup)
 				httpRouteMatches = append(httpRouteMatches, matches...)
 			}
 		} else {
-			log.Error().Str(errcode.Kind, errcode.ErrInvalidEgressMatches.String()).
+			log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidEgressMatches)).
 				Msgf("Unsupported match object specified: %v, ignoring it", match)
 		}
 	}

--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -106,7 +106,7 @@ func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity iden
 				}
 				hostnames, err := mc.GetServiceHostnames(apexService, locality)
 				if err != nil {
-					log.Error().Err(err).Str(errcode.Kind, errcode.ErrServiceHostnames.String()).
+					log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrServiceHostnames)).
 						Msgf("Error getting service hostnames for apex service %v", apexService)
 					continue
 				}
@@ -147,7 +147,7 @@ func (mc *MeshCatalog) buildInboundPolicies(t *access.TrafficTarget, svc service
 
 	hostnames, err := mc.GetServiceHostnames(svc, service.LocalNS)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrServiceHostnames.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrServiceHostnames)).
 			Msgf("Error getting service hostnames for service %s", svc)
 		return inboundPolicies
 	}
@@ -180,7 +180,7 @@ func (mc *MeshCatalog) buildInboundPermissiveModePolicies(svc service.MeshServic
 
 	hostnames, err := mc.GetServiceHostnames(svc, service.LocalNS)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrServiceHostnames.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrServiceHostnames)).
 			Msgf("Error getting service hostnames for service %s", svc)
 		return inboundPolicies
 	}

--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -86,7 +86,7 @@ func (mc *MeshCatalog) listInboundPoliciesForTrafficSplits(upstreamIdentity iden
 		// fetch all routes referenced in traffic target
 		routeMatches, err := mc.routesFromRules(t.Spec.Rules, t.Namespace)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingSMIHTTPRouteGroupForTrafficTarget.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingSMIHTTPRouteGroupForTrafficTarget)).
 				Msgf("Error finding route matches from TrafficTarget %s in namespace %s", t.Name, t.Namespace)
 			continue
 		}
@@ -140,7 +140,7 @@ func (mc *MeshCatalog) buildInboundPolicies(t *access.TrafficTarget, svc service
 	// fetch all routes referenced in traffic target
 	routeMatches, err := mc.routesFromRules(t.Spec.Rules, t.Namespace)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingSMIHTTPRouteGroupForTrafficTarget.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingSMIHTTPRouteGroupForTrafficTarget)).
 			Msgf("Error finding route matches from TrafficTarget %s in namespace %s", t.Name, t.Namespace)
 		return inboundPolicies
 	}
@@ -231,7 +231,7 @@ func (mc *MeshCatalog) getHTTPPathsPerRoute() (map[trafficpolicy.TrafficSpecName
 	for _, trafficSpecs := range mc.meshSpec.ListHTTPTrafficSpecs() {
 		log.Debug().Msgf("Discovered TrafficSpec resource: %s/%s", trafficSpecs.Namespace, trafficSpecs.Name)
 		if trafficSpecs.Spec.Matches == nil {
-			log.Error().Str(errcode.Kind, errcode.ErrSMIHTTPRouteGroupNoMatch.String()).
+			log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrSMIHTTPRouteGroupNoMatch)).
 				Msgf("TrafficSpec %s/%s has no matches in route; Skipping...", trafficSpecs.Namespace, trafficSpecs.Name)
 			continue
 		}

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -72,7 +72,7 @@ func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespa
 		}
 		hostnames, err := mc.GetServiceHostnames(svc, locality)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrServiceHostnames.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrServiceHostnames)).
 				Msgf("Error getting service hostnames for apex service %v", svc)
 			continue
 		}
@@ -130,7 +130,7 @@ func (mc *MeshCatalog) ListOutboundServicesForIdentity(serviceIdentity identity.
 				}
 				destServices, err := mc.getServicesForServiceIdentity(sa.ToServiceIdentity())
 				if err != nil {
-					log.Error().Err(err).Str(errcode.Kind, errcode.ErrNoMatchingServiceForServiceAccount.String()).
+					log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrNoMatchingServiceForServiceAccount)).
 						Msgf("No Services found matching Service Account %s in Namespace %s", t.Spec.Destination.Name, t.Namespace)
 					break
 				}
@@ -161,7 +161,7 @@ func (mc *MeshCatalog) buildOutboundPermissiveModePolicies(sourceNamespace strin
 		}
 		hostnames, err := mc.GetServiceHostnames(destService, locality)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrServiceHostnames.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrServiceHostnames)).
 				Msgf("Error getting service hostnames for service %s", destService)
 			continue
 		}
@@ -213,7 +213,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 		}
 		hostnames, err := mc.GetServiceHostnames(destService, locality)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrServiceHostnames.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrServiceHostnames)).
 				Msgf("Error getting service hostnames for service %s", destService)
 			continue
 		}

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -96,7 +96,7 @@ func (mc *MeshCatalog) listOutboundTrafficPoliciesForTrafficSplits(sourceNamespa
 
 		if apexServices.Contains(svc) {
 			// TODO: enhancement(#2759)
-			log.Error().Str(errcode.Kind, errcode.ErrMultipleSMISplitPerServiceUnsupported.String()).
+			log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMultipleSMISplitPerServiceUnsupported)).
 				Msgf("Skipping Traffic Split policy %s in namespaces %s as there is already a traffic split policy for apex service %v", split.Name, split.Namespace, svc)
 		} else {
 			outboundPoliciesFromSplits = append(outboundPoliciesFromSplits, policy)
@@ -169,7 +169,7 @@ func (mc *MeshCatalog) buildOutboundPermissiveModePolicies(sourceNamespace strin
 		weightedCluster := getDefaultWeightedClusterForService(destService)
 		policy := trafficpolicy.NewOutboundTrafficPolicy(destService.FQDN(), hostnames)
 		if err := policy.AddRoute(trafficpolicy.WildCardRouteMatch, weightedCluster); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrAddingRouteToOutboundTrafficPolicy.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrAddingRouteToOutboundTrafficPolicy)).
 				Msgf("Error adding route to outbound policy in permissive mode for destination %s", destService)
 			continue
 		}
@@ -186,7 +186,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 	// fetch services running workloads with destination service account
 	destServices, err := mc.getDestinationServicesFromTrafficTarget(t)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingServiceForTrafficTargetDestination.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingServiceForTrafficTargetDestination)).
 			Msgf("Error resolving destination services from TraficTarget %s/%s", t.Namespace, t.Name)
 		return nil
 	}
@@ -194,7 +194,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 	// fetch all routes referenced in the TrafficTarget
 	routeMatches, err := mc.routesFromRules(t.Spec.Rules, t.Namespace)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingSMIHTTPRouteGroupForTrafficTarget.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingSMIHTTPRouteGroupForTrafficTarget)).
 			Msgf("Error finding route matches from TrafficTarget %s/%s", t.Namespace, t.Name)
 		return nil
 	}
@@ -228,7 +228,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 			if _, ok := routeMatch.Headers[hostHeaderKey]; ok {
 				policyWithHostHeader := trafficpolicy.NewOutboundTrafficPolicy(routeMatch.Headers[hostHeaderKey], []string{routeMatch.Headers[hostHeaderKey]})
 				if err := policyWithHostHeader.AddRoute(trafficpolicy.WildCardRouteMatch, weightedCluster); err != nil {
-					log.Error().Err(err).Str(errcode.Kind, errcode.ErrAddingRouteToOutboundTrafficPolicy.String()).
+					log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrAddingRouteToOutboundTrafficPolicy)).
 						Msgf("Error adding Route to outbound policy for source %s/%s and destination %s/%s with host header %s", source.Namespace, source.Name, destService.Namespace, destService.Name, routeMatch.Headers[hostHeaderKey])
 					continue
 				}
@@ -239,7 +239,7 @@ func (mc *MeshCatalog) buildOutboundPolicies(sourceServiceIdentity identity.Serv
 		}
 		if needWildCardRoute {
 			if err := policy.AddRoute(trafficpolicy.WildCardRouteMatch, weightedCluster); err != nil {
-				log.Error().Err(err).Str(errcode.Kind, errcode.ErrAddingRouteToOutboundTrafficPolicy.String()).
+				log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrAddingRouteToOutboundTrafficPolicy)).
 					Msgf("Error adding wildcard route to outbound policy for source %s/%s and destination %s/%s", source.Namespace, source.Name, destService.Namespace, destService.Name)
 				continue
 			}
@@ -280,7 +280,7 @@ func (mc *MeshCatalog) GetWeightedClustersForUpstream(upstream service.MeshServi
 		}
 
 		if apexServices.Contains(split.Spec.Service) {
-			log.Error().Str(errcode.Kind, errcode.ErrMultipleSMISplitPerServiceUnsupported.String()).
+			log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMultipleSMISplitPerServiceUnsupported)).
 				Msgf("Skipping traffic split policy %s/%s as there is already a corresponding policy for apex service %s", split.Namespace, split.Name, split.Spec.Service)
 			continue
 		}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -103,7 +103,7 @@ func (mc *MeshCatalog) ListServiceIdentitiesForService(svc service.MeshService) 
 	for _, provider := range mc.serviceProviders {
 		serviceIDs, err := provider.ListServiceIdentitiesForService(svc)
 		if err != nil {
-			log.Err(err).Str(errcode.Kind, errcode.ErrGettingServiceIdentitiesForService.String()).
+			log.Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentitiesForService)).
 				Msgf("Error getting ServiceIdentities for Service %s", svc)
 			return nil, err
 		}

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -93,7 +93,7 @@ func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcIdentity identity
 
 		if spec.Destination.Kind != serviceAccountKind {
 			// Destination kind is not valid
-			log.Error().Str(errcode.Kind, errcode.ErrInvalidDestinationKind.String()).
+			log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidDestinationKind)).
 				Msgf("Applied TrafficTarget policy %s has invalid Destination kind: %s", trafficTarget.Name, spec.Destination.Kind)
 			continue
 		}
@@ -107,7 +107,7 @@ func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcIdentity identity
 			for _, source := range spec.Sources {
 				if source.Kind != serviceAccountKind {
 					// Destination kind is not valid
-					log.Error().Str(errcode.Kind, errcode.ErrInvalidSourceKind.String()).
+					log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidSourceKind)).
 						Msgf("Applied TrafficTarget policy %s has invalid Source kind: %s", trafficTarget.Name, spec.Destination.Kind)
 					continue
 				}
@@ -121,7 +121,7 @@ func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcIdentity identity
 			for _, source := range spec.Sources {
 				if source.Kind != serviceAccountKind {
 					// Destination kind is not valid
-					log.Error().Str(errcode.Kind, errcode.ErrInvalidSourceKind.String()).
+					log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidSourceKind)).
 						Msgf("Applied TrafficTarget policy %s has invalid Source kind: %s", trafficTarget.Name, spec.Destination.Kind)
 					continue
 				}

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -163,14 +163,16 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 	}
 	certPrivKey, err := rsa.GenerateKey(rand.Reader, cm.keySize)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingPrivateKey.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGeneratingPrivateKey)).
 			Msgf("Error generating private key for certificate with CN=%s", cn)
 		return nil, fmt.Errorf("failed to generate private key for certificate with CN=%s: %s", cn, err)
 	}
 
 	privKeyPEM, err := certificate.EncodeKeyDERtoPEM(certPrivKey)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEncodingKeyDERtoPEM.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingKeyDERtoPEM)).
 			Msgf("Error encoding private key for certificate with CN=%s", cn)
 		return nil, err
 	}
@@ -187,13 +189,15 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csr, certPrivKey)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrCreatingCertReq.String())
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrCreatingCertReq))
 		return nil, fmt.Errorf("error creating x509 certificate request: %s", err)
 	}
 
 	csrPEM, err := certificate.EncodeCertReqDERtoPEM(csrDER)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEncodingCertDERtoPEM.String())
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM))
 		return nil, fmt.Errorf("failed to encode certificate request DER to PEM CN=%s: %s", cn, err)
 	}
 

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -39,7 +39,8 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 
 	rsaKey, err := rsa.GenerateKey(rand.Reader, rsaBits)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingPrivateKey.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGeneratingPrivateKey)).
 			Msgf("Error generating key for CA for org %s", rootCertOrganization)
 		return nil, err
 	}
@@ -47,21 +48,24 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 	// Self-sign the root certificate
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &rsaKey.PublicKey, rsaKey)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrCreatingRootCert.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrCreatingRootCert)).
 			Msgf("Error issuing x509.CreateCertificate command for SerialNumber=%s", serialNumber)
 		return nil, errors.Wrap(err, errCreateCert.Error())
 	}
 
 	pemCert, err := certificate.EncodeCertDERtoPEM(derBytes)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEncodingCertDERtoPEM.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM)).
 			Msgf("Error encoding certificate with SerialNumber=%s", serialNumber)
 		return nil, err
 	}
 
 	pemKey, err := certificate.EncodeKeyDERtoPEM(rsaKey)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEncodingKeyDERtoPEM.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingKeyDERtoPEM)).
 			Msgf("Error encoding private key for certificate with SerialNumber=%s", serialNumber)
 		return nil, err
 	}
@@ -83,7 +87,8 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expiration time.Time) (certificate.Certificater, error) {
 	x509Cert, err := certificate.DecodePEMCertificate(pemCert)
 	if err != nil {
-		log.Err(err).Str(errcode.Kind, errcode.ErrDecodingPEMCert.String()).
+		// TODO: Need to push metric?
+		log.Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingPEMCert)).
 			Msg("Error converting PEM cert to x509 to obtain serial number")
 		return nil, err
 	}

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -18,7 +18,9 @@ import (
 
 func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
 	if cm.ca == nil {
-		log.Error().Str(errcode.Kind, errcode.ErrInvalidCA.String()).Msgf("Invalid CA provided for issuance of certificate with CN=%s", cn)
+		// TODO: Need to push metric?
+		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidCA)).
+			Msgf("Invalid CA provided for issuance of certificate with CN=%s", cn)
 		return nil, errNoIssuingCA
 	}
 
@@ -30,7 +32,8 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 	}
 	certPrivKey, err := rsa.GenerateKey(rand.Reader, cm.keySize)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingPrivateKey.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGeneratingPrivateKey)).
 			Msgf("Error generating private key for certificate with CN=%s", cn)
 		return nil, errors.Wrap(err, errGeneratingPrivateKey.Error())
 	}
@@ -60,33 +63,38 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 
 	x509Root, err := certificate.DecodePEMCertificate(cm.ca.GetCertificateChain())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDecodingPEMCert.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingPEMCert)).
 			Msg("Error decoding Root Certificate's PEM")
 	}
 
 	rsaKeyRoot, err := certificate.DecodePEMPrivateKey(cm.ca.GetPrivateKey())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDecodingPEMPrivateKey.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingPEMPrivateKey)).
 			Msg("Error decoding Root Certificate's Private Key PEM ")
 	}
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, x509Root, &certPrivKey.PublicKey, rsaKeyRoot)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrCreatingCert.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrCreatingCert)).
 			Msgf("Error issuing x509.CreateCertificate command for SerialNumber=%s", serialNumber)
 		return nil, errors.Wrap(err, errCreateCert.Error())
 	}
 
 	certPEM, err := certificate.EncodeCertDERtoPEM(derBytes)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEncodingCertDERtoPEM.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM)).
 			Msgf("Error encoding certificate with SerialNumber=%s", serialNumber)
 		return nil, err
 	}
 
 	privKeyPEM, err := certificate.EncodeKeyDERtoPEM(certPrivKey)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEncodingKeyDERtoPEM.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingKeyDERtoPEM)).
 			Msgf("Error encoding private key for certificate with SerialNumber=%s", serialNumber)
 		return nil, err
 	}

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -94,7 +94,9 @@ func (cm *CertManager) getIssuingCA(issue func(certificate.CommonName, time.Dura
 func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Duration) (certificate.Certificater, error) {
 	secret, err := cm.client.Logical().Write(getIssueURL(cm.role).String(), getIssuanceData(cn, validityPeriod))
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrIssuingCert.String()).Msgf("Error issuing new certificate for CN=%s", cn)
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrIssuingCert)).
+			Msgf("Error issuing new certificate for CN=%s", cn)
 		return nil, err
 	}
 

--- a/pkg/certificate/rotor/rotor.go
+++ b/pkg/certificate/rotor/rotor.go
@@ -59,7 +59,8 @@ func (r *CertRotor) checkAndRotate() {
 			// Remove the certificate from the cache of the certificate manager
 			newCert, err := r.certManager.RotateCertificate(cert.GetCommonName())
 			if err != nil {
-				log.Error().Err(err).Str(errcode.Kind, errcode.ErrRotatingCert.String()).
+				// TODO: Need to push metric?
+				log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrRotatingCert)).
 					Msgf("Error rotating cert SerialNumber=%s", cert.GetSerialNumber())
 				continue
 			}

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -100,7 +100,7 @@ func (c *Client) run(stop <-chan struct{}) {
 	log.Debug().Msgf("Started OSM MeshConfig informer")
 	log.Debug().Msg("[MeshConfig Client] Waiting for MeshConfig informer's cache to sync")
 	if !cache.WaitForCacheSync(stop, c.informer.HasSynced) {
-		// TODO: Need to push metric
+		// TODO: Need to push metric?
 		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigInformerInitCache)).Msg("Failed initial cache sync for MeshConfig informer")
 		return
 	}

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -76,7 +76,7 @@ func (c *Client) runMeshConfigListener(stop <-chan struct{}) {
 		case msg := <-cfgSubChannel:
 			psubMsg, ok := msg.(events.PubSubMessage)
 			if !ok {
-				log.Error().Str(errcode.Kind, errcode.ErrPubSubMessageFormat.String()).Msgf("Type assertion failed for PubSubMessage, %v\n", msg)
+				log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrPubSubMessageFormat)).Msgf("Type assertion failed for PubSubMessage, %v\n", msg)
 				continue
 			}
 

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -100,7 +100,8 @@ func (c *Client) run(stop <-chan struct{}) {
 	log.Debug().Msgf("Started OSM MeshConfig informer")
 	log.Debug().Msg("[MeshConfig Client] Waiting for MeshConfig informer's cache to sync")
 	if !cache.WaitForCacheSync(stop, c.informer.HasSynced) {
-		log.Error().Str(errcode.Kind, errcode.ErrMeshConfigInformerInitCache.String()).Msg("Failed initial cache sync for MeshConfig informer")
+		// TODO: Need to push metric
+		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigInformerInitCache)).Msg("Failed initial cache sync for MeshConfig informer")
 		return
 	}
 
@@ -133,7 +134,7 @@ func meshConfigUpdatedMessageHandler(psubMsg *events.PubSubMessage) {
 	prevMeshConfig, okPrevCast := psubMsg.OldObj.(*v1alpha1.MeshConfig)
 	newMeshConfig, okNewCast := psubMsg.NewObj.(*v1alpha1.MeshConfig)
 	if !okPrevCast || !okNewCast {
-		log.Error().Str(errcode.Kind, errcode.ErrMeshConfigStructCasting.String()).Msgf("[%s] Error casting old/new MeshConfigs objects (%v %v)",
+		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigStructCasting)).Msgf("[%s] Error casting old/new MeshConfigs objects (%v %v)",
 			psubMsg.AnnouncementType, okPrevCast, okNewCast)
 		return
 	}
@@ -191,7 +192,7 @@ func (c *Client) getMeshConfig() *v1alpha1.MeshConfig {
 	meshConfigCacheKey := c.getMeshConfigCacheKey()
 	item, exists, err := c.cache.GetByKey(meshConfigCacheKey)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMeshConfigFetchFromCache.String()).Msgf("Error getting MeshConfig from cache with key %s", meshConfigCacheKey)
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigFetchFromCache)).Msgf("Error getting MeshConfig from cache with key %s", meshConfigCacheKey)
 		return &v1alpha1.MeshConfig{}
 	}
 

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -52,7 +52,7 @@ func marshalConfigToJSON(config *configv1alpha1.MeshConfigSpec) (string, error) 
 func (c *Client) GetMeshConfigJSON() (string, error) {
 	cm, err := marshalConfigToJSON(&c.getMeshConfig().Spec)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMeshConfigMarshaling.String()).Msgf("Error marshaling MeshConfig %s: %+v", c.getMeshConfigCacheKey(), c.getMeshConfig())
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigMarshaling)).Msgf("Error marshaling MeshConfig %s: %+v", c.getMeshConfigCacheKey(), c.getMeshConfig())
 		return "", err
 	}
 	return cm, nil

--- a/pkg/envoy/ads/cache_stream.go
+++ b/pkg/envoy/ads/cache_stream.go
@@ -34,7 +34,7 @@ func (s *Server) allPodUpdater() {
 	for _, pod := range allpods {
 		proxy, err := GetProxyFromPod(pod)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingProxyFromPod.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingProxyFromPod)).
 				Msgf("Could not get proxy from pod %s/%s", pod.Namespace, pod.Name)
 			continue
 		}

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -24,7 +24,7 @@ func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery
 				log.Debug().Err(recvErr).Msgf("[grpc] Connection terminated")
 				return
 			}
-			log.Error().Err(recvErr).Str(errcode.Kind, errcode.ErrGRPCConnectionFailed.String()).
+			log.Error().Err(recvErr).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGRPCConnectionFailed)).
 				Msgf("[grpc] Connection error")
 			return
 		}

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -77,7 +77,7 @@ func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.Aggregat
 		// Generate the resources for this request
 		resources, err := s.getTypeResources(proxy, finalReq)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrGeneratingReqResource.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGeneratingReqResource)).
 				Msgf("Error generating response for typeURI: %s, proxy %s", typeURI.Short(), proxy.String())
 			thereWereErrors = true
 			continue
@@ -98,7 +98,7 @@ func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.Aggregat
 	if s.cacheEnabled {
 		// Store the aggregated resources as a full snapshot
 		if err := s.RecordFullSnapshot(proxy, cacheResourceMap); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrRecordingSnapshot.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrRecordingSnapshot)).
 				Msgf("Failed to record snapshot for proxy %s: %v", proxy.GetCertificateCommonName(), err)
 			thereWereErrors = true
 		}
@@ -129,7 +129,7 @@ func (s *Server) SendDiscoveryResponse(proxy *envoy.Proxy, request *xds_discover
 	for _, res := range resourcesToSend {
 		proto, err := ptypes.MarshalAny(res)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 				Msgf("Error marshalling resource %s for proxy %s", typeURI, proxy.GetCertificateSerialNumber())
 			continue
 		}
@@ -159,7 +159,7 @@ func (s *Server) SendDiscoveryResponse(proxy *envoy.Proxy, request *xds_discover
 
 	// Send the response
 	if err := (*server).Send(response); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrSendingDiscoveryResponse.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrSendingDiscoveryResponse)).
 			Msgf("Error sending response for type %s to proxy %s", typeURI.Short(), proxy.String())
 		return err
 	}

--- a/pkg/envoy/ads/secrets.go
+++ b/pkg/envoy/ads/secrets.go
@@ -25,7 +25,7 @@ func makeRequestForAllSecrets(proxy *envoy.Proxy, meshCatalog catalog.MeshCatalo
 	// TODO(draychev): The proxy Certificate should revolve around ServiceIdentity, not specific to ServiceAccount [https://github.com/openservicemesh/osm/issues/3186]
 	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServiceIdentity.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentity)).
 			Msgf("Error looking up proxy identity for proxy %s", proxy.String())
 		return nil
 	}

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -72,7 +72,7 @@ func (s *Server) withXdsLogMutex(f func()) {
 func (s *Server) Start(ctx context.Context, cancel context.CancelFunc, port int, adsCert certificate.Certificater) error {
 	grpcServer, lis, err := utils.NewGrpc(ServerType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetIssuingCA())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrStartingADSServer.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrStartingADSServer)).
 			Msg("Error starting ADS server")
 		return err
 	}

--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -31,7 +31,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 	}
 	pbHTTPProtocolOptions, err := ptypes.MarshalAny(httpProtocolOptions)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling HttpProtocolOptions struct into an anypb.Any message")
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 	accessLogger := &xds_accesslog_stream.StdoutAccessLog{}
 	pbAccessLog, err := ptypes.MarshalAny(accessLogger)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling StdoutAccessLog struct into an anypb.Any message")
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 	}
 	pbUpstreamTLSContext, err := ptypes.MarshalAny(upstreamTLSContext)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling UpstreamTlsContext struct into an anypb.Any message")
 		return nil, err
 	}

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -281,7 +281,7 @@ func getEgressClusters(clusterConfigs []*trafficpolicy.EgressClusterConfig) []*x
 			// Cluster config does not have a Host specified, route it to its original destination.
 			// Used for TCP based clusters
 			if originalDestinationEgressCluster, err := getOriginalDestinationEgressCluster(config.Name); err != nil {
-				log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingOrgDstEgressCluster.String()).
+				log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingOrgDstEgressCluster)).
 					Msg("Error building the original destination cluster for the given egress cluster config")
 			} else {
 				egressClusters = append(egressClusters, originalDestinationEgressCluster)
@@ -290,7 +290,7 @@ func getEgressClusters(clusterConfigs []*trafficpolicy.EgressClusterConfig) []*x
 			// Cluster config has a Host specified, route it based on the Host resolved using DNS.
 			// Used for HTTP based clusters
 			if cluster, err := getDNSResolvableEgressCluster(config); err != nil {
-				log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingDNSEgressCluster.String()).
+				log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingDNSEgressCluster)).
 					Msg("Error building cluster for the given egress cluster config")
 			} else {
 				egressClusters = append(egressClusters, cluster)

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -122,7 +122,7 @@ func getMulticlusterGatewayUpstreamServiceCluster(catalog catalog.MeshCataloger,
 
 	ports, err := catalog.GetTargetPortToProtocolMappingForService(upstreamSvc)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServicePorts.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServicePorts)).
 			Msgf("Failed to get ports for service %s", upstreamSvc)
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func getLocalServiceCluster(catalog catalog.MeshCataloger, proxyServiceName serv
 
 	ports, err := catalog.GetTargetPortToProtocolMappingForService(proxyServiceName)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServicePorts.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServicePorts)).
 			Msgf("Failed to get ports for service %s", proxyServiceName)
 		return nil, err
 	}

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -20,7 +20,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServiceIdentity.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentity)).
 			Msgf("Error looking up identity for proxy %s", proxy.String())
 		return nil, err
 	}
@@ -37,7 +37,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		for _, dstService := range meshCatalog.ListOutboundServicesForMulticlusterGateway() {
 			cluster, err := getMulticlusterGatewayUpstreamServiceCluster(meshCatalog, dstService, opts...)
 			if err != nil {
-				log.Error().Err(err).Str(errcode.Kind, errcode.ErrObtainingUpstreamServiceCluster.String()).
+				log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrObtainingUpstreamServiceCluster)).
 					Msgf("Failed to construct service cluster for service %s for proxy with XDS Certificate SerialNumber=%s on Pod with UID=%s",
 						dstService.Name, proxy.GetCertificateSerialNumber(), proxy.String())
 				return nil, err
@@ -51,7 +51,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	for _, dstService := range meshCatalog.ListOutboundServicesForIdentity(proxyIdentity) {
 		cluster, err := getUpstreamServiceCluster(proxyIdentity, dstService, opts...)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrObtainingUpstreamServiceCluster.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrObtainingUpstreamServiceCluster)).
 				Msgf("Failed to construct service cluster for service %s for proxy %s", dstService.Name, proxy.String())
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	svcList, err := proxyRegistry.ListProxyServices(proxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingServiceList.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingServiceList)).
 			Msgf("Error looking up MeshService for proxy %s", proxy.String())
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		localClusterName := envoy.GetLocalClusterNameForService(proxyService)
 		localCluster, err := getLocalServiceCluster(meshCatalog, proxyService, localClusterName)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingLocalServiceCluster.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingLocalServiceCluster)).
 				Msgf("Failed to get local cluster config for proxy %s", proxyService)
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func removeDups(clusters []*xds_cluster.Cluster) []types.Resource {
 	var cdsResources []types.Resource
 	for _, cluster := range clusters {
 		if alreadyAdded.Contains(cluster.Name) {
-			log.Error().Str(errcode.Kind, errcode.ErrDuplicateClusters.String()).
+			log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDuplicateClusters)).
 				Msgf("Found duplicate clusters with name %s; duplicate will not be sent to proxy.", cluster.Name)
 			continue
 		}

--- a/pkg/envoy/lds/auth.go
+++ b/pkg/envoy/lds/auth.go
@@ -47,7 +47,7 @@ func getExtAuthzHTTPFilter(extAuthConfig *auth.ExtAuthConfig) *xds_hcm.HttpFilte
 
 	extAuthMarshalled, err := ptypes.MarshalAny(extAuth)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msg("Failed to marshal External Authorization config")
 	}
 

--- a/pkg/envoy/lds/egress.go
+++ b/pkg/envoy/lds/egress.go
@@ -85,7 +85,7 @@ func (lb *listenerBuilder) getEgressTCPFilterChain(match trafficpolicy.TrafficMa
 
 	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy for TrafficMatch %v", match)
 		return nil, err
 	}

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -22,7 +22,7 @@ import (
 func (lb *listenerBuilder) getIngressFilterChains(svc service.MeshService) []*xds_listener.FilterChain {
 	ingressPolicy, err := lb.meshCatalog.GetIngressTrafficPolicy(svc)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrIngressFilterChain.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrIngressFilterChain)).
 			Msgf("Error getting ingress filter chain for proxy with identity %s and service %s", lb.serviceIdentity, svc)
 		return nil
 	}
@@ -136,7 +136,7 @@ func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *t
 
 	default:
 		err := errors.Errorf("Unsupported ingress protocol %s on proxy with identity %s. Ingress protocol must be one of 'http, https'", trafficMatch.Protocol, lb.serviceIdentity)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrUnsupportedProtocolForService.String()).Msg("Error building filter chain for ingress")
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUnsupportedProtocolForService)).Msg("Error building filter chain for ingress")
 		return nil, err
 	}
 

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -128,7 +128,7 @@ func (lb *listenerBuilder) getInboundMeshHTTPFilterChain(proxyService service.Me
 	// Construct downstream TLS context
 	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (lb *listenerBuilder) getInboundMeshTCPFilterChain(proxyService service.Mes
 	// Construct downstream TLS context
 	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (lb *listenerBuilder) getInboundTCPFilters(proxyService service.MeshService
 	}
 	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy object for egress HTTPS filter chain")
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (lb *listenerBuilder) getOutboundTCPFilter(upstream service.MeshService) (*
 
 	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy object needed by outbound TCP filter for upstream service %s", upstream)
 		return nil, err
 	}

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -36,7 +36,7 @@ func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshS
 
 	protocolToPortMap, err := lb.meshCatalog.GetTargetPortToProtocolMappingForService(proxyService)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServicePorts.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServicePorts)).
 			Msgf("Error retrieving port to protocol mapping for service %s", proxyService)
 		return filterChains
 	}
@@ -299,14 +299,14 @@ func (lb *listenerBuilder) getOutboundFilterChainMatchForService(dstSvc service.
 
 	endpoints, err := lb.meshCatalog.GetResolvableServiceEndpoints(dstSvc)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingResolvableServiceEndpoints.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingResolvableServiceEndpoints)).
 			Msgf("Error getting GetResolvableServiceEndpoints for %q", dstSvc)
 		return nil, err
 	}
 
 	if len(endpoints) == 0 {
 		err := errors.Errorf("Endpoints not found for service %q", dstSvc)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrEndpointsNotFound.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEndpointsNotFound)).
 			Msgf("Error constructing HTTP filter chain match for service %q", dstSvc)
 		return nil, err
 	}
@@ -436,7 +436,7 @@ func (lb *listenerBuilder) getOutboundFilterChainPerUpstream() []*xds_listener.F
 		log.Trace().Msgf("Building outbound filter chain for upstream service %s for proxy with identity %s", upstreamSvc, lb.serviceIdentity)
 		protocolToPortMap, err := lb.meshCatalog.GetPortToProtocolMappingForService(upstreamSvc)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServicePorts.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServicePorts)).
 				Msgf("Error retrieving port to protocol mapping for upstream service %s", upstreamSvc)
 			continue
 		}

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -126,7 +126,7 @@ func newInboundListener() *xds_listener.Listener {
 func buildPrometheusListener(connManager *xds_hcm.HttpConnectionManager) (*xds_listener.Listener, error) {
 	marshalledConnManager, err := ptypes.MarshalAny(connManager)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling HttpConnectionManager object")
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func getDefaultPassthroughFilterChain() (*xds_listener.FilterChain, error) {
 	}
 	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy object for egress HTTPS filter chain")
 		return nil, err
 	}

--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -26,7 +26,7 @@ func (lb *listenerBuilder) buildRBACFilter() (*xds_listener.Filter, error) {
 
 	marshalledNetworkRBACPolicy, err := ptypes.MarshalAny(networkRBACPolicy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling RBAC policy: %v", networkRBACPolicy)
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func (lb *listenerBuilder) buildInboundRBACPolicies() (*xds_network_rbac.RBAC, e
 	// Build an RBAC policies based on SMI TrafficTarget policies
 	for _, targetPolicy := range trafficTargets {
 		if policy, err := buildRBACPolicyFromTrafficTarget(targetPolicy); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrBuildingRBACPolicy.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrBuildingRBACPolicy)).
 				Msgf("Error building RBAC policy for proxy identity %s from TrafficTarget %s", proxyIdentity, targetPolicy.Name)
 		} else {
 			rbacPolicies[targetPolicy.Name] = policy

--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -44,7 +44,7 @@ func (lb *listenerBuilder) buildInboundRBACPolicies() (*xds_network_rbac.RBAC, e
 	proxyIdentity := identity.ServiceIdentity(lb.serviceIdentity.String())
 	trafficTargets, err := lb.meshCatalog.ListInboundTrafficTargetsWithRoutes(lb.serviceIdentity)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingInboundTrafficTargets.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingInboundTrafficTargets)).
 			Msgf("Error listing allowed inbound traffic targets for proxy identity %s", proxyIdentity)
 		return nil, err
 	}

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -21,7 +21,7 @@ import (
 func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_discovery.DiscoveryRequest, cfg configurator.Configurator, _ certificate.Manager, proxyRegistry *registry.ProxyRegistry) ([]types.Resource, error) {
 	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServiceIdentity.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentity)).
 			Msgf("Error retrieving ServiceAccount for proxy %s", proxy.String())
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	svcList, err := proxyRegistry.ListProxyServices(proxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingServiceList.String()).Msgf("Error looking up MeshService for proxy %s", proxy.String())
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingServiceList)).Msgf("Error looking up MeshService for proxy %s", proxy.String())
 		return nil, err
 	}
 	// Create inbound filter chains per service behind proxy

--- a/pkg/envoy/lds/tracing.go
+++ b/pkg/envoy/lds/tracing.go
@@ -19,7 +19,7 @@ func getHTTPTracingConfig(apiEndpoint string) (*xds_hcm.HttpConnectionManager_Tr
 
 	zipkinConfMarshalled, err := ptypes.MarshalAny(zipkinTracingConf)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling Zipkin config")
 		return nil, err
 	}

--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -24,14 +24,14 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, discoveryR
 
 	proxyIdentity, err := envoy.GetServiceIdentityFromProxyCertificate(proxy.GetCertificateCommonName())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingServiceIdentity.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentity)).
 			Msgf("Error looking up Service Account for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
 		return nil, err
 	}
 
 	services, err := proxyRegistry.ListProxyServices(proxy)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrFetchingServiceList.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingServiceList)).
 			Msgf("Error looking up services for Envoy with serial number=%q", proxy.GetCertificateSerialNumber())
 		return nil, err
 	}

--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -172,7 +172,7 @@ func buildInboundRoutes(rules []*trafficpolicy.Rule) []*xds_route.Route {
 		// Each route is associated with an RBAC policy
 		rbacPolicyForRoute, err := buildInboundRBACFilterForRule(rule)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrBuildingRBACPolicyForRoute.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrBuildingRBACPolicyForRoute)).
 				Msgf("Error building RBAC policy for rule [%v], skipping route addition", rule)
 			continue
 		}

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -88,7 +88,7 @@ func GetTLSParams() *xds_auth.TlsParameters {
 func GetAccessLog() []*xds_accesslog_filter.AccessLog {
 	accessLog, err := ptypes.MarshalAny(getStdoutAccessLog())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling AccessLog object")
 		return nil
 	}
@@ -329,7 +329,7 @@ func getCertificateCommonNameMeta(cn certificate.CommonName) (*certificateCommon
 	}
 	proxyUUID, err := uuid.Parse(chunks[0])
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrParsingXDSCertCN.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrParsingXDSCertCN)).
 			Msgf("Error parsing %s into uuid.UUID", chunks[0])
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func GetPodFromCertificate(cn certificate.CommonName, kubecontroller k8s.Control
 	}
 
 	if len(pods) == 0 {
-		log.Error().Str(errcode.Kind, errcode.ErrFetchingPodFromCert.String()).
+		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrFetchingPodFromCert)).
 			Msgf("Did not find Pod with label %s = %s in namespace %s",
 				constants.EnvoyUniqueIDLabelName, cnMeta.ProxyUUID, cnMeta.ServiceIdentity.ToK8sServiceAccount().Namespace)
 		return nil, ErrDidNotFindPodForCertificate
@@ -372,7 +372,7 @@ func GetPodFromCertificate(cn certificate.CommonName, kubecontroller k8s.Control
 	// This is a limitation we set in place in order to make the mesh easy to understand and reason about.
 	// When a pod belongs to more than one service XDS will not program the Envoy proxy, leaving it out of the mesh.
 	if len(pods) > 1 {
-		log.Error().Str(errcode.Kind, errcode.ErrPodBelongsToMultipleServices.String()).
+		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrPodBelongsToMultipleServices)).
 			Msgf("Found more than one pod with label %s = %s in namespace %s. There can be only one!",
 				constants.EnvoyUniqueIDLabelName, cnMeta.ProxyUUID, cnMeta.ServiceIdentity.ToK8sServiceAccount().Namespace)
 		return nil, ErrMoreThanOnePodForCertificate

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -334,12 +334,12 @@ const (
 	// ErrNilAdmissionReq indicates the received admission request was nil
 	ErrNilAdmissionReq
 
-	// ErrDetermingPodInjectionEnablement indicates the enablement of a pod for sidecar injection could not be determined
-	ErrDetermingPodInjectionEnablement
+	// ErrDeterminingPodInjectionEnablement indicates the enablement of a pod for sidecar injection could not be determined
+	ErrDeterminingPodInjectionEnablement
 
-	// ErrDetermingNamespaceInjectionEnablement indicates the enablement of a namespace for sidecar injection could not
+	// ErrDeterminingNamespaceInjectionEnablement indicates the enablement of a namespace for sidecar injection could not
 	// be determined
-	ErrDetermingNamespaceInjectionEnablement
+	ErrDeterminingNamespaceInjectionEnablement
 
 	// ErrDeterminingPodPortExclusions indicates the oubound port exclusions for a pod could not be obtained
 	ErrDeterminingPodPortExclusions
@@ -864,12 +864,12 @@ The AdmissionResponse could not be written.
 The AdmissionRequest was empty.
 `,
 
-	ErrDetermingPodInjectionEnablement: `
+	ErrDeterminingPodInjectionEnablement: `
 It could not be determined if the pod specified in the AdmissionRequest is
 enabled for sidecar injection.
 `,
 
-	ErrDetermingNamespaceInjectionEnablement: `
+	ErrDeterminingNamespaceInjectionEnablement: `
 It could not be determined if the namespace specified in the
 AdmissionRequest is enabled for sidecar injection.
 `,

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -32,7 +32,8 @@ var candidateVersions = []string{networkingV1.SchemeGroupVersion.String(), netwo
 func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{}, cfg configurator.Configurator, certProvider certificate.Manager) (Monitor, error) {
 	supportedIngressVersions, err := getSupportedIngressVersions(kubeClient.Discovery())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingSupportedIngressVersions.String()).
+		// TODO: Need to push metric
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingSupportedIngressVersions)).
 			Msgf("Error retrieving ingress API versions supported by k8s API server")
 		return nil, err
 	}

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -32,7 +32,7 @@ var candidateVersions = []string{networkingV1.SchemeGroupVersion.String(), netwo
 func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{}, cfg configurator.Configurator, certProvider certificate.Manager) (Monitor, error) {
 	supportedIngressVersions, err := getSupportedIngressVersions(kubeClient.Discovery())
 	if err != nil {
-		// TODO: Need to push metric
+		// TODO: Need to push metric?
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingSupportedIngressVersions)).
 			Msgf("Error retrieving ingress API versions supported by k8s API server")
 		return nil, err

--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -53,7 +53,7 @@ func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Config
 
 	configYAML, err := utils.ProtoToYAML(bootstrapConfig)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingProtoToYAML.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingProtoToYAML)).
 			Msgf("Failed to marshal envoy bootstrap config to yaml")
 		return nil, err
 	}

--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -160,7 +160,7 @@ func getXdsCluster(config envoyBootstrapConfigMeta) (*xds_cluster.Cluster, error
 	}
 	pbHTTPProtocolOptions, err := ptypes.MarshalAny(httpProtocolOptions)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling HttpProtocolOptions struct into an anypb.Any message")
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func getXdsCluster(config envoyBootstrapConfigMeta) (*xds_cluster.Cluster, error
 	}
 	pbUpstreamTLSContext, err := ptypes.MarshalAny(upstreamTLSContext)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling UpstreamTlsContext struct into an anypb.Any message")
 		return nil, err
 	}

--- a/pkg/injector/envoy_config_health_probes.go
+++ b/pkg/injector/envoy_config_health_probes.go
@@ -140,7 +140,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 		}
 		pbHTTPConnectionManager, err := ptypes.MarshalAny(httpConnectionManager)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 				Msgf("Error marshaling HttpConnectionManager struct into an anypb.Any message")
 			return nil, err
 		}
@@ -170,7 +170,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 		}
 		pbTCPProxy, err := ptypes.MarshalAny(tcpProxy)
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 				Msgf("Error marshaling TcpProxy struct into an anypb.Any message")
 			return nil, err
 		}
@@ -234,7 +234,7 @@ func getVirtualHost(newPath, clusterName, originalProbePath string) *xds_route.V
 func getHTTPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
 	accessLog, err := ptypes.MarshalAny(getStdoutAccessLog())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msg("Error marshalling AccessLog object")
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func getHTTPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
 func getTCPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
 	accessLog, err := ptypes.MarshalAny(getTCPStdoutAccessLog())
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingXDSResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msg("Error marshalling tcp AccessLog object")
 		return nil, err
 	}

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -109,7 +109,7 @@ func makePatches(req *admissionv1.AdmissionRequest, pod *corev1.Pod) []jsonpatch
 	original := req.Object.Raw
 	current, err := json.Marshal(pod)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingKubernetesResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingKubernetesResource)).
 			Msgf("Error marshaling Pod with UID=%s", pod.ObjectMeta.UID)
 	}
 	admissionResponse := admission.PatchResponseFromRaw(original, current)

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -122,7 +122,8 @@ func (wh *mutatingWebhook) run(stop <-chan struct{}) {
 		// Generate a key pair from your pem-encoded cert and key ([]byte).
 		cert, err := tls.X509KeyPair(wh.cert.GetCertificateChain(), wh.cert.GetPrivateKey())
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrParsingMutatingWebhookCert.String()).
+			// TODO: Need to push metric?
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrParsingMutatingWebhookCert)).
 				Msg("Error parsing webhook certificate")
 			return
 		}
@@ -133,7 +134,8 @@ func (wh *mutatingWebhook) run(stop <-chan struct{}) {
 		}
 
 		if err := server.ListenAndServeTLS("", ""); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrStartingInjectionWebhookHTTPServer.String()).
+			// TODO: Need to push metric?
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrStartingInjectionWebhookHTTPServer)).
 				Msg("Sidecar injection webhook HTTP server failed to start")
 			return
 		}
@@ -160,7 +162,7 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 func (wh *mutatingWebhook) getAdmissionReqResp(proxyUUID uuid.UUID, admissionRequestBody []byte) (requestForNamespace string, admissionResp admissionv1.AdmissionReview) {
 	var admissionReq admissionv1.AdmissionReview
 	if _, _, err := webhook.Deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDecodingAdmissionReqBody.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingAdmissionReqBody)).
 			Msg("Error decoding admission request body")
 		admissionResp.Response = webhook.AdmissionError(err)
 	} else {
@@ -181,7 +183,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	// Read timeout from request url
 	reqTimeout, err := readTimeout(req)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrParsingReqTimeout.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrParsingReqTimeout)).
 			Msg("Could not read timeout from request url")
 	}
 	// Execute at return of this handler
@@ -190,7 +192,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	if contentType := req.Header.Get(webhook.HTTPHeaderContentType); contentType != webhook.ContentTypeJSON {
 		err := errors.Errorf("Invalid content type %s; Expected %s", contentType, webhook.ContentTypeJSON)
 		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrInvalidAdmissionReqHeader.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidAdmissionReqHeader)).
 			Msgf("Responded to admission request with HTTP %v", http.StatusUnsupportedMediaType)
 		return
 	}
@@ -217,7 +219,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	}
 
 	if _, err := w.Write(resp); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrWritingAdmissionResp.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrWritingAdmissionResp)).
 			Msgf("Error writing admission response for pod with UUID %s in namespace %s", proxyUUID, requestForNamespace)
 	} else {
 		success = true // read by the deferred function
@@ -228,7 +230,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 
 func (wh *mutatingWebhook) mutate(req *admissionv1.AdmissionRequest, proxyUUID uuid.UUID) *admissionv1.AdmissionResponse {
 	if req == nil {
-		log.Error().Str(errcode.Kind, errcode.ErrNilAdmissionReq.String()).Msg("nil admission Request")
+		log.Error().Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrNilAdmissionReq)).Msg("nil admission Request")
 		return webhook.AdmissionError(errNilAdmissionRequest)
 	}
 
@@ -290,7 +292,7 @@ func (wh *mutatingWebhook) mustInject(pod *corev1.Pod, namespace string) (bool, 
 	// Check if the pod is annotated for injection
 	podInjectAnnotationExists, podInject, err := isAnnotatedForInjection(pod.Annotations, "Pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDetermingPodInjectionEnablement.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDeterminingPodInjectionEnablement)).
 			Msg("Error determining if the pod is enabled for sidecar injection")
 		return false, err
 	}
@@ -303,7 +305,7 @@ func (wh *mutatingWebhook) mustInject(pod *corev1.Pod, namespace string) (bool, 
 	}
 	nsInjectAnnotationExists, nsInject, err := isAnnotatedForInjection(ns.Annotations, "Namespace", ns.Name)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDetermingNamespaceInjectionEnablement.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDeterminingNamespaceInjectionEnablement)).
 			Msgf("Error determining if namespace %s is enabled for sidecar injection", namespace)
 		return false, err
 	}
@@ -337,7 +339,7 @@ func (wh *mutatingWebhook) getPortExclusionListForPod(pod *corev1.Pod, namespace
 	// Check if the pod is annotated for outbound port exclusion
 	ports, err := isAnnotatedForPortExclusion(pod.Annotations, annotation, pod.Kind, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDeterminingPodPortExclusions.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDeterminingPodPortExclusions)).
 			Msgf("Error determining port exclusions for annotation %s on pod %s/%s", annotation, namespace, pod.Name)
 		return ports, err
 	}
@@ -424,7 +426,8 @@ func updateMutatingWebhookCABundle(cert certificate.Certificater, webhookName st
 	}
 
 	if _, err = mwc.Patch(context.Background(), webhookName, types.StrategicMergePatchType, patchJSON, metav1.PatchOptions{}); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrUpdatingMutatingWebhookCABundle.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingMutatingWebhookCABundle)).
 			Msgf("Error updating CA Bundle for MutatingWebhookConfiguration %s", webhookName)
 		return err
 	}

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -211,7 +211,7 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	resp, err := json.Marshal(&admissionResp)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error marshalling admission response: %s", err), http.StatusInternalServerError)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingKubernetesResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingKubernetesResource)).
 			Msgf("Error marshalling admission response; Responded to admission request for pod with UUID %s in namespace %s with HTTP %v", proxyUUID, requestForNamespace, http.StatusInternalServerError)
 		return
 	}
@@ -235,7 +235,7 @@ func (wh *mutatingWebhook) mutate(req *admissionv1.AdmissionRequest, proxyUUID u
 	// Decode the Pod spec from the request
 	var pod corev1.Pod
 	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrUnmarshallingKubernetesResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUnmarshallingKubernetesResource)).
 			Msgf("Error unmarshaling request to pod with UUID %s in namespace %s", proxyUUID, req.Namespace)
 		return webhook.AdmissionError(err)
 	}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -64,7 +64,8 @@ func (r *MutatingWebhookConfigurationReconciler) Reconcile(ctx context.Context, 
 		}
 
 		if err := r.Update(ctx, instance); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrUpdatingMutatingWebhookCABundle.String()).
+			// TODO: Need to push metric?
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingMutatingWebhookCABundle)).
 				Msgf("Error updating MutatingWebhookConfiguration %s", req.Name)
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -52,7 +52,8 @@ func updateValidatingWebhookCABundle(webhookConfigName string, certificater cert
 	}
 
 	if _, err = vwc.Patch(context.Background(), webhookConfigName, types.StrategicMergePatchType, patchJSON, metav1.PatchOptions{}); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrUpdatingValidatingWebhookCABundle.String()).
+		// TODO: Need to push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingValidatingWebhookCABundle)).
 			Msgf("Error updating CA Bundle for ValidatingWebhookConfiguration %s", webhookConfigName)
 		return err
 	}

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -122,7 +122,7 @@ func (s *ValidatingWebhookServer) doValidation(w http.ResponseWriter, req *http.
 	resp, err := json.Marshal(&admissionResp)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Error marshalling admission response: %s", err), http.StatusInternalServerError)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrMarshallingKubernetesResource.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingKubernetesResource)).
 			Msgf("Error marshalling admission response; Responded to admission request in namespace %s with HTTP %v", requestForNamespace, http.StatusInternalServerError)
 		return
 	}

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -106,7 +106,7 @@ func (s *ValidatingWebhookServer) doValidation(w http.ResponseWriter, req *http.
 	if contentType := req.Header.Get(webhook.HTTPHeaderContentType); contentType != webhook.ContentTypeJSON {
 		err := errors.Errorf("Invalid content type %s; Expected %s", contentType, webhook.ContentTypeJSON)
 		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrInvalidAdmissionReqHeader.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidAdmissionReqHeader)).
 			Msgf("Responded to admission request with HTTP %v", http.StatusUnsupportedMediaType)
 		return
 	}
@@ -128,7 +128,7 @@ func (s *ValidatingWebhookServer) doValidation(w http.ResponseWriter, req *http.
 	}
 
 	if _, err := w.Write(resp); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrWritingAdmissionResp.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrWritingAdmissionResp)).
 			Msgf("Error writing admission response for request in namespace %s", requestForNamespace)
 	}
 
@@ -138,7 +138,7 @@ func (s *ValidatingWebhookServer) doValidation(w http.ResponseWriter, req *http.
 func (s *ValidatingWebhookServer) getAdmissionReqResp(admissionRequestBody []byte) (requestForNamespace string, admissionResp admissionv1.AdmissionReview) {
 	var admissionReq admissionv1.AdmissionReview
 	if _, _, err := webhook.Deserializer.Decode(admissionRequestBody, nil, &admissionReq); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrDecodingAdmissionReqBody.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingAdmissionReqBody)).
 			Msg("Error decoding admission request body")
 		admissionResp.Response = webhook.AdmissionError(err)
 	} else {
@@ -198,7 +198,8 @@ func (s *ValidatingWebhookServer) run(port int, certificater certificate.Certifi
 		// Generate a key pair from your pem-encoded cert and key
 		cert, err := tls.X509KeyPair(certificater.GetCertificateChain(), certificater.GetPrivateKey())
 		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrParsingValidatingWebhookCert.String()).
+			// TODO: Need to push metric
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrParsingValidatingWebhookCert)).
 				Msg("Error parsing webhook certificate")
 			return
 		}
@@ -209,7 +210,8 @@ func (s *ValidatingWebhookServer) run(port int, certificater certificate.Certifi
 		}
 
 		if err := server.ListenAndServeTLS("", ""); err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.ErrStartingValidatingWebhookHTTPServer.String()).
+			// TODO: Need to push metric?
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrStartingValidatingWebhookHTTPServer)).
 				Msg("Resource validator webhook HTTP server failed to start")
 			return
 		}
@@ -220,7 +222,8 @@ func (s *ValidatingWebhookServer) run(port int, certificater certificate.Certifi
 
 	// Stop the server
 	if err := server.Shutdown(ctx); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrShuttingDownValidatingWebhookHTTPServer.String()).
+		// TODO: Needto push metric?
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrShuttingDownValidatingWebhookHTTPServer)).
 			Msg("Error shutting down resource validator webhook HTTP server")
 	} else {
 		log.Info().Msg("Done shutting down resource validator webhook HTTP server")

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -34,7 +34,7 @@ var (
 func GetAdmissionRequestBody(w http.ResponseWriter, req *http.Request) ([]byte, error) {
 	emptyBodyError := func() ([]byte, error) {
 		http.Error(w, errEmptyAdmissionRequestBody.Error(), http.StatusBadRequest)
-		log.Error().Err(errEmptyAdmissionRequestBody).Str(errcode.Kind, errcode.ErrNilAdmissionReqBody.String()).
+		log.Error().Err(errEmptyAdmissionRequestBody).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrNilAdmissionReqBody)).
 			Msgf("Responded to admission request with HTTP %v", http.StatusBadRequest)
 
 		return nil, errEmptyAdmissionRequestBody
@@ -47,7 +47,7 @@ func GetAdmissionRequestBody(w http.ResponseWriter, req *http.Request) ([]byte, 
 	admissionRequestBody, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		log.Error().Err(err).Str(errcode.Kind, errcode.ErrReadingAdmissionReqBody.String()).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrReadingAdmissionReqBody)).
 			Msgf("Error reading admission request body; Responded to admission request with HTTP %v", http.StatusInternalServerError)
 		return admissionRequestBody, err
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Increments the ErrCodeCounter metric for logged 
error codes that are defined by OSM. When an error is logged, the
corresponding error code is added to the log's context and the
ErrCodeCounter is incremented with the error code as a label value.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:

In this PR I added the ErrCodeCounter metric to the list of registered metrics for the osm-injector. To validate that the ErrCodeCounter metric was being exposed at the metrics endpoint, I added an error log line to a method I knew would be executed 5 times. After running the automated demo, I port forwarded the metrics endpoint on the osm-injector pod to verify the ErrcodeCounter metric was present and showed the expected count.
![injectorMetricsEndpoint](https://user-images.githubusercontent.com/64559656/128414690-a5cb3a77-5f85-4338-ade8-dd7c67e2cd96.PNG)

Then I port forwarded Prometheus to verify the new metric was being scraped and no updates to the Prometheus config map were required.
![injectorErrorCodeMetric](https://user-images.githubusercontent.com/64559656/128413618-1c088a7f-896d-4167-b295-8202829225fa.PNG)

I cannot force all of the errors to occur that have been modified in this PR. However, I validated that with the same logging configuration (use of the GetErrCodeWithMetrics method to increment the error code metric and return the error code as a string) the ErrCodeCounter metric was properly exposed and scraped and had the expected count value.

Additionally, I verified that metrics incremented prior to being registered with the Prometheus client are still captured. 

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
