### PR TITLE
feat(reconciler): Enable reconciler for crds in osm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,10 @@ export BOOKWAREHOUSE_NAMESPACE=bookwarehouse
 # Default: false
 # export ENABLE_EGRESS=true
 
+# optional: ENABLE_RECONCILER (true/false)
+# Default: false
+# export ENABLE_RECONCILER=true
+
 # optional: DEPLOY_GRAFANA (true/false)
 # Default: false
 # export DEPLOY_GRAFANA=true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,12 +290,13 @@ jobs:
           go-version: 1.16
         id: go
 
-      - name: Run Simulation w/ Tresor, SMI policies, and egress disabled
+      - name: Run Simulation w/ Tresor, SMI policies, egress disabled and reconciler disabled
         env:
           CERT_MANAGER: "tresor"
           BOOKSTORE_SVC: "bookstore"
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "0"
           ENABLE_EGRESS: "false"
+          ENABLE_RECONCILER: "false"
           DEPLOY_TRAFFIC_SPLIT: "true"
           CTR_TAG: ${{ github.sha }}
           USE_PRIVATE_REGISTRY: "false"

--- a/.github/workflows/openshift-nightly.yml
+++ b/.github/workflows/openshift-nightly.yml
@@ -32,12 +32,13 @@ jobs:
         run: |
           make build-osm
           go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.skip="\bHTTP ingress\b" -ginkgo.skip="\bUpgrade\b" -test.timeout 180m -deployOnOpenShift=true
-      - name: Run Simulation w/ Tresor, SMI policies, and egress disabled
+      - name: Run Simulation w/ Tresor, SMI policies, egress disabled and reconciler disabled
         env:
           CERT_MANAGER: "tresor"
           BOOKSTORE_SVC: "bookstore"
           BOOKTHIEF_EXPECTED_RESPONSE_CODE: "0"
           ENABLE_EGRESS: "false"
+          ENABLE_RECONCILER: "false"
           DEPLOY_TRAFFIC_SPLIT: "true"
           DEPLOY_ON_OPENSHIFT: "true"
           TIMEOUT: 150s

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.enableFluentbit | bool | `false` | Enable Fluent Bit sidecar deployment on OSM controller's pod |
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` | Enable permissive traffic policy mode |
 | OpenServiceMesh.enablePrivilegedInitContainer | bool | `false` | Run init container in privileged mode |
+| OpenServiceMesh.enableReconciler | bool | `false` | Enable reconciler for OSM's CRDs and mutating webhook |
 | OpenServiceMesh.enforceSingleMesh | bool | `false` | Enforce only deploying one mesh in the cluster |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error` |
 | OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |

--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -64,6 +64,7 @@ spec:
             "--cert-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
             "--cert-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
             "--cert-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
+            "--enable-reconciler", "{{.Values.OpenServiceMesh.enableReconciler}}",
           ]
           resources:
             limits:

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -136,6 +136,7 @@
                 "enableDebugServer",
                 "enablePermissiveTrafficPolicy",
                 "enableEgress",
+                "enableReconciler",
                 "deployPrometheus",
                 "deployGrafana",
                 "enableFluentbit",
@@ -340,6 +341,15 @@
                     "type": "boolean",
                     "title": "The enableEgress schema",
                     "description": "Indicates whether egress should be enabled or not.",
+                    "examples": [
+                        false
+                    ]
+                },
+                "enableReconciler": {
+                    "$id": "#/properties/OpenServiceMesh/properties/enableReconciler",
+                    "type": "boolean",
+                    "title": "The enableReconciler schema",
+                    "description": "Indicates whether OSM's reconciler should be enabled or not.",
                     "examples": [
                         false
                     ]

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -117,6 +117,9 @@ OpenServiceMesh:
   # -- Enable egress in the mesh
   enableEgress: false
 
+  # -- Enable reconciler for OSM's CRDs and mutating webhook
+  enableReconciler: false
+
   # -- Deploy Prometheus with OSM installation
   deployPrometheus: false
 

--- a/demo/run-osm-demo.sh
+++ b/demo/run-osm-demo.sh
@@ -29,6 +29,7 @@ CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_DEBUG_SERVER="${ENABLE_DEBUG_SERVER:-true}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
+ENABLE_RECONCILER="${ENABLE_RECONCILER:-false}"
 DEPLOY_GRAFANA="${DEPLOY_GRAFANA:-false}"
 DEPLOY_JAEGER="${DEPLOY_JAEGER:-false}"
 TRACING_ADDRESS="${TRACING_ADDRESS:-jaeger.${K8S_NAMESPACE}.svc.cluster.local}"
@@ -110,6 +111,7 @@ if [ "$CERT_MANAGER" = "vault" ]; then
       --set=OpenServiceMesh.image.pullPolicy="$IMAGE_PULL_POLICY" \
       --set=OpenServiceMesh.enableDebugServer="$ENABLE_DEBUG_SERVER" \
       --set=OpenServiceMesh.enableEgress="$ENABLE_EGRESS" \
+      --set=OpenServiceMesh.enableReconciler="$ENABLE_RECONCILER" \
       --set=OpenServiceMesh.deployGrafana="$DEPLOY_GRAFANA" \
       --set=OpenServiceMesh.deployJaeger="$DEPLOY_JAEGER" \
       --set=OpenServiceMesh.tracing.enable="$DEPLOY_JAEGER" \
@@ -133,6 +135,7 @@ else
       --set=OpenServiceMesh.image.pullPolicy="$IMAGE_PULL_POLICY" \
       --set=OpenServiceMesh.enableDebugServer="$ENABLE_DEBUG_SERVER" \
       --set=OpenServiceMesh.enableEgress="$ENABLE_EGRESS" \
+      --set=OpenServiceMesh.enableReconciler="$ENABLE_RECONCILER" \
       --set=OpenServiceMesh.deployGrafana="$DEPLOY_GRAFANA" \
       --set=OpenServiceMesh.deployJaeger="$DEPLOY_JAEGER" \
       --set=OpenServiceMesh.tracing.enable="$DEPLOY_JAEGER" \

--- a/demo/run-osm-multicluster-demo.sh
+++ b/demo/run-osm-multicluster-demo.sh
@@ -33,6 +33,7 @@ CTR_TAG="${CTR_TAG:-$(git rev-parse HEAD)}"
 IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-Always}"
 ENABLE_DEBUG_SERVER="${ENABLE_DEBUG_SERVER:-true}"
 ENABLE_EGRESS="${ENABLE_EGRESS:-false}"
+ENABLE_RECONCILER="${ENABLE_RECONCILER:-false}"
 DEPLOY_GRAFANA="${DEPLOY_GRAFANA:-false}"
 DEPLOY_JAEGER="${DEPLOY_JAEGER:-false}"
 ENABLE_FLUENTBIT="${ENABLE_FLUENTBIT:-false}"
@@ -119,6 +120,7 @@ for CONTEXT in $MULTICLUSTER_CONTEXTS; do
         --set=OpenServiceMesh.image.pullPolicy="$IMAGE_PULL_POLICY" \
         --set=OpenServiceMesh.enableDebugServer="$ENABLE_DEBUG_SERVER" \
         --set=OpenServiceMesh.enableEgress="$ENABLE_EGRESS" \
+        --set=OpenServiceMesh.enableReconciler="$ENABLE_RECONCILER" \
         --set=OpenServiceMesh.deployGrafana="$DEPLOY_GRAFANA" \
         --set=OpenServiceMesh.deployJaeger="$DEPLOY_JAEGER" \
         --set=OpenServiceMesh.enableFluentbit="$ENABLE_FLUENTBIT" \

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -2,6 +2,7 @@ package crdconversion
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/tests"
 )
 
@@ -28,52 +30,76 @@ func (mc mockCertificate) GetExpiration() time.Time                  { return ti
 func (mc mockCertificate) GetSerialNumber() certificate.SerialNumber { return "serial_number" }
 
 func TestUpdateCrdConversionWebhookConfiguration(t *testing.T) {
-	assert := tassert.New(t)
-	cert := mockCertificate{}
+	testCases := []struct {
+		name             string
+		enableReconciler bool
+	}{
+		{name: "reconciler enabled",
+			enableReconciler: true,
+		},
+		{name: "reconciler disabled",
+			enableReconciler: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			cert := mockCertificate{}
 
-	crdClient := fake.NewSimpleClientset(&apiv1.CustomResourceDefinition{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CustomResourceDefinition",
-			APIVersion: "apiextensions.k8s.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "tests.test.openservicemesh.io",
-		},
-		Spec: apiv1.CustomResourceDefinitionSpec{
-			Group: "test.openservicemesh.io",
-			Names: apiv1.CustomResourceDefinitionNames{
-				Plural:   "tests",
-				Singular: "test",
-				Kind:     "test",
-				ListKind: "testList",
-			},
-			Scope: apiv1.NamespaceScoped,
-			Versions: []apiv1.CustomResourceDefinitionVersion{{
-				Name:    "v1alpha1",
-				Served:  true,
-				Storage: true,
-				Schema: &apiv1.CustomResourceValidation{
-					OpenAPIV3Schema: &apiv1.JSONSchemaProps{
-						Type:       "object",
-						Properties: make(map[string]apiv1.JSONSchemaProps),
+			crdClient := fake.NewSimpleClientset(&apiv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "CustomResourceDefinition",
+					APIVersion: "apiextensions.k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "tests.test.openservicemesh.io",
+					Labels: map[string]string{
+						constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
 					},
 				},
-			}},
-		},
-	})
+				Spec: apiv1.CustomResourceDefinitionSpec{
+					Group: "test.openservicemesh.io",
+					Names: apiv1.CustomResourceDefinitionNames{
+						Plural:   "tests",
+						Singular: "test",
+						Kind:     "test",
+						ListKind: "testList",
+					},
+					Scope: apiv1.NamespaceScoped,
+					Versions: []apiv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiv1.JSONSchemaProps{
+								Type:       "object",
+								Properties: make(map[string]apiv1.JSONSchemaProps),
+							},
+						},
+					}},
+				},
+			})
 
-	err := updateCrdConversionWebhookConfiguration(cert, crdClient.ApiextensionsV1(), tests.Namespace, "tests.test.openservicemesh.io", "/testconversion")
-	assert.Nil(err)
+			err := updateCrdConfiguration(cert, crdClient.ApiextensionsV1(), tests.Namespace, "tests.test.openservicemesh.io", "/testconversion", tc.enableReconciler)
+			assert.Nil(err)
 
-	crds, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
-	assert.Nil(err)
+			crds, err := crdClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
+			assert.Nil(err)
 
-	crd := crds.Items[0]
-	assert.Equal(crd.Spec.Conversion.Strategy, apiv1.WebhookConverter)
-	assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, []byte("chain"))
-	assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace, tests.Namespace)
-	assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Name, crdConverterServiceName)
-	assert.Equal(crd.Spec.Conversion.Webhook.ConversionReviewVersions, conversionReviewVersions)
+			crd := crds.Items[0]
+			assert.Equal(crd.Spec.Conversion.Strategy, apiv1.WebhookConverter)
+			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, []byte("chain"))
+			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace, tests.Namespace)
+			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Name, crdConverterServiceName)
+			assert.Equal(crd.Spec.Conversion.Webhook.ConversionReviewVersions, conversionReviewVersions)
+
+			assert.Equal(crd.Labels[constants.OSMAppNameLabelKey], constants.OSMAppNameLabelValue)
+			if tc.enableReconciler {
+				assert.Len(crd.Labels, 2)
+				assert.Equal(crd.Labels[constants.ReconcileLabel], strconv.FormatBool(true))
+			}
+		})
+	}
 }
 
 func TestNewConversionWebhook(t *testing.T) {
@@ -89,8 +115,9 @@ func TestNewConversionWebhook(t *testing.T) {
 	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(keySize).AnyTimes()
 	fakeCertManager := tresor.NewFakeCertManager(mockConfigurator)
 	osmNamespace := "-osm-namespace-"
+	enablesReconciler := false
 	stop := make(<-chan struct{})
 
-	actualErr := NewConversionWebhook(crdConversionConfig, kubeClient, crdClient.ApiextensionsV1(), fakeCertManager, osmNamespace, stop)
+	actualErr := NewConversionWebhook(crdConversionConfig, kubeClient, crdClient.ApiextensionsV1(), fakeCertManager, osmNamespace, enablesReconciler, stop)
 	assert.NotNil(actualErr)
 }

--- a/pkg/reconciler/client.go
+++ b/pkg/reconciler/client.go
@@ -29,13 +29,13 @@ func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient client
 
 	// Initialize informers
 	informerInitHandlerMap := map[k8s.InformerKey]func(){
-		crdInformerKey:             c.initCustomResourceDefinitionMonitor,
+		CrdInformerKey:             c.initCustomResourceDefinitionMonitor,
 		mutatingWebhookInformerKey: c.initMutatingWebhookConfigurationMonitor,
 	}
 
 	// If specific informers are not selected to be initialized, initialize all informers
 	if len(selectInformers) == 0 {
-		selectInformers = []k8s.InformerKey{crdInformerKey, mutatingWebhookInformerKey}
+		selectInformers = []k8s.InformerKey{CrdInformerKey, mutatingWebhookInformerKey}
 	}
 
 	for _, informer := range selectInformers {
@@ -63,10 +63,10 @@ func (c *client) initCustomResourceDefinitionMonitor() {
 	informerFactory := customResourceDefinitionInformer.NewFilteredCustomResourceDefinitionInformer(c.apiServerClient, k8s.DefaultKubeEventResyncInterval, cache.Indexers{nameIndex: metaNameIndexFunc}, options)
 
 	// Add informer
-	c.informers[crdInformerKey] = informerFactory
+	c.informers[CrdInformerKey] = informerFactory
 
 	// Add event handler to informer
-	c.informers[crdInformerKey].AddEventHandler(c.crdEventHandler())
+	c.informers[CrdInformerKey].AddEventHandler(c.crdEventHandler())
 }
 
 // Initializes mutating webhook monitoring

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -15,8 +15,8 @@ import (
 var log = logger.New("reconciler")
 
 const (
-	// crdInformerKey lookup identifier
-	crdInformerKey k8s.InformerKey = "CRDInformerKey"
+	// CrdInformerKey lookup identifier
+	CrdInformerKey k8s.InformerKey = "CRDInformerKey"
 
 	// mutatingWebhookInformerKey lookup identifier
 	mutatingWebhookInformerKey k8s.InformerKey = "MutatingWebhookConfigInformerKey"

--- a/tests/e2e/e2e_reconciler_test.go
+++ b/tests/e2e/e2e_reconciler_test.go
@@ -1,0 +1,60 @@
+package e2e
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Test OSM Reconciler",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 9,
+	},
+	func() {
+		Context("Enable Reconciler", func() {
+			It("Update and delete meshConfig crd", func() {
+
+				// Install OSM with reconciler enabled
+				installOpts := Td.GetOSMInstallOpts()
+				installOpts.EnableReconciler = true
+				Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+				_, err := Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(map[string]string{"app": "osm-bootstrap"}).String(),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Get the meshConfig crd
+				crd, err := Td.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "meshconfigs.config.openservicemesh.io", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				originalSpecServed := crd.Spec.Versions[0].Served
+
+				// update the spec served from true to false
+				crd.Spec.Versions[0].Served = false
+				_, err = Td.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), crd, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// verify that crd remains unchanged
+				Eventually(func() (bool, error) {
+					updatedCrd, err := Td.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "meshconfigs.config.openservicemesh.io", metav1.GetOptions{})
+					return updatedCrd.Spec.Versions[0].Served, err
+				}, 3*time.Second).Should(Equal(originalSpecServed))
+
+				// delete the crd
+				err = Td.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), "meshconfigs.config.openservicemesh.io", metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// verify crd exists in the cluster after deletion
+				_, err = Td.APIServerClient.ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), "meshconfigs.config.openservicemesh.io", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"github.com/onsi/ginkgo"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/kind/pkg/cluster"
@@ -66,9 +67,10 @@ type OsmTestData struct {
 	ClusterOS string // The operating system of the working nodes in the cluster. Mixed OS traffic is not supported.
 
 	// Cluster handles and rest config
-	Env        *cli.EnvSettings
-	RestConfig *rest.Config
-	Client     *kubernetes.Clientset
+	Env             *cli.EnvSettings
+	RestConfig      *rest.Config
+	Client          *kubernetes.Clientset
+	APIServerClient *clientset.Clientset
 
 	SmiClients *smiClients
 
@@ -95,6 +97,7 @@ type InstallOSMOpts struct {
 	DeployPrometheus        bool
 	DeployJaeger            bool
 	DeployFluentbit         bool
+	EnableReconciler        bool
 
 	VaultHost     string
 	VaultProtocol string


### PR DESCRIPTION
**Description**:

Enables the reconciler in osm bootstrap to reconcile the crds in osm.
This can be enabled/disabled on install by specifying the required helm
value. By default the reconciler is disabled.

e2e test has been added for the same.

part of #4065

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Testing done**:  An e2e test had been added to validation the new functionality

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
