### PR TITLE
feat(cli): add verbose flag

### DIFF
--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	goflag "flag"
+	"fmt"
 	"io"
 	"os"
 
@@ -83,4 +84,8 @@ func main() {
 }
 
 func debug(format string, v ...interface{}) {
+	if settings.Verbose() {
+		format = fmt.Sprintf("[debug] %s\n", format)
+		fmt.Printf(format, v...)
+	}
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -82,6 +82,7 @@ type EnvConfigInstall struct {
 type EnvSettings struct {
 	envConfig EnvConfig
 	config    *genericclioptions.ConfigFlags
+	verbose   bool
 }
 
 // New relevant environment variables set and returns EnvSettings
@@ -106,6 +107,7 @@ func New() *EnvSettings {
 // AddFlags binds flags to the given flagset.
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.envConfig.Install.Namespace, "osm-namespace", s.envConfig.Install.Namespace, "namespace for osm control plane")
+	fs.BoolVar(&s.verbose, "verbose", s.verbose, "enable verbose output")
 }
 
 // Config returns the environment config
@@ -121,6 +123,11 @@ func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 // Namespace gets the namespace from the configuration
 func (s *EnvSettings) Namespace() string {
 	return s.envConfig.Install.Namespace
+}
+
+// Verbose gets whether verbose output is enabled from the configuration
+func (s *EnvSettings) Verbose() bool {
+	return s.verbose
 }
 
 // IsManaged returns true in a managed OSM environment (ex. managed by a cloud distributor)


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add debug flag to OSM cli to log verbose output when enabled. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| Documentation              | [ ] |
| Install                    | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Ingress                    | [ ] |
| Egress                     | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| SMI Policy                 | [ ] |
| Sidecar Injection          | [ ] |
| Security                   | [ ] |
| Upgrade                    | [ ] |
| Tests                      | [ ] |
| CI System                  | [ ] |
| Demo                       | [ ] |
| Performance                | [ ] |
| Other                      | [ ] |


<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**: Sample output with debug flag enabled, with an invalid CTR_TAG provided. 

Install CMD: 
`./bin/osm install --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" --set=OpenServiceMesh.image.tag="$CTR_TAG" --debug`

Output: 

`2021/08/20 13:53:19 [debug] Loading OSM helm chart`
`2021/08/20 13:53:19 [debug] Verifying no osm-controller in same namespace`
`2021/08/20 13:53:19 [debug] Verifying enforce-single-mesh`
`2021/08/20 13:53:19 [debug] Overriding helm chart values`
`2021/08/20 13:53:19 [debug] Beginning OSM installation`
`2021/08/20 13:53:20 [debug] creating 1 resource(s)`
`2021/08/20 13:53:20 [debug] CRD meshconfigs.config.openservicemesh.io is already present. Skipping.`
`2021/08/20 13:53:20 [debug] creating 1 resource(s)`
`2021/08/20 13:53:20 [debug] CRD multiclusterservices.config.openservicemesh.io is already present. Skipping.`
`2021/08/20 13:53:20 [debug] creating 1 resource(s)`
`2021/08/20 13:53:20 [debug] CRD egresses.policy.openservicemesh.io is already present. Skipping.`
`2021/08/20 13:53:21 [debug] creating 1 resource(s)`
`2021/08/20 13:53:21 [debug] CRD ingressbackends.policy.openservicemesh.io is already present. Skipping.`
`2021/08/20 13:53:21 [debug] creating 1 resource(s)`
`2021/08/20 13:53:21 [debug] CRD httproutegroups.specs.smi-spec.io is already present. Skipping.`
`2021/08/20 13:53:21 [debug] creating 1 resource(s)`
`2021/08/20 13:53:21 [debug] CRD tcproutes.specs.smi-spec.io is already present. Skipping.`
`2021/08/20 13:53:22 [debug] creating 1 resource(s)`
`2021/08/20 13:53:22 [debug] CRD traffictargets.access.smi-spec.io is already present. Skipping.`
`2021/08/20 13:53:22 [debug] creating 1 resource(s)`
`2021/08/20 13:53:22 [debug] CRD trafficsplits.split.smi-spec.io is already present. Skipping.`
`2021/08/20 13:53:25 [debug] creating 1 resource(s)`
`2021/08/20 13:53:25 [debug] Starting delete for "osm-upgrade-crds" ServiceAccount`
`2021/08/20 13:53:25 [debug] serviceaccounts "osm-upgrade-crds" not found`
`2021/08/20 13:53:26 [debug] creating 1 resource(s)`
`2021/08/20 13:53:26 [debug] Starting delete for "osm-upgrade-crds" ClusterRole`
`2021/08/20 13:53:27 [debug] creating 1 resource(s)`
`2021/08/20 13:53:27 [debug] Starting delete for "osm-upgrade-crds" ClusterRoleBinding`
`2021/08/20 13:53:28 [debug] creating 1 resource(s)`
`2021/08/20 13:53:28 [debug] Starting delete for "osm-upgrade-crds" Job`
`2021/08/20 13:53:28 [debug] jobs.batch "osm-upgrade-crds" not found`
`2021/08/20 13:53:28 [debug] creating 1 resource(s)`
`2021/08/20 13:53:28 [debug] Watching for changes to Job osm-upgrade-crds with timeout of 5m0s`
`2021/08/20 13:53:28 [debug] Add/Modify event for osm-upgrade-crds: ADDED`
`2021/08/20 13:53:28 [debug] osm-upgrade-crds: Jobs active: 0, jobs failed: 0, jobs succeeded: 0`
`2021/08/20 13:53:28 [debug] Add/Modify event for osm-upgrade-crds: MODIFIED`
`2021/08/20 13:53:28 [debug] osm-upgrade-crds: Jobs active: 1, jobs failed: 0, jobs succeeded: 0`
`Status for pod osm-upgrade-crds-pc8rj in namespace osm-system:
 {Pending [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2021-08-20 13:53:27 -0400 EDT  } {Ready False 0001-01-01 00:00:00 +0000 UTC 2021-08-20 13:53:27 -0400 EDT ContainersNotReady containers with unready status: [crds-upgrade]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 2021-08-20 13:53:27 -0400 EDT ContainersNotReady containers with unready status: [crds-upgrade]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2021-08-20 13:53:27 -0400 EDT  }]    10.240.0.4 10.244.1.64 [{10.244.1.64}] 2021-08-20 13:53:27 -0400 EDT [] [{crds-upgrade {&ContainerStateWaiting{Reason:ImagePullBackOff,Message:Back-off pulling image "openservicemesh/osm-crds:latest-main-1",} nil nil} {nil nil nil} false 0 openservicemesh/osm-crds:latest-main-1   0xc001416a78}] BestEffort []}`

`Error: failed pre-install: timed out waiting for the condition`



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
