### PR TITLE
envoy/registry: do not track disconnected proxies

### DIFF
--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -34,8 +34,6 @@ func (ds DebugConfig) getProxies() http.Handler {
 			ds.getProxy(certificate.CommonName(specificProxy[0]), w)
 		} else {
 			printProxies(w, listConnected(), "Connected")
-			// TODO(#2481): Print expected proxies once #2481 is addressed
-			printProxies(w, ds.proxyRegistry.ListDisconnectedProxies(), "Disconnected")
 		}
 	})
 }

--- a/pkg/envoy/registry/debugger.go
+++ b/pkg/envoy/registry/debugger.go
@@ -1,8 +1,6 @@
 package registry
 
 import (
-	"time"
-
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy"
 )
@@ -13,21 +11,7 @@ func (pr *ProxyRegistry) ListConnectedProxies() map[certificate.CommonName]*envo
 	pr.connectedProxies.Range(func(cnIface, propsIface interface{}) bool {
 		cn := cnIface.(certificate.CommonName)
 		props := propsIface.(connectedProxy)
-		if _, isDisconnected := pr.disconnectedProxies.Load(cn); !isDisconnected {
-			proxies[cn] = props.proxy
-		}
-		return true // continue the iteration
-	})
-	return proxies
-}
-
-// ListDisconnectedProxies lists the Envoy proxies disconnected and the time last seen.
-func (pr *ProxyRegistry) ListDisconnectedProxies() map[certificate.CommonName]time.Time {
-	proxies := make(map[certificate.CommonName]time.Time)
-	pr.disconnectedProxies.Range(func(cnInterface, disconnectedProxyInterface interface{}) bool {
-		cn := cnInterface.(certificate.CommonName)
-		props := disconnectedProxyInterface.(disconnectedProxy)
-		proxies[cn] = props.lastSeen
+		proxies[cn] = props.proxy
 		return true // continue the iteration
 	})
 	return proxies

--- a/pkg/envoy/registry/debugger_test.go
+++ b/pkg/envoy/registry/debugger_test.go
@@ -23,12 +23,9 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 	})
 
 	Context("Test register/unregister proxies", func() {
-		It("no proxies connected or disconnected", func() {
+		It("no proxies connected", func() {
 			connectedProxies := proxyRegistry.ListConnectedProxies()
 			Expect(len(connectedProxies)).To(Equal(0))
-
-			disconnectedProxies := proxyRegistry.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(0))
 		})
 
 		It("one proxy connected to OSM", func() {
@@ -36,9 +33,6 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 
 			connectedProxies := proxyRegistry.ListConnectedProxies()
 			Expect(len(connectedProxies)).To(Equal(1))
-
-			disconnectedProxies := proxyRegistry.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(0))
 
 			_, ok := connectedProxies[certCommonName]
 			Expect(ok).To(BeTrue())
@@ -49,12 +43,6 @@ var _ = Describe("Test catalog proxy register/unregister", func() {
 
 			connectedProxies := proxyRegistry.ListConnectedProxies()
 			Expect(len(connectedProxies)).To(Equal(0))
-
-			disconnectedProxies := proxyRegistry.ListDisconnectedProxies()
-			Expect(len(disconnectedProxies)).To(Equal(1))
-
-			_, ok := disconnectedProxies[certCommonName]
-			Expect(ok).To(BeTrue())
 		})
 	})
 })

--- a/pkg/envoy/registry/registry.go
+++ b/pkg/envoy/registry/registry.go
@@ -40,11 +40,6 @@ func (pr *ProxyRegistry) RegisterProxy(proxy *envoy.Proxy) {
 // UnregisterProxy unregisters the given proxy from the catalog.
 func (pr *ProxyRegistry) UnregisterProxy(p *envoy.Proxy) {
 	pr.connectedProxies.Delete(p.GetCertificateCommonName())
-
-	pr.disconnectedProxies.Store(p.GetCertificateCommonName(), disconnectedProxy{
-		lastSeen: time.Now(),
-	})
-
 	log.Debug().Msgf("Unregistered proxy %s", p.String())
 }
 

--- a/pkg/envoy/registry/types.go
+++ b/pkg/envoy/registry/types.go
@@ -16,8 +16,7 @@ var log = logger.New("proxy-registry")
 type ProxyRegistry struct {
 	ProxyServiceMapper
 
-	connectedProxies    sync.Map
-	disconnectedProxies sync.Map
+	connectedProxies sync.Map
 
 	// Maintain a mapping of pod UID to CN of the Envoy on the given pod
 	podUIDToCN sync.Map
@@ -34,8 +33,4 @@ type connectedProxy struct {
 
 	// When the proxy connected to the XDS control plane
 	connectedAt time.Time
-}
-
-type disconnectedProxy struct {
-	lastSeen time.Time
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Proxies are expected to disconnect when the corresponding
pods are recycled.
Since the cluster can go through a lot of churn, keeping
track of disconnected proxies results in additional
memory consumption and bookkeeping which is better avoided.
It is easy enough to know how many times a proxy has
reconnected to a control plane after a disconnect using
the osm_proxy_reconnect_count metric.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
