### PR TITLE
meshConfig: add validation for ingressgateway certificate

### DIFF
--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -194,6 +194,7 @@ spec:
                           type: array
                           items:
                             type: string
+                          minItems: 1
                         validityDuration:
                           description: Certificate validity duration, represented as a sequence of decimal numbers each with optional fraction and a unit suffix
                           type: string


### PR DESCRIPTION
**Description**:

Validation added to the `subjectAltName` for the ingress gateway
certificate in the meshConfig. Going forward, this field (if specified) will have to contain
atleast one element.

Fixes #4353

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Testing done**: This change has been verified manually by updating the meshConfig by providing an empty array for the `subjectAltNames`. The crd update fails and provides the following error 

`meshconfigs.config.openservicemesh.io "osm-mesh-config" was not valid: # *spec.certificate.ingressGateway.subjectAltNames: Invalid value: 0: spec.certificate.ingressGateway.subjectAltNames in body should have at least 1 items`

thereby forcing users to provide a value whenever the ingressgateway certificate details are provided.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution? 

2. Is this a breaking change? `no`
