### PR TITLE
envoy: add helper to convert IP CIDR string to XDS object

### DIFF
--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -1,6 +1,7 @@
 package envoy
 
 import (
+	"net"
 	"strings"
 
 	xds_accesslog_filter "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -14,6 +15,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -405,4 +407,20 @@ func GetKindFromProxyCertificate(cn certificate.CommonName) (ProxyKind, error) {
 	}
 
 	return cnMeta.ProxyKind, nil
+}
+
+// GetCIDRRangeFromStr converts the given CIDR as a string to an XDS CidrRange object
+func GetCIDRRangeFromStr(cidr string) (*xds_core.CidrRange, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+
+	prefixLen, _ := ipNet.Mask.Size()
+	return &xds_core.CidrRange{
+		AddressPrefix: ip.String(),
+		PrefixLen: &wrapperspb.UInt32Value{
+			Value: uint32(prefixLen),
+		},
+	}, nil
 }

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -11,6 +11,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	tassert "github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -358,4 +359,41 @@ func TestGetKindFromProxyCertificate(t *testing.T) {
 	assert.Nil(err, fmt.Sprintf("Expected err to be nil; Actually it was %+v", err))
 	expectedProxyKind := KindGateway
 	assert.Equal(expectedProxyKind, actualProxyKind)
+}
+
+func TestGetCIDRRangeFromStr(t *testing.T) {
+	testCases := []struct {
+		name              string
+		cidr              string
+		expectedCIDRRange *xds_core.CidrRange
+		expectErr         bool
+	}{
+		{
+			name: "valid CIDR range",
+			cidr: "10.0.0.0/10",
+			expectedCIDRRange: &xds_core.CidrRange{
+				AddressPrefix: "10.0.0.0",
+				PrefixLen: &wrapperspb.UInt32Value{
+					Value: 10,
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name:              "invalid CIDR range",
+			cidr:              "10.0.0.1",
+			expectedCIDRRange: nil,
+			expectErr:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			actual, err := GetCIDRRangeFromStr(tc.cidr)
+			assert.Equal(tc.expectedCIDRRange, actual)
+			assert.Equal(tc.expectErr, err != nil)
+		})
+	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a helper to convert IP CIDR represented as a string
to an XDS CidrRange object, to avoid code duplication.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
