### PR TITLE
[backport] charts/osm: add namespace to preset-mesh-config resource (#4084)

### DIFF
--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: preset-mesh-config
+  namespace: {{ include "osm.namespace" . }}
 data:
   preset-mesh-config.json: |
     {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Backports 22f70495 from main.
...
The preset-mesh-config resource was not namespaced.
Resolves #4083

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Install                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
