### PR TITLE
fix(cli): uninstall mesh assume yes flag

### DIFF
--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -93,7 +93,7 @@ func newUninstallMeshCmd(config *action.Configuration, in io.Reader, out io.Writ
 
 	f := cmd.Flags()
 	f.StringVar(&uninstall.meshName, "mesh-name", defaultMeshName, "Name of the service mesh")
-	f.BoolVarP(&uninstall.force, "force", "f", false, "Attempt to uninstall the osm control plane instance without prompting for confirmation.  If the control plane with specified mesh name does not exist, do not display a diagnostic message or modify the exit status to reflect an error.")
+	f.BoolVarP(&uninstall.force, "force", "f", false, "Attempt to uninstall the osm control plane instance without prompting for confirmation.")
 	f.BoolVarP(&uninstall.deleteClusterWideResources, "delete-cluster-wide-resources", "a", false, "Cluster wide resources (such as osm CRDs, mutating webhook configurations, validating webhook configurations and osm secrets) are fully deleted from the cluster after control plane components are deleted.")
 	f.BoolVar(&uninstall.deleteNamespace, "delete-namespace", false, "Attempt to delete the namespace after control plane components are deleted")
 	f.Uint16VarP(&uninstall.localPort, "local-port", "p", constants.OSMHTTPServerPort, "Local port to use for port forwarding")


### PR DESCRIPTION
When `osm uninstall mesh -f` is run, the `force`
flag is intended for the user to skip the uninstall
confirmation prompt only.

Even if this code is specified, the code in uninstall
mesh does not supress diagnostic messages or errors
when it encounters an error during mesh uninstallation.

This proposed fix instead changes the force flag to
'--assume-yes' flag to make this behavior clear, only
skipping the confirmation prompt but not supressing
diagnostic messages and errors.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

**Testing done**: Local testing + unit testing

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? NA