### PR TITLE
[v0.11 backport] fix(ci): fix image scan

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -61,7 +61,7 @@ jobs:
   imagescan:
     name: Scan images for security vulnerabilities
     runs-on: ubuntu-latest
-    needs: images
+    needs: [images, version]
     env:
       CTR_TAG: ${{ needs.version.outputs.version }}
       CTR_REGISTRY: openservicemesh

--- a/dockerfiles/Dockerfile.init
+++ b/dockerfiles/Dockerfile.init
@@ -1,2 +1,2 @@
-FROM alpine:3.12
+FROM alpine:3
 RUN apk add --no-cache iptables


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Backport of #4357

This change adds the `version` job as a dependency of the `imagescan`
job in the pre-release workflow which is required for
`${{ needs.version.outputs.version }}` to correctly evaluate.

The base image of the `init` container has also been updated to fix a
vulnerability.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
