### PR TITLE
demo: use default namespace if unset

### DIFF
--- a/demo/cmd/common/books.go
+++ b/demo/cmd/common/books.go
@@ -58,8 +58,8 @@ var (
 	maxIterationsStr                       = utils.GetEnv("CI_MAX_ITERATIONS_THRESHOLD", "0") // 0 for unlimited
 	bookstoreServiceName                   = utils.GetEnv("BOOKSTORE_SVC", "bookstore")
 	warehouseServiceName                   = utils.GetEnv("WAREHOUSE_SVC", "bookwarehouse")
-	bookstoreNamespace                     = os.Getenv(BookstoreNamespaceEnvVar)
-	bookwarehouseNamespace                 = os.Getenv(BookwarehouseNamespaceEnvVar)
+	bookstoreNamespace                     = utils.GetEnv(BookstoreNamespaceEnvVar, "bookstore")
+	bookwarehouseNamespace                 = utils.GetEnv(BookwarehouseNamespaceEnvVar, "bookwarehouse")
 
 	// Due to a limitation on kubernetes on Windows we need to use the FQDN
 	// otherwise DNS will not be able to resolve it.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Uses the default namespaces if unset. This removes
the need for the environment variables in demo
manifests when using the defaults.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Demo                       | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
