### PR TITLE
Typo fix for dev guide README

### DIFF
--- a/docs/development_guide/README.md
+++ b/docs/development_guide/README.md
@@ -166,7 +166,7 @@ and each change would be accompanied by a unit test.
 To run all unit tests you can use the following `Makefile` target:
 
 ```bash
-make go-tests
+make go-test
 ```
 
 You can run the tests exclusively for the package you are working on. For example the following command will

--- a/docs/development_guide/README.md
+++ b/docs/development_guide/README.md
@@ -166,7 +166,7 @@ and each change would be accompanied by a unit test.
 To run all unit tests you can use the following `Makefile` target:
 
 ```bash
-make go-test
+make go-test-coverage
 ```
 
 You can run the tests exclusively for the package you are working on. For example the following command will


### PR DESCRIPTION
Fixes #4281 

Signed-off-by: Bridget Kromhout <bridget@kromhout.org>


**Description**:
As @clarenceb points out in https://github.com/openservicemesh/osm/issues/4281, we have a typo in the dev guide README. 


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Documentation              | [X] |



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? not applicable

2. Is this a breaking change? no
