### PR TITLE
tests/e2e: skip traffic split selector test for OpenShift

### DIFF
--- a/tests/e2e/e2e_trafficsplit_selector_test.go
+++ b/tests/e2e/e2e_trafficsplit_selector_test.go
@@ -48,6 +48,10 @@ var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment
 
 func testTrafficSplitSelector() {
 	It("Tests HTTP traffic split when root service selector matches backends", func() {
+		if Td.DeployOnOpenShift {
+			Skip("Skipping test: TrafficSplit selector test not supported on OpenShift")
+		}
+
 		clientNs := "client"
 		clientName := "client"
 		serviceNs := "server"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The traffic split selector test uses default service accounts
and doesn't need to be tested on OpenShift. The security
context constraints would need to be applied for this test
to work on OpenShift, while the test itself is primarily
testing the label selector logic in the control plane.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
