### PR TITLE
ref(build): build windows images with explicit buildx builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,8 +208,8 @@ $(DOCKER_WINDOWS_DEMO_TARGETS): OS = windows
 $(DOCKER_WINDOWS_DEMO_TARGETS): NAME=$(@:docker-build-windows-%=%)
 $(DOCKER_WINDOWS_DEMO_TARGETS):
 	make OS=windows build-$(NAME)
-	@if ! docker buildx ls | grep -q "img-builder "; then  echo "Setting buildx img-builder"; docker buildx create --name img-builder --use; fi
-	docker buildx build --platform "windows/amd64" -t $(CTR_REGISTRY)/$(NAME)-windows:$(CTR_TAG) $(ARGS) -f dockerfiles/Dockerfile.$(NAME).windows demo/bin/$(NAME)
+	@if ! docker buildx ls | grep -q "img-builder "; then  echo "Creating buildx img-builder"; docker buildx create --name img-builder; fi
+	docker buildx build --builder img-builder --platform "windows/amd64" -t $(CTR_REGISTRY)/$(NAME)-windows:$(CTR_TAG) $(ARGS) -f dockerfiles/Dockerfile.$(NAME).windows demo/bin/$(NAME)
 
 docker-build-init:
 	docker build -t $(CTR_REGISTRY)/init:$(CTR_TAG) - < dockerfiles/Dockerfile.init


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change modifies the Makefile targets for building Windows images
with buildx to use the `img-builder` builder explicitly because the
effects of the `--use` flag on `docker buildx create` will not persist
if a user changes the default builder. This way we still ensure a
builder that can build windows/amd64 images exists and use that each
time no matter what the default builder is.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: local manual testing

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
