### PR TITLE
Exempt milestone items from going stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
+          exempt-all-milestones: true


### PR DESCRIPTION
**Description**:

Change the behavior of the stale job to ignore items that belong to a
milestone. If we have set an item in a milestone then we do not want it
to be marked stale and closed.

Signed-off-by: Thomas Stringer <thstring@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Not applicable.