### PR TITLE
Automate stale issue and PR cleanup

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: 'Label and close stale issues and PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'


### PR DESCRIPTION
**Description**:

GitHub Action to daily (at midnight) label issues and PRs that have had
no activity (60 days). Once a stale PR/issue has been labeled, it will
then be closed after another span of inactivity (7 days). This will help
us minimize noise and automate the cleanup of inactive items.

Signed-off-by: Thomas Stringer <thstring@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Not applicable.