### PR TITLE
fix(build): check if windows tag exists correctly

### DIFF
--- a/scripts/publish-image.sh
+++ b/scripts/publish-image.sh
@@ -27,14 +27,18 @@ if [ -z "${CTR_TAG}" ]; then
 fi
 
 if [[ "$VERIFY_TAGS" == "true" ]]; then
-    tokenUri="https://auth.docker.io/token?service=registry.docker.io&scope=repository:$IMAGE_REPO/$IMAGE_NAME:pull"
+    image="$IMAGE_NAME"
+    if [[ $OS == "windows" ]]; then
+      image="$image-windows"
+    fi
+    tokenUri="https://auth.docker.io/token?service=registry.docker.io&scope=repository:$IMAGE_REPO/$image:pull"
     bearerToken="$(curl --silent --get "$tokenUri" | jq --raw-output '.token')"
-    listUri="https://registry-1.docker.io/v2/$IMAGE_REPO/$IMAGE_NAME/tags/list"
+    listUri="https://registry-1.docker.io/v2/$IMAGE_REPO/$image/tags/list"
     authz="Authorization: Bearer $bearerToken"
     version_list="$(curl --silent --get -H "Accept: application/json" -H "$authz" "$listUri" | jq --raw-output '.')"
     exists=$(echo "$version_list" | jq --arg t "${CTR_TAG}" '.tags | index($t)')
     if [[ $exists != null ]]; then
-        echo "image $IMAGE_REPO/$IMAGE_NAME:$CTR_TAG already exists and \$VERIFY_TAGS is set"
+        echo "image $IMAGE_REPO/$image:$CTR_TAG already exists and \$VERIFY_TAGS is set"
         exit 1
     fi
 fi


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, when checking if a tag on a windows image exists, the linux
image is checked. This change fixes it so the windows image is checked
instead.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
