### PR TITLE
fix(upgrade): handle removed values

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,7 +248,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         env:
           K8S_NAMESPACE: "osm-system"
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\]' -ginkgo.skip='Upgrade'
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\]'
         continue-on-error: true
       - name: Upload PR test logs
         if: ${{ steps.pr_test.conclusion != 'skipped' }}
@@ -269,7 +269,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         env:
           K8S_NAMESPACE: "osm-system"
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\]' -ginkgo.skip='Upgrade'
+        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\]'
         continue-on-error: true
       - name: Upload Push test logs
         if: ${{ steps.push_test.conclusion != 'skipped' }}
@@ -282,25 +282,6 @@ jobs:
         run: exit 1
       - name: Clean Push tests logs
         if: ${{ steps.push_test.conclusion != 'skipped' }}
-        run: rm -rf /tmp/test*
-
-      # Upgrade tests
-      - name: Run Upgrade tests
-        id: upgrade_tests
-        env:
-          K8S_NAMESPACE: "osm-system"
-        run: go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=KindCluster -test.timeout 0 -test.failfast -ginkgo.failFast -ginkgo.focus='\[Bucket ${{ matrix.bucket }}\].*Upgrade'
-        continue-on-error: true
-      - name: Upload Upgrade test logs
-        uses: actions/upload-artifact@v2
-        with:
-          name: upgrade_test_logs_bucket_${{ matrix.bucket }}
-          path: /tmp/test**/*
-      - name: Check continue Upgrade tests
-        # Only fail CI when upgrade fails if we're running on a release branch. The main branch may introduce breaking changes at any time.
-        if: ${{ steps.upgrade_tests.outcome == 'failure' && !(!(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release-') || github.event_name == 'pull_request' && startsWith(github.base_ref, 'refs/heads/release-'))) }}
-        run: exit 1
-      - name: Clean Upgrade test logs
         run: rm -rf /tmp/test*
 
   integration-tresor:

--- a/cmd/cli/mesh_upgrade_test.go
+++ b/cmd/cli/mesh_upgrade_test.go
@@ -36,11 +36,9 @@ func defaultMeshUpgradeCmd() *meshUpgradeCmd {
 	}
 
 	return &meshUpgradeCmd{
-		out:               ioutil.Discard,
-		meshName:          defaultMeshName,
-		chart:             chart,
-		containerRegistry: defaultContainerRegistry,
-		osmImageTag:       defaultOsmImageTag,
+		out:      ioutil.Discard,
+		meshName: defaultMeshName,
+		chart:    chart,
 	}
 }
 
@@ -56,10 +54,12 @@ func TestMeshUpgradeDefault(t *testing.T) {
 
 	u := defaultMeshUpgradeCmd()
 
-	upgraded, err := action.NewGet(config).Run(u.meshName)
+	getVals := action.NewGetValues(config)
+	getVals.AllValues = true
+	upgraded, err := getVals.Run(u.meshName)
 	a.Nil(err)
 
-	meshName, err := chartutil.Values(upgraded.Config).PathValue("osm.meshName")
+	meshName, err := chartutil.Values(upgraded).PathValue("osm.meshName")
 	a.Nil(err)
 	a.Equal(defaultMeshName, meshName)
 	err = u.run(config)
@@ -78,32 +78,38 @@ func TestMeshUpgradeOverridesInstallDefaults(t *testing.T) {
 	a.Nil(err)
 
 	u := defaultMeshUpgradeCmd()
-	u.osmImageTag = "upgraded"
+	defaultImageRegVal, err := chartutil.Values(u.chart.Values).PathValue("osm.image.registry")
+	a.NoError(err)
+	defaultImageReg := defaultImageRegVal.(string)
+	upgradedImageReg := "upgraded-" + defaultImageReg
+	u.setOptions = []string{"osm.image.registry=" + upgradedImageReg}
 
 	err = u.run(config)
 	a.Nil(err)
 
-	upgraded, err := action.NewGet(config).Run(u.meshName)
+	getVals := action.NewGetValues(config)
+	getVals.AllValues = true
+	upgraded, err := getVals.Run(u.meshName)
 	a.Nil(err)
 
-	osmImageTag, err := chartutil.Values(upgraded.Config).PathValue("osm.image.tag")
+	osmImageReg, err := chartutil.Values(upgraded).PathValue("osm.image.registry")
 	a.Nil(err)
-	a.Equal("upgraded", osmImageTag)
+	a.Equal(upgradedImageReg, osmImageReg)
 
 	// Successive upgrades overriddes image-tag values from the previous upgrade
 	u = defaultMeshUpgradeCmd()
 	err = u.run(config)
 	a.Nil(err)
 
-	upgraded, err = action.NewGet(config).Run(u.meshName)
+	upgraded, err = getVals.Run(u.meshName)
 	a.Nil(err)
 
-	osmImageTag, err = chartutil.Values(upgraded.Config).PathValue("osm.image.tag")
+	osmImageReg, err = chartutil.Values(upgraded).PathValue("osm.image.registry")
 	a.Nil(err)
-	a.Equal(defaultOsmImageTag, osmImageTag)
+	a.Equal(defaultImageReg, osmImageReg)
 }
 
-func TestMeshUpgradeKeepsInstallOverrides(t *testing.T) {
+func TestMeshUpgradeDropsInstallOverrides(t *testing.T) {
 	a := assert.New(t)
 
 	config := meshUpgradeConfig()
@@ -112,7 +118,7 @@ func TestMeshUpgradeKeepsInstallOverrides(t *testing.T) {
 	i.chartPath = testChartPath
 	i.setOptions = []string{
 		"osm.enableEgress=true",
-		"osm.osmImageTag=installed",
+		"osm.image.registry=installed",
 		"osm.envoyLogLevel=trace",
 	}
 
@@ -124,23 +130,19 @@ func TestMeshUpgradeKeepsInstallOverrides(t *testing.T) {
 	err = u.run(config)
 	a.Nil(err)
 
-	upgraded, err := action.NewGet(config).Run(u.meshName)
+	getVals := action.NewGetValues(config)
+	getVals.AllValues = true
+	upgraded, err := getVals.Run(u.meshName)
 	a.Nil(err)
 
-	// enableEgress should be unchanged by default
-	egressEnabled, err := chartutil.Values(upgraded.Config).PathValue("osm.enableEgress")
-	a.Nil(err)
-	a.Equal(true, egressEnabled)
-
-	// envoyLogLevel should be unchanged by default
-	envoyLogLevel, err := chartutil.Values(upgraded.Config).PathValue("osm.envoyLogLevel")
-	a.Nil(err)
-	a.Equal("trace", envoyLogLevel)
-
-	// image tag should be updated by default
-	tag, err := chartutil.Values(upgraded.Config).PathValue("osm.image.tag")
-	a.Nil(err)
-	a.Equal(defaultOsmImageTag, tag)
+	// Values overridden at install should be the same as their defaults in the
+	// chart after an upgrade that sets no values
+	for _, valKey := range []string{"osm.enableEgress", "osm.image.registry", "osm.envoyLogLevel"} {
+		def, defErr := chartutil.Values(u.chart.Values).PathValue(valKey)
+		upgradedVal, upgErr := chartutil.Values(upgraded).PathValue(valKey)
+		a.Equal(def, upgradedVal)
+		a.Equal(defErr, upgErr)
+	}
 }
 
 func TestMeshUpgradeToModifiedChart(t *testing.T) {
@@ -172,11 +174,36 @@ func TestMeshUpgradeToModifiedChart(t *testing.T) {
 	err = u.run(config)
 	a.Nil(err)
 
-	upgraded, err := action.NewGet(config).Run(u.meshName)
+	getVals := action.NewGetValues(config)
+	getVals.AllValues = true
+	upgraded, err := getVals.Run(u.meshName)
 	a.Nil(err)
 
-	// When a default is changed in values.yaml, keep the old one
-	namespace, err := chartutil.Values(upgraded.Config).PathValue("osm.namespace")
+	// When a default is changed in values.yaml, use the new one
+	namespace, err := chartutil.Values(upgraded).PathValue("osm.namespace")
 	a.Nil(err)
-	a.Equal(oldNamespace, namespace)
+	a.Equal(newNamespace, namespace)
+}
+
+func TestMeshUpgradeRemovedValue(t *testing.T) {
+	a := assert.New(t)
+
+	config := meshUpgradeConfig()
+
+	i := getDefaultInstallCmd(ioutil.Discard)
+	i.chartPath = testChartPath
+	err := i.run(config)
+	a.NoError(err)
+
+	u := defaultMeshUpgradeCmd()
+
+	// Upgrade to a "new version" of the chart with a deleted value.
+	_, err = chartutil.Values(u.chart.Values).PathValue("osm.namespace")
+	a.NoError(err)
+	delete(u.chart.Values["osm"].(map[string]interface{}), "namespace")
+	// Schema only accepting the remaining values
+	u.chart.Schema = []byte(`{"properties": {"osm": {"properties": {"image": {}, "imagePullSecrets": {}}, "additionalProperties": false}}}`)
+
+	err = u.run(config)
+	a.NoError(err)
 }

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -85,6 +85,7 @@ Create a new commit on the patch branch to update the hardcoded version informat
 * The chart and app version in [charts/osm/Chart.yaml](/charts/osm/Chart.yaml) to the release version.
 * The Helm chart [README.md](/charts/osm/README.md)
   - Necessary changes should be made automatically by running `make chart-readme`
+* If this the first release on a new release branch, update the [upgrade e2e test](/tests/e2e/e2e_upgrade_test.go) install version from `i.Version = ">0.0.0-0"` to the previous minor release. e.g. When cutting the release-v1.1 branch, this should be updated to `"1.0"`.
 
 Once patches and version information have been updated on the patch branch off of the release branch, create a pull request from the patch branch to the release branch. When creating your pull request, generate the release checklist for the description by adding the following to the PR URL: `?expand=1&template=release_pull_request_template.md`. Alternatively, copy the raw template from [release_pull_request_template.md](/.github/PULL_REQUEST_TEMPLATE/release_pull_request_template.md).
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,6 +15,7 @@
 The following changes are not backward compatible with the previous release.
 
 - Top level Helm chart keys are renamed from `OpenServiceMesh` to `osm`
+- `osm mesh upgrade` no longer carries over values from previous releases. Use the `--set` flag on `osm mesh upgrade` to pass values as needed. The `--container-registry` and `--osm-image-tag` flags have also been removed in favor of `--set`.
 
 ### Deprecation notes
 


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Currently, upgrading OSM with `osm mesh upgrade` fails when the newer
chart version removes or renames values from the installed chart because
values.schema.json defines `"additionalProperties": false` on each
object and `osm mesh upgrade` uses all the values from the installed
chart.

Now, the `osm mesh upgrade` command will not use any values from the old
release. Users can specify them with the new `--set` flag.

Fixes #4330

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Manually ran affected tests and other upgrade scenarios based on the existing e2e test.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [X] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [X] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? Yes, release notes have been updated.
