### PR TITLE
ref(cert): remove expiration field from osm-ca-bundle secret data

### DIFF
--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -189,7 +189,6 @@ func TestGetCertificateFromKubernetes(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					constants.KubernetesOpaqueSecretCAKey:             certPEM,
-					constants.KubernetesOpaqueSecretCAExpiration:      []byte("2020-05-07T14:25:18.677Z"),
 					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
 				},
 			},
@@ -210,7 +209,6 @@ func TestGetCertificateFromKubernetes(t *testing.T) {
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					constants.KubernetesOpaqueSecretCAExpiration:      []byte("2020-05-07T14:25:18.677Z"),
 					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
 				},
 			},
@@ -225,39 +223,7 @@ func TestGetCertificateFromKubernetes(t *testing.T) {
 					Namespace: ns,
 				},
 				Data: map[string][]byte{
-					constants.KubernetesOpaqueSecretCAKey:        certPEM,
-					constants.KubernetesOpaqueSecretCAExpiration: []byte("2020-05-07T14:25:18.677Z"),
-				},
-			},
-			expectError:  true,
-			expectNilVal: true,
-		},
-		{
-			// Error when Expiration is missing
-			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: ns,
-				},
-				Data: map[string][]byte{
-					constants.KubernetesOpaqueSecretCAKey:             certPEM,
-					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
-				},
-			},
-			expectError:  true,
-			expectNilVal: true,
-		},
-		{
-			// Error when Parsing expiration date
-			secret: &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: ns,
-				},
-				Data: map[string][]byte{
-					constants.KubernetesOpaqueSecretCAKey:             certPEM,
-					constants.KubernetesOpaqueSecretCAExpiration:      []byte("Invalid expiration date"),
-					constants.KubernetesOpaqueSecretRootPrivateKeyKey: keyPEM,
+					constants.KubernetesOpaqueSecretCAKey: certPEM,
 				},
 			},
 			expectError:  true,

--- a/pkg/certificate/providers/tresor/ca.go
+++ b/pkg/certificate/providers/tresor/ca.go
@@ -84,7 +84,7 @@ func NewCA(cn certificate.CommonName, validityPeriod time.Duration, rootCertCoun
 }
 
 // NewCertificateFromPEM is a helper returning a certificate.Certificater from the PEM components given.
-func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expiration time.Time) (certificate.Certificater, error) {
+func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey) (certificate.Certificater, error) {
 	x509Cert, err := certificate.DecodePEMCertificate(pemCert)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
@@ -92,12 +92,13 @@ func NewCertificateFromPEM(pemCert pem.Certificate, pemKey pem.PrivateKey, expir
 			Msg("Error converting PEM cert to x509 to obtain serial number")
 		return nil, err
 	}
+
 	rootCertificate := Certificate{
 		commonName:   certificate.CommonName(x509Cert.Subject.CommonName),
 		serialNumber: certificate.SerialNumber(x509Cert.SerialNumber.String()),
 		certChain:    pemCert,
 		privateKey:   pemKey,
-		expiration:   expiration,
+		expiration:   x509Cert.NotAfter,
 	}
 
 	rootCertificate.issuingCA = rootCertificate.GetCertificateChain()

--- a/pkg/certificate/providers/tresor/ca_test.go
+++ b/pkg/certificate/providers/tresor/ca_test.go
@@ -6,98 +6,116 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
+	"testing"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
 
-var _ = Describe("Test creation of a new CA", func() {
-	Context("Create a new CA", func() {
-		rootCertCountry := "US"
-		rootCertLocality := "CA"
-		cert, err := NewCA("Tresor CA for Testing", 2*time.Second, rootCertCountry, rootCertLocality, rootCertOrganization)
-		It("should create a new CA", func() {
-			Expect(err).ToNot(HaveOccurred())
+func TestNewCA(t *testing.T) {
+	assert := tassert.New(t)
+	rootCertCountry := "US"
+	rootCertLocality := "CA"
 
-			x509Cert, err := certificate.DecodePEMCertificate(cert.GetCertificateChain())
-			Expect(err).ToNot(HaveOccurred())
+	cert, err := NewCA("Tresor CA for Testing", 2*time.Second, rootCertCountry, rootCertLocality, rootCertOrganization)
+	assert.Nil(err)
 
-			Expect(x509Cert.NotAfter.Sub(x509Cert.NotBefore)).To(Equal(2 * time.Second))
-			Expect(x509Cert.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
-			Expect(x509Cert.IsCA).To(BeTrue())
+	x509Cert, err := certificate.DecodePEMCertificate(cert.GetCertificateChain())
+	assert.Nil(err)
+
+	assert.Equal(2*time.Second, x509Cert.NotAfter.Sub(x509Cert.NotBefore))
+	assert.Equal(x509.KeyUsageCertSign|x509.KeyUsageCRLSign, x509Cert.KeyUsage)
+	assert.True(x509Cert.IsCA)
+}
+
+func TestNewCertificateFromPEM(t *testing.T) {
+	assert := tassert.New(t)
+	cn := certificate.CommonName("Test CA")
+	rootCertCountry := "US"
+	rootCertLocality := "CA"
+	rootCertOrganization := "Root Cert Organization"
+
+	notBefore := time.Now()
+	notAfter := notBefore.Add(1 * time.Hour)
+	serialNumber := big.NewInt(1)
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   cn.String(),
+			Country:      []string{rootCertCountry},
+			Locality:     []string{rootCertLocality},
+			Organization: []string{rootCertOrganization},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.Nil(err)
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &rsaKey.PublicKey, rsaKey)
+	assert.Nil(err)
+
+	pemCert, err := certificate.EncodeCertDERtoPEM(derBytes)
+	assert.Nil(err)
+
+	pemKey, err := certificate.EncodeKeyDERtoPEM(rsaKey)
+	assert.Nil(err)
+
+	tests := []struct {
+		name                   string
+		pemCert                pem.Certificate
+		pemKey                 pem.PrivateKey
+		expectedBeforeAfterDif time.Duration
+		expectedExpiration     time.Time
+		expectedKeyUsage       x509.KeyUsage
+		expectedIsCA           bool
+		expectedCN             certificate.CommonName
+		expectedErr            bool
+	}{
+		{
+			name:                   "valid pem cert and pem key",
+			pemCert:                pemCert,
+			pemKey:                 pemKey,
+			expectedBeforeAfterDif: 1 * time.Hour,
+			expectedExpiration:     notAfter.UTC().Truncate(time.Second), // when the certificate is created time is convert to UTC and truncated
+			expectedKeyUsage:       x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+			expectedIsCA:           true,
+			expectedCN:             cn,
+			expectedErr:            false,
+		},
+		{
+			name:        "invalid pem cert and pem key",
+			pemCert:     []byte(""),
+			pemKey:      []byte(""),
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c, err := NewCertificateFromPEM(test.pemCert, test.pemKey)
+			assert.Equal(test.expectedErr, err != nil)
+
+			if !test.expectedErr {
+				assert.Equal(test.expectedCN, c.GetCommonName())
+				assert.Equal(test.expectedExpiration, c.GetExpiration())
+
+				x509Cert, err := certificate.DecodePEMCertificate(c.GetCertificateChain())
+				assert.Nil(err)
+				assert.Equal(test.expectedExpiration, x509Cert.NotAfter)
+				assert.Equal(test.expectedBeforeAfterDif, x509Cert.NotAfter.Sub(x509Cert.NotBefore))
+				assert.Equal(test.expectedKeyUsage, x509Cert.KeyUsage)
+				assert.Equal(test.expectedIsCA, x509Cert.IsCA)
+				assert.Equal(test.expectedCN.String(), x509Cert.Subject.CommonName)
+			}
 		})
-	})
-})
-
-var _ = Describe("Test creation from pem", func() {
-	Context("valid pem cert and pem key", func() {
-		cn := certificate.CommonName("Test CA")
-		rootCertCountry := "US"
-		rootCertLocality := "CA"
-		rootCertOrganization := "Root Cert Organization"
-
-		notBefore := time.Now()
-		notAfter := notBefore.Add(1 * time.Hour)
-		serialNumber := big.NewInt(1)
-
-		template := &x509.Certificate{
-			SerialNumber: serialNumber,
-			Subject: pkix.Name{
-				CommonName:   cn.String(),
-				Country:      []string{rootCertCountry},
-				Locality:     []string{rootCertLocality},
-				Organization: []string{rootCertOrganization},
-			},
-			NotBefore:             notBefore,
-			NotAfter:              notAfter,
-			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-			BasicConstraintsValid: true,
-			IsCA:                  true,
-		}
-
-		rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
-		Expect(err).ToNot(HaveOccurred())
-
-		derBytes, err := x509.CreateCertificate(rand.Reader, template, template, &rsaKey.PublicKey, rsaKey)
-		Expect(err).ToNot(HaveOccurred())
-
-		pemCert, err := certificate.EncodeCertDERtoPEM(derBytes)
-		Expect(err).ToNot(HaveOccurred())
-
-		pemKey, err := certificate.EncodeKeyDERtoPEM(rsaKey)
-		Expect(err).ToNot(HaveOccurred())
-
-		expiration := time.Now().Add(1 * time.Hour)
-
-		c, err := NewCertificateFromPEM(pemCert, pemKey, expiration)
-		Expect(err).ToNot(HaveOccurred())
-
-		It("Should have the correct CN", func() {
-			Expect(c.GetCommonName()).To(Equal(cn))
-		})
-
-		It("should decode PEM to x509 ", func() {
-			Expect(err).ToNot(HaveOccurred())
-
-			x509Cert, err := certificate.DecodePEMCertificate(c.GetCertificateChain())
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(x509Cert.NotAfter.Sub(x509Cert.NotBefore)).To(Equal(1 * time.Hour))
-			Expect(x509Cert.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
-			Expect(x509Cert.IsCA).To(BeTrue())
-			Expect(x509Cert.Subject.CommonName).To(Equal(cn.String()))
-		})
-	})
-
-	Context("Test NewCertificateFromPEM()", func() {
-		expiration := time.Now().Add(1 * time.Hour)
-
-		It("invalid pem cert and pem key should returns en error", func() {
-			_, err := NewCertificateFromPEM([]byte(""), []byte(""), expiration)
-			Expect(err).To(HaveOccurred())
-		})
-	})
-})
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -124,14 +124,8 @@ const (
 	// KubernetesOpaqueSecretRootPrivateKeyKey is the key which holds the CA's private key in a Kubernetes secret.
 	KubernetesOpaqueSecretRootPrivateKeyKey = "private.key"
 
-	// KubernetesOpaqueSecretCAExpiration is the key which holds the CA's expiration in a Kubernetes secret.
-	KubernetesOpaqueSecretCAExpiration = "expiration"
-
 	// EnvoyUniqueIDLabelName is the label applied to pods with the unique ID of the Envoy sidecar.
 	EnvoyUniqueIDLabelName = "osm-proxy-uuid"
-
-	// TimeDateLayout is the layout for time.Parse used in this repo
-	TimeDateLayout = "2006-01-02T15:04:05.000Z"
 
 	// ----- Environment Variables
 

--- a/pkg/ingress/gateway_test.go
+++ b/pkg/ingress/gateway_test.go
@@ -403,7 +403,7 @@ func secretIsForSAN(secret *corev1.Secret, san string) bool {
 		return false
 	}
 
-	cert, err := tresor.NewCertificateFromPEM(pemCert, pemKey, time.Now() /* value doesn't matter here */)
+	cert, err := tresor.NewCertificateFromPEM(pemCert, pemKey)
 	if err != nil {
 		log.Error().Err(err).Msg("Error getting certificate from PEM")
 		return false


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Removes the use of the required expiration date data field in the
osm-ca-bundle. The certificate's expiration can be obtained
directly from the certificate rather than from the expiration
field.

This change also updates the logs in GetCertificateFromSecret to
reflect the broader use of the function.

Updates `ca_test.go` to use go testing package rather than ginko
and gomega. Adds checks for notAfter and expiration values on
the x509 certificate and the certificator respectively.

**Note:** It is no longer necessary to perform any formatting on
expiration time.

Resolves #4467

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Updated unit tests to verify the expiration is correctly set using the notAfter value obtained from the decoded x509 cert
- On a kind cluster ran the automated demo
  - verified `osm-ca-bundle` formatting when it was created by OSM using Tresor as the certificate provider
  - verified OSM successfully obtained data from the `osm-ca-bundle` secret without an expiration field when created by the user 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No - will make a follow-up PR in the docs repo