### PR TITLE
ingress/client: remove unnecessary check for namespace

### DIFF
--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -138,11 +138,6 @@ func (c client) GetIngressNetworkingV1beta1(meshService service.MeshService) ([]
 			continue
 		}
 
-		// Extra safety - make sure we do not pay attention to Ingresses outside of observed namespaces
-		if !c.kubeController.IsMonitoredNamespace(ingress.Namespace) {
-			continue
-		}
-
 		// Check if the ingress resource belongs to the same namespace as the service
 		if ingress.Namespace != meshService.Namespace {
 			// The ingress resource does not belong to the namespace of the service
@@ -179,11 +174,6 @@ func (c client) GetIngressNetworkingV1(meshService service.MeshService) ([]*netw
 		ingress, ok := ingressInterface.(*networkingV1.Ingress)
 		if !ok {
 			log.Error().Msg("Failed type assertion for Ingress in ingress cache")
-			continue
-		}
-
-		// Extra safety - make sure we do not pay attention to Ingresses outside of observed namespaces
-		if !c.kubeController.IsMonitoredNamespace(ingress.Namespace) {
 			continue
 		}
 

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -134,7 +134,7 @@ func (c client) GetIngressBackendPolicy(svc service.MeshService) *policyV1alpha1
 	for _, ingressBackendIface := range c.caches.ingressBackend.List() {
 		ingressBackend := ingressBackendIface.(*policyV1alpha1.IngressBackend)
 
-		if !c.kubeController.IsMonitoredNamespace(ingressBackend.Namespace) {
+		if ingressBackend.Namespace != svc.Namespace {
 			continue
 		}
 
@@ -142,7 +142,7 @@ func (c client) GetIngressBackendPolicy(svc service.MeshService) *policyV1alpha1
 		// Multiple IngressBackend policies for the same backend will be prevented
 		// using a validating webhook.
 		for _, backend := range ingressBackend.Spec.Backends {
-			if ingressBackend.Namespace == svc.Namespace && backend.Name == svc.Name {
+			if backend.Name == svc.Name {
 				return ingressBackend
 			}
 		}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes a redundant check in the ingress cache that checks
if the namespace is monitored. The check is redundant because
there is already a check that ensures the ingress resource
namespace is the same as the MeshService namespace, where
MeshService's namespace is guaranteed to be monitored.

IsMonitoredNamespace() usage should be avoided if possible,
since repeated cache access of the backing thread-safe map
results in performance issues due to contention.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
