### PR TITLE
injector: add support to configure IP range inclusions

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -147,6 +147,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.osmController.resource | object | `{"limits":{"cpu":"1.5","memory":"1G"},"requests":{"cpu":"0.5","memory":"128M"}}` | OSM controller's container resource parameters. See https://docs.openservicemesh.io/docs/guides/ha_scale/scale/ for more details. |
 | osm.osmNamespace | string | `""` | Namespace to deploy OSM in. If not specified, the Helm release namespace is used. |
 | osm.outboundIPRangeExclusionList | list | `[]` | Specifies a global list of IP ranges to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
+| osm.outboundIPRangeInclusionList | list | `[]` | Specifies a global list of IP ranges to include for outbound traffic interception by the sidecar proxy. If specified, must be a list of IP ranges of the form a.b.c.d/x. |
 | osm.outboundPortExclusionList | list | `[]` | Specifies a global list of ports to exclude from outbound traffic interception by the sidecar proxy. If specified, must be a list of positive integers. |
 | osm.prometheus.image | string | `"prom/prometheus:v2.18.1"` | Image used for Prometheus |
 | osm.prometheus.port | int | `7070` | Prometheus service's port |

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -17,7 +17,8 @@ data:
         "enablePermissiveTrafficPolicyMode": {{.Values.osm.enablePermissiveTrafficPolicy | mustToJson}},
         "outboundPortExclusionList": {{.Values.osm.outboundPortExclusionList | mustToJson}},
         "inboundPortExclusionList": {{.Values.osm.inboundPortExclusionList | mustToJson}},
-        "outboundIPRangeExclusionList": {{.Values.osm.outboundIPRangeExclusionList | mustToJson}}
+        "outboundIPRangeExclusionList": {{.Values.osm.outboundIPRangeExclusionList | mustToJson}},
+        "outboundIPRangeInclusionList": {{.Values.osm.outboundIPRangeInclusionList | mustToJson}}
       },
       "observability": {
         "enableDebugServer": {{.Values.osm.enableDebugServer | mustToJson}},

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -997,6 +997,22 @@
                         ]
                     ]
                 },
+                "outboundIPRangeInclusionList": {
+                    "$id": "#/properties/osm/properties/outboundIPRangeInclusionList",
+                    "type": "array",
+                    "title": "The outboundIPRangeInclusionList schema",
+                    "description": "Outbound IP range inclusion list for sidecar traffic interception",
+                    "items": {
+                        "type": "string",
+                        "pattern": "((?:\\d{1,3}\\.){3}\\d{1,3})\\/(\\d{1,2})$"
+                    },
+                    "examples": [
+                        [
+                            "8.8.8.8/32",
+                            "10.0.0.0/24"
+                        ]
+                    ]
+                },
                 "outboundPortExclusionList": {
                     "$id": "#/properties/osm/properties/outboundPortExclusionList",
                     "type": "array",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -227,6 +227,10 @@ osm:
   # If specified, must be a list of IP ranges of the form a.b.c.d/x.
   outboundIPRangeExclusionList: []
 
+  # -- Specifies a global list of IP ranges to include for outbound traffic interception by the sidecar proxy.
+  # If specified, must be a list of IP ranges of the form a.b.c.d/x.
+  outboundIPRangeInclusionList: []
+
   # -- Specifies a global list of ports to exclude from outbound traffic interception by the sidecar proxy.
   # If specified, must be a list of positive integers.
   outboundPortExclusionList: []

--- a/pkg/injector/exclusions.go
+++ b/pkg/injector/exclusions.go
@@ -19,6 +19,9 @@ const (
 
 	// outboundIPRangeExclusionListAnnotation is the annotation used for outbound IP range exclusions
 	outboundIPRangeExclusionListAnnotation = "openservicemesh.io/outbound-ip-range-exclusion-list"
+
+	// outboundIPRangeInclusionListAnnotation is the annotation used for outbound IP range inclusions
+	outboundIPRangeInclusionListAnnotation = "openservicemesh.io/outbound-ip-range-inclusion-list"
 )
 
 // getPortExclusionListForPod gets a list of ports to exclude from sidecar traffic interception for the given
@@ -75,16 +78,16 @@ func mergePortExclusionLists(podSpecificPortExclusionList, globalPortExclusionLi
 	return portExclusionListMerged
 }
 
-// getOutboundIPRangeExclusionListForPod gets a list of IP ranges to exclude from sidecar traffic interception for the given
+// getOutboundIPRangeListForPod returns a list of IP ranges to include/exclude from sidecar traffic interception for the given
 // pod and annotation kind.
 //
-// IP ranges are excluded from sidecar interception when the pod is explicitly annotated with a single or
+// IP ranges are included/excluded from sidecar interception when the pod is explicitly annotated with a single or
 // comma separate list of IP CIDR ranges.
 //
-// The kind of exclusion (inbound vs outbound) is determined by the specified annotation.
+// The kind of exclusion (inclusion vs exclusion) is determined by the specified annotation.
 //
 // The function returns an error when it is unable to determine whether IP ranges need to be excluded from outbound sidecar interception.
-func getOutboundIPRangeExclusionListForPod(pod *corev1.Pod, namespace string, annotation string) ([]string, error) {
+func getOutboundIPRangeListForPod(pod *corev1.Pod, namespace string, annotation string) ([]string, error) {
 	ipRangeExclusionsStr, ok := pod.Annotations[annotation]
 	if !ok {
 		// No port exclusion annotation specified
@@ -105,18 +108,18 @@ func getOutboundIPRangeExclusionListForPod(pod *corev1.Pod, namespace string, an
 	return ipRanges, nil
 }
 
-// mergeIPRangeExclusionLists merges the pod specific and global IP range exclusion lists
-func mergeIPRangeExclusionLists(podSpecificExclusionList, globalExclusionList []string) []string {
+// mergeIPRangeLists merges the pod specific and global IP range (exclusion/inclusion) lists
+func mergeIPRangeLists(podSpecific, global []string) []string {
 	ipSet := mapset.NewSet()
 	var ipRanges []string
 
-	for _, ip := range podSpecificExclusionList {
+	for _, ip := range podSpecific {
 		if addedToSet := ipSet.Add(ip); addedToSet {
 			ipRanges = append(ipRanges, ip)
 		}
 	}
 
-	for _, ip := range globalExclusionList {
+	for _, ip := range global {
 		if addedToSet := ipSet.Add(ip); addedToSet {
 			ipRanges = append(ipRanges, ip)
 		}

--- a/pkg/injector/exclusions_test.go
+++ b/pkg/injector/exclusions_test.go
@@ -128,7 +128,7 @@ func TestMergePortExclusionLists(t *testing.T) {
 	}
 }
 
-func TestGetOutboundIPRangeExclusionListForPod(t *testing.T) {
+func TestGetOutboundIPRangeListForPod(t *testing.T) {
 	testCases := []struct {
 		name             string
 		podAnnotation    map[string]string
@@ -137,16 +137,30 @@ func TestGetOutboundIPRangeExclusionListForPod(t *testing.T) {
 		expectedIPRanges []string
 	}{
 		{
-			name:             "valid annotation",
+			name:             "valid exclusion annotation",
 			podAnnotation:    map[string]string{outboundIPRangeExclusionListAnnotation: "10.0.0.0/8, 2.2.2.2/32"},
 			forAnnotation:    outboundIPRangeExclusionListAnnotation,
 			expectedError:    nil,
 			expectedIPRanges: []string{"10.0.0.0/8", "2.2.2.2/32"},
 		},
 		{
-			name:             "no annotation",
+			name:             "no exclusion annotation",
 			podAnnotation:    nil,
 			forAnnotation:    outboundIPRangeExclusionListAnnotation,
+			expectedError:    nil,
+			expectedIPRanges: nil,
+		},
+		{
+			name:             "valid inclusion annotation",
+			podAnnotation:    map[string]string{outboundIPRangeInclusionListAnnotation: "10.0.0.0/8, 2.2.2.2/32"},
+			forAnnotation:    outboundIPRangeInclusionListAnnotation,
+			expectedError:    nil,
+			expectedIPRanges: []string{"10.0.0.0/8", "2.2.2.2/32"},
+		},
+		{
+			name:             "no inclusion annotation",
+			podAnnotation:    nil,
+			forAnnotation:    outboundIPRangeInclusionListAnnotation,
 			expectedError:    nil,
 			expectedIPRanges: nil,
 		},
@@ -173,7 +187,7 @@ func TestGetOutboundIPRangeExclusionListForPod(t *testing.T) {
 				},
 			}
 
-			ipRanges, err := getOutboundIPRangeExclusionListForPod(pod, "test", tc.forAnnotation)
+			ipRanges, err := getOutboundIPRangeListForPod(pod, "test", tc.forAnnotation)
 			if tc.expectedError != nil {
 				a.EqualError(tc.expectedError, err.Error())
 			} else {
@@ -184,7 +198,7 @@ func TestGetOutboundIPRangeExclusionListForPod(t *testing.T) {
 	}
 }
 
-func TestMergeIPRangeExclusionLists(t *testing.T) {
+func TestMergeIPRangeLists(t *testing.T) {
 	testCases := []struct {
 		name        string
 		podSpecific []string
@@ -203,7 +217,7 @@ func TestMergeIPRangeExclusionLists(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
 
-			actual := mergeIPRangeExclusionLists(tc.podSpecific, tc.global)
+			actual := mergeIPRangeLists(tc.podSpecific, tc.global)
 			a.ElementsMatch(tc.expected, actual)
 		})
 	}

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -7,9 +7,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
 
-func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string, outboundPortExclusionList []int,
+func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string,
+	outboundIPRangeInclusionList []string, outboundPortExclusionList []int,
 	inboundPortExclusionList []int, enablePrivilegedInitContainer bool) corev1.Container {
-	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundPortExclusionList, inboundPortExclusionList)
+	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
 
 	return corev1.Container{
 		Name:  containerName,

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		It("Creates init container without ip range exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, nil, privileged)
 
 			expected := corev1.Container{
 				Name:    "-container-name-",

--- a/pkg/injector/iptables_test.go
+++ b/pkg/injector/iptables_test.go
@@ -3,19 +3,53 @@ package injector
 import (
 	"testing"
 
-	tassert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateIptablesCommands(t *testing.T) {
-	assert := tassert.New(t)
-
-	outboundIPRangeExclusion := []string{"1.1.1.1/32", "2.2.2.2/32"}
-	outboundPortExclusion := []int{10, 20}
-	inboundPortExclusion := []int{30, 40}
-
-	actual := generateIptablesCommands(outboundIPRangeExclusion, outboundPortExclusion, inboundPortExclusion)
-
-	expected := `iptables-restore --noflush <<EOF
+	testCases := []struct {
+		name                      string
+		outboundIPRangeExclusions []string
+		outboundIPRangeInclusions []string
+		outboundPortExclusions    []int
+		inboundPortExclusions     []int
+		expected                  string
+	}{
+		{
+			name: "no exclusions or inclusions",
+			expected: `iptables-restore --noflush <<EOF
+# OSM sidecar interception rules
+*nat
+:OSM_PROXY_INBOUND - [0:0]
+:OSM_PROXY_IN_REDIRECT - [0:0]
+:OSM_PROXY_OUTBOUND - [0:0]
+:OSM_PROXY_OUT_REDIRECT - [0:0]
+-A OSM_PROXY_IN_REDIRECT -p tcp -j REDIRECT --to-port 15003
+-A PREROUTING -p tcp -j OSM_PROXY_INBOUND
+-A OSM_PROXY_INBOUND -p tcp --dport 15010 -j RETURN
+-A OSM_PROXY_INBOUND -p tcp --dport 15901 -j RETURN
+-A OSM_PROXY_INBOUND -p tcp --dport 15902 -j RETURN
+-A OSM_PROXY_INBOUND -p tcp --dport 15903 -j RETURN
+-A OSM_PROXY_INBOUND -p tcp -j OSM_PROXY_IN_REDIRECT
+-A OSM_PROXY_OUT_REDIRECT -p tcp -j REDIRECT --to-port 15001
+-A OSM_PROXY_OUT_REDIRECT -p tcp --dport 15000 -j ACCEPT
+-A OUTPUT -p tcp -j OSM_PROXY_OUTBOUND
+-A OSM_PROXY_OUTBOUND -o lo ! -d 127.0.0.1/32 -m owner --uid-owner 1500 -j OSM_PROXY_IN_REDIRECT
+-A OSM_PROXY_OUTBOUND -o lo -m owner ! --uid-owner 1500 -j RETURN
+-A OSM_PROXY_OUTBOUND -m owner --uid-owner 1500 -j RETURN
+-A OSM_PROXY_OUTBOUND -d 127.0.0.1/32 -j RETURN
+-A OSM_PROXY_OUTBOUND -j OSM_PROXY_OUT_REDIRECT
+COMMIT
+EOF
+`,
+		},
+		{
+			name:                      "with exclusions and inclusions",
+			outboundIPRangeExclusions: []string{"1.1.1.1/32", "2.2.2.2/32"},
+			outboundIPRangeInclusions: []string{"3.3.3.3/32", "4.4.4.4/32"},
+			outboundPortExclusions:    []int{10, 20},
+			inboundPortExclusions:     []int{30, 40},
+			expected: `iptables-restore --noflush <<EOF
 # OSM sidecar interception rules
 *nat
 :OSM_PROXY_INBOUND - [0:0]
@@ -37,13 +71,23 @@ func TestGenerateIptablesCommands(t *testing.T) {
 -A OSM_PROXY_OUTBOUND -o lo -m owner ! --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -m owner --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -d 127.0.0.1/32 -j RETURN
--A OSM_PROXY_OUTBOUND -j OSM_PROXY_OUT_REDIRECT
--I OSM_PROXY_OUTBOUND -d 1.1.1.1/32 -j RETURN
--I OSM_PROXY_OUTBOUND -d 2.2.2.2/32 -j RETURN
--I OSM_PROXY_OUTBOUND -p tcp --match multiport --dports 10,20 -j RETURN
+-A OSM_PROXY_OUTBOUND -d 1.1.1.1/32 -j RETURN
+-A OSM_PROXY_OUTBOUND -d 2.2.2.2/32 -j RETURN
+-A OSM_PROXY_OUTBOUND -p tcp --match multiport --dports 10,20 -j RETURN
+-A OSM_PROXY_OUTBOUND -d 3.3.3.3/32 -j OSM_PROXY_OUT_REDIRECT
+-A OSM_PROXY_OUTBOUND -d 4.4.4.4/32 -j OSM_PROXY_OUT_REDIRECT
+-A OSM_PROXY_OUTBOUND -j RETURN
 COMMIT
 EOF
-`
+`,
+		},
+	}
 
-	assert.Equal(expected, actual)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			actual := generateIptablesCommands(tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions)
+			a.Equal(tc.expected, actual)
+		})
+	}
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds support to configure IP range inclusions globally
or scoped to pods, similar to the IP range exclusions
functionality.

- Makes IP range related functions generic to handle
  exclusions and inclusions
- Updates iptables rules to order exclusions correctly
  before inclusions
- Adds install option to specify global IP range
  inclusions

Part of #4396

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Ran the demo with inclusion ranges specified and verified it works
as expected.
```
./demo/run-osm-demo.sh --set="osm.outboundIPRangeInclusionList={10.244.0.0/16,10.96.0.0/16}"
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Sidecar Injection          | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No, will be done once the feature is complete.