### PR TITLE
Add demo book app watcher for terminal and raw JSON from web API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,10 @@ $(DEMO_BUILD_TARGETS):
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./demo/bin/$(NAME)/$(NAME) ./demo/cmd/$(NAME)
 	@if [ -f demo/$(NAME).html.template ]; then cp demo/$(NAME).html.template demo/bin/$(NAME); fi
 
+.PHONE: build-bookwatcher
+build-bookwatcher:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ./demo/bin/bookwatcher/bookwatcher ./demo/cmd/bookwatcher
+
 .PHONY: demo-build
 demo-build: $(DEMO_BUILD_TARGETS) build-init-osm-controller build-osm-controller build-osm-injector build-osm-crds build-osm-crd-converter
 

--- a/demo/cmd/bookwatcher/bookwatcher.go
+++ b/demo/cmd/bookwatcher/bookwatcher.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/openservicemesh/osm/demo/cmd/common"
+)
+
+func clearScreen() {
+	fmt.Print("\033[H\033[2J")
+}
+
+func printGreenln(msg string) {
+	fmt.Printf("\033[32m%s\033[0m\n", msg)
+}
+
+func printYellowln(msg string) {
+	fmt.Printf("\033[33m%s\033[0m\n", msg)
+}
+
+func printRedln(msg string) {
+	fmt.Printf("\033[31m%s\033[0m\n", msg)
+}
+
+func getBookBuyer(bookBuyerPurchases *common.BookBuyerPurchases, wg *sync.WaitGroup, errc chan<- error) {
+	defer wg.Done()
+
+	resp, err := http.Get("http://localhost:8080/raw")
+	if err != nil {
+		errc <- fmt.Errorf("error fetching bookbuyer data: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	output, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		errc <- fmt.Errorf("error reading bookbuyer data: %v", err)
+		return
+	}
+
+	err = json.Unmarshal(output, bookBuyerPurchases)
+	if err != nil {
+		errc <- fmt.Errorf("error unmarshalling bookbuyer data: %v", err)
+	}
+}
+
+func getBookThief(bookThiefThievery *common.BookThiefThievery, wg *sync.WaitGroup, errc chan<- error) {
+	defer wg.Done()
+
+	resp, err := http.Get("http://localhost:8083/raw")
+	if err != nil {
+		errc <- fmt.Errorf("error fetching bookthief data: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	output, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		errc <- fmt.Errorf("error reading bookthief data: %v", err)
+		return
+	}
+
+	err = json.Unmarshal(output, bookThiefThievery)
+	if err != nil {
+		errc <- fmt.Errorf("error unmarshalling bookthief data: %v", err)
+	}
+}
+
+func getBookStorePurchases(bookStorePurchases *common.BookStorePurchases, port int, wg *sync.WaitGroup, errc chan<- error) {
+	defer wg.Done()
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/raw", port))
+	if err != nil {
+		errc <- fmt.Errorf("error fetching bookstore data (port %d): %v", port, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	output, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		errc <- fmt.Errorf("error reading bookstore data (port %d): %v", port, err)
+		return
+	}
+
+	err = json.Unmarshal(output, bookStorePurchases)
+	if err != nil {
+		errc <- fmt.Errorf("error unmarshalling bookstore data (port %d): %v", port, err)
+	}
+}
+
+func main() {
+	bookBuyerPurchases := &common.BookBuyerPurchases{}
+	bookThiefThievery := &common.BookThiefThievery{}
+	bookStorePurchasesV1 := &common.BookStorePurchases{}
+	bookStorePurchasesV2 := &common.BookStorePurchases{}
+	wg := &sync.WaitGroup{}
+	errc := make(chan error, 4)
+
+	for {
+		clearScreen()
+
+		bookBuyerPurchasesTemp := *bookBuyerPurchases
+		wg.Add(1)
+		go getBookBuyer(bookBuyerPurchases, wg, errc)
+
+		bookThiefThieveryTemp := *bookThiefThievery
+		wg.Add(1)
+		go getBookThief(bookThiefThievery, wg, errc)
+
+		bookStorePurchasesV1Temp := *bookStorePurchasesV1
+		wg.Add(1)
+		go getBookStorePurchases(bookStorePurchasesV1, 8081, wg, errc)
+
+		bookStorePurchasesV2Temp := *bookStorePurchasesV2
+		wg.Add(1)
+		go getBookStorePurchases(bookStorePurchasesV2, 8082, wg, errc)
+
+		complete := make(chan bool)
+		go func() {
+			wg.Wait()
+			close(complete)
+		}()
+
+		select {
+		case err := <-errc:
+			wg.Wait()
+			close(errc)
+			log.Fatal(err)
+		case <-complete:
+			break
+		}
+
+		bookBuyerHasChanged := bookBuyerPurchases.BooksBought-bookBuyerPurchasesTemp.BooksBought != 0 ||
+			bookBuyerPurchases.BooksBoughtV1-bookBuyerPurchasesTemp.BooksBoughtV1 != 0 ||
+			bookBuyerPurchases.BooksBoughtV2-bookBuyerPurchasesTemp.BooksBoughtV2 != 0
+
+		bookThiefHasChanged := bookThiefThievery.BooksStolen-bookThiefThieveryTemp.BooksStolen != 0 ||
+			bookThiefThievery.BooksStolenV1-bookThiefThieveryTemp.BooksStolenV1 != 0 ||
+			bookThiefThievery.BooksStolenV2-bookThiefThieveryTemp.BooksStolenV2 != 0
+
+		bookStoreV1HasChanged := bookStorePurchasesV1.BooksSold-bookStorePurchasesV1Temp.BooksSold != 0
+		bookStoreV2HasChanged := bookStorePurchasesV2.BooksSold-bookStorePurchasesV2Temp.BooksSold != 0
+
+		printFunc := printYellowln
+		if bookBuyerHasChanged {
+			printFunc = printGreenln
+		}
+		printFunc(fmt.Sprintf(
+			"bookbuyer     Books bought: %d  V1 books bought: %d  V2 books bought: %d",
+			bookBuyerPurchases.BooksBought,
+			bookBuyerPurchases.BooksBoughtV1,
+			bookBuyerPurchases.BooksBoughtV2,
+		))
+
+		printFunc = printYellowln
+		if bookThiefHasChanged {
+			printFunc = printRedln
+		}
+		printFunc(fmt.Sprintf(
+			"bookthief     Books stolen: %d  V1 books stolen: %d  V2 books stolen: %d",
+			bookThiefThievery.BooksStolen,
+			bookThiefThievery.BooksStolenV1,
+			bookThiefThievery.BooksStolenV2,
+		))
+
+		printFunc = printYellowln
+		if bookStoreV1HasChanged {
+			printFunc = printGreenln
+		}
+		printFunc(fmt.Sprintf("bookstore v1  Books sold: %d", bookStorePurchasesV1.BooksSold))
+
+		printFunc = printYellowln
+		if bookStoreV2HasChanged {
+			printFunc = printGreenln
+		}
+		printFunc(fmt.Sprintf("bookstore v2  Books sold: %d", bookStorePurchasesV2.BooksSold))
+
+		time.Sleep(1 * time.Second)
+	}
+}

--- a/demo/cmd/bookwatcher/bookwatcher.go
+++ b/demo/cmd/bookwatcher/bookwatcher.go
@@ -12,6 +12,13 @@ import (
 	"github.com/openservicemesh/osm/demo/cmd/common"
 )
 
+const (
+	bookBuyerPort   = 8080
+	bookStoreV1Port = 8081
+	bookStoreV2Port = 8082
+	bookThiefPort   = 8083
+)
+
 func clearScreen() {
 	fmt.Print("\033[H\033[2J")
 }
@@ -31,7 +38,7 @@ func printRedln(msg string) {
 func getBookBuyer(bookBuyerPurchases *common.BookBuyerPurchases, wg *sync.WaitGroup, errc chan<- error) {
 	defer wg.Done()
 
-	resp, err := http.Get("http://localhost:8080/raw")
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/raw", bookBuyerPort))
 	if err != nil {
 		errc <- fmt.Errorf("error fetching bookbuyer data: %v", err)
 		return
@@ -53,7 +60,7 @@ func getBookBuyer(bookBuyerPurchases *common.BookBuyerPurchases, wg *sync.WaitGr
 func getBookThief(bookThiefThievery *common.BookThiefThievery, wg *sync.WaitGroup, errc chan<- error) {
 	defer wg.Done()
 
-	resp, err := http.Get("http://localhost:8083/raw")
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/raw", bookThiefPort))
 	if err != nil {
 		errc <- fmt.Errorf("error fetching bookthief data: %v", err)
 		return
@@ -115,11 +122,11 @@ func main() {
 
 		bookStorePurchasesV1Temp := *bookStorePurchasesV1
 		wg.Add(1)
-		go getBookStorePurchases(bookStorePurchasesV1, 8081, wg, errc)
+		go getBookStorePurchases(bookStorePurchasesV1, bookStoreV1Port, wg, errc)
 
 		bookStorePurchasesV2Temp := *bookStorePurchasesV2
 		wg.Add(1)
-		go getBookStorePurchases(bookStorePurchasesV2, 8082, wg, errc)
+		go getBookStorePurchases(bookStorePurchasesV2, bookStoreV2Port, wg, errc)
 
 		complete := make(chan bool)
 		go func() {

--- a/demo/cmd/bookwatcher/bookwatcher.go
+++ b/demo/cmd/bookwatcher/bookwatcher.go
@@ -43,7 +43,11 @@ func getBookBuyer(bookBuyerPurchases *common.BookBuyerPurchases, wg *sync.WaitGr
 		errc <- fmt.Errorf("error fetching bookbuyer data: %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			errc <- fmt.Errorf("error closing response: %v", err)
+		}
+	}()
 
 	output, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -65,7 +69,11 @@ func getBookThief(bookThiefThievery *common.BookThiefThievery, wg *sync.WaitGrou
 		errc <- fmt.Errorf("error fetching bookthief data: %v", err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			errc <- fmt.Errorf("error closing response: %v", err)
+		}
+	}()
 
 	output, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -87,7 +95,11 @@ func getBookStorePurchases(bookStorePurchases *common.BookStorePurchases, port i
 		errc <- fmt.Errorf("error fetching bookstore data (port %d): %v", port, err)
 		return
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			errc <- fmt.Errorf("error closing response: %v", err)
+		}
+	}()
 
 	output, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -140,7 +152,6 @@ func main() {
 			close(errc)
 			log.Fatal(err)
 		case <-complete:
-			break
 		}
 
 		bookBuyerHasChanged := bookBuyerPurchases.BooksBought-bookBuyerPurchasesTemp.BooksBought != 0 ||

--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -13,6 +14,25 @@ import (
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
+
+// BookBuyerPurchases is all of the books that the bookbuyer has bought
+type BookBuyerPurchases struct {
+	BooksBought   int64 `json:"booksBought"`
+	BooksBoughtV1 int64 `json:"booksBoughtV1"`
+	BooksBoughtV2 int64 `json:"booksBoughtV2"`
+}
+
+// BookThiefThievery is all of the books the bookthief has stolen
+type BookThiefThievery struct {
+	BooksStolen   int64 `json:"booksStolen"`
+	BooksStolenV1 int64 `json:"booksStolenV1"`
+	BooksStolenV2 int64 `json:"booksStolenV2"`
+}
+
+// BookStorePurchases are all of the books sold from the bookstore
+type BookStorePurchases struct {
+	BooksSold int64 `json:"booksSold"`
+}
 
 const (
 	// RestockWarehouseURL is a header string constant.
@@ -311,4 +331,18 @@ func getHTTPEgressExpectedResponseCode() int {
 	}
 
 	return http.StatusNotFound
+}
+
+// GetRawGenerator returns a function that can be used to write a response of book data
+func GetRawGenerator(books interface{}) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		booksRaw, err := json.Marshal(books)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to marshal book data")
+		}
+		_, err = w.Write(booksRaw)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to write raw output")
+		}
+	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

When I'm testing or demo'ing OSM, I am in the terminal. The demo app requires you to use the browser or curl the markup of the different services (bookbuyer, bookthief, etc.). This is very manual and requires some visual grep'ing as well as manual refreshing.

This PR adds a `/raw` route to bookbuyer, bookthief, and bookstore to get their JSON data. It also adds a bookwatcher bin that polls the different raw endpoints and displays the output. The text color is as follows:

* Yellow - data hasn't changed since last poll iteration
* Green - data for bookbuyer and bookstore has changed
* Red - books were stolen by the bookthief since last poll iteration

This refreshes the terminal every second. Below are screenshots showing the experience.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Demo                       | [X] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:

![osm_demo_bookbuyer1](https://user-images.githubusercontent.com/1445483/128560793-0c323ad2-534b-4dfa-81d0-69756837fa53.png)

This shows that since the last iteration, the bookbuyer has bought a book (or books) and the bookstore V1 has sold a book (or books).

![osm_demo_bookthief1](https://user-images.githubusercontent.com/1445483/128560873-4bbea44e-1bfb-421d-a3a7-5a80eedf7150.png)

This shows that since the last iteration, the bookthief has stolen a book (or books) and bookstore V1 has sold a book (or books).

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?

No.

2. Is this a breaking change?

No.