### PR TITLE
tests(e2e): add cleanup test

### DIFF
--- a/tests/e2e/e2e_osm_reinstall_test.go
+++ b/tests/e2e/e2e_osm_reinstall_test.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Test reinstalling OSM in the same namespace with the same mesh name",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 4,
+	},
+	func() {
+		It("Becomes ready after being reinstalled", func() {
+			opts := Td.GetOSMInstallOpts()
+			Expect(Td.InstallOSM(opts)).To(Succeed())
+
+			By("Deleting OSM")
+			stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "delete", "-f", "--osm-namespace", opts.ControlPlaneNS)
+			Td.T.Log(stdout)
+			if err != nil {
+				Td.T.Logf("stderr:\n%s", stderr)
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reinstalling OSM")
+			// Invoke the CLI directly because Td.InstallOSM unconditionally
+			// creates the namespace which fails when it already exists.
+			stdout, stderr, err = Td.RunLocal(filepath.FromSlash("../../bin/osm"), "install", "--verbose", "--timeout=5m", "--osm-namespace", opts.ControlPlaneNS, "--set", "OpenServiceMesh.image.registry="+opts.ContainerRegistryLoc+",OpenServiceMesh.image.tag="+opts.OsmImagetag)
+			Td.T.Log(stdout)
+			if err != nil {
+				Td.T.Logf("stderr:\n%s", stderr)
+			}
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a new e2e test that installs OSM, deletes it, then
reinstalls OSM in the same namespace with the same mesh name to verify
deleting OSM doesn't prevent a new control plane from successfully
coming up.

Fixes #1851
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Ran the test locally
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
