### PR TITLE
test(windows): Enable more Windows tests

### DIFF
--- a/tests/e2e/e2e_egress_test.go
+++ b/tests/e2e/e2e_egress_test.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	. "github.com/openservicemesh/osm/tests/framework"
 )
 
@@ -45,7 +44,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 				Expect(err).NotTo(HaveOccurred())
 
 				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(sourceNs, 240*time.Second, 1, nil)).To(Succeed())
+				Expect(Td.WaitForPodsRunningReady(sourceNs, Td.PodDeploymentTimeout, 1, nil)).To(Succeed())
 				protocols := []string{
 					"http://",
 					"https://",
@@ -59,12 +58,6 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 					for _, test := range egressURLs {
 						urls = append(urls, protocol+test)
 					}
-				}
-
-				waitTime := 60 * time.Second
-				if Td.ClusterOS == constants.OSWindows {
-					//TODO(#4027): Make the timeouts equal on all platforms.
-					waitTime = 5 * 60 * time.Second
 				}
 
 				for _, url := range urls {
@@ -83,7 +76,7 @@ var _ = OSMDescribe("HTTP and HTTPS Egress",
 						}
 						Td.T.Logf("%s > REST req succeeded: %d", url, result.StatusCode)
 						return true
-					}, 5, waitTime)
+					}, 5, Td.ReqSuccessTimeout)
 					Expect(cond).To(BeTrue())
 				}
 

--- a/tests/e2e/e2e_tcp_egress_test.go
+++ b/tests/e2e/e2e_tcp_egress_test.go
@@ -16,6 +16,10 @@ var _ = OSMDescribe("Test TCP traffic from 1 pod client -> egress server",
 	OSMDescribeInfo{
 		Tier:   1,
 		Bucket: 9,
+		// TODO(#1610): This test assumes that the user can create a pod that is not part of the mesh.
+		// On Windows we set the HNS policies on all pods on the cluster and as a result we can't
+		// have pods that are not part of the mesh. This will be resolved when OSM CNI is available.
+		OS: constants.OSLinux,
 	},
 	func() {
 		Context("SimpleClientServer egress TCP", func() {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -217,8 +217,13 @@ func (td *OsmTestData) InitTestData(t GinkgoTInterface) error {
 
 	if td.DeployOnWindowsWorkers {
 		td.ClusterOS = constants.OSWindows
+		//TODO(#4027): Make the timeouts equal on all platforms.
+		td.ReqSuccessTimeout = 5 * 60 * time.Second
+		td.PodDeploymentTimeout = 240 * time.Second
 	} else {
 		td.ClusterOS = constants.OSLinux
+		td.ReqSuccessTimeout = 60 * time.Second
+		td.PodDeploymentTimeout = 90 * time.Second
 	}
 
 	// String parameter validation

--- a/tests/framework/constants.go
+++ b/tests/framework/constants.go
@@ -74,5 +74,8 @@ const (
 	EnvoyOSMWindowsImage = "openservicemesh/envoy-windows-nanoserver@sha256:94590d10bc8a46c60cd3a3858d80f3d6577d4e9a191fa05c0077f8b3d6002e22"
 
 	// WindowsNanoserverDockerImage is the base Windows image that is compatible with the test cluster.
-	WindowsNanoserverDockerImage = "mcr.microsoft.com/windows/nanoserver/insider:10.0.20348.1"
+	WindowsNanoserverDockerImage = "mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022"
+
+	// HttpbinOSMWindowsImage is the Windows based httpbin image used for testing.
+	HttpbinOSMWindowsImage = "openservicemesh/go-http-win@sha256:dd81377aa0ff749a5a9a7a1a25786a710f77991c94b3015f674163e32d7fe5f8"
 )

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -1,6 +1,8 @@
 package framework
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
@@ -65,6 +67,9 @@ type OsmTestData struct {
 	ClusterVersion                 string // Kind cluster version, ex. v1.20.2
 
 	ClusterOS string // The operating system of the working nodes in the cluster. Mixed OS traffic is not supported.
+
+	ReqSuccessTimeout    time.Duration // ReqSuccessTimeout timeout duration that the test expects for all requests from the client to server to succeed.
+	PodDeploymentTimeout time.Duration // PodDeploymentTimeout timeout duration that the test expects for all pods to be in ready state after they are deployed.
 
 	// Cluster handles and rest config
 	Env             *cli.EnvSettings


### PR DESCRIPTION
Despite issue #4141 I was able to validate and enable a bunch of tests on Windows

1. Add a Windows pod for tcp requests
2. Add a Windows pod for httpbin
3. Aggregate timeouts accross platform on a single variable

Signed-off-by: Sotiris Nanopoulos <sonanopo@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [x] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
