### PR TITLE
feat(sidecar): add tls protocol version and cipher suites config to

### DIFF
--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -86,6 +86,36 @@ spec:
                     configResyncInterval:
                       description: Resync interval for regular proxy broadcast updates
                       type: string
+                    tlsMinProtocolVersion:
+                      description: The minimum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+                      type: string
+                      enum:
+                        - TLS_AUTO
+                        - TLSv1_0
+                        - TLSv1_1
+                        - TLSv1_2
+                        - TLSv1_3
+                      default: TLSv1_2
+                    tlsMaxProtocolVersion:
+                      description: The maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+                      type: string
+                      enum:
+                        - TLS_AUTO
+                        - TLSv1_0
+                        - TLSv1_1
+                        - TLSv1_2
+                        - TLSv1_3
+                      default: TLSv1_3
+                    cipherSuites:
+                      description: A list of ciphers that listener supports when negotiating TLS 1.0-1.2. This setting has no effect when negotiating TLS 1.3. For valid cipher names, see the latest OpenSSL ciphers manual page. E.g. https://www.openssl.org/docs/man1.1.1/apps/ciphers.html.
+                      type: array
+                      items:
+                        type: string
+                    ecdhCurves:
+                      description: A list of ECDH curves that TLS connection supports. If not specified, the curves are [X25519, P-256] for non-FIPS build and P-256 for builds using BoringSSL FIPS.
+                      type: array
+                      items:
+                        type: string
                 traffic:
                   description: Configuration for traffic management
                   type: object

--- a/pkg/apis/config/v1alpha2/mesh_config.go
+++ b/pkg/apis/config/v1alpha2/mesh_config.go
@@ -65,6 +65,18 @@ type SidecarSpec struct {
 
 	// Resources defines the compute resources for the sidecar.
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// TLSMinProtocolVersion defines the minimum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+	TLSMinProtocolVersion string `json:"tlsMinProtocolVersion,omitempty"`
+
+	// TLSMaxProtocolVersion defines the maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+	TLSMaxProtocolVersion string `json:"tlsMaxProtocolVersion,omitempty"`
+
+	// CipherSuites defines a list of ciphers that listener supports when negotiating TLS 1.0-1.2. This setting has no effect when negotiating TLS 1.3. For valid cipher names, see the latest OpenSSL ciphers manual page. E.g. https://www.openssl.org/docs/man1.1.1/apps/ciphers.html.
+	CipherSuites []string `json:"cipherSuites,omitempty"`
+
+	// ECDHCurves defines a list of ECDH curves that TLS connection supports. If not specified, the curves are [X25519, P-256] for non-FIPS build and P-256 for builds using BoringSSL FIPS.
+	ECDHCurves []string `json:"ecdhCurves,omitempty"`
 }
 
 // TrafficSpec is the type used to represent OSM's traffic management configuration.

--- a/pkg/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -317,6 +317,16 @@ func (in *PortSpec) DeepCopy() *PortSpec {
 func (in *SidecarSpec) DeepCopyInto(out *SidecarSpec) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.CipherSuites != nil {
+		in, out := &in.CipherSuites, &out.CipherSuites
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ECDHCurves != nil {
+		in, out := &in.ECDHCurves, &out.ECDHCurves
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -41,6 +41,11 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 		return nil, err
 	}
 
+	minVersionInt := xds_transport_sockets.TlsParameters_TlsProtocol_value[config.TLSMinProtocolVersion]
+	maxVersionInt := xds_transport_sockets.TlsParameters_TlsProtocol_value[config.TLSMaxProtocolVersion]
+	tlsMinVersion := xds_transport_sockets.TlsParameters_TlsProtocol(minVersionInt)
+	tlsMaxVersion := xds_transport_sockets.TlsParameters_TlsProtocol(maxVersionInt)
+
 	upstreamTLSContext := &xds_transport_sockets.UpstreamTlsContext{
 		CommonTlsContext: &xds_transport_sockets.CommonTlsContext{
 			AlpnProtocols: []string{
@@ -56,8 +61,10 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 				},
 			},
 			TlsParams: &xds_transport_sockets.TlsParameters{
-				TlsMinimumProtocolVersion: xds_transport_sockets.TlsParameters_TLSv1_2,
-				TlsMaximumProtocolVersion: xds_transport_sockets.TlsParameters_TLSv1_3,
+				TlsMinimumProtocolVersion: tlsMinVersion,
+				TlsMaximumProtocolVersion: tlsMaxVersion,
+				CipherSuites:              config.CipherSuites,
+				EcdhCurves:                config.ECDHCurves,
 			},
 			TlsCertificates: []*xds_transport_sockets.TlsCertificate{
 				{

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -15,14 +15,18 @@ func TestBuildFromConfig(t *testing.T) {
 	cert := tresor.NewFakeCertificate()
 
 	config := Config{
-		NodeID:           cert.GetCommonName().String(),
-		AdminPort:        15000,
-		XDSClusterName:   constants.OSMControllerName,
-		TrustedCA:        cert.GetIssuingCA(),
-		CertificateChain: cert.GetCertificateChain(),
-		PrivateKey:       cert.GetPrivateKey(),
-		XDSHost:          "osm-controller.osm-system.svc.cluster.local",
-		XDSPort:          15128,
+		NodeID:                cert.GetCommonName().String(),
+		AdminPort:             15000,
+		XDSClusterName:        constants.OSMControllerName,
+		TrustedCA:             cert.GetIssuingCA(),
+		CertificateChain:      cert.GetCertificateChain(),
+		PrivateKey:            cert.GetPrivateKey(),
+		XDSHost:               "osm-controller.osm-system.svc.cluster.local",
+		XDSPort:               15128,
+		TLSMinProtocolVersion: "TLSv1_0",
+		TLSMaxProtocolVersion: "TLSv1_2",
+		CipherSuites:          []string{"abc", "xyz"},
+		ECDHCurves:            []string{"ABC", "XYZ"},
 	}
 
 	bootstrapConfig, err := BuildFromConfig(config)
@@ -82,8 +86,14 @@ static_resources:
             private_key:
               inline_bytes: eXk=
           tls_params:
-            tls_maximum_protocol_version: TLSv1_3
-            tls_minimum_protocol_version: TLSv1_2
+            cipher_suites:
+            - abc
+            - xyz
+            ecdh_curves:
+            - ABC
+            - XYZ
+            tls_maximum_protocol_version: TLSv1_2
+            tls_minimum_protocol_version: TLSv1_0
           validation_context:
             trusted_ca:
               inline_bytes: eHg=

--- a/pkg/envoy/bootstrap/types.go
+++ b/pkg/envoy/bootstrap/types.go
@@ -33,4 +33,16 @@ type Config struct {
 
 	// PrivateKey is the private key for the certificate used by the proxy to connect to the XDS cluster
 	PrivateKey []byte
+
+	// TLSMinProtocolVersion is the minimum supported TLS protocol version
+	TLSMinProtocolVersion string
+
+	// TLSMaxProtocolVersion is the maximum supported TLS protocol version
+	TLSMaxProtocolVersion string
+
+	// CipherSuites is the list of cipher that TLS 1.0-1.2 supports
+	CipherSuites []string
+
+	// ECDHCurves is the list of ECDH curves it supports
+	ECDHCurves []string
 }

--- a/pkg/injector/envoy_config.go
+++ b/pkg/injector/envoy_config.go
@@ -21,14 +21,18 @@ import (
 
 func getEnvoyConfigYAML(config envoyBootstrapConfigMeta, cfg configurator.Configurator) ([]byte, error) {
 	bootstrapConfig, err := bootstrap.BuildFromConfig(bootstrap.Config{
-		NodeID:           config.NodeID,
-		AdminPort:        constants.EnvoyAdminPort,
-		XDSClusterName:   constants.OSMControllerName,
-		TrustedCA:        config.RootCert,
-		CertificateChain: config.Cert,
-		PrivateKey:       config.Key,
-		XDSHost:          config.XDSHost,
-		XDSPort:          config.XDSPort,
+		NodeID:                config.NodeID,
+		AdminPort:             constants.EnvoyAdminPort,
+		XDSClusterName:        constants.OSMControllerName,
+		TrustedCA:             config.RootCert,
+		CertificateChain:      config.Cert,
+		PrivateKey:            config.Key,
+		XDSHost:               config.XDSHost,
+		XDSPort:               config.XDSPort,
+		TLSMinProtocolVersion: config.TLSMinProtocolVersion,
+		TLSMaxProtocolVersion: config.TLSMaxProtocolVersion,
+		CipherSuites:          config.CipherSuites,
+		ECDHCurves:            config.ECDHCurves,
 	})
 	if err != nil {
 		log.Error().Err(err).Msgf("Error building Envoy boostrap config")
@@ -113,6 +117,11 @@ func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamesp
 		// OriginalHealthProbes stores the path and port for liveness, readiness, and startup health probes as initially
 		// defined on the Pod Spec.
 		OriginalHealthProbes: originalHealthProbes,
+
+		TLSMinProtocolVersion: wh.configurator.GetMeshConfig().Spec.Sidecar.TLSMinProtocolVersion,
+		TLSMaxProtocolVersion: wh.configurator.GetMeshConfig().Spec.Sidecar.TLSMaxProtocolVersion,
+		CipherSuites:          wh.configurator.GetMeshConfig().Spec.Sidecar.CipherSuites,
+		ECDHCurves:            wh.configurator.GetMeshConfig().Spec.Sidecar.ECDHCurves,
 	}
 	yamlContent, err := getEnvoyConfigYAML(configMeta, wh.configurator)
 	if err != nil {

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -146,8 +146,9 @@ func TestCreatePatch(t *testing.T) {
 
 			if tc.os == constants.OSLinux {
 				mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
-				mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 			}
+
+			mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("").Times(1)
 			mockConfigurator.EXPECT().GetProxyResources().Return(corev1.ResourceRequirements{}).Times(1)
 			mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
@@ -190,6 +191,7 @@ func TestCreatePatch(t *testing.T) {
 		}
 
 		mockConfigurator.EXPECT().GetEnvoyImage().Return("")
+		mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
 		pod := tests.NewOsSpecificPodFixture(namespace, podName, tests.BookstoreServiceAccountName, nil, constants.OSLinux)
 

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -56,4 +56,10 @@ type envoyBootstrapConfigMeta struct {
 	// The bootstrap Envoy config will be affected by the liveness, readiness, startup probes set on
 	// the pod this Envoy is fronting.
 	OriginalHealthProbes healthProbes
+
+	// Sidecar TLS configuration
+	TLSMinProtocolVersion string
+	TLSMaxProtocolVersion string
+	CipherSuites          []string
+	ECDHCurves            []string
 }


### PR DESCRIPTION
meshconfig

Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Add TLS protocol related sidecar configuration to MeshConfig.

* TLS minimum protocol version
* TLS maximum protocol version
* Cipher suites
* ECDH curves

These configuration details can be found on [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto)

Resovles: #4401 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

* Unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [X] |
| Sidecar Injection          | [X] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No
