### PR TITLE
parameterize all images used in helm charts

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.configResyncInterval | string | `"0s"` | Sets the resync interval for regular proxy broadcast updates, set to 0s to not enforce any resync |
 | OpenServiceMesh.controlPlaneTolerations | list | `[]` | Node tolerations applied to control plane pods. The specified tolerations allow pods to schedule onto nodes with matching taints. |
 | OpenServiceMesh.controllerLogLevel | string | `"info"` | Controller log verbosity |
+| OpenServiceMesh.curlImage | string | `"curlimages/curl"` | Curl image for control plane init container |
 | OpenServiceMesh.deployGrafana | bool | `false` | Deploy Grafana with OSM installation |
 | OpenServiceMesh.deployJaeger | bool | `false` | Deploy Jaeger during OSM installation |
 | OpenServiceMesh.deployPrometheus | bool | `false` | Deploy Prometheus with OSM installation |
@@ -99,7 +100,9 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.fluentBit.tag | string | `"1.6.4"` | Fluent Bit sidecar image tag |
 | OpenServiceMesh.fluentBit.workspaceId | string | `""` | WorkspaceId for Fluent Bit output plugin to Log Analytics |
 | OpenServiceMesh.grafana.enableRemoteRendering | bool | `false` | Enable Remote Rendering in Grafana |
+| OpenServiceMesh.grafana.image | string | `"grafana/grafana:7.0.1"` | Image used for Grafana |
 | OpenServiceMesh.grafana.port | int | `3000` | Grafana service's port |
+| OpenServiceMesh.grafana.rendererImage | string | `"grafana/grafana-image-renderer:2.0.0-beta1"` | Image used for Grafana Renderer |
 | OpenServiceMesh.image.digest | object | `{"osmBootstrap":"","osmCRDs":"","osmController":"","osmInjector":"","osmSidecarInit":""}` | Image digest (defaults to latest compatible tag) |
 | OpenServiceMesh.image.digest.osmBootstrap | string | `""` | osm-boostrap's image digest |
 | OpenServiceMesh.image.digest.osmCRDs | string | `""` | osm-crds' image digest |
@@ -140,6 +143,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.osmNamespace | string | `""` | Namespace to deploy OSM in. If not specified, the Helm release namespace is used. |
 | OpenServiceMesh.outboundIPRangeExclusionList | list | `[]` | Specifies a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
 | OpenServiceMesh.outboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
+| OpenServiceMesh.prometheus.image | string | `"prom/prometheus:v2.18.1"` | Image used for Prometheus |
 | OpenServiceMesh.prometheus.port | int | `7070` | Prometheus service's port |
 | OpenServiceMesh.prometheus.resources | object | `{"limits":{"cpu":"1","memory":"2G"},"requests":{"cpu":"0.5","memory":"512M"}}` | Prometheus's container resource parameters |
 | OpenServiceMesh.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
@@ -149,6 +153,7 @@ The following table lists the configurable parameters of the osm chart and their
 | OpenServiceMesh.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | OpenServiceMesh.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | OpenServiceMesh.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |
+| OpenServiceMesh.tracing.image | string | `"jaegertracing/all-in-one"` | Image used for tracing |
 | OpenServiceMesh.tracing.port | int | `9411` | Port of the tracing collector service |
 | OpenServiceMesh.validatorWebhook.webhookConfigurationName | string | `""` | Name of the ValidatingWebhookConfiguration |
 | OpenServiceMesh.vault.host | string | `""` | Hashicorp Vault host/service - where Vault is installed |

--- a/charts/osm/templates/grafana-deployment.yaml
+++ b/charts/osm/templates/grafana-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: grafana
-          image: "grafana/grafana:7.0.1"
+          image: {{.Values.OpenServiceMesh.grafana.image}}
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -67,7 +67,7 @@ spec:
           - name: GF_LOG_FILTERS
             value: "rendering:debug"
         - name: renderer
-          image: grafana/grafana-image-renderer:2.0.0-beta1
+          image: {{.Values.OpenServiceMesh.grafana.rendererImage}}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/charts/osm/templates/jaeger-deployment.yaml
+++ b/charts/osm/templates/jaeger-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: jaeger
-        image: jaegertracing/all-in-one
+        image: {{ .Values.OpenServiceMesh.tracing.image }}
         args:
           - --collector.zipkin.host-port={{ .Values.OpenServiceMesh.tracing.port }}
         imagePullPolicy: IfNotPresent

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         kubernetes.io/os: linux
       initContainers:
         - name: init-osm-controller
-          image: curlimages/curl
+          image: {{ .Values.OpenServiceMesh.curlImage }}
           args:
           - /bin/sh
           - -c

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         kubernetes.io/os: linux
       initContainers:
         - name: init-osm-injector
-          image: curlimages/curl
+          image: {{ .Values.OpenServiceMesh.curlImage }}
           args:
           - /bin/sh
           - -c

--- a/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         kubernetes.io/os: linux
       initContainers:
         - name: osm-multicluster-gateway-init
-          image: curlimages/curl
+          image: {{ .Values.OpenServiceMesh.curlImage }}
           args:
           - /bin/sh
           - -c

--- a/charts/osm/templates/prometheus-deployment.yaml
+++ b/charts/osm/templates/prometheus-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - --storage.tsdb.path=/prometheus/
         - --storage.tsdb.retention.time={{.Values.OpenServiceMesh.prometheus.retention.time}}
         - --web.listen-address=:{{.Values.OpenServiceMesh.prometheus.port}}
-        image: prom/prometheus:v2.18.1
+        image: {{.Values.OpenServiceMesh.prometheus.image}}
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -133,6 +133,7 @@
             "required": [
                 "image",
                 "sidecarImage",
+                "curlImage",
                 "caBundleSecretName",
                 "enableDebugServer",
                 "enablePermissiveTrafficPolicy",
@@ -302,6 +303,15 @@
                     "description": "The proxy side car image to run.",
                     "examples": [
                         "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
+                    ]
+                },
+                "curlImage": {
+                    "$id": "#/properties/OpenServiceMesh/properties/curlImage",
+                    "type": "string",
+                    "title": "The curlImage schema",
+                    "description": "The curl image for control plane init containers.",
+                    "examples": [
+                        "curlimages/curl"
                     ]
                 },
                 "sidecarWindowsImage": {
@@ -624,7 +634,8 @@
                         "enable",
                         "address",
                         "port",
-                        "endpoint"
+                        "endpoint",
+                        "image"
                     ],
                     "properties": {
                         "enable": {
@@ -663,6 +674,15 @@
                             "description": "API path of the collector",
                             "examples": [
                                 "/api/v2/spans"
+                            ]
+                        },
+                        "image": {
+                            "$id": "#/properties/OpenServiceMesh/properties/tracing/properties/image",
+                            "type": "string",
+                            "title": "Jaeger's image schema",
+                            "description": "Image used for jaeger",
+                            "examples": [
+                                "jaegertracing/all-in-one"
                             ]
                         }
                     },
@@ -983,7 +1003,9 @@
                     "description": "Grafana configuration parameters",
                     "required": [
                         "port",
-                        "enableRemoteRendering"
+                        "enableRemoteRendering",
+                        "image",
+                        "rendererImage"
                     ],
                     "properties": {
                         "port": {
@@ -1005,12 +1027,32 @@
                             "examples": [
                                 true
                             ]
+                        },
+                        "image": {
+                            "$id": "#/properties/OpenServiceMesh/properties/grafana/properties/image",
+                            "type": "string",
+                            "title": "Grafana's image schema",
+                            "description": "Image used for Grafana",
+                            "examples": [
+                                "grafana/grafana:7.0.1"
+                            ]
+                        },
+                        "rendererImage": {
+                            "$id": "#/properties/OpenServiceMesh/properties/grafana/properties/rendererImage",
+                            "type": "string",
+                            "title": "Grafana's rendererImage schema",
+                            "description": "Renderer image used for Grafana",
+                            "examples": [
+                                "grafana/grafana-image-renderer:2.0.0-beta1"
+                            ]
                         }
                     },
                     "examples": [
                         {
                             "port": 3000,
-                            "enableRemoteRendering": true
+                            "enableRemoteRendering": true,
+                            "image": "grafana/grafana:7.0.1",
+                            "rendererImage": "grafana/grafana-image-renderer:2.0.0-beta1"
                         }
                     ],
                     "additionalProperties": false
@@ -1112,7 +1154,8 @@
                     "required": [
                         "resources",
                         "port",
-                        "retention"
+                        "retention",
+                        "image"
                     ],
                     "properties": {
                         "resources": {
@@ -1148,6 +1191,15 @@
                                     ]
                                 }
                             }
+                        },
+                        "image": {
+                            "$id": "#/properties/OpenServiceMesh/properties/prometheus/properties/image",
+                            "type": "string",
+                            "title": "Prometheus's image schema",
+                            "description": "Image used for Prometheus",
+                            "examples": [
+                                "prom/prometheus:v2.18.1"
+                            ]
                         }
                     },
                     "additionalProperties": false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -33,6 +33,8 @@ OpenServiceMesh:
   sidecarImage: envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd
   # -- Envoy sidecar image for Windows workloads (v1.19.1)
   sidecarWindowsImage: envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85
+  # -- Curl image for control plane init container
+  curlImage: curlimages/curl
 
   #
   # -- OSM controller parameters
@@ -79,6 +81,8 @@ OpenServiceMesh:
     retention:
       # -- Prometheus data retention time
       time: 15d
+    # -- Image used for Prometheus
+    image: prom/prometheus:v2.18.1
 
   certificateProvider:
     # -- The Certificate manager type: `tresor`, `vault` or `cert-manager`
@@ -120,6 +124,10 @@ OpenServiceMesh:
     port: 3000
     # -- Enable Remote Rendering in Grafana
     enableRemoteRendering: false
+    # -- Image used for Grafana
+    image: grafana/grafana:7.0.1
+    # -- Image used for Grafana Renderer
+    rendererImage: grafana/grafana-image-renderer:2.0.0-beta1
 
   # -- Enable the debug HTTP server on OSM controller
   enableDebugServer: false
@@ -208,6 +216,8 @@ OpenServiceMesh:
     port: 9411
     # -- Tracing collector's API path where the spans will be sent to
     endpoint: "/api/v2/spans"
+    # -- Image used for tracing
+    image: jaegertracing/all-in-one
 
   # -- Specifies a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy.
   # If specified, must be a list of IP ranges of the form a.b.c.d/x.


### PR DESCRIPTION
**Description**:

Update all the images used in the helm charts to be parameterized via
the values.yaml.

Fixes #4315

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
