### PR TITLE
validator: fix scoping and remove unused code

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -250,7 +250,7 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.CertificateIssuanceFailure, "Error issuing certificate for the validating webhook")
 	}
 
-	if _, err := validator.NewValidatingWebhook(validatorWebhookConfigName, constants.ValidatorWebhookPort, webhookHandlerCert, kubeClient, stop); err != nil {
+	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, constants.ValidatorWebhookPort, webhookHandlerCert, kubeClient, stop); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error starting the validating webhook server")
 	}
 

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -24,8 +24,8 @@ func TestHandleValidation(t *testing.T) {
 		Group:   "fake.osm.io",
 		Version: "v1alpha1",
 	}
-	s := ValidatingWebhookServer{
-		Validators: map[string]Validator{
+	s := validatingWebhookServer{
+		validators: map[string]validateFunc{
 			gvk.String(): func(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
 				f := fakeObj{}
 				if err := json.Unmarshal(req.Object.Raw, &f); err != nil {

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -192,7 +192,7 @@ func TestIngressBackendValidator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
-			resp, err := IngressBackendValidator(tc.input)
+			resp, err := ingressBackendValidator(tc.input)
 			assert.Equal(tc.expResp, resp)
 			if err != nil {
 				assert.Equal(tc.expErrStr, err.Error())
@@ -202,7 +202,6 @@ func TestIngressBackendValidator(t *testing.T) {
 }
 
 func TestEgressValidator(t *testing.T) {
-	assert := tassert.New(t)
 	testCases := []struct {
 		name      string
 		input     *admissionv1.AdmissionRequest
@@ -303,106 +302,9 @@ func TestEgressValidator(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp, err := EgressValidator(tc.input)
-			assert.Equal(tc.expResp, resp)
-			if err != nil {
-				assert.Equal(tc.expErrStr, err.Error())
-			}
-		})
-	}
-}
+			assert := tassert.New(t)
 
-func TestMeshConfigValidator(t *testing.T) {
-	assert := tassert.New(t)
-	testCases := []struct {
-		name      string
-		input     *admissionv1.AdmissionRequest
-		expResp   *admissionv1.AdmissionResponse
-		expErrStr string
-	}{
-		{
-			name: "MeshConfig with invalid duration fails",
-			input: &admissionv1.AdmissionRequest{
-				Kind: metav1.GroupVersionKind{
-					Group:   "v1alpha1",
-					Version: "config.openservicemesh.io",
-					Kind:    "MeshConfig",
-				},
-				Object: runtime.RawExtension{
-					Raw: []byte(`
-					{
-						"apiVersion": "v1alpha1",
-						"kind": "Egress",
-						"spec": {
-							"certificate": {
-								"serviceCertValidityDuration": "abc"
-							}
-						}
-					}
-					`),
-				},
-			},
-
-			expResp:   nil,
-			expErrStr: "'Certificate.ServiceCertValidityDuration' abc is not valid",
-		},
-		{
-			name: "MeshConfig with duration lower than minimum duration fails",
-			input: &admissionv1.AdmissionRequest{
-				Kind: metav1.GroupVersionKind{
-					Group:   "v1alpha1",
-					Version: "config.openservicemesh.io",
-					Kind:    "MeshConfig",
-				},
-				Object: runtime.RawExtension{
-					Raw: []byte(`
-					{
-						"apiVersion": "v1alpha1",
-						"kind": "Egress",
-						"spec": {
-							"certificate": {
-								"serviceCertValidityDuration": "0.5s"
-							}
-						}
-					}
-					`),
-				},
-			},
-
-			expResp:   nil,
-			expErrStr: "'Certificate.ServiceCertValidityDuration' 500000000 is lower than 120000000000",
-		},
-		{
-			name: "MeshConfig with valid duration passes",
-			input: &admissionv1.AdmissionRequest{
-				Kind: metav1.GroupVersionKind{
-					Group:   "v1alpha1",
-					Version: "config.openservicemesh.io",
-					Kind:    "MeshConfig",
-				},
-				Object: runtime.RawExtension{
-					Raw: []byte(`
-					{
-						"apiVersion": "v1alpha1",
-						"kind": "Egress",
-						"spec": {
-							"certificate": {
-								"serviceCertValidityDuration": "1h"
-							}
-						}
-					}
-					`),
-				},
-			},
-
-			expResp:   nil,
-			expErrStr: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := MeshConfigValidator(tc.input)
+			resp, err := egressValidator(tc.input)
 			assert.Equal(tc.expResp, resp)
 			if err != nil {
 				assert.Equal(tc.expErrStr, err.Error())


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Fixes the scoping of types only required within the
  pkg to not be exported.
- Removes unused code for MeshConfig which is not being
  validated and cannot because of being in the same namespace
  as the validating webhook, which would result in race
  conditions similar to the ones observed with osm-config
  ConfigMap and it's corresponding validating webhook.
- Removes unnecessary complexity with default validators.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
