### PR TITLE
feat(multicluster): config cluster LB weight

### DIFF
--- a/charts/osm/crds/config_multicluster_service.yaml
+++ b/charts/osm/crds/config_multicluster_service.yaml
@@ -86,6 +86,10 @@ spec:
                         type: integer
                         minimum: 0
                         default: 0
+                      priority:
+                        description: Priority of the remote cluster in locality based load balancing
+                        type: integer
+                        minimum: 0
                       certificate:
                         description: mTLS certificates (optional)
                         type: string

--- a/demo/deploy-MultiClusterService.sh
+++ b/demo/deploy-MultiClusterService.sh
@@ -28,5 +28,6 @@ spec:
   clusters:
   - name: $BETA_CLUSTER
     address: $BETA_OSM_GATEWAY_IP:15443
+    weight: 20
   serviceAccount: bookstore-v1
 EOF

--- a/demo/multicluster-fault-injection.sh
+++ b/demo/multicluster-fault-injection.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+
+# shellcheck disable=SC1091
+source .env
+
+BOOKBUYER_NAMESPACE="${BOOKBUYER_NAMESPACE:-bookbuyer}"
+BOOKSTORE_NAMESPACE="${BOOKSTORE_NAMESPACE:-bookstore}"
+BOOKSTORE_SVC="bookstore-v1"
+
+action=$1
+
+if [ "$action" != "apply" ] && [ "$action" != "delete" ]; then
+  echo "Must pass in 'apply' or 'delete' as parameter.
+
+Usage: multicluster-fault-inject.sh [apply|delete]
+
+apply:  inject faults to bookstore service
+delete: remove faults from bookstore service"
+  exit 1
+fi
+
+kubectl "$action" -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: errors
+  namespace: $BOOKSTORE_NAMESPACE
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: $BOOKSTORE_SVC
+      purpose: fault
+  template:
+    metadata:
+      labels:
+        app: $BOOKSTORE_SVC
+        purpose: fault
+      annotations:
+        openservicemesh.io/sidecar-injection: "false"
+    spec:
+      serviceAccountName: "$BOOKSTORE_SVC"
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+        - image: curlimages/curl
+          imagePullPolicy: IfNotPresent
+          name: curl
+          command: ["sleep", "365d"]
+EOF

--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -126,6 +126,7 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
         --set=OpenServiceMesh.envoyLogLevel="$ENVOY_LOG_LEVEL" \
         --set=OpenServiceMesh.controllerLogLevel="trace" \
         --set=OpenServiceMesh.featureFlags.enableMulticlusterMode="true" \
+        --set=OpenServiceMesh.featureFlags.enableEnvoyActiveHealthChecks="true" \
         --timeout="$TIMEOUT" \
         $optionalInstallArgs
 
@@ -157,6 +158,10 @@ done
 
 echo "Switching to $ALPHA_CLUSTER"
 kubectl config use-context "$ALPHA_CLUSTER"
+
+echo "Injecting unavailable workloads to $BOOKSTORE_NAMESPACE/$BOOKBUYER_SVC"
+./demo/multicluster-fault-injection.sh apply
+echo "Run './demo/multicluster-fault-injection.sh delete' after the demo if you want to remove the injected faulty workloads."
 
 echo "Bookbuyer logs... (showing identity of responding bookstore pods)"
 sleep 2

--- a/pkg/apis/config/v1alpha1/multi_cluster_service.go
+++ b/pkg/apis/config/v1alpha1/multi_cluster_service.go
@@ -50,6 +50,9 @@ type ClusterSpec struct {
 
 	// Weight defines the load balancing weight of the remote cluster
 	Weight int `json:"weight,omitempty"`
+
+	// Priority defines the priority of the remote cluster in locality based load balancing
+	Priority int `json:"priority,omitempty"`
 }
 
 // PortSpec contains information on service's port.

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -30,8 +30,13 @@ type Provider interface {
 
 // Endpoint is a tuple of IP and Port representing an instance of a service
 type Endpoint struct {
-	net.IP `json:"ip"`
-	Port   `json:"port"`
+	net.IP   `json:"ip"`
+	Port     `json:"port"`
+	Weight   `json:"weight"`
+	Priority `json:"priority,omitempty"`
+
+	// Zone is the zone the endpoint resides in.
+	Zone string `json:"name"`
 }
 
 func (ep Endpoint) String() string {
@@ -40,3 +45,9 @@ func (ep Endpoint) String() string {
 
 // Port is a numerical type representing a port on which a service is exposed
 type Port uint32
+
+// Weight is the load assignment weight to the endpoint. The assignment works on the endpoints with the same priority.
+type Weight uint32
+
+// Priority is the priority of the remote cluster in locality based load balancing
+type Priority uint32

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -760,8 +760,10 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 						Name:    "remote-cluster-1",
 					},
 					{
-						Address: "5.6.7.8:8080",
-						Name:    "remote-cluster-2",
+						Address:  "5.6.7.8:8080",
+						Name:     "remote-cluster-2",
+						Weight:   1,
+						Priority: 2,
 					},
 				},
 				ServiceAccount: destSA.Name,
@@ -783,12 +785,18 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 
 	assert.ElementsMatch(endpoints, []endpoint.Endpoint{
 		{
-			IP:   net.ParseIP("1.2.3.4"),
-			Port: 8080,
+			IP:       net.ParseIP("1.2.3.4"),
+			Port:     8080,
+			Weight:   0,
+			Priority: 0,
+			Zone:     "remote-cluster-1",
 		},
 		{
-			IP:   net.ParseIP("5.6.7.8"),
-			Port: 8080,
+			IP:       net.ParseIP("5.6.7.8"),
+			Port:     8080,
+			Weight:   1,
+			Priority: 2,
+			Zone:     "remote-cluster-2",
 		},
 	})
 }

--- a/pkg/providers/kube/multiclusterservice.go
+++ b/pkg/providers/kube/multiclusterservice.go
@@ -48,8 +48,11 @@ func (c *client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount
 			}
 
 			ep := endpoint.Endpoint{
-				IP:   ip,
-				Port: endpoint.Port(port),
+				IP:       ip,
+				Port:     endpoint.Port(port),
+				Weight:   endpoint.Weight(cluster.Weight),
+				Priority: endpoint.Priority(cluster.Priority),
+				Zone:     cluster.Name,
 			}
 			endpoints = append(endpoints, ep)
 		}

--- a/pkg/providers/kube/multiclusterservice_test.go
+++ b/pkg/providers/kube/multiclusterservice_test.go
@@ -51,6 +51,7 @@ func TestHelperFunctions(t *testing.T) {
 	expectedEndpoint := []endpoint.Endpoint{{
 		IP:   net.IPv4(1, 2, 3, 4),
 		Port: 5678,
+		Zone: "alpha",
 	}}
 
 	toReturnServices := []v1alpha1.MultiClusterService{{


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Multicluster mode support locality based load balancing. [Here is the POC](https://github.com/openservicemesh/osm/issues/3557). Traffic will be balanced to remote clusters when local cluster starts to lose available workloads.

[Here is the design doc for this feature](https://docs.google.com/document/d/1OxDPYkdffEJmraSMZpl83JOt3Kjxjfmoehp4T1ebpfs/edit#).

In this PR, we have some assumptions.

* Local endpoints have priority of 0, which is the highest priority

Related issue: #3043 

#### Multicluster demo changes

After adding this feature, in the original multicluster demo, traffic will be 100% routed to alpha cluster.  Locality based LB starts to work when the workload availability of the highest priority subset drops to below 71% (by Envoy default). To demonstrate this behavior, a new process of injecting faulty workloads is added to the multicluster demo, which injects 4 unresponsive bookstore pods, makes the availability to 20%. Thus, the demo can still traffic being splitted between alpha and beta clusters. Without the change, the multicluster demo will route traffic on alpha cluster only.

Here is how we check the healthiness of pods from bookbstore:

```
$ osm proxy get clusters bookbuyer-7577c96df9-tbsfw -n bookbuyer | grep 'health'

osm-controller::10.0.74.109:15128::health_flags::healthy
bookstore/bookstore-v1::10.1.9.49:14001::health_flags::healthy
bookstore/bookstore-v1::10.1.9.24:14001::health_flags::/failed_active_hc
bookstore/bookstore-v1::10.1.8.69:14001::health_flags::/failed_active_hc
bookstore/bookstore-v1::10.1.8.231:14001::health_flags::/failed_active_hc
bookstore/bookstore-v1::10.1.8.46:14001::health_flags::/failed_active_hc
bookstore/bookstore-v1::10.1.17.0:15443::health_flags::healthy
envoy-metrics-cluster::127.0.0.1:15000::health_flags::healthy
```

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

✅ Unit test
✅ Manual test
✅ Multicluster demo

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [X] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No
