### PR TITLE
pkg/smi: allow filter options while listing items in cache

### DIFF
--- a/pkg/smi/fake.go
+++ b/pkg/smi/fake.go
@@ -19,6 +19,7 @@ type fakeMeshSpec struct {
 }
 
 // NewFakeMeshSpecClient creates a fake Mesh Spec used for testing.
+// TODO(DEPRECATE): This fake is not extendable enough, deprecate it and use mocks or re-implement fakes
 func NewFakeMeshSpecClient() MeshSpec {
 	return fakeMeshSpec{
 		trafficSplits:   []*split.TrafficSplit{&tests.TrafficSplit},
@@ -33,9 +34,15 @@ func NewFakeMeshSpecClient() MeshSpec {
 	}
 }
 
-// ListTrafficSplits lists TrafficSplit SMI resources for the fake Mesh Spec.
-func (f fakeMeshSpec) ListTrafficSplits() []*split.TrafficSplit {
-	return f.trafficSplits
+// ListTrafficSplits lists TrafficSplit SMI resources for the fake Mesh Spec
+func (f fakeMeshSpec) ListTrafficSplits(opts ...TrafficSplitListOption) []*split.TrafficSplit {
+	var trafficSplits []*split.TrafficSplit
+	for _, s := range f.trafficSplits {
+		if filteredSplit := filterTrafficSplit(s, opts...); filteredSplit != nil {
+			trafficSplits = append(trafficSplits, filteredSplit)
+		}
+	}
+	return trafficSplits
 }
 
 // ListServiceAccounts fetches all service accounts declared with SMI Spec for the fake Mesh Spec.
@@ -63,7 +70,13 @@ func (f fakeMeshSpec) GetTCPRoute(_ string) *spec.TCPRoute {
 	return nil
 }
 
-// ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec.
-func (f fakeMeshSpec) ListTrafficTargets() []*access.TrafficTarget {
-	return f.trafficTargets
+// ListTrafficTargets lists TrafficTarget SMI resources for the fake Mesh Spec
+func (f fakeMeshSpec) ListTrafficTargets(opts ...TrafficTargetListOption) []*access.TrafficTarget {
+	var trafficTargets []*access.TrafficTarget
+	for _, t := range f.trafficTargets {
+		if filteredTarget := filterTrafficTarget(t, opts...); filteredTarget != nil {
+			trafficTargets = append(trafficTargets, filteredTarget)
+		}
+	}
+	return trafficTargets
 }

--- a/pkg/smi/mock_meshspec_generated.go
+++ b/pkg/smi/mock_meshspec_generated.go
@@ -108,29 +108,37 @@ func (mr *MockMeshSpecMockRecorder) ListTCPTrafficSpecs() *gomock.Call {
 }
 
 // ListTrafficSplits mocks base method
-func (m *MockMeshSpec) ListTrafficSplits() []*v1alpha2.TrafficSplit {
+func (m *MockMeshSpec) ListTrafficSplits(arg0 ...TrafficSplitListOption) []*v1alpha2.TrafficSplit {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTrafficSplits")
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListTrafficSplits", varargs...)
 	ret0, _ := ret[0].([]*v1alpha2.TrafficSplit)
 	return ret0
 }
 
 // ListTrafficSplits indicates an expected call of ListTrafficSplits
-func (mr *MockMeshSpecMockRecorder) ListTrafficSplits() *gomock.Call {
+func (mr *MockMeshSpecMockRecorder) ListTrafficSplits(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficSplits", reflect.TypeOf((*MockMeshSpec)(nil).ListTrafficSplits))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficSplits", reflect.TypeOf((*MockMeshSpec)(nil).ListTrafficSplits), arg0...)
 }
 
 // ListTrafficTargets mocks base method
-func (m *MockMeshSpec) ListTrafficTargets() []*v1alpha3.TrafficTarget {
+func (m *MockMeshSpec) ListTrafficTargets(arg0 ...TrafficTargetListOption) []*v1alpha3.TrafficTarget {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTrafficTargets")
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListTrafficTargets", varargs...)
 	ret0, _ := ret[0].([]*v1alpha3.TrafficTarget)
 	return ret0
 }
 
 // ListTrafficTargets indicates an expected call of ListTrafficTargets
-func (mr *MockMeshSpecMockRecorder) ListTrafficTargets() *gomock.Call {
+func (mr *MockMeshSpecMockRecorder) ListTrafficTargets(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficTargets", reflect.TypeOf((*MockMeshSpec)(nil).ListTrafficTargets))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTrafficTargets", reflect.TypeOf((*MockMeshSpec)(nil).ListTrafficTargets), arg0...)
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
There is a use case to only get a subset of items in the
cache for TrafficTarget and TrafficSplit resources based
on certain fields being set on the resources. This change
implements optional filters that clients can use to filter
the returned items from the cache without needing to define
additional functions. With this change, the TrafficTarget
cache can be filtered based on the destination identity,
and the TrafficSplit cache can be filtered based on the
apex and backend service.

Required for #4052

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
