### PR TITLE
fix(tests): disable smi validate test for NoInstall

### DIFF
--- a/tests/e2e/e2e_validate_smi_traffic_target_test.go
+++ b/tests/e2e/e2e_validate_smi_traffic_target_test.go
@@ -58,6 +58,9 @@ var _ = OSMDescribe("Test SMI TrafficTarget Validation",
 
 		Context("With SMI validation disabled ", func() {
 			It("allows SMI traffic target to be created regardless of whether the namespace matches the destination namespace in any namespace", func() {
+				if Td.InstType == NoInstall {
+					Skip("SMI Validation is not configurable via MeshConfig so cannot be tested with NoInstall")
+				}
 				var (
 					source                  = framework.RandomNameWithPrefix("source")
 					destination             = framework.RandomNameWithPrefix("destination")


### PR DESCRIPTION
This PR disables the SMI traffic target validation disable test when test type is NoInstall because it requires updating the validation configuration which is not possible at this point through the MeshConfig object.

resolves #4208 

Co-authored-by: Niranjan Shankar nshankar@microsoft.com
Signed-off-by: Michelle Noorali <minooral@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution? NA

2. Is this a breaking change? 
