### PR TITLE
fix(validatingWebhookCert): Update validating webhook secret creation to support multiple control plane instances

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/reconciler"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
-	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers"
 	"github.com/openservicemesh/osm/pkg/config"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -253,14 +252,7 @@ func main() {
 
 	clientset := extensionsClientset.NewForConfigOrDie(kubeConfig)
 
-	webhookHandlerCert, err := certManager.IssueCertificate(
-		certificate.CommonName(fmt.Sprintf("%s.%s.svc", validator.ValidatorWebhookSvc, osmNamespace)),
-		constants.XDSCertificateValidityPeriod)
-	if err != nil {
-		events.GenericEventRecorder().FatalEvent(err, events.CertificateIssuanceFailure, "Error issuing certificate for the validating webhook")
-	}
-
-	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, osmNamespace, osmVersion, meshName, enableReconciler, validateTrafficTarget, constants.ValidatorWebhookPort, webhookHandlerCert, kubeClient, stop); err != nil {
+	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, osmNamespace, osmVersion, meshName, enableReconciler, validateTrafficTarget, constants.ValidatorWebhookPort, certManager, kubeClient, stop); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error starting the validating webhook server")
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -97,8 +97,11 @@ const (
 	// XDSCertificateValidityPeriod is the TTL of the certificates used for Envoy to xDS communication.
 	XDSCertificateValidityPeriod = 87600 * time.Hour // a decade
 
-	// WebhookCertificateSecretName is the default value for webhook secret name
-	WebhookCertificateSecretName = "mutating-webhook-cert-secret"
+	// MutatingWebhookCertificateSecretName is the default value for mutating webhook secret name
+	MutatingWebhookCertificateSecretName = "mutating-webhook-cert-secret"
+
+	// ValidatingWebhookCertificateSecretName is the default value for validating webhook secret name
+	ValidatingWebhookCertificateSecretName = "validating-webhook-cert-secret" // #nosec G101: Potential hardcoded credentials
 
 	// CrdConverterCertificateSecretName is the default value for conversion webhook secret name
 	CrdConverterCertificateSecretName = "crd-converter-cert-secret" // #nosec G101: Potential hardcoded credentials

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -63,7 +63,7 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 
 	// The following function ensures to atomically create or get the certificate from Kubernetes
 	// secret API store. Multiple instances should end up with the same webhookHandlerCert after this function executed.
-	webhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.WebhookCertificateSecretName, webhookHandlerCert, kubeClient)
+	webhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.MutatingWebhookCertificateSecretName, webhookHandlerCert, kubeClient)
 	if err != nil {
 		return errors.Errorf("Error fetching webhook certificate from k8s secret: %s", err)
 	}


### PR DESCRIPTION
**Description**:

Update the logic of validating webhook secret creation to avoid race
conditions when multiple replicas of osm-controller are created.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Testing done**:  Prior to this change, increasing the replica count of osm-controller gave the following error on running the demo locally

`Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "osm-validator.k8s.io": Post "https://osm-validator.osm-system.svc:9093/validate?timeout=10s": x509: certificate signed by unknown authority`


After this change the error no longer occurs 

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
