### PR TITLE
chore: rearrange content in mysql deployment script

### DIFF
--- a/demo/deploy-mysql.sh
+++ b/demo/deploy-mysql.sh
@@ -7,9 +7,78 @@ source .env
 DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
 USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-true}"
 
-kubectl apply -f docs/example/manifests/apps/mysql.yaml -n "$BOOKWAREHOUSE_NAMESPACE"
-
 kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql
+  namespace: $BOOKWAREHOUSE_NAMESPACE
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  namespace: $BOOKWAREHOUSE_NAMESPACE
+spec:
+  ports:
+  - port: 3306
+    targetPort: 3306
+    name: client
+    appProtocol: tcp
+  selector:
+    app: mysql
+  clusterIP: None
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  namespace: $BOOKWAREHOUSE_NAMESPACE
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      serviceAccountName: mysql
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: mypassword
+        - name: MYSQL_DATABASE
+          value: booksdemo
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - mountPath: /mysql-data
+          name: data
+        readinessProbe:
+          tcpSocket:
+            port: 3306
+          initialDelaySeconds: 15
+          periodSeconds: 10
+      volumes:
+        - name: data
+          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 250M
+---
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha3
 metadata:

--- a/docs/example/manifests/apps/mysql.yaml
+++ b/docs/example/manifests/apps/mysql.yaml
@@ -65,3 +65,31 @@ spec:
       resources:
         requests:
           storage: 250M
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: mysql
+  namespace: bookwarehouse
+spec:
+  destination:
+    kind: ServiceAccount
+    name: mysql
+    namespace: bookwarehouse
+  rules:
+  - kind: TCPRoute
+    name: tcp-route
+  sources:
+  - kind: ServiceAccount
+    name: bookwarehouse
+    namespace: bookwarehouse
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: tcp-route
+  namespace: bookwarehouse
+spec:
+  matches:
+    ports:
+    - 3306


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Files in docs/example/manifests are to be used by following
documentation for manual demo, rather than be exectued by automated
demo. Thus the content in the manifest files need to be complete.

This change completes the MySQL deployment manifest file, and updates
the automated demo script accordingly.

The updated docs/example/manifests/apps/mysql.yaml will be referred from manual demo doc page.

Related issue #3932 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

CI test to ensure automated demo is not broken.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [X] |
| Documentation              | [X] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No
