### PR TITLE
feat(ads) implement a logger for the snapshot cache

### DIFF
--- a/pkg/envoy/ads/cache_log.go
+++ b/pkg/envoy/ads/cache_log.go
@@ -1,0 +1,25 @@
+package ads
+
+// scLogger implements envoy control plane's log.Logger and delegates calls to the `log` variable defined in
+// types.go. It is used for the envoy snapshot cache.
+type scLogger struct{}
+
+// Debugf logs a formatted debugging message.
+func (l *scLogger) Debugf(format string, args ...interface{}) {
+	log.Debug().Msgf(format, args...)
+}
+
+// Infof logs a formatted informational message.
+func (l *scLogger) Infof(format string, args ...interface{}) {
+	log.Info().Msgf(format, args...)
+}
+
+// Warnf logs a formatted warning message.
+func (l *scLogger) Warnf(format string, args ...interface{}) {
+	log.Warn().Msgf(format, args...)
+}
+
+// Errorf logs a formatted error message.
+func (l *scLogger) Errorf(format string, args ...interface{}) {
+	log.Error().Msgf(format, args...)
+}

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -81,9 +81,7 @@ func (s *Server) Start(ctx context.Context, cancel context.CancelFunc, port int,
 	}
 
 	if s.cacheEnabled {
-		// TODO: Zerolog can't be passed as snapshot cache internal logger as it doesn't implement golang's logger interface
-		// passing nil as logger (third argument) for now
-		s.ch = cachev3.NewSnapshotCache(false, cachev3.IDHash{}, nil)
+		s.ch = cachev3.NewSnapshotCache(false, cachev3.IDHash{}, &scLogger{})
 		s.srv = serverv3.NewServer(ctx, s.ch, &Callbacks{})
 
 		xds_discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, s.srv)


### PR DESCRIPTION
Simply wrap our default logger around the snapshot cache's 
expected logging interface`

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?