### PR TITLE
feat(reconciler): Add reconciler client, informers and reconcile logic to osm

### DIFF
--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -150,6 +150,11 @@ func main() {
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Start the default metrics store
+	metricsstore.DefaultMetricsStore.Start(
+		metricsstore.DefaultMetricsStore.ErrCodeCounter,
+	)
+
 	// Initialize Configurator to retrieve mesh specific config
 	cfg := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName)
 

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -39,6 +39,9 @@ const (
 
 	// ErrStartingIngressClient indicates the Ingress client failed to start
 	ErrStartingIngressClient
+
+	// ErrStartingReconciler indicates the reconciler client failed to start
+	ErrStartingReconciler
 )
 
 // Range 2000-2500 is reserved for errors related to traffic policies
@@ -333,6 +336,21 @@ const (
 	ErrParsingValidatingWebhookCert
 )
 
+// Range 7000-7100 reserved for errors related to OSM Reconciler
+const (
+	// ErrUpdatingCRD indicates an error occurred when OSM Reconciler failed to update a modified CRD
+	ErrUpdatingCRD ErrCode = iota + 7000
+
+	// ErrAddingDeletedCRD indicates an error occurred when OSM Reconciler failed to add a deleted CRD
+	ErrAddingDeletedCRD
+
+	// ErrUpdatingMutatingWebhook indicates an error occurred when OSM Reconciler failed to update the mutating webhook
+	ErrUpdatingMutatingWebhook
+
+	// ErrAddingDeletedMutatingWebhook indicates an error occurred when OSM Reconciler failed to add a deleted mutating webhook
+	ErrAddingDeletedMutatingWebhook
+)
+
 // String returns the error code as a string, ex. E1000
 func (e ErrCode) String() string {
 	return fmt.Sprintf("E%d", e)
@@ -387,6 +405,11 @@ reconciler failed to start.
 
 	ErrStartingIngressClient: `
 The Ingress client created by the osm-controller to monitor Ingress resources
+failed to start.
+`,
+
+	ErrStartingReconciler: `
+The Reconciler client to monitor updates and deletes to OSM's CRDs and mutating webhook
 failed to start.
 `,
 
@@ -817,5 +840,21 @@ The ValidatingWebhookConfiguration could not be patched with the CA Bundle.
 	ErrParsingValidatingWebhookCert: `
 The validating webhook certificate could not be parsed.
 The validating webhook HTTP server was not started.
+`,
+
+	ErrUpdatingCRD: `
+An error occurred while updating the CRD to its original state.
+`,
+
+	ErrAddingDeletedCRD: `
+An error occurred while adding back a deleted CRD.
+`,
+
+	ErrUpdatingMutatingWebhook: `
+An error occurred while updating the mutating webhook to its original state.
+`,
+
+	ErrAddingDeletedMutatingWebhook: `
+An error occurred while adding back the deleted mutating webhook.
 `,
 }

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -43,8 +43,8 @@ const (
 	// webhookTimeoutStr is the url variable name for timeout
 	webhookMutateTimeoutKey = "timeout"
 
-	// injectorServiceName is the name of the OSM sidecar injector service
-	injectorServiceName = "osm-injector"
+	// InjectorServiceName is the name of the OSM sidecar injector service
+	InjectorServiceName = "osm-injector"
 
 	// outboundPortExclusionListAnnotation is the annotation used for outbound port exclusions
 	outboundPortExclusionListAnnotation = "openservicemesh.io/outbound-port-exclusion-list"
@@ -59,7 +59,7 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned with the MutatingWebhookConfiguration
 	webhookHandlerCert, err := certManager.IssueCertificate(
-		certificate.CommonName(fmt.Sprintf("%s.%s.svc", injectorServiceName, osmNamespace)),
+		certificate.CommonName(fmt.Sprintf("%s.%s.svc", InjectorServiceName, osmNamespace)),
 		constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing certificate for the mutating webhook: %+v", err)

--- a/pkg/reconciler/client.go
+++ b/pkg/reconciler/client.go
@@ -1,0 +1,115 @@
+package reconciler
+
+import (
+	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	customResourceDefinitionInformer "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	internalinterfaces "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/errcode"
+	"github.com/openservicemesh/osm/pkg/k8s"
+)
+
+// NewReconcilerClient implements a client to reconcile osm managed resources
+func NewReconcilerClient(kubeClient kubernetes.Interface, crdClient clientset.Interface, meshName string, stop chan struct{}, selectInformers ...k8s.InformerKey) error {
+	// Initialize client object
+	c := client{
+		kubeClient:      kubeClient,
+		meshName:        meshName,
+		apiServerClient: crdClient,
+		informers:       informerCollection{},
+	}
+
+	// Initialize informers
+	informerInitHandlerMap := map[k8s.InformerKey]func(){
+		crdInformerKey:             c.initCustomResourceDefinitionMonitor,
+		mutatingWebhookInformerKey: c.initMutatingWebhookConfigurationMonitor,
+	}
+
+	// If specific informers are not selected to be initialized, initialize all informers
+	if len(selectInformers) == 0 {
+		selectInformers = []k8s.InformerKey{crdInformerKey, mutatingWebhookInformerKey}
+	}
+
+	for _, informer := range selectInformers {
+		informerInitHandlerMap[informer]()
+	}
+
+	if err := c.run(stop); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrStartingReconciler)).
+			Msg("Could not start osm reconciler client")
+		return err
+	}
+
+	return nil
+}
+
+// Initializes CustomResourceDefinition monitoring
+func (c *client) initCustomResourceDefinitionMonitor() {
+	osmCrdsLabel := map[string]string{constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue}
+
+	labelSelector := fields.SelectorFromSet(osmCrdsLabel).String()
+	options := internalinterfaces.TweakListOptionsFunc(func(opt *metav1.ListOptions) {
+		opt.LabelSelector = labelSelector
+	})
+
+	informerFactory := customResourceDefinitionInformer.NewFilteredCustomResourceDefinitionInformer(c.apiServerClient, k8s.DefaultKubeEventResyncInterval, cache.Indexers{nameIndex: metaNameIndexFunc}, options)
+
+	// Add informer
+	c.informers[crdInformerKey] = informerFactory
+
+	// Add event handler to informer
+	c.informers[crdInformerKey].AddEventHandler(c.crdEventHandler())
+}
+
+// Initializes mutating webhook monitoring
+func (c *client) initMutatingWebhookConfigurationMonitor() {
+	osmMwhcLabel := map[string]string{constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue, constants.OSMAppInstanceLabelKey: c.meshName}
+	labelSelector := fields.SelectorFromSet(osmMwhcLabel).String()
+	option := informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
+		opt.LabelSelector = labelSelector
+	})
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(c.kubeClient, k8s.DefaultKubeEventResyncInterval, option)
+
+	// Add informer
+	c.informers[mutatingWebhookInformerKey] = informerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
+
+	// Add event handler to informer
+	c.informers[mutatingWebhookInformerKey].AddEventHandler(c.mutatingWebhookEventHandler())
+}
+
+func (c *client) run(stop <-chan struct{}) error {
+	log.Info().Msg("OSM reconciler client started")
+	var hasSynced []cache.InformerSynced
+	var names []string
+
+	if c.informers == nil {
+		log.Error().Err(errInitInformers).Msg("No resources added to reconciler's informer")
+		return errInitInformers
+	}
+
+	for name, informer := range c.informers {
+		if informer == nil {
+			continue
+		}
+
+		log.Info().Msgf("Starting reconciler informer: %s", name)
+		go informer.Run(stop)
+		names = append(names, (string)(name))
+		hasSynced = append(hasSynced, informer.HasSynced)
+	}
+
+	log.Info().Msgf("Waiting for reconciler informer's cache to sync")
+	if !cache.WaitForCacheSync(stop, hasSynced...) {
+		return errSyncingCaches
+	}
+
+	log.Info().Msgf("Cache sync finished for reconciler informer : %v", names)
+	return nil
+}

--- a/pkg/reconciler/crd_handler.go
+++ b/pkg/reconciler/crd_handler.go
@@ -1,0 +1,74 @@
+package reconciler
+
+import (
+	"context"
+	reflect "reflect"
+	"strings"
+
+	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/errcode"
+)
+
+// crdEventHandler creates crd events handlers.
+func (c client) crdEventHandler() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldCrd := oldObj.(*apiv1.CustomResourceDefinition)
+			newCrd := newObj.(*apiv1.CustomResourceDefinition)
+			log.Debug().Msgf("CRD update event for %s", newCrd.Name)
+			if !isCRDUpdated(oldCrd, newCrd) {
+				return
+			}
+			c.reconcileCrd(oldCrd, newCrd)
+		},
+
+		DeleteFunc: func(obj interface{}) {
+			crd := obj.(*apiv1.CustomResourceDefinition)
+			c.addCrd(crd)
+			log.Debug().Msgf("CRD delete event for %s", crd.Name)
+		},
+	}
+}
+
+func (c client) reconcileCrd(oldCrd, newCrd *apiv1.CustomResourceDefinition) {
+	newCrd.Spec = oldCrd.Spec
+	newCrd.ObjectMeta.Name = oldCrd.ObjectMeta.Name
+	newCrd.ObjectMeta.Labels = oldCrd.ObjectMeta.Labels
+	if _, err := c.apiServerClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), newCrd, metav1.UpdateOptions{}); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingCRD)).
+			Msgf("Error updating crd: %s", newCrd.Name)
+	}
+	log.Debug().Msgf("Successfully reconciled CRD %s", newCrd.Name)
+}
+
+func (c client) addCrd(oldCrd *apiv1.CustomResourceDefinition) {
+	oldCrd.ResourceVersion = ""
+	if _, err := c.apiServerClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), oldCrd, metav1.CreateOptions{}); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrAddingDeletedCRD)).
+			Msgf("Error adding back deleted crd: %s", oldCrd.Name)
+	}
+	log.Debug().Msgf("Successfully added back CRD %s", oldCrd.Name)
+}
+
+func isCRDUpdated(oldCrd, newCrd *apiv1.CustomResourceDefinition) bool {
+	crdSpecEqual := reflect.DeepEqual(oldCrd.Spec, newCrd.Spec)
+	crdNameChanged := strings.Compare(oldCrd.ObjectMeta.Name, newCrd.ObjectMeta.Name)
+	crdLabelsChanged := isLabelModified(constants.OSMAppNameLabelKey, constants.OSMAppNameLabelValue, newCrd.ObjectMeta.Labels)
+	crdUpdated := !crdSpecEqual || crdNameChanged != 0 || crdLabelsChanged
+	return crdUpdated
+}
+
+func isLabelModified(key string, expectedValue string, labelMap map[string]string) bool {
+	if value, ok := labelMap[key]; ok {
+		if !strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(expectedValue)) {
+			return true
+		}
+	} else {
+		return true
+	}
+	return false
+}

--- a/pkg/reconciler/crd_handler_test.go
+++ b/pkg/reconciler/crd_handler_test.go
@@ -1,0 +1,868 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiservertestclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const (
+	meshName = "test-mesh"
+)
+
+func TestCRDEventHandlerUpdateFunc(t *testing.T) {
+	testCases := []struct {
+		name        string
+		originalCrd apiv1.CustomResourceDefinition
+		updatedCrd  apiv1.CustomResourceDefinition
+		crdUpdated  bool
+	}{
+		{
+			name: "crd spec changed",
+			originalCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			updatedCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  false,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			crdUpdated: true,
+		},
+		{
+			name: "crd new label added",
+			originalCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			updatedCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+						"some":                       "label",
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			crdUpdated: false,
+		},
+		{
+			name: "crd name changed",
+			originalCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			updatedCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io.NEW",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			crdUpdated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+
+			kubeClient := testclient.NewSimpleClientset()
+			crdClient := apiservertestclient.NewSimpleClientset(&tc.originalCrd)
+
+			c := client{
+				kubeClient:      kubeClient,
+				meshName:        meshName,
+				apiServerClient: crdClient,
+				informers:       informerCollection{},
+			}
+			// Invoke update handler
+			handlers := c.crdEventHandler()
+			handlers.UpdateFunc(&tc.originalCrd, &tc.updatedCrd)
+
+			if tc.crdUpdated {
+				a.Equal(&tc.originalCrd, &tc.updatedCrd)
+			} else {
+				a.NotEqual(&tc.originalCrd, &tc.updatedCrd)
+			}
+
+			crd, err := c.apiServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), tc.originalCrd.Name, metav1.GetOptions{})
+			a.Nil(err)
+
+			if tc.crdUpdated {
+				a.Equal(crd, &tc.updatedCrd)
+			} else {
+				a.Equal(crd, &tc.originalCrd)
+			}
+		})
+	}
+}
+
+func TestCRDEventHandlerDeleteFunc(t *testing.T) {
+	originalCrd := apiv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CustomResourceDefinition",
+			APIVersion: "apiextensions.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "meshconfigs.config.openservicemesh.io",
+			Labels: map[string]string{
+				constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+			},
+		},
+		Spec: apiv1.CustomResourceDefinitionSpec{
+			Group: "config.openservicemesh.io",
+			Names: apiv1.CustomResourceDefinitionNames{
+				Plural:     "meshconfigs",
+				Singular:   "meshconfig",
+				ShortNames: []string{"meshconfig"},
+				Kind:       "MeshConfig",
+				ListKind:   "MeshConfigList",
+			},
+			Scope: "Namespaced",
+			Versions: []apiv1.CustomResourceDefinitionVersion{{
+				Name:    "v1alpha1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiv1.JSONSchemaProps{
+							"spec": {
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"sidecar": {
+										Type:        "object",
+										Description: "Configuration for Envoy sidecar",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"enablePrivilegedInitContainer": {
+												Type:        "boolean",
+												Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+											},
+											"logLevel": {
+												Type:        "string",
+												Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	a := tassert.New(t)
+	kubeClient := testclient.NewSimpleClientset()
+	crdClient := apiservertestclient.NewSimpleClientset(&originalCrd)
+
+	c := client{
+		kubeClient:      kubeClient,
+		meshName:        meshName,
+		apiServerClient: crdClient,
+		informers:       informerCollection{},
+	}
+	// Invoke delete handler
+	handlers := c.crdEventHandler()
+	handlers.DeleteFunc(&originalCrd)
+
+	// verify crd exists after deletion
+	crd, err := c.apiServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), originalCrd.Name, metav1.GetOptions{})
+	a.Nil(err)
+	a.Equal(crd, &originalCrd)
+}
+
+func TestIsCRDUpdated(t *testing.T) {
+	testCases := []struct {
+		name        string
+		originalCrd apiv1.CustomResourceDefinition
+		updatedCrd  apiv1.CustomResourceDefinition
+		crdUpdated  bool
+	}{
+		{
+			name: "crd spec changed",
+			originalCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			updatedCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  false,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			crdUpdated: true,
+		},
+		{
+			name: "crd new label added",
+			originalCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			updatedCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+						"some":                       "label",
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			crdUpdated: false,
+		},
+		{
+			name: "crd name changed",
+			originalCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			updatedCrd: apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "meshconfigs.config.openservicemesh.io.NEW",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+					},
+				},
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "config.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:     "meshconfigs",
+						Singular:   "meshconfig",
+						ShortNames: []string{"meshconfig"},
+						Kind:       "MeshConfig",
+						ListKind:   "MeshConfigList",
+					},
+					Scope: "Namespaced",
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type: "object",
+								Properties: map[string]apiv1.JSONSchemaProps{
+									"spec": {
+										Type: "object",
+										Properties: map[string]apiv1.JSONSchemaProps{
+											"sidecar": {
+												Type:        "object",
+												Description: "Configuration for Envoy sidecar",
+												Properties: map[string]apiv1.JSONSchemaProps{
+													"enablePrivilegedInitContainer": {
+														Type:        "boolean",
+														Description: "Enables privileged init containers for pods in mesh. When false, init containers only have NET_ADMIN.",
+													},
+													"logLevel": {
+														Type:        "string",
+														Description: "Sets the logging verbosity of Envoy proxy sidecar, only applicable to newly created pods joining the mesh.",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			crdUpdated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			result := isCRDUpdated(&tc.originalCrd, &tc.updatedCrd)
+			assert.Equal(result, tc.crdUpdated)
+		})
+	}
+}
+
+func TestIsLabelModified(t *testing.T) {
+	testCases := []struct {
+		name          string
+		labelMap      map[string]string
+		key           string
+		value         string
+		labelModified bool
+	}{
+		{
+			name: "labels not modified",
+			labelMap: map[string]string{
+				constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+			},
+			key:           constants.OSMAppNameLabelKey,
+			value:         constants.OSMAppNameLabelValue,
+			labelModified: false,
+		},
+		{
+			name: "labels modified",
+			labelMap: map[string]string{
+				constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+			},
+			key:           constants.OSMAppNameLabelKey,
+			value:         "test",
+			labelModified: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			result := isLabelModified(tc.key, tc.value, tc.labelMap)
+			assert.Equal(result, tc.labelModified)
+		})
+	}
+}

--- a/pkg/reconciler/errors.go
+++ b/pkg/reconciler/errors.go
@@ -1,0 +1,8 @@
+package reconciler
+
+import "github.com/pkg/errors"
+
+var (
+	errSyncingCaches = errors.New("Failed initial cache sync for reconciler informers")
+	errInitInformers = errors.New("Informer not initialized")
+)

--- a/pkg/reconciler/mutating_webhook.go
+++ b/pkg/reconciler/mutating_webhook.go
@@ -10,21 +10,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openservicemesh/osm/pkg/certificate/providers"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/injector"
-	"github.com/openservicemesh/osm/pkg/logger"
 )
-
-var log = logger.New("reconciler")
 
 // MutatingWebhookConfigurationReconciler reconciles a MutatingWebhookConfiguration object
 // TODO: Deprecate as a part of #4065
 type MutatingWebhookConfigurationReconciler struct {
-	client.Client
+	runtimeclient.Client
 	KubeClient   *kubernetes.Clientset
 	Scheme       *runtime.Scheme
 	OsmWebhook   string
@@ -39,7 +36,7 @@ func (r *MutatingWebhookConfigurationReconciler) Reconcile(ctx context.Context, 
 
 		if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
 			log.Error().Err(err).Msgf("Error reading object %s ", req.NamespacedName)
-			return ctrl.Result{}, client.IgnoreNotFound(err)
+			return ctrl.Result{}, runtimeclient.IgnoreNotFound(err)
 		}
 
 		var shouldUpdate bool
@@ -68,7 +65,7 @@ func (r *MutatingWebhookConfigurationReconciler) Reconcile(ctx context.Context, 
 			// TODO(#3962): metric might not be scraped before process restart resulting from this error
 			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingMutatingWebhookCABundle)).
 				Msgf("Error updating MutatingWebhookConfiguration %s", req.Name)
-			return ctrl.Result{}, client.IgnoreNotFound(err)
+			return ctrl.Result{}, runtimeclient.IgnoreNotFound(err)
 		}
 
 		log.Debug().Msgf("Successfully updated CA Bundle for MutatingWebhookConfiguration %s ", req.Name)

--- a/pkg/reconciler/mutating_webhook_handler.go
+++ b/pkg/reconciler/mutating_webhook_handler.go
@@ -1,0 +1,67 @@
+package reconciler
+
+import (
+	"context"
+	reflect "reflect"
+	"strings"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/errcode"
+	"github.com/openservicemesh/osm/pkg/injector"
+)
+
+// mutatingWebhookEventHandler creates mutating webhook events handlers.
+func (c client) mutatingWebhookEventHandler() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldMwhc := oldObj.(*admissionv1.MutatingWebhookConfiguration)
+			newMwhc := newObj.(*admissionv1.MutatingWebhookConfiguration)
+			log.Debug().Msgf("mutating webhook update event for %s", newMwhc.Name)
+			if !c.isMutatingWebhookUpdated(oldMwhc, newMwhc) {
+				return
+			}
+
+			c.reconcileMutatingWebhook(oldMwhc, newMwhc)
+		},
+
+		DeleteFunc: func(obj interface{}) {
+			mwhc := obj.(*admissionv1.MutatingWebhookConfiguration)
+			c.addMutatingWebhook(mwhc)
+			log.Debug().Msgf("mutating webhook delete event for %s", mwhc.Name)
+		},
+	}
+}
+
+func (c client) reconcileMutatingWebhook(oldMwhc, newMwhc *admissionv1.MutatingWebhookConfiguration) {
+	newMwhc.Webhooks = oldMwhc.Webhooks
+	newMwhc.ObjectMeta.Name = oldMwhc.ObjectMeta.Name
+	newMwhc.ObjectMeta.Labels = oldMwhc.ObjectMeta.Labels
+	if _, err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(context.Background(), newMwhc, metav1.UpdateOptions{}); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingMutatingWebhook)).
+			Msgf("Error updating mutating webhook: %s", newMwhc.Name)
+	}
+	log.Debug().Msgf("Successfully reconciled CRD %s", newMwhc.Name)
+}
+
+func (c client) addMutatingWebhook(oldMwhc *admissionv1.MutatingWebhookConfiguration) {
+	oldMwhc.ResourceVersion = ""
+	if _, err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Create(context.Background(), oldMwhc, metav1.CreateOptions{}); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrAddingDeletedMutatingWebhook)).
+			Msgf("Error adding back deleted mutating webhook: %s", oldMwhc.Name)
+	}
+	log.Debug().Msgf("Successfully added back mutating webhook %s", oldMwhc.Name)
+}
+
+func (c *client) isMutatingWebhookUpdated(oldMwhc, newMwhc *admissionv1.MutatingWebhookConfiguration) bool {
+	webhookEqual := reflect.DeepEqual(oldMwhc.Webhooks, newMwhc.Webhooks)
+	mwhcNameChanged := strings.Compare(oldMwhc.ObjectMeta.Name, newMwhc.ObjectMeta.Name)
+	mwhcLabelsChanged := isLabelModified(constants.OSMAppNameLabelKey, constants.OSMAppNameLabelValue, newMwhc.ObjectMeta.Labels) ||
+		isLabelModified(constants.OSMAppInstanceLabelKey, c.meshName, newMwhc.ObjectMeta.Labels) ||
+		isLabelModified("app", injector.InjectorServiceName, newMwhc.ObjectMeta.Labels)
+	mwhcUpdated := !webhookEqual || mwhcNameChanged != 0 || mwhcLabelsChanged
+	return mwhcUpdated
+}

--- a/pkg/reconciler/mutating_webhook_handler_test.go
+++ b/pkg/reconciler/mutating_webhook_handler_test.go
@@ -1,0 +1,483 @@
+package reconciler
+
+import (
+	"context"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
+	apiservertestclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/injector"
+)
+
+var testWebhookServicePath = "/path"
+
+func TestMutatingWebhookEventHandlerUpdateFunc(t *testing.T) {
+	testCases := []struct {
+		name         string
+		originalMwhc admissionv1.MutatingWebhookConfiguration
+		updatedMwhc  admissionv1.MutatingWebhookConfiguration
+		mwhcUpdated  bool
+	}{
+		{
+			name: "webhook changed",
+			originalMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+								constants.OSMAppInstanceLabelKey: meshName,
+							},
+						},
+					},
+				},
+			},
+			updatedMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "new-test-service-name-",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"some-key": "some-value",
+							},
+						},
+					},
+				},
+			},
+			mwhcUpdated: true,
+		},
+		{
+			name: "mutating webhook new label added",
+			originalMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+								constants.OSMAppInstanceLabelKey: meshName,
+							},
+						},
+					},
+				},
+			},
+			updatedMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+						"some":                           "label",
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name-",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"some-key": "some-value",
+							},
+						},
+					},
+				},
+			},
+			mwhcUpdated: true,
+		},
+		{
+			name: "mutataing webhook name changed",
+			originalMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+								constants.OSMAppInstanceLabelKey: meshName,
+							},
+						},
+					},
+				},
+			},
+			updatedMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--updatedWebhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name-",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"some-key": "some-value",
+							},
+						},
+					},
+				},
+			},
+			mwhcUpdated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+
+			kubeClient := testclient.NewSimpleClientset(&tc.originalMwhc)
+			crdClient := apiservertestclient.NewSimpleClientset()
+
+			c := client{
+				kubeClient:      kubeClient,
+				meshName:        meshName,
+				apiServerClient: crdClient,
+				informers:       informerCollection{},
+			}
+			// Invoke update handler
+			handlers := c.mutatingWebhookEventHandler()
+			handlers.UpdateFunc(&tc.originalMwhc, &tc.updatedMwhc)
+
+			if tc.mwhcUpdated {
+				a.Equal(&tc.originalMwhc, &tc.updatedMwhc)
+			} else {
+				a.NotEqual(&tc.originalMwhc, &tc.updatedMwhc)
+			}
+
+			crd, err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), tc.originalMwhc.Name, metav1.GetOptions{})
+			a.Nil(err)
+
+			if tc.mwhcUpdated {
+				a.Equal(crd, &tc.updatedMwhc)
+			} else {
+				a.Equal(crd, &tc.originalMwhc)
+			}
+		})
+	}
+}
+
+func TestMutatingWebhookEventHandlerDeleteFunc(t *testing.T) {
+	originalMwhc := admissionv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "--webhookName--",
+			Labels: map[string]string{
+				constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+				constants.OSMAppInstanceLabelKey: meshName,
+			},
+		},
+		Webhooks: []admissionv1.MutatingWebhook{
+			{
+				Name: injector.MutatingWebhookName,
+				ClientConfig: v1.WebhookClientConfig{
+					Service: &v1.ServiceReference{
+						Namespace: "test-namespace",
+						Name:      "test-service-name",
+						Path:      &testWebhookServicePath,
+					},
+				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+			},
+		},
+	}
+
+	a := tassert.New(t)
+	kubeClient := testclient.NewSimpleClientset(&originalMwhc)
+	crdClient := apiservertestclient.NewSimpleClientset()
+
+	c := client{
+		kubeClient:      kubeClient,
+		meshName:        meshName,
+		apiServerClient: crdClient,
+		informers:       informerCollection{},
+	}
+	// Invoke delete handler
+	handlers := c.mutatingWebhookEventHandler()
+	handlers.DeleteFunc(&originalMwhc)
+
+	// verify mwhc exists after deletion
+	mwhc, err := c.kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), originalMwhc.Name, metav1.GetOptions{})
+	a.Nil(err)
+	a.Equal(mwhc, &originalMwhc)
+}
+
+func TestIsMutatingWebhookUpdated(t *testing.T) {
+	testCases := []struct {
+		name         string
+		originalMwhc admissionv1.MutatingWebhookConfiguration
+		updatedMwhc  admissionv1.MutatingWebhookConfiguration
+		mwhcUpdated  bool
+	}{
+		{
+			name: "webhook changed",
+			originalMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+								constants.OSMAppInstanceLabelKey: meshName,
+							},
+						},
+					},
+				},
+			},
+			updatedMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "new-test-service-name-",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"some-key": "some-value",
+							},
+						},
+					},
+				},
+			},
+			mwhcUpdated: true,
+		},
+		{
+			name: "mutating webhook new label added",
+			originalMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+								constants.OSMAppInstanceLabelKey: meshName,
+							},
+						},
+					},
+				},
+			},
+			updatedMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+						"some":                           "label",
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name-",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"some-key": "some-value",
+							},
+						},
+					},
+				},
+			},
+			mwhcUpdated: true,
+		},
+		{
+			name: "mutataing webhook name changed",
+			originalMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--webhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+								constants.OSMAppInstanceLabelKey: meshName,
+							},
+						},
+					},
+				},
+			},
+			updatedMwhc: admissionv1.MutatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "--updatedWebhookName--",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+						constants.OSMAppInstanceLabelKey: meshName,
+					},
+				},
+				Webhooks: []admissionv1.MutatingWebhook{
+					{
+						Name: injector.MutatingWebhookName,
+						ClientConfig: v1.WebhookClientConfig{
+							Service: &v1.ServiceReference{
+								Namespace: "test-namespace",
+								Name:      "test-service-name-",
+								Path:      &testWebhookServicePath,
+							},
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"some-key": "some-value",
+							},
+						},
+					},
+				},
+			},
+			mwhcUpdated: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			kubeClient := testclient.NewSimpleClientset(&tc.originalMwhc)
+			crdClient := apiservertestclient.NewSimpleClientset()
+
+			c := client{
+				kubeClient:      kubeClient,
+				meshName:        meshName,
+				apiServerClient: crdClient,
+				informers:       informerCollection{},
+			}
+			result := c.isMutatingWebhookUpdated(&tc.originalMwhc, &tc.updatedMwhc)
+			assert.Equal(result, tc.mwhcUpdated)
+		})
+	}
+}

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -1,0 +1,46 @@
+package reconciler
+
+import (
+	"fmt"
+
+	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var log = logger.New("reconciler")
+
+const (
+	// crdInformerKey lookup identifier
+	crdInformerKey k8s.InformerKey = "CRDInformerKey"
+
+	// mutatingWebhookInformerKey lookup identifier
+	mutatingWebhookInformerKey k8s.InformerKey = "MutatingWebhookConfigInformerKey"
+
+	// nameIndex is the lookup name for the most comment index function, which is to index by the name field
+	nameIndex string = "name"
+)
+
+// informerCollection is the type holding the collection of informers we keep
+type informerCollection map[k8s.InformerKey]cache.SharedIndexInformer
+
+// client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster
+type client struct {
+	meshName        string
+	kubeClient      kubernetes.Interface
+	apiServerClient clientset.Interface
+	informers       informerCollection
+}
+
+// metaNameIndexFunc is a default index function that indexes based on an object's name
+func metaNameIndexFunc(obj interface{}) ([]string, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return []string{""}, fmt.Errorf("object has no meta: %v", err)
+	}
+	return []string{meta.GetName()}, nil
+}


### PR DESCRIPTION
**Description**:

Add a reconciler client that initializes infromers to track changes to
the crds and mutating webhook that osm manages.

Add handlers to manage the reconcilialtion of crds and mutating webhook
in osm.

Note: This PR doesn't integrate the reconciler with OSM yet, there will up a follow up PR for this and it will be feature flagged.

Part of #4065

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Testing done**: unit tests added 

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
