### PR TITLE
tests/framework: wait for deletion and dump namespace

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1240,7 +1240,7 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 				},
 			)
 			if err != nil {
-				td.T.Logf("Cleanup of namespaces timed out: %s", err)
+				td.T.Logf("Error polling namespaces for deletion: %s", err)
 
 				// Dump the namespaces that failed to terminate
 				stdout, stderr, _ := td.RunLocal("kubectl", "get", "namespace", "-l", osmTest, "-o", "yaml")

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -980,6 +980,7 @@ func (td *OsmTestData) DeleteNs(nsName string) error {
 			td.T.Logf("WARNING: failed to list helm releases in namespace %s, skipping release cleanup: %v", nsName, err)
 		} else {
 			del := action.NewUninstall(helm)
+			del.Wait = true
 			for _, release := range releases {
 				if _, err := del.Run(release.Name); err != nil {
 					td.T.Logf("WARNING: failed to delete helm release %s in namespace %s: %v", release.Name, nsName, err)
@@ -1239,7 +1240,13 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 				},
 			)
 			if err != nil {
-				td.T.Logf("Poll err: %v", err)
+				td.T.Logf("Cleanup of namespaces timed out: %s", err)
+
+				// Dump the namespaces that failed to terminate
+				stdout, stderr, _ := td.RunLocal("kubectl", "get", "namespace", "-l", osmTest, "-o", "yaml")
+				td.T.Logf("Namespace info:")
+				td.T.Logf("stdout:\n%s", stdout)
+				td.T.Logf("stderr:\n%s", stderr)
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Waits for resources created by Helm to delete prior
to performing deletion of the entire namespace.
Without this, some dangling resources can be left
behind in the cluster such and the namespace could
be stuck in the terminating state.
Also dumps the namespaces that fail to terminate. This
is necessary to root cause namespace deletion issues.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Used this change to root cause a bug in uninstall that left
namespaces in a dangling state.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`