### PR TITLE
catalog/ingress: check backend's port in addition to name

### DIFF
--- a/pkg/catalog/ingress_test.go
+++ b/pkg/catalog/ingress_test.go
@@ -2652,6 +2652,45 @@ func TestGetIngressTrafficPolicy(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name:                        "MeshService.TargetPort does not match ingress backend port",
+			ingressBackendPolicyEnabled: true,
+			// meshSvc.TargetPort does not match ingressBackend.Spec.Backends[].Port.Number
+			meshSvc: service.MeshService{Name: "foo", Namespace: "testns", Protocol: "http", TargetPort: 90},
+			ingressBackend: &policyV1alpha1.IngressBackend{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-backend-1",
+					Namespace: "testns",
+				},
+				Spec: policyV1alpha1.IngressBackendSpec{
+					Backends: []policyV1alpha1.BackendSpec{
+						{
+							Name: "foo",
+							Port: policyV1alpha1.PortSpec{
+								Number:   80,
+								Protocol: "http",
+							},
+						},
+					},
+					Sources: []policyV1alpha1.IngressSourceSpec{
+						{
+							Kind: policyV1alpha1.KindIPRange,
+							Name: "10.0.0.0/10",
+						},
+						{
+							Kind: policyV1alpha1.KindIPRange,
+							Name: "20.0.0.0/10",
+						},
+						{
+							Kind: policyV1alpha1.KindIPRange,
+							Name: "invalid", // should be ignored
+						},
+					},
+				},
+			},
+			expectedPolicy: nil,
+			expectError:    false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Checks that the IngressBackend's port matches the TargetPort
of the service. This is important in deployments where there
are multiple MeshServices with the same name, in which case
the IngressBackend configuration corresponding to the service
name and port must be used. Multiple MeshService objects with
the same name and different port number will exist when there
is a k8s service with multiple ports per service.

Without this change, IngressBackend configuration for a service
with multiple ports can result in conflicts where duplicate
configs are generated per MeshService.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Tested IngressBackend with multiple port per service.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Ingress                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
