### PR TITLE
feat(windows): Make Egress test pass on Windows

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -139,6 +139,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.19.0"` | Envoy sidecar image |
+| OpenServiceMesh.sidecarWindowsImage | string | `"envoyproxy/envoy-windows:v1.19.0"` |  |
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |

--- a/charts/osm/crds/config_meshconfig.yaml
+++ b/charts/osm/crds/config_meshconfig.yaml
@@ -64,6 +64,11 @@ spec:
                     envoyImage:
                       description: Image for the Envoy sidecar
                       type: string
+                      default: "envoyproxy/envoy-alpine:v1.19.0"
+                    envoyWindowsImage:
+                      description: Image for the Envoy sidecar on Windows workers
+                      type: string
+                      default: "envoyproxy/envoy-windows:v1.19.0"
                     initContainerImage:
                       description: Image for the init container
                       type: string

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -10,6 +10,7 @@ data:
         "logLevel": "{{.Values.OpenServiceMesh.envoyLogLevel}}",
         "maxDataPlaneConnections": {{.Values.OpenServiceMesh.maxDataPlaneConnections}},
         "envoyImage": "{{.Values.OpenServiceMesh.sidecarImage}}",
+        "envoyWindowsImage": "{{.Values.OpenServiceMesh.sidecarWindowsImage}}",
         "initContainerImage": "{{ .Values.OpenServiceMesh.image.registry }}/init:{{ .Values.OpenServiceMesh.image.tag }}",
         "configResyncInterval": "{{.Values.OpenServiceMesh.configResyncInterval}}"
       },

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -257,6 +257,15 @@
                         "envoyproxy/envoy-alpine:v1.19.0"
                     ]
                 },
+                "sidecarWindowsImage": {
+                    "$id": "#/properties/OpenServiceMesh/properties/sidecarWindowsImage",
+                    "type": "string",
+                    "title": "The sidecarWindowsImage schema",
+                    "description": "The proxy side car image to run on Windows payloads.",
+                    "examples": [
+                        "envoyproxy/envoy-windows:v1.19.0"
+                    ]
+                },
                 "certificateProvider": {
                     "$id": "#/properties/OpenServiceMesh/properties/certificateProvider",
                     "type": "object",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -18,6 +18,7 @@ OpenServiceMesh:
   imagePullSecrets: []
   # -- Envoy sidecar image
   sidecarImage: envoyproxy/envoy-alpine:v1.19.0
+  sidecarWindowsImage: envoyproxy/envoy-windows:v1.19.0
 
   #
   # -- OSM controller parameters

--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -1,8 +1,6 @@
 package bootstrap
 
 import (
-	"time"
-
 	xds_accesslog_config "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	xds_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -13,7 +11,6 @@ import (
 	xds_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -140,8 +137,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 		StaticResources: &xds_bootstrap.Bootstrap_StaticResources{
 			Clusters: []*xds_cluster.Cluster{
 				{
-					Name:           config.XDSClusterName,
-					ConnectTimeout: durationpb.New(time.Millisecond * 250),
+					Name: config.XDSClusterName,
 					ClusterDiscoveryType: &xds_cluster.Cluster_Type{
 						Type: xds_cluster.Cluster_LOGICAL_DNS,
 					},

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -58,8 +58,7 @@ node:
   id: foo.bar.co.uk
 static_resources:
   clusters:
-  - connect_timeout: 0.250s
-    load_assignment:
+  - load_assignment:
       cluster_name: osm-controller
       endpoints:
       - lb_endpoints:

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -25,8 +25,7 @@ node:
   id: foo.bar.co.uk
 static_resources:
   clusters:
-  - connect_timeout: 0.250s
-    load_assignment:
+  - load_assignment:
       cluster_name: osm-controller
       endpoints:
       - lb_endpoints:

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/fatih/color"
 	. "github.com/onsi/ginkgo"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const (
@@ -89,9 +91,13 @@ func (td *OsmTestData) HTTPRequest(ht HTTPRequestDef) HTTPRequestResult {
 	// -s silent progress, -o output to devnull, '-D -' dump headers to "-" (stdout), -i Status code
 	// -I skip body download, '-w StatusCode:%{http_code}' prints Status code label-like for easy parsing
 	// -L follow redirects
-	commandStr := fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} -L %s", StatusCodeWord, ht.Destination)
+	var commandStr string
+	if td.ClusterOS == constants.OSWindows {
+		commandStr = fmt.Sprintf("curl.exe -s -o NUL -D - -I -w %s:%%{http_code} -L %s", StatusCodeWord, ht.Destination)
+	} else {
+		commandStr = fmt.Sprintf("/usr/bin/curl -s -o /dev/null -D - -I -w %s:%%{http_code} -L %s", StatusCodeWord, ht.Destination)
+	}
 	command := strings.Fields(commandStr)
-
 	stdout, stderr, err := td.RunRemote(ht.SourceNs, ht.SourcePod, ht.SourceContainer, command)
 	if err != nil {
 		// Error codes from the execution come through err

--- a/tests/framework/constants.go
+++ b/tests/framework/constants.go
@@ -66,3 +66,13 @@ const (
 	// ControlPlaneOnly will collect logs only for control plane processes
 	ControlPlaneOnly CollectLogsType = "controlPlaneOnly"
 )
+
+// Windows Specific container images
+const (
+	// EnvoyOSMWindowsImage is Envoy Windows image used for testing.
+	// On Windows until Windows Server 2022 is publicly available we have to rely on this testing images.
+	EnvoyOSMWindowsImage = "openservicemesh/envoy-windows-nanoserver@sha256:94590d10bc8a46c60cd3a3858d80f3d6577d4e9a191fa05c0077f8b3d6002e22"
+
+	// WindowsNanoserverDockerImage is the base Windows image that is compatible with the test cluster.
+	WindowsNanoserverDockerImage = "mcr.microsoft.com/windows/nanoserver/insider:10.0.20348.1"
+)

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -72,7 +72,8 @@ type OsmTestData struct {
 
 	ClusterProvider *cluster.Provider // provider, used when kindCluster is used
 
-	DeployOnOpenShift bool // Determines whether to configure tests for OpenShift
+	DeployOnOpenShift      bool // Determines whether to configure tests for OpenShift
+	DeployOnWindowsWorkers bool // Determines whether to configure tests to run on Windows workers
 }
 
 // InstallOSMOpts describes install options for OSM


### PR DESCRIPTION
This PR modifies the `e2e_egress_test` to be able to run on Windows nodes

Verified locally in an AKS cluster:

 ```
    Ran 1 of 42 Specs in 471.548 seconds
    SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 41 Skipped
    --- PASS: TestSuite (471.56s)
```

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [x] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
