### PR TITLE
bug(*): Change memory targetAverageUtilization to targetAverageValue

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -117,11 +117,11 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.image.tag | string | `"latest-main"` | Container image tag for control plane images |
 | osm.imagePullSecrets | list | `[]` | `osm-controller` image pull secret |
 | osm.inboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from inbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
-| osm.injector.autoScale | object | `{"cpu":{"targetAverageUtilization":80},"enable":false,"maxReplicas":5,"memory":{"targetAverageUtilization":80},"minReplicas":1}` | Auto scale configuration |
+| osm.injector.autoScale | object | `{"cpu":{"targetAverageUtilization":80},"enable":false,"maxReplicas":5,"memory":{"targetAverageValue":"40M"},"minReplicas":1}` | Auto scale configuration |
 | osm.injector.autoScale.cpu.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | osm.injector.autoScale.enable | bool | `false` | Enable Autoscale |
 | osm.injector.autoScale.maxReplicas | int | `5` | Maximum replicas for autoscale |
-| osm.injector.autoScale.memory.targetAverageUtilization | int | `80` | Average target memory utilization (%) |
+| osm.injector.autoScale.memory.targetAverageValue | string | `"40M"` | Average target memory value |
 | osm.injector.autoScale.minReplicas | int | `1` | Minimum replicas for autoscale |
 | osm.injector.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | osm.injector.podLabels | object | `{}` | Sidecar injector's pod labels |
@@ -135,11 +135,11 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.osmBootstrap.podLabels | object | `{}` | OSM bootstrap's pod labels |
 | osm.osmBootstrap.replicaCount | int | `1` | OSM bootstrap's replica count |
 | osm.osmBootstrap.resource | object | `{"limits":{"cpu":"0.5","memory":"128M"},"requests":{"cpu":"0.3","memory":"128M"}}` | OSM bootstrap's container resource parameters |
-| osm.osmController.autoScale | object | `{"cpu":{"targetAverageUtilization":80},"enable":false,"maxReplicas":5,"memory":{"targetAverageUtilization":80},"minReplicas":1}` | Auto scale configuration |
+| osm.osmController.autoScale | object | `{"cpu":{"targetAverageUtilization":80},"enable":false,"maxReplicas":5,"memory":{"targetAverageValue":"50M"},"minReplicas":1}` | Auto scale configuration |
 | osm.osmController.autoScale.cpu.targetAverageUtilization | int | `80` | Average target CPU utilization (%) |
 | osm.osmController.autoScale.enable | bool | `false` | Enable Autoscale |
 | osm.osmController.autoScale.maxReplicas | int | `5` | Maximum replicas for autoscale |
-| osm.osmController.autoScale.memory.targetAverageUtilization | int | `80` | Average target memory utilization (%) |
+| osm.osmController.autoScale.memory.targetAverageValue | string | `"50M"` | Average target memory value |
 | osm.osmController.autoScale.minReplicas | int | `1` | Minimum replicas for autoscale |
 | osm.osmController.enablePodDisruptionBudget | bool | `false` | Enable Pod Disruption Budget |
 | osm.osmController.podLabels | object | `{}` | OSM controller's pod labels |

--- a/charts/osm/templates/osm-controller-hpa.yaml
+++ b/charts/osm/templates/osm-controller-hpa.yaml
@@ -23,5 +23,5 @@ spec:
       name: memory
       target:
         type: Utilization
-        averageValue: {{.Values.osm.osmController.autoScale.memory.targetAverageUtilization}}
+        averageValue: {{.Values.osm.osmController.autoScale.memory.targetAverageValue}}
 {{- end }}

--- a/charts/osm/templates/osm-injector-hpa.yaml
+++ b/charts/osm/templates/osm-injector-hpa.yaml
@@ -23,5 +23,5 @@ spec:
       name: memory
       target:
         type: Utilization
-        averageValue: {{.Values.osm.injector.autoScale.memory.targetAverageUtilization}}
+        averageValue: {{.Values.osm.injector.autoScale.memory.targetAverageValue}}
 {{- end }}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -139,18 +139,16 @@
                     "title": "Autoscale memory resource schema",
                     "description": "Autoscale memory configuration",
                     "required": [
-                        "targetAverageUtilization"
+                        "targetAverageValue"
                     ],
                     "properties": {
-                        "targetAverageUtilization": {
-                            "$id": "#/properties/definitions/properties/autoScale/properties/memory/properties/targetAverageUtilization",
-                            "type": "integer",
-                            "title": "Autoscale memory targetAverageUtilization",
-                            "description": "Indicates average target memory utilization (percentage) for autoscale.",
-                            "minimum": 0,
-                            "maximum": 100,
-                            "examples": [
-                                80
+                        "targetAverageValue": {
+                            "$id": "#/properties/definitions/properties/autoScale/properties/memory/properties/targetAverageValue",
+                            "type": "string",
+                            "title": "Autoscale memory targetAverageValue",
+                            "description": "Indicates average target memory value for autoscale.",
+                            "examples":[
+                                "2M"
                             ]
                         }
                     },

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -65,8 +65,8 @@ osm:
         # -- Average target CPU utilization (%)
         targetAverageUtilization: 80
       memory:
-        # -- Average target memory utilization (%)
-        targetAverageUtilization: 80
+        # -- Average target memory value
+        targetAverageValue: "50M"
 
   #
   # -- Prometheus parameters
@@ -264,8 +264,8 @@ osm:
         # -- Average target CPU utilization (%)
         targetAverageUtilization: 80
       memory:
-      # -- Average target memory utilization (%)
-        targetAverageUtilization: 80
+      # -- Average target memory value
+        targetAverageValue: "40M"
     # -- Mutating webhook timeout
     webhookTimeoutSeconds: 20
 


### PR DESCRIPTION
**Description**:
Could not use targetAverageUtilization for memory, as metrics-server showed memory in bytes instead of a percentage.
![image](https://user-images.githubusercontent.com/69616256/149247546-3a0371f5-65df-4152-9f60-447b720b27de.png)
Change memory from targetAverageUtilization to targetAverageValue, memory values were set based on memory usage of the bookstore demo for osm-controller and osm-injector, so that only 1 replica was needed.
![image](https://user-images.githubusercontent.com/69616256/149249072-8b085444-a382-49ab-806e-9ba48f05f2d4.png)


Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

**Testing done**:
Ran bookstore demo to determine memory limits.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no 
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no
