### PR TITLE
Ensure single mesh deployment is enforced in OSM by default

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -78,7 +78,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.enablePermissiveTrafficPolicy | bool | `false` | Enable permissive traffic policy mode |
 | OpenServiceMesh.enablePrivilegedInitContainer | bool | `false` | Run init container in privileged mode |
 | OpenServiceMesh.enableReconciler | bool | `false` | Enable reconciler for OSM's CRDs and mutating webhook |
-| OpenServiceMesh.enforceSingleMesh | bool | `false` | Enforce only deploying one mesh in the cluster |
+| OpenServiceMesh.enforceSingleMesh | bool | `true` | Enforce only deploying one mesh in the cluster |
 | OpenServiceMesh.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error` |
 | OpenServiceMesh.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |
 | OpenServiceMesh.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API. When enabled, fine grained control over Egress (external) traffic is enforced |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -185,7 +185,7 @@ OpenServiceMesh:
   controllerLogLevel: info
 
   # -- Enforce only deploying one mesh in the cluster
-  enforceSingleMesh: false
+  enforceSingleMesh: true
 
   # -- Prefix used in name of the webhook configuration resources
   webhookConfigNamePrefix: osm-webhook

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -57,7 +57,7 @@ plane should watch for sidecar injection of Envoy proxies.
 const (
 	defaultChartPath         = ""
 	defaultMeshName          = "osm"
-	defaultEnforceSingleMesh = false
+	defaultEnforceSingleMesh = true
 )
 
 // chartTGZSource is the `helm package`d representation of the default Helm chart.


### PR DESCRIPTION
**Description**:

Enforcing single mesh in a cluster by defalut for OSM.

part of #4162

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
