### PR TITLE
[backport] ads: change resource difference condition from superser to equals

### DIFF
--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -258,15 +258,9 @@ func respondToRequest(proxy *envoy.Proxy, discoveryRequest *xds_discovery.Discov
 	// Get resources last sent prior to this request
 	resourcesLastSent := proxy.GetLastResourcesSent(typeURL)
 
-	// If what we last sent is a superset of what the
-	// requests resources subscribes to, it's ACK and nothing needs to be done.
-	// Otherwise, envoy might be asking us for additional resources that have to be sent along last time's resources.
-	// Difference returns elemenets of <requested> that are not part of elements of <last sent>
-
-	requestedResourcesDifference := resourcesRequested.Difference(resourcesLastSent)
-	if requestedResourcesDifference.Cardinality() != 0 {
-		log.Debug().Msgf("Proxy SerialNumber=%s PodUID=%s: request difference in v:%d - requested: %v lastSent: %v (diff: %v), triggering update",
-			proxy.GetCertificateSerialNumber(), proxy.GetPodUID(), requestVersion, resourcesRequested, resourcesLastSent, requestedResourcesDifference)
+	if !resourcesRequested.Equal(resourcesLastSent) {
+		log.Debug().Msgf("Proxy %s: request difference in v:%d - requested: %v lastSent: %v, triggering update",
+			proxy.String(), requestVersion, resourcesRequested, resourcesLastSent)
 		return true
 	}
 


### PR DESCRIPTION
This PR backports 9507072.

In SotW protocol variants, unsubscriptions are communicated by the client
(proxy) by removing the specific resource from the resources requested list.

https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#unsubscribing-from-resources

This seems to not work well with our superset diff logic as it seems that
envoy does expect to be replied to anytime the set of resources change from,
even if the previous reply could have already covered the new set of requested
resources.

Changing superset logic to equals will make OSM reply as long as the requested
resources are different from the last sent under any circumstance (adding or removing
subscribed resources).

Signed-off-by: Eduard Serra <eduser25@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
