### PR TITLE
feat(Windows): Add Windows nightly job

### DIFF
--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -1,0 +1,36 @@
+name: Windows Nightly Job
+on: 
+  workflow_run:
+    workflows: ["Windows Images"]
+    types: [completed]
+
+env:
+  CTR_REGISTRY: openservicemesh
+  CTR_TAG: latest-main
+
+jobs:
+  test:
+    name: Windows Cluster Nightly Job
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout v2
+        uses: actions/checkout@v2
+      - name: Authenticate and set context
+        uses: azure/k8s-set-context@v1
+        with:
+          method: kubeconfig
+          kubeconfig: ${{ secrets.CI_WINDOWS_KUBECONFIG }}
+        id: setcontext
+      - name: Setup Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+      - name: Run e2es
+        run: |
+          make build-osm
+          go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.focus='\[Cross-platform\]|\[windows\]' -test.timeout 180m -deployOnWindowsWorkers=true
+      - name: Cleanup resources
+        if: ${{ always() }}
+        run: |
+          kubectl delete service vault -n osm-system --ignore-not-found --wait

--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -15,6 +15,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 	OSMDescribeInfo{
 		Tier:   1,
 		Bucket: 2,
+		OS:     OSCrossPlatform,
 	},
 	func() {
 		Context("Egress", func() {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -82,7 +82,7 @@ var _ = AfterSuite(func() {
 })
 
 func (o OSMDescribeInfo) String() string {
-	return fmt.Sprintf("[Tier %d][Bucket %d]", o.Tier, o.Bucket)
+	return fmt.Sprintf("[Tier %d][Bucket %d][%s]", o.Tier, o.Bucket, o.OS)
 }
 
 // OSMDescribe givens the description of an e2e test

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -11,6 +11,9 @@ import (
 	"github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
 )
 
+// OSCrossPlatform indicates that a test can run on all operating systems.
+const OSCrossPlatform string = "Cross-platform"
+
 // OSMDescribeInfo is a struct to represent the Tier and Bucket of a given e2e test
 type OSMDescribeInfo struct {
 	// Tier represents the priority of the test. Lower value indicates higher priority.
@@ -19,6 +22,9 @@ type OSMDescribeInfo struct {
 	// Bucket indicates in which test Bucket the test will run in for CI. Each
 	// Bucket is run in parallel while tests in the same Bucket run sequentially.
 	Bucket int
+
+	// OS indicates which OS the test can run on.
+	OS string
 }
 
 // InstallType defines several OSM test deployment scenarios


### PR DESCRIPTION
Fixes #3883 Adds a nightly job for Windows tests.

Cluster is installed via AKS-engine on the CNCF subscription.

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
