### PR TITLE
feat(cli): latest verion availability notification on osm version

### DIFF
--- a/cmd/cli/version_latest.go
+++ b/cmd/cli/version_latest.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+func getLatestReleaseVersion() (string, error) {
+	url := "https://api.github.com/repos/openservicemesh/osm/releases/latest"
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to create GET request for latest release version from %s", url)
+	}
+
+	req.Header.Add("Accept", "application/vnd.github.v3+json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to fetch latest release version from %s", url)
+	}
+	//nolint: errcheck
+	//#nosec G307
+	defer resp.Body.Close()
+
+	latestReleaseVersionInfo := map[string]interface{}{}
+	if err := json.NewDecoder(resp.Body).Decode(&latestReleaseVersionInfo); err != nil {
+		return "", errors.Wrapf(err, "unable to decode latest release version information from %s", url)
+	}
+
+	latestVersion, ok := latestReleaseVersionInfo["tag_name"]
+	if !ok {
+		return "", errors.Errorf("tag_name key not found in latest release version information from %s", url)
+	}
+	return fmt.Sprint(latestVersion), nil
+}
+
+func outputLatestReleaseVersion(out io.Writer, latestRelease string, currentRelease string) error {
+	latest, err := version.ParseSemantic(latestRelease)
+	if err != nil {
+		return err
+	}
+	current, err := version.ParseSemantic(currentRelease)
+	if err != nil {
+		return err
+	}
+	if current.LessThan(latest) {
+		fmt.Fprintf(out, "\nOSM %s is now available. Please see https://github.com/openservicemesh/osm/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n", latestRelease)
+	}
+	return nil
+}

--- a/cmd/cli/version_latest_test.go
+++ b/cmd/cli/version_latest_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestOutputLatestReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		err     error
+		output  string
+	}{
+		{
+			name:    "invalid current version",
+			current: "v1.0.0.0",
+			latest:  "v1.0.0",
+			err:     fmt.Errorf("illegal version string \"v1.0.0.0\""),
+			output:  "",
+		},
+		{
+			name:    "invalid latest version",
+			current: "v1.0.0",
+			latest:  "1.0.0.0",
+			err:     fmt.Errorf("illegal version string \"1.0.0.0\""),
+			output:  "",
+		},
+		{
+			name:    "current is less than latest version",
+			current: "v1.21.4",
+			latest:  "v1.21.5",
+			err:     nil,
+			output:  "\nOSM v1.21.5 is now available. Please see https://github.com/openservicemesh/osm/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n",
+		},
+		{
+			name:    "current is latest version",
+			current: "v1.23.1",
+			latest:  "v1.23.1",
+			err:     nil,
+			output:  "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			buf := bytes.NewBuffer(nil)
+			err := outputLatestReleaseVersion(buf, test.latest, test.current)
+
+			assert.Equal(test.err, err)
+			assert.Equal(test.output, buf.String())
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/jetstack/cert-manager v1.3.1
@@ -156,7 +157,6 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
-	github.com/hashicorp/go-multierror v1.0.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.5.4 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Gets the latest OSM release version and compares it to the current
CLI version. If the latest version is newer than the current
version, a notification is displayed. This notification is only
displayed in the `osm version` cmd output.

Adds a `version-only` flag that hides warnings and upgrade notifications.

Errors are grouped at the end of the cmd output.

**New `osm version` output:**

```shell
$ osm version
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
Mesh [osm] Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}

OSM v1.0.0 is now available. Please see https://github.com/openservicemesh/osm/releases/latest.
WARNING: upgrading could introduce breaking changes. Please review the release notes.

$ osm version  --version-only
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
Mesh [osm] Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}

$ osm version  --version-only --client-only
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
```
Example output when there is an error getting the mesh version:
```shell
$ osm version
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}

OSM v0.11.1 is now available. Please see https://github.com/openservicemesh/osm/releases/latest.
WARNING: upgrading could introduce breaking changes. Please review the release notes.
Error: 1 error occurred:
        * Failed to get mesh version: No mesh found in namespace [osm-system]
```

Example output when there is an error getting the mesh version and the latest release information:
```shell
$ osm version
CLI Version: version.Info{Version:"v0.11.1", GitCommit:"c01aefae509d59735d7908a32a359327ff3f2322", BuildDate:"2021-10-20-20:33"}
Error: 2 errors occurred:
        * Failed to get mesh version: No mesh found in namespace [osm-system]
        * Failed to output latest release information:  HTTP request failed
```
**Note**: Since "dev" is not a valid version, a dev build of OSM will produce the following error
```shell
$ osm version
CLI Version: version.Info{Version:"dev", GitCommit:"be44de85705abaf8e503e389b9975c237360bdf3", BuildDate:""}
Mesh [osm] Version: version.Info{Version:"dev", GitCommit:"be44de85705abaf8e503e389b9975c237360bdf3", BuildDate:""}
Error: 1 error occurred:
        * Failed to output latest release information: could not parse "dev" as version
```
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Wrote unit tests for parsing and outputting the latest release notification
- Manually verified the `osm-version` outputs
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ x ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no
