### PR TITLE
tests/framework: optionally retry on pod creation failure

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -150,6 +150,7 @@ func registerFlags(td *OsmTestData) {
 	flag.BoolVar(&td.EnableNsMetricTag, "EnableMetricsTag", true, "Enable tagging Namespaces for metrics collection")
 	flag.BoolVar(&td.DeployOnOpenShift, "deployOnOpenShift", false, "Configure tests to run on OpenShift")
 	flag.BoolVar(&td.DeployOnWindowsWorkers, "deployOnWindowsWorkers", false, "Configure tests to run on Windows workers")
+	flag.BoolVar(&td.RetryAppPodCreation, "retryAppPodCreation", true, "Retry app pod creation on error")
 }
 
 // ValidateStringParams validates input string parameters are valid

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -74,6 +74,8 @@ type OsmTestData struct {
 
 	DeployOnOpenShift      bool // Determines whether to configure tests for OpenShift
 	DeployOnWindowsWorkers bool // Determines whether to configure tests to run on Windows workers
+
+	RetryAppPodCreation bool // Whether to retry app pod creation due to issue #3973
 }
 
 // InstallOSMOpts describes install options for OSM


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Optionally retries on app pod creation failure when the
webhook configuration is not processed by the API server
on time. This is required as a workaround due to potential
delays in the k8s API server to process the updated webhook
configuration after osm-injector patches the webhook.

If this change does not address #3973, it should be reverted.
A large number of test iterations is required to verify this
change in the CI.

Potential fix for #3973. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CI System                  | [X] |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
