### PR TITLE
ref(k8s): remove IsMetricsEnabled from Controller

### DIFF
--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -111,7 +111,6 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient versio
 	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookstoreV1Service).Return([]identity.K8sServiceAccount{tests.BookstoreServiceAccount}, nil).AnyTimes()
 	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookstoreV2Service).Return([]identity.K8sServiceAccount{tests.BookstoreV2ServiceAccount}, nil).AnyTimes()
 	mockKubeController.EXPECT().ListServiceIdentitiesForService(tests.BookbuyerService).Return([]identity.K8sServiceAccount{tests.BookbuyerServiceAccount}, nil).AnyTimes()
-	mockKubeController.EXPECT().IsMetricsEnabled(gomock.Any()).Return(true).AnyTimes()
 
 	mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(nil).AnyTimes()
 	mockPolicyController.EXPECT().GetIngressBackendPolicy(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/errcode"
+	"github.com/openservicemesh/osm/pkg/k8s"
 )
 
 // NewResponse creates a new Cluster Discovery Response.
@@ -80,7 +81,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	// Add an inbound prometheus cluster (from Prometheus to localhost)
 	if pod, err := envoy.GetPodFromCertificate(proxy.GetCertificateCommonName(), meshCatalog.GetKubeController()); err != nil {
 		log.Warn().Str("proxy", proxy.String()).Msg("Could not find pod for connecting proxy, no metadata was recorded")
-	} else if meshCatalog.GetKubeController().IsMetricsEnabled(pod) {
+	} else if k8s.IsMetricsEnabled(pod) {
 		clusters = append(clusters, getPrometheusCluster())
 	}
 

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -114,7 +114,6 @@ func TestNewResponse(t *testing.T) {
 	assert.Nil(err)
 
 	mockKubeController.EXPECT().ListPods().Return([]*v1.Pod{&newPod1})
-	mockKubeController.EXPECT().IsMetricsEnabled(&newPod1).Return(true)
 
 	resp, err := NewResponse(mockCatalog, proxy, nil, mockConfigurator, nil, proxyRegistry)
 	assert.Nil(err)

--- a/pkg/envoy/lds/response.go
+++ b/pkg/envoy/lds/response.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy/registry"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/k8s"
 )
 
 // NewResponse creates a new Listener Discovery Response.
@@ -88,7 +89,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 
 	if pod, err := envoy.GetPodFromCertificate(proxy.GetCertificateCommonName(), meshCatalog.GetKubeController()); err != nil {
 		log.Warn().Str("proxy", proxy.String()).Msgf("Could not find pod for connecting proxy, no metadata was recorded")
-	} else if meshCatalog.GetKubeController().IsMetricsEnabled(pod) {
+	} else if k8s.IsMetricsEnabled(pod) {
 		// Build Prometheus listener config
 		prometheusConnManager := getPrometheusConnectionManager()
 		if prometheusListener, err := buildPrometheusListener(prometheusConnManager); err != nil {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -314,7 +314,7 @@ func (c client) ListServiceIdentitiesForService(svc service.MeshService) ([]iden
 }
 
 // IsMetricsEnabled returns true if the pod in the mesh is correctly annotated for prometheus scrapping
-func (c client) IsMetricsEnabled(pod *corev1.Pod) bool {
+func IsMetricsEnabled(pod *corev1.Pod) bool {
 	isScrapingEnabled := false
 	prometheusScrapeAnnotation, ok := pod.Annotations[constants.PrometheusScrapeAnnotation]
 	if !ok {

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,12 +1,9 @@
 package k8s
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -21,7 +18,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
-	"github.com/openservicemesh/osm/pkg/tests"
 )
 
 var (
@@ -532,75 +528,57 @@ func TestListServiceIdentitiesForService(t *testing.T) {
 func TestIsMetricsEnabled(t *testing.T) {
 	testCases := []struct {
 		name                    string
-		addPrometheusAnnotation bool
+		pod                     *corev1.Pod
 		expectedMetricsScraping bool
-		scrapingAnnotation      string
 	}{
 		{
-			name:                    "pod without prometheus scraping annotation",
-			scrapingAnnotation:      "false",
-			addPrometheusAnnotation: false,
+			name: "pod without prometheus scraping annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
 			expectedMetricsScraping: false,
 		},
 		{
-			name:                    "pod with prometheus scraping annotation set to true",
-			scrapingAnnotation:      "true",
-			addPrometheusAnnotation: true,
+			name: "pod with prometheus scraping annotation set to true",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.PrometheusScrapeAnnotation: "true",
+					},
+				},
+			},
 			expectedMetricsScraping: true,
 		},
 		{
-			name:                    "pod with prometheus scraping annotation set to false",
-			scrapingAnnotation:      "false",
-			addPrometheusAnnotation: true,
+			name: "pod with prometheus scraping annotation set to false",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.PrometheusScrapeAnnotation: "false",
+					},
+				},
+			},
 			expectedMetricsScraping: false,
 		},
 		{
-			name:                    "pod with incorrect prometheus scraping annotation",
-			scrapingAnnotation:      "no",
-			addPrometheusAnnotation: true,
+			name: "pod with incorrect prometheus scraping annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.PrometheusScrapeAnnotation: "no",
+					},
+				},
+			},
 			expectedMetricsScraping: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert := tassert.New(t)
-
-			kubeClient := testclient.NewSimpleClientset()
-			stop := make(chan struct{})
-			kubeController, err := NewKubernetesController(kubeClient, nil, testMeshName, stop, nil)
-			assert.Nil(err)
-			assert.NotNil(kubeController)
-
-			proxyUUID := uuid.New()
-			namespace := uuid.New().String()
-			podlabels := map[string]string{
-				constants.AppLabel:               tests.SelectorValue,
-				constants.EnvoyUniqueIDLabelName: proxyUUID.String(),
-			}
-
-			// Ensure correct presetup
-			pods, err := kubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-			assert.Nil(err)
-			assert.Len(pods.Items, 0)
-
-			newPod1 := tests.NewPodFixture(namespace, fmt.Sprintf("pod-1-%s", proxyUUID), tests.BookstoreServiceAccountName, podlabels)
-
-			if tc.addPrometheusAnnotation {
-				newPod1.Annotations = map[string]string{
-					constants.PrometheusScrapeAnnotation: tc.scrapingAnnotation,
-				}
-			}
-			_, err = kubeClient.CoreV1().Pods(namespace).Create(context.TODO(), &newPod1, metav1.CreateOptions{})
-			assert.Nil(err)
-
-			// Ensure correct setup
-			pods, err = kubeClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{})
-			assert.Nil(err)
-			assert.Len(pods.Items, 1)
-
-			actual := kubeController.IsMetricsEnabled(&newPod1)
-			assert.Equal(actual, tc.expectedMetricsScraping)
+			actual := IsMetricsEnabled(tc.pod)
+			tassert.Equal(t, actual, tc.expectedMetricsScraping)
 		})
 	}
 }

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -80,20 +80,6 @@ func (mr *MockControllerMockRecorder) GetService(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetService", reflect.TypeOf((*MockController)(nil).GetService), arg0)
 }
 
-// IsMetricsEnabled mocks base method.
-func (m *MockController) IsMetricsEnabled(arg0 *v1.Pod) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsMetricsEnabled", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsMetricsEnabled indicates an expected call of IsMetricsEnabled.
-func (mr *MockControllerMockRecorder) IsMetricsEnabled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMetricsEnabled", reflect.TypeOf((*MockController)(nil).IsMetricsEnabled), arg0)
-}
-
 // IsMonitoredNamespace mocks base method.
 func (m *MockController) IsMonitoredNamespace(arg0 string) bool {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -105,9 +105,6 @@ type Controller interface {
 	// GetEndpoints returns the endpoints for a given service, if found
 	GetEndpoints(service.MeshService) (*corev1.Endpoints, error)
 
-	// IsMetricsEnabled returns true if the pod in the mesh is correctly annotated for prometheus scrapping
-	IsMetricsEnabled(*corev1.Pod) bool
-
 	// UpdateStatus updates the status subresource for the given resource and GroupVersionKind
 	// The object within the 'interface{}' must be a pointer to the underlying resource
 	UpdateStatus(interface{}) (metav1.Object, error)


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The `IsMetricsEnabled` method on the `k8s.Controller` interface does not
depend on any implementation details, only the `*v1.Pod` passed to it.
Making it a plain function removes this unnecessary dependency on
setting up a `k8s.Controller`.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Ran affected unit tests locally

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
