### PR TITLE
chore(grafana): update Grafana version

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -103,9 +103,9 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.fluentBit.tag | string | `"1.6.4"` | Fluent Bit sidecar image tag |
 | osm.fluentBit.workspaceId | string | `""` | WorkspaceId for Fluent Bit output plugin to Log Analytics |
 | osm.grafana.enableRemoteRendering | bool | `false` | Enable Remote Rendering in Grafana |
-| osm.grafana.image | string | `"grafana/grafana:7.0.1"` | Image used for Grafana |
+| osm.grafana.image | string | `"grafana/grafana:8.2.2"` | Image used for Grafana |
 | osm.grafana.port | int | `3000` | Grafana service's port |
-| osm.grafana.rendererImage | string | `"grafana/grafana-image-renderer:2.0.0-beta1"` | Image used for Grafana Renderer |
+| osm.grafana.rendererImage | string | `"grafana/grafana-image-renderer:3.2.1"` | Image used for Grafana Renderer |
 | osm.image.digest | object | `{"osmBootstrap":"","osmCRDs":"","osmController":"","osmInjector":"","osmSidecarInit":""}` | Image digest (defaults to latest compatible tag) |
 | osm.image.digest.osmBootstrap | string | `""` | osm-boostrap's image digest |
 | osm.image.digest.osmCRDs | string | `""` | osm-crds' image digest |

--- a/charts/osm/grafana/dashboards/osm-control-plane.json
+++ b/charts/osm/grafana/dashboards/osm-control-plane.json
@@ -158,7 +158,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -265,7 +265,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -350,7 +350,7 @@
           }
         ],
         "title": "Active Connections to Control Plane",
-        "type": "graph",
+        "type": "timeseries",
         "timeFrom": null,
         "timeShift": null,
         "renderer": "flot",
@@ -485,7 +485,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -617,7 +617,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/charts/osm/grafana/dashboards/osm-data-plane-container.json
+++ b/charts/osm/grafana/dashboards/osm-data-plane-container.json
@@ -144,7 +144,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -238,7 +238,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -346,7 +346,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -440,7 +440,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
+++ b/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
@@ -149,7 +149,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -372,7 +372,7 @@
           "options": {}
         }
       ],
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -490,7 +490,7 @@
           "options": {}
         }
       ],
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -883,7 +883,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -999,7 +999,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1113,7 +1113,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1216,7 +1216,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",
@@ -1310,7 +1310,7 @@
         "sort": 0,
         "value_type": "individual"
       },
-      "type": "graph",
+      "type": "timeseries",
       "xaxis": {
         "buckets": null,
         "mode": "time",

--- a/charts/osm/grafana/dashboards/osm-pod.json
+++ b/charts/osm/grafana/dashboards/osm-pod.json
@@ -157,7 +157,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -264,7 +264,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -349,7 +349,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -471,7 +471,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -566,7 +566,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -661,7 +661,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -746,7 +746,7 @@
           }
         ],
         "title": "Active Connections to other services",
-        "type": "graph",
+        "type": "timeseries",
         "timeFrom": null,
         "timeShift": null,
         "renderer": "flot",
@@ -914,7 +914,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1008,7 +1008,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1103,7 +1103,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/charts/osm/grafana/dashboards/osm-service-to-service.json
+++ b/charts/osm/grafana/dashboards/osm-service-to-service.json
@@ -157,7 +157,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -264,7 +264,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -372,7 +372,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -466,7 +466,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -560,7 +560,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -645,7 +645,7 @@
           }
         ],
         "title": "Active Connections between services",
-        "type": "graph",
+        "type": "timeseries",
         "timeFrom": null,
         "timeShift": null,
         "renderer": "flot",
@@ -780,7 +780,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -912,7 +912,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/charts/osm/grafana/dashboards/osm-workload.json
+++ b/charts/osm/grafana/dashboards/osm-workload.json
@@ -157,7 +157,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -264,7 +264,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -373,7 +373,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -468,7 +468,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -563,7 +563,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -648,7 +648,7 @@
           }
         ],
         "title": "Active Connections to other services",
-        "type": "graph",
+        "type": "timeseries",
         "timeFrom": null,
         "timeShift": null,
         "renderer": "flot",
@@ -816,7 +816,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -910,7 +910,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",
@@ -1005,7 +1005,7 @@
           "sort": 0,
           "value_type": "individual"
         },
-        "type": "graph",
+        "type": "timeseries",
         "xaxis": {
           "buckets": null,
           "mode": "time",

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1034,7 +1034,7 @@
                             "title": "Grafana's image schema",
                             "description": "Image used for Grafana",
                             "examples": [
-                                "grafana/grafana:7.0.1"
+                                "grafana/grafana:8.2.2"
                             ]
                         },
                         "rendererImage": {
@@ -1043,7 +1043,7 @@
                             "title": "Grafana's rendererImage schema",
                             "description": "Renderer image used for Grafana",
                             "examples": [
-                                "grafana/grafana-image-renderer:2.0.0-beta1"
+                                "grafana/grafana-image-renderer:3.2.1"
                             ]
                         }
                     },
@@ -1051,8 +1051,8 @@
                         {
                             "port": 3000,
                             "enableRemoteRendering": true,
-                            "image": "grafana/grafana:7.0.1",
-                            "rendererImage": "grafana/grafana-image-renderer:2.0.0-beta1"
+                            "image": "grafana/grafana:8.2.2",
+                            "rendererImage": "grafana/grafana-image-renderer:3.2.1"
                         }
                     ],
                     "additionalProperties": false

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -125,9 +125,9 @@ osm:
     # -- Enable Remote Rendering in Grafana
     enableRemoteRendering: false
     # -- Image used for Grafana
-    image: grafana/grafana:7.0.1
+    image: grafana/grafana:8.2.2
     # -- Image used for Grafana Renderer
-    rendererImage: grafana/grafana-image-renderer:2.0.0-beta1
+    rendererImage: grafana/grafana-image-renderer:3.2.1
 
   # -- Enable the debug HTTP server on OSM controller
   enableDebugServer: false


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updates image versions for grafana and grafana image renderer. The
version of grafana that osm currently uses is not supported by
Grafana Labs. Therefore, osm cannot share dashboards in the grafana
dashboard library.

Updates outdated graph type to timeseries.

Part of #4282 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**

Installed osm with Prometheus and Grafana enabled. The Grafana instance behaved as
expected and the time-series graphs were rendered correctly.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ x ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
