### PR TITLE
chore: Fix typo in windows-nightly

### DIFF
--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -1,7 +1,7 @@
 name: Windows Nightly Job
 on: 
   workflow_run:
-    workflows: ["Windows Images"]
+    workflows: ["Nightly Images"]
     types: [completed]
 
 env:


### PR DESCRIPTION
Fix typo that caused the pipeline to not be scheduled yesterday

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>
