### PR TITLE
[backports] Fixes for permissive mode, replicas, k8s version check

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.9.1
 appVersion: v0.9.1
 
 # This specifies a particular range of k8s versions that the application is compatible with.
-kubeVersion: ">= 1.18.0"
+kubeVersion: ">= 1.18.0-0"

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.injector.autoScale.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | OpenServiceMesh.injector.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
-| OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count |
+| OpenServiceMesh.injector.replicaCount | int | `1` | Sidecar injector's replica count (ignored when autoscale.enable is true) |
 | OpenServiceMesh.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
 | OpenServiceMesh.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | OpenServiceMesh.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
@@ -115,7 +115,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.osmController.autoScale.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | OpenServiceMesh.osmController.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | OpenServiceMesh.osmController.podLabels | object | `{}` | OSM controller's pod labels |
-| OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count |
+| OpenServiceMesh.osmController.replicaCount | int | `1` | OSM controller's replica count (ignored when autoscale.enable is true) |
 | OpenServiceMesh.osmController.resource | object | `{"limits":{"cpu":"1.5","memory":"512M"},"requests":{"cpu":"0.5","memory":"128M"}}` | OSM controller's container resource parameters |
 | OpenServiceMesh.osmNamespace | string | `""` | Namespace to deploy OSM in. If not specified, the Helm release namespace is used. |
 | OpenServiceMesh.outboundIPRangeExclusionList | list | `[]` | Specifies a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -9,7 +9,9 @@ metadata:
     meshName: {{ .Values.OpenServiceMesh.meshName }}
     {{ if .Values.OpenServiceMesh.enforceSingleMesh }}enforceSingleMesh: "true"{{ end }}
 spec:
+  {{- if not .Values.OpenServiceMesh.osmController.autoScale.enable }}
   replicas: {{ .Values.OpenServiceMesh.osmController.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: osm-controller

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     app: osm-injector
     meshName: {{ .Values.OpenServiceMesh.meshName }}
 spec:
+  {{- if not .Values.OpenServiceMesh.injector.autoScale.enable }}
   replicas: {{ .Values.OpenServiceMesh.injector.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: osm-injector

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -22,7 +22,7 @@ OpenServiceMesh:
   #
   # -- OSM controller parameters
   osmController:
-    # -- OSM controller's replica count
+    # -- OSM controller's replica count (ignored when autoscale.enable is true)
     replicaCount: 1
     # -- OSM controller's container resource parameters
     resource:
@@ -207,7 +207,7 @@ OpenServiceMesh:
   #
   # -- OSM's sidecar injector parameters
   injector:
-    # -- Sidecar injector's replica count
+    # -- Sidecar injector's replica count (ignored when autoscale.enable is true)
     replicaCount: 1
     # -- Sidecar injector's container resource parameters
     resource:

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -20,7 +20,7 @@ func (mc *MeshCatalog) ListOutboundTrafficPolicies(downstreamIdentity identity.S
 	downstreamServiceAccount := downstreamIdentity.ToK8sServiceAccount()
 	if mc.configurator.IsPermissiveTrafficPolicyMode() {
 		var outboundPolicies []*trafficpolicy.OutboundTrafficPolicy
-		mergedPolicies := trafficpolicy.MergeOutboundPolicies(DisallowPartialHostnamesMatch, outboundPolicies, mc.buildOutboundPermissiveModePolicies()...)
+		mergedPolicies := trafficpolicy.MergeOutboundPolicies(DisallowPartialHostnamesMatch, outboundPolicies, mc.buildOutboundPermissiveModePolicies(downstreamServiceAccount.Namespace)...)
 		outboundPolicies = mergedPolicies
 		return outboundPolicies
 	}
@@ -131,7 +131,7 @@ func (mc *MeshCatalog) ListAllowedOutboundServicesForIdentity(serviceIdentity id
 	return allowedServices
 }
 
-func (mc *MeshCatalog) buildOutboundPermissiveModePolicies() []*trafficpolicy.OutboundTrafficPolicy {
+func (mc *MeshCatalog) buildOutboundPermissiveModePolicies(sourceNamespace string) []*trafficpolicy.OutboundTrafficPolicy {
 	var outPolicies []*trafficpolicy.OutboundTrafficPolicy
 
 	k8sServices := mc.kubeController.ListServices()
@@ -141,7 +141,7 @@ func (mc *MeshCatalog) buildOutboundPermissiveModePolicies() []*trafficpolicy.Ou
 	}
 
 	for _, destService := range destServices {
-		hostnames, err := mc.getServiceHostnames(destService, false)
+		hostnames, err := mc.getServiceHostnames(destService, sourceNamespace == destService.Namespace)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error getting service hostnames for service %s", destService)
 			continue


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change backports ada49d0d, d2e01b0f, and a4c20d8e
for release v0.9.2.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
