### PR TITLE
crdconversion: handle MeshConfig optional field

### DIFF
--- a/pkg/crdconversion/config_meshconfig_conversion.go
+++ b/pkg/crdconversion/config_meshconfig_conversion.go
@@ -39,8 +39,11 @@ func convertMeshConfig(obj *unstructured.Unstructured, toVersion string) (*unstr
 		switch toVersion {
 		case "config.openservicemesh.io/v1alpha1":
 			log.Debug().Msgf("Converting MeshConfig v1alpha2 -> v1alpha1")
-			// v1alpha2 is backward compatible with v1alpha1, so no conversion is
-			// necessary at this moment.
+			// Remove spec.traffic.outboundIPRangeInclusionList field not supported in v1alpha1
+			_, found, err := unstructured.NestedSlice(convertedObject.Object, "spec", "traffic", "outboundIPRangeInclusionList")
+			if found && err == nil {
+				unstructured.RemoveNestedField(convertedObject.Object, "spec", "traffic", "outboundIPRangeInclusionList")
+			}
 
 		default:
 			return nil, statusErrorWithMessage("Unexpected conversion to-version for MeshConfig resource: %s", toVersion)

--- a/pkg/crdconversion/config_meshconfig_conversion_test.go
+++ b/pkg/crdconversion/config_meshconfig_conversion_test.go
@@ -1,0 +1,69 @@
+package crdconversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	configv1alpha1 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha1"
+	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+)
+
+func TestConvertMeshConfig(t *testing.T) {
+	testCases := []struct {
+		name      string
+		request   runtime.Object
+		toVersion string
+		verifyFn  func(*assert.Assertions, *unstructured.Unstructured, metav1.Status)
+	}{
+		{
+			name: "v1alpha2 -> v1alpha1 should remove additional field",
+			request: &configv1alpha2.MeshConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "config.openservicemesh.io/v1alpha2",
+					Kind:       "MeshConfig",
+				},
+				Spec: configv1alpha2.MeshConfigSpec{
+					Traffic: configv1alpha2.TrafficSpec{
+						OutboundIPRangeInclusionList: []string{"1.1.1.1/32"},
+					},
+				},
+			},
+			toVersion: "config.openservicemesh.io/v1alpha1",
+			verifyFn: func(a *assert.Assertions, converted *unstructured.Unstructured, status metav1.Status) {
+				a.Equal(status, statusSucceed())
+
+				_, found, _ := unstructured.NestedSlice(converted.Object, "spec", "traffic", "outboundIPRangeInclusionList")
+				a.False(found)
+			},
+		},
+		{
+			name: "v1alpha1 -> v1alpha2",
+			request: &configv1alpha1.MeshConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "config.openservicemesh.io/v1alpha1",
+					Kind:       "MeshConfig",
+				},
+				Spec: configv1alpha1.MeshConfigSpec{},
+			},
+			toVersion: "config.openservicemesh.io/v1alpha2",
+			verifyFn: func(a *assert.Assertions, converted *unstructured.Unstructured, status metav1.Status) {
+				a.Equal(status, statusSucceed())
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.request)
+			a.Nil(err)
+			unstructuredReq := &unstructured.Unstructured{Object: obj}
+			converted, status := convertMeshConfig(unstructuredReq, tc.toVersion)
+			tc.verifyFn(a, converted, status)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Handles the conversion of the optional field in
v1alpha2 and adds a test for conversion between
v1alpha1 and v1alpha2 of MeshConfig.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`