### PR TITLE
fix(cli): fix proxy get command truncating output

### DIFF
--- a/cmd/cli/proxy_get.go
+++ b/cmd/cli/proxy_get.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"io"
 	"os"
 
@@ -99,8 +98,7 @@ func (cmd *proxyGetCmd) run() error {
 		out = fd         // write output to file
 	}
 
-	w := bufio.NewWriter(out)
-	_, err = w.WriteString(string(envoyProxyConfig))
+	_, err = out.Write(envoyProxyConfig)
 	return err
 }
 


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, `osm proxy get` is truncating output after around 160K on my
Mac. While trying to figure out where the problem was, I found using
`Write` instead of `WriteString` fixed it for reasons I don't
understand. Removing the intermediate `bufio.Writer` is just an extra
simplification.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:
No automated tests for this yet, so manual testing on my Mac.


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
