### PR TITLE
ref(cli): extract policy check-pod helpers into pkg/cli for reuse

### DIFF
--- a/pkg/cli/policy_check.go
+++ b/pkg/cli/policy_check.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	serviceAccountKind = "ServiceAccount"
+)
+
+// DoesTargetRefDstPod checks whether the TrafficTarget spec refers to the destination pod's service account
+func DoesTargetRefDstPod(spec v1alpha3.TrafficTargetSpec, dstPod *corev1.Pod) bool {
+	if spec.Destination.Kind != serviceAccountKind {
+		return false
+	}
+
+	// Map traffic targets to the given pods
+	if spec.Destination.Name == dstPod.Spec.ServiceAccountName && spec.Destination.Namespace == dstPod.Namespace {
+		return true
+	}
+	return false
+}
+
+// DoesTargetRefSrcPod checks whether the TrafficTarget spec refers to the source pod's service account
+func DoesTargetRefSrcPod(spec v1alpha3.TrafficTargetSpec, srcPod *corev1.Pod) bool {
+	for _, source := range spec.Sources {
+		if source.Kind != serviceAccountKind {
+			continue
+		}
+
+		if source.Name == srcPod.Spec.ServiceAccountName && source.Namespace == srcPod.Namespace {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Extracts helpers to be reused by osm-health: https://github.com/openservicemesh/osm-health/pull/69

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [x] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
no