### PR TITLE
Add MeshConfig upgrade when upgrading a mesh

### DIFF
--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -94,11 +94,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: OSM_ENVOY_IMAGE
+            - name: OSM_DEFAULT_ENVOY_IMAGE
               value: "{{ .Values.osm.sidecarImage }}"
-            - name: OSM_ENVOY_WINDOWS_IMAGE
+            - name: OSM_DEFAULT_ENVOY_WINDOWS_IMAGE
               value: "{{ .Values.osm.sidecarWindowsImage }}"
-            - name: OSM_INIT_CONTAINER_IMAGE
+            - name: OSM_DEFAULT_INIT_CONTAINER_IMAGE
               value: '{{ include "osmSidecarInit.image" . }}'
     {{- if .Values.osm.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -94,6 +94,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: OSM_ENVOY_IMAGE
+              value: "{{ .Values.osm.sidecarImage }}"
+            - name: OSM_ENVOY_WINDOWS_IMAGE
+              value: "{{ .Values.osm.sidecarWindowsImage }}"
+            - name: OSM_INIT_CONTAINER_IMAGE
+              value: '{{ include "osmSidecarInit.image" . }}'
     {{- if .Values.osm.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.osm.imagePullSecrets | indent 8 }}

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -10,9 +10,6 @@ data:
         "enablePrivilegedInitContainer": {{.Values.osm.enablePrivilegedInitContainer | mustToJson}},
         "logLevel": {{.Values.osm.envoyLogLevel | mustToJson}},
         "maxDataPlaneConnections": {{.Values.osm.maxDataPlaneConnections | mustToJson}},
-        "envoyImage": {{.Values.osm.sidecarImage | mustToJson}},
-        "envoyWindowsImage": {{.Values.osm.sidecarWindowsImage | mustToJson}},
-        "initContainerImage": "{{ include "osmSidecarInit.image" . }}",
         "configResyncInterval": {{.Values.osm.configResyncInterval | mustToJson}}
       },
       "traffic": {

--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -66,11 +66,9 @@ spec:
                     envoyImage:
                       description: Image for the Envoy sidecar
                       type: string
-                      default: "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
                     envoyWindowsImage:
                       description: Image for the Envoy sidecar on Windows workers
                       type: string
-                      default: "envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"
                     initContainerImage:
                       description: Image for the init container
                       type: string

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -127,7 +127,7 @@ func (c *client) GetEnvoyLogLevel() string {
 func (c *client) GetEnvoyImage() string {
 	image := c.getMeshConfig().Spec.Sidecar.EnvoyImage
 	if image == "" {
-		image = os.Getenv("OSM_ENVOY_IMAGE")
+		image = os.Getenv("OSM_DEFAULT_ENVOY_IMAGE")
 	}
 	return image
 }
@@ -136,7 +136,7 @@ func (c *client) GetEnvoyImage() string {
 func (c *client) GetEnvoyWindowsImage() string {
 	image := c.getMeshConfig().Spec.Sidecar.EnvoyWindowsImage
 	if image == "" {
-		image = os.Getenv("OSM_ENVOY_WINDOWS_IMAGE")
+		image = os.Getenv("OSM_DEFAULT_ENVOY_WINDOWS_IMAGE")
 	}
 	return image
 }
@@ -145,7 +145,7 @@ func (c *client) GetEnvoyWindowsImage() string {
 func (c *client) GetInitContainerImage() string {
 	image := c.getMeshConfig().Spec.Sidecar.InitContainerImage
 	if image == "" {
-		image = os.Getenv("OSM_INIT_CONTAINER_IMAGE")
+		image = os.Getenv("OSM_DEFAULT_INIT_CONTAINER_IMAGE")
 	}
 	return image
 }

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -3,6 +3,7 @@ package configurator
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -124,17 +125,29 @@ func (c *client) GetEnvoyLogLevel() string {
 
 // GetEnvoyImage returns the envoy image
 func (c *client) GetEnvoyImage() string {
-	return c.getMeshConfig().Spec.Sidecar.EnvoyImage
+	image := c.getMeshConfig().Spec.Sidecar.EnvoyImage
+	if image == "" {
+		image = os.Getenv("OSM_ENVOY_IMAGE")
+	}
+	return image
 }
 
 // GetEnvoyWindowsImage returns the envoy windows image
 func (c *client) GetEnvoyWindowsImage() string {
-	return c.getMeshConfig().Spec.Sidecar.EnvoyWindowsImage
+	image := c.getMeshConfig().Spec.Sidecar.EnvoyWindowsImage
+	if image == "" {
+		image = os.Getenv("OSM_ENVOY_WINDOWS_IMAGE")
+	}
+	return image
 }
 
 // GetInitContainerImage returns the init container image
 func (c *client) GetInitContainerImage() string {
-	return c.getMeshConfig().Spec.Sidecar.InitContainerImage
+	image := c.getMeshConfig().Spec.Sidecar.InitContainerImage
+	if image == "" {
+		image = os.Getenv("OSM_INIT_CONTAINER_IMAGE")
+	}
+	return image
 }
 
 // GetServiceCertValidityPeriod returns the validity duration for service certificates, and a default in case of invalid duration


### PR DESCRIPTION
**Description**:

This fixes issue #4371. Prior to this fix if there was a change to the envoy sidecar image then this would not get reflected or upgraded in the mesh config. Upon further testing we cannot just patch that in because if there are missing required keys (as indicated by the CRD) then the patch itself will fail (see the *Testing done* section below on the missing required key error when attempting to patch).

This PR adds the functionality for a complete upgrade of the mesh config by doing two things:

1. Compare CRD required fields with the current MeshConfig. If there are missing required keys then patch them in.
2. Compare the envoy sidecar image. If the default has been upgraded between the old and the new version _and_ the user has not modified the default in their mesh config, then upgrade this value.

**Testing done**:

Integration tests and manual testing.

Prior to this change:

```
 $ osm version
Version: v0.9.2; Commit: 7df9badece2f251515a2bc5e5ac79438b0c58812; Date: 2021-08-19-21:02

 $ osm install
OSM installed successfully in namespace [osm-system] with mesh name [osm]

 $ git log --oneline -1
8dccabbf (HEAD -> main, upstream/main) injector: rename iptables chains for clarity (#4379)

 $ go run ./cmd/cli mesh upgrade
OSM successfully upgraded mesh [osm] in namespace [osm-system]
```

Even though the mesh was upgraded, the envoy sidecar image remains the old version in the mesh config:

```
 $ kubectl get configmap -n osm-system preset-mesh-config -o jsonpath='{.data.preset-mesh-config\.json}' | jq -r '.sidecar.envoyImage'
envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd

 $ kubectl get meshconfig -n osm-system osm-mesh-config -o jsonpath='{.spec.sidecar.envoyImage}'
envoyproxy/envoy-alpine:v1.18.3
```

If you try to patch that it errors because of a missing key:

```
 $ kubectl patch meshconfig -n osm-system osm-mesh-config --type=json --patch='[{"op":"replace","path":"/spec/sidecar/envoyImage","value":"envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"}]'
The MeshConfig "osm-mesh-config" is invalid: spec.certificate.certKeyBitSize: Required value
```

With this PR:

```
 $ kubectl get meshconfig -n osm-system osm-mesh-config -o jsonpath='{.spec.sidecar.envoyImage}'
envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd

 $ kubectl get meshconfig -n osm-system osm-mesh-config -o jsonpath='{.spec.certificate.certKeyBitSize}'
2048
```

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Upgrade                    | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?

No.

2. Is this a breaking change?

No.
