### PR TITLE
docs/examples: add tcp-echo manifest

### DIFF
--- a/docs/example/manifests/apps/tcp-echo.yaml
+++ b/docs/example/manifests/apps/tcp-echo.yaml
@@ -1,0 +1,55 @@
+# Note: create and add the `tcp-demo` namespace to the mesh prior to deploying this app
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+  labels:
+    app: tcp-echo
+spec:
+  ports:
+  - name: tcp
+    port: 9000
+    appProtocol: tcp # required for TCP based routing
+  selector:
+    app: tcp-echo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tcp-echo
+  namespace: tcp-demo
+  labels:
+    app: tcp-echo
+    version: v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tcp-echo
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: tcp-echo
+        version: v1
+    spec:
+      serviceAccountName: tcp-echo
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      containers:
+      - name: tcp-echo-server
+        image: "openservicemesh/tcp-echo-server:latest"
+        imagePullPolicy: Always
+        command: ["/tcp-echo-server"]
+        args: [ "--port", "9000" ]
+        ports:
+        - containerPort: 9000
+          name: tcp-echo-server


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds the manifest for the tcp-echo service required
to demo TCP routing in OSM.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Tested TCP access to the `tcp-echo` service.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Demo                       | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
