### PR TITLE
injector: allow redirection of app traffic to itself

### DIFF
--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -52,6 +52,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 -A OSM_PROXY_OUT_REDIRECT -p tcp -j REDIRECT --to-port 15001
 -A OSM_PROXY_OUT_REDIRECT -p tcp --dport 15000 -j ACCEPT
 -A OUTPUT -p tcp -j OSM_PROXY_OUTBOUND
+-A OSM_PROXY_OUTBOUND -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1500 -j OSM_PROXY_IN_REDIRECT
+-A OSM_PROXY_OUTBOUND -o lo -m owner ! --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -m owner --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -d 127.0.0.1/32 -j RETURN
 -A OSM_PROXY_OUTBOUND -j OSM_PROXY_OUT_REDIRECT

--- a/pkg/injector/iptables_test.go
+++ b/pkg/injector/iptables_test.go
@@ -33,6 +33,8 @@ func TestGenerateIptablesCommands(t *testing.T) {
 -A OSM_PROXY_OUT_REDIRECT -p tcp -j REDIRECT --to-port 15001
 -A OSM_PROXY_OUT_REDIRECT -p tcp --dport 15000 -j ACCEPT
 -A OUTPUT -p tcp -j OSM_PROXY_OUTBOUND
+-A OSM_PROXY_OUTBOUND -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1500 -j OSM_PROXY_IN_REDIRECT
+-A OSM_PROXY_OUTBOUND -o lo -m owner ! --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -m owner --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -d 127.0.0.1/32 -j RETURN
 -A OSM_PROXY_OUTBOUND -j OSM_PROXY_OUT_REDIRECT


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change allows an app to invoke itself by enabling
the necessary iptables rules. It allows an app to direct
traffic to itself when:
1. app directs traffic to its pod IP
2. app directs traffic to its k8s service IP
   which is then resolved to the local pod IP
   by Envoy.

Resolves #4340

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Tested app sending traffic to itself via k8s service
and pod IP.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Sidecar Injection          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
