### PR TITLE
fix(grafana): remove irate from active connection query

### DIFF
--- a/charts/osm/grafana/dashboards/osm-pod.json
+++ b/charts/osm/grafana/dashboards/osm-pod.json
@@ -439,7 +439,7 @@
         "pluginVersion": "7.0.1",
         "targets": [
           {
-            "expr": "irate(envoy_cluster_upstream_cx_active{source_pod_name=\"$source_pod\",source_namespace=\"$source_namespace\",envoy_cluster_name!~\"osm-controller|envoy-metrics-cluster|envoy-tracing-cluster|passthrough-outbound\"}[1m])",
+            "expr": "envoy_cluster_upstream_cx_active{source_pod_name=\"$source_pod\",source_namespace=\"$source_namespace\",envoy_cluster_name!~\"osm-controller|envoy-metrics-cluster|envoy-tracing-cluster|passthrough-outbound\"}",
             "legendFormat": "{{envoy_cluster_name}}",
             "refId": "A"
           }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Removes the irate function from the envoy cluster upstream active
connection query used in the OSM Pod to Service dashboard. The
irate function is meant to be used on counters, not gauges. 

Resolves #4323

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

Verified the updated query generated the expected data on the active connections graph.

**New Dashboard**:
![image](https://user-images.githubusercontent.com/64559656/139962676-e08adc9d-bdad-48ee-9599-492cf0aa649b.png)

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ x ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
