### PR TITLE
feat(cli): add remote version to osm version output

### DIFF
--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -13,6 +13,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -122,6 +123,16 @@ func getControllerDeployments(clientSet kubernetes.Interface) (*appsv1.Deploymen
 		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 	}
 	return deploymentsClient.List(context.TODO(), listOptions)
+}
+
+// getControllerPods returns a list of osm-controller Pods in a specified namespace
+func getControllerPods(clientSet kubernetes.Interface, namespace string) (*corev1.PodList, error) {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{constants.AppLabel: constants.OSMControllerName}}
+	podClient := clientSet.CoreV1().Pods(namespace)
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+	return podClient.List(context.TODO(), metav1.ListOptions{LabelSelector: listOptions.LabelSelector})
 }
 
 // getMeshNames returns a set of mesh names corresponding to meshes within the cluster

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,32 +1,147 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 
+	"github.com/openservicemesh/osm/pkg/constants"
+	httpserverconstants "github.com/openservicemesh/osm/pkg/httpserver/constants"
 	"github.com/openservicemesh/osm/pkg/version"
 )
 
 const versionHelp = `
-This command prints out all the version information used by OSM
+This command prints the OSM CLI and remote mesh version information
 `
 
-// PrintCliVersion prints the version
-func PrintCliVersion(out io.Writer) {
-	_, _ = fmt.Fprintf(out, "Version: %s; Commit: %s; Date: %s\n", version.Version, version.GitCommit, version.BuildDate)
+type versionCmd struct {
+	out           io.Writer
+	namespace     string
+	clientOnly    bool
+	clientset     kubernetes.Interface
+	remoteVersion remoteVersionGetter
+}
+
+type remoteVersionGetter interface {
+	proxyGetMeshVersion(pod string, namespace string, clientset kubernetes.Interface) (*version.Info, error)
+}
+
+type remoteVersion struct{}
+
+type remoteVersionInfo struct {
+	meshName string
+	version  *version.Info
+}
+
+type versionInfo struct {
+	cliVersionInfo    *version.Info
+	remoteVersionInfo *remoteVersionInfo
 }
 
 func newVersionCmd(out io.Writer) *cobra.Command {
+	versionCmd := &versionCmd{
+		out: out,
+	}
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "osm cli version",
+		Short: "osm cli and mesh version",
 		Long:  versionHelp,
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			PrintCliVersion(out)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var versionInfo versionInfo
+			var err error
+
+			cliVersionInfo := version.GetInfo()
+			versionInfo.cliVersionInfo = &cliVersionInfo
+
+			if !versionCmd.clientOnly {
+				err = versionCmd.setKubeClientset()
+				if err == nil {
+					versionCmd.namespace = settings.Namespace()
+					versionCmd.remoteVersion = &remoteVersion{}
+					versionInfo.remoteVersionInfo, err = versionCmd.getMeshVersion()
+				}
+			}
+
+			versionCmd.outputVersionInfo(versionInfo)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get mesh version")
+			}
+			return nil
 		},
 	}
+
+	f := cmd.Flags()
+	f.BoolVar(&versionCmd.clientOnly, "client-only", false, "only show the OSM CLI version")
+
 	return cmd
+}
+
+func (v *versionCmd) setKubeClientset() error {
+	config, err := settings.RESTClientGetter().ToRESTConfig()
+	if err != nil {
+		return errors.Wrap(err, "Error fetching kubeconfig")
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return errors.Wrap(err, "Could not access Kubernetes cluster, check kubeconfig")
+	}
+	v.clientset = clientset
+	return nil
+}
+
+func (v *versionCmd) getMeshVersion() (*remoteVersionInfo, error) {
+	var version *version.Info
+	var versionInfo *remoteVersionInfo
+
+	controllerPods, err := getControllerPods(v.clientset, v.namespace)
+	if err != nil {
+		return nil, err
+	}
+	if len(controllerPods.Items) == 0 {
+		return nil, errors.Errorf("No mesh found in namespace [%s]", v.namespace)
+	}
+
+	controllerPod := controllerPods.Items[0]
+	version, err = v.remoteVersion.proxyGetMeshVersion(controllerPod.Name, v.namespace, v.clientset)
+	if err != nil {
+		return nil, err
+	}
+	versionInfo = &remoteVersionInfo{
+		meshName: controllerPod.Labels[constants.OSMAppInstanceLabelKey],
+		version:  version,
+	}
+	return versionInfo, nil
+}
+
+func (r *remoteVersion) proxyGetMeshVersion(pod string, namespace string, clientset kubernetes.Interface) (*version.Info, error) {
+	resp, err := clientset.CoreV1().Pods(namespace).ProxyGet("", pod, strconv.Itoa(constants.OSMHTTPServerPort), httpserverconstants.VersionPath, nil).DoRaw(context.TODO())
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error retrieving mesh version from pod [%s] in namespace [%s]", pod, namespace)
+	}
+	if len(resp) == 0 {
+		return nil, errors.Errorf("Empty response received from pod [%s] in namespace [%s]", pod, namespace)
+	}
+
+	versionInfo := &version.Info{}
+	err = json.Unmarshal(resp, versionInfo)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error unmarshalling retrieved mesh version from pod [%s] in namespace [%s]", pod, namespace)
+	}
+
+	return versionInfo, nil
+}
+
+func (v *versionCmd) outputVersionInfo(versionInfo versionInfo) {
+	fmt.Fprintf(v.out, "CLI Version: %#v\n", *versionInfo.cliVersionInfo)
+	if versionInfo.remoteVersionInfo != nil {
+		fmt.Fprintf(v.out, "Mesh [%s] Version: %#v\n", versionInfo.remoteVersionInfo.meshName, *versionInfo.remoteVersionInfo.version)
+	}
 }

--- a/cmd/cli/version_test.go
+++ b/cmd/cli/version_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pkg/errors"
+	tassert "github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/version"
+)
+
+type fakeRemoteVersion struct {
+	err         error
+	versionInfo *version.Info
+}
+
+func (f *fakeRemoteVersion) proxyGetMeshVersion(pod string, namespace string, clientset kubernetes.Interface) (*version.Info, error) {
+	return f.versionInfo, f.err
+}
+
+func TestGetMeshVersion(t *testing.T) {
+	tests := []struct {
+		name                   string
+		namespace              string
+		remoteVersion          *version.Info
+		remoteVersionInfo      *remoteVersionInfo
+		controllerPods         []*corev1.Pod
+		proxyGetMeshVersionErr error
+		expectedErr            error
+	}{
+		{
+			name:                   "no mesh in namespace",
+			namespace:              "test",
+			remoteVersion:          nil,
+			remoteVersionInfo:      nil,
+			controllerPods:         []*corev1.Pod{},
+			proxyGetMeshVersionErr: nil,
+			expectedErr:            errors.Errorf("No mesh found in namespace [test]"),
+		},
+		{
+			name:              "mesh in namespace and proxyGetMeshVersion fails",
+			namespace:         "test",
+			remoteVersion:     nil,
+			remoteVersionInfo: nil,
+			controllerPods: []*corev1.Pod{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "controllerPod",
+						Namespace: "test",
+						Labels: map[string]string{
+							constants.AppLabel:               constants.OSMControllerName,
+							constants.OSMAppInstanceLabelKey: "osm",
+						},
+					},
+				},
+			},
+			proxyGetMeshVersionErr: errors.Errorf("Error retrieving mesh version from pod [controllerPod] in namespace [test]"),
+			expectedErr:            errors.Errorf("Error retrieving mesh version from pod [controllerPod] in namespace [test]"),
+		},
+		{
+			name:      "mesh in namespace and remote version found",
+			namespace: "test",
+			remoteVersion: &version.Info{
+				Version:   "v0.0.0",
+				GitCommit: "xxxxxxx",
+				BuildDate: "Date",
+			},
+			remoteVersionInfo: &remoteVersionInfo{
+				meshName: "osm",
+				version: &version.Info{
+					Version:   "v0.0.0",
+					GitCommit: "xxxxxxx",
+					BuildDate: "Date",
+				},
+			},
+			controllerPods: []*corev1.Pod{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "controllerPod",
+						Namespace: "test",
+						Labels: map[string]string{
+							constants.AppLabel:               constants.OSMControllerName,
+							constants.OSMAppInstanceLabelKey: "osm",
+						},
+					},
+				},
+			},
+			proxyGetMeshVersionErr: nil,
+			expectedErr:            nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			buf := bytes.NewBuffer(nil)
+
+			objs := make([]runtime.Object, len(test.controllerPods))
+			for i := range test.controllerPods {
+				objs[i] = test.controllerPods[i]
+			}
+
+			cmd := versionCmd{
+				out:       buf,
+				namespace: test.namespace,
+				clientset: fake.NewSimpleClientset(objs...),
+				remoteVersion: &fakeRemoteVersion{
+					err:         test.proxyGetMeshVersionErr,
+					versionInfo: test.remoteVersion,
+				},
+				clientOnly: false,
+			}
+
+			remoteVersionInfo, err := cmd.getMeshVersion()
+			if err != nil && test.expectedErr != nil {
+				assert.Equal(test.expectedErr.Error(), err.Error())
+			} else {
+				assert.Equal(test.expectedErr, err)
+			}
+
+			assert.Equal(test.remoteVersionInfo, remoteVersionInfo)
+		})
+	}
+}
+
+func TestOutputVersionInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		versionInfo versionInfo
+		expected    string
+		clientOnly  bool
+	}{
+		{
+			name: "cli and no mesh",
+			versionInfo: versionInfo{
+				cliVersionInfo: &version.Info{
+					Version:   "v0.0.0",
+					GitCommit: "xxxxxxx",
+					BuildDate: "0000-00-00-00:00",
+				},
+			},
+			expected:   "CLI Version: version.Info{Version:\"v0.0.0\", GitCommit:\"xxxxxxx\", BuildDate:\"0000-00-00-00:00\"}\n",
+			clientOnly: true,
+		},
+		{
+			name: "cli and mesh",
+			versionInfo: versionInfo{
+				cliVersionInfo: &version.Info{
+					Version:   "v0.0.0",
+					GitCommit: "xxxxxxx",
+					BuildDate: "0000-00-00-00:00",
+				},
+				remoteVersionInfo: &remoteVersionInfo{
+					meshName: "test",
+					version: &version.Info{
+						Version:   "v0.0.0",
+						GitCommit: "xxxxxxx",
+						BuildDate: "0000-00-00-00:00",
+					},
+				},
+			},
+			expected:   "CLI Version: version.Info{Version:\"v0.0.0\", GitCommit:\"xxxxxxx\", BuildDate:\"0000-00-00-00:00\"}\nMesh [test] Version: version.Info{Version:\"v0.0.0\", GitCommit:\"xxxxxxx\", BuildDate:\"0000-00-00-00:00\"}\n",
+			clientOnly: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			buf := bytes.NewBuffer(nil)
+			cmd := versionCmd{
+				out:        buf,
+				clientOnly: test.clientOnly,
+			}
+			cmd.outputVersionInfo(test.versionInfo)
+
+			assert.Equal(buf.String(), test.expected)
+		})
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -33,14 +33,19 @@ type Info struct {
 	BuildDate string `json:"build_date,omitempty"`
 }
 
+// GetInfo returns the version info
+func GetInfo() Info {
+	return Info{
+		Version:   Version,
+		BuildDate: BuildDate,
+		GitCommit: GitCommit,
+	}
+}
+
 // GetVersionHandler returns an HTTP handler that returns the version info
 func GetVersionHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		versionInfo := Info{
-			Version:   Version,
-			BuildDate: BuildDate,
-			GitCommit: GitCommit,
-		}
+		versionInfo := GetInfo()
 
 		if jsonVersionInfo, err := json.Marshal(versionInfo); err != nil {
 			log.Error().Err(err).Msgf("Error marshaling version info struct: %+v", versionInfo)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds remote version to `osm version` CLI command output. By default,
the CLI and Mesh version will be included in the output. A remote
flag (by default set to true) can be set to false to only output
the CLI version. If there is any failure getting the mesh version,
the CLI version is printed along with the failure message.

A different mesh can be specified by overriding the default osm namespace
 via the OSM_CONFIG or the global `--osm-namespace` flag.

Part of #4289

**Previous `osm version` output:**

```shell
Version: v0.11.1; Commit: c01aefae509d59735d7908a32a359327ff3f2322; Date: 2021-10-20-20:33
```

**New `osm version` output:**

```shell
$ osm version
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
Mesh [osm] Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}

$ osm version --remote=false
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
```
Example output when there is an error getting the mesh version:
```shell
$ osm version
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
Error: Failed to get mesh version: No mesh found in namespace [osm-system]
```
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Wrote unit tests for getting the controller pods and mesh version, and for verifying the output format
- Manually verified the `osm version` outputs with OSM installed on a kind and AKS cluster
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ x ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
