### PR TITLE
feat(cli): add support controller-debug-server cmd

### DIFF
--- a/cmd/cli/support.go
+++ b/cmd/cli/support.go
@@ -20,6 +20,7 @@ func newSupportCmd(config *action.Configuration, stdout io.Writer, stderr io.Wri
 		Args:  cobra.NoArgs,
 	}
 	cmd.AddCommand(newSupportErrInfoCmd(stdout))
+	cmd.AddCommand(newOsmControllerDebugServerCmd(stdout))
 	cmd.AddCommand(newSupportBugReportCmd(config, stdout, stderr))
 
 	return cmd

--- a/cmd/cli/support_debug_server.go
+++ b/cmd/cli/support_debug_server.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
+	"github.com/pkg/browser"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/k8s"
+)
+
+const openOsmControllerDebugServerDesc = `
+TODO
+`
+
+type osmControllerDebugServerCmd struct {
+	out         io.Writer
+	config      *rest.Config
+	clientSet   kubernetes.Interface
+	namespace   string
+	localPort   uint16
+	remotePort  uint16
+	openBrowser bool
+	sigintChan  chan os.Signal // Allows interacting with the command from outside
+}
+
+func newOsmControllerDebugServerCmd(out io.Writer) *cobra.Command {
+	debugServerCmd := &osmControllerDebugServerCmd{
+		out:        out,
+		sigintChan: make(chan os.Signal, 1),
+	}
+
+	cmd := &cobra.Command{
+		Use:   "controller-debug-server",
+		Short: "open osm-controller debug server through redirection",
+		Long:  openOsmControllerDebugServerDesc,
+		RunE: func(_ *cobra.Command, args []string) error {
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
+			}
+			debugServerCmd.config = config
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return errors.Errorf("Could not access Kubernetes cluster, check kubeconfig: %s", err)
+			}
+			debugServerCmd.clientSet = clientset
+
+			debugServerCmd.namespace = settings.Namespace()
+			return debugServerCmd.run()
+		},
+	}
+
+	cmd.Flags().Uint16VarP(&debugServerCmd.localPort, "local-port", "p", constants.DebugPort, "Local port to use")
+	cmd.Flags().Uint16VarP(&debugServerCmd.remotePort, "remote-port", "r", constants.DebugPort, "Remote port on osm-controller's debug server")
+	cmd.Flags().BoolVarP(&debugServerCmd.openBrowser, "open-browser", "b", true, "Triggers browser open, true by default")
+
+	return cmd
+}
+
+func (d *osmControllerDebugServerCmd) run() error {
+	fmt.Fprintf(d.out, "[+] Starting osm-controller debug server forwarding\n")
+
+	meshControllerPods := k8s.GetOSMControllerPods(d.clientSet, d.namespace)
+	if len(meshControllerPods.Items) <= 0 {
+		return errors.Errorf("Could not find any osm-controller pods in namespace %s", d.namespace)
+	}
+	// Will select first running Pod available
+	var osmControllerPod *corev1.Pod
+	for _, p := range meshControllerPods.Items {
+		pod := p // prevents aliasing address of loop variable which is the same in each iteration
+		if pod.Status.Phase == corev1.PodRunning {
+			osmControllerPod = &pod
+			break
+		}
+	}
+	if osmControllerPod == nil {
+		return errors.Errorf("Could not find any running osm-controller pods in namespace %s", d.namespace)
+	}
+
+	fmt.Fprintf(d.out, "[+] Performing port redirection for pod [%s] in namespace [%s] for remote port [%d] to local port [%d]\n",
+		osmControllerPod.Name, osmControllerPod.Namespace, d.remotePort, d.localPort)
+
+	dialer, err := k8s.DialerToPod(d.config, d.clientSet, osmControllerPod.Name, osmControllerPod.Namespace)
+	if err != nil {
+		return err
+	}
+	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", d.localPort, d.remotePort))
+	if err != nil {
+		return fmt.Errorf("error setting up port forwarding: %s", err)
+	}
+
+	err = portForwarder.Start(func(*k8s.PortForwarder) error {
+		if d.openBrowser {
+			url := fmt.Sprintf("http://localhost:%d%s", d.localPort, constants.DebugServerIndexPath)
+			fmt.Fprintf(d.out, "[+] Issuing open browser %s\n", url)
+			_ = browser.OpenURL(url)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("port forwarding failed: %s", err)
+	}
+
+	// The command should only exit when a signal is received from the OS.
+	// Exiting before will result in port forwarding to stop causing the browser
+	// if open to not render the dashboard.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	<-sigChan
+
+	// portforwarder.Stop() triggered implicitly by SIGINT. Ensure it completes
+	// before exiting.
+	<-portForwarder.Done()
+
+	return nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -70,6 +70,9 @@ const (
 	// DebugPort is the port on which OSM exposes its debug server
 	DebugPort = 9092
 
+	// DebugServerIndexPath is the path on which OSM exposes its debug server
+	DebugServerIndexPath = "/debug"
+
 	// ValidatorWebhookPort is the port on which the resource validator webhook listens
 	ValidatorWebhookPort = 9093
 

--- a/pkg/debugger/server.go
+++ b/pkg/debugger/server.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/pprof"
 
+	"github.com/openservicemesh/osm/pkg/constants"
+
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -33,7 +35,7 @@ func (ds DebugConfig) GetHandlers() map[string]http.Handler {
 	}
 
 	// provides an index of the available /debug endpoints
-	handlers["/debug"] = ds.getDebugIndex(handlers)
+	handlers[constants.DebugServerIndexPath] = ds.getDebugIndex(handlers)
 
 	return handlers
 }


### PR DESCRIPTION
Adds "osm support controller-debug-server" cmd,
which performs port-redirection and opens the browser
to facilitate opening the osm-controller debug server.

This is useful for both project maintainers and osm
users that want to debug a running osm instance without
needing to clone the repo to run
"scripts/port-forward-osm-debug.sh" or to remember
kubectl port-forward commands.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>

**Testing done**: Built and ran the command -> browser with redirect to debug server opened automatically.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs] NA(https://github.com/openservicemesh/osm-docs) repo (if applicable)?