### PR TITLE
feat(reconciler) : enable validating webhook reconciler in osm

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -70,7 +70,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "create", "delete", "update", "patch"]
   - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
 
   {{- if .Values.OpenServiceMesh.pspEnabled }}
@@ -140,7 +140,8 @@ spec:
              kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
              kubectl apply -f /osm-crds;
              {{- if .Values.OpenServiceMesh.enableReconciler }}
-             kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.OpenServiceMesh.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found
+             kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.OpenServiceMesh.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found;
+             kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.OpenServiceMesh.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-controller --ignore-not-found;
              {{- end }}
       nodeSelector:
         kubernetes.io/arch: amd64

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -60,6 +60,7 @@ spec:
           args: [
             "--verbosity", "{{.Values.OpenServiceMesh.controllerLogLevel}}",
             "--osm-namespace", "{{ include "osm.namespace" . }}",
+            "--osm-version", "{{ .Chart.AppVersion }}",
             "--osm-service-account", "{{ .Release.Name }}",
             "--mesh-name", "{{.Values.OpenServiceMesh.meshName}}",
             "--validator-webhook-config", "{{ include "osm.validatorWebhookConfigName" . }}",
@@ -73,6 +74,7 @@ spec:
             "--cert-manager-issuer-name", "{{.Values.OpenServiceMesh.certmanager.issuerName}}",
             "--cert-manager-issuer-kind", "{{.Values.OpenServiceMesh.certmanager.issuerKind}}",
             "--cert-manager-issuer-group", "{{.Values.OpenServiceMesh.certmanager.issuerGroup}}",
+            "--enable-reconciler={{.Values.OpenServiceMesh.enableReconciler}}",
           ]
           resources:
             limits:

--- a/charts/osm/templates/osm-validator-webhook.yaml
+++ b/charts/osm/templates/osm-validator-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.OpenServiceMesh.enableReconciler }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -41,3 +42,4 @@ webhooks:
         - egresses
   sideEffects: NoneOnDryRun
   admissionReviewVersions: ["v1"]
+{{- end }}

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -93,7 +93,7 @@ func init() {
 	flags.StringVar(&certManagerOptions.IssuerGroup, "cert-manager-issuer-group", "cert-manager.io", "cert-manager issuer group")
 
 	// Reconciler options
-	flags.BoolVar(&enableReconciler, "enable-reconciler", false, "Enable reconciler for CDRs and mutating webhook")
+	flags.BoolVar(&enableReconciler, "enable-reconciler", false, "Enable reconciler for CDRs, mutating webhook and validating webhook")
 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = admissionv1.AddToScheme(scheme)

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -310,14 +310,14 @@ const (
 	// ErrUpdatingMutatingWebhookCABundle indicates the MutatingWebhookConfiguration could not be patched with the CA Bundle
 	ErrUpdatingMutatingWebhookCABundle
 
-	// ErrCreatingMutatingWebhook indicates the MutatingWebhookConfiguration could not be created
-	ErrCreatingMutatingWebhook
-
 	// ErrReadingAdmissionReqBody indicates the AdmissionRequest body could not be read
 	ErrReadingAdmissionReqBody
 
 	// ErrNilAdmissionReqBody indicates the admissionRequest body was nil
 	ErrNilAdmissionReqBody
+
+	// ErrCreatingMutatingWebhook indicates the MutatingWebhookConfiguration could not be created
+	ErrCreatingMutatingWebhook
 )
 
 // Range 6700-6800 reserved for errors related to the validating webhook
@@ -334,21 +334,30 @@ const (
 
 	// ErrParsingWebhookCert indicates the validating webhook certificate could not be parsed
 	ErrParsingValidatingWebhookCert
+
+	// ErrCreatingValidatingWebhook indicates the ValidatingWebhookConfiguration could not be created
+	ErrCreatingValidatingWebhook
 )
 
 // Range 7000-7100 reserved for errors related to OSM Reconciler
 const (
-	// ErrUpdatingCRD indicates an error occurred when OSM Reconciler failed to update a modified CRD
-	ErrUpdatingCRD ErrCode = iota + 7000
+	// ErrReconcilingUpdatedCRD indicates an error occurred when OSM Reconciler failed to update a modified CRD
+	ErrReconcilingUpdatedCRD ErrCode = iota + 7000
 
-	// ErrAddingDeletedCRD indicates an error occurred when OSM Reconciler failed to add a deleted CRD
-	ErrAddingDeletedCRD
+	// ErrReconcilingDeletedCRD indicates an error occurred when OSM Reconciler failed to add a deleted CRD
+	ErrReconcilingDeletedCRD
 
-	// ErrUpdatingMutatingWebhook indicates an error occurred when OSM Reconciler failed to update the mutating webhook
-	ErrUpdatingMutatingWebhook
+	// ErrReconcilingUpdatedMutatingWebhook indicates an error occurred when OSM Reconciler failed to update the mutating webhook
+	ErrReconcilingUpdatedMutatingWebhook
 
-	// ErrAddingDeletedMutatingWebhook indicates an error occurred when OSM Reconciler failed to add a deleted mutating webhook
-	ErrAddingDeletedMutatingWebhook
+	// ErrReconcilingDeletedMutatingWebhook indicates an error occurred when OSM Reconciler failed to add a deleted mutating webhook
+	ErrReconcilingDeletedMutatingWebhook
+
+	// ErrReconcilingUpdatedValidatingWebhook indicates an error occurred when OSM Reconciler failed to update the validating webhook
+	ErrReconcilingUpdatedValidatingWebhook
+
+	// ErrReconcilingDeletedValidatingWebhook indicates an error occurred when OSM Reconciler failed to add a deleted validating webhook
+	ErrReconcilingDeletedValidatingWebhook
 )
 
 // String returns the error code as a string, ex. E1000
@@ -836,24 +845,36 @@ The validating webhook HTTP server failed to start.
 The ValidatingWebhookConfiguration could not be patched with the CA Bundle.
 `,
 
+	ErrCreatingValidatingWebhook: `
+The ValidatingWebhookConfiguration could not be created.
+`,
+
 	ErrParsingValidatingWebhookCert: `
 The validating webhook certificate could not be parsed.
 The validating webhook HTTP server was not started.
 `,
 
-	ErrUpdatingCRD: `
-An error occurred while updating the CRD to its original state.
+	ErrReconcilingUpdatedCRD: `
+An error occurred while reconciling the updated CRD to its original state.
 `,
 
-	ErrAddingDeletedCRD: `
-An error occurred while adding back a deleted CRD.
+	ErrReconcilingDeletedCRD: `
+An error occurred while reconciling the deleted CRD.
 `,
 
-	ErrUpdatingMutatingWebhook: `
-An error occurred while updating the mutating webhook to its original state.
+	ErrReconcilingUpdatedMutatingWebhook: `
+An error occurred while reconciling the updated mutating webhook to its original state.
 `,
 
-	ErrAddingDeletedMutatingWebhook: `
-An error occurred while adding back the deleted mutating webhook.
+	ErrReconcilingDeletedMutatingWebhook: `
+An error occurred while reconciling the deleted mutating webhook.
+`,
+
+	ErrReconcilingUpdatedValidatingWebhook: `
+An error occurred while while reconciling the updated validating webhook to its original state.
+`,
+
+	ErrReconcilingDeletedValidatingWebhook: `
+An error occurred while reconciling the deleted validating webhook.
 `,
 }

--- a/pkg/reconciler/crd_handler.go
+++ b/pkg/reconciler/crd_handler.go
@@ -3,14 +3,12 @@ package reconciler
 import (
 	"context"
 	reflect "reflect"
-	"strconv"
 	"strings"
 
 	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
@@ -40,7 +38,7 @@ func (c client) reconcileCrd(oldCrd, newCrd *apiv1.CustomResourceDefinition) {
 	newCrd.ObjectMeta.Name = oldCrd.ObjectMeta.Name
 	newCrd.ObjectMeta.Labels = oldCrd.ObjectMeta.Labels
 	if _, err := c.apiServerClient.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), newCrd, metav1.UpdateOptions{}); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingCRD)).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrReconcilingUpdatedCRD)).
 			Msgf("Error updating crd: %s", newCrd.Name)
 	}
 	log.Debug().Msgf("Successfully reconciled CRD %s", newCrd.Name)
@@ -49,7 +47,7 @@ func (c client) reconcileCrd(oldCrd, newCrd *apiv1.CustomResourceDefinition) {
 func (c client) addCrd(oldCrd *apiv1.CustomResourceDefinition) {
 	oldCrd.ResourceVersion = ""
 	if _, err := c.apiServerClient.ApiextensionsV1().CustomResourceDefinitions().Create(context.Background(), oldCrd, metav1.CreateOptions{}); err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrAddingDeletedCRD)).
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrReconcilingDeletedCRD)).
 			Msgf("Error adding back deleted crd: %s", oldCrd.Name)
 	}
 	log.Debug().Msgf("Successfully added back CRD %s", oldCrd.Name)
@@ -57,9 +55,8 @@ func (c client) addCrd(oldCrd *apiv1.CustomResourceDefinition) {
 
 func isCRDUpdated(oldCrd, newCrd *apiv1.CustomResourceDefinition) bool {
 	crdSpecEqual := reflect.DeepEqual(oldCrd.Spec, newCrd.Spec)
-	crdNameChanged := strings.Compare(oldCrd.ObjectMeta.Name, newCrd.ObjectMeta.Name)
-	crdLabelsChanged := isLabelModified(constants.OSMAppNameLabelKey, constants.OSMAppNameLabelValue, newCrd.ObjectMeta.Labels) || isLabelModified(constants.ReconcileLabel, strconv.FormatBool(true), newCrd.ObjectMeta.Labels)
-	crdUpdated := !crdSpecEqual || crdNameChanged != 0 || crdLabelsChanged
+	crdNameChanged := strings.Compare(oldCrd.ObjectMeta.Name, newCrd.ObjectMeta.Name) != 0
+	crdUpdated := !crdSpecEqual || crdNameChanged
 	return crdUpdated
 }
 

--- a/pkg/reconciler/crd_handler_test.go
+++ b/pkg/reconciler/crd_handler_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	meshName = "test-mesh"
+	meshName   = "test-mesh"
+	osmVersion = "test-version"
 )
 
 func TestCRDEventHandlerUpdateFunc(t *testing.T) {
@@ -464,7 +465,7 @@ func TestCRDEventHandlerDeleteFunc(t *testing.T) {
 
 	a := tassert.New(t)
 	kubeClient := testclient.NewSimpleClientset()
-	apiServerClient := apiservertestclient.NewSimpleClientset(&originalCrd)
+	apiServerClient := apiservertestclient.NewSimpleClientset()
 
 	c := client{
 		kubeClient:      kubeClient,

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -21,6 +21,9 @@ const (
 	// MutatingWebhookInformerKey lookup identifier
 	MutatingWebhookInformerKey k8s.InformerKey = "MutatingWebhookConfigInformerKey"
 
+	// ValidatingWebhookInformerKey lookup identifier
+	ValidatingWebhookInformerKey k8s.InformerKey = "ValidatingWebhookConfigInformerKey"
+
 	// nameIndex is the lookup name for the most comment index function, which is to index by the name field
 	nameIndex string = "name"
 )
@@ -31,6 +34,7 @@ type informerCollection map[k8s.InformerKey]cache.SharedIndexInformer
 // client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster
 type client struct {
 	meshName        string
+	osmVersion      string
 	kubeClient      kubernetes.Interface
 	apiServerClient clientset.Interface
 	informers       informerCollection

--- a/pkg/reconciler/validating_webhook_handler.go
+++ b/pkg/reconciler/validating_webhook_handler.go
@@ -1,0 +1,65 @@
+package reconciler
+
+import (
+	"context"
+	reflect "reflect"
+	"strings"
+
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/errcode"
+)
+
+// validatingWebhookEventHandler creates validating webhook events handlers.
+func (c client) validatingWebhookEventHandler() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldVwhc := oldObj.(*admissionv1.ValidatingWebhookConfiguration)
+			newVwhc := newObj.(*admissionv1.ValidatingWebhookConfiguration)
+			log.Debug().Msgf("validating webhook update event for %s", newVwhc.Name)
+			if !c.isValidatingWebhookUpdated(oldVwhc, newVwhc) {
+				return
+			}
+
+			c.reconcileValidatingWebhook(oldVwhc, newVwhc)
+		},
+
+		DeleteFunc: func(obj interface{}) {
+			vwhc := obj.(*admissionv1.ValidatingWebhookConfiguration)
+			c.addValidatingWebhook(vwhc)
+			log.Debug().Msgf("validating webhook delete event for %s", vwhc.Name)
+		},
+	}
+}
+
+func (c client) reconcileValidatingWebhook(oldVwhc, newVwhc *admissionv1.ValidatingWebhookConfiguration) {
+	newVwhc.Webhooks = oldVwhc.Webhooks
+	newVwhc.ObjectMeta.Name = oldVwhc.ObjectMeta.Name
+	newVwhc.ObjectMeta.Labels = oldVwhc.ObjectMeta.Labels
+	if _, err := c.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(context.Background(), newVwhc, metav1.UpdateOptions{}); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrReconcilingUpdatedValidatingWebhook)).
+			Msgf("Error updating validating webhook: %s", newVwhc.Name)
+	}
+	log.Debug().Msgf("Successfully reconciled validating webhook %s", newVwhc.Name)
+}
+
+func (c client) addValidatingWebhook(oldVwhc *admissionv1.ValidatingWebhookConfiguration) {
+	oldVwhc.ResourceVersion = ""
+	if _, err := c.kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.Background(), oldVwhc, metav1.CreateOptions{}); err != nil {
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrReconcilingDeletedValidatingWebhook)).
+			Msgf("Error adding back deleted validating webhook: %s", oldVwhc.Name)
+	}
+	log.Debug().Msgf("Successfully added back validating webhook %s", oldVwhc.Name)
+}
+
+func (c *client) isValidatingWebhookUpdated(oldVwhc, newVwhc *admissionv1.ValidatingWebhookConfiguration) bool {
+	webhookEqual := reflect.DeepEqual(oldVwhc.Webhooks, newVwhc.Webhooks)
+	vwhcNameChanged := strings.Compare(oldVwhc.ObjectMeta.Name, newVwhc.ObjectMeta.Name) != 0
+	vwhcLabelsChanged := isLabelModified("app", constants.OSMControllerName, newVwhc.ObjectMeta.Labels) ||
+		isLabelModified(constants.OSMAppVersionLabelKey, c.osmVersion, newVwhc.ObjectMeta.Labels)
+	vwhcUpdated := !webhookEqual || vwhcNameChanged || vwhcLabelsChanged
+	return vwhcUpdated
+}

--- a/pkg/validator/patch_test.go
+++ b/pkg/validator/patch_test.go
@@ -1,0 +1,82 @@
+package validator
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	tassert "github.com/stretchr/testify/assert"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func TestCreateValidatingWebhook(t *testing.T) {
+	assert := tassert.New(t)
+	webhookName := "--webhookName--"
+	meshName := "test-mesh"
+	osmNamespace := "test-namespace"
+	osmVersion := "test-version"
+	webhookPath := validationAPIPath
+	webhookPort := int32(constants.ValidatorWebhookPort)
+
+	mockCtrl := gomock.NewController(t)
+	cert := certificate.NewMockCertificater(mockCtrl)
+	cert.EXPECT().GetCertificateChain()
+
+	kubeClient := fake.NewSimpleClientset()
+	err := createValidatingWebhook(kubeClient, cert, webhookName, meshName, osmNamespace, osmVersion)
+	assert.Nil(err)
+
+	webhooks, err := kubeClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.TODO(), metav1.ListOptions{})
+	assert.Nil(err)
+	assert.Len(webhooks.Items, 1)
+
+	wh := webhooks.Items[0]
+	assert.Len(wh.Webhooks, 1)
+	assert.Equal(wh.ObjectMeta.Name, webhookName)
+	assert.EqualValues(wh.ObjectMeta.Labels, map[string]string{
+		constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
+		constants.OSMAppInstanceLabelKey: meshName,
+		constants.OSMAppVersionLabelKey:  osmVersion,
+		"app":                            constants.OSMControllerName,
+		constants.ReconcileLabel:         strconv.FormatBool(true),
+	})
+
+	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Namespace, osmNamespace)
+	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Name, ValidatorWebhookSvc)
+	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Path, &webhookPath)
+	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Port, &webhookPort)
+
+	assert.Equal(wh.Webhooks[0].NamespaceSelector.MatchLabels[constants.OSMKubeResourceMonitorAnnotation], meshName)
+	assert.EqualValues(wh.Webhooks[0].NamespaceSelector.MatchExpressions, []metav1.LabelSelectorRequirement{
+		{
+			Key:      constants.IgnoreLabel,
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+		{
+			Key:      "name",
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{osmNamespace},
+		},
+		{
+			Key:      "control-plane",
+			Operator: metav1.LabelSelectorOpDoesNotExist,
+		},
+	})
+	assert.ElementsMatch(wh.Webhooks[0].Rules, []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"policy.openservicemesh.io"},
+				APIVersions: []string{"v1alpha1"},
+				Resources:   []string{"ingressbackends", "egresses"},
+			},
+		},
+	})
+	assert.Equal(wh.Webhooks[0].AdmissionReviewVersions, []string{"v1"})
+}

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -4,4 +4,4 @@ import (
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
-var log = logger.New("osm-validator")
+var log = logger.New(ValidatorWebhookSvc)


### PR DESCRIPTION
**Description**:

- Enable a reconciler in osm-controller for the validating webhook

- Deployment of the validating webhook is via helm or osm-controller
depending on if the reconciler has been enabled. The cleanup script has
been updated to ensure that the validating webhook gets deleted.

- e2e tests for the reconciler has been extended to include a test for
the validating webhook.

Part of #4065

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Testing done**: e2e and unit tests have been updated

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
