### PR TITLE
[backport] GetServiceHostnames: Fix nil pointer dereference

### DIFF
--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -177,12 +177,12 @@ func (mc *MeshCatalog) listMeshServices() []service.MeshService {
 // If the service is in the same namespace, it returns the shorthand hostname for the service that does not
 // include its namespace, ex: bookstore, bookstore:80
 func (mc *MeshCatalog) getServiceHostnames(meshService service.MeshService, sameNamespace bool) ([]string, error) {
-	svc := mc.kubeController.GetService(meshService)
-	if svc == nil {
-		return nil, errors.Errorf("Error fetching service %q", meshService)
+	k8sSvc := mc.kubeController.GetService(meshService)
+	if k8sSvc == nil {
+		return nil, errors.Errorf("Service %s not found", meshService.String())
 	}
 
-	hostnames := kubernetes.GetHostnamesForService(svc, sameNamespace)
+	hostnames := kubernetes.GetHostnamesForService(k8sSvc, sameNamespace)
 	return hostnames, nil
 }
 


### PR DESCRIPTION
**Description**:

Under the condition of the service disappearing (or not being
present yet due to informer latency), there was a condition
that could try to dereference a nil pointer.

Fixes #3902

Signed-off-by: Eduard Serra <eduser25@gmail.com>

Backport commit https://github.com/openservicemesh/osm/pull/3903/commits/ed7d04cdc1d467a1893fb38287b2c0b934953af6


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
