### PR TITLE
[backport] Do not send SDS on full config updates

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -114,7 +114,8 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			}
 
 			// Queue a full configuration update
-			<-s.workqueues.AddJob(newJob(envoy.XDSResponseOrder, nil))
+			// Do not send SDS, let envoy figure out what certs does it want.
+			<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeCDS, envoy.TypeEDS, envoy.TypeLDS, envoy.TypeRDS}, nil))
 
 		case certUpdateMsg := <-certAnnouncement:
 			cert := certUpdateMsg.(events.PubSubMessage).NewObj.(certificate.Certificater)


### PR DESCRIPTION
Description:

Backport commit : c32f3c5

Theres a misshandle of XDS resources as our full config push could record we sent some
resources that could be ignored by envoy if envoy is still not interested in them.

Later requests from envoy for that resource and that nonce could ask for resources we have
already sent but were ignored at a previous time, hence making a request an ACK which is not.

This commit prevents pushing certificates on full config updates, which will make SDS almost
entirely envoy-driven; it will prevent us pushing unnecessary certificates that envoy did not
request, hence never potentially allowing us to send ignored resources at a response.

Signed-off-by: Eduard Serra eduser25@gmail.com


1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
1. Is this a breaking change?
No