### PR TITLE
feat(e2e): Remove dependency on oc for SCC

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1435,14 +1435,14 @@ func (td *OsmTestData) GrabLogs() error {
 	return nil
 }
 
-// AddOpenShiftSCC adds the specified SecurityContextConstraint to the given service account
-func (td *OsmTestData) AddOpenShiftSCC(scc, serviceAccount, namespace string) error {
+// addOpenShiftSCC adds the specified SecurityContextConstraint to the given service account
+func (td *OsmTestData) addOpenShiftSCC(scc, serviceAccount, namespace string) error {
 	if !td.DeployOnOpenShift {
 		return errors.Errorf("Tests are not configured for OpenShift. Try again with -deployOnOpenShift=true")
 	}
 
 	roleName := serviceAccount + "-scc"
-	roleDefinition := td.SimpleRole(roleName, namespace)
+	roleDefinition := td.simpleRole(roleName, namespace)
 	policyRule := rbacv1.PolicyRule{
 		APIGroups:     []string{"security.openshift.io"},
 		ResourceNames: []string{scc},
@@ -1451,13 +1451,13 @@ func (td *OsmTestData) AddOpenShiftSCC(scc, serviceAccount, namespace string) er
 	}
 	roleDefinition.Rules = []rbacv1.PolicyRule{policyRule}
 
-	_, err := td.CreateRole(namespace, &roleDefinition)
+	_, err := td.createRole(namespace, &roleDefinition)
 	if err != nil {
 		return errors.Errorf("Failed to create Role %s: %s", roleName, err)
 	}
 
 	roleBindingName := serviceAccount + "-scc"
-	roleBindingDefinition := td.SimpleRoleBinding(roleBindingName, namespace)
+	roleBindingDefinition := td.simpleRoleBinding(roleBindingName, namespace)
 	subject := rbacv1.Subject{
 		Kind:      "ServiceAccount",
 		Name:      serviceAccount,
@@ -1471,7 +1471,7 @@ func (td *OsmTestData) AddOpenShiftSCC(scc, serviceAccount, namespace string) er
 	}
 	roleBindingDefinition.RoleRef = roleRef
 
-	_, err = td.CreateRoleBinding(namespace, &roleBindingDefinition)
+	_, err = td.createRoleBinding(namespace, &roleBindingDefinition)
 	if err != nil {
 		return errors.Errorf("Failed to create RoleBinding %s: %s", roleBindingName, err)
 	}

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -20,6 +20,7 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -79,6 +80,28 @@ func (td *OsmTestData) CreateServiceAccount(ns string, svcAccount *corev1.Servic
 		return svcAc, err
 	}
 	return svcAc, nil
+}
+
+// CreateRole is a wrapper to create a role
+func (td *OsmTestData) CreateRole(ns string, role *rbacv1.Role) (*rbacv1.Role, error) {
+	r, err := td.Client.RbacV1().Roles(ns).Create(context.Background(), role, metav1.CreateOptions{})
+	if err != nil {
+		err := fmt.Errorf("Could not create Role: %v", err)
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// CreateRoleBinding is a wrapper to create a role binding
+func (td *OsmTestData) CreateRoleBinding(ns string, roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+	rb, err := td.Client.RbacV1().RoleBindings(ns).Create(context.Background(), roleBinding, metav1.CreateOptions{})
+	if err != nil {
+		err := fmt.Errorf("Could not create RoleBinding: %v", err)
+		return nil, err
+	}
+
+	return rb, nil
 }
 
 // CreatePod is a wrapper to create a pod
@@ -278,6 +301,28 @@ func (td *OsmTestData) SimpleServiceAccount(name string, namespace string) corev
 		},
 	}
 	return serviceAccountDefinition
+}
+
+// SimpleRole returns a k8s typed definition for a role.
+func (td *OsmTestData) SimpleRole(name string, namespace string) rbacv1.Role {
+	roleDefinition := rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return roleDefinition
+}
+
+// SimpleRoleBinding returns a k8s typed definition for a role binding.
+func (td *OsmTestData) SimpleRoleBinding(name string, namespace string) rbacv1.RoleBinding {
+	roleBindingDefinition := rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	return roleBindingDefinition
 }
 
 // getKubernetesServerVersionNumber returns the version number in chunks, ex. v1.19.3 => [1, 19, 3]

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -76,14 +76,14 @@ func (td *OsmTestData) CreateServiceAccount(ns string, svcAccount *corev1.Servic
 		return nil, err
 	}
 	if Td.DeployOnOpenShift {
-		err = Td.AddOpenShiftSCC("privileged", svcAc.Name, svcAc.Namespace)
+		err = Td.addOpenShiftSCC("privileged", svcAc.Name, svcAc.Namespace)
 		return svcAc, err
 	}
 	return svcAc, nil
 }
 
-// CreateRole is a wrapper to create a role
-func (td *OsmTestData) CreateRole(ns string, role *rbacv1.Role) (*rbacv1.Role, error) {
+// createRole is a wrapper to create a role
+func (td *OsmTestData) createRole(ns string, role *rbacv1.Role) (*rbacv1.Role, error) {
 	r, err := td.Client.RbacV1().Roles(ns).Create(context.Background(), role, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create Role: %v", err)
@@ -93,8 +93,8 @@ func (td *OsmTestData) CreateRole(ns string, role *rbacv1.Role) (*rbacv1.Role, e
 	return r, nil
 }
 
-// CreateRoleBinding is a wrapper to create a role binding
-func (td *OsmTestData) CreateRoleBinding(ns string, roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+// createRoleBinding is a wrapper to create a role binding
+func (td *OsmTestData) createRoleBinding(ns string, roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 	rb, err := td.Client.RbacV1().RoleBindings(ns).Create(context.Background(), roleBinding, metav1.CreateOptions{})
 	if err != nil {
 		err := fmt.Errorf("Could not create RoleBinding: %v", err)
@@ -303,8 +303,8 @@ func (td *OsmTestData) SimpleServiceAccount(name string, namespace string) corev
 	return serviceAccountDefinition
 }
 
-// SimpleRole returns a k8s typed definition for a role.
-func (td *OsmTestData) SimpleRole(name string, namespace string) rbacv1.Role {
+// simpleRole returns a k8s typed definition for a role.
+func (td *OsmTestData) simpleRole(name string, namespace string) rbacv1.Role {
 	roleDefinition := rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -314,8 +314,8 @@ func (td *OsmTestData) SimpleRole(name string, namespace string) rbacv1.Role {
 	return roleDefinition
 }
 
-// SimpleRoleBinding returns a k8s typed definition for a role binding.
-func (td *OsmTestData) SimpleRoleBinding(name string, namespace string) rbacv1.RoleBinding {
+// simpleRoleBinding returns a k8s typed definition for a role binding.
+func (td *OsmTestData) simpleRoleBinding(name string, namespace string) rbacv1.RoleBinding {
 	roleBindingDefinition := rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes dependency on oc binary by using the client-go API directly to program SecurityContextConstraints for OpenShift
Fixes #3999 
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
2. Is this a breaking change?
No