### PR TITLE
tests: remove kubectl dependency for namespace info

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1240,12 +1240,8 @@ func (td *OsmTestData) Cleanup(ct CleanupType) {
 			)
 			if err != nil {
 				td.T.Logf("Error polling namespaces for deletion: %s", err)
-
-				// Dump the namespaces that failed to terminate
-				stdout, stderr, _ := td.RunLocal("kubectl", "get", "namespace", "-l", osmTest, "-o", "yaml")
-				td.T.Logf("Namespace info:")
-				td.T.Logf("stdout:\n%s", stdout)
-				td.T.Logf("stderr:\n%s", stderr)
+				testNsInfo, _ := json.MarshalIndent(testNs, "", "  ")
+				td.T.Logf("Namespaces info:\n%s", string(testNsInfo))
 			}
 		}
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Removes the dependency on kubectl to dump the namespace
info. Previously this was done to unblock debugging
of CI failures in a timely manner.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`