### PR TITLE
cli: provide environment override capability

### DIFF
--- a/cmd/cli/env.go
+++ b/cmd/cli/env.go
@@ -42,34 +42,29 @@ package main
 import (
 	"fmt"
 	"io"
-	"sort"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 )
 
 const envHelp = `
 This command prints out all the environment information used by OSM
 `
 
-func newEnvCmd(out io.Writer) *cobra.Command {
+func newEnvCmd(stdout io.Writer, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "osm client environment information",
 		Long:  envHelp,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			envVars := settings.EnvVars()
-
-			// Sort the variables by alphabetical order.
-			// This allows for a constant output across calls to 'osm env'.
-			var keys []string
-			for k := range envVars {
-				keys = append(keys, k)
+			envConfig := settings.Config()
+			config, err := yaml.Marshal(&envConfig)
+			if err != nil {
+				fmt.Fprintf(stderr, "Error redendering environment information: %s", err)
+				return
 			}
-			sort.Strings(keys)
-			for _, k := range keys {
-				fmt.Fprintf(out, "%s=\"%s\"\n", k, envVars[k])
-			}
+			fmt.Printf("--- \n%s\n", string(config))
 		},
 	}
 	return cmd

--- a/cmd/cli/mesh.go
+++ b/cmd/cli/mesh.go
@@ -22,7 +22,10 @@ func newMeshCmd(config *action.Configuration, in io.Reader, out io.Writer) *cobr
 		Args:  cobra.NoArgs,
 	}
 	cmd.AddCommand(newMeshList(out))
-	cmd.AddCommand(newMeshUpgradeCmd(config, out))
+
+	if !settings.IsManaged() {
+		cmd.AddCommand(newMeshUpgradeCmd(config, out))
+	}
 
 	return cmd
 }

--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -37,17 +37,23 @@ func newRootCmd(config *action.Configuration, stdin io.Reader, stdout io.Writer,
 	// Add subcommands here
 	cmd.AddCommand(
 		newMeshCmd(config, stdin, stdout),
-		newEnvCmd(stdout),
-		newInstallCmd(config, stdout),
-		newDashboardCmd(config, stdout),
+		newEnvCmd(stdout, stderr),
 		newNamespaceCmd(stdout),
 		newMetricsCmd(stdout),
 		newVersionCmd(stdout),
 		newProxyCmd(config, stdout),
 		newPolicyCmd(stdout, stderr),
-		newUninstallCmd(config, stdin, stdout),
 		newSupportCmd(config, stdout, stderr),
 	)
+
+	// Add subcommands related to unmanaged environments
+	if !settings.IsManaged() {
+		cmd.AddCommand(
+			newInstallCmd(config, stdout),
+			newUninstallCmd(config, stdin, stdout),
+			newDashboardCmd(config, stdout),
+		)
+	}
 
 	_ = flags.Parse(args)
 

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -43,53 +43,74 @@ environment variables: https://github.com/helm/helm/blob/master/pkg/cli/environm
 package cli
 
 import (
+	"fmt"
 	"os"
+	"path"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
+	"gopkg.in/yaml.v2"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 const (
-	defaultOSMNamespace = "osm-system"
-	osmNamespaceEnvVar  = "OSM_NAMESPACE"
+	osmConfigEnvVar = "OSM_CONFIG"
 )
+
+const (
+	installKindManaged    = "managed"
+	installKindSelfHosted = "self-hosted"
+)
+
+const (
+	defaultOSMNamespace = "osm-system"
+)
+
+// EnvConfig represents the environment configuration of OSM
+type EnvConfig struct {
+	Install EnvConfigInstall `yaml:"install"`
+}
+
+// EnvConfigInstall represents the environment configuration of OSM install
+type EnvConfigInstall struct {
+	Kind         string `yaml:"kind"`
+	Distribution string `yaml:"distribution"`
+	Namespace    string `yaml:"namespace"`
+}
 
 // EnvSettings describes all of the cli environment settings
 type EnvSettings struct {
-	namespace string
+	envConfig EnvConfig
 	config    *genericclioptions.ConfigFlags
 }
 
 // New relevant environment variables set and returns EnvSettings
 func New() *EnvSettings {
+	envConfig, err := envFromConfig()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing environment configuration: %s\n", err)
+		os.Exit(1)
+	}
+
 	env := &EnvSettings{
-		namespace: envOr(osmNamespaceEnvVar, defaultOSMNamespace),
+		envConfig: *envConfig,
 	}
 
 	// bind to kubernetes config flags
 	env.config = &genericclioptions.ConfigFlags{
-		Namespace: &env.namespace,
+		Namespace: &env.envConfig.Install.Namespace,
 	}
 	return env
 }
 
-func envOr(name, defaultVal string) string {
-	if v, ok := os.LookupEnv(name); ok {
-		return v
-	}
-	return defaultVal
-}
-
 // AddFlags binds flags to the given flagset.
 func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&s.namespace, "osm-namespace", s.namespace, "namespace for osm control plane")
+	fs.StringVar(&s.envConfig.Install.Namespace, "osm-namespace", s.envConfig.Install.Namespace, "namespace for osm control plane")
 }
 
-// EnvVars returns a map of all OSM related environment variables
-func (s *EnvSettings) EnvVars() map[string]string {
-	return map[string]string{
-		osmNamespaceEnvVar: s.Namespace(),
-	}
+// Config returns the environment config
+func (s *EnvSettings) Config() EnvConfig {
+	return s.envConfig
 }
 
 // RESTClientGetter gets the kubeconfig from EnvSettings
@@ -99,8 +120,55 @@ func (s *EnvSettings) RESTClientGetter() genericclioptions.RESTClientGetter {
 
 // Namespace gets the namespace from the configuration
 func (s *EnvSettings) Namespace() string {
-	if ns, _, err := s.config.ToRawKubeConfigLoader().Namespace(); err == nil {
-		return ns
+	return s.envConfig.Install.Namespace
+}
+
+// IsManaged returns true in a managed OSM environment (ex. managed by a cloud distributor)
+func (s *EnvSettings) IsManaged() bool {
+	return s.envConfig.Install.Kind == installKindManaged
+}
+
+// envFromConfig returns the environment information from the config file.
+// The config file is looked up as follows:
+// 1. Look for config file specified in OSM_CONFIG env var. If set, use it.
+// 2. If 1. is not applicable, look for a file in $HOME/.osm/config; if file exists use it
+// 3. If neither of 1. and 2. apply, use system defaults.
+func envFromConfig() (*EnvConfig, error) {
+	configFile, ok := os.LookupEnv(osmConfigEnvVar)
+	if !ok {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		configFile = path.Join(homeDir, ".osm", "config.yaml")
 	}
-	return "default"
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		// Config file does not exist, use defaults
+		return &EnvConfig{
+			Install: EnvConfigInstall{
+				Kind:      installKindSelfHosted,
+				Namespace: defaultOSMNamespace,
+			},
+		}, nil
+	}
+
+	// Populate environment info from config file
+	f, err := os.Open(filepath.Clean(configFile))
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing file: %s\n", err)
+		}
+	}()
+
+	var cfg EnvConfig
+	decoder := yaml.NewDecoder(f)
+	err = decoder.Decode(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Provides the capability to override default namespace
and commands in osm cli. This is required to provide
a better experience of osm cli in managed environments,
where users can be advised to use a config file to to override
defaults.

It works as follows:
1. If osm config file is present, either in $HOME/.osm/config
   or specified via the OSM_CONFIG env var, this file will be
   used for environment defaults. This works similar to
   KUBECONFIG where the env variable overrides the static
   file if present.
2. If osm config file is not present, defaults values are
   used for the environment configurations.
3. If the install kind is set to `managed` in the config file,
   then install/uninstall/upgrade/dashboard commands which
   are only meant for self-hosted environments are disabled.

Part of #3978

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
1. When no config file is specified via OSM_CONFIG env var or $HOME/.osm/config:
```
$ osm env
--- 
install:
  kind: self-hosted
  distribution: ""
  namespace: osm-system

$ osm -h | grep osm-namespace
      --osm-namespace string   namespace for osm control plane (default "osm-system")
```

2. When OSM_CONFIG env var is used to specify a config file:
```
$ cat /tmp/osmconfig.yaml 
install:
  kind: managed
  distribution: AKS
  namespace: kube-system

$ OSM_CONFIG=/tmp/osmconfig.yaml osm env
--- 
install:
  kind: managed
  distribution: AKS
  namespace: kube-system

$ OSM_CONFIG=/tmp/osmconfig.yaml osm -h | grep osm-namespace
      --osm-namespace string   namespace for osm control plane (default "kube-system")
```

3. When $HOME/.osm/config is present and OSM_CONFIG env var is not set:
```
 cat ~/.osm/config.yaml
install:
  kind: self-hosted
  distribution: Kind
  namespace: osm-system

$ osm env
--- 
install:
  kind: self-hosted
  distribution: Kind
  namespace: osm-system

$ osm -h | grep osm-namespace
      --osm-namespace string   namespace for osm control plane (default "osm-system")
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
