### PR TITLE
feat(injector): add iptables inbound rule for inbound localhost

### DIFF
--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -62,6 +62,9 @@ var iptablesInboundStaticRules = []string{
 	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", readinessProbePort),
 	fmt.Sprintf("iptables -t nat -A PROXY_INBOUND -p tcp --dport %d -j RETURN", startupProbePort),
 
+	// Skip localhost traffic, doesn't need to be routed via the proxy
+	"iptables -t nat -A PROXY_INBOUND -d 127.0.0.1/32 -j RETURN",
+
 	// Redirect remaining inbound traffic to Envoy
 	"iptables -t nat -A PROXY_INBOUND -p tcp -j PROXY_IN_REDIRECT",
 }


### PR DESCRIPTION
Adds a rule so that incoming traffic where the destination is
localhost does not go through the Envoy sidecar.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [x] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution? NA

2. Is this a breaking change? NA
