### PR TITLE
k8s: Simplify GetKubernetesEventHandlers()

### DIFF
--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -39,7 +39,7 @@ func NewConfigController(kubeConfig *rest.Config, kubeController k8s.Controller,
 		Update: announcements.MultiClusterServiceUpdated,
 		Delete: announcements.MultiClusterServiceDeleted,
 	}
-	client.informer.Informer().AddEventHandler(k8s.GetKubernetesEventHandlers(multiclusterInformerName, "Kube", shouldObserve, multiclusterServiceEventTypes))
+	client.informer.Informer().AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, multiclusterServiceEventTypes))
 
 	if err := client.run(stop); err != nil {
 		return client, errors.Errorf("Could not start %s client: %s", apiGroup, err)

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -17,10 +17,6 @@ import (
 
 const (
 	meshConfigInformerName = "MeshConfig"
-	meshConfigProviderName = "OSM"
-
-	// DefaultMeshConfigName is the default name of MeshConfig object
-	DefaultMeshConfigName = "osm-mesh-config"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -48,7 +44,7 @@ func newConfigurator(meshConfigClientSet versioned.Interface, stop <-chan struct
 		Update: announcements.MeshConfigUpdated,
 		Delete: announcements.MeshConfigDeleted,
 	}
-	informer.AddEventHandler(k8s.GetKubernetesEventHandlers(meshConfigInformerName, meshConfigProviderName, nil, eventTypes))
+	informer.AddEventHandler(k8s.GetKubernetesEventHandlers(nil, eventTypes))
 
 	// start listener
 	go c.runMeshConfigListener(stop)

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -64,13 +64,13 @@ func NewIngressClient(kubeClient kubernetes.Interface, kubeController k8s.Contro
 	if v1Supported, ok := supportedIngressVersions[networkingV1.SchemeGroupVersion.String()]; ok && v1Supported {
 		c.informerV1 = informerFactory.Networking().V1().Ingresses().Informer()
 		c.cacheV1 = c.informerV1.GetStore()
-		c.informerV1.AddEventHandler(k8s.GetKubernetesEventHandlers("IngressV1", "Kubernetes", shouldObserve, ingressEventTypes))
+		c.informerV1.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, ingressEventTypes))
 	}
 
 	if v1beta1Supported, ok := supportedIngressVersions[networkingV1beta1.SchemeGroupVersion.String()]; ok && v1beta1Supported {
 		c.informerV1beta1 = informerFactory.Networking().V1beta1().Ingresses().Informer()
 		c.cacheV1Beta1 = c.informerV1beta1.GetStore()
-		c.informerV1beta1.AddEventHandler(k8s.GetKubernetesEventHandlers("IngressV1beta1", "Kubernetes", shouldObserve, ingressEventTypes))
+		c.informerV1beta1.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, ingressEventTypes))
 	}
 
 	if err := c.run(stop); err != nil {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -80,7 +80,7 @@ func (c *client) initNamespaceMonitor() {
 		Update: announcements.NamespaceUpdated,
 		Delete: announcements.NamespaceDeleted,
 	}
-	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers((string)(Namespaces), providerName, nil, nsEventTypes))
+	c.informers[Namespaces].AddEventHandler(GetKubernetesEventHandlers(nil, nsEventTypes))
 }
 
 // Function to filter K8s meta Objects by OSM's isMonitoredNamespace
@@ -102,7 +102,7 @@ func (c *client) initServicesMonitor() {
 		Update: announcements.ServiceUpdated,
 		Delete: announcements.ServiceDeleted,
 	}
-	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers((string)(Services), providerName, c.shouldObserve, svcEventTypes))
+	c.informers[Services].AddEventHandler(GetKubernetesEventHandlers(c.shouldObserve, svcEventTypes))
 }
 
 // Initializes Service Account monitoring
@@ -115,7 +115,7 @@ func (c *client) initServiceAccountsMonitor() {
 		Update: announcements.ServiceAccountUpdated,
 		Delete: announcements.ServiceAccountDeleted,
 	}
-	c.informers[ServiceAccounts].AddEventHandler(GetKubernetesEventHandlers((string)(ServiceAccounts), providerName, c.shouldObserve, svcEventTypes))
+	c.informers[ServiceAccounts].AddEventHandler(GetKubernetesEventHandlers(c.shouldObserve, svcEventTypes))
 }
 
 func (c *client) initPodMonitor() {
@@ -127,7 +127,7 @@ func (c *client) initPodMonitor() {
 		Update: announcements.PodUpdated,
 		Delete: announcements.PodDeleted,
 	}
-	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers((string)(Pods), providerName, c.shouldObserve, podEventTypes))
+	c.informers[Pods].AddEventHandler(GetKubernetesEventHandlers(c.shouldObserve, podEventTypes))
 }
 
 func (c *client) initEndpointMonitor() {
@@ -139,7 +139,7 @@ func (c *client) initEndpointMonitor() {
 		Update: announcements.EndpointUpdated,
 		Delete: announcements.EndpointDeleted,
 	}
-	c.informers[Endpoints].AddEventHandler(GetKubernetesEventHandlers((string)(Endpoints), providerName, c.shouldObserve, eptEventTypes))
+	c.informers[Endpoints].AddEventHandler(GetKubernetesEventHandlers(c.shouldObserve, eptEventTypes))
 }
 
 func (c *client) run(stop <-chan struct{}) error {

--- a/pkg/k8s/event_handlers.go
+++ b/pkg/k8s/event_handlers.go
@@ -22,7 +22,7 @@ type EventTypes struct {
 }
 
 // GetKubernetesEventHandlers creates Kubernetes events handlers.
-func GetKubernetesEventHandlers(informerName, providerName string, shouldObserve observeFilter, eventTypes EventTypes) cache.ResourceEventHandlerFuncs {
+func GetKubernetesEventHandlers(shouldObserve observeFilter, eventTypes EventTypes) cache.ResourceEventHandlerFuncs {
 	if shouldObserve == nil {
 		shouldObserve = func(obj interface{}) bool { return true }
 	}

--- a/pkg/k8s/event_handlers_test.go
+++ b/pkg/k8s/event_handlers_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 const (
-	testProvider  = "test-provider"
-	testInformer  = "test-informer"
 	testNamespace = "test-namespace"
 )
 
@@ -39,7 +37,7 @@ func TestGetKubernetesEventHandlers(t *testing.T) {
 		Update: announcements.PodUpdated,
 		Delete: announcements.PodDeleted,
 	}
-	handlers := GetKubernetesEventHandlers(testInformer, testProvider, shouldObserve, eventTypes)
+	handlers := GetKubernetesEventHandlers(shouldObserve, eventTypes)
 	handlers.AddFunc(&pod)
 	an := <-podAddChannel
 	a.Len(podAddChannel, 0)
@@ -61,7 +59,7 @@ func TestGetKubernetesEventHandlers(t *testing.T) {
 
 	// should not add the event to the announcement channel
 	pod.Namespace = "not-a-monitored-namespace"
-	handlers = GetKubernetesEventHandlers(testInformer, testProvider, shouldObserve, EventTypes{})
+	handlers = GetKubernetesEventHandlers(shouldObserve, EventTypes{})
 	handlers.AddFunc(&pod)
 	a.Len(podAddChannel, 0)
 
@@ -83,7 +81,7 @@ func TestUpdateEvent(t *testing.T) {
 	updatedPod.Labels = nil // updated does not have any labels
 
 	// Invoke update handler
-	handlers := GetKubernetesEventHandlers(testInformer, testProvider, nil, EventTypes{Update: announcements.PodUpdated})
+	handlers := GetKubernetesEventHandlers(nil, EventTypes{Update: announcements.PodUpdated})
 	handlers.UpdateFunc(&originalPod, &updatedPod)
 
 	// Compare old vs new object

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -42,9 +42,6 @@ const (
 const (
 	// DefaultKubeEventResyncInterval is the default resync interval for k8s events
 	DefaultKubeEventResyncInterval = 5 * time.Minute
-
-	// providerName is the name of the Kubernetes event provider
-	providerName = "Kubernetes"
 )
 
 // InformerKey stores the different Informers we keep for K8s resources

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -64,13 +64,13 @@ func newPolicyClient(policyClient policyClientset.Interface, kubeController k8s.
 		Update: announcements.EgressUpdated,
 		Delete: announcements.EgressDeleted,
 	}
-	informerCollection.egress.AddEventHandler(k8s.GetKubernetesEventHandlers("Egress", "Policy", shouldObserve, egressEventTypes))
+	informerCollection.egress.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, egressEventTypes))
 	ingressBackendEventTypes := k8s.EventTypes{
 		Add:    announcements.IngressBackendAdded,
 		Update: announcements.IngressBackendUpdated,
 		Delete: announcements.IngressBackendDeleted,
 	}
-	informerCollection.ingressBackend.AddEventHandler(k8s.GetKubernetesEventHandlers("IngressBackend", "Policy", shouldObserve, ingressBackendEventTypes))
+	informerCollection.ingressBackend.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, ingressBackendEventTypes))
 
 	err := client.run(stop)
 	if err != nil {

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -124,28 +124,28 @@ func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTraf
 		Update: a.TrafficSplitUpdated,
 		Delete: a.TrafficSplitDeleted,
 	}
-	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficSplit", "SMI", shouldObserve, splitEventTypes))
+	informerCollection.TrafficSplit.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, splitEventTypes))
 
 	routeGroupEventTypes := k8s.EventTypes{
 		Add:    a.RouteGroupAdded,
 		Update: a.RouteGroupUpdated,
 		Delete: a.RouteGroupDeleted,
 	}
-	informerCollection.HTTPRouteGroup.AddEventHandler(k8s.GetKubernetesEventHandlers("HTTPRouteGroup", "SMI", shouldObserve, routeGroupEventTypes))
+	informerCollection.HTTPRouteGroup.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, routeGroupEventTypes))
 
 	tcpRouteEventTypes := k8s.EventTypes{
 		Add:    a.TCPRouteAdded,
 		Update: a.TCPRouteUpdated,
 		Delete: a.TCPRouteDeleted,
 	}
-	informerCollection.TCPRoute.AddEventHandler(k8s.GetKubernetesEventHandlers("TCPRoute", "SMI", shouldObserve, tcpRouteEventTypes))
+	informerCollection.TCPRoute.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, tcpRouteEventTypes))
 
 	trafficTargetEventTypes := k8s.EventTypes{
 		Add:    a.TrafficTargetAdded,
 		Update: a.TrafficTargetUpdated,
 		Delete: a.TrafficTargetDeleted,
 	}
-	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers("TrafficTarget", "SMI", shouldObserve, trafficTargetEventTypes))
+	informerCollection.TrafficTarget.AddEventHandler(k8s.GetKubernetesEventHandlers(shouldObserve, trafficTargetEventTypes))
 
 	err := client.run(stop)
 	if err != nil {


### PR DESCRIPTION
As it turns out the first 2 parameters of `GetKubernetesEventHandlers()` are no longer used.

This PR removes `informerName`, `providerName` and all places where these are passed to `GetKubernetesEventHandlers()`.