### PR TITLE
fix(lint): remove deprecated golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,10 +12,10 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - gosec
     - govet
     - misspell
+    - revive
     - unused
     - whitespace
 
@@ -27,12 +27,12 @@ issues:
   exclude-rules:
     # Ignore error for ginkgo and gomega dot imports
     - linters:
-        - golint
+        - revive
       source: ". \"github.com/onsi/(ginkgo|gomega)\""
       text: "dot imports"
     # Ignore error for test framework imports
     - linters:
-        - golint
+        - revive
       source: ". \"github.com/openservicemesh/osm/tests/framework\""
       text: "dot imports"
     # Exclude staticcheck messages for deprecated function, variable or constant

--- a/mockspec/generate.go
+++ b/mockspec/generate.go
@@ -21,7 +21,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer rulesfile.Close() //nolint: gosec,go-lint,errcheck
+	defer rulesfile.Close() //nolint: gosec,errcheck
 
 	scanner := bufio.NewScanner(rulesfile)
 	for scanner.Scan() {

--- a/pkg/bugreport/run.go
+++ b/pkg/bugreport/run.go
@@ -123,7 +123,9 @@ func runCmdAndWriteToFile(cmdList []string, outFile string) error {
 	if err != nil {
 		return err
 	}
-	defer outfile.Close() //nolint: errcheck, #nosec G307
+	//nolint: errcheck
+	//#nosec G307
+	defer outfile.Close()
 	cmd.Stdout = outfile
 	cmd.Stderr = outfile
 

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -100,8 +100,8 @@ func TestNamespaceErr(t *testing.T) {
 	// doesn't matter, this was just the simplest way to force an error to
 	// occur. Users of this package are not able to do this, but the resulting
 	// behavior is the same as if any other error had occurred.
-	kConfigPath := "This doesn't even look like a valid path name"
-	env.config.KubeConfig = &kConfigPath
+	configPath := "This doesn't even look like a valid path name"
+	env.config.KubeConfig = &configPath
 
 	tassert.Equal(t, env.Namespace(), "osm-system")
 }

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -20,7 +20,7 @@ var _ endpoint.Provider = (*client)(nil)
 var _ service.Provider = (*client)(nil)
 
 // NewClient returns a client that has all components necessary to connect to and maintain state of a Kubernetes cluster.
-func NewClient(kubeController k8s.Controller, configClient config.Controller, cfg configurator.Configurator) *client { //nolint:golint // exported func returns unexported type
+func NewClient(kubeController k8s.Controller, configClient config.Controller, cfg configurator.Configurator) *client { //nolint: revive // unexported-return
 	return &client{
 		kubeController:   kubeController,
 		configClient:     configClient,

--- a/pkg/ticker/ticker.go
+++ b/pkg/ticker/ticker.go
@@ -24,7 +24,7 @@ type ResyncTicker struct {
 var (
 	log = logger.New("ticker")
 	// Local reference to global ticker
-	rTicker *ResyncTicker = nil
+	rTicker *ResyncTicker
 )
 
 // InitTicker initializes a global ticker that is configured via

--- a/tests/e2e/e2e_permissive_test.go
+++ b/tests/e2e/e2e_permissive_test.go
@@ -35,7 +35,7 @@ func testPermissiveMode(withSourceKubernetesService bool) {
 	const sourceNs = "client"
 	const destNs = "server"
 	const extSourceNs = "ext-client"
-	var meshNs []string = []string{sourceNs, destNs}
+	var meshNs = []string{sourceNs, destNs}
 
 	It("Tests HTTP traffic for client pod -> server pod with permissive mode", func() {
 		// Install OSM

--- a/tests/e2e/e2e_trafficsplit_recursive_split.go
+++ b/tests/e2e/e2e_trafficsplit_recursive_split.go
@@ -247,7 +247,7 @@ func testRecursiveTrafficSplit(appProtocol string) {
 		}
 
 		var results HTTPMultipleResults
-		var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+		var serversSeen = map[string]bool{} // Just counts unique servers seen
 		success := Td.WaitForRepeatedSuccess(func() bool {
 			curlSuccess := true
 

--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -294,7 +294,7 @@ func testTrafficSplit(appProtocol string, permissiveMode bool) {
 		}
 
 		var results HTTPMultipleResults
-		var serversSeen map[string]bool = map[string]bool{} // Just counts unique servers seen
+		var serversSeen = map[string]bool{} // Just counts unique servers seen
 		success := Td.WaitForRepeatedSuccess(func() bool {
 			curlSuccess := true
 

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -669,7 +669,7 @@ func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
 	waitGroup.Wait()
 
 	if errController != nil || errInjector != nil {
-		return errors.New(fmt.Sprintf("OSM Control plane was not ready in time (%v, %v, %v)", errController, errInjector, errBootstrap))
+		return fmt.Errorf("OSM Control plane was not ready in time (%v, %v, %v)", errController, errInjector, errBootstrap)
 	}
 
 	return nil

--- a/tests/framework/common_traffic.go
+++ b/tests/framework/common_traffic.go
@@ -191,7 +191,7 @@ func (td *OsmTestData) GRPCRequest(req GRPCRequestDef) GRPCRequestResult {
 // MapCurlOuput maps stdout from our specific curl,
 // it expects headers on stdout like "<name>: <value...>"
 func mapCurlOuput(curlOut string) map[string]string {
-	var ret map[string]string = make(map[string]string)
+	var ret = make(map[string]string)
 	scanner := bufio.NewScanner(strings.NewReader(curlOut))
 
 	for scanner.Scan() {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

go-lint has been deprecated. This change removes go-lint from the list of enabled linters in `golangci.yml`. 
The following warnings will beresolved:

`  level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."`
`"[runner/nolint] Found unknown linters in //nolint directives: #nosec g307, go-lint"`

Replaces go-lint with[ revive](https://revive.run/). The default behavior of revive is compatible with go-lint.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ x ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
