### PR TITLE
chore(crdConverter): Rename crd converter to osm bootstrap

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -69,9 +69,6 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.configResyncInterval | string | `"0s"` | Sets the resync interval for regular proxy broadcast updates, set to 0s to not enforce any resync |
 | OpenServiceMesh.controlPlaneTolerations | list | `[]` | Node tolerations applied to control plane pods. The specified tolerations allow pods to schedule onto nodes with matching taints. |
 | OpenServiceMesh.controllerLogLevel | string | `"info"` | Controller log verbosity |
-| OpenServiceMesh.crdConverter.podLabels | object | `{}` | CRD converter's pod labels |
-| OpenServiceMesh.crdConverter.replicaCount | int | `1` | CRD converter's replica count |
-| OpenServiceMesh.crdConverter.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | CRD converter's container resource parameters |
 | OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana with OSM installation |
 | OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger during OSM installation |
 | OpenServiceMesh.deployPrometheus | bool | `false` | Deploy Prometheus with OSM installation |
@@ -121,6 +118,9 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
 | OpenServiceMesh.multicluster | object | `{"gatewayLogLevel":"error"}` | OSM multicluster feature configuration |
 | OpenServiceMesh.multicluster.gatewayLogLevel | string | `"error"` | Log level for the multicluster gateway |
+| OpenServiceMesh.osmBootstrap.podLabels | object | `{}` | OSM bootstrap's pod labels |
+| OpenServiceMesh.osmBootstrap.replicaCount | int | `1` | OSM bootstrap's replica count |
+| OpenServiceMesh.osmBootstrap.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | OSM bootstrap's container resource parameters |
 | OpenServiceMesh.osmController.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |
 | OpenServiceMesh.osmController.autoScale.enable | bool | `false` | Enable Autoscale |
 | OpenServiceMesh.osmController.autoScale.maxReplicas | int | `5` | Maximum replicas for autoscale |

--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app: osm-bootstrap
     meshName: {{ .Values.OpenServiceMesh.meshName }}
 spec:
-  replicas: {{ .Values.OpenServiceMesh.crdConverter.replicaCount }}
+  replicas: {{ .Values.OpenServiceMesh.osmBootstrap.replicaCount }}
   selector:
     matchLabels:
       app: osm-bootstrap
@@ -17,8 +17,8 @@ spec:
       labels:
         {{- include "osm.labels" . | nindent 8 }}
         app: osm-bootstrap
-  {{- if .Values.OpenServiceMesh.crdConverter.podLabels }}
-  {{- toYaml .Values.OpenServiceMesh.crdConverter.podLabels | nindent 8 }}
+  {{- if .Values.OpenServiceMesh.osmBootstrap.podLabels }}
+  {{- toYaml .Values.OpenServiceMesh.osmBootstrap.podLabels | nindent 8 }}
   {{- end }}
       annotations:
         prometheus.io/scrape: 'true'
@@ -59,11 +59,11 @@ spec:
           ]
           resources:
             limits:
-              cpu: "{{.Values.OpenServiceMesh.crdConverter.resource.limits.cpu}}"
-              memory: "{{.Values.OpenServiceMesh.crdConverter.resource.limits.memory}}"
+              cpu: "{{.Values.OpenServiceMesh.osmBootstrap.resource.limits.cpu}}"
+              memory: "{{.Values.OpenServiceMesh.osmBootstrap.resource.limits.memory}}"
             requests:
-              cpu: "{{.Values.OpenServiceMesh.crdConverter.resource.requests.cpu}}"
-              memory: "{{.Values.OpenServiceMesh.crdConverter.resource.requests.memory}}"
+              cpu: "{{.Values.OpenServiceMesh.osmBootstrap.resource.requests.cpu}}"
+              memory: "{{.Values.OpenServiceMesh.osmBootstrap.resource.requests.memory}}"
           readinessProbe:
             initialDelaySeconds: 5
             timeoutSeconds: 5

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -152,7 +152,7 @@
                 "osmController",
                 "enablePrivilegedInitContainer",
                 "injector",
-                "crdConverter",
+                "osmBootstrap",
                 "featureFlags"
             ],
             "properties": {
@@ -692,21 +692,21 @@
                     },
                     "additionalProperties": false
                 },
-                "crdConverter": {
-                    "$id": "#/properties/OpenServiceMesh/properties/crdConverter",
+                "osmBootstrap": {
+                    "$id": "#/properties/OpenServiceMesh/properties/osmBootstrap",
                     "type": "object",
-                    "title": "The CRD converter schema",
-                    "description": "CRD converter's configurations",
+                    "title": "The OSM bootstrap schema",
+                    "description": "OSM bootstrap's configurations",
                     "required": [
                         "replicaCount",
                         "resource"
                     ],
                     "properties": {
                         "replicaCount": {
-                            "$id": "#/properties/OpenServiceMesh/properties/crdConverter/properties/replicaCount",
+                            "$id": "#/properties/OpenServiceMesh/properties/osmBootstrap/properties/replicaCount",
                             "type": "integer",
                             "title": "The replicaCount schema",
-                            "description": "The number of replicas of the CRD converter pod.",
+                            "description": "The number of replicas of the OSM bootstrap pod.",
                             "examples": [
                                 1
                             ]
@@ -715,10 +715,10 @@
                             "$ref": "#/definitions/containerResources"
                         },
                         "podLabels": {
-                            "$id": "#/properties/OpenServiceMesh/properties/crdConverter/properties/podLabels",
+                            "$id": "#/properties/OpenServiceMesh/properties/osmBootstrap/properties/podLabels",
                             "type": "object",
                             "title": "The podLabels schema",
-                            "description": "Labels for the CRD converter pod.",
+                            "description": "Labels for the OSM bootstrap pod.",
                             "default": {}
                         }
                     },

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -275,11 +275,11 @@ OpenServiceMesh:
   controlPlaneTolerations: []
 
   #
-  # -- OSM's CRD converter parameters
-  crdConverter:
-    # -- CRD converter's replica count
+  # -- OSM bootstrap parameters
+  osmBootstrap:
+    # -- OSM bootstrap's replica count
     replicaCount: 1
-    # -- CRD converter's container resource parameters
+    # -- OSM bootstrap's container resource parameters
     resource:
       limits:
         cpu: "0.5"
@@ -287,7 +287,7 @@ OpenServiceMesh:
       requests:
         cpu: "0.3"
         memory: "64M"
-    # -- CRD converter's pod labels
+    # -- OSM bootstrap's pod labels
     podLabels: {}
 
   #

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -137,12 +137,12 @@ func main() {
 	}
 
 	// Initialize the generic Kubernetes event recorder and associate it with the osm-bootstrap pod resource
-	crdConverterPod, err := getBootstrapPod(kubeClient)
+	bootstrapPod, err := getBootstrapPod(kubeClient)
 	if err != nil {
 		log.Fatal().Msg("Error fetching osm-bootstrap pod")
 	}
 	eventRecorder := events.GenericEventRecorder()
-	if err := eventRecorder.Initialize(crdConverterPod, kubeClient, osmNamespace); err != nil {
+	if err := eventRecorder.Initialize(bootstrapPod, kubeClient, osmNamespace); err != nil {
 		log.Fatal().Msg("Error initializing generic event recorder")
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -108,7 +108,7 @@ const (
 	// WebhookCertificateSecretName is the default value for webhook secret name
 	WebhookCertificateSecretName = "mutating-webhook-cert-secret"
 
-	// CrdConverterCertificateSecretName is the default value for webhook secret name
+	// CrdConverterCertificateSecretName is the default value for conversion webhook secret name
 	CrdConverterCertificateSecretName = "crd-converter-cert-secret" // #nosec G101: Potential hardcoded credentials
 
 	// RegexMatchAll is a regex pattern match for all

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -43,8 +43,8 @@ const (
 	OsmPrometheusAppLabel = "osm-prometheus"
 	// OsmInjectorAppLabel is the OSM injector deployment app label
 	OsmInjectorAppLabel = "osm-injector"
-	// OsmCrdConverterAppLabel is the OSM crd converter deployment app label
-	OsmCrdConverterAppLabel = "osm-bootstrap"
+	// OsmBootstrapAppLabel is the OSM bootstrap deployment app label
+	OsmBootstrapAppLabel = "osm-bootstrap"
 
 	// OSM Grafana Dashboard specifics
 
@@ -60,7 +60,7 @@ const (
 
 var (
 	// OsmCtlLabels is the list of app labels for OSM CTL
-	OsmCtlLabels = []string{OsmControllerAppLabel, OsmGrafanaAppLabel, OsmPrometheusAppLabel, OsmInjectorAppLabel, OsmCrdConverterAppLabel}
+	OsmCtlLabels = []string{OsmControllerAppLabel, OsmGrafanaAppLabel, OsmPrometheusAppLabel, OsmInjectorAppLabel, OsmBootstrapAppLabel}
 
 	// NginxIngressSvc is the namespaced name of the nginx ingress service
 	NginxIngressSvc = types.NamespacedName{Namespace: "ingress-ns", Name: "ingress-nginx-controller"}
@@ -490,7 +490,7 @@ func (td *OsmTestData) GetPrometheusPodHandle(ns string, prometheusPodName strin
 }
 
 func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
-	var errController, errInjector, errCrdsConverter error
+	var errController, errInjector, errBootstrap error
 	waitGroup := sync.WaitGroup{}
 	waitGroup.Add(3)
 
@@ -516,9 +516,9 @@ func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
 
 	go func() {
 		defer GinkgoRecover()
-		errCrdsConverter = td.WaitForPodsRunningReady(td.OsmNamespace, timeout, 1, &metav1.LabelSelector{
+		errBootstrap = td.WaitForPodsRunningReady(td.OsmNamespace, timeout, 1, &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"app": OsmCrdConverterAppLabel,
+				"app": OsmBootstrapAppLabel,
 			},
 		})
 		waitGroup.Done()
@@ -527,7 +527,7 @@ func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
 	waitGroup.Wait()
 
 	if errController != nil || errInjector != nil {
-		return errors.New(fmt.Sprintf("OSM Control plane was not ready in time (%v, %v, %v)", errController, errInjector, errCrdsConverter))
+		return errors.New(fmt.Sprintf("OSM Control plane was not ready in time (%v, %v, %v)", errController, errInjector, errBootstrap))
 	}
 
 	return nil


### PR DESCRIPTION
**Description**:

Updated naming for `crdConverter` to `osmBootstrap` as needed.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
