### PR TITLE
test(pipeline): Push latest-main images nightly

### DIFF
--- a/.github/workflows/nightly-images.yml
+++ b/.github/workflows/nightly-images.yml
@@ -1,0 +1,37 @@
+name: Nightly Images
+on: 
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  images:
+    name: Docker Images
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_USER: ${{ secrets.RELEASE_DOCKER_USER }}
+      DOCKER_PASS: ${{ secrets.RELEASE_DOCKER_PASS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+      - name: Setup Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+      - name: Docker Login
+        run: docker login --username "$DOCKER_USER" --password-stdin <<< "$DOCKER_PASS"
+      - name: Push images with git sha tag
+        env:
+          CTR_TAG: latest-main
+        run: make docker-push

--- a/.github/workflows/nightly-noinstall.yml
+++ b/.github/workflows/nightly-noinstall.yml
@@ -1,12 +1,18 @@
 name: OSM NoInstall Nightly Job
 on: 
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_run:
+    workflows: ["Nightly Images"]
+    types: [completed]
+
+env:
+  CTR_REGISTRY: openservicemesh
+  CTR_TAG: latest-main
 
 jobs:
   test:
     name: NoInstall Nightly Job
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       KUBECONFIG: ${{ github.workspace }}/kind-kubeconfig
     steps:
@@ -54,13 +60,7 @@ jobs:
           ./bin/osm install \
             --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
             --set=OpenServiceMesh.image.tag="$CTR_TAG"
-        env: 
-          CTR_REGISTRY: openservicemesh
-          CTR_TAG: ${{ github.sha }}
       - name: Run e2es
         run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -test.timeout 60m -installType=NoInstall
-        env: 
-          CTR_REGISTRY: openservicemesh
-          CTR_TAG: ${{ github.sha }}
       - name: Kind cleanup
         run: kind delete cluster --name $KIND_CLUSTER_NAME

--- a/.github/workflows/openshift-nightly.yml
+++ b/.github/workflows/openshift-nightly.yml
@@ -1,16 +1,18 @@
 name: OpenShift Nightly Job
 on: 
-  schedule:
-    - cron: "0 0 * * *"
+  workflow_run:
+    workflows: ["Nightly Images"]
+    types: [completed]
 
 env:
   CTR_REGISTRY: openservicemesh
-  CTR_TAG: ${{ github.sha }}
+  CTR_TAG: latest-main
 
 jobs:
   test:
     name: OpenShift Nightly Job
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout v2
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Create a nightly images job to push OSM images to dockerhub with tag `latest-main`. After this succeeds, it will trigger the nightly-noinstall job and openshift-nightly job. 

Resolves https://github.com/openservicemesh/osm/issues/3961



<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [X] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
