### PR TITLE
(multicluster) : update gateway ip to osm-multicluster-gateway external ip

### DIFF
--- a/charts/osm/templates/osm-multicluster-gateway-service.yaml
+++ b/charts/osm/templates/osm-multicluster-gateway-service.yaml
@@ -15,5 +15,6 @@ spec:
       targetPort: 15443
   selector:
     app: osm-multicluster-gateway
+  # NOTE : This will expose an external IP for the gateway and the gateway acts as a passthrough to all the downstreams in the cluster.
   type: LoadBalancer
 {{- end }}

--- a/demo/deploy-MultiClusterService.sh
+++ b/demo/deploy-MultiClusterService.sh
@@ -12,8 +12,7 @@ BETA_CLUSTER="${BETA_CLUSTER:-beta}"
 BOOKSTORE_NAMESPACE="${BOOKSTORE_NAMESPACE:-bookstore}"
 
 kubectl config use-context "$BETA_CLUSTER"
-# TODO : the Pod IP of osm-multicluster-gateway is used cause the clusters are in the same vnet, this needs to be updated to leverage the IP of osm-multicluster-gateway service
-BETA_OSM_GATEWAY_IP=$(kubectl get pods -n 'osm-system' --selector app=osm-multicluster-gateway -o json | jq -r '.items[].status.podIP')
+BETA_OSM_GATEWAY_IP=$(kubectl get svc -n 'osm-system' --selector app=osm-multicluster-gateway -o json | jq -r '.items[0].status.loadBalancer.ingress[0].ip')
 
 
 kubectl config use-context "$ALPHA_CLUSTER"


### PR DESCRIPTION
**Description**:

Update multicluster demo to use the external ip of
osm-multicluster-gateway service rather than the pod ip. This removes
the limitation of the clusters being in the same vnet

Part of #3456

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Testing done**:
 Manually ran the multicluster demo on two clusters that are not in the same Vnet and verified that the demo ran as expected.


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution? `no`

2. Is this a breaking change? `no`
