### PR TITLE
docs(envoy): update docs for sidecar LogLevel

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` | Enable permissive traffic policy mode |
 | OpenServiceMesh.enablePrivilegedInitContainer | bool | `false` | Run init container in privileged mode |
 | OpenServiceMesh.enforceSingleMesh | bool | `false` | Enforce only deploying one mesh in the cluster |
-| OpenServiceMesh.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar |
+| OpenServiceMesh.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error` |
 | OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |
 | OpenServiceMesh.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API. When enabled, fine grained control over Egress (external) traffic is enforced |
 | OpenServiceMesh.featureFlags.enableEnvoyActiveHealthChecks | bool | `false` | Enable Envoy active health checks |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -156,7 +156,7 @@ OpenServiceMesh:
   # -- Enable mesh-wide HTTPS ingress capability (HTTP ingress is the default)
   useHTTPSIngress: false
 
-  # -- Log level for the Envoy proxy sidecar
+  # -- Log level for the Envoy proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error`
   envoyLogLevel: error
 
   # -- Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits

--- a/pkg/apis/config/v1alpha1/mesh_config.go
+++ b/pkg/apis/config/v1alpha1/mesh_config.go
@@ -45,7 +45,7 @@ type SidecarSpec struct {
 	// EnablePrivilegedInitContainer defines a boolean indicating whether the init container for a meshed pod should run as privileged.
 	EnablePrivilegedInitContainer bool `json:"enablePrivilegedInitContainer,omitempty"`
 
-	// LogLevel defines the  logging level for the sidecar's logs.
+	// LogLevel defines the logging level for the sidecar's logs. Non developers should generally never set this value. In production environments the LogLevel should be set to error.
 	LogLevel string `json:"logLevel,omitempty"`
 
 	// EnvoyImage defines the container image used for the Envoy proxy sidecar.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds a note to the description of the LogLevel value. This change
clarifies that the envoy log level should not be set by non-developers.
In production environments, the LogLevel should be set to `error`.

Addresses #2754

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ x ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
