### PR TITLE
demo: Correct Warehouse service name and namespace (order in URL)

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -57,15 +57,15 @@ var (
 	minSuccessThresholdStr                 = utils.GetEnv("CI_MIN_SUCCESS_THRESHOLD", "1")
 	maxIterationsStr                       = utils.GetEnv("CI_MAX_ITERATIONS_THRESHOLD", "0") // 0 for unlimited
 	bookstoreServiceName                   = utils.GetEnv("BOOKSTORE_SVC", "bookstore")
+	warehouseServiceName                   = utils.GetEnv("WAREHOUSE_SVC", "bookwarehouse")
 	bookstoreNamespace                     = os.Getenv(BookstoreNamespaceEnvVar)
-	warehouseServiceName                   = "bookwarehouse"
 	bookwarehouseNamespace                 = os.Getenv(BookwarehouseNamespaceEnvVar)
 
 	// Due to a limitation on kubernetes on Windows we need to use the FQDN
 	// otherwise DNS will not be able to resolve it.
 	// https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/#dns-limitations
 	bookstoreService = fmt.Sprintf("%s.%s.svc.cluster.local:%d", bookstoreServiceName, bookstoreNamespace, bookstorePort)
-	warehouseService = fmt.Sprintf("%s.%s.svc.cluster.local:%d", bookwarehouseNamespace, warehouseServiceName, bookwarehousePort)
+	warehouseService = fmt.Sprintf("%s.%s.svc.cluster.local:%d", warehouseServiceName, bookwarehouseNamespace, bookwarehousePort)
 	booksBought      = fmt.Sprintf("http://%s/books-bought", bookstoreService)
 	buyBook          = fmt.Sprintf("http://%s/buy-a-book/new", bookstoreService)
 	chargeAccountURL = fmt.Sprintf("http://%s/%s", warehouseService, RestockWarehouseURL)


### PR DESCRIPTION
This PR fixes the URL of the `warehouse` pod, which currently has the name and namespace of the warehouse service transposed.

Example of the error observed on `bookstore` pod (which connects to bookwarehouse):
```bash
12:45AM ERR RestockBooks: Error posting to http://sim-run-bd6eace2-2398-4b73-8182-d20880aa2e10-warehouse.bookwarehouse.svc.cluster.local:14001/restock-books error="Post \"http://sim-run-bd6eace2-2398-4b73-8182-d20880aa2e10-warehouse.bookwarehouse.svc.cluster.local:14001/restock-books\": dial tcp: lookup sim-run-bd6eace2-2398-4b73-8182-d20880aa2e10-warehouse.bookwarehouse.svc.cluster.local on 10.0.0.10:53: no such host" component=demo file=books.go:114
```

In `http://sim-run-bd6eace2-2398-4b73-8182-d20880aa2e10-warehouse.bookwarehouse.svc.cluster.local`:
- `sim-run-bd6eace2-2398-4b73-8182-d20880aa2e10-warehouse` is the actual namespace but it is placed in the slot for the service
- `bookwarehouse` is the service name but it is in the slot for the namespace