### PR TITLE
Makefile: document why BUILD_DATE is only set for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOBIN  = $(GOPATH)/bin
 GOX    = go run github.com/mitchellh/gox
 
 VERSION ?= dev
-BUILD_DATE ?=
+BUILD_DATE ?= $$(date +%F)
 GIT_SHA=$$(git rev-parse HEAD)
 BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate
 BUILD_VERSION_VAR := github.com/openservicemesh/osm/pkg/version.Version

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ GOBIN  = $(GOPATH)/bin
 GOX    = go run github.com/mitchellh/gox
 
 VERSION ?= dev
-BUILD_DATE ?= $$(date +%F)
+# BUILD_DATE is set for releases only. This is deliberately empty.
+# See: https://github.com/openservicemesh/osm/pull/3377
+BUILD_DATE ?=
 GIT_SHA=$$(git rev-parse HEAD)
 BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate
 BUILD_VERSION_VAR := github.com/openservicemesh/osm/pkg/version.Version


### PR DESCRIPTION
I noticed that `osm version` did not output the date when the binary was built.

Adding this to the Makefile addresses this for local builds.

```bash
$ ./bin/osm version

Version: dev; Commit: 46cf0d0db532875bf16b99585cec6c675803a695; Date: 2021-09-30
```