### PR TITLE
ref(cdrUpgradeHook) : change crd upgrade hook from pod to job

### DIFF
--- a/charts/osm/templates/crds-upgrade-hook.yaml
+++ b/charts/osm/templates/crds-upgrade-hook.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
@@ -22,7 +22,7 @@ metadata:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-upgrade-crds
@@ -41,31 +41,36 @@ metadata:
     {{- include "osm.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: {{ .Release.Name }}-upgrade-crds
   namespace: {{ include "osm.namespace" . }}
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
   labels:
     {{- include "osm.labels" . | nindent 4 }}
 spec:
-  serviceAccountName: {{ .Release.Name }}-upgrade-crds
-  restartPolicy: OnFailure
-  containers:
-  - name: crds-upgrade
-    image: "{{ .Values.OpenServiceMesh.image.registry }}/osm-crds:{{ .Values.OpenServiceMesh.image.tag }}"
-    imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}
-    command:
-            - sh
-            - -c
-            - >
-             kubectl apply -f /osm-crds;
+  template:
+    metadata:
+      name: crds-upgrade
+    spec:
+      serviceAccountName: {{ .Release.Name }}-upgrade-crds
+      restartPolicy: Never
+      containers:
+      - name: crds-upgrade
+        image: "{{ .Values.OpenServiceMesh.image.registry }}/osm-crds:{{ .Values.OpenServiceMesh.image.tag }}"
+        args:
+            - apply
+            - -f
+            - /osm-crds
+        imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}
+      nodeSelector:
+        kubernetes.io/os: linux
 {{- if .Values.OpenServiceMesh.imagePullSecrets }}
-  imagePullSecrets:
+      imagePullSecrets:
 {{ toYaml .Values.OpenServiceMesh.imagePullSecrets | indent 8 }}
 {{- end }}


### PR DESCRIPTION
**Description**:

This commit changes the order of hook deletion as helm evaluated them in
ascending order based on weights.

Also the hook has been converted to a job as helm kills the pod before
kubectl exec is run. With job, helm waits until the pod is run and
reached completion.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [X] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |

**Testing done**:

Verified that the hook runs as expected with the changes 

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
