### PR TITLE
tests/e2e: reset k8s version in version test

### DIFF
--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -117,4 +117,6 @@ func testK8sVersion(version string) {
 
 		Expect(cond).To(BeTrue(), "Failed testing HTTP traffic for %s", srcToDestStr)
 	})
+
+	Td.ClusterVersion = "" // reset version so the default is used
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes a bug where the default version is not reset
in the global test context. As a result, the tests
running after this test in the same test context
use the non-default version set by the test.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
