### PR TITLE
test(e2e): enable verbose for install

### DIFF
--- a/.github/workflows/nightly-noinstall.yml
+++ b/.github/workflows/nightly-noinstall.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install OSM via OSM CLI
         run: |
           make build-osm
-          ./bin/osm install \
+          ./bin/osm install --verbose \
             --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
             --set=OpenServiceMesh.image.tag="$CTR_TAG"
       - name: Run e2es

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -98,6 +98,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
   # shellcheck disable=SC2086
   bin/osm install \
       --osm-namespace "$K8S_NAMESPACE" \
+      --verbose \
       --mesh-name "$MESH_NAME" \
       --set=OpenServiceMesh.certificateProvider.kind="$CERT_MANAGER" \
       --set=OpenServiceMesh.vault.host="$VAULT_HOST" \
@@ -123,6 +124,7 @@ else
   # shellcheck disable=SC2086
   bin/osm install \
       --osm-namespace "$K8S_NAMESPACE" \
+      --verbose \
       --mesh-name "$MESH_NAME" \
       --set=OpenServiceMesh.certificateProvider.kind="$CERT_MANAGER" \
       --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \

--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -111,6 +111,7 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
     # shellcheck disable=SC2086
     bin/osm install \
         --osm-namespace "$K8S_NAMESPACE" \
+        --verbose \
         --mesh-name "$MESH_NAME" \
         --set=OpenServiceMesh.image.registry="$CTR_REGISTRY" \
         --set=OpenServiceMesh.imagePullSecrets[0].name="$CTR_REGISTRY_CREDS_NAME" \

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -447,6 +447,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	var args []string
 	args = append(args, "install",
 		"--osm-namespace="+instOpts.ControlPlaneNS,
+		"--verbose",
 		fmt.Sprintf("--timeout=%v", 90*time.Second),
 	)
 


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Backport commit to release-v0.10 to enable verbose output for osm installation in e2es. This way, for pipelines like osm-build that run v0.10 e2es for releases, it will be easier to identify the cause of failures, rather than trying to reproduce the error locally and fetch logs. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
