### PR TITLE
injector: skip injection when pod belongs to host network

### DIFF
--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -248,6 +248,19 @@ var _ = Describe("Testing mustInject, isNamespaceInjectable", func() {
 		Expect(inject).To(BeTrue())
 	})
 
+	It("should return false when the pod belongs to the host network", func() {
+		p := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				HostNetwork: true,
+			},
+		}
+
+		inject, err := wh.mustInject(p, "")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeFalse())
+	})
+
 	It("should return false when the pod is disabled for sidecar injection", func() {
 		testNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Skips sidecar injection for pods that belong to the host
network. Without this, the iptable rules installed
will result in routing failures in the host, rendering
the cluster unusable.

Part of #4359

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Sidecar Injection          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
