### PR TITLE
fix(chart): set additionalProperties on root in schema

### DIFF
--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1266,5 +1266,6 @@
                 }
             }
         }
-    }
+    },
+    "additionalProperties": false
 }


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change sets `"additionalProperties": false` in values.schema.json
on the root object to catch errors like `osm install --set doesntExist=true`,
which previously were allowed.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
