### PR TITLE
chore(lint): disable specific gosec rules with nosec

### DIFF
--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -41,8 +41,9 @@ func GetPodLogs(kubeClient kubernetes.Interface, namespace string, podName strin
 		fmt.Println("Error in opening stream: ", err)
 		os.Exit(1)
 	}
-
-	defer logStream.Close() //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer logStream.Close()
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(logStream)
 	if err != nil {
@@ -147,7 +148,9 @@ func SearchLogsForSuccess(kubeClient kubernetes.Interface, namespace string, pod
 
 	go func() {
 		defer close(result)
-		defer logStream.Close() //nolint: errcheck,gosec
+		//nolint: errcheck
+		//#nosec G307
+		defer logStream.Close()
 
 		r := bufio.NewReader(logStream)
 		type readResult struct {

--- a/cmd/cli/proxy_get.go
+++ b/cmd/cli/proxy_get.go
@@ -94,8 +94,10 @@ func (cmd *proxyGetCmd) run() error {
 		if err != nil {
 			return errors.Errorf("Error opening file %s: %s", cmd.outFile, err)
 		}
-		defer fd.Close() //nolint: errcheck, gosec
-		out = fd         // write output to file
+		//nolint: errcheck
+		//#nosec G307
+		defer fd.Close()
+		out = fd // write output to file
 	}
 
 	_, err = out.Write(envoyProxyConfig)

--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -115,7 +115,9 @@ func RestockBooks(amount int) {
 		return
 	}
 
-	defer resp.Body.Close() //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer resp.Body.Close()
 	for _, hdr := range interestingHeaders {
 		log.Info().Msgf("RestockBooks (%s) adding header {%s: %s}", chargeAccountURL, hdr, getHeader(resp.Header, hdr))
 	}
@@ -257,7 +259,9 @@ func fetch(url string) (responseCode int, identity string) {
 	if err != nil {
 		fmt.Printf("Error fetching %s: %s\n", url, err)
 	} else {
-		defer resp.Body.Close() //nolint: errcheck,gosec
+		//nolint: errcheck
+		//#nosec G307
+		defer resp.Body.Close()
 		responseCode = resp.StatusCode
 		for _, hdr := range interestingHeaders {
 			fmt.Printf("%s: %s\n", hdr, getHeader(resp.Header, hdr))

--- a/demo/cmd/tcp-client/tcp-client.go
+++ b/demo/cmd/tcp-client/tcp-client.go
@@ -76,7 +76,9 @@ func main() {
 			}
 		}
 
-		conn.Close() //nolint: errcheck,gosec
+		//nolint: errcheck
+		//#nosec G104
+		conn.Close()
 		log.Info().Msgf("Ended connection #%d ---------------------------", connectionCounter)
 	}
 }

--- a/demo/cmd/tcp-echo-server/tcp-echo-server.go
+++ b/demo/cmd/tcp-echo-server/tcp-echo-server.go
@@ -48,7 +48,9 @@ func main() {
 }
 
 func echoResponse(conn net.Conn) {
-	defer conn.Close() //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer conn.Close()
 	reader := bufio.NewReader(conn)
 
 	for {

--- a/mockspec/generate.go
+++ b/mockspec/generate.go
@@ -21,7 +21,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer rulesfile.Close() //nolint: gosec,errcheck
+	//nolint: errcheck
+	//#nosec G307
+	defer rulesfile.Close()
 
 	scanner := bufio.NewScanner(rulesfile)
 	for scanner.Scan() {

--- a/pkg/cli/chart_source.go
+++ b/pkg/cli/chart_source.go
@@ -15,7 +15,9 @@ func GetChartSource(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(packagedPath)                  //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer os.Remove(packagedPath)
 	packaged, err := ioutil.ReadFile(packagedPath) // #nosec G304
 	if err != nil {
 		return nil, err

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -62,7 +62,9 @@ func (httpProbe HTTPProbe) Probe() (int, error) {
 		return http.StatusServiceUnavailable, err
 	}
 
-	defer resp.Body.Close() //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer resp.Body.Close()
 	return resp.StatusCode, nil
 }
 

--- a/tests/e2e/e2e_fluentbit_output_test.go
+++ b/tests/e2e/e2e_fluentbit_output_test.go
@@ -89,7 +89,9 @@ func getPodLogs(namespace string, podName string, containerName string) (string,
 		return "Error in opening stream", err
 	}
 
-	defer logStream.Close() //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer logStream.Close()
 	buf := new(bytes.Buffer)
 	_, err = buf.ReadFrom(logStream)
 	if err != nil {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -389,7 +389,9 @@ func (td *OsmTestData) LoadImagesToKind(imageNames []string) error {
 	}
 
 	reader := bytes.NewReader(imageReader)
-	defer imageData.Close() //nolint: errcheck,gosec
+	//nolint: errcheck
+	//#nosec G307
+	defer imageData.Close()
 	nodes, err := td.ClusterProvider.ListNodes(td.ClusterName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list kind nodes")


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Replaces gosec in the nolint directive with a nosec annotation to
disable a specific gosec rule.

Note: The nolint and nosec directives need to be on separate lines.
If they are on the same line, nolint will see nosec as an unknown
linter and a warning will be generated when running golangci-lint.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ X ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
