### PR TITLE
fix(cleanuphook): Delete mwhc and vwhc in all scenarios

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -78,10 +78,8 @@ spec:
             - >
              kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
              kubectl apply -f /osm-crds;
-             {{- if .Values.OpenServiceMesh.enableReconciler }}
              kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.OpenServiceMesh.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found;
              kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.OpenServiceMesh.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-controller --ignore-not-found;
-             {{- end }}
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux


### PR DESCRIPTION
**Description**:

The cleanup hook had a condition to delete the mwhc and vwhc only when
the reconciler is enabled, which is incorrect. These two resources
need to be deleted always.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>


**Testing done**:  Manually verified that the webhooks are no longer on the cluster on osm uninstall with reconciler disabled. 

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
