### PR TITLE
feat(windows): Change the deployments to deploy demo on Windows

### DIFF
--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -310,6 +310,10 @@ contour:
       registry: docker.io
       repository: projectcontour/contour
       tag: v1.18.0
+    # -- Only deploy Contour on linux pods
+    nodeSelector:
+      kubernetes.io/os: linux
+
   # -- Contour envoy edge proxy configuration
   envoy:
     image:

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -30,6 +30,30 @@ if [ "$DEPLOY_ON_OPENSHIFT" = true ] ; then
     fi
 fi
 
+CONTAINER_NAME="bookbuyer"
+if [ "$OS" = windows ]; then
+CONTAINER_NAME="bookbuyer-windows"
+fi
+
+echo -e "Deploy bookbuyer Service"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookbuyer
+  namespace: $BOOKBUYER_NAMESPACE
+  labels:
+    app: bookbuyer
+spec:
+  ports:
+  - port: 14001
+    name: bookbuyer-port
+
+  selector:
+    app: bookbuyer
+EOF
+
+
 echo -e "Deploy BookBuyer Deployment"
 kubectl apply -f - <<EOF
 apiVersion: apps/v1
@@ -52,11 +76,11 @@ spec:
       serviceAccountName: bookbuyer
       nodeSelector:
         kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
+        kubernetes.io/os: ${OS}
       containers:
         # Main container with APP
         - name: bookbuyer
-          image: "${CTR_REGISTRY}/bookbuyer:${CTR_TAG}"
+          image: "${CTR_REGISTRY}/${CONTAINER_NAME}:${CTR_TAG}"
           imagePullPolicy: Always
           command: ["/bookbuyer"]
 

--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -10,6 +10,10 @@ KUBE_CONTEXT=$(kubectl config current-context)
 
 kubectl delete deployment "$SVC" -n "$BOOKSTORE_NAMESPACE"  --ignore-not-found
 
+CONTAINER_NAME="bookstore"
+if [ "$OS" = windows ]; then
+CONTAINER_NAME="bookstore-windows"
+fi
 # Create a top level service just for the bookstore domain
 echo -e "Deploy bookstore Service"
 kubectl apply -f - <<EOF
@@ -77,9 +81,9 @@ spec:
       serviceAccountName: bookstore
       nodeSelector:
         kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
+        kubernetes.io/os: ${OS}
       containers:
-        - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
+        - image: "${CTR_REGISTRY}/${CONTAINER_NAME}:${CTR_TAG}"
           imagePullPolicy: Always
           name: $SVC
           ports:

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -32,6 +32,11 @@ if [ "$DEPLOY_ON_OPENSHIFT" = true ] ; then
     fi
 fi
 
+CONTAINER_NAME="bookthief"
+if [ "$OS" = windows ]; then
+CONTAINER_NAME="bookthief-windows"
+fi
+
 kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Service
@@ -70,11 +75,11 @@ spec:
       serviceAccountName: bookthief
       nodeSelector:
         kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
+        kubernetes.io/os: ${OS}
       containers:
         # Main container with APP
         - name: bookthief
-          image: "${CTR_REGISTRY}/bookthief:${CTR_TAG}"
+          image: "${CTR_REGISTRY}/${CONTAINER_NAME}:${CTR_TAG}"
           imagePullPolicy: Always
           command: ["/bookthief"]
 

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -27,6 +27,11 @@ if [ "$DEPLOY_ON_OPENSHIFT" = true ] ; then
     fi
 fi
 
+CONTAINER_NAME="bookwarehouse"
+if [ "$OS" = windows ]; then
+CONTAINER_NAME="bookwarehouse-windows"
+fi
+
 echo -e "Deploy Bookwarehouse Service"
 kubectl apply -f - <<EOF
 apiVersion: v1
@@ -66,11 +71,11 @@ spec:
       serviceAccountName: bookwarehouse
       nodeSelector:
         kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
+        kubernetes.io/os: ${OS}
       containers:
         # Main container with APP
         - name: bookwarehouse
-          image: "${CTR_REGISTRY}/bookwarehouse:${CTR_TAG}"
+          image: "${CTR_REGISTRY}/${CONTAINER_NAME}:${CTR_TAG}"
           imagePullPolicy: Always
           command: ["/bookwarehouse"]
           env:

--- a/demo/run-osm-windows-demo.sh
+++ b/demo/run-osm-windows-demo.sh
@@ -41,8 +41,6 @@ TIMEOUT="${TIMEOUT:-90s}"
 USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
 PUBLISH_IMAGES="${PUBLISH_IMAGES:-true}"
 
-export OS=linux
-
 # For any additional installation arguments. Used heavily in CI.
 optionalInstallArgs=$*
 
@@ -52,6 +50,8 @@ exit_error() {
     exit 1
 }
 
+export OS="windows"
+
 # Check if Docker daemon is running
 docker info > /dev/null || { echo "Docker daemon is not running"; exit 1; }
 
@@ -60,6 +60,7 @@ make build-osm
 # cleanup stale resources from previous runs
 ./demo/clean-kubernetes.sh
 
+# exit 1
 # The demo uses osm's namespace as defined by environment variables, K8S_NAMESPACE
 # to house the control plane components.
 #
@@ -119,6 +120,8 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --set=OpenServiceMesh.deployPrometheus="$DEPLOY_PROMETHEUS" \
       --set=OpenServiceMesh.envoyLogLevel="$ENVOY_LOG_LEVEL" \
       --set=OpenServiceMesh.controllerLogLevel="trace" \
+      --set=OpenServiceMesh.sidecarWindowsImage="osmwindevregistry.azurecr.io/envoy-windows-nanoserver" \
+      --set=OpenServiceMesh.featureFlags.enableWASMStats=false \
       --timeout="$TIMEOUT" \
       $optionalInstallArgs
 else
@@ -141,6 +144,8 @@ else
       --set=OpenServiceMesh.deployPrometheus="$DEPLOY_PROMETHEUS" \
       --set=OpenServiceMesh.envoyLogLevel="$ENVOY_LOG_LEVEL" \
       --set=OpenServiceMesh.controllerLogLevel="trace" \
+      --set=OpenServiceMesh.sidecarWindowsImage="osmwindevregistry.azurecr.io/envoy-windows-nanoserver" \
+      --set=OpenServiceMesh.featureFlags.enableWASMStats=false \
       --timeout="$TIMEOUT" \
       $optionalInstallArgs
 fi


### PR DESCRIPTION
With this change you can deploy the demo on cluster with Windows nodes

1. Added a `run-osm-windows-demo.sh` with the options needed to run osm on Windows
2. Configured the timeouts to accomodate for some intermittent failures on Windows
3. Added a bookbuyer service to be able to visualize the demo

Fixes #3886

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
