### PR TITLE
[reconciler]: fix label assignment on mwhc

### DIFF
--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -421,13 +421,9 @@ func createOrUpdateMutatingWebhook(clientSet kubernetes.Interface, cert certific
 
 	mwhc := admissionregv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: webhookName,
-			Labels: map[string]string{
-				constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
-				constants.OSMAppInstanceLabelKey: meshName,
-				constants.OSMAppVersionLabelKey:  osmVersion,
-				constants.AppLabel:               constants.OSMInjectorName,
-				constants.ReconcileLabel:         strconv.FormatBool(true)}},
+			Name:   webhookName,
+			Labels: mwhcLabels,
+		},
 		Webhooks: []admissionregv1.MutatingWebhook{
 			{
 				Name: MutatingWebhookName,


### PR DESCRIPTION
**Description**:

Fixed label assignment on the mwhc by reusing the locally created labels
for correct assignment of reconciler labels.

Signed-off-by: Sneha Chhabria <snchh@microsoft.com>

**Testing done**: Manually verified the change

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no` 
