### PR TITLE
Get bug-report previous control plane logs if containers were restarted

### DIFF
--- a/pkg/bugreport/controlplane.go
+++ b/pkg/bugreport/controlplane.go
@@ -31,6 +31,15 @@ func (c *Config) collectControlPlaneLogs() error {
 			return fmt.Errorf("error writing control pod logs: %w", err)
 		}
 		c.completionSuccess("Collected report for Pod %s/%s", pod.Namespace, pod.Name)
+
+		if pod.Status.ContainerStatuses[0].RestartCount > 0 {
+			cmd = append(cmd, "--previous")
+			outPath = path.Join(c.rootNamespaceDirPath(), pod.Namespace, rootPodDirName, pod.Name, commandsDirName, strings.Join(cmd, "_"))
+			if err := runCmdAndWriteToFile(cmd, outPath); err != nil {
+				return fmt.Errorf("error writing previous control pod logs: %w", err)
+			}
+			c.completionSuccess("Collected previous report for Pod %s/%s", pod.Namespace, pod.Name)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**Description**:

This PR adds the check to `osm support bug-report` when it fetches control plane logs. It will look to see if the container was restarted, and if it was then it also pulls the previous container logs. This could help in the situation where we are troubleshooting an issue that causes restart.

**Testing done**:

Manual testing. Created the kind cluster `make kind-demo` and then docker exec'd into the `osm-worker` node container and killed the osm-controller process. Then I ran `osm support bug-report` and saw that the previous logs for osm-controller were retrieved.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?

No.

2. Is this a breaking change?

No.