### PR TITLE
ingress: don't error if candidate group version is not available

### DIFF
--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -113,10 +113,6 @@ const (
 
 	// ErrUnmarshallingKubernetesResource indicates that a Kubernetes resource could not be unmarshalled
 	ErrUnmarshallingKubernetesResource
-
-	// ErrGettingSupportedIngressVersions indicates the mapping of Ingress API versions to the corresponding values indicating
-	// if they are supported could not be configured
-	ErrGettingSupportedIngressVersions
 )
 
 // Range 4000-4100 reserved for errors related to certificate providers
@@ -551,10 +547,6 @@ A Kubernetes resource could not be marshalled.
 A Kubernetes resource could not be unmarshalled.
 `,
 
-	ErrGettingSupportedIngressVersions: `
-The Ingress API versions supported by the k8s API server could not be obtained.
-`,
-
 	//
 	// Range 4000-4100
 	//
@@ -728,7 +720,7 @@ The proxy was not allowed to be a part of the mesh.
 `,
 
 	ErrGRPCStreamClosedByProxy: `
-The gRPC stream was closed by the proxy and no DiscoveryRequests can be received. 
+The gRPC stream was closed by the proxy and no DiscoveryRequests can be received.
 The Stream Agreggated Resource server was terminated for the specified proxy.
 `,
 
@@ -809,7 +801,7 @@ The corresponding certificate resource was ignored by the system.
 `,
 
 	ErrGettingServiceCertSecret: `
-An XDS secret containing a TLS certificate could not be retrieved. 
+An XDS secret containing a TLS certificate could not be retrieved.
 The corresponding secret request was ignored by the system.
 `,
 
@@ -835,7 +827,7 @@ A protobuf ProtoMessage could not be converted into YAML.
 `,
 
 	ErrParsingMutatingWebhookCert: `
-The mutating webhook certificate could not be parsed. 
+The mutating webhook certificate could not be parsed.
 The mutating webhook HTTP server was not started.
 `,
 
@@ -852,8 +844,8 @@ The timeout from an AdmissionRequest could not be parsed.
 `,
 
 	ErrInvalidAdmissionReqHeader: `
-The AdmissionRequest's header was invalid. The content type obtained from the 
-header is not supported. 
+The AdmissionRequest's header was invalid. The content type obtained from the
+header is not supported.
 `,
 
 	ErrWritingAdmissionResp: `
@@ -907,7 +899,7 @@ The ValidatingWebhookConfiguration could not be patched with the CA Bundle.
 `,
 
 	ErrParsingValidatingWebhookCert: `
-The validating webhook certificate could not be parsed. 
+The validating webhook certificate could not be parsed.
 The validating webhook HTTP server was not started.
 `,
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
If a candidate API GroupVersion (ex. networking.k8s.io/v1beta1) is not
available, don't error. Only error if none of the candidates are
available (already the case).
This is required for OSM to work in k8s v1.22, where the
networking.k8s.io/v1beta1 is deprecated.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
