### PR TITLE
bug(*): Fix memory targetAverageUtilization

### DIFF
--- a/charts/osm/templates/osm-controller-hpa.yaml
+++ b/charts/osm/templates/osm-controller-hpa.yaml
@@ -23,5 +23,5 @@ spec:
       name: memory
       target:
         type: Utilization
-        averageValue: {{.Values.osm.osmController.autoScale.memory.targetAverageUtilization}}
+        averageUtilization: {{.Values.osm.osmController.autoScale.memory.targetAverageUtilization}}
 {{- end }}

--- a/charts/osm/templates/osm-injector-hpa.yaml
+++ b/charts/osm/templates/osm-injector-hpa.yaml
@@ -23,5 +23,5 @@ spec:
       name: memory
       target:
         type: Utilization
-        averageValue: {{.Values.osm.injector.autoScale.memory.targetAverageUtilization}}
+        averageUtilization: {{.Values.osm.injector.autoScale.memory.targetAverageUtilization}}
 {{- end }}


### PR DESCRIPTION
**Description**:
Update HPA yamls from averageValue to averageUtilization
and resolves #4451

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

**Testing done**:
Ran HPA enabled for osmController and injector for bookstore demo and percentages are seen for both CPU and memory utilization.
![image](https://user-images.githubusercontent.com/69616256/149576705-c70f7407-4c24-4237-a7e4-d4c31700eb30.png)

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no
