### PR TITLE
test(e2e): ensure only meshed pods can communicate in permissive mode

### DIFF
--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -34,7 +34,8 @@ var _ = OSMDescribe("Permissive Traffic Policy Mode",
 func testPermissiveMode(withSourceKubernetesService bool) {
 	const sourceNs = "client"
 	const destNs = "server"
-	var ns []string = []string{sourceNs, destNs}
+	const extSourceNs = "ext-client"
+	var meshNs []string = []string{sourceNs, destNs}
 
 	It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
 		// Install OSM
@@ -43,11 +44,14 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 		meshConfig, _ := Td.GetMeshConfig(Td.OsmNamespace)
 
-		// Create Test NS
-		for _, n := range ns {
+		// Create test NS in mesh
+		for _, n := range meshNs {
 			Expect(Td.CreateNs(n, nil)).To(Succeed())
 			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 		}
+
+		// Create non mesh test NS
+		Expect(Td.CreateNs(extSourceNs, nil)).To(Succeed())
 
 		// Get simple pod definitions for the HTTP server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
@@ -62,9 +66,9 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 
 		_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
 		Expect(err).NotTo(HaveOccurred())
-		dstPod, err := Td.CreatePod(destNs, podDef)
+		_, err = Td.CreatePod(destNs, podDef)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = Td.CreateService(destNs, svcDef)
+		dstSvc, err := Td.CreateService(destNs, svcDef)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(Td.WaitForPodsRunningReady(destNs, 90*time.Second, 1, nil)).To(Succeed())
@@ -98,7 +102,39 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 			SourcePod:       srcPod.Name,
 			SourceContainer: "client",
 
-			Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		// Get simple Pod definitions for the non mesh client
+		svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
+			Name:      "ext-client",
+			Namespace: extSourceNs,
+			Command:   []string{"/bin/bash", "-c", "--"},
+			Args:      []string{"while true; do sleep 30; done;"},
+			Image:     "songrgg/alpine-debug",
+			Ports:     []int{80},
+			OS:        Td.ClusterOS,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = Td.CreateServiceAccount(extSourceNs, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		extSrcPod, err := Td.CreatePod(extSourceNs, podDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		if withSourceKubernetesService {
+			_, err = Td.CreateService(extSourceNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		Expect(Td.WaitForPodsRunningReady(extSourceNs, 90*time.Second, 1, nil)).To(Succeed())
+
+		extReq := HTTPRequestDef{
+			SourceNs:        extSrcPod.Namespace,
+			SourcePod:       extSrcPod.Name,
+			SourceContainer: "ext-client",
+
+			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 		}
 
 		By("Ensuring traffic is allowed when permissive mode is enabled")
@@ -111,6 +147,20 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 				return false
 			}
 			Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+			return true
+		}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+		Expect(cond).To(BeTrue())
+
+		By("Ensuring traffic is not allowed from non mesh clients when permissive mode is enabled")
+
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(extReq)
+
+			if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 56 ") {
+				Td.T.Logf("> REST req received unexpected response (status: %d) %v", result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> REST req succeeded, got expected error: %v", result.Err)
 			return true
 		}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
 		Expect(cond).To(BeTrue())


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds an e2e test to validate a random pod outside of the mesh cannot 
successfully communicate with a pod running within a mesh in permissive
mode.

Resolves #3910
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ X ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
