### PR TITLE
chore(release): update image version to v0.9.2

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.2-rc.1
+version: 0.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.9.2-rc.1
+appVersion: 0.9.2
 
 # This specifies a particular range of k8s versions that the application is compatible with.
 kubeVersion: ">= 1.18.0-0"

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -94,7 +94,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.grafana.port | int | `3000` | Grafana service's port |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy |
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` | Container image registry |
-| OpenServiceMesh.image.tag | string | `"v0.9.2-rc.1"` | Container image tag |
+| OpenServiceMesh.image.tag | string | `"v0.9.2"` | Container image tag |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.inboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
 | OpenServiceMesh.injector.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |

--- a/charts/osm/crds/meshconfig.yaml
+++ b/charts/osm/crds/meshconfig.yaml
@@ -71,7 +71,7 @@ spec:
                     initContainerImage:
                       description: Image for the init container
                       type: string
-                      default: "openservicemesh/init:v0.9.2-rc.1"
+                      default: "openservicemesh/init:v0.9.2"
                     resources:
                       type: object
                       properties:

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -12,7 +12,7 @@ OpenServiceMesh:
     # -- Container image pull policy
     pullPolicy: IfNotPresent
     # -- Container image tag
-    tag: v0.9.2-rc.1
+    tag: v0.9.2
 
   # -- `osm-controller` image pull secret
   imagePullSecrets: []

--- a/cmd/cli/mesh_upgrade.go
+++ b/cmd/cli/mesh_upgrade.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultContainerRegistry = "openservicemesh"
-	defaultOsmImageTag       = "v0.9.2-rc.1"
+	defaultOsmImageTag       = "v0.9.2"
 )
 
 const upgradeDesc = `

--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -31,7 +31,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookbuyer
-          image: openservicemesh/bookbuyer:v0.9.2-rc.1
+          image: openservicemesh/bookbuyer:v0.9.2
           imagePullPolicy: Always
           command: ["/bookbuyer"]
           env:

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -46,7 +46,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:v0.9.2-rc.1
+          image: openservicemesh/bookstore:v0.9.2
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -46,7 +46,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:v0.9.2-rc.1
+          image: openservicemesh/bookstore:v0.9.2
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -30,7 +30,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookthief
-          image: openservicemesh/bookthief:v0.9.2-rc.1
+          image: openservicemesh/bookthief:v0.9.2
           imagePullPolicy: Always
           command: ["/bookthief"]
           env:

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -47,6 +47,6 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookwarehouse
-          image: openservicemesh/bookwarehouse:v0.9.2-rc.1
+          image: openservicemesh/bookwarehouse:v0.9.2
           imagePullPolicy: Always
           command: ["/bookwarehouse"]

--- a/docs/example/manifests/meshconfig/mesh-config.yaml
+++ b/docs/example/manifests/meshconfig/mesh-config.yaml
@@ -8,7 +8,7 @@ spec:
     logLevel: error
     maxDataPlaneConnections: 0
     envoyImage: "envoyproxy/envoy-alpine:v1.18.3"
-    initContainerImage: "openservicemesh/init:v0.9.2-rc.1"
+    initContainerImage: "openservicemesh/init:v0.9.2"
     configResyncInterval: "0s"
   traffic:
     enableEgress: false

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -249,7 +249,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			name:                  "GetInitContainerImage",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal("openservicemesh/init:v0.9.2-rc.1", cfg.GetInitContainerImage())
+				assert.Equal("openservicemesh/init:v0.9.2", cfg.GetInitContainerImage())
 			},
 			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -62,7 +62,7 @@ const (
 	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.18.3"
 
 	// DefaultInitContainerImage is the default init container image if not defined in the osm MeshConfig
-	DefaultInitContainerImage = "openservicemesh/init:v0.9.2-rc.1"
+	DefaultInitContainerImage = "openservicemesh/init:v0.9.2"
 
 	// EnvoyPrometheusInboundListenerPort is Envoy's inbound listener port number for prometheus
 	EnvoyPrometheusInboundListenerPort = 15010


### PR DESCRIPTION
**Description**:

- [X] I have cherry-picked any changes [labelled](https://github.com/openservicemesh/osm/labels) `needs-cherry-pick-vX.Y.Z`
- [X] I have made all of the following version and patch updates:
  1. Updated the container image tag in charts/osm/values.yaml
  2. Updated the chart **and** app version in charts/osm/Chart.yaml
  3. Updated the image tags used in the demo manifests
  4. Regenerated the Helm chart README.md

- [X] I have checked that the base branch for this PR is correct as defined by the release guide

Is this a release candidate? `no`

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>



