### PR TITLE
ref(k8s): remove K8sServiceToMeshServices from Controller

### DIFF
--- a/pkg/envoy/registry/services.go
+++ b/pkg/envoy/registry/services.go
@@ -60,7 +60,7 @@ func (k *KubeProxyServiceMapper) ListProxyServices(p *envoy.Proxy) ([]service.Me
 
 func kubernetesServicesToMeshServices(kubeController k8s.Controller, kubernetesServices []v1.Service) (meshServices []service.MeshService) {
 	for _, svc := range kubernetesServices {
-		meshServices = append(meshServices, kubeController.K8sServiceToMeshServices(svc)...)
+		meshServices = append(meshServices, k8s.ServiceToMeshServices(kubeController, svc)...)
 	}
 	return meshServices
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -338,7 +338,9 @@ func (c client) UpdateStatus(resource interface{}) (metav1.Object, error) {
 	}
 }
 
-func (c client) K8sServiceToMeshServices(svc corev1.Service) []service.MeshService {
+// ServiceToMeshServices translates a k8s service with one or more ports to one or more
+// MeshService objects per port.
+func ServiceToMeshServices(c Controller, svc corev1.Service) []service.MeshService {
 	var meshServices []service.MeshService
 
 	for _, portSpec := range svc.Spec.Ports {

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -824,7 +824,7 @@ func TestK8sServicesToMeshServices(t *testing.T) {
 			assert.Nil(err)
 			assert.NotNil(kubeController)
 
-			actual := kubeController.K8sServiceToMeshServices(tc.svc)
+			actual := ServiceToMeshServices(kubeController, tc.svc)
 			assert.ElementsMatch(tc.expected, actual)
 		})
 	}

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -108,20 +108,6 @@ func (mr *MockControllerMockRecorder) IsMonitoredNamespace(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMonitoredNamespace", reflect.TypeOf((*MockController)(nil).IsMonitoredNamespace), arg0)
 }
 
-// K8sServiceToMeshServices mocks base method.
-func (m *MockController) K8sServiceToMeshServices(arg0 v1.Service) []service.MeshService {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "K8sServiceToMeshServices", arg0)
-	ret0, _ := ret[0].([]service.MeshService)
-	return ret0
-}
-
-// K8sServiceToMeshServices indicates an expected call of K8sServiceToMeshServices.
-func (mr *MockControllerMockRecorder) K8sServiceToMeshServices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "K8sServiceToMeshServices", reflect.TypeOf((*MockController)(nil).K8sServiceToMeshServices), arg0)
-}
-
 // ListMonitoredNamespaces mocks base method.
 func (m *MockController) ListMonitoredNamespaces() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -111,8 +111,4 @@ type Controller interface {
 	// UpdateStatus updates the status subresource for the given resource and GroupVersionKind
 	// The object within the 'interface{}' must be a pointer to the underlying resource
 	UpdateStatus(interface{}) (metav1.Object, error)
-
-	// K8sServiceToMeshServices translates a k8s service with one or more ports to one or more
-	// MeshService objects per port.
-	K8sServiceToMeshServices(corev1.Service) []service.MeshService
 }

--- a/pkg/providers/kube/client.go
+++ b/pkg/providers/kube/client.go
@@ -163,7 +163,7 @@ func (c *client) getServicesByLabels(podLabels map[string]string, targetNamespac
 		}
 		selector := labels.Set(svcRawSelector).AsSelector()
 		if selector.Matches(labels.Set(podLabels)) {
-			finalList = append(finalList, c.kubeController.K8sServiceToMeshServices(*svc)...)
+			finalList = append(finalList, k8s.ServiceToMeshServices(c.kubeController, *svc)...)
 		}
 	}
 
@@ -208,7 +208,7 @@ func (c *client) GetResolvableEndpointsForService(svc service.MeshService) []end
 func (c *client) ListServices() []service.MeshService {
 	var services []service.MeshService
 	for _, svc := range c.kubeController.ListServices() {
-		services = append(services, c.kubeController.K8sServiceToMeshServices(*svc)...)
+		services = append(services, k8s.ServiceToMeshServices(c.kubeController, *svc)...)
 	}
 	return services
 }

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -312,6 +312,7 @@ func TestGetServicesForServiceIdentity(t *testing.T) {
 						Selector: map[string]string{
 							"k1": "v1", // matches labels on pod ns1/p1
 						},
+						Ports: []corev1.ServicePort{{}},
 					},
 				},
 				{
@@ -327,7 +328,7 @@ func TestGetServicesForServiceIdentity(t *testing.T) {
 				},
 			},
 			expected: []service.MeshService{
-				{Namespace: "ns1", Name: "s1"}, // ns1/s1 matches pod ns1/p1 with service account ns1/sa1
+				{Namespace: "ns1", Name: "s1", Protocol: "http"}, // ns1/s1 matches pod ns1/p1 with service account ns1/sa1
 			},
 		},
 	}
@@ -345,11 +346,7 @@ func TestGetServicesForServiceIdentity(t *testing.T) {
 
 			mockKubeController.EXPECT().ListPods().Return(tc.pods)
 			mockKubeController.EXPECT().ListServices().Return(tc.services)
-			mockKubeController.EXPECT().K8sServiceToMeshServices(gomock.Any()).DoAndReturn(func(svc corev1.Service) []service.MeshService {
-				return []service.MeshService{
-					{Name: svc.Name, Namespace: svc.Namespace},
-				}
-			}).AnyTimes()
+			mockKubeController.EXPECT().GetEndpoints(gomock.Any()).Return(nil, nil).AnyTimes()
 
 			actual := c.GetServicesForServiceIdentity(tc.svcIdentity)
 			assert.ElementsMatch(tc.expected, actual)


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change removes the `K8sServiceToMeshServices` method from the k8s
`Controller` interface. Since `K8sServiceToMeshServices` only relies on
the `GetEndpoints` method already in the interface and nothing specific
to the unexported `client` implementation, it has been converted to a
function that accepts a `Controller`.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Ran affected unit tests locally.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
