### PR TITLE
rds/ingress: remove WASM mesh headers

### DIFF
--- a/pkg/envoy/rds/response.go
+++ b/pkg/envoy/rds/response.go
@@ -62,7 +62,7 @@ func NewResponse(cataloger catalog.MeshCataloger, proxy *envoy.Proxy, discoveryR
 		ingressTrafficPolicies = trafficpolicy.MergeInboundPolicies(catalog.AllowPartialHostnamesMatch, ingressTrafficPolicies, ingressPolicy.HTTPRoutePolicies...)
 	}
 	if len(ingressTrafficPolicies) > 0 {
-		ingressRouteConfig := route.BuildIngressConfiguration(ingressTrafficPolicies, proxy, cfg)
+		ingressRouteConfig := route.BuildIngressConfiguration(ingressTrafficPolicies)
 		rdsResources = append(rdsResources, ingressRouteConfig)
 	}
 

--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -103,7 +103,7 @@ func BuildRouteConfiguration(inbound []*trafficpolicy.InboundTrafficPolicy, outb
 }
 
 // BuildIngressConfiguration constructs the Envoy constructs ([]*xds_route.RouteConfiguration) for implementing ingress routes
-func BuildIngressConfiguration(ingress []*trafficpolicy.InboundTrafficPolicy, proxy *envoy.Proxy, cfg configurator.Configurator) *xds_route.RouteConfiguration {
+func BuildIngressConfiguration(ingress []*trafficpolicy.InboundTrafficPolicy) *xds_route.RouteConfiguration {
 	if len(ingress) == 0 {
 		return nil
 	}
@@ -113,17 +113,6 @@ func BuildIngressConfiguration(ingress []*trafficpolicy.InboundTrafficPolicy, pr
 		virtualHost := buildVirtualHostStub(ingressVirtualHost, in.Name, in.Hostnames)
 		virtualHost.Routes = buildInboundRoutes(in.Rules)
 		ingressRouteConfig.VirtualHosts = append(ingressRouteConfig.VirtualHosts, virtualHost)
-	}
-
-	if featureFlags := cfg.GetFeatureFlags(); featureFlags.EnableWASMStats {
-		for k, v := range proxy.StatsHeaders() {
-			ingressRouteConfig.ResponseHeadersToAdd = append(ingressRouteConfig.ResponseHeadersToAdd, &core.HeaderValueOption{
-				Header: &core.HeaderValue{
-					Key:   k,
-					Value: v,
-				},
-			})
-		}
 	}
 
 	return ingressRouteConfig

--- a/pkg/envoy/rds/route/route_config_test.go
+++ b/pkg/envoy/rds/route/route_config_test.go
@@ -134,9 +134,6 @@ func TestBuildRouteConfiguration(t *testing.T) {
 }
 
 func TestBuildIngressRouteConfiguration(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	mockCfg := configurator.NewMockConfigurator(mockCtrl)
-
 	testCases := []struct {
 		name                      string
 		ingressPolicies           []*trafficpolicy.InboundTrafficPolicy
@@ -214,11 +211,7 @@ func TestBuildIngressRouteConfiguration(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
-
-			mockCfg.EXPECT().GetFeatureFlags().Return(v1alpha1.FeatureFlags{
-				EnableWASMStats: false,
-			}).AnyTimes()
-			actual := BuildIngressConfiguration(tc.ingressPolicies, nil, mockCfg)
+			actual := BuildIngressConfiguration(tc.ingressPolicies)
 
 			if tc.expectedRouteConfigFields == nil {
 				assert.Nil(actual)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This is a follow-up to b333f451 where the internal
mesh headers added to the HTTP response for ingress
are removed, so mesh information such as pod names
are not leaked externally.

For example, the following info should not be leaked 
externally with ingress HTTP response.
```
osm-stats-pod: httpbin-7c6464475-bn6x2
osm-stats-namespace: httpbin
osm-stats-kind: Deployment
osm-stats-name: httpbin
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |

<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:
Tested ingress.

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
