### PR TITLE
metrics: add counters related to proxy response send

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -301,6 +301,8 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.ProxyReconnectCount,
 		metricsstore.DefaultMetricsStore.ProxyConfigUpdateTime,
 		metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount,
+		metricsstore.DefaultMetricsStore.ProxyResponseSendSuccessCount,
+		metricsstore.DefaultMetricsStore.ProxyResponseSendErrorCount,
 		metricsstore.DefaultMetricsStore.ErrCodeCounter,
 	)
 }

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -37,6 +37,12 @@ type MetricsStore struct {
 	// ProxyBroadcastEventCounter is the metric for the total number of ProxyBroadcast events published
 	ProxyBroadcastEventCount prometheus.Counter
 
+	// ProxyResponseSendSuccessCount is the metric for the total number of successful responses sent to the proxies
+	ProxyResponseSendSuccessCount prometheus.Counter
+
+	// ProxyResponseSendErrorCount is the metric for the total number of errors encountered while sending responses to proxies
+	ProxyResponseSendErrorCount prometheus.Counter
+
 	/*
 	 * Injector metrics
 	 */
@@ -101,6 +107,20 @@ func init() {
 		Subsystem: "proxy",
 		Name:      "reconnect_count",
 		Help:      "Represents the number of reconnects from known proxies to OSM controller",
+	})
+
+	defaultMetricsStore.ProxyResponseSendSuccessCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "response_send_success_count",
+		Help:      "Represents the number of responses successfully sent to proxies",
+	})
+
+	defaultMetricsStore.ProxyResponseSendErrorCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "response_send_error_count",
+		Help:      "Represents the number of responses that errored when being set to proxies",
 	})
 
 	defaultMetricsStore.ProxyConfigUpdateTime = prometheus.NewHistogramVec(


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds metrics counters for successful and failed sends
to proxies.

Resolves #4191

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
```
# HELP osm_proxy_response_send_error_count Represents the number of responses that errored when being set to proxies
# TYPE osm_proxy_response_send_error_count counter
osm_proxy_response_send_error_count 0
# HELP osm_proxy_response_send_success_count Represents the number of responses successfully sent to proxies
# TYPE osm_proxy_response_send_success_count counter
osm_proxy_response_send_success_count 555
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Observability              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
