### PR TITLE
[backport] ingress: don't error if candidate group version is not available (#4007)

### DIFF
--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -29,12 +29,6 @@ var candidateVersions = []string{networkingV1.SchemeGroupVersion.String(), netwo
 
 // NewIngressClient implements ingress.Monitor and creates the Kubernetes client to monitor Ingress resources.
 func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{}, _ configurator.Configurator) (Monitor, error) {
-	supportedIngressVersions, err := getSupportedIngressVersions(kubeClient.Discovery())
-	if err != nil {
-		log.Error().Err(err).Msgf("Error retrieving ingress API versions supported by k8s API server")
-		return nil, err
-	}
-
 	// Ignore ingresses that have the ignore label
 	ignoreLabel, _ := labels.NewRequirement(constants.IgnoreLabel, selection.DoesNotExist, nil)
 	option := informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
@@ -58,6 +52,8 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 		cacheSynced:    make(chan interface{}),
 		kubeController: kubeController,
 	}
+
+	supportedIngressVersions := getSupportedIngressVersions(kubeClient.Discovery())
 
 	if v1Supported, ok := supportedIngressVersions[networkingV1.SchemeGroupVersion.String()]; ok && v1Supported {
 		c.informerV1 = informerFactory.Networking().V1().Ingresses().Informer()
@@ -205,14 +201,12 @@ func (c client) GetIngressNetworkingV1(meshService service.MeshService) ([]*netw
 }
 
 // getSupportedIngressVersions returns a map comprising of keys matching candidate ingress API versions
-// and corresponding values indidicating if they are supported by the k8s API server or not. An error
-// is returned in case this cannot be determined.
+// and corresponding values indidicating if they are supported by the k8s API server or not.
 // Example return values:
-// - only networking.k8s.io/v1 is supported: {'networking.k8s.io/v1': true, 'networking.k8s.io/v1beta1': false}, nil
-// - only networking.k8s.io/v1beta1 is supported: {'networking.k8s.io/v1': false, 'networking.k8s.io/v1beta1': true}, nil
-// - both networking.k8s.io/v1 and networking.k8s.io/v1beta1 are supported: {'networking.k8s.io/v1': true, 'networking.k8s.io/v1beta1': true}, nil
-// - on error: nil, error
-func getSupportedIngressVersions(client discovery.ServerResourcesInterface) (map[string]bool, error) {
+// - only networking.k8s.io/v1 is supported: {'networking.k8s.io/v1': true, 'networking.k8s.io/v1beta1': false}
+// - only networking.k8s.io/v1beta1 is supported: {'networking.k8s.io/v1': false, 'networking.k8s.io/v1beta1': true}
+// - both networking.k8s.io/v1 and networking.k8s.io/v1beta1 are supported: {'networking.k8s.io/v1': true, 'networking.k8s.io/v1beta1': true}
+func getSupportedIngressVersions(client discovery.ServerResourcesInterface) map[string]bool {
 	versions := make(map[string]bool)
 
 	for _, groupVersion := range candidateVersions {
@@ -221,7 +215,8 @@ func getSupportedIngressVersions(client discovery.ServerResourcesInterface) (map
 
 		list, err := client.ServerResourcesForGroupVersion(groupVersion)
 		if err != nil {
-			return nil, err
+			// The 'groupVersion' is not supported by the API server
+			continue
 		}
 
 		for _, elem := range list.APIResources {
@@ -232,5 +227,5 @@ func getSupportedIngressVersions(client discovery.ServerResourcesInterface) (map
 		}
 	}
 
-	return versions, nil
+	return versions
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Backports f96e93d9 to allow v0.9.2 to work with v1.22
of k8s.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
