### PR TITLE
chore(release): update version to v0.11.0-rc.1

### DIFF
--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.9.2
+version: v0.11.0-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: latest-main
+appVersion: v0.11.0-rc.1
 
 # This specifies the minimum Kubernetes version OSM is compatible with.
 kubeVersion: ">= 1.19.0-0"

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -100,15 +100,15 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.fluentBit.workspaceId | string | `""` | WorkspaceId for Fluent Bit output plugin to Log Analytics |
 | OpenServiceMesh.grafana.enableRemoteRendering | bool | `false` | Enable Remote Rendering in Grafana |
 | OpenServiceMesh.grafana.port | int | `3000` | Grafana service's port |
-| OpenServiceMesh.image.digest | object | `{"osmBootstrap":"","osmCRDs":"","osmController":"","osmInjector":"","osmSidecarInit":""}` | Image digest (defaults to latest compatible tag) |
-| OpenServiceMesh.image.digest.osmBootstrap | string | `""` | osm-boostrap's image digest |
-| OpenServiceMesh.image.digest.osmCRDs | string | `""` | osm-crds' image digest |
-| OpenServiceMesh.image.digest.osmController | string | `""` | osm-controller's image digest |
-| OpenServiceMesh.image.digest.osmInjector | string | `""` | osm-injector's image digest |
-| OpenServiceMesh.image.digest.osmSidecarInit | string | `""` | Sidecar init container's image digest |
+| OpenServiceMesh.image.digest | object | `{"osmBootstrap":"sha256:35b657184c0c145b19e1614575cf1c8e4800621a3c4ea3067f71d3e0431beed5","osmCRDs":"sha256:4d85f94733f2fd009c7b956276aca9ac86b1be6ecca91243486254307a5beaae","osmController":"sha256:147e6155b6bbb69c97715e552cf2effbb26ede3380d379bb7e0de03493c85045","osmInjector":"sha256:cf301763aa21b7973b5fc963399e553dac88517d590cfb72eceb2f985fb63a86","osmSidecarInit":"sha256:0da5863eb304717a73079054fc8b1b5c18cede6903224701a011166551e63990"}` | Image digest (ignored when image.tag is set) |
+| OpenServiceMesh.image.digest.osmBootstrap | string | `"sha256:35b657184c0c145b19e1614575cf1c8e4800621a3c4ea3067f71d3e0431beed5"` | osm-boostrap's image digest |
+| OpenServiceMesh.image.digest.osmCRDs | string | `"sha256:4d85f94733f2fd009c7b956276aca9ac86b1be6ecca91243486254307a5beaae"` | osm-crds' image digest |
+| OpenServiceMesh.image.digest.osmController | string | `"sha256:147e6155b6bbb69c97715e552cf2effbb26ede3380d379bb7e0de03493c85045"` | osm-controller's image digest |
+| OpenServiceMesh.image.digest.osmInjector | string | `"sha256:cf301763aa21b7973b5fc963399e553dac88517d590cfb72eceb2f985fb63a86"` | osm-injector's image digest |
+| OpenServiceMesh.image.digest.osmSidecarInit | string | `"sha256:0da5863eb304717a73079054fc8b1b5c18cede6903224701a011166551e63990"` | Sidecar init container's image digest |
 | OpenServiceMesh.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy for control plane containers |
 | OpenServiceMesh.image.registry | string | `"openservicemesh"` | Container image registry for control plane images |
-| OpenServiceMesh.image.tag | string | `"latest-main"` | Container image tag for control plane images |
+| OpenServiceMesh.image.tag | string | `""` | Container image tag for control plane images (must not be set on release branches) |
 | OpenServiceMesh.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | OpenServiceMesh.inboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
 | OpenServiceMesh.injector.autoScale | object | `{"enable":false,"maxReplicas":5,"minReplicas":1,"targetAverageUtilization":80}` | Auto scale configuration |

--- a/charts/osm/templates/_helpers.tpl
+++ b/charts/osm/templates/_helpers.tpl
@@ -42,45 +42,45 @@ securityContext:
 
 {{/* osm-controller image */}}
 {{- define "osmController.image" -}}
-{{- if .Values.OpenServiceMesh.image.digest.osmController -}}
-{{- printf "%s/osm-controller@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmController -}}
-{{- else -}}
+{{- if .Values.OpenServiceMesh.image.tag -}}
 {{- printf "%s/osm-controller:%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.tag -}}
+{{- else -}}
+{{- printf "%s/osm-controller@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmController -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-injector image */}}
 {{- define "osmInjector.image" -}}
-{{- if .Values.OpenServiceMesh.image.digest.osmInjector -}}
-{{- printf "%s/osm-injector@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmInjector -}}
-{{- else -}}
+{{- if .Values.OpenServiceMesh.image.tag -}}
 {{- printf "%s/osm-injector:%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.tag -}}
+{{- else -}}
+{{- printf "%s/osm-injector@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmInjector -}}
 {{- end -}}
 {{- end -}}
 
 {{/* Sidecar init image */}}
 {{- define "osmSidecarInit.image" -}}
-{{- if .Values.OpenServiceMesh.image.digest.osmSidecarInit -}}
-{{- printf "%s/init@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmSidecarInit -}}
-{{- else -}}
+{{- if .Values.OpenServiceMesh.image.tag -}}
 {{- printf "%s/init:%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.tag -}}
+{{- else -}}
+{{- printf "%s/init@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmSidecarInit -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-bootstrap image */}}
 {{- define "osmBootstrap.image" -}}
-{{- if .Values.OpenServiceMesh.image.digest.osmBootstrap -}}
-{{- printf "%s/osm-bootstrap@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmBootstrap -}}
-{{- else -}}
+{{- if .Values.OpenServiceMesh.image.tag -}}
 {{- printf "%s/osm-bootstrap:%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.tag -}}
+{{- else -}}
+{{- printf "%s/osm-bootstrap@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmBootstrap -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-crds image */}}
 {{- define "osmCRDs.image" -}}
-{{- if .Values.OpenServiceMesh.image.digest.osmCRDs -}}
-{{- printf "%s/osm-crds@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmCRDs -}}
-{{- else -}}
+{{- if .Values.OpenServiceMesh.image.tag -}}
 {{- printf "%s/osm-crds:%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.tag -}}
+{{- else -}}
+{{- printf "%s/osm-crds@%s" .Values.OpenServiceMesh.image.registry .Values.OpenServiceMesh.image.digest.osmCRDs -}}
 {{- end -}}
 {{- end -}}

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -11,20 +11,20 @@ OpenServiceMesh:
     registry: openservicemesh
     # -- Container image pull policy for control plane containers
     pullPolicy: IfNotPresent
-    # -- Container image tag for control plane images
-    tag: "latest-main"
-    # -- Image digest (defaults to latest compatible tag)
+    # -- Container image tag for control plane images (must not be set on release branches)
+    tag: ""
+    # -- Image digest (ignored when image.tag is set)
     digest:
       # -- osm-controller's image digest
-      osmController: ""
+      osmController: "sha256:147e6155b6bbb69c97715e552cf2effbb26ede3380d379bb7e0de03493c85045"
       # -- osm-injector's image digest
-      osmInjector: ""
+      osmInjector: "sha256:cf301763aa21b7973b5fc963399e553dac88517d590cfb72eceb2f985fb63a86"
       # -- Sidecar init container's image digest
-      osmSidecarInit: ""
+      osmSidecarInit: "sha256:0da5863eb304717a73079054fc8b1b5c18cede6903224701a011166551e63990"
       # -- osm-crds' image digest
-      osmCRDs: ""
+      osmCRDs: "sha256:4d85f94733f2fd009c7b956276aca9ac86b1be6ecca91243486254307a5beaae"
       # -- osm-boostrap's image digest
-      osmBootstrap: ""
+      osmBootstrap: "sha256:35b657184c0c145b19e1614575cf1c8e4800621a3c4ea3067f71d3e0431beed5"
 
 
   # -- `osm-controller` image pull secret

--- a/cmd/cli/mesh_upgrade.go
+++ b/cmd/cli/mesh_upgrade.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	defaultContainerRegistry = "openservicemesh"
-	defaultOsmImageTag       = "latest-main"
+	defaultOsmImageTag       = "v0.11.0-rc.1"
 )
 
 const upgradeDesc = `

--- a/docs/example/manifests/apps/bookbuyer.yaml
+++ b/docs/example/manifests/apps/bookbuyer.yaml
@@ -31,7 +31,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookbuyer
-          image: openservicemesh/bookbuyer:latest-main
+          image: openservicemesh/bookbuyer:v0.11.0-rc.1
           imagePullPolicy: Always
           command: ["/bookbuyer"]
           env:

--- a/docs/example/manifests/apps/bookstore-v2.yaml
+++ b/docs/example/manifests/apps/bookstore-v2.yaml
@@ -46,7 +46,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:latest-main
+          image: openservicemesh/bookstore:v0.11.0-rc.1
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookstore.yaml
+++ b/docs/example/manifests/apps/bookstore.yaml
@@ -46,7 +46,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookstore
-          image: openservicemesh/bookstore:latest-main
+          image: openservicemesh/bookstore:v0.11.0-rc.1
           imagePullPolicy: Always
           ports:
             - containerPort: 14001

--- a/docs/example/manifests/apps/bookthief.yaml
+++ b/docs/example/manifests/apps/bookthief.yaml
@@ -30,7 +30,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookthief
-          image: openservicemesh/bookthief:latest-main
+          image: openservicemesh/bookthief:v0.11.0-rc.1
           imagePullPolicy: Always
           command: ["/bookthief"]
           env:

--- a/docs/example/manifests/apps/bookwarehouse.yaml
+++ b/docs/example/manifests/apps/bookwarehouse.yaml
@@ -47,6 +47,6 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: bookwarehouse
-          image: openservicemesh/bookwarehouse:latest-main
+          image: openservicemesh/bookwarehouse:v0.11.0-rc.1
           imagePullPolicy: Always
           command: ["/bookwarehouse"]

--- a/docs/example/manifests/meshconfig/mesh-config.yaml
+++ b/docs/example/manifests/meshconfig/mesh-config.yaml
@@ -8,7 +8,7 @@ spec:
     logLevel: error
     maxDataPlaneConnections: 0
     envoyImage: "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
-    initContainerImage: "openservicemesh/init:latest-main"
+    initContainerImage: "openservicemesh/init:v0.11.0-rc.1"
     configResyncInterval: "0s"
   traffic:
     enableEgress: false


### PR DESCRIPTION
Signed-off-by: jaellio <jaellio@microsoft.com>

**Changes to note:**

The logic in `_helpers.tpl` to determine the control plane and demo app image names was modified. If the `OpenServiceMesh.image.tag` is set in `charts/osm/values.yaml` it will be used by default to configure the image names. If the image tag is not set, the image digests defined by `OpenServiceMesh.image.digest` will be used. 

Prior to this change, setting the image digests in `charts/osm/values.yaml` was causing the demo to fail. By default, the image digests were used to configure the image names.  In the demo, the new images that were pushed to the local container registry did not have the same digests as the digests generated from the pre-release workflow. When attempting to pull the images from the local registry with the digests from the pre-release workflow the images didn't exist.

<!--

Use the checklist below to ensure your release PR is complete before marking it ready for review.

-->

- [x] I have cherry-picked any changes [labelled](https://github.com/openservicemesh/osm/labels) `needs-cherry-pick-vX.Y.Z`
- [x] I have made all of the following version and patch updates:
  1. Updated the container image tag in charts/osm/values.yaml
  2. Updated the chart **and** app version in charts/osm/Chart.yaml
  3. Updated the image tags used in the demo manifests
  4. Regenerated the Helm chart README.md

- [x] I have checked that the base branch for this PR is correct as defined by the release guide
<!--
  If this PR is for updating the release branch, ensure the base branch is `release-vX.Y`.
  If this PR is for making changes on the main branch, ensure the base branch is `main`. 
-->

Is this a release candidate? Yes

**Description**: Update OSM version to v0.11.0-rc.1
