### PR TITLE
chore(security/scan): Scan docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,6 +178,37 @@ jobs:
           make pkg/envoy/lds/stats.wasm
           go test -v ./tests/scenarios/...
 
+  imagescan:
+    name: Scan images for security vulnerabilities
+    runs-on: ubuntu-latest
+    needs: build
+    env: 
+      CTR_TAG: ${{ github.sha }}
+      CTR_REGISTRY: "localhost:5000"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Restore Module Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomod2-
+      - name: Restore Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+      - name: Setup Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+      - name: Build docker images
+        run: make docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-bootstrap docker-build-init
+      - name: Scan docker images for vulnerabilities
+        run: make trivy-scan-images
+
   e2etest:
     name: Go test e2e
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -57,3 +57,28 @@ jobs:
         with:
           name: osm_image_digests
           path: /tmp/osm_image_digest_*
+
+imagescan:
+  name: Scan images for security vulnerabilities
+  runs-on: ubuntu-latest
+  needs: build
+  env: 
+    CTR_TAG: ${{ needs.version.outputs.version }}
+    CTR_REGISTRY: openservicemesh
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Restore Module Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod2-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gomod2-
+    - name: Restore Build Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
+    - name: Scan docker images for vulnerabilities
+      run: make trivy-scan-images

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,24 @@ build-ci: embed-files
 clean-image-digest:
 	@rm -f "$(CTR_DIGEST_FILE)"
 
+trivy-scan-images:
+	wget https://github.com/aquasecurity/trivy/releases/download/v0.18.0/trivy_0.18.0_Linux-64bit.tar.gz
+	tar zxvf trivy_0.18.0_Linux-64bit.tar.gz
+
+	# Show all vulnerabilities in logs
+	./trivy $(CTR_REGISTRY)/osm-controller:$(CTR_TAG)
+	./trivy $(CTR_REGISTRY)/osm-injector:$(CTR_TAG)
+	./trivy $(CTR_REGISTRY)/init:$(CTR_TAG)
+	./trivy $(CTR_REGISTRY)/osm-bootstrap:$(CTR_TAG)
+	./trivy $(CTR_REGISTRY)/osm-crds:$(CTR_TAG)
+
+	# Exit if vulnerability exists
+	./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "$(CTR_REGISTRY)/osm-controller:$(CTR_TAG)" || exit 1
+	./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "$(CTR_REGISTRY)/osm-injector:$(CTR_TAG)" || exit 1
+	./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "$(CTR_REGISTRY)/init:$(CTR_TAG)" || exit 1
+	./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "$(CTR_REGISTRY)/osm-bootstrap:$(CTR_TAG)" || exit 1
+	./trivy --exit-code 1 --ignore-unfixed --severity MEDIUM,HIGH,CRITICAL "$(CTR_REGISTRY)/osm-crds:$(CTR_TAG)" || exit 1
+
 # OSM control plane components
 DOCKER_PUSH_CONTROL_PLANE_TARGETS = $(addprefix docker-push-, init osm-controller osm-injector osm-crds osm-bootstrap)
 .PHONY: $(DOCKER_PUSH_CONTROL_PLANE_TARGETS)


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add step in the CI and the release job to scan docker images for potential security vulnerabilities via Trivy. The Jobs will show all security scan outputs in the logs, but will only exit with failure if the severity level is Medium, High, or Critical, and will continue if if the level is Unknown or Low.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Tested by running truly scan on OSM controller, injector, init, bootstrap, and crds images, both in Dockerhub and in localhost:5000 registry.  

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [X] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
