### PR TITLE
charts/osm: use official Contour image

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -150,6 +150,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
 | OpenServiceMesh.vault.token | string | `""` | token that should be used to connect to Vault |
 | OpenServiceMesh.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
+| contour.contour | object | `{"image":{"registry":"docker.io","repository":"projectcontour/contour","tag":"v1.18.0"}}` | Contour controller configuration |
 | contour.enabled | bool | `false` | Enables deployment of Contour control plane and gateway |
 | contour.envoy | object | `{"image":{"registry":"docker.io","repository":"envoyproxy/envoy-alpine","tag":"v1.19.0"}}` | Contour envoy edge proxy configuration |
 

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -301,6 +301,12 @@ OpenServiceMesh:
 contour:
   # -- Enables deployment of Contour control plane and gateway
   enabled: false
+  # -- Contour controller configuration
+  contour:
+    image:
+      registry: docker.io
+      repository: projectcontour/contour
+      tag: v1.18.0
   # -- Contour envoy edge proxy configuration
   envoy:
     image:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
By default, the Bitnami Helm chart for Contour
uses an image from the Bitnami repo, which is
not the image officially used by projectcontour
upstream. This change uses the [default upstream
image](https://github.com/projectcontour/contour/blob/release-1.18/examples/render/contour.yaml#L2721) and registry for the Contour controller.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
```
$ helm template charts/osm/ --set contour.enabled=true  | grep image.*contour
          image: docker.io/projectcontour/contour:v1.18.0
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |
| Install                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
