### PR TITLE
ref(chart): push vault validation to chart

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -61,9 +61,9 @@ spec:
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
-            "--vault-host", "{{.Values.osm.vault.host}}",
+            "--vault-host", "{{ required "osm.vault.host is required when osm.certificateProvider.kind==vault" .Values.osm.vault.host }}",
             "--vault-protocol", "{{.Values.osm.vault.protocol}}",
-            "--vault-token", "{{.Values.osm.vault.token}}",
+            "--vault-token", "{{ required "osm.vault.token is required when osm.certificateProvider.kind==vault" .Values.osm.vault.token }}",
             {{- end }}
             "--cert-manager-issuer-name", "{{.Values.osm.certmanager.issuerName}}",
             "--cert-manager-issuer-kind", "{{.Values.osm.certmanager.issuerKind}}",

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -249,28 +249,6 @@ func (i *installCmd) validateOptions() error {
 		return errors.Wrap(err, "invalid format for --set")
 	}
 
-	if setOptions, ok := s["osm"].(map[string]interface{}); ok {
-		// if the certificate provider kind is vault, ensure all relevant information (vault-host, vault-token) is available
-		if certProvider, ok := setOptions["certificateProvider"].(map[string]interface{}); ok && certProvider["kind"] == "vault" {
-			var missingFields []string
-			vaultOptions, ok := setOptions["vault"].(map[string]interface{})
-			if !ok {
-				missingFields = append(missingFields, "osm.vault.host", "osm.vault.token")
-			} else {
-				if vaultOptions["host"] == nil || vaultOptions["host"] == "" {
-					missingFields = append(missingFields, "osm.vault.host")
-				}
-				if vaultOptions["token"] == nil || vaultOptions["token"] == "" {
-					missingFields = append(missingFields, "osm.vault.token")
-				}
-			}
-
-			if len(missingFields) != 0 {
-				return errors.Errorf("Missing arguments for certificate-manager vault: %v", missingFields)
-			}
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change moves the validation for the `osm.vault.host` and
`osm.vault.token` values from the CLI to the chart so the same
validation is performed when using `helm` directly.

Part of #2147

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Unit tests updated.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A