### PR TITLE
tests/framework: logs k8s server version

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -306,6 +306,13 @@ nodeRegistration:
 		}
 	}
 
+	k8sServerVersion, err := Td.getKubernetesServerVersionNumber()
+	if err != nil {
+		return errors.Wrap(err, "Error getting k8s server version")
+	}
+
+	// Logs v<major>.<minor>.<patch>
+	td.T.Logf("> k8s server version: v%s\n", strings.Trim(strings.Join(strings.Fields(fmt.Sprint(k8sServerVersion)), "."), "[]"))
 	return nil
 }
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Logs k8s server version.
Resolves #4047

**Testing done**:
```
> ID for test: 2950264260, Test dir (abs): /tmp/test-2950264260
> k8s server version: v1.21.1
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
