### PR TITLE
messaging/broker: batch proxy update events

### DIFF
--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -1,6 +1,7 @@
 package messaging
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/cskr/pubsub"
@@ -13,17 +14,28 @@ import (
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
+const (
+	// proxyUpdateSlidingWindow is the sliding window duration used to batch proxy update events
+	proxyUpdateSlidingWindow = 2 * time.Second
+
+	// proxyUpdateMaxWindow is the max window duration used to batch proxy update events, and is
+	// the max amount of time a proxy update event can be held for batching before being dispatched.
+	proxyUpdateMaxWindow = 10 * time.Second
+)
+
 // NewBroker returns a new message broker instance and starts the internal goroutine
 // to process events added to the workqueue.
 func NewBroker(stopCh <-chan struct{}) *Broker {
 	b := &Broker{
 		queue:             workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		proxyUpdatePubSub: pubsub.New(0),
+		proxyUpdateCh:     make(chan interface{}),
 		kubeEventPubSub:   pubsub.New(0),
 		certPubSub:        pubsub.New(0),
 	}
 
-	go b.run(stopCh)
+	go b.runWorkqueueProcessor(stopCh)
+	go b.runProxyUpdateDispatcher(stopCh)
 
 	return b
 }
@@ -43,9 +55,21 @@ func (b *Broker) GetCertPubSub() *pubsub.PubSub {
 	return b.certPubSub
 }
 
-// run starts a goroutine to process events from the workqueue until
+// GetTotalQProxyEventCount returns the total number of events read from the workqueue
+// pertaining to proxy updates
+func (b *Broker) GetTotalQProxyEventCount() uint64 {
+	return atomic.LoadUint64(&b.totalQProxyEventCount)
+}
+
+// GetTotalDispatchedProxyEventCount returns the total number of events dispatched
+// to subscribed proxies
+func (b *Broker) GetTotalDispatchedProxyEventCount() uint64 {
+	return atomic.LoadUint64(&b.totalDispatchedProxyEventCount)
+}
+
+// runWorkqueueProcessor starts a goroutine to process events from the workqueue until
 // signalled to stop on the given channel.
-func (b *Broker) run(stopCh <-chan struct{}) {
+func (b *Broker) runWorkqueueProcessor(stopCh <-chan struct{}) {
 	// Start the goroutine workqueue to process kubernetes events
 	// The continuous processing of items in the workqueue will run
 	// until signalled to stop.
@@ -62,6 +86,115 @@ func (b *Broker) run(stopCh <-chan struct{}) {
 	)
 }
 
+// runProxyUpdateDispatcher runs the dispatcher responsible for batching
+// proxy update events received in close proximity.
+// It batches proxy update events with the use of 2 timers:
+// 1. Sliding window timer that resets when a proxy update event is received
+// 2. Max window timer that caps the max duration a sliding window can be reset to
+// When either of the above timers expire, the proxy update event is published
+// on the dedicated pub-sub instance.
+func (b *Broker) runProxyUpdateDispatcher(stopCh <-chan struct{}) {
+	// batchTimer and maxTimer are updated by the dispatcher routine
+	// when events are processed and timeouts expire. They are initialized
+	// with a large timeout (a decade) so they don't time out till an event
+	// is received.
+	noTimeout := 87600 * time.Hour // A decade
+	slidingTimer := time.NewTimer(noTimeout)
+	maxTimer := time.NewTimer(noTimeout)
+
+	// dispatchPending indicates whether a proxy update event is pending
+	// from being published on the pub-sub. A proxy update event will
+	// be held for 'proxyUpdateSlidingWindow' duration to be able to
+	// coalesce multiple proxy update events within that duration, before
+	// it is dispatched on the pub-sub. The 'proxyUpdateSlidingWindow' duration
+	// is a sliding window, which means each event received within a window
+	// slides the window further ahead in time, up to a max of 'proxyUpdateMaxWindow'.
+	//
+	// This mechanism is necessary to avoid triggering proxy update pub-sub events in
+	// a hot loop, which would otherwise result in CPU spikes on the controller.
+	// We want to coalesce as many proxy update events within the 'proxyUpdateMaxWindow'
+	// duration.
+	dispatchPending := false
+	batchCount := 0 // number of proxy update events batched per dispatch
+
+	for {
+		var msg events.PubSubMessage
+
+		select {
+		case event, ok := <-b.proxyUpdateCh:
+			if !ok {
+				log.Warn().Msgf("Proxy update event chan closed, exiting dispatcher")
+				return
+			}
+
+			msg, ok = event.(events.PubSubMessage)
+			if !ok {
+				log.Error().Msgf("Expected type PubSubMessage, got %T", msg)
+				continue
+			}
+
+			if !dispatchPending {
+				// No proxy update events are pending send on the pub-sub.
+				// Reset the dispatch timers. The events will be dispatched
+				// when either of the timers expire.
+				if !slidingTimer.Stop() {
+					<-slidingTimer.C
+				}
+				slidingTimer.Reset(proxyUpdateSlidingWindow)
+				if !maxTimer.Stop() {
+					<-maxTimer.C
+				}
+				maxTimer.Reset(proxyUpdateMaxWindow)
+				dispatchPending = true
+				batchCount++
+				log.Trace().Msgf("Pending dispatch of msg kind %s", msg.Kind)
+			} else {
+				// A proxy update event is pending dispatch. Update the sliding window.
+				if !slidingTimer.Stop() {
+					<-slidingTimer.C
+				}
+				slidingTimer.Reset(proxyUpdateSlidingWindow)
+				batchCount++
+				log.Trace().Msgf("Reset sliding window for msg kind %s", msg.Kind)
+			}
+
+		case <-slidingTimer.C:
+			slidingTimer.Reset(noTimeout) // 'slidingTimer' drained in this case statement
+			// Stop and drain 'maxTimer' before Reset()
+			if !maxTimer.Stop() {
+				// Drain channel. Refer to Reset() doc for more info.
+				<-maxTimer.C
+			}
+			maxTimer.Reset(noTimeout)
+			b.proxyUpdatePubSub.Pub(msg, announcements.ProxyUpdate.String())
+			atomic.AddUint64(&b.totalDispatchedProxyEventCount, 1)
+			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
+			log.Trace().Msgf("Sliding window expired, msg kind %s, batch size %d", msg.Kind, batchCount)
+			dispatchPending = false
+			batchCount = 0
+
+		case <-maxTimer.C:
+			maxTimer.Reset(noTimeout) // 'maxTimer' drained in this case statement
+			// Stop and drain 'slidingTimer' before Reset()
+			if !slidingTimer.Stop() {
+				// Drain channel. Refer to Reset() doc for more info.
+				<-slidingTimer.C
+			}
+			slidingTimer.Reset(noTimeout)
+			b.proxyUpdatePubSub.Pub(msg, announcements.ProxyUpdate.String())
+			atomic.AddUint64(&b.totalDispatchedProxyEventCount, 1)
+			metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
+			log.Trace().Msgf("Max window expired, msg kind %s, batch size %d", msg.Kind, batchCount)
+			dispatchPending = false
+			batchCount = 0
+
+		case <-stopCh:
+			log.Info().Msg("Proxy update dispatcher received stop signal, exiting")
+			return
+		}
+	}
+}
+
 // processEvent processes an event dispatched from the workqueue.
 // It does the following:
 // 1. If the event must update a proxy, it publishes a proxy update message
@@ -72,8 +205,8 @@ func (b *Broker) processEvent(msg events.PubSubMessage) {
 	// Update proxies if applicable
 	if shouldUpdateProxy(msg) {
 		log.Trace().Msgf("Msg kind %s will update proxies", msg.Kind)
-		b.proxyUpdatePubSub.Pub(msg, announcements.ProxyUpdate.String())
-		metricsstore.DefaultMetricsStore.ProxyBroadcastEventCount.Inc()
+		atomic.AddUint64(&b.totalQProxyEventCount, 1)
+		b.proxyUpdateCh <- msg
 	}
 
 	// Publish event to other interested clients, e.g. log level changes, debug server on/off etc.

--- a/pkg/messaging/types.go
+++ b/pkg/messaging/types.go
@@ -15,9 +15,12 @@ var (
 
 // Broker implements the message broker functionality
 type Broker struct {
-	queue             workqueue.RateLimitingInterface
-	proxyUpdatePubSub *pubsub.PubSub
-	kubeEventPubSub   *pubsub.PubSub
-	certPubSub        *pubsub.PubSub
-	totalQEventCount  uint64
+	queue                          workqueue.RateLimitingInterface
+	proxyUpdatePubSub              *pubsub.PubSub
+	proxyUpdateCh                  chan interface{}
+	kubeEventPubSub                *pubsub.PubSub
+	certPubSub                     *pubsub.PubSub
+	totalQEventCount               uint64
+	totalQProxyEventCount          uint64
+	totalDispatchedProxyEventCount uint64
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Implements batch processing of proxy update events
to reduce the number of events propagated to the XDS
routine, through event coalescing, when the events
are triggered in close proximity in time. Without
this change, when a large number of events are
received in a short time interval, not coalescing
the events will trigger a large number of proxy
update events on the pub-sub, that will result
in the osm-controller's CPU spiking, and also
that of envoy based on how soon the XDS state
machine converges.

This implements a sliding window much like how
the dispatcher routine in mesh-catalog would
handle proxy events prior to the introduction
of a message broker, except that it resolves
potential memory leaks that might arise when
the timers are reset during a processing window.

It also updates a test to not use rate limiting
because it slows the test by about ~25s, and the
ticker test to use the counter exposed by the
broker.

Resolves #4238

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
