### PR TITLE
fix(openshift): Create env file for cleanup

### DIFF
--- a/.github/workflows/openshift-nightly.yml
+++ b/.github/workflows/openshift-nightly.yml
@@ -62,4 +62,5 @@ jobs:
           K8S_NAMESPACE: osm-system
           TIMEOUT: 90s
         run: |
+          touch .env
           ./demo/clean-kubernetes.sh


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Clean up stage of openshift nightly job fails if e2e fails since there is no .env file for the clean-kubernetes script. This does not occur if the demo step fails since that already performs the `touch .env` step.

Example of failing step: https://github.com/openservicemesh/osm/runs/3236304092?check_suite_focus=true
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [X] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
2. Is this a breaking change?
No