### PR TITLE
revert(psp): Remove PSP code for 1.0.0

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -144,7 +144,6 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.prometheus.resources | object | `{"limits":{"cpu":"1","memory":"2G"},"requests":{"cpu":"0.5","memory":"512M"}}` | Prometheus's container resource parameters |
 | OpenServiceMesh.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
 | OpenServiceMesh.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
-| OpenServiceMesh.pspEnabled | bool | `false` | Run OSM with PodSecurityPolicy configured |
 | OpenServiceMesh.sidecarImage | string | `"envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"` | Envoy sidecar image for Linux workloads (v1.19.1) |
 | OpenServiceMesh.sidecarWindowsImage | string | `"envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"` | Envoy sidecar image for Windows workloads (v1.19.1) |
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |

--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -1,57 +1,3 @@
-{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: {{ .Release.Name }}-cleanup-psp
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
-    helm.sh/hook-weight: "-1"
-    helm.sh/hook: post-delete
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  requiredDropCapabilities:
-    - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
-    - 'persistentVolumeClaim'
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    # Require the container to run without root privileges.
-    rule: 'MustRunAsNonRoot'
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-{{- end }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -72,13 +18,6 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
-
-  {{- if .Values.OpenServiceMesh.pspEnabled }}
-  - apiGroups: ["extensions"]
-    resourceNames: ["{{ .Release.Name }}-cleanup-psp"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/osm/templates/grafana-rbac.yaml
+++ b/charts/osm/templates/grafana-rbac.yaml
@@ -1,55 +1,4 @@
 {{- if .Values.OpenServiceMesh.deployGrafana}}
-{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: {{ .Release.Name }}-grafana-psp
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  requiredDropCapabilities:
-    - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
-    - 'persistentVolumeClaim'
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    # Require the container to run without root privileges.
-    rule: 'MustRunAsNonRoot'
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-{{- end }}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -68,13 +17,6 @@ metadata:
     {{- include "osm.labels" . | nindent 4 }}
     app: osm-grafana
   name: {{.Release.Name}}-grafana
-rules:
-  {{- if .Values.OpenServiceMesh.pspEnabled }}
-  - apiGroups: ["extensions"]
-    resourceNames: ["{{ .Release.Name }}-grafana-psp"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-  {{- end }}
 
 ---
 

--- a/charts/osm/templates/jaeger-rbac.yaml
+++ b/charts/osm/templates/jaeger-rbac.yaml
@@ -1,55 +1,4 @@
 {{- if .Values.OpenServiceMesh.deployJaeger }}
-{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: {{ .Release.Name }}-jaeger-psp
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  requiredDropCapabilities:
-    - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
-    - 'persistentVolumeClaim'
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    # Require the container to run without root privileges.
-    rule: 'MustRunAsNonRoot'
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-{{- end }}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -68,13 +17,6 @@ metadata:
     {{- include "osm.labels" . | nindent 4 }}
     app: jaeger
   name: {{.Release.Name}}-jaeger
-rules:
-  {{- if .Values.OpenServiceMesh.pspEnabled }}
-  - apiGroups: ["extensions"]
-    resourceNames: ["{{ .Release.Name }}-jaeger-psp"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-  {{- end }}
 
 ---
 

--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         prometheus.io/port: '9091'
     spec:
       serviceAccountName: {{ .Release.Name }}
-      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       nodeSelector:

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         prometheus.io/port: '9091'
     spec:
       serviceAccountName: {{ .Release.Name }}
-      {{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
+      {{- if not (.Capabilities.APIVersions.Has "security.openshift.io/v1") }}
       {{- include "restricted.securityContext" . | nindent 6 }}
       {{- end }}
       nodeSelector:

--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -1,72 +1,3 @@
-{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: osm-psp
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  requiredDropCapabilities:
-    - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
-    - 'persistentVolumeClaim'
-    {{- if .Values.OpenServiceMesh.enableFluentbit }}
-    - 'hostPath'
-    {{- end }}
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    {{- if not .Values.OpenServiceMesh.enableFluentbit }}
-    # Require the container to run without root privileges.
-    rule: 'MustRunAsNonRoot'
-    {{- end }}
-    {{- if .Values.OpenServiceMesh.enableFluentbit }}
-    # Allow root privileges to allow fluentbit access to logs.
-    rule: 'RunAsAny'
-    {{- end }}
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-  {{- if .Values.OpenServiceMesh.enableFluentbit }}
-  allowedHostPaths:
-  - pathPrefix: "/var/log/containers"
-    readOnly: true
-  - pathPrefix: "/var/log/pods"
-    readOnly: true
-  - pathPrefix: "/var/lib/docker/containers"
-    readOnly: true
-  {{- end }}
-{{- end }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -145,12 +76,6 @@ rules:
     verbs: ["use"]
   {{- end }}
 
-  {{- if .Values.OpenServiceMesh.pspEnabled }}
-  - apiGroups: ["extensions"]
-    resourceNames: ["osm-psp"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-  {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/osm/templates/prometheus-rbac.yaml
+++ b/charts/osm/templates/prometheus-rbac.yaml
@@ -1,55 +1,4 @@
 {{- if .Values.OpenServiceMesh.deployPrometheus }}
-{{- if and (not (.Capabilities.APIVersions.Has "security.openshift.io/v1")) .Values.OpenServiceMesh.pspEnabled }}
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: {{ .Release.Name }}-prometheus-psp
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
-    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
-    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
-spec:
-  privileged: false
-  # Required to prevent escalations to root.
-  allowPrivilegeEscalation: false
-  # This is redundant with non-root + disallow privilege escalation,
-  # but we can provide it for defense in depth.
-  requiredDropCapabilities:
-    - ALL
-  # Allow core volume types.
-  volumes:
-    - 'configMap'
-    - 'emptyDir'
-    - 'projected'
-    - 'secret'
-    - 'downwardAPI'
-    # Assume that persistentVolumes set up by the cluster admin are safe to use.
-    - 'persistentVolumeClaim'
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  runAsUser:
-    # Require the container to run without root privileges.
-    rule: 'MustRunAsNonRoot'
-  seLinux:
-    # This policy assumes the nodes are using AppArmor rather than SELinux.
-    rule: 'RunAsAny'
-  supplementalGroups:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: 'MustRunAs'
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-{{- end }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -65,12 +14,6 @@ rules:
     verbs: ["list", "get", "watch"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get"]
-  {{- if .Values.OpenServiceMesh.pspEnabled }}
-  - apiGroups: ["extensions"]
-    resourceNames: ["{{ .Release.Name }}-prometheus-psp"]
-    resources: ["podsecuritypolicies"]
-    verbs: ["use"]
-  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -285,9 +285,6 @@ OpenServiceMesh:
     # -- Log level for the multicluster gateway
     gatewayLogLevel: error
 
-  # -- Run OSM with PodSecurityPolicy configured
-  pspEnabled: false
-
   # -- Node tolerations applied to control plane pods.
   # The specified tolerations allow pods to schedule onto nodes with matching taints.
   controlPlaneTolerations: []


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes PSP code.

PSP was deprecated in OSM in 0.10.0 with removal scheduled for 1.0.0

Fixes #4122 
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
2. Is this a breaking change?
No