### PR TITLE
log: Fixing Err() statements - change from Info to Error

### DIFF
--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -103,7 +103,7 @@ func (mc *MeshCatalog) ListServiceIdentitiesForService(svc service.MeshService) 
 	for _, provider := range mc.serviceProviders {
 		serviceIDs, err := provider.ListServiceIdentitiesForService(svc)
 		if err != nil {
-			log.Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentitiesForService)).
+			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentitiesForService)).
 				Msgf("Error getting ServiceIdentities for Service %s", svc)
 			return nil, err
 		}

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -88,7 +88,7 @@ func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expir
 	x509Cert, err := certificate.DecodePEMCertificate(pemCert)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
-		log.Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingPEMCert)).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrDecodingPEMCert)).
 			Msg("Error converting PEM cert to x509 to obtain serial number")
 		return nil, err
 	}

--- a/pkg/envoy/ads/debugger.go
+++ b/pkg/envoy/ads/debugger.go
@@ -20,7 +20,7 @@ func (s *Server) GetXDSLog() *map[certificate.CommonName]map[envoy.TypeURI][]tim
 	})
 
 	if err != nil {
-		log.Err(err).Msgf("Failed to copy xdsLogMap")
+		log.Error().Err(err).Msgf("Failed to copy xdsLogMap")
 	}
 
 	return &logsCopy

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -373,7 +373,7 @@ func (s *Server) recordPodMetadata(p *envoy.Proxy) error {
 	cn := p.GetCertificateCommonName()
 	certSA, err := envoy.GetServiceIdentityFromProxyCertificate(cn)
 	if err != nil {
-		log.Err(err).Msgf("Error getting service account from XDS certificate with CommonName=%s", cn)
+		log.Error().Err(err).Msgf("Error getting service account from XDS certificate with CommonName=%s", cn)
 		return err
 	}
 

--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -24,7 +24,7 @@ func (lb *listenerBuilder) buildMulticlusterGatewayListener() (*xds_listener.Lis
 	upstreamServices := lb.meshCatalog.ListOutboundServicesForMulticlusterGateway()
 	filterChains, err := getMulticlusterGatewayFilterChains(upstreamServices)
 	if err != nil {
-		log.Err(err).Str(constants.LogFieldContext, constants.LogContextMulticluster).Msg("[Multicluster] Error creating Multicluster gateway filter chain")
+		log.Error().Err(err).Str(constants.LogFieldContext, constants.LogContextMulticluster).Msg("[Multicluster] Error creating Multicluster gateway filter chain")
 		return nil, err
 	}
 

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 	getExpectedEnvoyYAML := func(filename string) string {
 		expectedEnvoyConfig, err := ioutil.ReadFile(filepath.Clean(path.Join(directoryForYAMLFiles, filename)))
 		if err != nil {
-			log.Err(err).Msgf("Error reading expected Envoy bootstrap YAML from file %s", filename)
+			log.Error().Err(err).Msgf("Error reading expected Envoy bootstrap YAML from file %s", filename)
 		}
 		Expect(err).ToNot(HaveOccurred())
 		return string(expectedEnvoyConfig)
@@ -94,7 +94,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 	saveActualEnvoyYAML := func(filename string, actualContent []byte) {
 		err := ioutil.WriteFile(filepath.Clean(path.Join(directoryForYAMLFiles, filename)), actualContent, 0600)
 		if err != nil {
-			log.Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filename)
+			log.Error().Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filename)
 		}
 		Expect(err).ToNot(HaveOccurred())
 	}

--- a/pkg/injector/health_probes.go
+++ b/pkg/injector/health_probes.go
@@ -86,7 +86,7 @@ func rewriteProbe(probe *corev1.Probe, probeType, path string, port int32, conta
 	var err error
 	originalProbe.port, err = getPort(*definedPort, containerPorts)
 	if err != nil {
-		log.Err(err).Msgf("Error finding a matching port for %+v on container %+v", *definedPort, containerPorts)
+		log.Error().Err(err).Msgf("Error finding a matching port for %+v on container %+v", *definedPort, containerPorts)
 	}
 	*definedPort = intstr.IntOrString{Type: intstr.Int, IntVal: port}
 

--- a/pkg/injector/test/test_helpers.go
+++ b/pkg/injector/test/test_helpers.go
@@ -35,7 +35,7 @@ func LoadExpectedEnvoyYAML(expectationFilePath string) string {
 	log.Info().Msgf("Loading test expectation from %s", filepath.Clean(expectationFilePath))
 	expectedEnvoyConfig, err := ioutil.ReadFile(filepath.Clean(expectationFilePath))
 	if err != nil {
-		log.Err(err).Msgf("Error reading expected Envoy bootstrap YAML from file %s", expectationFilePath)
+		log.Error().Err(err).Msgf("Error reading expected Envoy bootstrap YAML from file %s", expectationFilePath)
 	}
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return string(expectedEnvoyConfig)
@@ -66,7 +66,7 @@ func MarshalXdsStructAndSaveToFile(m protoreflect.ProtoMessage, filePath string)
 	log.Info().Msgf("Saving %s...", filePath)
 	err = ioutil.WriteFile(filepath.Clean(filePath), configYAML, 0600)
 	if err != nil {
-		log.Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filePath)
+		log.Error().Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filePath)
 	}
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return string(configYAML)
@@ -79,7 +79,7 @@ func MarshalAndSaveToFile(someStruct interface{}, filePath string) string {
 	log.Info().Msgf("Saving %s...", filePath)
 	err = ioutil.WriteFile(filepath.Clean(filePath), fileContent, 0600)
 	if err != nil {
-		log.Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filePath)
+		log.Error().Err(err).Msgf("Error writing actual Envoy Cluster XDS YAML to file %s", filePath)
 	}
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	return string(fileContent)

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -267,7 +267,7 @@ func (c *client) ListServices() ([]service.MeshService, error) {
 func (c *client) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.ServiceIdentity, error) {
 	serviceAccounts, err := c.kubeController.ListServiceIdentitiesForService(svc)
 	if err != nil {
-		log.Err(err).Msgf("Error getting ServiceAccounts for Service %s", svc)
+		log.Error().Err(err).Msgf("Error getting ServiceAccounts for Service %s", svc)
 		return nil, err
 	}
 

--- a/pkg/providers/kube/multiclusterservice.go
+++ b/pkg/providers/kube/multiclusterservice.go
@@ -43,7 +43,7 @@ func (c *client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount
 		for _, cluster := range svc.Spec.Clusters {
 			ip, port, err := getIPPort(cluster)
 			if err != nil {
-				log.Err(err).Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("Error getting IP and Port for cluster=%s for service %s", cluster.Name, svc)
+				log.Error().Err(err).Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("Error getting IP and Port for cluster=%s for service %s", cluster.Name, svc)
 				continue
 			}
 


### PR DESCRIPTION
`log.Err(err).Msg()` results in Info
`log.Error().Err(err).Msg()` does the right thing and emits an Error()

Script to fix this:
```bash
perl -p -i -e 's/log\.Err\(/log.Error().Err(/g' $(grep -Iir "log.Err(" $(find . -name "*.go") | awk -F: '{print $1}')
```

Before:
![image](https://user-images.githubusercontent.com/49918230/131198191-e1770fd2-d6a5-470a-8365-4c147e5033c9.png)


After:
![image](https://user-images.githubusercontent.com/49918230/131198180-a6051669-77b8-4848-8eaf-3153b20835d4.png)
