### PR TITLE
ref(tests): randomize k8s resource names in tests

### DIFF
--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/tests/framework"
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 
@@ -17,9 +18,12 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 	},
 	func() {
 		Context("CertManagerSimpleClientServer", func() {
-			const sourceNs = "client"
-			const destNs = "server"
-			var ns []string = []string{sourceNs, destNs}
+			var (
+				clientNamespace     = framework.RandomNameWithPrefix("client")
+				serverNamespace     = framework.RandomNameWithPrefix("server")
+				clientContainerName = framework.RandomNameWithPrefix("container")
+				ns                  = []string{clientNamespace, serverNamespace}
+			)
 
 			It("Tests HTTP traffic for client pod -> server pod", func() {
 				// Install OSM
@@ -33,54 +37,55 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 5 /* 3 cert-manager pods, 1 controller, 1 injector */, nil)).To(Succeed())
 
-				// Create Test NS
+				// Create namespaces
 				for _, n := range ns {
 					Expect(Td.CreateNs(n, nil)).To(Succeed())
 					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 				}
 
 				// Get simple pod definitions for the HTTP server
-				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
+				serverSvcAccDef, serverPodDef, serverSvcDef, err := Td.SimplePodApp(
 					SimplePodAppDef{
-						Name:      "server",
-						Namespace: destNs,
+						PodName:   framework.RandomNameWithPrefix("pod"),
+						Namespace: serverNamespace,
 						Image:     "kennethreitz/httpbin",
 						Ports:     []int{80},
 						OS:        Td.ClusterOS,
 					})
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(serverNamespace, &serverSvcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				dstPod, err := Td.CreatePod(destNs, podDef)
+				dstPod, err := Td.CreatePod(serverNamespace, serverPodDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(destNs, svcDef)
+				_, err = Td.CreateService(serverNamespace, serverSvcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(destNs, 60*time.Second, 1, nil)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(serverNamespace, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Get simple Pod definitions for the client
-				svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
-					Name:      "client",
-					Namespace: sourceNs,
-					Command:   []string{"/bin/bash", "-c", "--"},
-					Args:      []string{"while true; do sleep 30; done;"},
-					Image:     "songrgg/alpine-debug",
-					Ports:     []int{80},
-					OS:        Td.ClusterOS,
+				clientSvcAccDef, clientPodDef, clientSvcDef, err := Td.SimplePodApp(SimplePodAppDef{
+					PodName:       framework.RandomNameWithPrefix("pod"),
+					Namespace:     clientNamespace,
+					ContainerName: clientContainerName,
+					Command:       []string{"/bin/bash", "-c", "--"},
+					Args:          []string{"while true; do sleep 30; done;"},
+					Image:         "songrgg/alpine-debug",
+					Ports:         []int{80},
+					OS:            Td.ClusterOS,
 				})
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
+				_, err = Td.CreateServiceAccount(clientNamespace, &clientSvcAccDef)
 				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := Td.CreatePod(sourceNs, podDef)
+				srcPod, err := Td.CreatePod(clientNamespace, clientPodDef)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(sourceNs, svcDef)
+				_, err = Td.CreateService(clientNamespace, clientSvcDef)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(sourceNs, 60*time.Second, 1, nil)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(clientNamespace, 60*time.Second, 1, nil)).To(Succeed())
 
 				// Deploy allow rule client->server
 				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
@@ -88,17 +93,17 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 						RouteGroupName:    "routes",
 						TrafficTargetName: "test-target",
 
-						SourceNamespace:      sourceNs,
-						SourceSVCAccountName: "client",
+						SourceNamespace:      clientNamespace,
+						SourceSVCAccountName: clientSvcAccDef.Name,
 
-						DestinationNamespace:      destNs,
-						DestinationSvcAccountName: "server",
+						DestinationNamespace:      serverNamespace,
+						DestinationSvcAccountName: serverSvcAccDef.Name,
 					})
 
 				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = Td.CreateHTTPRouteGroup(sourceNs, httpRG)
+				_, err = Td.CreateHTTPRouteGroup(clientNamespace, httpRG)
 				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(sourceNs, trafficTarget)
+				_, err = Td.CreateTrafficTarget(clientNamespace, trafficTarget)
 				Expect(err).NotTo(HaveOccurred())
 
 				// All ready. Expect client to reach server
@@ -108,9 +113,9 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 						Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
-							SourceContainer: "client",
+							SourceContainer: clientContainerName,
 
-							Destination: fmt.Sprintf("%s.%s", dstPod.Name, dstPod.Namespace),
+							Destination: fmt.Sprintf("%s.%s", serverSvcDef.Name, dstPod.Namespace),
 						})
 
 					if result.Err != nil || result.StatusCode != 200 {

--- a/tests/e2e/e2e_debug_server_test.go
+++ b/tests/e2e/e2e_debug_server_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openservicemesh/osm/tests/framework"
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 
@@ -18,7 +19,7 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 	},
 	func() {
 		Context("DebugServer", func() {
-			const sourceNs = "client"
+			var sourceNs = framework.RandomNameWithPrefix("client")
 
 			It("Starts debug server only when enableDebugServer flag is enabled", func() {
 				// Install OSM
@@ -32,7 +33,7 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 
 				// Get simple Pod definitions for the client
 				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(SimplePodAppDef{
-					Name:      "client",
+					PodName:   "client",
 					Namespace: sourceNs,
 					Command:   []string{"/bin/bash", "-c", "--"},
 					Args:      []string{"while true; do sleep 30; done;"},
@@ -56,7 +57,7 @@ var _ = OSMDescribe("Test Debug Server by toggling enableDebugServer",
 				req := HTTPRequestDef{
 					SourceNs:        srcPod.Namespace,
 					SourcePod:       srcPod.Name,
-					SourceContainer: "client",
+					SourceContainer: srcPod.Name,
 
 					Destination: controllerDest,
 				}

--- a/tests/e2e/e2e_deployment_client_server_test.go
+++ b/tests/e2e/e2e_deployment_client_server_test.go
@@ -29,13 +29,15 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 		var maxTestDuration = 150 * time.Second
 
 		Context("DeploymentsClientServer", func() {
-			const destApp = "server"
-			const sourceAppBaseName = "client"
-			var sourceNamespaces []string = []string{}
+			var (
+				destApp           = "server"
+				sourceAppBaseName = "client"
+				sourceNamespaces  = []string{}
 
-			// Total (numberOfClientApps x replicaSetPerApp) pods
-			numberOfClientServices := 5
-			replicaSetPerService := 5
+				// Total (numberOfClientApps x replicaSetPerApp) pods
+				numberOfClientServices = 5
+				replicaSetPerService   = 5
+			)
 
 			// Used across the test to wait for concurrent steps to finish
 			var wg sync.WaitGroup
@@ -62,13 +64,15 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				// Use a deployment with multiple replicaset at serverside
 				svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
-						Name:         "server",
-						Namespace:    destApp,
-						ReplicaCount: int32(replicaSetPerService),
-						Image:        "simonkowallik/httpbin",
-						Ports:        []int{DefaultUpstreamServicePort},
-						Command:      HttpbinCmd,
-						OS:           Td.ClusterOS,
+						DeploymentName:     destApp,
+						Namespace:          destApp,
+						ServiceName:        destApp,
+						ServiceAccountName: destApp,
+						ReplicaCount:       int32(replicaSetPerService),
+						Image:              "simonkowallik/httpbin",
+						Ports:              []int{DefaultUpstreamServicePort},
+						Command:            HttpbinCmd,
+						OS:                 Td.ClusterOS,
 					})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -105,14 +109,17 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 				for _, srcClient := range sourceNamespaces {
 					svcAccDef, deploymentDef, svcDef, err = Td.SimpleDeploymentApp(
 						SimpleDeploymentAppDef{
-							Name:         srcClient,
-							Namespace:    srcClient,
-							ReplicaCount: int32(replicaSetPerService),
-							Command:      []string{"/bin/bash", "-c", "--"},
-							Args:         []string{"while true; do sleep 30; done;"},
-							Image:        "songrgg/alpine-debug",
-							Ports:        []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
-							OS:           Td.ClusterOS,
+							DeploymentName:     srcClient,
+							Namespace:          srcClient,
+							ServiceAccountName: srcClient,
+							ServiceName:        srcClient,
+							ContainerName:      srcClient,
+							ReplicaCount:       int32(replicaSetPerService),
+							Command:            []string{"/bin/bash", "-c", "--"},
+							Args:               []string{"while true; do sleep 30; done;"},
+							Image:              "songrgg/alpine-debug",
+							Ports:              []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
+							OS:                 Td.ClusterOS,
 						})
 					Expect(err).NotTo(HaveOccurred())
 

--- a/tests/e2e/e2e_egress_policy_test.go
+++ b/tests/e2e/e2e_egress_policy_test.go
@@ -69,7 +69,7 @@ func testEgressPolicy(scenario testScenario) {
 
 		// Create simple pod definitions for the source
 		srcSvcAcc, srcPodDef, _, err := Td.SimplePodApp(SimplePodAppDef{
-			Name:      sourceName,
+			PodName:   sourceName,
 			Namespace: sourceNs,
 			Command:   []string{"/bin/bash", "-c", "--"},
 			Args:      []string{"while true; do sleep 30; done;"},

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -71,7 +71,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 						result := Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
-							SourceContainer: "client",
+							SourceContainer: srcPod.Name,
 
 							Destination: url,
 						})
@@ -96,7 +96,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 						result := Td.HTTPRequest(HTTPRequestDef{
 							SourceNs:        srcPod.Namespace,
 							SourcePod:       srcPod.Name,
-							SourceContainer: "client",
+							SourceContainer: srcPod.Name,
 
 							Destination: url,
 						})

--- a/tests/e2e/e2e_garbage_collector_test.go
+++ b/tests/e2e/e2e_garbage_collector_test.go
@@ -37,14 +37,14 @@ var _ = OSMDescribe("Test garbage collection for unused envoy bootstrap config s
 				// User app
 				svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
 					SimpleDeploymentAppDef{
-						Name:         userService,
-						Namespace:    userService,
-						ReplicaCount: int32(userReplicaSet),
-						Command:      []string{"/bin/bash", "-c", "--"},
-						Args:         []string{"while true; do sleep 30; done;"},
-						Image:        "songrgg/alpine-debug",
-						Ports:        []int{80},
-						OS:           Td.ClusterOS,
+						DeploymentName: userService,
+						Namespace:      userService,
+						ReplicaCount:   int32(userReplicaSet),
+						Command:        []string{"/bin/bash", "-c", "--"},
+						Args:           []string{"while true; do sleep 30; done;"},
+						Image:          "songrgg/alpine-debug",
+						Ports:          []int{80},
+						OS:             Td.ClusterOS,
 					})
 				Expect(err).NotTo(HaveOccurred())
 

--- a/tests/e2e/e2e_grpc_secure_origination_test.go
+++ b/tests/e2e/e2e_grpc_secure_origination_test.go
@@ -47,12 +47,13 @@ func testSecureGRPCTraffic() {
 		// Get simple pod definitions for the gRPC server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:        destName,
-				Namespace:   destName,
-				Image:       "moul/grpcbin",
-				Ports:       []int{grpcbinSecurePort},
-				AppProtocol: "tcp",
-				OS:          Td.ClusterOS,
+				PodName:            destName,
+				Namespace:          destName,
+				ServiceAccountName: destName,
+				Image:              "moul/grpcbin",
+				Ports:              []int{grpcbinSecurePort},
+				AppProtocol:        "tcp",
+				OS:                 Td.ClusterOS,
 			})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -79,7 +80,7 @@ func testSecureGRPCTraffic() {
 				TrafficTargetName: trafficTargetName,
 
 				SourceNamespace:      sourceName,
-				SourceSVCAccountName: sourceName,
+				SourceSVCAccountName: srcPod.Spec.ServiceAccountName,
 
 				DestinationNamespace:      destName,
 				DestinationSvcAccountName: destName,
@@ -95,7 +96,7 @@ func testSecureGRPCTraffic() {
 		clientToServer := GRPCRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s:%d", dstSvc.Name, dstSvc.Namespace, grpcbinSecurePort),
 

--- a/tests/e2e/e2e_ignore_namespace_test.go
+++ b/tests/e2e/e2e_ignore_namespace_test.go
@@ -39,7 +39,7 @@ var _ = OSMDescribe("Ignore Namespaces",
 				// Get simple Pod definitions
 				svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 					SimplePodAppDef{
-						Name:      "pod1",
+						PodName:   "pod1",
 						Namespace: ignoreNs,
 						Command:   []string{"/bin/bash", "-c", "--"},
 						Args:      []string{"while true; do sleep 30; done;"},

--- a/tests/e2e/e2e_ingressbackend.go
+++ b/tests/e2e/e2e_ingressbackend.go
@@ -14,6 +14,7 @@ import (
 
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
+	"github.com/openservicemesh/osm/tests/framework"
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 
@@ -33,7 +34,7 @@ var _ = OSMDescribe("Ingress using IngressBackend API",
 	})
 
 func testIngressBackend() {
-	const destNs = "server"
+	var destNs = framework.RandomNameWithPrefix("server")
 
 	It("allows ingress traffic", func() {
 		// Install OSM
@@ -46,7 +47,7 @@ func testIngressBackend() {
 		// Get simple pod definitions for the HTTP server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      "server",
+				PodName:   "server",
 				Namespace: destNs,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{serverPort},

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -43,7 +43,7 @@ func testIPExclusion() {
 		// Set up the destination HTTP server. It is not part of the mesh
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      destName,
+				PodName:   destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -74,7 +74,7 @@ func testIPExclusion() {
 		clientToServer := HTTPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 		}

--- a/tests/e2e/e2e_k8s_ingress_http_test.go
+++ b/tests/e2e/e2e_k8s_ingress_http_test.go
@@ -35,7 +35,7 @@ var _ = OSMDescribe("HTTP ingress using k8s Ingress API",
 			// Get simple pod definitions for the HTTP server
 			svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 				SimplePodAppDef{
-					Name:      "server",
+					PodName:   "server",
 					Namespace: destNs,
 					Image:     "kennethreitz/httpbin",
 					Ports:     []int{80},

--- a/tests/e2e/e2e_k8s_version_test.go
+++ b/tests/e2e/e2e_k8s_version_test.go
@@ -50,7 +50,7 @@ func testK8sVersion(version string) {
 		// Get simple pod definitions for the HTTP server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      destName,
+				PodName:   destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -78,10 +78,10 @@ func testK8sVersion(version string) {
 				TrafficTargetName: "test-target",
 
 				SourceNamespace:      sourceName,
-				SourceSVCAccountName: sourceName,
+				SourceSVCAccountName: srcPod.Spec.ServiceAccountName,
 
 				DestinationNamespace:      destName,
-				DestinationSvcAccountName: destName,
+				DestinationSvcAccountName: svcAccDef.Name,
 			})
 
 		// Configs have to be put into a monitored NS
@@ -94,7 +94,7 @@ func testK8sVersion(version string) {
 		clientToServer := HTTPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 		}

--- a/tests/e2e/e2e_multiple_ports_per_service_test.go
+++ b/tests/e2e/e2e_multiple_ports_per_service_test.go
@@ -48,7 +48,7 @@ func testMultipleServicePorts() {
 		// Create an HTTP server that clients will send requests to.
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      serverName,
+				PodName:   serverName,
 				Namespace: serverName,
 				Image:     "kennethreitz/httpbin",
 				// To test multiple ports per service, an additional port 90 is exposed
@@ -85,7 +85,7 @@ func testMultipleServicePorts() {
 		clientToServerRequest := HTTPRequestDef{
 			SourceNs:        clientName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: clientName,
+			SourceContainer: srcPod.Name,
 			Destination:     fmt.Sprintf("%s.%s:%d", serverService.Name, serverService.Namespace, servicePort),
 		}
 

--- a/tests/e2e/e2e_multiple_services_per_pod_test.go
+++ b/tests/e2e/e2e_multiple_services_per_pod_test.go
@@ -46,7 +46,7 @@ func testMultipleServicePerPod() {
 		// Create an HTTP server that clients will send requests to
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      destName,
+				PodName:   destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -70,7 +70,7 @@ func testMultipleServicePerPod() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Expect it to be up and running in it's receiver namespace
-		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(podDef.Name, 90*time.Second, 1, nil)).To(Succeed())
 
 		srcPod := setupSource(sourceName, false /* no service for client */)
 
@@ -81,11 +81,11 @@ func testMultipleServicePerPod() {
 				RouteGroupName:    "routes",
 				TrafficTargetName: "test-target",
 
-				SourceNamespace:      sourceName,
-				SourceSVCAccountName: sourceName,
+				SourceNamespace:      srcPod.Namespace,
+				SourceSVCAccountName: srcPod.Spec.ServiceAccountName,
 
 				DestinationNamespace:      destName,
-				DestinationSvcAccountName: destName,
+				DestinationSvcAccountName: svcAccDef.Name,
 			})
 
 		// Configs have to be put into a monitored NS
@@ -98,7 +98,7 @@ func testMultipleServicePerPod() {
 		clientToFirstService := HTTPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s", firstSvc.Name, firstSvc.Namespace),
 		}
@@ -124,7 +124,7 @@ func testMultipleServicePerPod() {
 		clientToSecondService := HTTPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s", secondSvc.Name, secondSvc.Namespace),
 		}

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -56,7 +56,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 		// Get simple pod definitions for the HTTP server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      "server",
+				PodName:   "server",
 				Namespace: destNs,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -75,7 +75,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 
 		// Get simple Pod definitions for the client
 		svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
-			Name:      "client",
+			PodName:   "client",
 			Namespace: sourceNs,
 			Command:   []string{"/bin/bash", "-c", "--"},
 			Args:      []string{"while true; do sleep 30; done;"},
@@ -107,7 +107,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 
 		// Get simple Pod definitions for the non mesh client
 		svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
-			Name:      "ext-client",
+			PodName:   "ext-client",
 			Namespace: extSourceNs,
 			Command:   []string{"/bin/bash", "-c", "--"},
 			Args:      []string{"while true; do sleep 30; done;"},

--- a/tests/e2e/e2e_pod_client_server_test.go
+++ b/tests/e2e/e2e_pod_client_server_test.go
@@ -53,7 +53,7 @@ func testTraffic(withSourceKubernetesService bool) {
 		// Get simple pod definitions for the HTTP server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      destName,
+				PodName:   destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -81,10 +81,10 @@ func testTraffic(withSourceKubernetesService bool) {
 				TrafficTargetName: "test-target",
 
 				SourceNamespace:      sourceName,
-				SourceSVCAccountName: sourceName,
+				SourceSVCAccountName: srcPod.Spec.ServiceAccountName,
 
 				DestinationNamespace:      destName,
-				DestinationSvcAccountName: destName,
+				DestinationSvcAccountName: svcAccDef.Name,
 			})
 
 		// Configs have to be put into a monitored NS
@@ -144,7 +144,7 @@ func testTraffic(withSourceKubernetesService bool) {
 func setupSource(sourceName string, withKubernetesService bool) *v1.Pod {
 	// Get simple Pod definitions for the client
 	svcAccDef, podDef, svcDef, err := Td.SimplePodApp(SimplePodAppDef{
-		Name:      sourceName,
+		PodName:   sourceName,
 		Namespace: sourceName,
 		Command:   []string{"sleep", "365d"},
 		Image:     "curlimages/curl",

--- a/tests/e2e/e2e_port_exclusion_test.go
+++ b/tests/e2e/e2e_port_exclusion_test.go
@@ -47,7 +47,7 @@ func testGlobalPortExclusion() {
 		// Set up the destination HTTP server. It is not part of the mesh
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      destName,
+				PodName:   destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -78,7 +78,7 @@ func testGlobalPortExclusion() {
 		clientToServer := HTTPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 		}
@@ -125,7 +125,7 @@ func testPodLevelPortExclusion() {
 		// Set up the destination HTTP server. It is not part of the mesh
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:      destName,
+				PodName:   destName,
 				Namespace: destName,
 				Image:     "kennethreitz/httpbin",
 				Ports:     []int{80},
@@ -145,7 +145,7 @@ func testPodLevelPortExclusion() {
 
 		// Set up the source curl client. It will be a part of the mesh
 		svcAccDef, podDef, svcDef, err = Td.SimplePodApp(SimplePodAppDef{
-			Name:      sourceName,
+			PodName:   sourceName,
 			Namespace: sourceName,
 			Command:   []string{"sleep", "365d"},
 			Image:     "curlimages/curl",
@@ -174,7 +174,7 @@ func testPodLevelPortExclusion() {
 		clientToServer := HTTPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 		}

--- a/tests/e2e/e2e_proxy_resource_limits.go
+++ b/tests/e2e/e2e_proxy_resource_limits.go
@@ -96,7 +96,7 @@ func createSimpleApp(appName string, ns string) {
 	// Get simple pod definitions for the HTTP server
 	svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 		SimplePodAppDef{
-			Name:      appName,
+			PodName:   appName,
 			Namespace: ns,
 			Command:   []string{"/bin/bash", "-c", "--"},
 			Args:      []string{"while true; do sleep 30; done;"},

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -50,7 +50,7 @@ func testTCPEgressTraffic() {
 		// Get simple pod definitions for the TCP server
 		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
 			SimplePodAppDef{
-				Name:        destName,
+				PodName:     destName,
 				Namespace:   destName,
 				Image:       fmt.Sprintf("%s/tcp-echo-server:%s", installOpts.ContainerRegistryLoc, installOpts.OsmImagetag),
 				Command:     []string{"/tcp-echo-server"},
@@ -78,7 +78,7 @@ func testTCPEgressTraffic() {
 		clientToServer := TCPRequestDef{
 			SourceNs:        sourceName,
 			SourcePod:       srcPod.Name,
-			SourceContainer: sourceName,
+			SourceContainer: srcPod.Name,
 
 			DestinationHost: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
 			DestinationPort: destinationPort,


### PR DESCRIPTION
+ Adds a RandomName() func to e2e test framework to
more easily generate a random resource name
+ Modifies helper functions that create resource defs to use
random resource names if resource names are not specifically
supplied to helpers
+ includes some cleanup of tests although more is needed in
follow up

resolves #2953

Signed-off-by: Michelle Noorali <minooral@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
