### PR TITLE
pkg/*: simplify interface function signatures

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -192,7 +192,7 @@ func main() {
 	}
 
 	// A nil configClient is passed in if multi cluster mode is not enabled.
-	kubeProvider := kube.NewClient(k8sClient, configClient, constants.KubeProviderName, cfg)
+	kubeProvider := kube.NewClient(k8sClient, configClient, cfg)
 
 	endpointsProviders := []endpoint.Provider{kubeProvider}
 	serviceProviders := []service.Provider{kubeProvider}

--- a/pkg/catalog/endpoint_test.go
+++ b/pkg/catalog/endpoint_test.go
@@ -30,8 +30,7 @@ var _ = Describe("Test catalog functions", func() {
 	mc := newFakeMeshCatalog()
 	Context("Testing ListEndpointsForService()", func() {
 		It("lists endpoints for a given service", func() {
-			actual, err := mc.listEndpointsForService(tests.BookstoreV1Service)
-			Expect(err).ToNot(HaveOccurred())
+			actual := mc.listEndpointsForService(tests.BookstoreV1Service)
 
 			expected := []endpoint.Endpoint{
 				tests.Endpoint,
@@ -40,10 +39,9 @@ var _ = Describe("Test catalog functions", func() {
 		})
 	})
 
-	Context("Testing GetResolvableServiceEndpoints()", func() {
+	Context("Testing getDNSResolvableServiceEndpoints()", func() {
 		It("returns the endpoint for the service", func() {
-			actual, err := mc.GetResolvableServiceEndpoints(tests.BookstoreV1Service)
-			Expect(err).ToNot(HaveOccurred())
+			actual := mc.getDNSResolvableServiceEndpoints(tests.BookstoreV1Service)
 
 			expected := []endpoint.Endpoint{
 				tests.Endpoint,
@@ -189,8 +187,7 @@ func TestListAllowedUpstreamEndpointsForService(t *testing.T) {
 			}
 
 			if tc.permissiveMode {
-				actual, err := mc.ListAllowedUpstreamEndpointsForService(tc.proxyIdentity, tc.upstreamSvc)
-				assert.Nil(err)
+				actual := mc.ListAllowedUpstreamEndpointsForService(tc.proxyIdentity, tc.upstreamSvc)
 				assert.ElementsMatch(actual, tc.expectedEndpoints)
 				return
 			}
@@ -204,7 +201,7 @@ func TestListAllowedUpstreamEndpointsForService(t *testing.T) {
 					k8sService := tests.NewServiceFixture(svc.Name, svc.Namespace, map[string]string{})
 					mockKubeController.EXPECT().GetService(svc).Return(k8sService).AnyTimes()
 				}
-				mockServiceProvider.EXPECT().GetServicesForServiceIdentity(sa).Return(services, nil).AnyTimes()
+				mockServiceProvider.EXPECT().GetServicesForServiceIdentity(sa).Return(services).AnyTimes()
 			}
 
 			var pods []*v1.Pod
@@ -238,8 +235,7 @@ func TestListAllowedUpstreamEndpointsForService(t *testing.T) {
 				}
 			}
 
-			actual, err := mc.ListAllowedUpstreamEndpointsForService(tc.proxyIdentity, tc.upstreamSvc)
-			assert.Nil(err)
+			actual := mc.ListAllowedUpstreamEndpointsForService(tc.proxyIdentity, tc.upstreamSvc)
 			assert.ElementsMatch(actual, tc.expectedEndpoints)
 		})
 	}

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -3,12 +3,6 @@ package catalog
 import "github.com/pkg/errors"
 
 var (
-	// errServiceNotFoundForAnyProvider is an error for when OSM cannot find a service for the given service account.
-	errServiceNotFoundForAnyProvider = errors.New("no service found for service account with any of the mesh supported providers")
-
 	// errNoTrafficSpecFoundForTrafficPolicy is an error for when OSM cannot find a traffic spec for the given traffic policy.
 	errNoTrafficSpecFoundForTrafficPolicy = errors.New("no traffic spec found for the traffic policy")
-
-	// errServiceNotFound is an error for when OSM cannot find a service.
-	errServiceNotFound = errors.New("service not found")
 )

--- a/pkg/catalog/ingress.go
+++ b/pkg/catalog/ingress.go
@@ -85,7 +85,7 @@ func (mc *MeshCatalog) getIngressTrafficPolicy(svc service.MeshService) (*traffi
 			switch source.Kind {
 			case policyV1alpha1.KindService:
 				sourceMeshSvc := service.MeshService{Name: source.Name, Namespace: source.Namespace}
-				endpoints, _ := mc.listEndpointsForService(sourceMeshSvc)
+				endpoints := mc.listEndpointsForService(sourceMeshSvc)
 				if len(endpoints) == 0 {
 					ingressBackendWithStatus.Status = policyV1alpha1.IngressBackendStatus{
 						CurrentStatus: "error",

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -110,28 +110,12 @@ func (mr *MockMeshCatalogerMockRecorder) GetOutboundMeshTrafficPolicy(arg0 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundMeshTrafficPolicy", reflect.TypeOf((*MockMeshCataloger)(nil).GetOutboundMeshTrafficPolicy), arg0)
 }
 
-// GetResolvableServiceEndpoints mocks base method
-func (m *MockMeshCataloger) GetResolvableServiceEndpoints(arg0 service.MeshService) ([]endpoint.Endpoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResolvableServiceEndpoints", arg0)
-	ret0, _ := ret[0].([]endpoint.Endpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetResolvableServiceEndpoints indicates an expected call of GetResolvableServiceEndpoints
-func (mr *MockMeshCatalogerMockRecorder) GetResolvableServiceEndpoints(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvableServiceEndpoints", reflect.TypeOf((*MockMeshCataloger)(nil).GetResolvableServiceEndpoints), arg0)
-}
-
 // ListAllowedUpstreamEndpointsForService mocks base method
-func (m *MockMeshCataloger) ListAllowedUpstreamEndpointsForService(arg0 identity.ServiceIdentity, arg1 service.MeshService) ([]endpoint.Endpoint, error) {
+func (m *MockMeshCataloger) ListAllowedUpstreamEndpointsForService(arg0 identity.ServiceIdentity, arg1 service.MeshService) []endpoint.Endpoint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllowedUpstreamEndpointsForService", arg0, arg1)
 	ret0, _ := ret[0].([]endpoint.Endpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ListAllowedUpstreamEndpointsForService indicates an expected call of ListAllowedUpstreamEndpointsForService
@@ -141,12 +125,11 @@ func (mr *MockMeshCatalogerMockRecorder) ListAllowedUpstreamEndpointsForService(
 }
 
 // ListInboundServiceIdentities mocks base method
-func (m *MockMeshCataloger) ListInboundServiceIdentities(arg0 identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+func (m *MockMeshCataloger) ListInboundServiceIdentities(arg0 identity.ServiceIdentity) []identity.ServiceIdentity {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInboundServiceIdentities", arg0)
 	ret0, _ := ret[0].([]identity.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ListInboundServiceIdentities indicates an expected call of ListInboundServiceIdentities
@@ -171,12 +154,11 @@ func (mr *MockMeshCatalogerMockRecorder) ListInboundTrafficTargetsWithRoutes(arg
 }
 
 // ListOutboundServiceIdentities mocks base method
-func (m *MockMeshCataloger) ListOutboundServiceIdentities(arg0 identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+func (m *MockMeshCataloger) ListOutboundServiceIdentities(arg0 identity.ServiceIdentity) []identity.ServiceIdentity {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListOutboundServiceIdentities", arg0)
 	ret0, _ := ret[0].([]identity.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ListOutboundServiceIdentities indicates an expected call of ListOutboundServiceIdentities
@@ -214,12 +196,11 @@ func (mr *MockMeshCatalogerMockRecorder) ListOutboundServicesForMulticlusterGate
 }
 
 // ListServiceIdentitiesForService mocks base method
-func (m *MockMeshCataloger) ListServiceIdentitiesForService(arg0 service.MeshService) ([]identity.ServiceIdentity, error) {
+func (m *MockMeshCataloger) ListServiceIdentitiesForService(arg0 service.MeshService) []identity.ServiceIdentity {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceIdentitiesForService", arg0)
 	ret0, _ := ret[0].([]identity.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ListServiceIdentitiesForService indicates an expected call of ListServiceIdentitiesForService

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -550,7 +550,7 @@ func TestGetOutboundMeshTrafficPolicy(t *testing.T) {
 			// Mock calls to k8s client caches
 			mockCfg.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).AnyTimes()
 			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha1.FeatureFlags{}).AnyTimes()
-			mockServiceProvider.EXPECT().ListServices().Return(allMeshServices, nil).AnyTimes()
+			mockServiceProvider.EXPECT().ListServices().Return(allMeshServices).AnyTimes()
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(trafficTargets).AnyTimes()
 			mockServiceProvider.EXPECT().GetID().Return("test").AnyTimes()
 			mockEndpointProvider.EXPECT().GetID().Return("test").AnyTimes()
@@ -573,11 +573,11 @@ func TestGetOutboundMeshTrafficPolicy(t *testing.T) {
 			if !tc.permissiveMode {
 				for _, target := range trafficTargets {
 					dstSvcIdentity := identity.K8sServiceAccount{Namespace: target.Spec.Destination.Namespace, Name: target.Spec.Destination.Name}.ToServiceIdentity()
-					mockServiceProvider.EXPECT().GetServicesForServiceIdentity(dstSvcIdentity).Return(svcIdentityToSvcMapping[dstSvcIdentity.String()], nil).AnyTimes()
+					mockServiceProvider.EXPECT().GetServicesForServiceIdentity(dstSvcIdentity).Return(svcIdentityToSvcMapping[dstSvcIdentity.String()]).AnyTimes()
 				}
 			} else {
 				for svcIdentity, services := range svcIdentityToSvcMapping {
-					mockServiceProvider.EXPECT().GetServicesForServiceIdentity(svcIdentity).Return(services, nil).AnyTimes()
+					mockServiceProvider.EXPECT().GetServicesForServiceIdentity(svcIdentity).Return(services).AnyTimes()
 				}
 			}
 
@@ -676,7 +676,7 @@ func TestGetDestinationServicesFromTrafficTarget(t *testing.T) {
 	}
 
 	destK8sService := tests.NewServiceFixture(destMeshService.Name, destMeshService.Namespace, map[string]string{})
-	mockServiceProvider.EXPECT().GetServicesForServiceIdentity(destSA.ToServiceIdentity()).Return([]service.MeshService{destMeshService}, nil).AnyTimes()
+	mockServiceProvider.EXPECT().GetServicesForServiceIdentity(destSA.ToServiceIdentity()).Return([]service.MeshService{destMeshService}).AnyTimes()
 	mockEndpointProvider.EXPECT().GetID().Return("fake").AnyTimes()
 	mockServiceProvider.EXPECT().GetID().Return("fake").AnyTimes()
 	mockKubeController.EXPECT().GetService(destMeshService).Return(destK8sService).AnyTimes()
@@ -704,8 +704,7 @@ func TestGetDestinationServicesFromTrafficTarget(t *testing.T) {
 		},
 	}
 
-	actual, err := mc.getDestinationServicesFromTrafficTarget(trafficTarget)
-	assert.Nil(err)
+	actual := mc.getDestinationServicesFromTrafficTarget(trafficTarget)
 	assert.Equal([]service.MeshService{destMeshService}, actual)
 }
 
@@ -931,7 +930,7 @@ func TestListAllowedUpstreamServicesIncludeApex(t *testing.T) {
 			}
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(true).Times(1)
-			mockServiceProvider.EXPECT().ListServices().Return(meshServices, nil).Times(1)
+			mockServiceProvider.EXPECT().ListServices().Return(meshServices).Times(1)
 			if len(tc.trafficSplits) > 0 {
 				mockMeshSpec.EXPECT().ListTrafficSplits().Return(tc.trafficSplits).Times(1)
 			}

--- a/pkg/catalog/service.go
+++ b/pkg/catalog/service.go
@@ -1,49 +1,33 @@
 package catalog
 
 import (
-	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // getServicesForServiceIdentity returns a list of services corresponding to a service identity
-func (mc *MeshCatalog) getServicesForServiceIdentity(svcIdentity identity.ServiceIdentity) ([]service.MeshService, error) {
+func (mc *MeshCatalog) getServicesForServiceIdentity(svcIdentity identity.ServiceIdentity) []service.MeshService {
 	var services []service.MeshService
 
 	for _, provider := range mc.serviceProviders {
-		providerServices, err := provider.GetServicesForServiceIdentity(svcIdentity)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error getting K8s Services linked to Service Identity %s from provider %s", svcIdentity, provider.GetID())
-			continue
-		}
-
+		providerServices := provider.GetServicesForServiceIdentity(svcIdentity)
 		log.Trace().Msgf("Found Services %v linked to Service Identity %s from provider %s", providerServices, svcIdentity, provider.GetID())
 		services = append(services, providerServices...)
 	}
 
-	if len(services) == 0 {
-		return nil, errServiceNotFoundForAnyProvider
-	}
-
-	return services, nil
+	return services
 }
 
 // ListServiceIdentitiesForService lists the service identities associated with the given mesh service.
-func (mc *MeshCatalog) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.ServiceIdentity, error) {
+func (mc *MeshCatalog) ListServiceIdentitiesForService(svc service.MeshService) []identity.ServiceIdentity {
 	// Currently OSM uses kubernetes service accounts as service identities
 	var serviceIdentities []identity.ServiceIdentity
 	for _, provider := range mc.serviceProviders {
-		serviceIDs, err := provider.ListServiceIdentitiesForService(svc)
-		if err != nil {
-			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGettingServiceIdentitiesForService)).
-				Msgf("Error getting ServiceIdentities for Service %s", svc)
-			return nil, err
-		}
-
+		serviceIDs := provider.ListServiceIdentitiesForService(svc)
 		serviceIdentities = append(serviceIdentities, serviceIDs...)
 	}
 
-	return serviceIdentities, nil
+	return serviceIdentities
 }
 
 // listMeshServices returns all services in the mesh
@@ -51,12 +35,8 @@ func (mc *MeshCatalog) listMeshServices() []service.MeshService {
 	var services []service.MeshService
 
 	for _, provider := range mc.serviceProviders {
-		svcs, err := provider.ListServices()
-		if err != nil {
-			log.Error().Err(err).Msgf("Error listing services for provider %s", provider.GetID())
-			continue
-		}
-
+		svcs := provider.ListServices()
+		// TODO: handle duplicates when the codebase correctly supports multiple service providers
 		services = append(services, svcs...)
 	}
 

--- a/pkg/catalog/service_test.go
+++ b/pkg/catalog/service_test.go
@@ -8,9 +8,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 func TestListServiceIdentitiesForService(t *testing.T) {
@@ -26,7 +24,6 @@ func TestListServiceIdentitiesForService(t *testing.T) {
 	testCases := []struct {
 		svc                 service.MeshService
 		expectedSvcAccounts []identity.ServiceIdentity
-		expectedError       error
 	}{
 		{
 			service.MeshService{Name: "foo", Namespace: "ns-1"},
@@ -34,7 +31,6 @@ func TestListServiceIdentitiesForService(t *testing.T) {
 				identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}.ToServiceIdentity(),
 				identity.K8sServiceAccount{Name: "sa-2", Namespace: "ns-1"}.ToServiceIdentity(),
 			},
-			nil,
 		},
 		{
 			service.MeshService{Name: "foo", Namespace: "ns-1"},
@@ -42,67 +38,65 @@ func TestListServiceIdentitiesForService(t *testing.T) {
 				identity.K8sServiceAccount{Name: "sa-1", Namespace: "ns-1"}.ToServiceIdentity(),
 				identity.K8sServiceAccount{Name: "sa-2", Namespace: "ns-1"}.ToServiceIdentity(),
 			},
-			nil,
 		},
 		{
 			service.MeshService{Name: "foo", Namespace: "ns-1"},
 			nil,
-			errServiceNotFound,
 		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing test case %d", i), func(t *testing.T) {
-			mockServiceProvider.EXPECT().ListServiceIdentitiesForService(tc.svc).Return(tc.expectedSvcAccounts, tc.expectedError).Times(1)
-			serviceIdentities, err := mc.ListServiceIdentitiesForService(tc.svc)
+			mockServiceProvider.EXPECT().ListServiceIdentitiesForService(tc.svc).Return(tc.expectedSvcAccounts).Times(1)
+			serviceIdentities := mc.ListServiceIdentitiesForService(tc.svc)
 			assert.ElementsMatch(serviceIdentities, tc.expectedSvcAccounts)
-			assert.Equal(err, tc.expectedError)
 		})
 	}
 }
 
 func TestListMeshServices(t *testing.T) {
-	assert := tassert.New(t)
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	mockServiceProvider := service.NewMockProvider(mockCtrl)
-	mockKubeController := k8s.NewMockController(mockCtrl)
-	mc := MeshCatalog{
-		kubeController:   mockKubeController,
-		serviceProviders: []service.Provider{mockServiceProvider},
-	}
-
 	testCases := []struct {
-		name     string
-		services map[string]string // name: namespace
+		name                  string
+		provider1MeshServices []service.MeshService
+		provider2MeshServices []service.MeshService
+		expectedMeshServices  []service.MeshService
 	}{
 		{
-			name:     "services exist in mesh",
-			services: map[string]string{"bookstore": "bookstore-ns", "bookbuyer": "bookbuyer-ns", "bookwarehouse": "bookwarehouse"},
-		},
-		{
-			name:     "no services in mesh",
-			services: map[string]string{},
+			name: "services exist in mesh",
+			provider1MeshServices: []service.MeshService{
+				{Namespace: "ns1", Name: "s1"},
+				{Namespace: "ns2", Name: "s2"},
+			},
+			provider2MeshServices: []service.MeshService{
+				{Namespace: "ns3", Name: "s3"},
+				{Namespace: "ns4", Name: "s4"},
+			},
+			expectedMeshServices: []service.MeshService{
+				{Namespace: "ns1", Name: "s1"},
+				{Namespace: "ns2", Name: "s2"},
+				{Namespace: "ns3", Name: "s3"},
+				{Namespace: "ns4", Name: "s4"},
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			var expectedMeshServices, actual []service.MeshService
+			assert := tassert.New(t)
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+			provider1 := service.NewMockProvider(mockCtrl)
+			provider2 := service.NewMockProvider(mockCtrl)
 
-			for name, namespace := range tc.services {
-				expectedMeshServices = append(expectedMeshServices, tests.NewMeshServiceFixture(name, namespace))
+			mc := MeshCatalog{
+				serviceProviders: []service.Provider{provider1, provider2},
 			}
 
-			mockServiceProvider.EXPECT().ListServices().Return(expectedMeshServices, nil)
-			for _, provider := range mc.serviceProviders {
-				services, err := provider.ListServices()
-				if err != nil {
-					panic(err)
-				}
-				actual = append(actual, services...)
-			}
-			assert.Equal(expectedMeshServices, actual)
+			provider1.EXPECT().ListServices().Return(tc.provider1MeshServices)
+			provider2.EXPECT().ListServices().Return(tc.provider2MeshServices)
+
+			actual := mc.listMeshServices()
+			assert.ElementsMatch(tc.expectedMeshServices, actual)
 		})
 	}
 }

--- a/pkg/catalog/traffictarget.go
+++ b/pkg/catalog/traffictarget.go
@@ -24,13 +24,13 @@ const (
 
 // ListInboundServiceIdentities lists the downstream service identities that are allowed to connect to the given service identity
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (mc *MeshCatalog) ListInboundServiceIdentities(upstream identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+func (mc *MeshCatalog) ListInboundServiceIdentities(upstream identity.ServiceIdentity) []identity.ServiceIdentity {
 	return mc.getAllowedDirectionalServiceAccounts(upstream, inbound)
 }
 
 // ListOutboundServiceIdentities lists the upstream service identities the given service identity are allowed to connect to
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (mc *MeshCatalog) ListOutboundServiceIdentities(downstream identity.ServiceIdentity) ([]identity.ServiceIdentity, error) {
+func (mc *MeshCatalog) ListOutboundServiceIdentities(downstream identity.ServiceIdentity) []identity.ServiceIdentity {
 	return mc.getAllowedDirectionalServiceAccounts(downstream, outbound)
 }
 
@@ -83,7 +83,7 @@ func (mc *MeshCatalog) ListInboundTrafficTargetsWithRoutes(upstream identity.Ser
 }
 
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcIdentity identity.ServiceIdentity, direction trafficDirection) ([]identity.ServiceIdentity, error) {
+func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcIdentity identity.ServiceIdentity, direction trafficDirection) []identity.ServiceIdentity {
 	svcAccount := svcIdentity.ToK8sServiceAccount()
 	allowed := mapset.NewSet()
 
@@ -141,7 +141,7 @@ func (mc *MeshCatalog) getAllowedDirectionalServiceAccounts(svcIdentity identity
 		allowedSvcIdentities = append(allowedSvcIdentities, svcAccount.(identity.K8sServiceAccount).ToServiceIdentity())
 	}
 
-	return allowedSvcIdentities, nil
+	return allowedSvcIdentities
 }
 
 func trafficTargetIdentityToSvcAccount(identitySubject smiAccess.IdentityBindingSubject) identity.K8sServiceAccount {

--- a/pkg/catalog/traffictarget_test.go
+++ b/pkg/catalog/traffictarget_test.go
@@ -31,7 +31,6 @@ func TestListInboundServiceIdentities(t *testing.T) {
 		trafficTargets                   []*smiAccess.TrafficTarget
 		serviceIdentity                  identity.ServiceIdentity
 		expectedInboundServiceIdentities []identity.ServiceIdentity
-		expectError                      bool
 	}{
 		// Test case 1 begin ------------------------------------
 		// There is a valid inbound service account
@@ -96,8 +95,6 @@ func TestListInboundServiceIdentities(t *testing.T) {
 					Namespace: "ns-1",
 				}.ToServiceIdentity(),
 			},
-
-			false, // no errors expected
 		},
 		// Test case 1 end ------------------------------------
 
@@ -137,8 +134,6 @@ func TestListInboundServiceIdentities(t *testing.T) {
 
 			// allowed inbound service accounts: no match
 			nil,
-
-			false, // no errors expected
 		},
 		// Test case 2 end ------------------------------------
 
@@ -178,8 +173,6 @@ func TestListInboundServiceIdentities(t *testing.T) {
 
 			// allowed inbound service accounts: no match
 			nil,
-
-			false, // will log an error but function will ignore policy with error
 		},
 		// Test case 3 end ------------------------------------
 	}
@@ -189,8 +182,7 @@ func TestListInboundServiceIdentities(t *testing.T) {
 			// Mock TrafficTargets returned by MeshSpec, should return all TrafficTargets relevant for this test
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).Times(1)
 
-			actual, err := meshCatalog.ListInboundServiceIdentities(tc.serviceIdentity)
-			assert.Equal(err != nil, tc.expectError)
+			actual := meshCatalog.ListInboundServiceIdentities(tc.serviceIdentity)
 			assert.ElementsMatch(actual, tc.expectedInboundServiceIdentities)
 		})
 	}
@@ -210,7 +202,6 @@ func TestListOutboundServiceIdentities(t *testing.T) {
 		trafficTargets                    []*smiAccess.TrafficTarget
 		serviceIdentity                   identity.ServiceIdentity
 		expectedOutboundServiceIdentities []identity.ServiceIdentity
-		expectError                       bool
 	}{
 		// Test case 1 begin ------------------------------------
 		// There is a valid outbound service account
@@ -279,8 +270,6 @@ func TestListOutboundServiceIdentities(t *testing.T) {
 					Namespace: "ns-3",
 				}.ToServiceIdentity(),
 			},
-
-			false, // no errors expected
 		},
 		// Test case 1 end ------------------------------------
 
@@ -320,8 +309,6 @@ func TestListOutboundServiceIdentities(t *testing.T) {
 
 			// allowed inbound service accounts: no match
 			nil,
-
-			false, // no errors expected
 		},
 		// Test case 2 end ------------------------------------
 
@@ -361,8 +348,6 @@ func TestListOutboundServiceIdentities(t *testing.T) {
 
 			// allowed inbound service accounts: no match
 			nil,
-
-			false, // will log an error but function will ignore policy with error
 		},
 		// Test case 3 end ------------------------------------
 	}
@@ -372,8 +357,7 @@ func TestListOutboundServiceIdentities(t *testing.T) {
 			// Mock TrafficTargets returned by MeshSpec, should return all TrafficTargets relevant for this test
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(tc.trafficTargets).Times(1)
 
-			actual, err := meshCatalog.ListOutboundServiceIdentities(tc.serviceIdentity)
-			assert.Equal(err != nil, tc.expectError)
+			actual := meshCatalog.ListOutboundServiceIdentities(tc.serviceIdentity)
 			assert.ElementsMatch(actual, tc.expectedOutboundServiceIdentities)
 		})
 	}

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -50,23 +50,17 @@ type MeshCataloger interface {
 	ListOutboundServicesForMulticlusterGateway() []service.MeshService
 
 	// ListInboundServiceIdentities lists the downstream service identities that are allowed to connect to the given service identity
-	ListInboundServiceIdentities(identity.ServiceIdentity) ([]identity.ServiceIdentity, error)
+	ListInboundServiceIdentities(identity.ServiceIdentity) []identity.ServiceIdentity
 
 	// ListOutboundServiceIdentities lists the upstream service identities the given service identity are allowed to connect to
-	ListOutboundServiceIdentities(identity.ServiceIdentity) ([]identity.ServiceIdentity, error)
+	ListOutboundServiceIdentities(identity.ServiceIdentity) []identity.ServiceIdentity
 
 	// ListServiceIdentitiesForService lists the service identities associated with the given service
-	ListServiceIdentitiesForService(service.MeshService) ([]identity.ServiceIdentity, error)
+	ListServiceIdentitiesForService(service.MeshService) []identity.ServiceIdentity
 
 	// ListAllowedUpstreamEndpointsForService returns the list of endpoints over which the downstream client identity
 	// is allowed access the upstream service
-	ListAllowedUpstreamEndpointsForService(identity.ServiceIdentity, service.MeshService) ([]endpoint.Endpoint, error)
-
-	// GetResolvableServiceEndpoints returns the resolvable set of endpoint over which a service is accessible using its FQDN.
-	// These are the endpoint destinations we'd expect client applications sends the traffic towards to, when attempting to
-	// reach a specific service.
-	// If no LB/virtual IPs are assigned to the service, GetResolvableServiceEndpoints will return ListEndpointsForService
-	GetResolvableServiceEndpoints(service.MeshService) ([]endpoint.Endpoint, error)
+	ListAllowedUpstreamEndpointsForService(identity.ServiceIdentity, service.MeshService) []endpoint.Endpoint
 
 	// GetIngressTrafficPolicy returns the ingress traffic policy for the given mesh service
 	GetIngressTrafficPolicy(service.MeshService) (*trafficpolicy.IngressTrafficPolicy, error)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,9 +4,6 @@ package constants
 import "time"
 
 const (
-	// KubeProviderName is a string constant used for the ID string of the Kubernetes endpoints provider.
-	KubeProviderName = "Kubernetes"
-
 	// WildcardIPAddr is a string constant.
 	WildcardIPAddr = "0.0.0.0"
 

--- a/pkg/endpoint/mock_endpoint_provider_generated.go
+++ b/pkg/endpoint/mock_endpoint_provider_generated.go
@@ -50,12 +50,11 @@ func (mr *MockProviderMockRecorder) GetID() *gomock.Call {
 }
 
 // GetResolvableEndpointsForService mocks base method
-func (m *MockProvider) GetResolvableEndpointsForService(arg0 service.MeshService) ([]Endpoint, error) {
+func (m *MockProvider) GetResolvableEndpointsForService(arg0 service.MeshService) []Endpoint {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResolvableEndpointsForService", arg0)
 	ret0, _ := ret[0].([]Endpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetResolvableEndpointsForService indicates an expected call of GetResolvableEndpointsForService

--- a/pkg/endpoint/types.go
+++ b/pkg/endpoint/types.go
@@ -22,7 +22,7 @@ type Provider interface {
 
 	// GetResolvableEndpointsForService returns the expected endpoints that are to be reached when the service FQDN is resolved under
 	// the scope of the provider
-	GetResolvableEndpointsForService(service.MeshService) ([]Endpoint, error)
+	GetResolvableEndpointsForService(service.MeshService) []Endpoint
 
 	// GetID returns the unique identifier of the EndpointsProvider.
 	GetID() string

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -178,12 +178,7 @@ func getServiceIdentitiesFromCert(sdscert secrets.SDSCert, serviceIdentity ident
 				Msgf("Error unmarshalling upstream service for outbound cert %s", sdscert)
 			return nil, err
 		}
-		svcIdentities, err := meshCatalog.ListServiceIdentitiesForService(*meshSvc)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error listing service accounts for service %s", meshSvc)
-			return nil, err
-		}
-		return svcIdentities, nil
+		return meshCatalog.ListServiceIdentitiesForService(*meshSvc), nil
 
 	case secrets.RootCertTypeForMTLSInbound:
 		// Verify that the SDS cert request corresponding to the mTLS root validation cert matches the identity
@@ -205,12 +200,7 @@ func getServiceIdentitiesFromCert(sdscert secrets.SDSCert, serviceIdentity ident
 		// service identities that are allowed to connect to this upstream identity. This means, if the upstream proxy
 		// identity is 'X', the SANs for this certificate should correspond to all the downstream identities
 		// allowed to access 'X'.
-		svcIdentities, err := meshCatalog.ListInboundServiceIdentities(serviceIdentity)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error listing inbound service accounts for proxy with ServiceAccount %s", serviceIdentity)
-			return nil, err
-		}
-		return svcIdentities, nil
+		return meshCatalog.ListInboundServiceIdentities(serviceIdentity), nil
 
 	default:
 		log.Debug().Msgf("SAN matching not needed for cert %s", sdscert)

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -137,7 +137,7 @@ func TestGetRootCert(t *testing.T) {
 				d.mockCatalog.EXPECT().ListServiceIdentitiesForService(service.MeshService{
 					Name:      "service-2",
 					Namespace: "ns-2",
-				}).Return(associatedSvcAccounts, nil).Times(1)
+				}).Return(associatedSvcAccounts).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 
@@ -288,7 +288,7 @@ func TestGetSDSSecrets(t *testing.T) {
 					Name:      "service-2",
 					Namespace: "ns-2",
 				}
-				d.mockCatalog.EXPECT().ListServiceIdentitiesForService(svc).Return(associatedSvcAccounts, nil).Times(1)
+				d.mockCatalog.EXPECT().ListServiceIdentitiesForService(svc).Return(associatedSvcAccounts).Times(1)
 				d.mockCertificater.EXPECT().GetIssuingCA().Return([]byte("foo")).Times(1)
 			},
 

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -15,10 +15,13 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
+// Ensure interface compliance
+var _ endpoint.Provider = (*client)(nil)
+var _ service.Provider = (*client)(nil)
+
 // NewClient returns a client that has all components necessary to connect to and maintain state of a Kubernetes cluster.
-func NewClient(kubeController k8s.Controller, configClient config.Controller, providerIdent string, cfg configurator.Configurator) *client { //nolint:golint // exported func returns unexported type
+func NewClient(kubeController k8s.Controller, configClient config.Controller, cfg configurator.Configurator) *client { //nolint:golint // exported func returns unexported type
 	return &client{
-		providerIdent:    providerIdent,
 		kubeController:   kubeController,
 		configClient:     configClient,
 		meshConfigurator: cfg,
@@ -28,21 +31,16 @@ func NewClient(kubeController k8s.Controller, configClient config.Controller, pr
 // GetID returns a string descriptor / identifier of the compute provider.
 // Required by interfaces: EndpointsProvider, ServiceProvider
 func (c *client) GetID() string {
-	return c.providerIdent
+	return providerName
 }
 
 // ListEndpointsForService retrieves the list of IP addresses for the given service
 func (c *client) ListEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
-	log.Trace().Msgf("[%s] Getting Endpoints for service %s on Kubernetes", c.providerIdent, svc)
+	log.Trace().Msgf("Getting Endpoints for MeshService %s on Kubernetes", svc)
 
 	kubernetesEndpoints, err := c.kubeController.GetEndpoints(svc)
 	if err != nil || kubernetesEndpoints == nil {
-		log.Error().Err(err).Msgf("[%s] Error fetching Kubernetes Endpoints from cache for service %s", c.providerIdent, svc)
-		return nil
-	}
-
-	if !c.kubeController.IsMonitoredNamespace(kubernetesEndpoints.Namespace) {
-		// Doesn't belong to namespaces we are observing
+		log.Info().Msgf("No k8s endpoints found for MeshService %s", svc)
 		return nil
 	}
 
@@ -59,8 +57,8 @@ func (c *client) ListEndpointsForService(svc service.MeshService) []endpoint.End
 			for _, address := range kubernetesEndpoint.Addresses {
 				ip := net.ParseIP(address.IP)
 				if ip == nil {
-					log.Error().Msgf("[%s] Error parsing endopint IP address %s for service %s", c.providerIdent, address.IP, svc)
-					break
+					log.Error().Msgf("Error parsing endpoint IP address %s for MeshService %s", address.IP, svc)
+					continue
 				}
 				ept := endpoint.Endpoint{
 					IP:   ip,
@@ -76,7 +74,7 @@ func (c *client) ListEndpointsForService(svc service.MeshService) []endpoint.End
 		endpoints = append(endpoints, c.getMulticlusterEndpoints(svc)...)
 	}
 
-	log.Trace().Msgf("[%s][ListEndpointsForService] Endpoints for service %s: %+v", c.providerIdent, svc, endpoints)
+	log.Trace().Msgf("Endpoints for MeshService %s: %v", svc, endpoints)
 
 	return endpoints
 }
@@ -85,7 +83,7 @@ func (c *client) ListEndpointsForService(svc service.MeshService) []endpoint.End
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
 func (c *client) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdentity) []endpoint.Endpoint {
 	sa := serviceIdentity.ToK8sServiceAccount()
-	log.Trace().Msgf("[%s] (ListEndpointsForIdentity) Getting Endpoints for service account %s on Kubernetes", c.providerIdent, sa)
+	log.Trace().Msgf("[%s] (ListEndpointsForIdentity) Getting Endpoints for service account %s on Kubernetes", c.GetID(), sa)
 
 	var endpoints []endpoint.Endpoint
 	for _, pod := range c.kubeController.ListPods() {
@@ -99,7 +97,7 @@ func (c *client) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdenti
 		for _, podIP := range pod.Status.PodIPs {
 			ip := net.ParseIP(podIP.IP)
 			if ip == nil {
-				log.Error().Msgf("[%s] Error parsing IP address %s", c.providerIdent, podIP.IP)
+				log.Error().Msgf("[%s] Error parsing IP address %s", c.GetID(), podIP.IP)
 				break
 			}
 			ept := endpoint.Endpoint{IP: ip}
@@ -112,13 +110,13 @@ func (c *client) ListEndpointsForIdentity(serviceIdentity identity.ServiceIdenti
 		endpoints = append(endpoints, c.getMultiClusterServiceEndpointsForServiceAccount(sa.Name, sa.Namespace)...)
 	}
 
-	log.Trace().Msgf("[%s][ListEndpointsForIdentity] Endpoints for service identity (serviceAccount=%s) %s: %+v", c.providerIdent, serviceIdentity, sa, endpoints)
+	log.Trace().Msgf("[%s][ListEndpointsForIdentity] Endpoints for service identity (serviceAccount=%s) %s: %+v", c.GetID(), serviceIdentity, sa, endpoints)
 
 	return endpoints
 }
 
 // GetServicesForServiceIdentity retrieves a list of services for the given service identity.
-func (c *client) GetServicesForServiceIdentity(svcIdentity identity.ServiceIdentity) ([]service.MeshService, error) {
+func (c *client) GetServicesForServiceIdentity(svcIdentity identity.ServiceIdentity) []service.MeshService {
 	var meshServices []service.MeshService
 	svcSet := mapset.NewSet() // mapset is used to avoid duplicate elements in the output list
 
@@ -134,12 +132,7 @@ func (c *client) GetServicesForServiceIdentity(svcIdentity identity.ServiceIdent
 		}
 
 		podLabels := pod.ObjectMeta.Labels
-		meshServicesForPod, err := c.getServicesByLabels(podLabels, pod.Namespace)
-		if err != nil {
-			log.Error().Err(err).Msgf("[%s] Error retrieving service matching labels %v in namespace %s", c.providerIdent, podLabels, pod.Namespace)
-			return nil, err
-		}
-
+		meshServicesForPod := c.getServicesByLabels(podLabels, pod.Namespace)
 		for _, svc := range meshServicesForPod {
 			if added := svcSet.Add(svc); added {
 				meshServices = append(meshServices, svc)
@@ -147,18 +140,12 @@ func (c *client) GetServicesForServiceIdentity(svcIdentity identity.ServiceIdent
 		}
 	}
 
-	if len(meshServices) == 0 {
-		log.Error().Err(errServiceNotFound).Msgf("[%s] No services for service account %s", c.providerIdent, svcAccount)
-		return nil, errServiceNotFound
-	}
-
-	log.Trace().Msgf("[%s] Services for service account %s: %v", c.providerIdent, svcAccount, meshServices)
-	return meshServices, nil
+	log.Trace().Msgf("[%s] Services for service account %s: %v", c.GetID(), svcAccount, meshServices)
+	return meshServices
 }
 
 // getServicesByLabels gets Kubernetes services whose selectors match the given labels
-// TODO(shashank): simplify method signature
-func (c *client) getServicesByLabels(podLabels map[string]string, targetNamespace string) ([]service.MeshService, error) {
+func (c *client) getServicesByLabels(podLabels map[string]string, targetNamespace string) []service.MeshService {
 	var finalList []service.MeshService
 	serviceList := c.kubeController.ListServices()
 
@@ -180,32 +167,31 @@ func (c *client) getServicesByLabels(podLabels map[string]string, targetNamespac
 		}
 	}
 
-	return finalList, nil
+	return finalList
 }
 
 // GetResolvableEndpointsForService returns the expected endpoints that are to be reached when the service
 // FQDN is resolved
-func (c *client) GetResolvableEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {
+func (c *client) GetResolvableEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
 	var endpoints []endpoint.Endpoint
-	var err error
 
 	// Check if the service has been given Cluster IP
 	kubeService := c.kubeController.GetService(svc)
 	if kubeService == nil {
-		log.Error().Msgf("[%s] Could not find service %s", c.providerIdent, svc)
-		return nil, errServiceNotFound
+		log.Info().Msgf("No k8s services found for MeshService %s", svc)
+		return nil
 	}
 
 	if len(kubeService.Spec.ClusterIP) == 0 || kubeService.Spec.ClusterIP == corev1.ClusterIPNone {
 		// If service has no cluster IP or cluster IP is <none>, use final endpoint as resolvable destinations
-		return c.ListEndpointsForService(svc), nil
+		return c.ListEndpointsForService(svc)
 	}
 
 	// Cluster IP is present
 	ip := net.ParseIP(kubeService.Spec.ClusterIP)
 	if ip == nil {
-		log.Error().Msgf("[%s] Could not parse Cluster IP %s", c.providerIdent, kubeService.Spec.ClusterIP)
-		return nil, errParseClusterIP
+		log.Error().Msgf("[%s] Could not parse Cluster IP %s", c.GetID(), kubeService.Spec.ClusterIP)
+		return nil
 	}
 
 	for _, svcPort := range kubeService.Spec.Ports {
@@ -215,24 +201,24 @@ func (c *client) GetResolvableEndpointsForService(svc service.MeshService) ([]en
 		})
 	}
 
-	return endpoints, err
+	return endpoints
 }
 
 // ListServices returns a list of services that are part of monitored namespaces
-func (c *client) ListServices() ([]service.MeshService, error) {
+func (c *client) ListServices() []service.MeshService {
 	var services []service.MeshService
 	for _, svc := range c.kubeController.ListServices() {
 		services = append(services, c.kubeController.K8sServiceToMeshServices(*svc)...)
 	}
-	return services, nil
+	return services
 }
 
 // ListServiceIdentitiesForService lists the service identities associated with the given mesh service.
-func (c *client) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.ServiceIdentity, error) {
+func (c *client) ListServiceIdentitiesForService(svc service.MeshService) []identity.ServiceIdentity {
 	serviceAccounts, err := c.kubeController.ListServiceIdentitiesForService(svc)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error getting ServiceAccounts for Service %s", svc)
-		return nil, err
+		return nil
 	}
 
 	var serviceIdentities []identity.ServiceIdentity
@@ -241,5 +227,5 @@ func (c *client) ListServiceIdentitiesForService(svc service.MeshService) ([]ide
 		serviceIdentities = append(serviceIdentities, serviceIdentity)
 	}
 
-	return serviceIdentities, nil
+	return serviceIdentities
 }

--- a/pkg/providers/kube/errors.go
+++ b/pkg/providers/kube/errors.go
@@ -3,7 +3,5 @@ package kube
 import "github.com/pkg/errors"
 
 var (
-	errServiceNotFound            = errors.New("service not found")
-	errParseClusterIP             = errors.New("could not parse cluster IP")
 	errParseMulticlusterServiceIP = errors.New("could not parse multicluster service IP")
 )

--- a/pkg/providers/kube/fake.go
+++ b/pkg/providers/kube/fake.go
@@ -3,8 +3,6 @@ package kube
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/openservicemesh/osm/pkg/endpoint"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -63,31 +61,31 @@ func (f fakeClient) ListEndpointsForIdentity(serviceIdentity identity.ServiceIde
 	panic(fmt.Sprintf("You are asking for K8sServiceAccount=%s but the fake Kubernetes client has not been initialized with this. What we have is: %+v", sa, f.svcAccountEndpoints))
 }
 
-func (f fakeClient) GetServicesForServiceIdentity(serviceIdentity identity.ServiceIdentity) ([]service.MeshService, error) {
+func (f fakeClient) GetServicesForServiceIdentity(serviceIdentity identity.ServiceIdentity) []service.MeshService {
 	sa := serviceIdentity.ToK8sServiceAccount()
 	services, ok := f.services[sa]
 	if !ok {
-		return nil, errors.Errorf("ServiceAccount %s is not in cache: %+v", sa, f.services)
+		return nil
 	}
-	return services, nil
+	return services
 }
 
-func (f fakeClient) ListServices() ([]service.MeshService, error) {
+func (f fakeClient) ListServices() []service.MeshService {
 	var services []service.MeshService
 
 	for _, svcs := range f.services {
 		services = append(services, svcs...)
 	}
-	return services, nil
+	return services
 }
 
-func (f fakeClient) ListServiceIdentitiesForService(svc service.MeshService) ([]identity.ServiceIdentity, error) {
+func (f fakeClient) ListServiceIdentitiesForService(svc service.MeshService) []identity.ServiceIdentity {
 	var serviceIdentities []identity.ServiceIdentity
 
 	for svcID := range f.services {
 		serviceIdentities = append(serviceIdentities, svcID.ToServiceIdentity())
 	}
-	return serviceIdentities, nil
+	return serviceIdentities
 }
 
 // GetID returns the unique identifier of the Provider.
@@ -95,10 +93,10 @@ func (f fakeClient) GetID() string {
 	return "Fake Kubernetes Client"
 }
 
-func (f fakeClient) GetResolvableEndpointsForService(svc service.MeshService) ([]endpoint.Endpoint, error) {
+func (f fakeClient) GetResolvableEndpointsForService(svc service.MeshService) []endpoint.Endpoint {
 	endpoints, found := f.endpoints[svc.String()]
 	if !found {
-		return nil, errServiceNotFound
+		return nil
 	}
-	return endpoints, nil
+	return endpoints
 }

--- a/pkg/providers/kube/multiclusterservice.go
+++ b/pkg/providers/kube/multiclusterservice.go
@@ -18,7 +18,7 @@ func (c *client) getMulticlusterEndpoints(svc service.MeshService) []endpoint.En
 	var endpoints []endpoint.Endpoint
 	serviceIdentities, err := c.kubeController.ListServiceIdentitiesForService(svc)
 	if err != nil {
-		log.Error().Str(constants.LogFieldContext, constants.LogContextMulticluster).Err(err).Msgf("[%s] Error getting Multicluster service identities for service %s", c.providerIdent, svc.Name)
+		log.Error().Str(constants.LogFieldContext, constants.LogContextMulticluster).Err(err).Msgf("[%s] Error getting Multicluster service identities for service %s", c.GetID(), svc.Name)
 		return endpoints
 	}
 
@@ -27,7 +27,7 @@ func (c *client) getMulticlusterEndpoints(svc service.MeshService) []endpoint.En
 		endpoints = append(endpoints, remoteEndpoints...)
 	}
 
-	log.Debug().Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("[%s] Multicluster Endpoints for service %s: %+v", c.providerIdent, svc, endpoints)
+	log.Debug().Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("[%s] Multicluster Endpoints for service %s: %+v", c.GetID(), svc, endpoints)
 	return endpoints
 }
 
@@ -54,7 +54,7 @@ func (c *client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount
 			endpoints = append(endpoints, ep)
 		}
 	}
-	log.Debug().Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("[%s] Multicluster Endpoints for service account %s: %+v", c.providerIdent, serviceAccount, endpoints)
+	log.Debug().Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("[%s] Multicluster Endpoints for service account %s: %+v", c.GetID(), serviceAccount, endpoints)
 	return endpoints
 }
 

--- a/pkg/providers/kube/multiclusterservice_test.go
+++ b/pkg/providers/kube/multiclusterservice_test.go
@@ -65,7 +65,7 @@ func TestHelperFunctions(t *testing.T) {
 	}}
 	mockConfigController.EXPECT().GetMultiClusterServiceByServiceAccount(tests.BookbuyerServiceName, tests.Namespace).Return(toReturnServices).AnyTimes()
 
-	c = NewClient(mockKubeController, mockConfigController, "kubernetes-endpoint-provider", mockConfigurator)
+	c = NewClient(mockKubeController, mockConfigController, mockConfigurator)
 
 	// Test getMulticlusterEndpoints()
 	// returns Multicluster endpoints for a service

--- a/pkg/providers/kube/types.go
+++ b/pkg/providers/kube/types.go
@@ -7,13 +7,17 @@ import (
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
+const (
+	// providerName is the name of the Kubernetes client that implements service.Provider and endpoint.Provider interfaces
+	providerName = "kubernetes"
+)
+
 var (
 	log = logger.New("kube-provider")
 )
 
 // client is the type used to represent the k8s client for endpoints and service provider
 type client struct {
-	providerIdent    string
 	kubeController   k8s.Controller
 	configClient     config.Controller
 	meshConfigurator configurator.Configurator

--- a/pkg/service/mock_service_provider_generated.go
+++ b/pkg/service/mock_service_provider_generated.go
@@ -49,12 +49,11 @@ func (mr *MockProviderMockRecorder) GetID() *gomock.Call {
 }
 
 // GetServicesForServiceIdentity mocks base method
-func (m *MockProvider) GetServicesForServiceIdentity(arg0 identity.ServiceIdentity) ([]MeshService, error) {
+func (m *MockProvider) GetServicesForServiceIdentity(arg0 identity.ServiceIdentity) []MeshService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServicesForServiceIdentity", arg0)
 	ret0, _ := ret[0].([]MeshService)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetServicesForServiceIdentity indicates an expected call of GetServicesForServiceIdentity
@@ -64,12 +63,11 @@ func (mr *MockProviderMockRecorder) GetServicesForServiceIdentity(arg0 interface
 }
 
 // ListServiceIdentitiesForService mocks base method
-func (m *MockProvider) ListServiceIdentitiesForService(arg0 MeshService) ([]identity.ServiceIdentity, error) {
+func (m *MockProvider) ListServiceIdentitiesForService(arg0 MeshService) []identity.ServiceIdentity {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceIdentitiesForService", arg0)
 	ret0, _ := ret[0].([]identity.ServiceIdentity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ListServiceIdentitiesForService indicates an expected call of ListServiceIdentitiesForService
@@ -79,12 +77,11 @@ func (mr *MockProviderMockRecorder) ListServiceIdentitiesForService(arg0 interfa
 }
 
 // ListServices mocks base method
-func (m *MockProvider) ListServices() ([]MeshService, error) {
+func (m *MockProvider) ListServices() []MeshService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServices")
 	ret0, _ := ret[0].([]MeshService)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // ListServices indicates an expected call of ListServices

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -82,16 +82,14 @@ type WeightedCluster struct {
 // Provider is an interface to be implemented by components abstracting Kubernetes, and other compute/cluster providers
 type Provider interface {
 	// GetServicesForServiceIdentity retrieves the namespaced services for a given service identity
-	// TODO(shashank): simplify method signature
-	GetServicesForServiceIdentity(identity.ServiceIdentity) ([]MeshService, error)
+	GetServicesForServiceIdentity(identity.ServiceIdentity) []MeshService
 
 	// ListServices returns a list of services that are part of monitored namespaces
-	// TODO(shashank): simplify method signature
-	ListServices() ([]MeshService, error)
+	ListServices() []MeshService
 
 	// ListServiceIdentitiesForService returns service identities for given service
-	ListServiceIdentitiesForService(MeshService) ([]identity.ServiceIdentity, error)
+	ListServiceIdentitiesForService(MeshService) []identity.ServiceIdentity
 
-	// GetID returns the unique identifier of the ServiceProvider.
+	// GetID returns the unique identifier of the Provider
 	GetID() string
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change simplifies function signatures when a slice
is being returned to the caller by letting the caller
of the function decide on error conditions. In a lot
of cases, nil error values are always being returned
by many functions, and in cases where an error is returned
results in duplicate errors being propagated and logged 
across the call stack. 

Removing unnecessary error paths simplifies
the code and makes it easier to test.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
