### PR TITLE
[backport] injector: skip injection when pod belongs to host network (#4360)

### DIFF
--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -248,6 +248,19 @@ var _ = Describe("Testing mustInject, isNamespaceInjectable", func() {
 		Expect(inject).To(BeTrue())
 	})
 
+	It("should return false when the pod belongs to the host network", func() {
+		p := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				HostNetwork: true,
+			},
+		}
+
+		inject, err := wh.mustInject(p, "")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(inject).To(BeFalse())
+	})
+
 	It("should return false when the pod is disabled for sidecar injection", func() {
 		testNamespace := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Backports 0fcedaa7 to release v1.0.
---
Skips sidecar injection for pods that belong to the host
network. Without this, the iptable rules installed
will result in routing failures in the host, rendering
the cluster unusable.

Part of #4359

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Sidecar Injection          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
