### PR TITLE
demo: Fixing incorrect log line - should be generalized to 'web server'

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.go
+++ b/demo/cmd/bookbuyer/bookbuyer.go
@@ -71,7 +71,7 @@ func debugServer() {
 		router.HandleFunc(h.path, h.fn).Methods(h.method)
 	}
 	http.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {})
-	log.Info().Msgf("Bookstore running on port %d", *port)
+	log.Info().Msgf("Web server running on port %d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), router)
 	log.Fatal().Err(err).Msgf("Failed to start HTTP server on port %d", *port)
 }


### PR DESCRIPTION
This PR fixes a small log issue, where the `bookbuyer` pod claims it is `bookstore`, which is not true.

The fix generalized the message to announce that a 'Web server' is running, not specifically bookbuyer or a booskstore.

Example:
![image](https://user-images.githubusercontent.com/49918230/131596344-57e24a12-6e76-4190-920e-2581ff87aa8a.png)
