### PR TITLE
ref(e2e): return err for TrafficTarget ns mismatch

### DIFF
--- a/pkg/validator/errors.go
+++ b/pkg/validator/errors.go
@@ -1,0 +1,9 @@
+package validator
+
+import (
+	"errors"
+)
+
+// ErrTrafficTargetNamespaceMismatch indicates that the namespace of the Traffic Target does not
+//	match the destination namespace
+var ErrTrafficTargetNamespaceMismatch = errors.New("traffic target namespace mismatch")

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -67,8 +67,8 @@ func trafficTargetValidator(req *admissionv1.AdmissionRequest) (*admissionv1.Adm
 	}
 
 	if trafficTarget.Spec.Destination.Namespace != trafficTarget.Namespace {
-		return nil, errors.Errorf("The traffic target namespace (%s) must match spec.Destination.Namespace (%s)",
-			trafficTarget.Namespace, trafficTarget.Spec.Destination.Namespace)
+		log.Error().Err(ErrTrafficTargetNamespaceMismatch).Msgf("The traffic target namespace (%s) must match spec.Destination.Namespace (%s)", trafficTarget.Namespace, trafficTarget.Spec.Destination.Namespace)
+		return nil, ErrTrafficTargetNamespaceMismatch
 	}
 
 	return nil, nil

--- a/tests/e2e/e2e_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_smi_traffic_target_test.go
@@ -202,7 +202,7 @@ var _ = OSMDescribe("Test HTTP traffic with SMI TrafficTarget",
 
 // createPolicyForRoutePath creates an HTTPRouteGroup and TrafficTarget policy for the given source, destination and HTTP path regex
 func createPolicyForRoutePath(source, sourceNamespace, destination, destinationNamespace, pathRegex string) (smiSpecs.HTTPRouteGroup, smiAccess.TrafficTarget) {
-	routeGroupName := source + "-" + destination
+	routeGroupName := fmt.Sprintf("%s-%s", source, destination)
 	routeMatchName := "allowed-route"
 
 	routeGroup := smiSpecs.HTTPRouteGroup{


### PR DESCRIPTION
Addressing PR comment https://github.com/openservicemesh/osm/pull/4151#discussion_r715846486

Signed-off-by: Michelle Noorali <minooral@microsoft.com>


Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
