### PR TITLE
chore: use osm.tracingAddress in preset-mesh-config

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -139,7 +139,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.19.0"` | Envoy sidecar image |
-| OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
+| OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |
 | OpenServiceMesh.tracing.port | int | `9411` | Port of the tracing collector service |

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -28,7 +28,7 @@ data:
           "enable": {{.Values.OpenServiceMesh.tracing.enable}}{{- if .Values.OpenServiceMesh.tracing.enable }},{{- end }}
           {{- if .Values.OpenServiceMesh.tracing.enable }}
           "port": {{.Values.OpenServiceMesh.tracing.port}},
-          "address": {{.Values.OpenServiceMesh.tracing.address | quote}},
+          "address": {{include "osm.tracingAddress"}},
           "endpoint": {{.Values.OpenServiceMesh.tracing.endpoint  | quote}}
           {{- end }}
         }

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -188,7 +188,7 @@ OpenServiceMesh:
     # -- Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh
     enable: false
     # -- Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md
-    address: "jaeger.osm-system.svc.cluster.local"
+    address: ""
     # -- Port of the tracing collector service
     port: 9411
     # -- Tracing collector's API path where the spans will be sent to


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Removed `tracing.address` field from values.yaml. Tracing address should be generated by `osm.tracingAddress` helper function.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [X] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:

CI test

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
