### PR TITLE
charts/cleanup-hook: fix CRD reset logic

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -80,9 +80,9 @@ spec:
             - sh
             - -c
             - >
+             kubectl replace -f /osm-crds;
              kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
              kubectl delete --ignore-not-found secret -n '{{ include "osm.namespace" . }}' {{ .Values.osm.caBundleSecretName }} mutating-webhook-cert-secret validating-webhook-cert-secret crd-converter-cert-secret;
-             kubectl apply -f /osm-crds;
              kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found;
              kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-controller --ignore-not-found;
       nodeSelector:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes the CRD reset logic in the cleanup hook to:

1. Correctly `replace` the CRD modified by osm-boostrap
   to its initial state. osm-boostrap updates the CRDs
   to specify the CRD conversion spec referencing the
   CRD conversion webhook. Upon uninstall, the CRD
   conversion webhook is removed, and the cleanup
   hook attempts to reset the CRD to its initial
   state, albeit incorrectly. `kubectl apply`
   results in a `patch` request and a field is
   removed only if it is present in the
   `last-applied-configuration` annotation added
   by `kubectl` and not in the desired new config (see [this](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#merge-patch-calculation)).
   As a result, the `conversion` field in the CRDs
   was not being removed despite not being present
   in the original CRD spec applied prior to being
   patched by osm-bootstrap.

   This fix ensures the CRDs are correctly reset to
   their original state by using `kubectl replace`
   instead of `kubectl apply`.

2. Fixes the MeshConfig deletion order to happen
   **after** the CRD has been reset to its original
   state. Otherwise, deleting the MeshConfig will
   result in an attempt to perform CRD conversion,
   which will fail because of the CRD conversion
   webhook being already deleted prior to the hook
   being run.

   This has been fixed by first resetting the CRD
   to not perform the conversion, and then deleting
   the MeshConfig resource.

Resolves #4466

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Tested upgrade
- Verified #4466 is resolved 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Uninstall                    | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
