### PR TITLE
ref(tcp): support tcp-server-first inside the mesh

### DIFF
--- a/demo/deploy-mysql.sh
+++ b/demo/deploy-mysql.sh
@@ -24,7 +24,7 @@ spec:
   - port: 3306
     targetPort: 3306
     name: client
-    appProtocol: tcp
+    appProtocol: tcp-server-first
   selector:
     app: mysql
   clusterIP: None

--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -68,7 +68,7 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 
 		// Build the HTTP route configs for this service and port combination.
 		// If the port's protocol corresponds to TCP, we can skip this step
-		if upstreamSvc.Protocol == constants.ProtocolTCP {
+		if upstreamSvc.Protocol == constants.ProtocolTCP || upstreamSvc.Protocol == constants.ProtocolTCPServerFirst {
 			continue
 		}
 		// ---

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -878,7 +878,7 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 		},
 		{
 			name: "multiple services with different protocol, SMI mode, 1 TrafficTarget, 1 HTTPRouteGroup, 0 TrafficSplit",
-			// Port ns1/s2:90 uses TCP, so HTTP route configs for it should not be built
+			// Ports ns1/s2:90 and ns1/s3:91 use TCP, so HTTP route configs for them should not be built
 			upstreamIdentity: upstreamSvcAccount.ToServiceIdentity(),
 			upstreamServices: []service.MeshService{
 				{
@@ -894,6 +894,13 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 					Port:       90,
 					TargetPort: 90,
 					Protocol:   "tcp",
+				},
+				{
+					Name:       "s3",
+					Namespace:  "ns1",
+					Port:       91,
+					TargetPort: 91,
+					Protocol:   "tcp-server-first",
 				},
 			},
 			permissiveMode: false,
@@ -1008,6 +1015,12 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 						Service: service.MeshService{Namespace: "ns1", Name: "s2", Port: 90, TargetPort: 90, Protocol: "tcp"},
 						Address: "127.0.0.1",
 						Port:    90,
+					},
+					{
+						Name:    "ns1/s3|91|local",
+						Service: service.MeshService{Namespace: "ns1", Name: "s3", Port: 91, TargetPort: 91, Protocol: "tcp-server-first"},
+						Address: "127.0.0.1",
+						Port:    91,
 					},
 				},
 			},

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -108,7 +108,7 @@ func (mc *MeshCatalog) GetOutboundMeshTrafficPolicy(downstreamIdentity identity.
 
 		// Build the HTTP route configs for this service and port combination.
 		// If the port's protocol corresponds to TCP, we can skip this step
-		if meshSvc.Protocol == constants.ProtocolTCP {
+		if meshSvc.Protocol == constants.ProtocolTCP || meshSvc.Protocol == constants.ProtocolTCPServerFirst {
 			continue
 		}
 		// Create a route to access the upstream service via it's hostnames and upstream weighted clusters

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -43,7 +43,7 @@ func (lb *listenerBuilder) getInboundMeshFilterChains(proxyService service.MeshS
 		}
 		filterChains = append(filterChains, filterChainForPort)
 
-	case constants.ProtocolTCP:
+	case constants.ProtocolTCP, constants.ProtocolTCPServerFirst:
 		filterChainForPort, err := lb.getInboundMeshTCPFilterChain(proxyService, uint32(proxyService.TargetPort))
 		if err != nil {
 			log.Error().Err(err).Msgf("Error building inbound TCP filter chain for proxy:port %s:%d", proxyService, proxyService.TargetPort)
@@ -407,7 +407,7 @@ func (lb *listenerBuilder) getOutboundFilterChainPerUpstream() []*xds_listener.F
 				filterChains = append(filterChains, httpFilterChain)
 			}
 
-		case constants.ProtocolTCP:
+		case constants.ProtocolTCP, constants.ProtocolTCPServerFirst:
 			// Construct TCP filter chain
 			if tcpFilterChain, err := lb.getOutboundTCPFilterChainForService(*trafficMatch); err != nil {
 				log.Error().Err(err).Msgf("Error constructing outbound TCP filter chain for traffic match %s on proxy with identity %s", trafficMatch.Name, lb.serviceIdentity)

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -9,7 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/service"
 )
 
@@ -47,25 +46,6 @@ func GetServiceFromHostname(host string) string {
 	// For services that are not namespaced the service name contains the port as well
 	// Ex. service:port
 	return strings.Split(service, ":")[0]
-}
-
-// GetAppProtocolFromPortName returns the port's application protocol from its name, defaults to 'http' if not specified.
-func GetAppProtocolFromPortName(portName string) string {
-	portName = strings.ToLower(portName)
-
-	switch {
-	case strings.HasPrefix(portName, "http-"):
-		return "http"
-
-	case strings.HasPrefix(portName, "tcp-"):
-		return "tcp"
-
-	case strings.HasPrefix(portName, "grpc-"):
-		return "grpc"
-
-	default:
-		return constants.ProtocolHTTP
-	}
 }
 
 // GetKubernetesServerVersionNumber returns the Kubernetes server version number in chunks, ex. v1.19.3 => [1, 19, 3]

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -103,44 +103,6 @@ func TestGetServiceFromHostname(t *testing.T) {
 	}
 }
 
-func TestGetAppProtocolFromPortName(t *testing.T) {
-	testCases := []struct {
-		name             string
-		portName         string
-		expectedProtocal string
-	}{
-		{
-			name:             "tcp protocol",
-			portName:         "tcp-port-test",
-			expectedProtocal: "tcp",
-		},
-		{
-			name:             "http protocol",
-			portName:         "http-port-test",
-			expectedProtocal: "http",
-		},
-		{
-			name:             "grpc protocol",
-			portName:         "grpc-port-test",
-			expectedProtocal: "grpc",
-		},
-		{
-			name:             "default protocol",
-			portName:         "port-test",
-			expectedProtocal: "http",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert := tassert.New(t)
-
-			actual := GetAppProtocolFromPortName(tc.portName)
-			assert.Equal(tc.expectedProtocal, actual)
-		})
-	}
-}
-
 func TestGetKubernetesServerVersionNumber(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/tests/e2e/e2e_tcp_server_first_test.go
+++ b/tests/e2e/e2e_tcp_server_first_test.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/tests/framework"
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("TCP server-first traffic",
+	OSMDescribeInfo{
+		Tier:   1,
+		Bucket: 1,
+	},
+	func() {
+		var (
+			sourceNs = framework.RandomNameWithPrefix("client")
+			destNs   = framework.RandomNameWithPrefix("server")
+			ns       = []string{sourceNs, destNs}
+		)
+
+		It("TCP server-first traffic", func() {
+			// Install OSM
+			installOpts := Td.GetOSMInstallOpts()
+			installOpts.EnablePermissiveMode = true
+			Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+			// Create Test NS
+			for _, n := range ns {
+				Expect(Td.CreateNs(n, nil)).To(Succeed())
+				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+			}
+
+			destinationPort := 80
+
+			// Get simple pod definitions for the TCP server
+			svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
+				SimplePodAppDef{
+					PodName:     framework.RandomNameWithPrefix("server"),
+					Namespace:   destNs,
+					Image:       "busybox",
+					Command:     []string{"nc", "-lkp", strconv.Itoa(destinationPort), "-e", "sh", "-c", "while yes; do :; done"},
+					Ports:       []int{destinationPort},
+					AppProtocol: constants.ProtocolTCPServerFirst,
+					OS:          Td.ClusterOS,
+				},
+			)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = Td.CreateServiceAccount(destNs, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreatePod(destNs, podDef)
+			Expect(err).NotTo(HaveOccurred())
+			dstSvc, err := Td.CreateService(destNs, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Expect it to be up and running in it's receiver namespace
+			Expect(Td.WaitForPodsRunningReady(destNs, 120*time.Second, 1, nil)).To(Succeed())
+
+			svcAccDef, podDef, _, err = Td.SimplePodApp(SimplePodAppDef{
+				PodName:   framework.RandomNameWithPrefix("client"),
+				Namespace: sourceNs,
+				Command:   []string{"nc", dstSvc.Name + "." + dstSvc.Namespace, strconv.Itoa(destinationPort)},
+				Image:     "busybox",
+				OS:        Td.ClusterOS,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateServiceAccount(sourceNs, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreatePod(sourceNs, podDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(Td.WaitForPodsRunningReady(sourceNs, 120*time.Second, 1, nil)).To(Succeed())
+
+			Eventually(func() (string, error) {
+				return getPodLogs(sourceNs, podDef.Name, podDef.Name)
+			}, 5*time.Second).Should(ContainSubstring("\ny\n"), "Didn't get expected response from server")
+		})
+	})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the capability for OSM to handle ports with
`appProtocol: tcp-server-first` on services within the mesh.
Specifically, the main change is to add handling for `tcp-server-first`
ports in the mesh when we calculate the predicate function used to
disable the TLS and HTTP inspector listener filters. Previously, this
was only done for `tcp-server-first` ports specified in an Egress
policy resource.

Fixes #4313

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Tested manually with the example in #4313 and with the automated demo to ensure that still works as expected.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
