### PR TITLE
crdUpgrades: Update osm clean up hook to patch osm crds instead of deleting them

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -107,8 +107,8 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: {{ .Release.Name }}-cleanup
   namespace: {{ include "osm.namespace" . }}
@@ -118,26 +118,32 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
-  serviceAccountName: {{ .Release.Name }}-cleanup
-  restartPolicy: Never
-  nodeSelector:
-    kubernetes.io/arch: amd64
-    kubernetes.io/os: linux
-  containers:
-    - name: garbage-collector
-      image: bitnami/kubectl
-      imagePullPolicy: IfNotPresent
-      command:
-        - sh
-        - -c
-        - >
-         kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
-         kubectl delete crd meshconfigs.config.openservicemesh.io --ignore-not-found;
-         kubectl delete crd traffictargets.access.smi-spec.io --ignore-not-found;
-         kubectl delete crd httproutegroups.specs.smi-spec.io --ignore-not-found;
-         kubectl delete crd multiclusterservices.config.openservicemesh.io --ignore-not-found;
-         kubectl delete crd egresses.policy.openservicemesh.io --ignore-not-found;
-         kubectl delete crd ingressbackends.policy.openservicemesh.io --ignore-not-found;
-         kubectl delete crd trafficsplits.split.smi-spec.io --ignore-not-found;
-         kubectl delete crd tcproutes.specs.smi-spec.io --ignore-not-found;
+  template:
+    metadata:
+      name: {{ .Release.Name }}-cleanup
+      labels:
+        {{- include "osm.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup
+      restartPolicy: Never
+      containers:
+        - name: garbage-collector
+          image: bitnami/kubectl
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - >
+             kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
+             kubectl patch crd/meshconfigs.config.openservicemesh.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/traffictargets.access.smi-spec.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/httproutegroups.specs.smi-spec.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/multiclusterservices.config.openservicemesh.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/egresses.policy.openservicemesh.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/ingressbackends.policy.openservicemesh.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/trafficsplits.split.smi-spec.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+             kubectl patch crd/tcproutes.specs.smi-spec.io -p '{"spec":{"conversion":{"strategy":"None", "webhook":null}}}' --type=merge;
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
 

--- a/charts/osm/templates/crds-upgrade-hook.yaml
+++ b/charts/osm/templates/crds-upgrade-hook.yaml
@@ -69,6 +69,7 @@ spec:
             - /osm-crds
         imagePullPolicy: {{ .Values.OpenServiceMesh.image.pullPolicy }}
       nodeSelector:
+        kubernetes.io/arch: amd64
         kubernetes.io/os: linux
 {{- if .Values.OpenServiceMesh.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
**Description**:

Update the pre-delete clean up hook in osm to patch the crds, removing
the conversion webhook instead of deleting them on uninstall.

Fixes #3760

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |

**Testing done**:

Manually verified that the CRDs remain in the cluster after an uninstall and do not contain the conversion webhook spec


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
