### PR TITLE
configurator: simplify MeshConfig API

### DIFF
--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -68,21 +68,21 @@ func (c *client) getMeshConfigCacheKey() string {
 }
 
 // Returns the current MeshConfig
-func (c *client) getMeshConfig() *configv1alpha2.MeshConfig {
+func (c *client) getMeshConfig() configv1alpha2.MeshConfig {
+	var meshConfig configv1alpha2.MeshConfig
+
 	meshConfigCacheKey := c.getMeshConfigCacheKey()
 	item, exists, err := c.cache.GetByKey(meshConfigCacheKey)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigFetchFromCache)).Msgf("Error getting MeshConfig from cache with key %s", meshConfigCacheKey)
-		return &configv1alpha2.MeshConfig{}
+		return meshConfig
 	}
 
-	var meshConfig *configv1alpha2.MeshConfig
 	if !exists {
 		log.Warn().Msgf("MeshConfig %s does not exist. Default config values will be used.", meshConfigCacheKey)
-		meshConfig = &configv1alpha2.MeshConfig{}
-	} else {
-		meshConfig = item.(*configv1alpha2.MeshConfig)
+		return meshConfig
 	}
 
+	meshConfig = *item.(*configv1alpha2.MeshConfig)
 	return meshConfig
 }

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -24,7 +24,7 @@ func TestGetMeshConfig(t *testing.T) {
 	c := newConfigurator(meshConfigClient, stop, osmNamespace, osmMeshConfigName, nil)
 
 	// Returns empty MeshConfig if informer cache is empty
-	a.Equal(&configv1alpha2.MeshConfig{}, c.getMeshConfig())
+	a.Equal(configv1alpha2.MeshConfig{}, c.getMeshConfig())
 
 	newObj := &configv1alpha2.MeshConfig{
 		TypeMeta: metav1.TypeMeta{
@@ -38,5 +38,5 @@ func TestGetMeshConfig(t *testing.T) {
 	}
 	err := c.cache.Add(newObj)
 	a.Nil(err)
-	a.Equal(newObj, c.getMeshConfig())
+	a.Equal(*newObj, c.getMeshConfig())
 }

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -32,7 +32,7 @@ const (
 // The functions in this file implement the configurator.Configurator interface
 
 // GetMeshConfig returns the MeshConfig resource corresponding to the control plane
-func (c *client) GetMeshConfig() *configv1alpha2.MeshConfig {
+func (c *client) GetMeshConfig() configv1alpha2.MeshConfig {
 	return c.getMeshConfig()
 }
 
@@ -41,8 +41,8 @@ func (c *client) GetOSMNamespace() string {
 	return c.osmNamespace
 }
 
-func marshalConfigToJSON(config *configv1alpha2.MeshConfigSpec) (string, error) {
-	bytes, err := json.MarshalIndent(config, "", "    ")
+func marshalConfigToJSON(config configv1alpha2.MeshConfigSpec) (string, error) {
+	bytes, err := json.MarshalIndent(&config, "", "    ")
 	if err != nil {
 		return "", err
 	}
@@ -51,7 +51,7 @@ func marshalConfigToJSON(config *configv1alpha2.MeshConfigSpec) (string, error) 
 
 // GetMeshConfigJSON returns the MeshConfig in pretty JSON.
 func (c *client) GetMeshConfigJSON() (string, error) {
-	cm, err := marshalConfigToJSON(&c.getMeshConfig().Spec)
+	cm, err := marshalConfigToJSON(c.getMeshConfig().Spec)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigMarshaling)).Msgf("Error marshaling MeshConfig %s: %+v", c.getMeshConfigCacheKey(), c.getMeshConfig())
 		return "", err

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -31,7 +31,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 
 		stop := make(chan struct{})
 		cfg := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
-		tassert.Equal(t, &configv1alpha2.MeshConfig{}, cfg.getMeshConfig())
+		tassert.Equal(t, configv1alpha2.MeshConfig{}, cfg.getMeshConfig())
 	})
 
 	tests := []struct {
@@ -93,7 +93,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 						ServiceCertValidityDuration: "24h",
 					},
 				}
-				expectedConfigJSON, err := marshalConfigToJSON(expectedConfig)
+				expectedConfigJSON, err := marshalConfigToJSON(*expectedConfig)
 				assert.Nil(err)
 
 				configJSON, err := cfg.GetMeshConfigJSON()

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -178,10 +178,10 @@ func (mr *MockConfiguratorMockRecorder) GetMaxDataPlaneConnections() *gomock.Cal
 }
 
 // GetMeshConfig mocks base method.
-func (m *MockConfigurator) GetMeshConfig() *v1alpha2.MeshConfig {
+func (m *MockConfigurator) GetMeshConfig() v1alpha2.MeshConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMeshConfig")
-	ret0, _ := ret[0].(*v1alpha2.MeshConfig)
+	ret0, _ := ret[0].(v1alpha2.MeshConfig)
 	return ret0
 }
 

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -28,7 +28,7 @@ type client struct {
 // Configurator is the controller interface for K8s namespaces
 type Configurator interface {
 	// GetMeshConfig returns the MeshConfig resource corresponding to the control plane
-	GetMeshConfig() *configv1alpha2.MeshConfig
+	GetMeshConfig() configv1alpha2.MeshConfig
 
 	// GetOSMNamespace returns the namespace in which OSM controller pod resides
 	GetOSMNamespace() string

--- a/pkg/ingress/gateway.go
+++ b/pkg/ingress/gateway.go
@@ -23,12 +23,7 @@ import (
 // 2. Starts a goroutine to watch for changes to the MeshConfig resource and certificate rotation, and
 //    updates/removes the certificate and secret as necessary.
 func (c *client) provisionIngressGatewayCert(stop <-chan struct{}) error {
-	meshConfig := c.cfg.GetMeshConfig()
-	if meshConfig == nil {
-		return errors.New("MeshConfig cannot be nil")
-	}
-
-	defaultCertSpec := meshConfig.Spec.Certificate.IngressGateway
+	defaultCertSpec := c.cfg.GetMeshConfig().Spec.Certificate.IngressGateway
 	if defaultCertSpec != nil {
 		// Issue a certificate for the default certificate spec
 		if err := c.createAndStoreGatewayCert(*defaultCertSpec); err != nil {

--- a/pkg/ingress/gateway_test.go
+++ b/pkg/ingress/gateway_test.go
@@ -38,13 +38,13 @@ func TestProvisionIngressGatewayCert(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		meshConfig          *configv1alpha2.MeshConfig
+		meshConfig          configv1alpha2.MeshConfig
 		expectSecretToExist bool
 		expectErr           bool
 	}{
 		{
 			name: "ingress gateway cert spec does not exist",
-			meshConfig: &configv1alpha2.MeshConfig{
+			meshConfig: configv1alpha2.MeshConfig{
 				Spec: configv1alpha2.MeshConfigSpec{
 					Certificate: configv1alpha2.CertificateSpec{
 						IngressGateway: nil,
@@ -56,7 +56,7 @@ func TestProvisionIngressGatewayCert(t *testing.T) {
 		},
 		{
 			name: "ingress gateway cert spec exists",
-			meshConfig: &configv1alpha2.MeshConfig{
+			meshConfig: configv1alpha2.MeshConfig{
 				Spec: configv1alpha2.MeshConfigSpec{
 					Certificate: configv1alpha2.CertificateSpec{
 						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{
@@ -72,7 +72,7 @@ func TestProvisionIngressGatewayCert(t *testing.T) {
 		},
 		{
 			name: "ingress gateway cert spec has no SAN",
-			meshConfig: &configv1alpha2.MeshConfig{
+			meshConfig: configv1alpha2.MeshConfig{
 				Spec: configv1alpha2.MeshConfigSpec{
 					Certificate: configv1alpha2.CertificateSpec{
 						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Simplifies the signature of `GetMeshConfig()` in
the interface to return an object instead of a pointer.
MeshConfig is guaranteed to exist during controller
startup and there is already a fallback to return
a default MeshConfig object if not found in the
cache. Returning a pointer results in unnecessary
nil pointer handling on the caller side, which
makes the usage of this function indeterministic
when the implementation is deterministic.
This change guarantees to the caller of this function
that they will always receive a valid MeshConfig to
operate on.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
