### PR TITLE
[backport] fix(cli): do not throw error for osm version when no control plane (#4433)

### DIFF
--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -106,7 +106,7 @@ func (v *versionCmd) getMeshVersion() (*remoteVersionInfo, error) {
 		return nil, err
 	}
 	if len(controllerPods.Items) == 0 {
-		return nil, errors.Errorf("No mesh found in namespace [%s]", v.namespace)
+		return &remoteVersionInfo{}, nil
 	}
 
 	controllerPod := controllerPods.Items[0]
@@ -142,6 +142,10 @@ func (r *remoteVersion) proxyGetMeshVersion(pod string, namespace string, client
 func (v *versionCmd) outputVersionInfo(versionInfo versionInfo) {
 	fmt.Fprintf(v.out, "CLI Version: %#v\n", *versionInfo.cliVersionInfo)
 	if versionInfo.remoteVersionInfo != nil {
-		fmt.Fprintf(v.out, "Mesh [%s] Version: %#v\n", versionInfo.remoteVersionInfo.meshName, *versionInfo.remoteVersionInfo.version)
+		if versionInfo.remoteVersionInfo.meshName != "" {
+			fmt.Fprintf(v.out, "Mesh [%s] Version: %#v\n", versionInfo.remoteVersionInfo.meshName, *versionInfo.remoteVersionInfo.version)
+		} else {
+			fmt.Fprintf(v.out, "Mesh Version: No control plane found in namespace [%s]\n", v.namespace)
+		}
 	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
Backports 95fb3420 from main to release-v1.0
---
**Description**:

If a control plane is not installed in the specified namespace do
not throw an error for `osm version`. Currently, the command
returns an error in this scenario.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [x] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No
