### PR TITLE
feat(e2e): ensures namespace ignore label takes precedence

### DIFF
--- a/tests/e2e/e2e_ignore_namespace_test.go
+++ b/tests/e2e/e2e_ignore_namespace_test.go
@@ -21,9 +21,6 @@ var _ = OSMDescribe("Ignore Namespaces",
 	func() {
 		Context("Ignore Label", func() {
 			const ignoreNs = "ignore"
-			const monitorIgnoreNs = "mesh-ignore"
-			const sidecarMonitorIgnoreNs = "sidecar-monitor-ignore"
-			var ns []string = []string{ignoreNs, monitorIgnoreNs, sidecarMonitorIgnoreNs}
 
 			It("Tests the ignore label on a namespace disables sidecar injection", func() {
 				// Install OSM
@@ -32,17 +29,14 @@ var _ = OSMDescribe("Ignore Namespaces",
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				// Create test NS in mesh with ignore label
-				for _, n := range ns {
-					Expect(Td.CreateNs(n, map[string]string{constants.IgnoreLabel: "true"})).To(Succeed())
-				}
+				Expect(Td.CreateNs(ignoreNs, map[string]string{constants.IgnoreLabel: "true"})).To(Succeed())
 
-				// Add monitor-ignore to mesh with sidecar injection disabled
-				Expect(Td.AddNsToMesh(false, monitorIgnoreNs)).To(Succeed())
-				// Add sidecar-monitor-ignore to mesh with sidecar injection enabled
-				Expect(Td.AddNsToMesh(true, sidecarMonitorIgnoreNs)).To(Succeed())
+				// Add test NS to mesh with sidecar injection enabled
+				Expect(Td.AddNsToMesh(true, ignoreNs)).To(Succeed())
 
-				By("Ensuring pod is not injected with a sidecar when added a namespace with the ignore label")
+				By("Ensuring a pod is not injected with a sidecar when added to namespace the ignore, and sidecar injection labels set")
 
+				// Get simple Pod definitions
 				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 					SimplePodAppDef{
 						Name:      "pod1",
@@ -65,121 +59,6 @@ var _ = OSMDescribe("Ignore Namespaces",
 				Expect(Td.WaitForPodsRunningReady(ignoreNs, 90*time.Second, 1, nil)).To(Succeed())
 
 				pod, err = Td.Client.CoreV1().Pods(ignoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
-
-				By("Ensuring pod with a sidecar injection label is not injected with a sidecar when added to a namespace with the ignore label")
-
-				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
-					SimplePodAppDef{
-						Name:      "pod2",
-						Namespace: ignoreNs,
-						Command:   []string{"/bin/bash", "-c", "--"},
-						Args:      []string{"while true; do sleep 30; done;"},
-						Image:     "songrgg/alpine-debug",
-						Ports:     []int{80},
-						OS:        Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-				podDef.Annotations = map[string]string{constants.SidecarInjectionAnnotation: "enabled"}
-
-				_, err = Td.CreateServiceAccount(ignoreNs, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				pod, err = Td.CreatePod(ignoreNs, podDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(ignoreNs, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(Td.WaitForPodsRunningReady(ignoreNs, 90*time.Second, 1, nil)).To(Succeed())
-
-				pod, err = Td.Client.CoreV1().Pods(ignoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
-
-				By("Ensuring a pod is not injected with a sidecar when added to namespace with the monitored-by and ignore labels")
-
-				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
-					SimplePodAppDef{
-						Name:      "pod1",
-						Namespace: monitorIgnoreNs,
-						Command:   []string{"/bin/bash", "-c", "--"},
-						Args:      []string{"while true; do sleep 30; done;"},
-						Image:     "songrgg/alpine-debug",
-						Ports:     []int{80},
-						OS:        Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = Td.CreateServiceAccount(monitorIgnoreNs, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				pod, err = Td.CreatePod(monitorIgnoreNs, podDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(monitorIgnoreNs, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(Td.WaitForPodsRunningReady(monitorIgnoreNs, 90*time.Second, 1, nil)).To(Succeed())
-
-				pod, err = Td.Client.CoreV1().Pods(monitorIgnoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
-
-				By("Ensuring pod with a sidecar injection label is not injected with a sidecar when added to a namespace with the monitored-by and ignore labels")
-
-				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
-					SimplePodAppDef{
-						Name:      "pod2",
-						Namespace: monitorIgnoreNs,
-						Command:   []string{"/bin/bash", "-c", "--"},
-						Args:      []string{"while true; do sleep 30; done;"},
-						Image:     "songrgg/alpine-debug",
-						Ports:     []int{80},
-						OS:        Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-				podDef.Annotations = map[string]string{constants.SidecarInjectionAnnotation: "enabled"}
-
-				_, err = Td.CreateServiceAccount(monitorIgnoreNs, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				pod, err = Td.CreatePod(monitorIgnoreNs, podDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(monitorIgnoreNs, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(Td.WaitForPodsRunningReady(monitorIgnoreNs, 90*time.Second, 1, nil)).To(Succeed())
-
-				pod, err = Td.Client.CoreV1().Pods(monitorIgnoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
-
-				By("Ensuring a pod is not injected with a sidecar when added to namespace with the monitored-by, ignore, and sidecar injection labels set")
-
-				// Get simple Pod definitions
-				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
-					SimplePodAppDef{
-						Name:      "pod1",
-						Namespace: sidecarMonitorIgnoreNs,
-						Command:   []string{"/bin/bash", "-c", "--"},
-						Args:      []string{"while true; do sleep 30; done;"},
-						Image:     "songrgg/alpine-debug",
-						Ports:     []int{80},
-						OS:        Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = Td.CreateServiceAccount(sidecarMonitorIgnoreNs, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				pod, err = Td.CreatePod(sidecarMonitorIgnoreNs, podDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(sidecarMonitorIgnoreNs, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(Td.WaitForPodsRunningReady(sidecarMonitorIgnoreNs, 90*time.Second, 1, nil)).To(Succeed())
-
-				pod, err = Td.Client.CoreV1().Pods(sidecarMonitorIgnoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())

--- a/tests/e2e/e2e_ignore_namespace_test.go
+++ b/tests/e2e/e2e_ignore_namespace_test.go
@@ -1,0 +1,197 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Ignore Namespaces",
+	OSMDescribeInfo{
+		Tier:   1,
+		Bucket: 2,
+	},
+	func() {
+		Context("Ignore Label", func() {
+			const ignoreNs = "ignore"
+			const monitorIgnoreNs = "mesh-ignore"
+			const sidecarMonitorIgnoreNs = "sidecar-monitor-ignore"
+			var ns []string = []string{ignoreNs, monitorIgnoreNs, sidecarMonitorIgnoreNs}
+
+			It("Tests the ignore label on a namespace disables sidecar injection", func() {
+				// Install OSM
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnablePermissiveMode = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+				// Create test NS in mesh with ignore label
+				for _, n := range ns {
+					Expect(Td.CreateNs(n, map[string]string{constants.IgnoreLabel: "true"})).To(Succeed())
+				}
+
+				// Add monitor-ignore to mesh with sidecar injection disabled
+				Expect(Td.AddNsToMesh(false, monitorIgnoreNs)).To(Succeed())
+				// Add sidecar-monitor-ignore to mesh with sidecar injection enabled
+				Expect(Td.AddNsToMesh(true, sidecarMonitorIgnoreNs)).To(Succeed())
+
+				By("Ensuring pod is not injected with a sidecar when added a namespace with the ignore label")
+
+				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      "pod1",
+						Namespace: ignoreNs,
+						Command:   []string{"/bin/bash", "-c", "--"},
+						Args:      []string{"while true; do sleep 30; done;"},
+						Image:     "songrgg/alpine-debug",
+						Ports:     []int{80},
+						OS:        Td.ClusterOS,
+					})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = Td.CreateServiceAccount(ignoreNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				pod, err := Td.CreatePod(ignoreNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(ignoreNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(ignoreNs, 90*time.Second, 1, nil)).To(Succeed())
+
+				pod, err = Td.Client.CoreV1().Pods(ignoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
+
+				By("Ensuring pod with a sidecar injection label is not injected with a sidecar when added to a namespace with the ignore label")
+
+				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      "pod2",
+						Namespace: ignoreNs,
+						Command:   []string{"/bin/bash", "-c", "--"},
+						Args:      []string{"while true; do sleep 30; done;"},
+						Image:     "songrgg/alpine-debug",
+						Ports:     []int{80},
+						OS:        Td.ClusterOS,
+					})
+				Expect(err).NotTo(HaveOccurred())
+				podDef.Annotations = map[string]string{constants.SidecarInjectionAnnotation: "enabled"}
+
+				_, err = Td.CreateServiceAccount(ignoreNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				pod, err = Td.CreatePod(ignoreNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(ignoreNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(ignoreNs, 90*time.Second, 1, nil)).To(Succeed())
+
+				pod, err = Td.Client.CoreV1().Pods(ignoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
+
+				By("Ensuring a pod is not injected with a sidecar when added to namespace with the monitored-by and ignore labels")
+
+				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      "pod1",
+						Namespace: monitorIgnoreNs,
+						Command:   []string{"/bin/bash", "-c", "--"},
+						Args:      []string{"while true; do sleep 30; done;"},
+						Image:     "songrgg/alpine-debug",
+						Ports:     []int{80},
+						OS:        Td.ClusterOS,
+					})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = Td.CreateServiceAccount(monitorIgnoreNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				pod, err = Td.CreatePod(monitorIgnoreNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(monitorIgnoreNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(monitorIgnoreNs, 90*time.Second, 1, nil)).To(Succeed())
+
+				pod, err = Td.Client.CoreV1().Pods(monitorIgnoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
+
+				By("Ensuring pod with a sidecar injection label is not injected with a sidecar when added to a namespace with the monitored-by and ignore labels")
+
+				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      "pod2",
+						Namespace: monitorIgnoreNs,
+						Command:   []string{"/bin/bash", "-c", "--"},
+						Args:      []string{"while true; do sleep 30; done;"},
+						Image:     "songrgg/alpine-debug",
+						Ports:     []int{80},
+						OS:        Td.ClusterOS,
+					})
+				Expect(err).NotTo(HaveOccurred())
+				podDef.Annotations = map[string]string{constants.SidecarInjectionAnnotation: "enabled"}
+
+				_, err = Td.CreateServiceAccount(monitorIgnoreNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				pod, err = Td.CreatePod(monitorIgnoreNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(monitorIgnoreNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(monitorIgnoreNs, 90*time.Second, 1, nil)).To(Succeed())
+
+				pod, err = Td.Client.CoreV1().Pods(monitorIgnoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
+
+				By("Ensuring a pod is not injected with a sidecar when added to namespace with the monitored-by, ignore, and sidecar injection labels set")
+
+				// Get simple Pod definitions
+				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(
+					SimplePodAppDef{
+						Name:      "pod1",
+						Namespace: sidecarMonitorIgnoreNs,
+						Command:   []string{"/bin/bash", "-c", "--"},
+						Args:      []string{"while true; do sleep 30; done;"},
+						Image:     "songrgg/alpine-debug",
+						Ports:     []int{80},
+						OS:        Td.ClusterOS,
+					})
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = Td.CreateServiceAccount(sidecarMonitorIgnoreNs, &svcAccDef)
+				Expect(err).NotTo(HaveOccurred())
+				pod, err = Td.CreatePod(sidecarMonitorIgnoreNs, podDef)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = Td.CreateService(sidecarMonitorIgnoreNs, svcDef)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(Td.WaitForPodsRunningReady(sidecarMonitorIgnoreNs, 90*time.Second, 1, nil)).To(Succeed())
+
+				pod, err = Td.Client.CoreV1().Pods(sidecarMonitorIgnoreNs).Get(context.Background(), pod.Name, v1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(hasSidecar(pod.Spec.Containers)).To(BeFalse())
+			})
+		})
+	})
+
+func hasSidecar(containers []corev1.Container) bool {
+	for _, container := range containers {
+		if container.Name == constants.EnvoyContainerName {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This test verifies that the ignore label on a namespace resource
takes precedence over the values of the monitored-by label and the
sidecar injection annotation if they have been applied to a Ns.
The ignore label prevents sidecar injection from occurring in the
namespace the label is applied to.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ X ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
