### PR TITLE
injector: enforce using configured images

### DIFF
--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -129,29 +129,17 @@ func (c *client) GetEnvoyLogLevel() string {
 
 // GetEnvoyImage returns the envoy image
 func (c *client) GetEnvoyImage() string {
-	image := c.getMeshConfig().Spec.Sidecar.EnvoyImage
-	if image != "" {
-		return image
-	}
-	return constants.DefaultEnvoyImage
+	return c.getMeshConfig().Spec.Sidecar.EnvoyImage
 }
 
 // GetEnvoyWindowsImage returns the envoy windows image
 func (c *client) GetEnvoyWindowsImage() string {
-	image := c.getMeshConfig().Spec.Sidecar.EnvoyWindowsImage
-	if image != "" {
-		return image
-	}
-	return constants.DefaultEnvoyWindowsImage
+	return c.getMeshConfig().Spec.Sidecar.EnvoyWindowsImage
 }
 
 // GetInitContainerImage returns the init container image
 func (c *client) GetInitContainerImage() string {
-	initImage := c.getMeshConfig().Spec.Sidecar.InitContainerImage
-	if initImage != "" {
-		return initImage
-	}
-	return constants.DefaultInitContainerImage
+	return c.getMeshConfig().Spec.Sidecar.InitContainerImage
 }
 
 // GetServiceCertValidityPeriod returns the validity duration for service certificates, and a default in case of invalid duration

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -233,7 +233,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			name:                  "GetEnvoyImage",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal("envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd", cfg.GetEnvoyImage())
+				assert.Equal("", cfg.GetEnvoyImage())
 			},
 			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{
@@ -245,10 +245,25 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 		},
 		{
+			name:                  "GetEnvoyWindowsImage",
+			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
+			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal("", cfg.GetEnvoyWindowsImage())
+			},
+			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
+				Sidecar: v1alpha1.SidecarSpec{
+					EnvoyImage: "envoyproxy/envoy-windows:v1.17.1",
+				},
+			},
+			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
+				assert.Equal("envoyproxy/envoy-windows:v1.17.1", cfg.GetEnvoyImage())
+			},
+		},
+		{
 			name:                  "GetInitContainerImage",
 			initialMeshConfigData: &v1alpha1.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal("openservicemesh/init:v0.9.2", cfg.GetInitContainerImage())
+				assert.Equal("", cfg.GetInitContainerImage())
 			},
 			updatedMeshConfigData: &v1alpha1.MeshConfigSpec{
 				Sidecar: v1alpha1.SidecarSpec{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -58,17 +58,6 @@ const (
 	// DefaultOSMLogLevel is the default OSM log level if none is specified
 	DefaultOSMLogLevel = "info"
 
-	// DefaultEnvoyImage is the default envoy proxy sidecar image if not defined in the osm MeshConfig (v1.19.1)
-	DefaultEnvoyImage = "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
-
-	// DefaultEnvoyWindowsImage is the default envoy proxy windows sidecar image if not defined in the osm MeshConfig (v1.19.1)
-	// TODO(#3864): This should be updated to the nanoserver based image when it becomes available
-	// See https://github.com/envoyproxy/envoy/issues/16759
-	DefaultEnvoyWindowsImage = "envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"
-
-	// DefaultInitContainerImage is the default init container image if not defined in the osm MeshConfig
-	DefaultInitContainerImage = "openservicemesh/init:v0.9.2"
-
 	// EnvoyPrometheusInboundListenerPort is Envoy's inbound listener port number for prometheus
 	EnvoyPrometheusInboundListenerPort = 15010
 

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -956,8 +956,16 @@ func TestPodCreationHandler(t *testing.T) {
 }
 
 func TestWebhookMutate(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
+	mockConfigurator.EXPECT().GetEnvoyImage().Return("envoy-linux-image").AnyTimes()
+	mockConfigurator.EXPECT().GetEnvoyWindowsImage().Return("envoy-windows-image").AnyTimes()
+	mockConfigurator.EXPECT().GetInitContainerImage().Return("init-container-image").AnyTimes()
+
 	t.Run("invalid JSON", func(t *testing.T) {
-		var wh *mutatingWebhook
+		wh := &mutatingWebhook{
+			configurator: mockConfigurator,
+		}
 		req := &admissionv1.AdmissionRequest{
 			Object: runtime.RawExtension{Raw: []byte("{")},
 		}
@@ -978,6 +986,7 @@ func TestWebhookMutate(t *testing.T) {
 		wh := &mutatingWebhook{
 			nonInjectNamespaces: mapset.NewSet(),
 			kubeController:      kubeController,
+			configurator:        mockConfigurator,
 		}
 
 		req := &admissionv1.AdmissionRequest{
@@ -1010,8 +1019,9 @@ func TestWebhookMutate(t *testing.T) {
 		cfg.EXPECT().GetInboundPortExclusionList()
 		cfg.EXPECT().GetOutboundIPRangeExclusionList()
 		cfg.EXPECT().IsPrivilegedInitContainer()
-		cfg.EXPECT().GetInitContainerImage()
-		cfg.EXPECT().GetEnvoyImage()
+		cfg.EXPECT().GetInitContainerImage().Return("init-container-image").AnyTimes()
+		cfg.EXPECT().GetEnvoyImage().Return("envoy-linux-image").AnyTimes()
+		cfg.EXPECT().GetEnvoyWindowsImage().Return("envoy-windows-image").AnyTimes()
 		cfg.EXPECT().GetProxyResources()
 		cfg.EXPECT().GetEnvoyLogLevel()
 
@@ -1057,8 +1067,9 @@ func TestWebhookMutate(t *testing.T) {
 		cfg.EXPECT().GetInboundPortExclusionList()
 		cfg.EXPECT().GetOutboundIPRangeExclusionList()
 		cfg.EXPECT().IsPrivilegedInitContainer()
-		cfg.EXPECT().GetInitContainerImage()
-		cfg.EXPECT().GetEnvoyImage()
+		cfg.EXPECT().GetInitContainerImage().Return("init-container-image").AnyTimes()
+		cfg.EXPECT().GetEnvoyImage().Return("envoy-linux-image").AnyTimes()
+		cfg.EXPECT().GetEnvoyWindowsImage().Return("envoy-windows-image").AnyTimes()
 		cfg.EXPECT().GetProxyResources()
 		cfg.EXPECT().GetEnvoyLogLevel()
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change enforces that images configured by
the user or install time defaults are always
used at the time of sidecar injection.
Previously, default images were encoded in the
configurator which posed a security risk of
not using configured images in case those
values are unavailable in MeshConfig and the user
overrides the defaults. It's common practice for
users to use their own images from secure registries
of their choice, so OSM must enforce that. This problem
is made worse by the fact that OSM could silently use
defaults that the user is unaware of without raising
any warnings or approval from the user, which can
compromise their security requirements.

This change is also required to address #3715 where
default image digests will be encoded in the CLI
as a part of the release workflow without needing
to rebuild the control plane binaries.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Verified that configured images are always used.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Security                   | [X] |
| Sidecar Injection          | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
