### PR TITLE
fix(e2e): update upgrade test

### DIFF
--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -54,7 +54,7 @@ var _ = OSMDescribe("Upgrade from latest",
 			i.ReleaseName = releaseName
 			i.Timeout = 120 * time.Second
 			vals := map[string]interface{}{
-				"OpenServiceMesh": map[string]interface{}{
+				"osm": map[string]interface{}{
 					"deployPrometheus": true,
 					// Init container must be privileged if an OpenShift cluster is being used
 					"enablePrivilegedInitContainer": Td.DeployOnOpenShift,


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Now that the upgrade test is basing off of v1.0.0-rc.2, we need to
install with values under `osm.*` instead of `OpenServiceMesh.*`.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Ran the upgrade e2e test locally

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
