### PR TITLE
feat(reconciler): remove copying of crds in osm-bootstrap image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ build-osm-crds: clean-osm-crds
 .PHONY: build-osm-bootstrap
 build-osm-bootstrap: clean-osm-bootstrap
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o ./bin/osm-bootstrap/osm-bootstrap -ldflags "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w" ./cmd/osm-bootstrap
-	cp -R ./cmd/osm-bootstrap/crds ./bin/osm-crds
 
 .PHONY: build-osm
 build-osm: cmd/cli/chart.tgz

--- a/dockerfiles/Dockerfile.osm-bootstrap
+++ b/dockerfiles/Dockerfile.osm-bootstrap
@@ -1,2 +1,2 @@
 FROM gcr.io/distroless/static
-COPY . /
+COPY osm-bootstrap /


### PR DESCRIPTION
**Description**:

The initial reconciler design needed the original crds to compare for
the reconciler logic, given that the current implementation no longer
needs this it is being removed.

Part of #4065 

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
