### PR TITLE
fix(injector): make init container pullPolicy configurable

### DIFF
--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -66,6 +66,7 @@ spec:
             "--cert-manager-issuer-kind", "{{.Values.osm.certmanager.issuerKind}}",
             "--cert-manager-issuer-group", "{{.Values.osm.certmanager.issuerGroup}}",
             "--enable-reconciler={{.Values.osm.enableReconciler}}",
+            "--init-container-pull-policy={{.Values.osm.image.pullPolicy}}",
           ]
           resources:
             limits:

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -61,6 +61,8 @@ var (
 	vaultOptions       providers.VaultOptions
 	certManagerOptions providers.CertManagerOptions
 
+	initContainerPullPolicy string
+
 	scheme = runtime.NewScheme()
 )
 
@@ -100,6 +102,8 @@ func init() {
 
 	// Reconciler options
 	flags.BoolVar(&enableReconciler, "enable-reconciler", false, "Enable reconciler for CDRs, mutating webhook and validating webhook")
+
+	flags.StringVar(&initContainerPullPolicy, "init-container-pull-policy", "", "The pullPolicy to use for injected init containers")
 
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = admissionv1.AddToScheme(scheme)
@@ -172,7 +176,7 @@ func main() {
 	}
 
 	// Initialize the sidecar injector webhook
-	if err := injector.NewMutatingWebhook(injectorConfig, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookConfigName, osmVersion, webhookTimeout, enableReconciler, stop, cfg); err != nil {
+	if err := injector.NewMutatingWebhook(injectorConfig, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookConfigName, osmVersion, webhookTimeout, enableReconciler, stop, cfg, corev1.PullPolicy(initContainerPullPolicy)); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating sidecar injector webhook")
 	}
 

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -9,12 +9,13 @@ import (
 
 func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string,
 	outboundIPRangeInclusionList []string, outboundPortExclusionList []int,
-	inboundPortExclusionList []int, enablePrivilegedInitContainer bool) corev1.Container {
+	inboundPortExclusionList []int, enablePrivilegedInitContainer bool, pullPolicy corev1.PullPolicy) corev1.Container {
 	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
 
 	return corev1.Container{
-		Name:  containerName,
-		Image: cfg.GetInitContainerImage(),
+		Name:            containerName,
+		Image:           cfg.GetInitContainerImage(),
+		ImagePullPolicy: pullPolicy,
 		SecurityContext: &corev1.SecurityContext{
 			Privileged: &enablePrivilegedInitContainer,
 			Capabilities: &corev1.Capabilities{

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -27,12 +27,13 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		It("Creates init container without ip range exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, nil, privileged)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, nil, privileged, corev1.PullAlways)
 
 			expected := corev1.Container{
-				Name:    "-container-name-",
-				Image:   "-init-container-image-",
-				Command: []string{"/bin/sh"},
+				Name:            "-container-name-",
+				Image:           "-init-container-image-",
+				ImagePullPolicy: corev1.PullAlways,
+				Command:         []string{"/bin/sh"},
 				Args: []string{
 					"-c",
 					`iptables-restore --noflush <<EOF

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -158,7 +158,7 @@ func (wh *mutatingWebhook) configurePodInit(podOS string, pod *corev1.Pod, names
 	outboundIPRangeInclusionList := mergeIPRangeLists(podOutboundIPRangeInclusionList, globalOutboundIPRangeInclusionList)
 
 	// Add the init container to the pod spec
-	initContainer := getInitContainerSpec(constants.InitContainerName, wh.configurator, outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList, wh.configurator.IsPrivilegedInitContainer())
+	initContainer := getInitContainerSpec(constants.InitContainerName, wh.configurator, outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList, wh.configurator.IsPrivilegedInitContainer(), wh.initContainerPullPolicy)
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
 	return nil

--- a/pkg/injector/types.go
+++ b/pkg/injector/types.go
@@ -4,6 +4,7 @@ package injector
 
 import (
 	mapset "github.com/deckarep/golang-set"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -20,14 +21,15 @@ var log = logger.New("sidecar-injector")
 
 // mutatingWebhook is the type used to represent the webhook for sidecar injection
 type mutatingWebhook struct {
-	config         Config
-	kubeClient     kubernetes.Interface
-	certManager    certificate.Manager
-	kubeController k8s.Controller
-	osmNamespace   string
-	meshName       string
-	cert           certificate.Certificater
-	configurator   configurator.Configurator
+	config                  Config
+	kubeClient              kubernetes.Interface
+	certManager             certificate.Manager
+	kubeController          k8s.Controller
+	osmNamespace            string
+	meshName                string
+	cert                    certificate.Certificater
+	configurator            configurator.Configurator
+	initContainerPullPolicy corev1.PullPolicy
 
 	nonInjectNamespaces mapset.Set
 }

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -44,7 +44,7 @@ const (
 )
 
 // NewMutatingWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
-func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certManager certificate.Manager, kubeController k8s.Controller, meshName, osmNamespace, webhookConfigName, osmVersion string, webhookTimeout int32, enableReconciler bool, stop <-chan struct{}, cfg configurator.Configurator) error {
+func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certManager certificate.Manager, kubeController k8s.Controller, meshName, osmNamespace, webhookConfigName, osmVersion string, webhookTimeout int32, enableReconciler bool, stop <-chan struct{}, cfg configurator.Configurator, initContainerPullPolicy corev1.PullPolicy) error {
 	// This is a certificate issued for the webhook handler
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned with the MutatingWebhookConfiguration
@@ -63,14 +63,15 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 	}
 
 	wh := mutatingWebhook{
-		config:         config,
-		kubeClient:     kubeClient,
-		certManager:    certManager,
-		kubeController: kubeController,
-		osmNamespace:   osmNamespace,
-		meshName:       meshName,
-		cert:           webhookHandlerCert,
-		configurator:   cfg,
+		config:                  config,
+		kubeClient:              kubeClient,
+		certManager:             certManager,
+		kubeController:          kubeController,
+		osmNamespace:            osmNamespace,
+		meshName:                meshName,
+		cert:                    webhookHandlerCert,
+		configurator:            cfg,
+		initContainerPullPolicy: initContainerPullPolicy,
 
 		// Envoy sidecars should never be injected in these namespaces
 		nonInjectNamespaces: mapset.NewSetFromSlice([]interface{}{

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -569,7 +569,7 @@ var _ = Describe("Testing Injector Functions", func() {
 
 		_, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), webhookName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		actualErr := NewMutatingWebhook(Config{}, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, osmVersion, webhookTimeout, enableReconciler, stop, cfg)
+		actualErr := NewMutatingWebhook(Config{}, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, osmVersion, webhookTimeout, enableReconciler, stop, cfg, "")
 		Expect(actualErr).NotTo(HaveOccurred())
 		close(stop)
 	})
@@ -585,7 +585,7 @@ var _ = Describe("Testing Injector Functions", func() {
 
 		cfg.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
-		actualErr := NewMutatingWebhook(Config{}, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, osmVersion, webhookTimeout, enableReconciler, stop, cfg)
+		actualErr := NewMutatingWebhook(Config{}, kubeClient, certManager, kubeController, meshName, osmNamespace, webhookName, osmVersion, webhookTimeout, enableReconciler, stop, cfg, "")
 		Expect(actualErr).NotTo(HaveOccurred())
 		_, err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.Background(), webhookName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change uses the `osm.image.pullPolicy` value in the Helm chart for
the pull policy configured for injected init containers to make the
behavior consistent with other OSM images. Previously, using
`osm.image.pullPolicy=IfNotPresent` and `osm.image.tag=latest` would
configure the init container with that tag but an empty pull policy
which would be implicitly `Always`, which fails in environments where
the image is not meant to be pulled.

Fixes #3809
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Verified the command from the issue now works:

```
make test-e2e CTR_REGISTRY=localhost:5000 CTR_TAG=latest E2E_FLAGS="-installType=KindCluster -cleanupKindClusterBetweenTests -ginkgo.focus='SimpleClientServer egress TCP'"
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [X] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A