### PR TITLE
injector: support pod specific IP range exclusions

### DIFF
--- a/pkg/injector/exclusions.go
+++ b/pkg/injector/exclusions.go
@@ -1,12 +1,24 @@
 package injector
 
 import (
+	"net"
 	"strconv"
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// outboundPortExclusionListAnnotation is the annotation used for outbound port exclusions
+	outboundPortExclusionListAnnotation = "openservicemesh.io/outbound-port-exclusion-list"
+
+	// inboundPortExclusionListAnnotation is the annotation used for inbound port exclusions
+	inboundPortExclusionListAnnotation = "openservicemesh.io/inbound-port-exclusion-list"
+
+	// outboundIPRangeExclusionListAnnotation is the annotation used for outbound IP range exclusions
+	outboundIPRangeExclusionListAnnotation = "openservicemesh.io/outbound-ip-range-exclusion-list"
 )
 
 // getPortExclusionListForPod gets a list of ports to exclude from sidecar traffic interception for the given
@@ -41,7 +53,7 @@ func getPortExclusionListForPod(pod *corev1.Pod, namespace string, annotation st
 	return ports, nil
 }
 
-// mergePortExclusionLists merges the pod specific and global port exclusion list
+// mergePortExclusionLists merges the pod specific and global port exclusion lists
 func mergePortExclusionLists(podSpecificPortExclusionList, globalPortExclusionList []int) []int {
 	portExclusionListMap := mapset.NewSet()
 	var portExclusionListMerged []int
@@ -61,4 +73,54 @@ func mergePortExclusionLists(podSpecificPortExclusionList, globalPortExclusionLi
 	}
 
 	return portExclusionListMerged
+}
+
+// getOutboundIPRangeExclusionListForPod gets a list of IP ranges to exclude from sidecar traffic interception for the given
+// pod and annotation kind.
+//
+// IP ranges are excluded from sidecar interception when the pod is explicitly annotated with a single or
+// comma separate list of IP CIDR ranges.
+//
+// The kind of exclusion (inbound vs outbound) is determined by the specified annotation.
+//
+// The function returns an error when it is unable to determine whether IP ranges need to be excluded from outbound sidecar interception.
+func getOutboundIPRangeExclusionListForPod(pod *corev1.Pod, namespace string, annotation string) ([]string, error) {
+	ipRangeExclusionsStr, ok := pod.Annotations[annotation]
+	if !ok {
+		// No port exclusion annotation specified
+		return nil, nil
+	}
+
+	var ipRanges []string
+	log.Trace().Msgf("Pod with UID %s has IP range exclusion annotation: '%s:%s'", pod.UID, annotation, ipRangeExclusionsStr)
+
+	for _, ip := range strings.Split(ipRangeExclusionsStr, ",") {
+		ip := strings.TrimSpace(ip)
+		if _, _, err := net.ParseCIDR(ip); err != nil {
+			return nil, errors.Errorf("Invalid IP range '%s' specified for annotation '%s'", ip, annotation)
+		}
+		ipRanges = append(ipRanges, ip)
+	}
+
+	return ipRanges, nil
+}
+
+// mergeIPRangeExclusionLists merges the pod specific and global IP range exclusion lists
+func mergeIPRangeExclusionLists(podSpecificExclusionList, globalExclusionList []string) []string {
+	ipSet := mapset.NewSet()
+	var ipRanges []string
+
+	for _, ip := range podSpecificExclusionList {
+		if addedToSet := ipSet.Add(ip); addedToSet {
+			ipRanges = append(ipRanges, ip)
+		}
+	}
+
+	for _, ip := range globalExclusionList {
+		if addedToSet := ipSet.Add(ip); addedToSet {
+			ipRanges = append(ipRanges, ip)
+		}
+	}
+
+	return ipRanges
 }

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -41,12 +41,6 @@ const (
 
 	// webhookTimeoutStr is the url variable name for timeout
 	webhookMutateTimeoutKey = "timeout"
-
-	// outboundPortExclusionListAnnotation is the annotation used for outbound port exclusions
-	outboundPortExclusionListAnnotation = "openservicemesh.io/outbound-port-exclusion-list"
-
-	// inboundPortExclusionListAnnotation is the annotation used for inbound port exclusions
-	inboundPortExclusionListAnnotation = "openservicemesh.io/inbound-port-exclusion-list"
 )
 
 // NewMutatingWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds support for specifying pod specific outbound
IP range exclusions similar to port exclusions.
The pod specific and global IP range exclusions
will both apply to a pod being injected.

Also makes the following changes:
- Fails patching on invalid annotations
- Moves OS specific init container code to
  its own function

Related to #4396

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Sidecar Injection          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? no, will be done later