### PR TITLE
fix(maestro): update pod readiness checks

### DIFF
--- a/ci/cmd/maestro.go
+++ b/ci/cmd/maestro.go
@@ -30,6 +30,7 @@ const (
 	bookstoreV1Label   = "bookstore-v1"
 	bookstoreV2Label   = "bookstore-v2"
 	bookWarehouseLabel = "bookwarehouse"
+	mySQLLabel         = "mysql"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 	bookstoreV1Selector      = fmt.Sprintf("%s=%s", constants.AppLabel, bookstoreV1Label)
 	bookstoreV2Selector      = fmt.Sprintf("%s=%s", constants.AppLabel, bookstoreV2Label)
 	bookWarehouseSelector    = fmt.Sprintf("%s=%s", constants.AppLabel, bookWarehouseLabel)
+	mySQLSelector            = fmt.Sprintf("%s=%s", constants.AppLabel, mySQLLabel)
 
 	osmNamespace    = utils.GetEnv(maestro.OSMNamespaceEnvVar, "osm-system")
 	bookbuyerNS     = utils.GetEnv(maestro.BookbuyerNamespaceEnvVar, "bookbuyer")
@@ -59,7 +61,7 @@ var (
 )
 
 func main() {
-	log.Debug().Msgf("Looking for: %s/%s, %s/%s, %s/%s, %s/%s, %s/%s", bookBuyerLabel, bookbuyerNS, bookThiefLabel, bookthiefNS, bookstoreV1Label, bookstoreNS, bookstoreV2Label, bookstoreNS, bookWarehouseLabel, bookWarehouseNS)
+	log.Debug().Msgf("Looking for: %s/%s, %s/%s, %s/%s, %s/%s, %s/%s %s/%s", bookBuyerLabel, bookbuyerNS, bookThiefLabel, bookthiefNS, bookstoreV1Label, bookstoreNS, bookstoreV2Label, bookstoreNS, bookWarehouseLabel, bookWarehouseNS, mySQLLabel, bookWarehouseNS)
 
 	kubeClient := maestro.GetKubernetesClient()
 
@@ -158,6 +160,9 @@ func getPodNames(kubeClient kubernetes.Interface) (string, string, string, strin
 
 	wg.Add(1)
 	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookWarehouseNS, bookWarehouseSelector, &wg)
+
+	wg.Add(1)
+	go maestro.WaitForPodToBeReady(kubeClient, maxWaitForPod(), bookWarehouseNS, mySQLSelector, &wg)
 
 	wg.Wait()
 


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
These changes add a new check in the maestro that the MySQL pod  in the
bookwarehouse namespace is ready. It also updates
`WaitForPodToBeReady()` to check the `Ready` condition on the Pod which
is more complete than the existing check that each container in the Pod
is ready.

This should at least partially address the recent flakiness of the automated demo in CI.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Ran the automated demo and maestro locally.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
