### PR TITLE
chore(tlsversion): Add a tls minimum version for webhooks

### DIFF
--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -114,6 +114,7 @@ func (crdWh *crdConversionWebhook) run(stop <-chan struct{}) {
 		// #nosec G402
 		webhookServer.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS13,
 		}
 
 		if err := webhookServer.ListenAndServeTLS("", ""); err != nil {

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -48,7 +48,10 @@ func (httpProbe HTTPProbe) Probe() (int, error) {
 		// similar to how k8s api server handles HTTPS probes.
 		// #nosec G402
 		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+				MinVersion:         tls.VersionTLS13,
+			},
 		}
 		client.Transport = transport
 	}

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -126,6 +126,7 @@ func (wh *mutatingWebhook) run(stop <-chan struct{}) {
 		// #nosec G402
 		server.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS13,
 		}
 
 		if err := server.ListenAndServeTLS("", ""); err != nil {

--- a/pkg/utils/mtls.go
+++ b/pkg/utils/mtls.go
@@ -35,6 +35,7 @@ func setupMutualTLS(insecure bool, serverName string, certPem []byte, keyPem []b
 		ClientAuth:         tls.RequireAndVerifyClientCert,
 		Certificates:       []tls.Certificate{certif},
 		ClientCAs:          certPool,
+		MinVersion:         tls.VersionTLS13,
 	}
 	return grpc.Creds(credentials.NewTLS(&tlsConfig)), nil
 }

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -178,6 +178,7 @@ func (s *validatingWebhookServer) run(port int, certificater certificate.Certifi
 		// #nosec G402
 		server.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS13,
 		}
 
 		if err := server.ListenAndServeTLS("", ""); err != nil {


### PR DESCRIPTION
**Description**:

Add a minimum tls version for webhooks

fixed #4165

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
