### PR TITLE
ref(*): Unify all osm control pane pod names as one constant

### DIFF
--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Running the namespace add command", func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
 
-				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				_, err = addDeployment(fakeClientSet, constants.OSMControllerName, testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
 				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
@@ -110,7 +110,7 @@ var _ = Describe("Running the namespace add command", func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
 
-				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				_, err = addDeployment(fakeClientSet, constants.OSMControllerName, testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
 				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
@@ -154,7 +154,7 @@ var _ = Describe("Running the namespace add command", func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
 
-				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				_, err = addDeployment(fakeClientSet, constants.OSMControllerName, testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
 				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", true)
@@ -204,7 +204,7 @@ var _ = Describe("Running the namespace add command", func() {
 				fakeClientSet = fake.NewSimpleClientset()
 				testNamespace2 = "namespace2"
 
-				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				_, err = addDeployment(fakeClientSet, constants.OSMControllerName, testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
 				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
@@ -253,7 +253,7 @@ var _ = Describe("Running the namespace add command", func() {
 				_, err = fakeClientSet.AppsV1().Deployments(testNamespace).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 
-				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				_, err = addDeployment(fakeClientSet, constants.OSMControllerName, testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
 				Expect(err).To(BeNil())
 
 				nsSpec := createNamespaceSpec(testNamespace, "", false)
@@ -328,7 +328,7 @@ var _ = Describe("Running the namespace add command", func() {
 				out = new(bytes.Buffer)
 				fakeClientSet = fake.NewSimpleClientset()
 
-				_, err = addDeployment(fakeClientSet, "osm-controller", testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
+				_, err = addDeployment(fakeClientSet, constants.OSMControllerName, testMeshName, "osm-system-namespace", "testVersion0.1.2", true)
 				Expect(err).To(BeNil())
 
 				namespaceAddCmd := &namespaceAddCmd{

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -67,7 +67,7 @@ var (
 
 var (
 	flags = pflag.NewFlagSet(`osm-bootstrap`, pflag.ExitOnError)
-	log   = logger.New("osm-bootstrap/main")
+	log   = logger.New(constants.OSMBootstrapName)
 )
 
 func init() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -79,6 +79,9 @@ const (
 	// OSMInjectorName is the name of the OSM Injector.
 	OSMInjectorName = "osm-injector"
 
+	// OSMBootstrapName is the name of the OSM Bootstrap.
+	OSMBootstrapName = "osm-bootstrap"
+
 	// ADSServerPort is the port on which the Aggregated Discovery Service (ADS) listens for new gRPC connections from Envoy proxies
 	ADSServerPort = 15128
 

--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -22,9 +22,6 @@ const (
 	// webhookHealthPath is the HTTP path at which the health of the conversion webhook can be queried
 	webhookHealthPath = "/healthz"
 
-	// crdConverterServiceName is the name of the OSM crd converter webhook service
-	crdConverterServiceName = "osm-bootstrap"
-
 	// healthPort is the port on which the '/healthz` requests are served
 	healthPort = 9095
 
@@ -58,7 +55,7 @@ func NewConversionWebhook(config Config, kubeClient kubernetes.Interface, crdCli
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned with the ConversionWebhook on the CRD's
 	crdConversionWebhookHandlerCert, err := certManager.IssueCertificate(
-		certificate.CommonName(fmt.Sprintf("%s.%s.svc", crdConverterServiceName, osmNamespace)),
+		certificate.CommonName(fmt.Sprintf("%s.%s.svc", constants.OSMBootstrapName, osmNamespace)),
 		constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing certificate for the crd-converter: %+v", err)
@@ -187,7 +184,7 @@ func updateCrdConfiguration(cert certificate.Certificater, crdClient apiclient.A
 			ClientConfig: &apiv1.WebhookClientConfig{
 				Service: &apiv1.ServiceReference{
 					Namespace: osmNamespace,
-					Name:      crdConverterServiceName,
+					Name:      constants.OSMBootstrapName,
 					Path:      &crdConversionPath,
 				},
 				CABundle: cert.GetCertificateChain(),

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -90,7 +90,7 @@ func TestUpdateCrdConversionWebhookConfiguration(t *testing.T) {
 			assert.Equal(crd.Spec.Conversion.Strategy, apiv1.WebhookConverter)
 			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, []byte("chain"))
 			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace, tests.Namespace)
-			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Name, crdConverterServiceName)
+			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Name, constants.OSMBootstrapName)
 			assert.Equal(crd.Spec.Conversion.Webhook.ConversionReviewVersions, conversionReviewVersions)
 
 			assert.Equal(crd.Labels[constants.OSMAppNameLabelKey], constants.OSMAppNameLabelValue)

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -6,6 +6,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
 
@@ -16,7 +17,7 @@ func TestBuildFromConfig(t *testing.T) {
 	config := Config{
 		NodeID:           cert.GetCommonName().String(),
 		AdminPort:        15000,
-		XDSClusterName:   "osm-controller",
+		XDSClusterName:   constants.OSMControllerName,
 		TrustedCA:        cert.GetIssuingCA(),
 		CertificateChain: cert.GetCertificateChain(),
 		PrivateKey:       cert.GetPrivateKey(),

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 		EnvoyAdminPort: 15000,
 
-		XDSClusterName: "osm-controller",
+		XDSClusterName: constants.OSMControllerName,
 		XDSHost:        "osm-controller.b.svc.cluster.local",
 		XDSPort:        15128,
 

--- a/pkg/k8s/events/events.go
+++ b/pkg/k8s/events/events.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 // EventRecorder is a type used to record Kubernetes events
@@ -30,7 +32,7 @@ var (
 
 const (
 	// eventSource is the name of the event source which generates Kubernetes events
-	eventSource = "osm-controller"
+	eventSource = constants.OSMControllerName
 
 	// fatalEventPrefix is the prefix used with fatal event reasons which is used to identify Fatal events.
 	fatalEventPrefix = "Fatal"

--- a/tests/e2e/e2e_fluentbit_deployment_test.go
+++ b/tests/e2e/e2e_fluentbit_deployment_test.go
@@ -31,7 +31,7 @@ var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				pods, err := Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
-					LabelSelector: labels.SelectorFromSet(map[string]string{constants.AppLabel: OsmControllerAppLabel}).String(),
+					LabelSelector: labels.SelectorFromSet(map[string]string{constants.AppLabel: constants.OSMControllerName}).String(),
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 2 /* controller, injector */, nil)).To(Succeed())
 
 				pods, err = Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
-					LabelSelector: labels.SelectorFromSet(map[string]string{constants.AppLabel: OsmControllerAppLabel}).String(),
+					LabelSelector: labels.SelectorFromSet(map[string]string{constants.AppLabel: constants.OSMControllerName}).String(),
 				})
 
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/e2e/e2e_fluentbit_output_test.go
+++ b/tests/e2e/e2e_fluentbit_output_test.go
@@ -34,7 +34,7 @@ var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 				Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 				pods, err := Td.Client.CoreV1().Pods(Td.OsmNamespace).List(context.TODO(), metav1.ListOptions{
-					LabelSelector: labels.SelectorFromSet(map[string]string{constants.AppLabel: OsmControllerAppLabel}).String(),
+					LabelSelector: labels.SelectorFromSet(map[string]string{constants.AppLabel: constants.OSMControllerName}).String(),
 				})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -43,7 +43,7 @@ var _ = OSMDescribe("Test deployment of Fluent Bit sidecar",
 				for _, pod := range pods.Items {
 					// Wait until osm-controller has generated a log to check against
 					logLevel := "\"level\":\"info\""
-					err := waitForLogEmission(pod.Namespace, pod.Name, "osm-controller", logLevel)
+					err := waitForLogEmission(pod.Namespace, pod.Name, constants.OSMControllerName, logLevel)
 					Expect(err).To(BeNil())
 					for _, container := range pod.Spec.Containers {
 						if strings.Contains(container.Image, "fluent-bit") {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -586,7 +586,7 @@ func (td *OsmTestData) RestartOSMController(instOpts InstallOSMOpts) error {
 		return errors.Wrap(err, "error fetching controller pod")
 	}
 
-	controllerDeployment, errDeployment := td.Client.AppsV1().Deployments(instOpts.ControlPlaneNS).Get(context.TODO(), "osm-controller", metav1.GetOptions{})
+	controllerDeployment, errDeployment := td.Client.AppsV1().Deployments(instOpts.ControlPlaneNS).Get(context.TODO(), constants.OSMControllerName, metav1.GetOptions{})
 	if errDeployment != nil {
 		return errors.Wrap(err, "error fetching controller deployment")
 	}
@@ -620,11 +620,11 @@ func (td *OsmTestData) GetMeshConfig(namespace string) (*v1alpha1.MeshConfig, er
 // LoadOSMImagesIntoKind loads the OSM images to the node for Kind clusters
 func (td *OsmTestData) LoadOSMImagesIntoKind() error {
 	imageNames := []string{
-		"osm-controller",
-		"osm-injector",
+		constants.OSMControllerName,
+		constants.OSMInjectorName,
 		"init",
 		"osm-crds",
-		"osm-bootstrap",
+		constants.OSMBootstrapName,
 	}
 
 	return td.LoadImagesToKind(imageNames)

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -38,16 +38,10 @@ const (
 	// DefaultOsmPrometheusPort default OSM prometheus port
 	DefaultOsmPrometheusPort = 7070
 
-	// OsmControllerAppLabel is the OSM Controller deployment app label
-	OsmControllerAppLabel = "osm-controller"
 	// OsmGrafanaAppLabel is the OSM Grafana deployment app label
 	OsmGrafanaAppLabel = "osm-grafana"
 	// OsmPrometheusAppLabel is the OSM Prometheus deployment app label
 	OsmPrometheusAppLabel = "osm-prometheus"
-	// OsmInjectorAppLabel is the OSM injector deployment app label
-	OsmInjectorAppLabel = "osm-injector"
-	// OsmBootstrapAppLabel is the OSM bootstrap deployment app label
-	OsmBootstrapAppLabel = "osm-bootstrap"
 
 	// OSM Grafana Dashboard specifics
 
@@ -70,7 +64,7 @@ const (
 
 var (
 	// OsmCtlLabels is the list of app labels for OSM CTL
-	OsmCtlLabels = []string{OsmControllerAppLabel, OsmGrafanaAppLabel, OsmPrometheusAppLabel, OsmInjectorAppLabel, OsmBootstrapAppLabel}
+	OsmCtlLabels = []string{constants.OSMControllerName, OsmGrafanaAppLabel, OsmPrometheusAppLabel, constants.OSMInjectorName, constants.OSMBootstrapName}
 
 	// NginxIngressSvc is the namespaced name of the nginx ingress service
 	NginxIngressSvc = types.NamespacedName{Namespace: "ingress-ns", Name: "ingress-nginx-controller"}
@@ -689,7 +683,7 @@ func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
 		defer GinkgoRecover()
 		errController = td.WaitForPodsRunningReady(td.OsmNamespace, timeout, 1, &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				constants.AppLabel: OsmControllerAppLabel,
+				constants.AppLabel: constants.OSMControllerName,
 			},
 		})
 		waitGroup.Done()
@@ -699,7 +693,7 @@ func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
 		defer GinkgoRecover()
 		errInjector = td.WaitForPodsRunningReady(td.OsmNamespace, timeout, 1, &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				constants.AppLabel: OsmInjectorAppLabel,
+				constants.AppLabel: constants.OSMInjectorName,
 			},
 		})
 		waitGroup.Done()
@@ -709,7 +703,7 @@ func (td *OsmTestData) waitForOSMControlPlane(timeout time.Duration) error {
 		defer GinkgoRecover()
 		errBootstrap = td.WaitForPodsRunningReady(td.OsmNamespace, timeout, 1, &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				constants.AppLabel: OsmBootstrapAppLabel,
+				constants.AppLabel: constants.OSMBootstrapName,
 			},
 		})
 		waitGroup.Done()

--- a/tests/scale/osm_common_profile_resources.go
+++ b/tests/scale/osm_common_profile_resources.go
@@ -90,7 +90,7 @@ func getOSMTrackResources() []TrackedLabel {
 			Namespace: Td.OsmNamespace,
 			Label: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					constants.AppLabel: OsmControllerAppLabel,
+					constants.AppLabel: constants.OSMControllerName,
 				},
 			},
 		},


### PR DESCRIPTION
**Description**: 

Remove duplicate references of osm control plane pod names by creating a
constant and updating all code to use this.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
