### PR TITLE
backport(e2e): Configure privileged init container

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -563,7 +563,7 @@ func setMeshConfigToDefault(instOpts InstallOSMOpts, meshConfig *v1alpha1.MeshCo
 	meshConfig.Spec.Observability.EnableDebugServer = instOpts.EnableDebugServer
 
 	meshConfig.Spec.Sidecar.Resources = corev1.ResourceRequirements{}
-	meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer = false
+	meshConfig.Spec.Sidecar.EnablePrivilegedInitContainer = instOpts.EnablePrivilegedInitContainer
 	meshConfig.Spec.Sidecar.LogLevel = instOpts.EnvoyLogLevel
 	meshConfig.Spec.Sidecar.MaxDataPlaneConnections = 0
 	meshConfig.Spec.Sidecar.ConfigResyncInterval = "0s"


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Make enablePrivilegedInitContainer configurable so that release-v0.9 tests can run on openshift
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Ran 
```
go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.focus="\bDeploymentsClientServer\b" -deployOnOpenShift=true
```
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
2. Is this a breaking change?
No