### PR TITLE
update curl command for init containers

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -38,14 +38,7 @@ spec:
       initContainers:
         - name: init-osm-controller
           image: {{ .Values.osm.curlImage }}
-          args:
-          - /bin/sh
-          - -c
-          - >
-            set -x;
-            while [ $(curl --connect-timeout 2 -sw '%{http_code}' "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
-              sleep 10;
-            done
+          command: ["curl", "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz", "--connect-timeout", "2", "--retry", "50", "--retry-connrefused", "--retry-delay", "5"]
       containers:
         - name: osm-controller
           image: "{{ include "osmController.image" . }}"

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -37,14 +37,7 @@ spec:
       initContainers:
         - name: init-osm-injector
           image: {{ .Values.osm.curlImage }}
-          args:
-          - /bin/sh
-          - -c
-          - >
-            set -x;
-            while [ $(curl --connect-timeout 2 -sw '%{http_code}' "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz" -o /dev/null) -ne 200 ]; do
-              sleep 10;
-            done
+          command: ["curl", "http://osm-bootstrap.{{ include "osm.namespace" . }}.svc.cluster.local:9095/healthz", "--connect-timeout", "2", "--retry", "50", "--retry-connrefused", "--retry-delay", "5"]
       containers:
         - name: osm-injector
           image: "{{ include "osmInjector.image" . }}"


### PR DESCRIPTION
**Description**:

The args for the culr job on the init containers in osm-controller and
osm-injector has beeen updated to use curl params rather than bash

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Testing done**: Manually verified the demo and everything works as expected 

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
