### PR TITLE
Makefile: avoid prompt while overwriting file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ docker-build-osm-bootstrap: build-osm-bootstrap
 
 pkg/envoy/lds/stats.wasm: wasm/stats.cc wasm/Makefile
 	docker run --rm -v $(PWD)/wasm:/work -w /work openservicemesh/proxy-wasm-cpp-sdk:956f0d500c380cc1656a2d861b7ee12c2515a664 /build_wasm.sh
-	@mv wasm/stats.wasm $@
+	@mv -f wasm/stats.wasm $@
 
 .PHONY: docker-build
 docker-build: $(DOCKER_DEMO_TARGETS) docker-build-init docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-bootstrap


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Avoids a prompt if the file already exists.
```
LITE=1 -I/sdk -I/usr/local/include --js-library /sdk/proxy_wasm_intrinsics.js stats.cc /sdk/proxy_wasm_intrinsics_lite.pb.cc /sdk/struct_lite.pb.cc /sdk/proxy_wasm_intrinsics.cc /sdk/libprotobuf-lite.a -o stats.wasm
mv: replace 'pkg/envoy/lds/stats.wasm', overriding mode 0755 (rwxr-xr-x)?
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
