### PR TITLE
fix(e2e): isolate upgrade test

### DIFF
--- a/tests/e2e/e2e_trafficsplit_test.go
+++ b/tests/e2e/e2e_trafficsplit_test.go
@@ -19,7 +19,7 @@ import (
 var _ = OSMDescribe("Test HTTP from N Clients deployments to 1 Server deployment backed with Traffic split test",
 	OSMDescribeInfo{
 		Tier:   1,
-		Bucket: 10,
+		Bucket: 5,
 	},
 	func() {
 		Context("HTTP traffic splitting with SMI", func() {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: 
Currently, the upgrade e2e test fails when the MultiClusterService or
MeshConfig CRDs already exist on the cluster, which happens after any
other test runs right before it. This change puts the upgrade e2e test
in its own bucket to make sure that doesn't happen.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Covered by CI.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A