### PR TITLE
ref(preset-mesh-config): Change kind of preset-mesh-config to ConfigMap

### DIFF
--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -1,34 +1,44 @@
-apiVersion: config.openservicemesh.io/v1alpha1
-kind: MeshConfig
+apiVersion: v1
+kind: ConfigMap
 metadata:
   name: preset-mesh-config
-spec:
-  sidecar:
-    enablePrivilegedInitContainer: {{.Values.OpenServiceMesh.enablePrivilegedInitContainer}}
-    logLevel: {{.Values.OpenServiceMesh.envoyLogLevel}}
-    maxDataPlaneConnections: {{.Values.OpenServiceMesh.maxDataPlaneConnections}}
-    envoyImage: {{.Values.OpenServiceMesh.sidecarImage}}
-    initContainerImage: "{{ .Values.OpenServiceMesh.image.registry }}/init:{{ .Values.OpenServiceMesh.image.tag }}"
-    configResyncInterval: {{.Values.OpenServiceMesh.configResyncInterval}}
-  traffic:
-    enableEgress: {{.Values.OpenServiceMesh.enableEgress}}
-    useHTTPSIngress: {{.Values.OpenServiceMesh.useHTTPSIngress}}
-    enablePermissiveTrafficPolicyMode: {{.Values.OpenServiceMesh.enablePermissiveTrafficPolicy}}
-    outboundPortExclusionList: {{.Values.OpenServiceMesh.outboundPortExclusionList}}
-    inboundPortExclusionList: {{.Values.OpenServiceMesh.inboundPortExclusionList}}
-    outboundIPRangeExclusionList: {{.Values.OpenServiceMesh.outboundIPRangeExclusionList}}
-  observability:
-    enableDebugServer: {{.Values.OpenServiceMesh.enableDebugServer}}
-    tracing:
-      enable: {{.Values.OpenServiceMesh.tracing.enable}}
-      {{- if .Values.OpenServiceMesh.tracing.enable }}
-      port: {{.Values.OpenServiceMesh.tracing.port}}
-      address: {{.Values.OpenServiceMesh.tracing.address | quote}}
-      endpoint: {{.Values.OpenServiceMesh.tracing.endpoint  | quote}}
-      {{- end }}
-  certificate:
-    serviceCertValidityDuration: {{.Values.OpenServiceMesh.serviceCertValidityDuration}}
-  featureFlags: 
-    enableWASMStats: {{.Values.OpenServiceMesh.featureFlags.enableWASMStats}}
-    enableEgressPolicy: {{.Values.OpenServiceMesh.featureFlags.enableEgressPolicy}}
-    enableMulticlusterMode: {{.Values.OpenServiceMesh.featureFlags.enableMulticlusterMode}}
+data:
+  preset-mesh-config.json: |
+    {
+      "sidecar": {
+        "enablePrivilegedInitContainer": {{.Values.OpenServiceMesh.enablePrivilegedInitContainer}},
+        "logLevel": "{{.Values.OpenServiceMesh.envoyLogLevel}}",
+        "maxDataPlaneConnections": {{.Values.OpenServiceMesh.maxDataPlaneConnections}},
+        "envoyImage": "{{.Values.OpenServiceMesh.sidecarImage}}",
+        "initContainerImage": "{{ .Values.OpenServiceMesh.image.registry }}/init:{{ .Values.OpenServiceMesh.image.tag }}",
+        "configResyncInterval": "{{.Values.OpenServiceMesh.configResyncInterval}}"
+      },
+      "traffic": {
+        "enableEgress": {{.Values.OpenServiceMesh.enableEgress}},
+        "useHTTPSIngress": {{.Values.OpenServiceMesh.useHTTPSIngress}},
+        "enablePermissiveTrafficPolicyMode": {{.Values.OpenServiceMesh.enablePermissiveTrafficPolicy}},
+        "outboundPortExclusionList": {{.Values.OpenServiceMesh.outboundPortExclusionList}},
+        "inboundPortExclusionList": {{.Values.OpenServiceMesh.inboundPortExclusionList}},
+        "outboundIPRangeExclusionList": {{.Values.OpenServiceMesh.outboundIPRangeExclusionList}}
+      },
+      "observability": {
+        "enableDebugServer": {{.Values.OpenServiceMesh.enableDebugServer}},
+        "osmLogLevel": "{{.Values.OpenServiceMesh.controllerLogLevel}}",
+        "tracing": {
+          "enable": {{.Values.OpenServiceMesh.tracing.enable}}{{- if .Values.OpenServiceMesh.tracing.enable }},{{- end }}
+          {{- if .Values.OpenServiceMesh.tracing.enable }}
+          "port": {{.Values.OpenServiceMesh.tracing.port}},
+          "address": {{.Values.OpenServiceMesh.tracing.address | quote}},
+          "endpoint": {{.Values.OpenServiceMesh.tracing.endpoint  | quote}}
+          {{- end }}
+        }
+      },
+      "certificate": {
+        "serviceCertValidityDuration": "{{.Values.OpenServiceMesh.serviceCertValidityDuration}}"
+      },
+      "featureFlags": {
+        "enableWASMStats": {{.Values.OpenServiceMesh.featureFlags.enableWASMStats}},
+        "enableEgressPolicy": {{.Values.OpenServiceMesh.featureFlags.enableEgressPolicy}},
+        "enableMulticlusterMode": {{.Values.OpenServiceMesh.featureFlags.enableMulticlusterMode}}
+      }
+    }

--- a/cmd/init-osm-controller/init-osm-controller.go
+++ b/cmd/init-osm-controller/init-osm-controller.go
@@ -2,25 +2,28 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"os"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/version"
-
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
-	meshConfigName       = "osm-mesh-config"
-	presetMeshConfigName = "preset-mesh-config"
+	meshConfigName          = "osm-mesh-config"
+	presetMeshConfigName    = "preset-mesh-config"
+	presetMeshConfigJSONKey = "preset-mesh-config.json"
 )
 
 var (
@@ -55,7 +58,14 @@ func validateCLIParams() error {
 	return nil
 }
 
-func createDefaultMeshConfig(presetMeshConfig *v1alpha1.MeshConfig) *v1alpha1.MeshConfig {
+func createDefaultMeshConfig(presetMeshConfigMap *corev1.ConfigMap) *v1alpha1.MeshConfig {
+	presetMeshConfig := presetMeshConfigMap.Data[presetMeshConfigJSONKey]
+	presetMeshConfigSpec := v1alpha1.MeshConfigSpec{}
+	err := json.Unmarshal([]byte(presetMeshConfig), &presetMeshConfigSpec)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Error converting preset-mesh-config json string to meshConfig object")
+	}
+
 	return &v1alpha1.MeshConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MeshConfig",
@@ -64,7 +74,7 @@ func createDefaultMeshConfig(presetMeshConfig *v1alpha1.MeshConfig) *v1alpha1.Me
 		ObjectMeta: metav1.ObjectMeta{
 			Name: meshConfigName,
 		},
-		Spec: presetMeshConfig.Spec,
+		Spec: presetMeshConfigSpec,
 	}
 }
 
@@ -86,13 +96,14 @@ func main() {
 		log.Fatal().Err(err).Msgf("Failed creating kube config (kubeconfig=%s)", kubeConfigFilePath)
 	}
 
+	kubeClient := kubernetes.NewForConfigOrDie(kubeConfig)
 	configClient, err := configClientset.NewForConfig(kubeConfig)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Could not access Kubernetes cluster, check kubeconfig.")
 		return
 	}
 
-	presetMeshConfig, presetConfigErr := configClient.ConfigV1alpha1().MeshConfigs(osmNamespace).Get(context.TODO(), presetMeshConfigName, metav1.GetOptions{})
+	presetMeshConfigMap, presetConfigErr := kubeClient.CoreV1().ConfigMaps(osmNamespace).Get(context.TODO(), presetMeshConfigName, metav1.GetOptions{})
 	_, meshConfigErr := configClient.ConfigV1alpha1().MeshConfigs(osmNamespace).Get(context.TODO(), meshConfigName, metav1.GetOptions{})
 
 	// If the presetMeshConfig could not be loaded and a default meshConfig doesn't exist, return the error
@@ -101,7 +112,7 @@ func main() {
 		return
 	}
 
-	defaultMeshConfig := createDefaultMeshConfig(presetMeshConfig)
+	defaultMeshConfig := createDefaultMeshConfig(presetMeshConfigMap)
 
 	if createdMeshConfig, err := configClient.ConfigV1alpha1().MeshConfigs(osmNamespace).Create(context.TODO(), defaultMeshConfig, metav1.CreateOptions{}); err == nil {
 		log.Info().Msgf("MeshConfig created in %s, %v", osmNamespace, createdMeshConfig)

--- a/cmd/init-osm-controller/init-osm-controller_test.go
+++ b/cmd/init-osm-controller/init-osm-controller_test.go
@@ -4,49 +4,59 @@ import (
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
 )
 
 func TestCreateDefaultMeshConfig(t *testing.T) {
 	assert := tassert.New(t)
 
-	presetMeshConfig := &v1alpha1.MeshConfig{
+	presetMeshConfigMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       "MeshConfig",
-			APIVersion: "config.openservicemesh.io/v1alpha1",
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: presetMeshConfigName,
 		},
-		Spec: v1alpha1.MeshConfigSpec{
-			Sidecar: v1alpha1.SidecarSpec{
-				LogLevel:                      "error",
-				EnvoyImage:                    "envoyproxy/envoy-alpine:v1.18.3",
-				InitContainerImage:            "openservicemesh/init:v0.9.1",
-				EnablePrivilegedInitContainer: false,
-				MaxDataPlaneConnections:       0,
-				ConfigResyncInterval:          "2s",
-			},
-			Traffic: v1alpha1.TrafficSpec{
-				EnableEgress:                      true,
-				UseHTTPSIngress:                   false,
-				EnablePermissiveTrafficPolicyMode: true,
-			},
-			Observability: v1alpha1.ObservabilitySpec{
-				EnableDebugServer: false,
-				Tracing: v1alpha1.TracingSpec{
-					Enable: false,
-				},
-			},
-			Certificate: v1alpha1.CertificateSpec{
-				ServiceCertValidityDuration: "24h",
-			},
+		Data: map[string]string{
+			presetMeshConfigJSONKey: `{
+"sidecar": {
+  "enablePrivilegedInitContainer": false,
+  "logLevel": "error",
+  "maxDataPlaneConnections": 0,
+  "envoyImage": "envoyproxy/envoy-alpine:v1.18.3",
+  "initContainerImage": "openservicemesh/init:v0.9.0",
+  "configResyncInterval": "2s"
+},
+"traffic": {
+	"enableEgress": true,
+	"useHTTPSIngress": false,
+	"enablePermissiveTrafficPolicyMode": true,
+	"outboundPortExclusionList": [],
+	"inboundPortExclusionList": [],
+	"outboundIPRangeExclusionList": []
+  },
+  "observability": {
+	"enableDebugServer": false,
+	"osmLogLevel": "trace",
+	"tracing": {
+      "enable": false
+	}
+  },
+  "certificate": {
+	"serviceCertValidityDuration": "24h"
+  },
+  "featureFlags": {
+	"enableWASMStats": true,
+	"enableEgressPolicy": true,
+	"enableMulticlusterMode": false
+	}
+}`,
 		},
 	}
 
-	meshConfig := createDefaultMeshConfig(presetMeshConfig)
+	meshConfig := createDefaultMeshConfig(presetMeshConfigMap)
 	assert.Equal(meshConfig.Name, meshConfigName)
 	assert.Equal(meshConfig.Spec.Sidecar.LogLevel, "error")
 	assert.Equal(meshConfig.Spec.Sidecar.ConfigResyncInterval, "2s")


### PR DESCRIPTION
**Description**:

This commit changes the kind of preset-mesh-config from MeshConfig to
ConfigMap

Fixes #3654

Backporting change https://github.com/openservicemesh/osm/pull/3662/commits/2429d81ddc40539d834a7afa625656a1ed0d1f26

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Testing done**:

Manually verified the change

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?`no`
