### PR TITLE
[backport] crd-conversion: fix webhook port number (#4424)

### DIFF
--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -45,7 +45,7 @@ spec:
           image: "{{ include "osmBootstrap.image" . }}"
           imagePullPolicy: {{ .Values.osm.image.pullPolicy }}
           ports:
-            - name: "tls"
+            - name: "crdconversion"
               containerPort: 9443
             - name: "metrics"
               containerPort: 9091

--- a/charts/osm/templates/osm-bootstrap-service.yaml
+++ b/charts/osm/templates/osm-bootstrap-service.yaml
@@ -8,9 +8,8 @@ metadata:
     app: osm-bootstrap
 spec:
   ports:
-    - name: tls
+    - name: crdconversion
       port: 9443
-      targetPort: tls
     - name: health
       port: 9095
   selector:

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -180,7 +180,7 @@ func main() {
 	}
 
 	// Initialize the crd conversion webhook server to support the conversion of OSM's CRDs
-	crdConverterConfig.ListenPort = 9443
+	crdConverterConfig.ListenPort = constants.CRDConversionWebhookPort
 	if err := crdconversion.NewConversionWebhook(crdConverterConfig, kubeClient, crdClient, certManager, osmNamespace, enableReconciler, stop); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating crd conversion webhook")
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -162,6 +162,9 @@ const (
 
 	// OSMMeshConfig is the name of the OSM MeshConfig
 	OSMMeshConfig = "osm-mesh-config"
+
+	// CRDConversionWebhookPort is the port of the CRD conversion webhook service
+	CRDConversionWebhookPort = 9443
 )
 
 // Annotations used by the control plane

--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -12,6 +12,7 @@ import (
 	apiclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/pointer"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/providers"
@@ -186,6 +187,7 @@ func updateCrdConfiguration(cert certificate.Certificater, crdClient apiclient.A
 				Service: &apiv1.ServiceReference{
 					Namespace: osmNamespace,
 					Name:      constants.OSMBootstrapName,
+					Port:      pointer.Int32(constants.CRDConversionWebhookPort),
 					Path:      &crdConversionPath,
 				},
 				CABundle: cert.GetCertificateChain(),


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
Backports a70d654e from main to release-v1.0
---
**Description**:
Explicitly set's the webhook's port to 9443
in the Go code. If unset, the port defaults
to 443 which results in a mismatch.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Upgrade                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
