### PR TITLE
Fix typos in webhook creators

### DIFF
--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -396,8 +396,8 @@ func patchAdmissionResponse(resp *admissionv1.AdmissionResponse, patchBytes []by
 func createOrUpdateMutatingWebhook(clientSet kubernetes.Interface, cert certificate.Certificater, webhookTimeout int32, webhookName, meshName, osmNamespace, osmVersion string, enableReconciler bool) error {
 	webhookPath := webhookCreatePod
 	webhookPort := int32(constants.InjectorWebhookPort)
-	failuerPolicy := admissionregv1.Fail
-	matchPolict := admissionregv1.Exact
+	failurePolicy := admissionregv1.Fail
+	matchPolicy := admissionregv1.Exact
 
 	mwhcLabels := map[string]string{
 		constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
@@ -430,8 +430,8 @@ func createOrUpdateMutatingWebhook(clientSet kubernetes.Interface, cert certific
 						Port:      &webhookPort,
 					},
 					CABundle: cert.GetCertificateChain()},
-				FailurePolicy: &failuerPolicy,
-				MatchPolicy:   &matchPolict,
+				FailurePolicy: &failurePolicy,
+				MatchPolicy:   &matchPolicy,
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						constants.OSMKubeResourceMonitorAnnotation: meshName,

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -25,8 +25,8 @@ const (
 func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert certificate.Certificater, webhookName, meshName, osmNamespace, osmVersion string, validateTrafficTarget bool, enableReconciler bool) error {
 	webhookPath := validationAPIPath
 	webhookPort := int32(constants.ValidatorWebhookPort)
-	failuerPolicy := admissionregv1.Fail
-	matchPolict := admissionregv1.Exact
+	failurePolicy := admissionregv1.Fail
+	matchPolicy := admissionregv1.Exact
 
 	rules := []admissionregv1.RuleWithOperations{
 		{
@@ -77,8 +77,8 @@ func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert certif
 						Port:      &webhookPort,
 					},
 					CABundle: cert.GetCertificateChain()},
-				FailurePolicy: &failuerPolicy,
-				MatchPolicy:   &matchPolict,
+				FailurePolicy: &failurePolicy,
+				MatchPolicy:   &matchPolicy,
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						constants.OSMKubeResourceMonitorAnnotation: meshName,


### PR DESCRIPTION
**Description**:

This PR fixes a couple of typos in the webhook creator code paths.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.
