### PR TITLE
envoy: pin images to sha256 digest and update PullPolicy

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -139,8 +139,8 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
-| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.19.1"` | Envoy sidecar image |
-| OpenServiceMesh.sidecarWindowsImage | string | `"envoyproxy/envoy-windows:v1.19.1"` |  |
+| OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"` | Envoy sidecar image for Linux workloads (v1.19.1) |
+| OpenServiceMesh.sidecarWindowsImage | string | `"envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"` | Envoy sidecar image for Windows workloads (v1.19.1) |
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -254,7 +254,7 @@
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
                     "examples": [
-                        "envoyproxy/envoy-alpine:v1.19.1"
+                        "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
                     ]
                 },
                 "sidecarWindowsImage": {
@@ -263,7 +263,7 @@
                     "title": "The sidecarWindowsImage schema",
                     "description": "The proxy side car image to run on Windows payloads.",
                     "examples": [
-                        "envoyproxy/envoy-windows:v1.19.1"
+                        "envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"
                     ]
                 },
                 "certificateProvider": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -16,9 +16,10 @@ OpenServiceMesh:
 
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
-  # -- Envoy sidecar image
-  sidecarImage: envoyproxy/envoy-alpine:v1.19.1
-  sidecarWindowsImage: envoyproxy/envoy-windows:v1.19.1
+  # -- Envoy sidecar image for Linux workloads (v1.19.1)
+  sidecarImage: envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd
+  # -- Envoy sidecar image for Windows workloads (v1.19.1)
+  sidecarWindowsImage: envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85
 
   #
   # -- OSM controller parameters

--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -64,11 +64,11 @@ spec:
                     envoyImage:
                       description: Image for the Envoy sidecar
                       type: string
-                      default: "envoyproxy/envoy-alpine:v1.19.1"
+                      default: "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
                     envoyWindowsImage:
                       description: Image for the Envoy sidecar on Windows workers
                       type: string
-                      default: "envoyproxy/envoy-windows:v1.19.1"
+                      default: "envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"
                     initContainerImage:
                       description: Image for the init container
                       type: string

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -25,7 +25,7 @@ func TestCreateDefaultMeshConfig(t *testing.T) {
   "enablePrivilegedInitContainer": false,
   "logLevel": "error",
   "maxDataPlaneConnections": 0,
-  "envoyImage": "envoyproxy/envoy-alpine:v1.19.1",
+  "envoyImage": "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd",
   "initContainerImage": "openservicemesh/init:v0.9.2",
   "configResyncInterval": "2s"
 },

--- a/docs/example/manifests/meshconfig/mesh-config.yaml
+++ b/docs/example/manifests/meshconfig/mesh-config.yaml
@@ -7,7 +7,7 @@ spec:
     enablePrivilegedInitContainer: false
     logLevel: error
     maxDataPlaneConnections: 0
-    envoyImage: "envoyproxy/envoy-alpine:v1.19.1"
+    envoyImage: "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
     initContainerImage: "openservicemesh/init:v0.9.2"
     configResyncInterval: "0s"
   traffic:

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -233,7 +233,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			name:                  "GetEnvoyImage",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal("envoyproxy/envoy-alpine:v1.19.1", cfg.GetEnvoyImage())
+				assert.Equal("envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd", cfg.GetEnvoyImage())
 			},
 			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -58,13 +58,13 @@ const (
 	// DefaultOSMLogLevel is the default OSM log level if none is specified
 	DefaultOSMLogLevel = "info"
 
-	// DefaultEnvoyImage is the default envoy proxy sidecar image if not defined in the osm MeshConfig
-	DefaultEnvoyImage = "envoyproxy/envoy-alpine:v1.19.1"
+	// DefaultEnvoyImage is the default envoy proxy sidecar image if not defined in the osm MeshConfig (v1.19.1)
+	DefaultEnvoyImage = "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
 
-	// DefaultEnvoyWindowsImage is the default envoy proxy windows sidecar image if not defined in the osm MeshConfig
+	// DefaultEnvoyWindowsImage is the default envoy proxy windows sidecar image if not defined in the osm MeshConfig (v1.19.1)
 	// TODO(#3864): This should be updated to the nanoserver based image when it becomes available
 	// See https://github.com/envoyproxy/envoy/issues/16759
-	DefaultEnvoyWindowsImage = "envoyproxy/envoy-windows:v1.19.1"
+	DefaultEnvoyWindowsImage = "envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"
 
 	// DefaultInitContainerImage is the default init container image if not defined in the osm MeshConfig
 	DefaultInitContainerImage = "openservicemesh/init:v0.9.2"

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,
 				Image:           envoyImage,
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				SecurityContext: &corev1.SecurityContext{
 					RunAsUser: func() *int64 {
 						uid := constants.EnvoyUID
@@ -381,7 +381,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,
 				Image:           envoyImage,
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				SecurityContext: &corev1.SecurityContext{
 					WindowsOptions: &corev1.WindowsSecurityContextOptions{
 						RunAsUserName: func() *string {

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -46,7 +46,7 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator
 	return corev1.Container{
 		Name:            constants.EnvoyContainerName,
 		Image:           containerImage,
-		ImagePullPolicy: corev1.PullAlways,
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		SecurityContext: securityContext,
 		Ports:           getEnvoyContainerPorts(originalHealthProbes),
 		VolumeMounts: []corev1.VolumeMount{{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the default envoy image to use image digests
instead of tags to uniquely and immutably identify
a container image. Tags are mutable and are vulnerable
to supply chain attacks, so this change relies on image
digests to avoid such problems.

Additionally, updates the envoy container's image pull
policy to only pull the image if not present, as there
is no need to pull the image if it's already present.

Resolves #3715

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Verified demo locally

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Install                    | [X] |
| Security                   | [X] |
| Sidecar Injection          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
