### PR TITLE
fix: remove weight assignment to local endpoints

### DIFF
--- a/pkg/envoy/eds/cluster_load_assignment_test.go
+++ b/pkg/envoy/eds/cluster_load_assignment_test.go
@@ -45,18 +45,12 @@ func TestNewClusterLoadAssignment(t *testing.T) {
 										Address: envoy.GetAddress("1.1.1.1", 80),
 									},
 								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 50,
-								},
 							},
 							{
 								HostIdentifier: &xds_endpoint.LbEndpoint_Endpoint{
 									Endpoint: &xds_endpoint.Endpoint{
 										Address: envoy.GetAddress("2.2.2.2", 80),
 									},
-								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 50,
 								},
 							},
 						},
@@ -101,9 +95,6 @@ func TestNewClusterLoadAssignment(t *testing.T) {
 										Address: envoy.GetAddress("1.2.3.4", 80),
 									},
 								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 50,
-								},
 							},
 						},
 					},
@@ -117,9 +108,6 @@ func TestNewClusterLoadAssignment(t *testing.T) {
 									Endpoint: &xds_endpoint.Endpoint{
 										Address: envoy.GetAddress("2.3.4.5", 80),
 									},
-								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 50,
 								},
 							},
 						},
@@ -156,9 +144,6 @@ func TestNewClusterLoadAssignment(t *testing.T) {
 									Endpoint: &xds_endpoint.Endpoint{
 										Address: envoy.GetAddress("2.3.4.5", 80),
 									},
-								},
-								LoadBalancingWeight: &wrappers.UInt32Value{
-									Value: 100,
 								},
 							},
 						},


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Remove weight assignment to local endpoints. 

By default without any assignment, traffic will be equally balanced among local cluster.

Resolves issue #4092

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

Deployed books demo to testing cluster. Scaled bookstore-v1 deployment to 10 pods. 

Traffic is balanced among 10 pods, observed from logs.

Also fetched endpoints information from booksbuyer:

```
> osm proxy get clusters bookbuyer-684b97dfb5-f7kqc -n bookbuyer | grep weight

bookstore/bookstore-v1|14001::10.244.1.19:14001::weight::1
bookstore/bookstore-v1|14001::10.244.0.25:14001::weight::1
bookstore/bookstore-v1|14001::10.244.0.26:14001::weight::1
bookstore/bookstore-v1|14001::10.244.0.28:14001::weight::1
bookstore/bookstore-v1|14001::10.244.1.24:14001::weight::1
bookstore/bookstore-v1|14001::10.244.0.24:14001::weight::1
bookstore/bookstore-v1|14001::10.244.1.25:14001::weight::1
bookstore/bookstore-v1|14001::10.244.1.26:14001::weight::1
bookstore/bookstore-v1|14001::10.244.0.27:14001::weight::1
bookstore/bookstore-v1|14001::10.244.1.27:14001::weight::1
envoy-metrics-cluster::127.0.0.1:15000::weight::100
osm-controller::10.0.171.125:15128::weight::1
bookstore/bookstore-v2|14001::10.244.0.16:14001::weight::1
```

As we can see, internally each endpoint will have weight 1.


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

