### PR TITLE
fix(charts/osm/grafana/dashboards): remove avg and max envoy update time metrics from grafana dashboard

### DIFF
--- a/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
+++ b/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
@@ -101,7 +101,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 8,
         "w": 9,
         "x": 0,
         "y": 1
@@ -230,112 +230,6 @@
       }
     },
     {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {},
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "orange",
-                                "value": null
-                            }
-                        ]
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 3,
-                "w": 4.5,
-                "x": 0,
-                "y": 6
-            },
-            "id": 5,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "center",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "last"
-                    ],
-                    "values": false
-                }
-            },
-            "pluginVersion": "8.2.2",
-            "targets": [
-                {
-                    "expr": "avg_over_time(osm_proxy_config_update_time_sum{resource_type=\"$xds_path\", source_pod_name=~\"$osm_controller_instance\"}[1y:1s])",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{source_pod_name}}",
-                    "refId": "A"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Avg Envoy Update Time (s)",
-            "type": "stat"
-        },
-        {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-                "defaults": {
-                    "custom": {},
-                    "mappings": [],
-                    "thresholds": {
-                        "mode": "absolute",
-                        "steps": [
-                            {
-                                "color": "orange",
-                                "value": null
-                            }
-                        ]
-                    }
-                },
-                "overrides": []
-            },
-            "gridPos": {
-                "h": 3,
-                "w": 4.5,
-                "x": 4.5,
-                "y": 6
-            },
-            "id": 10,
-            "options": {
-                "colorMode": "value",
-                "graphMode": "area",
-                "justifyMode": "center",
-                "orientation": "auto",
-                "reduceOptions": {
-                    "calcs": [
-                        "last"
-                    ],
-                    "values": false
-                }
-            },
-            "pluginVersion": "8.2.2",
-            "targets": [
-                {
-                    "expr": "max_over_time(osm_proxy_config_update_time_sum{resource_type=\"$xds_path\", source_pod_name=~\"$osm_controller_instance\"}[1y:1s])",
-                    "format": "time_series",
-                    "instant": true,
-                    "interval": "",
-                    "legendFormat": "{{source_pod_name}}",
-                    "refId": "A"
-                }
-            ],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Max Envoy Update Time (s)",
-            "type": "stat"
-        },
-        {
       "collapsed": false,
       "datasource": null,
       "gridPos": {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Remove avg and max envoy update time metrics from grafana dashboard
and resolves #3987

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Observability              | [ x] |

Testing done:
- Ran osm demo script (demo/run-osm-demo.sh) with grafana enabled
- Ran port forward script for grafana (scripts/port-forward-grafana.sh) 
![image](https://user-images.githubusercontent.com/69616256/141358705-e35b1393-7335-4011-8517-512cebf1d42e.png)

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no
