### PR TITLE
[RFC] contributing: update maintainer requirement

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -61,7 +61,7 @@ A Maintainer must meet the rights, responsiblities, and requirements of a Contri
     * Participating in, and leading, community meetings
     * Helps run the project infrastructure
 * Requirements
-    * Experience as a Contributor for at least 6 months
+    * Experience as a Contributor for at least 3 months
     * Demonstrates a broad knowledge of the project across multiple areas
     * Is able to exercise judgement for the good of the project, independent of their employer, social circles, or teams
     * Mentors other Contributors
@@ -87,8 +87,8 @@ An approver may nominate a current contributor who has shown significant underst
 It is important for contributors to be and stay active to set an example and show commitment to the project. Inactivity is harmful to the project as it may lead to unexpected delays, contributor attrition, and a lost of trust in the project.
 
 * Inactivity is measured by:
-    * Periods of no contributions for longer than 6 months
-    * Periods of no communication for longer than 6 months
+    * Periods of no contributions for longer than 3 months
+    * Periods of no communication for longer than 3 months
 
 * Consequences of being inactive include:
     * Involuntary removal or demotion


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the contribution duration required
to become a maintainer to 3 months instead
of 6. 3 months is a more reasonable duration
to onboard new maintainers. Also updates the
inactivity duration to 3 months instead of 6.

**Maintainers action**:
If you agree with this change, kindly approve it. 
This change will only be merged if a majority
of maintainers approve. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
