### PR TITLE
envoy: update version to v1.19.0

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -138,7 +138,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
-| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.18.3"` | Envoy sidecar image |
+| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.19.0"` | Envoy sidecar image |
 | OpenServiceMesh.tracing.address | string | `"jaeger.osm-system.svc.cluster.local"` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |
@@ -151,6 +151,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.vault.token | string | `""` | token that should be used to connect to Vault |
 | OpenServiceMesh.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
 | contour.enabled | bool | `false` | Enables deployment of Contour control plane and gateway |
+| contour.envoy | object | `{"image":{"registry":"docker.io","repository":"envoyproxy/envoy-alpine","tag":"v1.19.0"}}` | Contour envoy edge proxy configuration |
 
 <!-- markdownlint-enable MD013 MD034 -->
 <!-- markdownlint-restore -->

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -254,7 +254,7 @@
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
                     "examples": [
-                        "envoyproxy/envoy-alpine:v1.18.3"
+                        "envoyproxy/envoy-alpine:v1.19.0"
                     ]
                 },
                 "certificateProvider": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -17,7 +17,7 @@ OpenServiceMesh:
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
   # -- Envoy sidecar image
-  sidecarImage: envoyproxy/envoy-alpine:v1.18.3
+  sidecarImage: envoyproxy/envoy-alpine:v1.19.0
 
   #
   # -- OSM controller parameters
@@ -301,3 +301,9 @@ OpenServiceMesh:
 contour:
   # -- Enables deployment of Contour control plane and gateway
   enabled: false
+  # -- Contour envoy edge proxy configuration
+  envoy:
+    image:
+      registry: docker.io
+      repository: envoyproxy/envoy-alpine
+      tag: v1.19.0

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -25,7 +25,7 @@ func TestCreateDefaultMeshConfig(t *testing.T) {
   "enablePrivilegedInitContainer": false,
   "logLevel": "error",
   "maxDataPlaneConnections": 0,
-  "envoyImage": "envoyproxy/envoy-alpine:v1.18.3",
+  "envoyImage": "envoyproxy/envoy-alpine:v1.19.0",
   "initContainerImage": "openservicemesh/init:v0.9.1",
   "configResyncInterval": "2s"
 },

--- a/docs/example/manifests/meshconfig/mesh-config.yaml
+++ b/docs/example/manifests/meshconfig/mesh-config.yaml
@@ -7,7 +7,7 @@ spec:
     enablePrivilegedInitContainer: false
     logLevel: error
     maxDataPlaneConnections: 0
-    envoyImage: "envoyproxy/envoy-alpine:v1.18.3"
+    envoyImage: "envoyproxy/envoy-alpine:v1.19.0"
     initContainerImage: "openservicemesh/init:v0.9.1"
     configResyncInterval: "0s"
   traffic:

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -233,7 +233,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			name:                  "GetEnvoyImage",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal("envoyproxy/envoy-alpine:v1.18.3", cfg.GetEnvoyImage())
+				assert.Equal("envoyproxy/envoy-alpine:v1.19.0", cfg.GetEnvoyImage())
 			},
 			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -62,12 +62,12 @@ const (
 	DefaultOSMLogLevel = "info"
 
 	// DefaultEnvoyImage is the default envoy proxy sidecar image if not defined in the osm MeshConfig
-	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.18.3"
+	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.19.0"
 
 	// DefaultEnvoyWindowsImage is the default envoy proxy windows sidecar image if not defined in the osm MeshConfig
 	// TODO(#3864): This should be updated to the nanoserver based image when it becomes available
 	// See https://github.com/envoyproxy/envoy/issues/16759
-	DefaultEnvoyWindowsImage = "envoyproxy/envoy-windows:v1.18.3"
+	DefaultEnvoyWindowsImage = "envoyproxy/envoy-windows:v1.19.0"
 
 	// DefaultInitContainerImage is the default init container image if not defined in the osm MeshConfig
 	DefaultInitContainerImage = "openservicemesh/init:v0.9.1"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the envoy version to v1.19.0 for both
OSM's sidecar and Contour's edge proxy.
Contour 1.18 uses Envoy v1.19.0 by default, but
the Bitnami Helm charts weren't updated to reflect
this change yet. This change also overrides Contour's
envoy image to match the [default upstream version](https://github.com/projectcontour/contour/blob/v1.18.0/examples/render/contour.yaml#L3107) so
that the same version of envoy is used for both the
sidecar and ingress gateway.

<!--

Please describe how are the changes tested? You can add supporting information, E.g. screenshots, logs etc.

-->
**Testing done**:
Tested ingress with Contour.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
