### PR TITLE
ref(*): removes unnecessary namespace check

### DIFF
--- a/pkg/config/multiclusterservice.go
+++ b/pkg/config/multiclusterservice.go
@@ -20,10 +20,6 @@ func (c client) ListMultiClusterServices() []v1alpha1.MultiClusterService {
 }
 
 func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []v1alpha1.MultiClusterService {
-	if !c.kubeController.IsMonitoredNamespace(namespace) {
-		return nil
-	}
-
 	var services []v1alpha1.MultiClusterService
 
 	for _, svc := range c.ListMultiClusterServices() {


### PR DESCRIPTION
This commit removes an unnecessary call to check if the namespace
is monitored which is already checked by ListMultiClusterServices().

resolves #4248

Signed-off-by: Michelle Noorali <minooral@microsoft.com>


Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No 
    -   Did you notify the maintainers and provide attribution? NA

2. Is this a breaking change? No
