### PR TITLE
[backport] fix(grafana): remove hardcoded control plane namespace (#4454)

### DIFF
--- a/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
+++ b/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
@@ -7,6 +7,12 @@
       "type": "datasource",
       "pluginId": "prometheus",
       "pluginName": "Prometheus"
+    },
+    {
+      "name": "CONTROL_PLANE_NAMESPACE",
+      "label": "OSM Control Plane Namespace",
+      "description": "Namespace containing the OSM Control plane",
+      "type": "constant"
     }
   ],
   "__requires": [
@@ -293,7 +299,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(container_cpu_usage_seconds_total{namespace=\"osm-system\", container!~\"POD\", container!~\"\"}[1m])",
+          "expr": "irate(container_cpu_usage_seconds_total{namespace=\"${CONTROL_PLANE_NAMESPACE}\", container!~\"POD\", container!~\"\"}[1m])",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"
@@ -411,7 +417,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_rss{namespace=\"osm-system\", container!=\"\", container!=\"POD\"}",
+          "expr": "container_memory_rss{namespace=\"${CONTROL_PLANE_NAMESPACE}\", container!=\"\", container!=\"POD\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
           "refId": "A"

--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -94,7 +94,7 @@ data:
   osm-control-plane.json: |
 {{ .Files.Get "grafana/dashboards/osm-control-plane.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
   osm-mesh-envoy-details.json: |
-{{ .Files.Get "grafana/dashboards/osm-mesh-envoy-details.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
+{{ .Files.Get "grafana/dashboards/osm-mesh-envoy-details.json" | replace "${DS_PROMETHEUS}" "Prometheus" | replace "${CONTROL_PLANE_NAMESPACE}" (include "osm.namespace" .) | indent 4 }}
 
 ---
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
Backports ec0da63a from main to release-v1.0
---
**Description**:

Removes the hardcoded default control plane namespace from the
Mesh and Envoy Details dashboard. Parameterizes the control plane
namespace. When installing OSM with automatic provisioning of
prometheus and grafana the control plane namespace variable will
be set to the namespace where OSM is being installed. When
importing the Mesh and Envoy Details dashboard, the user will have
the option to set the osm control plane namespace just as they are
able to set the datasource.


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?
