### PR TITLE
configurator: remove ip/port exclusion APIs

### DIFF
--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -173,21 +173,6 @@ func (c *client) GetCertKeyBitSize() int {
 	return bitSize
 }
 
-// GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
-func (c *client) GetOutboundIPRangeExclusionList() []string {
-	return c.getMeshConfig().Spec.Traffic.OutboundIPRangeExclusionList
-}
-
-// GetOutboundPortExclusionList returns the list of ports (positive integers) to exclude from outbound sidecar interception
-func (c *client) GetOutboundPortExclusionList() []int {
-	return c.getMeshConfig().Spec.Traffic.OutboundPortExclusionList
-}
-
-// GetInboundPortExclusionList returns the list of ports (positive integers) to exclude from inbound sidecar interception
-func (c *client) GetInboundPortExclusionList() []int {
-	return c.getMeshConfig().Spec.Traffic.InboundPortExclusionList
-}
-
 // IsPrivilegedInitContainer returns whether init containers should be privileged
 func (c *client) IsPrivilegedInitContainer() bool {
 	return c.getMeshConfig().Spec.Sidecar.EnablePrivilegedInitContainer

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -289,51 +289,6 @@ func TestCreateUpdateConfig(t *testing.T) {
 			},
 		},
 		{
-			name:                  "GetOutboundIPRangeExclusionList",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
-			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Nil(cfg.GetOutboundIPRangeExclusionList())
-			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
-					OutboundIPRangeExclusionList: []string{"1.1.1.1/32", "2.2.2.2/24"},
-				},
-			},
-			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal([]string{"1.1.1.1/32", "2.2.2.2/24"}, cfg.GetOutboundIPRangeExclusionList())
-			},
-		},
-		{
-			name:                  "GetOutboundPortExclusionList",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
-			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Nil(cfg.GetOutboundPortExclusionList())
-			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
-					OutboundPortExclusionList: []int{7070, 6080},
-				},
-			},
-			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal([]int{7070, 6080}, cfg.GetOutboundPortExclusionList())
-			},
-		},
-		{
-			name:                  "GetIboundPortExclusionList",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
-			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Nil(cfg.GetInboundPortExclusionList())
-			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
-					InboundPortExclusionList: []int{7070, 6080},
-				},
-			},
-			checkUpdate: func(assert *tassert.Assertions, cfg Configurator) {
-				assert.Equal([]int{7070, 6080}, cfg.GetInboundPortExclusionList())
-			},
-		},
-		{
 			name: "IsPrivilegedInitContainer",
 			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
 				Sidecar: configv1alpha2.SidecarSpec{

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -135,20 +135,6 @@ func (mr *MockConfiguratorMockRecorder) GetInboundExternalAuthConfig() *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInboundExternalAuthConfig", reflect.TypeOf((*MockConfigurator)(nil).GetInboundExternalAuthConfig))
 }
 
-// GetInboundPortExclusionList mocks base method.
-func (m *MockConfigurator) GetInboundPortExclusionList() []int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInboundPortExclusionList")
-	ret0, _ := ret[0].([]int)
-	return ret0
-}
-
-// GetInboundPortExclusionList indicates an expected call of GetInboundPortExclusionList.
-func (mr *MockConfiguratorMockRecorder) GetInboundPortExclusionList() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInboundPortExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetInboundPortExclusionList))
-}
-
 // GetInitContainerImage mocks base method.
 func (m *MockConfigurator) GetInitContainerImage() string {
 	m.ctrl.T.Helper()
@@ -232,34 +218,6 @@ func (m *MockConfigurator) GetOSMNamespace() string {
 func (mr *MockConfiguratorMockRecorder) GetOSMNamespace() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOSMNamespace", reflect.TypeOf((*MockConfigurator)(nil).GetOSMNamespace))
-}
-
-// GetOutboundIPRangeExclusionList mocks base method.
-func (m *MockConfigurator) GetOutboundIPRangeExclusionList() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOutboundIPRangeExclusionList")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// GetOutboundIPRangeExclusionList indicates an expected call of GetOutboundIPRangeExclusionList.
-func (mr *MockConfiguratorMockRecorder) GetOutboundIPRangeExclusionList() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundIPRangeExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundIPRangeExclusionList))
-}
-
-// GetOutboundPortExclusionList mocks base method.
-func (m *MockConfigurator) GetOutboundPortExclusionList() []int {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOutboundPortExclusionList")
-	ret0, _ := ret[0].([]int)
-	return ret0
-}
-
-// GetOutboundPortExclusionList indicates an expected call of GetOutboundPortExclusionList.
-func (mr *MockConfiguratorMockRecorder) GetOutboundPortExclusionList() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOutboundPortExclusionList", reflect.TypeOf((*MockConfigurator)(nil).GetOutboundPortExclusionList))
 }
 
 // GetProxyResources mocks base method.

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -81,15 +81,6 @@ type Configurator interface {
 	// GetCertKeyBitSize returns the certificate key bit size
 	GetCertKeyBitSize() int
 
-	// GetOutboundIPRangeExclusionList returns the list of IP ranges of the form x.x.x.x/y to exclude from outbound sidecar interception
-	GetOutboundIPRangeExclusionList() []string
-
-	// GetOutboundPortExclusionList returns the list of ports to exclude from outbound sidecar interception
-	GetOutboundPortExclusionList() []int
-
-	// GetInboundPortExclusionList returns the list of ports to exclude from inbound sidecar interception
-	GetInboundPortExclusionList() []int
-
 	// IsPrivilegedInitContainer determines whether init containers should be privileged
 	IsPrivilegedInitContainer() bool
 

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -67,16 +67,17 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	if !strings.EqualFold(podOS, constants.OSWindows) {
 		// Build outbound port exclusion list
 		podOutboundPortExclusionList, _ := wh.getPortExclusionListForPod(pod, namespace, outboundPortExclusionListAnnotation)
-		globalOutboundPortExclusionList := wh.configurator.GetOutboundPortExclusionList()
+		globalOutboundPortExclusionList := wh.configurator.GetMeshConfig().Spec.Traffic.OutboundPortExclusionList
 		outboundPortExclusionList := mergePortExclusionLists(podOutboundPortExclusionList, globalOutboundPortExclusionList)
 
 		// Build inbound port exclusion list
 		podInboundPortExclusionList, _ := wh.getPortExclusionListForPod(pod, namespace, inboundPortExclusionListAnnotation)
-		globalInboundPortExclusionList := wh.configurator.GetInboundPortExclusionList()
+		globalInboundPortExclusionList := wh.configurator.GetMeshConfig().Spec.Traffic.InboundPortExclusionList
 		inboundPortExclusionList := mergePortExclusionLists(podInboundPortExclusionList, globalInboundPortExclusionList)
 
 		// Add the Init Container
-		initContainer := getInitContainerSpec(constants.InitContainerName, wh.configurator, wh.configurator.GetOutboundIPRangeExclusionList(), outboundPortExclusionList, inboundPortExclusionList, wh.configurator.IsPrivilegedInitContainer())
+		globalOutboundIPRangeExclusionList := wh.configurator.GetMeshConfig().Spec.Traffic.OutboundIPRangeExclusionList
+		initContainer := getInitContainerSpec(constants.InitContainerName, wh.configurator, globalOutboundIPRangeExclusionList, outboundPortExclusionList, inboundPortExclusionList, wh.configurator.IsPrivilegedInitContainer())
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 	}
 

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -146,9 +146,7 @@ func TestCreatePatch(t *testing.T) {
 
 			if tc.os == constants.OSLinux {
 				mockConfigurator.EXPECT().IsPrivilegedInitContainer().Return(false).Times(1)
-				mockConfigurator.EXPECT().GetOutboundIPRangeExclusionList().Return(nil).Times(1)
-				mockConfigurator.EXPECT().GetOutboundPortExclusionList().Return(nil).Times(1)
-				mockConfigurator.EXPECT().GetInboundPortExclusionList().Return(nil).Times(1)
+				mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 			}
 			mockConfigurator.EXPECT().GetEnvoyLogLevel().Return("").Times(1)
 			mockConfigurator.EXPECT().GetProxyResources().Return(corev1.ResourceRequirements{}).Times(1)

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -1005,9 +1005,7 @@ func TestWebhookMutate(t *testing.T) {
 		kubeController.EXPECT().IsMonitoredNamespace(namespace).Return(true)
 
 		cfg := configurator.NewMockConfigurator(mockCtrl)
-		cfg.EXPECT().GetOutboundPortExclusionList()
-		cfg.EXPECT().GetInboundPortExclusionList()
-		cfg.EXPECT().GetOutboundIPRangeExclusionList()
+		cfg.EXPECT().GetMeshConfig().AnyTimes()
 		cfg.EXPECT().IsPrivilegedInitContainer()
 		cfg.EXPECT().GetInitContainerImage().Return("init-container-image").AnyTimes()
 		cfg.EXPECT().GetEnvoyImage().Return("envoy-linux-image").AnyTimes()
@@ -1053,9 +1051,7 @@ func TestWebhookMutate(t *testing.T) {
 		kubeController.EXPECT().IsMonitoredNamespace(namespace).Return(true)
 
 		cfg := configurator.NewMockConfigurator(mockCtrl)
-		cfg.EXPECT().GetOutboundPortExclusionList()
-		cfg.EXPECT().GetInboundPortExclusionList()
-		cfg.EXPECT().GetOutboundIPRangeExclusionList()
+		cfg.EXPECT().GetMeshConfig().AnyTimes()
 		cfg.EXPECT().IsPrivilegedInitContainer()
 		cfg.EXPECT().GetInitContainerImage().Return("init-container-image").AnyTimes()
 		cfg.EXPECT().GetEnvoyImage().Return("envoy-linux-image").AnyTimes()


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Simplifies the Configurator interface by leveraging
the `GetMeshConfig()` API instead of exposing iptables
related exclusion fields as separate APIs.

Note that this change only removes the APIs related
to IP/Port exclusions, to begin with, but the 
general concept applies to other fields as well.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Sidecar Injection          | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`