### PR TITLE
fix(osm-crds): use busybox base image

### DIFF
--- a/dockerfiles/Dockerfile.osm-crds
+++ b/dockerfiles/Dockerfile.osm-crds
@@ -1,2 +1,5 @@
-FROM bitnami/kubectl
+FROM busybox:1.33
+RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/linux/amd64/kubectl -O /bin/kubectl && \
+    chmod +x /bin/kubectl
 COPY * /osm-crds/
+ENTRYPOINT ["/bin/kubectl"]


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The `bitnami/kubectl` used as the base for the `osm-crds` image has
several reported vulnerabilities found with `trivy`. This change uses
`busybox` as the base image instead which has no reported
vulnerabilities.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [X] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
