### PR TITLE
feat(mockgen): improve error messaging; add ability to run one mockgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ rootfs/
 # Envoy config captured during development
 envoy_*.json
 
+# Interim files that can stick around from a bad mockgen run.
+gomock_reflect_*/

--- a/mockspec/generate.go
+++ b/mockspec/generate.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	singlePackage = flag.String("only-package", "", "Only generate mocks for the given package, ie: the first part of the line in the rules file")
+	packageName = flag.String("package-name", "", "Only generate mocks for the given package, ie: the first part of the line in the rules file")
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 		if len(ruleOptions) != 4 {
 			log.Fatalf("Invalid syntax for mockgen rule: %v", ruleOptions)
 		}
-		if *singlePackage == "" || *singlePackage == ruleOptions[0] {
+		if *packageName == "" || *packageName == ruleOptions[0] {
 			genMock(ruleOptions)
 		}
 	}

--- a/mockspec/generate.go
+++ b/mockspec/generate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"log"
 	"os"
 	"os/exec"
@@ -14,6 +15,10 @@ const (
 
 	// commentPrefix is the prefix used for comments in the rules file
 	commentPrefix = "#"
+)
+
+var (
+	singlePackage = flag.String("only-package", "", "Only generate mocks for the given package, ie: the first part of the line in the rules file")
 )
 
 func main() {
@@ -31,7 +36,14 @@ func main() {
 		if strings.HasPrefix(line, commentPrefix) || line == "" {
 			continue
 		}
-		genMock(line)
+
+		ruleOptions := strings.Split(line, ";")
+		if len(ruleOptions) != 4 {
+			log.Fatalf("Invalid syntax for mockgen rule: %v", ruleOptions)
+		}
+		if *singlePackage == "" || *singlePackage == ruleOptions[0] {
+			genMock(ruleOptions)
+		}
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -39,13 +51,9 @@ func main() {
 	}
 }
 
-func genMock(ruleStr string) {
-	ruleOptions := strings.Split(ruleStr, ";")
+func genMock(ruleOptions []string) {
 	for i := range ruleOptions {
 		ruleOptions[i] = strings.TrimSpace(ruleOptions[i])
-	}
-	if len(ruleOptions) != 4 {
-		log.Fatalf("Invalid syntax for mockgen rule: %v", ruleOptions)
 	}
 
 	packageName := ruleOptions[0]
@@ -64,6 +72,8 @@ func genMock(ruleStr string) {
 		interfaces,
 	}
 	cmd := exec.Command("go", cmdList...) // nolint gosec
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("Error generating mocks for rule: %v, err: %s", ruleOptions, err)
 	}
@@ -74,6 +84,8 @@ func genMock(ruleStr string) {
 		"-w", ruleOptions[1],
 	}
 	cmd = exec.Command("go", cmdList...) // nolint gosec
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("Error generating mocks for rule: %v, err: %s", ruleOptions, err)
 	}


### PR DESCRIPTION
Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

Mockgen errors are currently swalled by the generator:

```
2022/01/31 15:14:38 Error generating mocks for rule: [catalog pkg/catalog/mock_catalog_generated.go github.com/openservicemesh/osm/pkg/catalog MeshCataloger], err: exit status 1
```

This PR logs the error messages to stderr:

```
make check-mocks
# github.com/openservicemesh/osm/pkg/catalog
../pkg/catalog/catalog.go:22:3: unknown field 'provider' in struct literal of type MeshCatalog (but does have Provider)
../pkg/catalog/fake.go:135:25: undefined: endpoint.Provider
../pkg/catalog/fake.go:138:24: undefined: service.Provider
../pkg/catalog/fake.go:226:23: too many arguments in call to NewMeshCatalog
Error generating mocks for rule: [catalog pkg/catalog/mock_catalog_generated.go github.com/openservicemesh/osm/pkg/catalog MeshCataloger], err: exit status 1
```

On a successful run there is no change in output.

Since mockgen can take a while, I also add the ability to run mockgen with a single package.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No