### PR TITLE
ref(build): clean up VERIFY_TAGS

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Push images with version tag
         env:
           CTR_TAG: ${{ needs.version.outputs.version }}
-        run: make docker-push VERIFY_TAGS=1
+        run: make docker-push VERIFY_TAGS=true
       - name: Push images with latest tag
         env:
           CTR_TAG: latest

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DIST_DIRS       := find * -type d -exec
 CTR_REGISTRY    ?= openservicemesh
 CTR_TAG         ?= latest
 CTR_DIGEST_FILE ?= /tmp/osm_image_digest_$(CTR_TAG).txt
-VERIFY_TAGS ?= 0
+VERIFY_TAGS     ?= false
 
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
@@ -253,7 +253,7 @@ DOCKER_PUSH_CONTROL_PLANE_TARGETS = $(addprefix docker-push-, init osm-controlle
 .PHONY: $(DOCKER_PUSH_CONTROL_PLANE_TARGETS)
 $(DOCKER_PUSH_CONTROL_PLANE_TARGETS): NAME=$(@:docker-push-%=%)
 $(DOCKER_PUSH_CONTROL_PLANE_TARGETS):
-	@if [ $(VERIFY_TAGS) != 1 ]; then make docker-build-$(NAME) && docker push "$(CTR_REGISTRY)/$(NAME):$(CTR_TAG)"; else bash scripts/publish-image.sh "$(NAME)" "linux" "$(CTR_REGISTRY)"; fi
+	scripts/publish-image.sh "$(NAME)" "linux" "$(CTR_REGISTRY)" "$(CTR_TAG)"
 	@docker images --digests | grep "$(CTR_REGISTRY)/$(NAME)\s*$(CTR_TAG)" >> "$(CTR_DIGEST_FILE)"
 
 
@@ -262,15 +262,15 @@ DOCKER_PUSH_LINUX_TARGETS = $(addprefix docker-push-, $(DEMO_TARGETS))
 .PHONY: $(DOCKER_PUSH_LINUX_TARGETS)
 $(DOCKER_PUSH_LINUX_TARGETS): NAME=$(@:docker-push-%=%)
 $(DOCKER_PUSH_LINUX_TARGETS):
-	@if [ $(VERIFY_TAGS) != 1 ]; then make docker-build-$(NAME) && docker push "$(CTR_REGISTRY)/$(NAME):$(CTR_TAG)"; else bash scripts/publish-image.sh "$(NAME)" "linux" "$(CTR_REGISTRY)"; fi
+	scripts/publish-image.sh "$(NAME)" "linux" "$(CTR_REGISTRY)" "$(CTR_TAG)"
 
 
 # Windows demo applications
 DOCKER_PUSH_WINDOWS_TARGETS = $(addprefix docker-push-windows-, $(DEMO_TARGETS))
 .PHONY: $(DOCKER_PUSH_WINDOWS_TARGETS)
-$(DOCKER_PUSH_WINDOWS_TARGETS): NAME=$(@:docker-push-%=%)
+$(DOCKER_PUSH_WINDOWS_TARGETS): NAME=$(@:docker-push-windows-%=%)
 $(DOCKER_PUSH_WINDOWS_TARGETS):
-	@if [ $(VERIFY_TAGS) != 1 ]; then make ARGS=--output=type=registry docker-build-$(NAME); else bash scripts/publish-image.sh "$(NAME)" "windows" "$(CTR_REGISTRY)"; fi
+	scripts/publish-image.sh "$(NAME)" "windows" "$(CTR_REGISTRY)" "$(CTR_TAG)"
 
 
 .PHONY: docker-control-plane-push


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change refactors how images are pushed by using the
publish-image.sh script to do all `docker push` operations and enforcing
`VERIFY_TAGS` there, exiting with a non-zero exit code when appropriate.

In addition, `VERIFY_TAGS` uses the strings `true`/`false` instead of `1`/`0`.

Fixes #4144

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: manual local testing

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
