### PR TITLE
Add ingress information to bug report

### DIFF
--- a/pkg/bugreport/ingress.go
+++ b/pkg/bugreport/ingress.go
@@ -1,0 +1,138 @@
+package bugreport
+
+import (
+	"context"
+	"path"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	nginxIngressControllerLabelSelector   string = "app.kubernetes.io/name=ingress-nginx"
+	contourIngressControllerLabelSelector string = "app.kubernetes.io/name=contour"
+
+	ingressResourceName        string = "ingresses"
+	ingressBackendResourceName string = "ingressbackends"
+)
+
+func (c *Config) collectIngressReport() error {
+	namespaceList, err := c.KubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range namespaceList.Items {
+		ingressList, err := c.KubeClient.NetworkingV1().Ingresses(namespace.Name).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, ingress := range ingressList.Items {
+			for _, cmd := range ingressReportCommands(namespace.Name, ingress.Name, ingressResourceName) {
+				filename := path.Join(
+					c.rootNamespaceDirPath(),
+					namespace.Name,
+					ingressResourceName,
+					ingress.Name,
+					commandsDirName,
+					strings.Join(cmd, "_"),
+				)
+				if err := runCmdAndWriteToFile(cmd, filename); err != nil {
+					return err
+				}
+			}
+			c.completionSuccess("Collected report for ingress %s/%s", ingress.Namespace, ingress.Name)
+		}
+
+		ingressBackendList, err := c.PolicyClient.PolicyV1alpha1().IngressBackends(namespace.Name).List(context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+
+		for _, ingressBackend := range ingressBackendList.Items {
+			for _, cmd := range ingressReportCommands(namespace.Name, ingressBackend.Name, ingressBackendResourceName) {
+				filename := path.Join(
+					c.rootNamespaceDirPath(),
+					namespace.Name,
+					ingressBackendResourceName,
+					ingressBackend.Name,
+					commandsDirName,
+					strings.Join(cmd, "_"),
+				)
+				if err := runCmdAndWriteToFile(cmd, filename); err != nil {
+					return err
+				}
+			}
+			c.completionSuccess("Collected report for ingress backend %s/%s", ingressBackend.Namespace, ingressBackend.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *Config) collectIngressControllerReport() error {
+	ingressControllerLabelsSelectors := []string{
+		nginxIngressControllerLabelSelector,
+		contourIngressControllerLabelSelector,
+	}
+	for _, labelSelector := range ingressControllerLabelsSelectors {
+		if err := c.collectIngressControllerReportByLabelSelector(labelSelector); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Config) collectIngressControllerReportByLabelSelector(labelSelector string) error {
+	namespaceList, err := c.KubeClient.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range namespaceList.Items {
+		podList, err := c.KubeClient.CoreV1().Pods(namespace.Name).List(
+			context.Background(),
+			metav1.ListOptions{LabelSelector: labelSelector},
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, pod := range podList.Items {
+			cmds := append(
+				ingressControllerReportCommands(pod.Namespace, pod.Name),
+				ingressReportCommands(pod.Namespace, pod.Name, "pods")...,
+			)
+			for _, cmd := range cmds {
+				filename := path.Join(
+					c.rootNamespaceDirPath(),
+					namespace.Name,
+					rootPodDirName,
+					pod.Name,
+					commandsDirName,
+					strings.Join(cmd, "_"),
+				)
+				if err := runCmdAndWriteToFile(cmd, filename); err != nil {
+					return err
+				}
+			}
+			c.completionSuccess("Collected report for ingress controller %s/%s", pod.Namespace, pod.Name)
+		}
+	}
+
+	return nil
+}
+
+func ingressReportCommands(namespace, resourceName, resourceType string) [][]string {
+	return [][]string{
+		{"kubectl", "get", resourceType, "-n", namespace, resourceName, "-o", "yaml"},
+		{"kubectl", "describe", resourceType, "-n", namespace, resourceName},
+	}
+}
+
+func ingressControllerReportCommands(namespace, resourceName string) [][]string {
+	return [][]string{
+		{"kubectl", "logs", "-n", namespace, resourceName},
+	}
+}

--- a/pkg/bugreport/run.go
+++ b/pkg/bugreport/run.go
@@ -63,6 +63,21 @@ func (c *Config) Run() error {
 	c.completionSuccess("Finished generating report for control plane pods")
 	c.endSection()
 
+	// Generate report for ingress
+	if c.CollectIngress {
+		fmt.Fprintf(c.Stdout, "[+] Collecting ingress information\n")
+		if err := c.collectIngressReport(); err != nil {
+			c.completionFailure("Error getting ingress")
+			return errors.Wrap(err, "Error getting ingress")
+		}
+		if err := c.collectIngressControllerReport(); err != nil {
+			c.completionFailure("Error getting ingress controller")
+			return errors.Wrap(err, "Error getting ingress controller")
+		}
+		c.completionSuccess("Finished generating report for ingress")
+		c.endSection()
+	}
+
 	// Generate output file if not provided
 	if c.OutFile == "" {
 		outFd, err := ioutil.TempFile("", "*_osm-bug-report.tar.gz")

--- a/pkg/bugreport/types.go
+++ b/pkg/bugreport/types.go
@@ -6,6 +6,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+
+	policyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
 )
 
 // Config is the type used to hold the bug report configuration
@@ -13,10 +15,12 @@ type Config struct {
 	Stdout               io.Writer
 	Stderr               io.Writer
 	KubeClient           kubernetes.Interface
+	PolicyClient         policyClientset.Interface
 	ControlPlaneNamepace string
 	AppNamespaces        []string
 	AppDeployments       []types.NamespacedName
 	AppPods              []types.NamespacedName
 	OutFile              string
+	CollectIngress       bool
 	stagingDir           string
 }


### PR DESCRIPTION
**Description**:

This PR adds the ability to add ingress information into the bug report (with the `--ingress` param as well as included in `--all`). Having additional ingress information can help with troubleshooting issues.

Currently this supports automatically fetching diagnostics from nginx as well as Contour.

Resolves #4406.

**Testing done**:

## nginx ingress

```
$ go run ./cmd/cli support bug-report --ingress

...

[+] Collecting ingress information
✓ Collected report for ingress httpbin/httpbin
✓ Collected report for ingress backend httpbin/httpbin
✓ Collected report for ingress controller ingress-nginx/ingress-nginx-controller-54bfb9bb-8kvnv
✓ Finished generating report for ingress

...

$ tree ingress-nginx/
ingress-nginx/
└── pods
    └── ingress-nginx-controller-54bfb9bb-8kvnv
        └── commands
            ├── kubectl_describe_pods_-n_ingress-nginx_ingress-nginx-controller-54bfb9bb-8kvnv
            ├── kubectl_get_pods_-n_ingress-nginx_ingress-nginx-controller-54bfb9bb-8kvnv_-o_yaml
            └── kubectl_logs_-n_ingress-nginx_ingress-nginx-controller-54bfb9bb-8kvnv

3 directories, 3 files

$ tree httpbin/
httpbin/
├── ingressbackends
│   └── httpbin
│       └── commands
│           ├── kubectl_describe_ingressbackends_-n_httpbin_httpbin
│           └── kubectl_get_ingressbackends_-n_httpbin_httpbin_-o_yaml
└── ingresses
    └── httpbin
        └── commands
            ├── kubectl_describe_ingresses_-n_httpbin_httpbin
            └── kubectl_get_ingresses_-n_httpbin_httpbin_-o_yaml

6 directories, 4 files
```

## Contour ingress

```
$ go run ./cmd/cli support bug-report --ingress

...

[+] Collecting ingress information
✓ Collected report for ingress backend httpbin/httpbin
✓ Collected report for ingress controller osm-system/osm-contour-contour-6c98586744-q5g6d
✓ Collected report for ingress controller osm-system/osm-contour-contour-6c98586744-vxqj7
✓ Collected report for ingress controller osm-system/osm-contour-envoy-492q7
✓ Collected report for ingress controller osm-system/osm-contour-envoy-6knt6
✓ Collected report for ingress controller osm-system/osm-contour-envoy-6m6kv
✓ Collected report for ingress controller osm-system/osm-contour-envoy-9vs4w
✓ Collected report for ingress controller osm-system/osm-contour-envoy-m66r4
✓ Finished generating report for ingress

...

$ tree osm-system/                                                                                                                                                                   [28/1545]
osm-system/
└── pods
    ├── osm-bootstrap-5cb7586ffc-tlkn6
    │   └── commands
    │       └── kubectl_logs_-n_osm-system_osm-bootstrap-5cb7586ffc-tlkn6
    ├── osm-contour-contour-6c98586744-q5g6d
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-contour-6c98586744-q5g6d
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-contour-6c98586744-q5g6d_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-contour-6c98586744-q5g6d
    ├── osm-contour-contour-6c98586744-vxqj7
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-contour-6c98586744-vxqj7
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-contour-6c98586744-vxqj7_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-contour-6c98586744-vxqj7
    ├── osm-contour-envoy-492q7
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-envoy-492q7
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-envoy-492q7_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-envoy-492q7
    ├── osm-contour-envoy-6knt6
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-envoy-6knt6
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-envoy-6knt6_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-envoy-6knt6
    ├── osm-contour-envoy-6m6kv
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-envoy-6m6kv
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-envoy-6m6kv_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-envoy-6m6kv
    ├── osm-contour-envoy-9vs4w
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-envoy-9vs4w
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-envoy-9vs4w_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-envoy-9vs4w
    ├── osm-contour-envoy-m66r4
    │   └── commands
    │       ├── kubectl_describe_pods_-n_osm-system_osm-contour-envoy-m66r4
    │       ├── kubectl_get_pods_-n_osm-system_osm-contour-envoy-m66r4_-o_yaml
    │       └── kubectl_logs_-n_osm-system_osm-contour-envoy-m66r4
    ├── osm-controller-9db65477b-bhlzc
    │   └── commands
    │       └── kubectl_logs_-n_osm-system_osm-controller-9db65477b-bhlzc
    └── osm-injector-54d979f448-nfn25
        └── commands
            └── kubectl_logs_-n_osm-system_osm-injector-54d979f448-nfn25

21 directories, 24 files

$ tree httpbin/
httpbin/
└── ingressbackends
    └── httpbin
        └── commands
            ├── kubectl_describe_ingressbackends_-n_httpbin_httpbin
            └── kubectl_get_ingressbackends_-n_httpbin_httpbin_-o_yaml

3 directories, 2 files
```

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No.

2. Is this a breaking change?

No.