### PR TITLE
fix(init): set init container level security context

### DIFF
--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
@@ -23,6 +24,9 @@ func getInitContainerSpec(containerName string, cfg configurator.Configurator, o
 					"NET_ADMIN",
 				},
 			},
+			RunAsNonRoot: pointer.BoolPtr(false),
+			// User ID 0 corresponds to root
+			RunAsUser: pointer.Int64Ptr(0),
 		},
 		Command: []string{"/bin/sh"},
 		Args: []string{

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -18,6 +18,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 	privilegedFalse := false
 	privilegedTrue := true
+	runAsNonRootFalse := false
+	runAsUserID := int64(0)
 
 	mockCtrl := gomock.NewController(GinkgoT())
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
@@ -44,7 +46,9 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 							"NET_ADMIN",
 						},
 					},
-					Privileged: &privilegedFalse,
+					Privileged:   &privilegedFalse,
+					RunAsNonRoot: &runAsNonRootFalse,
+					RunAsUser:    &runAsUserID,
 				},
 				Stdin:     false,
 				StdinOnce: false,
@@ -76,7 +80,9 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 							"NET_ADMIN",
 						},
 					},
-					Privileged: &privilegedFalse,
+					Privileged:   &privilegedFalse,
+					RunAsNonRoot: &runAsNonRootFalse,
+					RunAsUser:    &runAsUserID,
 				},
 				Stdin:     false,
 				StdinOnce: false,
@@ -107,7 +113,9 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 							"NET_ADMIN",
 						},
 					},
-					Privileged: &privilegedTrue,
+					Privileged:   &privilegedTrue,
+					RunAsNonRoot: &runAsNonRootFalse,
+					RunAsUser:    &runAsUserID,
 				},
 				Stdin:     false,
 				StdinOnce: false,
@@ -138,7 +146,9 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 							"NET_ADMIN",
 						},
 					},
-					Privileged: &privilegedFalse,
+					Privileged:   &privilegedFalse,
+					RunAsNonRoot: &runAsNonRootFalse,
+					RunAsUser:    &runAsUserID,
 				},
 				Stdin:     false,
 				StdinOnce: false,
@@ -170,7 +180,9 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 							"NET_ADMIN",
 						},
 					},
-					Privileged: &privilegedFalse,
+					Privileged:   &privilegedFalse,
+					RunAsNonRoot: &runAsNonRootFalse,
+					RunAsUser:    &runAsUserID,
 				},
 				Stdin:     false,
 				StdinOnce: false,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Currently, pods having pod-level security contexts are causing the init container to not be able to program iptables. Setting `runAsNonRoot` and `runAsUser: 0` security context for the init container fixes this.

For example, the following security context in a bookstore demo pod causes an xtables permission denied error where the pod never finishes initializing/goes into crashLoopBackoff
```
      securityContext:
        fsGroup: 1000
        runAsGroup: 1000
        runAsUser: 1000
```
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
