### PR TITLE
test(ingress): increase timeout for TestHandleCertificateChange

### DIFF
--- a/pkg/ingress/gateway_test.go
+++ b/pkg/ingress/gateway_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	maxTimeToSubscribe           = 500 * time.Millisecond
 	maxTimeForEventToBePublished = 2 * time.Second
 	maxSecretPollTime            = 2 * time.Second
 	secretPollInterval           = 25 * time.Millisecond
@@ -335,7 +336,7 @@ func TestHandleCertificateChange(t *testing.T) {
 
 			go c.handleCertificateChange(tc.previousCertSpec, tc.stopChan)
 			defer close(tc.stopChan)
-			time.Sleep(maxTimeForEventToBePublished)
+			time.Sleep(maxTimeToSubscribe)
 
 			// If a secret is supposed to exist, create it
 			if tc.previousCertSpec != nil {
@@ -349,6 +350,7 @@ func TestHandleCertificateChange(t *testing.T) {
 					NewObj: tc.updatedMeshConfig,
 					OldObj: tc.previousMeshConfig,
 				}, announcements.MeshConfigUpdated.String())
+				time.Sleep(maxTimeForEventToBePublished)
 			}
 
 			if !tc.expectSecretToExist {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds a delay for subscription time and adds a delay after publishing
an event for `maxTimeForEventToBePublished`. The
original 2s delay for the secret to be created after publishing a
mesh config update event included the time to publish the event
and the time to issue a certificate. The max time alone for
publishing an event is 2s, so in some cases, this unit test may have
exceeded the timeout.

Resolves #4366

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

Unable to reproduce the timeout locally.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ x ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
