### PR TITLE
ingress: allow IPRange as a source in IngressBackend

### DIFF
--- a/pkg/apis/policy/v1alpha1/ingress_backend.go
+++ b/pkg/apis/policy/v1alpha1/ingress_backend.go
@@ -59,6 +59,9 @@ const (
 
 	// KindAuthenticatedPrincipal is the kind corresponding to an authenticated principal.
 	KindAuthenticatedPrincipal = "AuthenticatedPrincipal"
+
+	// KindIPRange is the kind corresponding to an IP address range represented in CIDR notation.
+	KindIPRange = "IPRange"
 )
 
 // IngressSourceSpec is the type used to represent the Source in the list of Sources specified in an

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -92,6 +92,17 @@ func ingressBackendValidator(req *admissionv1.AdmissionRequest) (*admissionv1.Ad
 		}
 	}
 
+	// Validate sources
+	for _, source := range ingressBackend.Spec.Sources {
+		switch source.Kind {
+		// Add validation for source kinds here
+		case policyv1alpha1.KindIPRange:
+			if _, _, err := net.ParseCIDR(source.Name); err != nil {
+				return nil, errors.Errorf("Invalid 'source.Name' value specified for IPRange. Expected CIDR notation 'a.b.c.d/x', got '%s'", source.Name)
+			}
+		}
+	}
+
 	return nil, nil
 }
 

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -186,6 +186,80 @@ func TestIngressBackendValidator(t *testing.T) {
 			expResp:   nil,
 			expErrStr: "",
 		},
+		{
+			name: "IngressBackend with valid source IPRange",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "IngressBackend",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "IngressBackend",
+						"spec": {
+							"backends": [
+								{
+									"name": "test",
+									"port": {
+										"number": 80,
+										"protocol": "http"
+									}
+								}
+							],
+							"sources": [
+								{
+									"kind": "IPRange",
+									"name": "10.0.0.0/10"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "",
+		},
+		{
+			name: "IngressBackend with invalid source IPRange errors",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "IngressBackend",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "IngressBackend",
+						"spec": {
+							"backends": [
+								{
+									"name": "test",
+									"port": {
+										"number": 80,
+										"protocol": "http"
+									}
+								}
+							],
+							"sources": [
+								{
+									"kind": "IPRange",
+									"name": "invalid"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "Invalid 'source.Name' value specified for IPRange. Expected CIDR notation 'a.b.c.d/x', got 'invalid'",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
To secure ingress traffic, OSM requires a source to be
specified in an IngressBackend configuration, which
can reference a k8s service within the cluster whose
endpoints are authorized to connect to the backend.
Some ingress solutions such as Azure Application Gateway
do not create a k8s service object to represent the gateway
instance. This change provides the facility to specify an
IP address range as a source so that a source IP range
can be specified to connect to a backend.

Part of #3779

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit testing

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
