### PR TITLE
pkg/*: fix data races in PubSub and ticker test

### DIFF
--- a/pkg/k8s/events/event_pubsub.go
+++ b/pkg/k8s/events/event_pubsub.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"sync"
+
 	"github.com/cskr/pubsub"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
@@ -14,6 +16,9 @@ const (
 var (
 	// Globally accessible instance, through singleton pattern using getPubSubInstance()
 	pubSubInstance *pubsub.PubSub
+
+	// pubSubOnce is used to ensure PubSub object creation happens just once
+	pubSubOnce sync.Once
 )
 
 // Subscribe is the Subscribe implementation for PubSub
@@ -59,8 +64,8 @@ func Unsub(unsubChan chan interface{}) {
 // Note that spawning the instance is not thread-safe. First call should happen on
 // a single-routine context to avoid races.
 func getPubSubInstance() *pubsub.PubSub {
-	if pubSubInstance == nil {
+	pubSubOnce.Do(func() {
 		pubSubInstance = pubsub.New(defaultAnnouncementChannelSize)
-	}
+	})
 	return pubSubInstance
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes a data race in PubSub singleton instantiation
where the singleton object creation is not protected
from concurrent initialization.
Fixes a data race in the ticker test where a variable
is written/read to/from without protected access from
multiple goroutines.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Verified `go test -race ./pkg/...` succeeds with this change. Previously
the tests would fail on data races in PubSub initialization and ticker test.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
