### PR TITLE
fix(healthcheck): set curl connect timeout

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           - -c
           - >
             set -x;
-            while [ $(curl -sw '%{http_code}' "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
+            while [ $(curl --connect-timeout 2 -sw '%{http_code}' "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
               sleep 10;
             done
       containers:

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           - -c
           - >
             set -x;
-            while [ $(curl -sw '%{http_code}' "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
+            while [ $(curl --connect-timeout 2 -sw '%{http_code}' "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
               sleep 10;
             done
       containers:


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Set a connect timeout for the curl request in init-osm-controller and init-osm-injector. In some environments and distributions, the curl request was hanging, which delayed the osm installation process and led to failures in e2es which had a 1m30s timeout. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Tested on kind with k8s v1.22.0, and installation succeeded consistently. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
