### PR TITLE
feat(errors): handle errors exactly once.

### DIFF
--- a/ci/cmd/maestro/kubernetes_tools.go
+++ b/ci/cmd/maestro/kubernetes_tools.go
@@ -112,8 +112,7 @@ func GetPodName(kubeClient kubernetes.Interface, namespace, selector string) (st
 	}
 
 	if len(podList.Items) == 0 {
-		log.Error().Msgf("Zero pods found for selector %s in namespace %s", selector, namespace)
-		return "", errNoPodsFound
+		return "", fmt.Errorf("zero pods found for selector %s in namespace %s", selector, namespace)
 	}
 
 	sort.SliceStable(podList.Items, func(i, j int) bool {
@@ -235,7 +234,7 @@ func WaitForPodToBeReady(kubeClient kubernetes.Interface, totalWait time.Duratio
 
 		podName, err := GetPodName(kubeClient, namespace, selector)
 		if err != nil {
-			log.Error().Err(err).Msgf("Error getting Pod w/ selector %q", selector)
+			log.Error().Err(err)
 			time.Sleep(WaitForPod)
 			// Pod might not be up yet, try again
 			continue

--- a/ci/cmd/maestro/types.go
+++ b/ci/cmd/maestro/types.go
@@ -1,7 +1,6 @@
 package maestro
 
 import (
-	"errors"
 	"time"
 
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -46,6 +45,5 @@ var (
 	// FailureLogsFromTimeSince is the interval we go back in time to get pod logs
 	FailureLogsFromTimeSince = 10 * time.Minute
 
-	log            = logger.NewPretty("ci/maestro")
-	errNoPodsFound = errors.New("no pods found")
+	log = logger.NewPretty("ci/maestro")
 )

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -90,7 +90,7 @@ func newInstallCmd(config *helm.Configuration, out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			kubeconfig, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(kubeconfig)
@@ -159,7 +159,7 @@ func (i *installCmd) loadOSMChart() error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Error loading chart for installation: %s", err)
+		return fmt.Errorf("error loading chart for installation: %s", err)
 	}
 
 	return nil

--- a/cmd/cli/mesh_list.go
+++ b/cmd/cli/mesh_list.go
@@ -48,7 +48,7 @@ func newMeshList(out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 			listCmd.config = config
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/metrics_disable.go
+++ b/cmd/cli/metrics_disable.go
@@ -39,7 +39,7 @@ func newMetricsDisable(out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/metrics_enable.go
+++ b/cmd/cli/metrics_enable.go
@@ -42,7 +42,7 @@ func newMetricsEnable(out io.Writer) *cobra.Command {
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -62,7 +62,7 @@ func newNamespaceAdd(out io.Writer) *cobra.Command {
 			namespaceAdd.namespaces = args
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/namespace_ignore.go
+++ b/cmd/cli/namespace_ignore.go
@@ -43,7 +43,7 @@ func newNamespaceIgnore(out io.Writer) *cobra.Command {
 			ignoreCmd.namespaces = args
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/namespace_list.go
+++ b/cmd/cli/namespace_list.go
@@ -41,7 +41,7 @@ func newNamespaceList(out io.Writer) *cobra.Command {
 
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/namespace_remove.go
+++ b/cmd/cli/namespace_remove.go
@@ -40,7 +40,7 @@ func newNamespaceRemove(out io.Writer) *cobra.Command {
 			namespaceRemove.namespace = args[0]
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			clientset, err := kubernetes.NewForConfig(config)

--- a/cmd/cli/policy_check_pods.go
+++ b/cmd/cli/policy_check_pods.go
@@ -65,7 +65,7 @@ func newPolicyCheckPods(out io.Writer) *cobra.Command {
 
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 
 			trafficPolicyCheckCmd.restConfig = config
@@ -125,7 +125,7 @@ func (cmd *trafficPolicyCheckCmd) checkTrafficPolicy(srcPod, dstPod *corev1.Pod)
 
 	// Check if permissive mode is enabled, in which case every meshed pod is allowed to communicate with each other
 	if permissiveMode, err := cmd.isPermissiveModeEnabled(); err != nil {
-		return errors.Errorf("Error checking if permissive mode is enabled: %s", err)
+		return errors.Errorf("error checking if permissive mode is enabled: %s", err)
 	} else if permissiveMode {
 		fmt.Fprintf(cmd.out, "[+] Permissive mode enabled for mesh operated by osm-controller running in '%s' namespace\n\n "+
 			"[+] Pod '%s/%s' is allowed to communicate to pod '%s/%s'\n",
@@ -137,7 +137,7 @@ func (cmd *trafficPolicyCheckCmd) checkTrafficPolicy(srcPod, dstPod *corev1.Pod)
 	fmt.Fprintf(cmd.out, "[+] SMI traffic policy mode enabled for mesh operated by osm-controller running in %s namespace\n\n", osmNamespace)
 	trafficTargets, err := cmd.smiAccessClient.AccessV1alpha3().TrafficTargets(dstPod.Namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return errors.Errorf("Error listing SMI TrafficTarget policies: %s", err)
+		return errors.Errorf("error listing SMI TrafficTarget policies: %s", err)
 	}
 
 	var foundTrafficTarget bool
@@ -182,7 +182,7 @@ func (cmd *trafficPolicyCheckCmd) isPermissiveModeEnabled() (bool, error) {
 	meshConfig, err := cmd.meshConfigClient.ConfigV1alpha2().MeshConfigs(osmNamespace).Get(context.TODO(), defaultOsmMeshConfigName, metav1.GetOptions{})
 
 	if err != nil {
-		return false, errors.Errorf("Error fetching MeshConfig %s: %s", defaultOsmMeshConfigName, err)
+		return false, errors.Errorf("error fetching MeshConfig %s: %s", defaultOsmMeshConfigName, err)
 	}
 	return meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode, nil
 }

--- a/cmd/cli/proxy_get.go
+++ b/cmd/cli/proxy_get.go
@@ -59,7 +59,7 @@ func newProxyGetCmd(config *action.Configuration, out io.Writer) *cobra.Command 
 			getCmd.pod = args[1]
 			conf, err := config.RESTClientGetter.ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 			getCmd.config = conf
 
@@ -92,7 +92,7 @@ func (cmd *proxyGetCmd) run() error {
 	if cmd.outFile != "" {
 		fd, err := os.Create(cmd.outFile)
 		if err != nil {
-			return errors.Errorf("Error opening file %s: %s", cmd.outFile, err)
+			return errors.Errorf("error opening file %s: %s", cmd.outFile, err)
 		}
 		//nolint: errcheck
 		//#nosec G307

--- a/cmd/cli/support_bugreport.go
+++ b/cmd/cli/support_bugreport.go
@@ -91,7 +91,7 @@ func newSupportBugReportCmd(config *action.Configuration, stdout io.Writer, stde
 		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 			bugReportCmd.kubeClient, err = kubernetes.NewForConfig(config)
 			if err != nil {

--- a/cmd/cli/support_err.go
+++ b/cmd/cli/support_err.go
@@ -60,11 +60,11 @@ func (cmd *errInfoCmd) run(errCode string) error {
 		// Print the error code description mapping only for the given error code
 		e, err := errcode.FromStr(errCode)
 		if err != nil {
-			return errors.Errorf("Error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", errCode)
+			return errors.Errorf("error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", errCode)
 		}
 		description, ok := errcode.ErrCodeMap[e]
 		if !ok {
-			return errors.Errorf("Error code '%s' is not a valid error code recognized by OSM", errCode)
+			return errors.Errorf("error code '%s' is not a valid error code recognized by OSM", errCode)
 		}
 		table.Append([]string{errCode, description})
 	} else {

--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -72,7 +72,7 @@ func newUninstallMeshCmd(config *action.Configuration, in io.Reader, out io.Writ
 			// get kubeconfig and initialize k8s client
 			kubeconfig, err := settings.RESTClientGetter().ToRESTConfig()
 			if err != nil {
-				return errors.Errorf("Error fetching kubeconfig: %s", err)
+				return errors.Errorf("error fetching kubeconfig: %s", err)
 			}
 			uninstall.config = kubeconfig
 
@@ -182,7 +182,7 @@ func (d *uninstallMeshCmd) run() error {
 					fmt.Fprintf(d.out, "OSM namespace [%s] not found\n", d.meshNamespace)
 					return nil
 				}
-				return errors.Errorf("Error occurred while deleting OSM namespace [%s] - %v", d.meshNamespace, err)
+				return errors.Errorf("error occurred while deleting OSM namespace [%s] - %v", d.meshNamespace, err)
 			}
 			fmt.Fprintf(d.out, "OSM namespace [%s] deleted successfully\n", d.meshNamespace)
 		} else {

--- a/cmd/cli/util.go
+++ b/cmd/cli/util.go
@@ -207,7 +207,7 @@ func getSupportedSmiForControllerPod(pod string, namespace string, restConfig *r
 
 	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", localPort, constants.OSMHTTPServerPort))
 	if err != nil {
-		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+		return nil, errors.Errorf("error setting up port forwarding: %s", err)
 	}
 
 	var smiSupported map[string]string
@@ -219,16 +219,16 @@ func getSupportedSmiForControllerPod(pod string, namespace string, restConfig *r
 		// #nosec G107: Potential HTTP request made with variable url
 		resp, err := http.Get(url)
 		if err != nil {
-			return errors.Errorf("Error fetching url %s: %s", url, err)
+			return errors.Errorf("error fetching url %s: %s", url, err)
 		}
 
 		if err := json.NewDecoder(resp.Body).Decode(&smiSupported); err != nil {
-			return errors.Errorf("Error rendering HTTP response: %s", err)
+			return errors.Errorf("error rendering HTTP response: %s", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Errorf("Error retrieving supported SMI versions for pod %s in namespace %s: %s", pod, namespace, err)
+		return nil, errors.Errorf("error retrieving supported SMI versions for pod %s in namespace %s: %s", pod, namespace, err)
 	}
 
 	for smiAPI, smiAPIVersion := range smiSupported {

--- a/cmd/cli/version_test.go
+++ b/cmd/cli/version_test.go
@@ -62,8 +62,8 @@ func TestGetMeshVersion(t *testing.T) {
 					},
 				},
 			},
-			proxyGetMeshVersionErr: errors.Errorf("Error retrieving mesh version from pod [controllerPod] in namespace [test]"),
-			expectedErr:            errors.Errorf("Error retrieving mesh version from pod [controllerPod] in namespace [test]"),
+			proxyGetMeshVersionErr: errors.Errorf("error retrieving mesh version from pod [controllerPod] in namespace [test]"),
+			expectedErr:            errors.Errorf("error retrieving mesh version from pod [controllerPod] in namespace [test]"),
 		},
 		{
 			name:      "mesh in namespace and remote version found",

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -258,7 +258,7 @@ func (b *bootstrap) ensureMeshConfig() error {
 func (b *bootstrap) initiatilizeKubernetesEventsRecorder() error {
 	bootstrapPod, err := b.getBootstrapPod()
 	if err != nil {
-		return errors.Errorf("Error fetching osm-bootstrap pod: %s", err)
+		return errors.Errorf("error fetching osm-bootstrap pod: %s", err)
 	}
 	eventRecorder := events.GenericEventRecorder()
 	return eventRecorder.Initialize(bootstrapPod, b.kubeClient, osmNamespace)
@@ -274,8 +274,7 @@ func (b *bootstrap) getBootstrapPod() (*corev1.Pod, error) {
 
 	pod, err := b.kubeClient.CoreV1().Pods(b.namespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		log.Error().Err(err).Msgf("Error retrieving osm-bootstrap pod %s", podName)
-		return nil, err
+		return nil, fmt.Errorf("error retrieving osm-bootstrap pod %s: %w", podName, err)
 	}
 
 	return pod, nil

--- a/cmd/osm-controller/gateway.go
+++ b/cmd/osm-controller/gateway.go
@@ -28,7 +28,7 @@ const (
 func bootstrapOSMMulticlusterGateway(kubeClient kubernetes.Interface, certManager certificate.Manager, osmNamespace string) error {
 	secret, err := kubeClient.CoreV1().Secrets(osmNamespace).Get(context.Background(), gatewayBootstrapSecretName, metav1.GetOptions{})
 	if err != nil {
-		return errors.Errorf("Error fetching OSM gateway's bootstrap config %s/%s", osmNamespace, gatewayBootstrapSecretName)
+		return errors.Errorf("error fetching OSM gateway's bootstrap config %s/%s", osmNamespace, gatewayBootstrapSecretName)
 	}
 
 	if bootstrapData, ok := secret.Data[bootstrapConfigKey]; !ok {
@@ -43,7 +43,7 @@ func bootstrapOSMMulticlusterGateway(kubeClient kubernetes.Interface, certManage
 	gatewayCN := multicluster.GetMulticlusterGatewaySubjectCommonName(osmServiceAccount, osmNamespace)
 	bootstrapCert, err := certManager.IssueCertificate(gatewayCN, constants.XDSCertificateValidityPeriod)
 	if err != nil {
-		return errors.Errorf("Error issuing bootstrap certificate for OSM gateway: %s", err)
+		return errors.Errorf("error issuing bootstrap certificate for OSM gateway: %w", err)
 	}
 
 	bootstrapConfig, err := bootstrap.BuildFromConfig(bootstrap.Config{
@@ -57,12 +57,12 @@ func bootstrapOSMMulticlusterGateway(kubeClient kubernetes.Interface, certManage
 		PrivateKey:       bootstrapCert.GetPrivateKey(),
 	})
 	if err != nil {
-		return errors.Errorf("Error building OSM gateway's bootstrap config from %s/%s", osmNamespace, gatewayBootstrapSecretName)
+		return errors.Errorf("error building OSM gateway's bootstrap config from %s/%s", osmNamespace, gatewayBootstrapSecretName)
 	}
 
 	bootstrapData, err := utils.ProtoToYAML(bootstrapConfig)
 	if err != nil {
-		return errors.Errorf("Error marshalling updated OSM gateway's bootstrap config from %s/%s", osmNamespace, gatewayBootstrapSecretName)
+		return errors.Errorf("error marshalling updated OSM gateway's bootstrap config from %s/%s", osmNamespace, gatewayBootstrapSecretName)
 	}
 
 	updatedSecret := &corev1.Secret{
@@ -81,7 +81,7 @@ func bootstrapOSMMulticlusterGateway(kubeClient kubernetes.Interface, certManage
 	}
 
 	if _, err = kubeClient.CoreV1().Secrets(osmNamespace).Patch(context.Background(), gatewayBootstrapSecretName, types.StrategicMergePatchType, patchJSON, metav1.PatchOptions{}); err != nil {
-		return errors.Errorf("Error patching OSM gateway's bootstrap secret %s/%s: %s", osmNamespace, gatewayBootstrapSecretName, err)
+		return errors.Errorf("error patching OSM gateway's bootstrap secret %s/%s: %s", osmNamespace, gatewayBootstrapSecretName, err)
 	}
 
 	return nil

--- a/cmd/osm-controller/validate.go
+++ b/cmd/osm-controller/validate.go
@@ -9,7 +9,7 @@ import (
 // validateCLIParams contains all checks necessary that various permutations of the CLI flags are consistent
 func validateCLIParams() error {
 	if err := validateCertificateManagerOptions(); err != nil {
-		return errors.Errorf("Error validating certificate manager options: %s", err)
+		return errors.Errorf("error validating certificate manager options: %s", err)
 	}
 
 	if meshName == "" {

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -191,15 +191,15 @@ func (cm *CertManager) issue(cn certificate.CommonName, validityPeriod time.Dura
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csr, certPrivKey)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrCreatingCertReq))
-		return nil, fmt.Errorf("error creating x509 certificate request: %s", err)
+		return nil, fmt.Errorf("%s: %s | error creating x509 certificate request: %w", errcode.Kind,
+			errcode.GetErrCodeWithMetric(errcode.ErrCreatingCertReq), err)
 	}
 
 	csrPEM, err := certificate.EncodeCertReqDERtoPEM(csrDER)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM))
-		return nil, fmt.Errorf("failed to encode certificate request DER to PEM CN=%s: %s", cn, err)
+		return nil, fmt.Errorf("%s: %s | failed to encode certificate request DER to PEM CN=%s: %w", errcode.Kind,
+			errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM), cn, err)
 	}
 
 	cr := &cmapi.CertificateRequest{

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -197,8 +197,7 @@ func GetCertificateFromSecret(ns string, secretName string, cert certificate.Cer
 	// and the ones that didn't share the same code.
 	cert, err := GetCertFromKubernetes(ns, secretName, kubeClient)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to fetch certificate from Kubernetes")
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch certificate from Kubernetes: %w", err)
 	}
 
 	return cert, nil
@@ -277,8 +276,7 @@ func GetCertFromKubernetes(ns string, secretName string, kubeClient kubernetes.I
 
 	cert, err := tresor.NewCertificateFromPEM(pemCert, pemKey)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to create new Certificate from PEM")
-		return nil, err
+		return nil, fmt.Errorf("failed to create new Certificate from PEM")
 	}
 
 	return cert, nil
@@ -301,7 +299,7 @@ func (c *Config) getHashiVaultOSMCertificateManager(options VaultOptions) (certi
 		c.msgBroker,
 	)
 	if err != nil {
-		return nil, nil, errors.Errorf("Error instantiating Hashicorp Vault as a Certificate Manager: %+v", err)
+		return nil, nil, errors.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %+v", err)
 	}
 
 	return vaultCertManager, vaultCertManager, nil
@@ -344,7 +342,7 @@ func (c *Config) getCertManagerOSMCertificateManager(options CertManagerOptions)
 		c.msgBroker,
 	)
 	if err != nil {
-		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager as a Certificate Manager: %+v", err)
+		return nil, nil, errors.Errorf("error instantiating Jetstack cert-manager as a Certificate Manager: %+v", err)
 	}
 
 	return certmanagerCertManager, certmanagerCertManager, nil

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -53,7 +53,7 @@ func NewCertManager(
 
 	var err error
 	if c.client, err = api.NewClient(config); err != nil {
-		return nil, errors.Errorf("Error creating Vault CertManager without TLS at %s", vaultAddr)
+		return nil, errors.Errorf("error creating Vault CertManager without TLS at %s", vaultAddr)
 	}
 
 	log.Info().Msgf("Created Vault CertManager, with role=%q at %v", role, vaultAddr)

--- a/pkg/cli/proxy_get.go
+++ b/pkg/cli/proxy_get.go
@@ -38,7 +38,7 @@ func GetEnvoyProxyConfig(clientSet kubernetes.Interface, config *rest.Config, na
 
 	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", localPort, constants.EnvoyAdminPort))
 	if err != nil {
-		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+		return nil, errors.Errorf("error setting up port forwarding: %s", err)
 	}
 
 	var envoyProxyConfig []byte
@@ -49,17 +49,17 @@ func GetEnvoyProxyConfig(clientSet kubernetes.Interface, config *rest.Config, na
 		// #nosec G107: Potential HTTP request made with variable url
 		resp, err := http.Get(url)
 		if err != nil {
-			return errors.Errorf("Error fetching url %s: %s", url, err)
+			return errors.Errorf("error fetching url %s: %s", url, err)
 		}
 
 		envoyProxyConfig, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return errors.Errorf("Error rendering HTTP response: %s", err)
+			return errors.Errorf("error rendering HTTP response: %s", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Errorf("Error retrieving proxy config for pod %s in namespace %s: %s", podName, namespace, err)
+		return nil, errors.Errorf("error retrieving proxy config for pod %s in namespace %s: %s", podName, namespace, err)
 	}
 
 	return envoyProxyConfig, nil

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -53,8 +53,8 @@ func marshalConfigToJSON(config configv1alpha2.MeshConfigSpec) (string, error) {
 func (c *client) GetMeshConfigJSON() (string, error) {
 	cm, err := marshalConfigToJSON(c.getMeshConfig().Spec)
 	if err != nil {
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigMarshaling)).Msgf("Error marshaling MeshConfig %s: %+v", c.getMeshConfigCacheKey(), c.getMeshConfig())
-		return "", err
+		return "", fmt.Errorf("%s: %s | error marshaling MeshConfig %s, %+v: %w", errcode.Kind,
+			errcode.GetErrCodeWithMetric(errcode.ErrMeshConfigMarshaling), c.getMeshConfigCacheKey(), c.getMeshConfig(), err)
 	}
 	return cm, nil
 }

--- a/pkg/debugger/envoy.go
+++ b/pkg/debugger/envoy.go
@@ -30,8 +30,7 @@ func (ds DebugConfig) getEnvoyConfig(pod *v1.Pod, url string) string {
 	client := &http.Client{}
 	resp, err := client.Get(fmt.Sprintf("http://%s:%d/%s", "localhost", portFwdRequest.LocalPort, url))
 	if err != nil {
-		log.Error().Err(err).Msgf("Error getting Pod with UID=%s", pod.ObjectMeta.UID)
-		return fmt.Sprintf("Error: %s", err)
+		return fmt.Sprintf("Error getting Pod with UID=%s: %s", pod.ObjectMeta.UID, err)
 	}
 
 	defer func() {
@@ -46,8 +45,7 @@ func (ds DebugConfig) getEnvoyConfig(pod *v1.Pod, url string) string {
 	}
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error getting Pod with UID=%s", pod.ObjectMeta.UID)
-		return fmt.Sprintf("Error: %s", err)
+		return fmt.Sprintf("Error getting Pod with UID=%s: %s", pod.ObjectMeta.UID, err)
 	}
 
 	return string(bodyBytes)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -53,8 +53,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 
 	if err := s.recordPodMetadata(proxy); err == errServiceAccountMismatch {
 		// Service Account mismatch
-		log.Error().Err(err).Str("proxy", proxy.String()).Msg("Mismatched service account for proxy")
-		return err
+		return fmt.Errorf("mismatched service account for proxy: %s: %w", proxy.String(), err)
 	}
 
 	s.proxyRegistry.RegisterProxy(proxy)
@@ -376,8 +375,7 @@ func (s *Server) recordPodMetadata(p *envoy.Proxy) error {
 	cn := p.GetCertificateCommonName()
 	certSA, err := envoy.GetServiceIdentityFromProxyCertificate(cn)
 	if err != nil {
-		log.Error().Err(err).Str("proxy", p.String()).Msgf("Error getting service account from XDS certificate with CommonName=%s", cn)
-		return err
+		return fmt.Errorf("Error getting service account from XDS certificate with CommonName=%s; proxy=%s; error=%w", cn, p.String(), err)
 	}
 
 	if certSA.ToK8sServiceAccount() != p.PodMetadata.ServiceAccount {

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -62,12 +62,12 @@ func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *t
 		tracingAPIEndpoint: lb.cfg.GetTracingEndpoint(),
 	}.build()
 	if err != nil {
-		return nil, errors.Errorf("Error building inbound HTTP connection manager for proxy with identity %s, traffic match: %v ", lb.serviceIdentity, trafficMatch)
+		return nil, errors.Errorf("error building inbound HTTP connection manager for proxy with identity %s, traffic match: %v ", lb.serviceIdentity, trafficMatch)
 	}
 
 	marshalledIngressConnManager, err := ptypes.MarshalAny(ingressConnManager)
 	if err != nil {
-		return nil, errors.Errorf("Error marshalling ingress HttpConnectionManager object for proxy with identity %s", lb.serviceIdentity)
+		return nil, errors.Errorf("error marshalling ingress HttpConnectionManager object for proxy with identity %s", lb.serviceIdentity)
 	}
 
 	var sourcePrefixes []*xds_core.CidrRange
@@ -115,7 +115,7 @@ func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *t
 
 		marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.serviceIdentity, !trafficMatch.SkipClientCertValidation))
 		if err != nil {
-			return nil, errors.Errorf("Error marshalling DownstreamTLSContext in ingress filter chain for proxy with identity %s", lb.serviceIdentity)
+			return nil, errors.Errorf("error marshalling DownstreamTLSContext in ingress filter chain for proxy with identity %s", lb.serviceIdentity)
 		}
 
 		filterChain.TransportSocket = &xds_core.TransportSocket{

--- a/pkg/envoy/rbac/policy.go
+++ b/pkg/envoy/rbac/policy.go
@@ -92,7 +92,7 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 				if andPermissionRule.Attribute == DestinationPort {
 					port, err := strconv.ParseUint(andPermissionRule.Value, 10, 32)
 					if err != nil {
-						return nil, errors.Errorf("Error parsing destination port value %s", andPermissionRule.Value)
+						return nil, errors.Errorf("error parsing destination port value %s", andPermissionRule.Value)
 					}
 					portPermission := GetDestinationPortPermission(uint32(port))
 					andPermissionRules = append(andPermissionRules, portPermission)
@@ -108,7 +108,7 @@ func (p *Policy) Generate() (*xds_rbac.Policy, error) {
 				if orPermissionRule.Attribute == DestinationPort {
 					port, err := strconv.ParseUint(orPermissionRule.Value, 10, 32)
 					if err != nil {
-						return nil, errors.Errorf("Error parsing destination port value %s", orPermissionRule.Value)
+						return nil, errors.Errorf("error parsing destination port value %s", orPermissionRule.Value)
 					}
 					portPermission := GetDestinationPortPermission(uint32(port))
 					orPermissionRules = append(orPermissionRules, portPermission)

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -375,7 +375,7 @@ func FromStr(e string) (ErrCode, error) {
 	errStr := strings.TrimLeft(e, "E")
 	errInt, err := strconv.Atoi(errStr)
 	if err != nil {
-		return ErrCode(0), errors.Errorf("Error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", e)
+		return ErrCode(0), errors.Errorf("error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", e)
 	}
 	return ErrCode(errInt), nil
 }

--- a/pkg/injector/health_probes.go
+++ b/pkg/injector/health_probes.go
@@ -90,14 +90,13 @@ func rewriteProbe(probe *corev1.Probe, probeType, path string, port int32, conta
 	if err != nil {
 		log.Error().Err(err).Msgf("Error finding a matching port for %+v on container %+v", *definedPort, containerPorts)
 	}
-	*definedPort = intstr.IntOrString{Type: intstr.Int, IntVal: port}
 	originalProbe.timeout = time.Duration(probe.TimeoutSeconds) * time.Second
 
 	log.Debug().Msgf(
 		"Rewriting %s probe (:%d%s) to :%d%s",
 		probeType,
 		originalProbe.port, originalProbe.path,
-		definedPort.IntValue(), newPath,
+		port, newPath,
 	)
 
 	return originalProbe

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -52,14 +52,14 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 		certificate.CommonName(fmt.Sprintf("%s.%s.svc", constants.OSMInjectorName, osmNamespace)),
 		constants.XDSCertificateValidityPeriod)
 	if err != nil {
-		return errors.Errorf("Error issuing certificate for the mutating webhook: %+v", err)
+		return errors.Errorf("error issuing certificate for the mutating webhook: %+v", err)
 	}
 
 	// The following function ensures to atomically create or get the certificate from Kubernetes
 	// secret API store. Multiple instances should end up with the same webhookHandlerCert after this function executed.
 	webhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.MutatingWebhookCertificateSecretName, webhookHandlerCert, kubeClient)
 	if err != nil {
-		return errors.Errorf("Error fetching webhook certificate from k8s secret: %s", err)
+		return errors.Errorf("error fetching webhook certificate from k8s secret: %s", err)
 	}
 
 	wh := mutatingWebhook{
@@ -85,7 +85,7 @@ func NewMutatingWebhook(config Config, kubeClient kubernetes.Interface, certMana
 	go wh.run(stop)
 
 	if err = createOrUpdateMutatingWebhook(wh.kubeClient, webhookHandlerCert, webhookTimeout, webhookConfigName, meshName, osmNamespace, osmVersion, enableReconciler); err != nil {
-		return errors.Errorf("Error creating MutatingWebhookConfiguration %s: %+v", webhookConfigName, err)
+		return errors.Errorf("error creating MutatingWebhookConfiguration %s: %+v", webhookConfigName, err)
 	}
 	return nil
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -286,7 +286,7 @@ func (c client) ListServiceIdentitiesForService(svc service.MeshService) ([]iden
 
 	k8sSvc := c.GetService(svc)
 	if k8sSvc == nil {
-		return nil, errors.Errorf("Error fetching service %q: %s", svc, errServiceNotFound)
+		return nil, errors.Errorf("error fetching service %q: %s", svc, errServiceNotFound)
 	}
 
 	svcAccountsSet := mapset.NewSet()

--- a/pkg/k8s/portforward.go
+++ b/pkg/k8s/portforward.go
@@ -29,7 +29,7 @@ func NewPortForwarder(dialer httpstream.Dialer, portSpec string) (*PortForwarder
 	readyChan := make(chan struct{})
 	forwarder, err := portforward.New(dialer, []string{portSpec}, stopChan, readyChan, ioutil.Discard, os.Stderr)
 	if err != nil {
-		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+		return nil, errors.Errorf("error setting up port forwarding: %s", err)
 	}
 
 	return &PortForwarder{
@@ -67,7 +67,7 @@ func (pf *PortForwarder) Start(readyFunc func(pf *PortForwarder) error) error {
 		return readyFunc(pf)
 
 	case err := <-errChan:
-		return errors.Errorf("Error during port forwarding: %s", err)
+		return errors.Errorf("error during port forwarding: %s", err)
 	}
 }
 
@@ -90,7 +90,7 @@ func (pf *PortForwarder) Done() <-chan struct{} {
 func DialerToPod(conf *rest.Config, clientSet kubernetes.Interface, podName string, namespace string) (httpstream.Dialer, error) {
 	roundTripper, upgrader, err := spdy.RoundTripperFor(conf)
 	if err != nil {
-		return nil, errors.Errorf("Error setting up round tripper for port forwarding: %s", err)
+		return nil, errors.Errorf("error setting up round tripper for port forwarding: %s", err)
 	}
 
 	serverURL := clientSet.CoreV1().RESTClient().Post().

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -56,12 +56,12 @@ func GetKubernetesServerVersionNumber(kubeClient kubernetes.Interface) ([]int, e
 
 	version, err := kubeClient.Discovery().ServerVersion()
 	if err != nil {
-		return nil, errors.Errorf("Error getting K8s server version: %s", err)
+		return nil, errors.Errorf("error getting K8s server version: %s", err)
 	}
 
 	ver, err := goversion.NewVersion(version.String())
 	if err != nil {
-		return nil, errors.Errorf("Error parsing k8s server version %s: %s", version, err)
+		return nil, errors.Errorf("error parsing k8s server version %s: %s", version, err)
 	}
 
 	return ver.Segments(), nil

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -44,14 +44,14 @@ func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName 
 		certificate.CommonName(fmt.Sprintf("%s.%s.svc", ValidatorWebhookSvc, osmNamespace)),
 		constants.XDSCertificateValidityPeriod)
 	if err != nil {
-		return errors.Errorf("Error issuing certificate for the validating webhook: %+v", err)
+		return errors.Errorf("error issuing certificate for the validating webhook: %+v", err)
 	}
 
 	// The following function ensures to atomically create or get the certificate from Kubernetes
 	// secret API store. Multiple instances should end up with the same webhookHandlerCert after this function executed.
 	webhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.ValidatingWebhookCertificateSecretName, webhookHandlerCert, kubeClient)
 	if err != nil {
-		return errors.Errorf("Error fetching webhook certificate from k8s secret: %s", err)
+		return errors.Errorf("error fetching webhook certificate from k8s secret: %s", err)
 	}
 
 	v := &validatingWebhookServer{
@@ -64,7 +64,7 @@ func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName 
 
 	// Create the ValidatingWebhook
 	if err := createOrUpdateValidatingWebhook(kubeClient, webhookHandlerCert, webhookConfigName, meshName, osmNamespace, osmVersion, validateTrafficTarget, enableReconciler); err != nil {
-		return errors.Errorf("Error creating ValidatingWebhookConfiguration %s: %+v", webhookConfigName, err)
+		return errors.Errorf("error creating ValidatingWebhookConfiguration %s: %+v", webhookConfigName, err)
 	}
 
 	go v.run(port, webhookHandlerCert, stop)

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -179,11 +179,11 @@ func MultiClusterServiceValidator(req *admissionv1.AdmissionRequest) (*admission
 		}
 		clusterAddress := strings.Split(cluster.Address, ":")
 		if net.ParseIP(clusterAddress[0]) == nil {
-			return nil, errors.Errorf("Error parsing IP address %s", cluster.Address)
+			return nil, errors.Errorf("error parsing IP address %s", cluster.Address)
 		}
 		_, err := strconv.ParseUint(clusterAddress[1], 10, 32)
 		if err != nil {
-			return nil, errors.Errorf("Error parsing port value %s", cluster.Address)
+			return nil, errors.Errorf("error parsing port value %s", cluster.Address)
 		}
 		clusterNames[cluster.Name] = true
 	}

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -171,7 +171,7 @@ func (td *OsmTestData) ValidateStringParams() error {
 func (td *OsmTestData) GetTestDirPath() string {
 	absPath, err := filepath.Abs(strings.Join([]string{td.TestDirBase, td.TestDirName}, "/"))
 	if err != nil {
-		td.T.Errorf("Error getting TestDirAbsPath: %v", err)
+		td.T.Errorf("error getting TestDirAbsPath: %v", err)
 	}
 	return absPath
 }
@@ -183,12 +183,12 @@ func (td *OsmTestData) GetTestFilePath(filename string) string {
 
 	err := os.Mkdir(testDirPath, 0750)
 	if err != nil && !os.IsExist(err) {
-		td.T.Errorf("Error on Mkdir for %s: %v", testDirPath, err)
+		td.T.Errorf("error on Mkdir for %s: %v", testDirPath, err)
 	}
 
 	absPath, err := filepath.Abs(strings.Join([]string{testDirPath, filename}, "/"))
 	if err != nil {
-		td.T.Errorf("Error computing TestDirAbsPath: %v", err)
+		td.T.Errorf("error computing TestDirAbsPath: %v", err)
 	}
 	return absPath
 }

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -130,7 +130,7 @@ func (td *OsmTestData) CreatePod(ns string, pod corev1.Pod) (*corev1.Pod, error)
 		}
 		return podRet, nil
 	}
-	return nil, errors.Errorf("Error creating pod in namespace %s after %d attempts", ns, maxRetries)
+	return nil, errors.Errorf("error creating pod in namespace %s after %d attempts", ns, maxRetries)
 }
 
 // CreateDeployment is a wrapper to create a deployment
@@ -149,7 +149,7 @@ func (td *OsmTestData) CreateDeployment(ns string, deployment appsv1.Deployment)
 		}
 		return deploymentRet, nil
 	}
-	return nil, errors.Errorf("Error creating Deployment in namespace %s after %d attempts", ns, maxRetries)
+	return nil, errors.Errorf("error creating Deployment in namespace %s after %d attempts", ns, maxRetries)
 }
 
 // CreateService is a wrapper to create a service
@@ -379,12 +379,12 @@ func (td *OsmTestData) simpleRoleBinding(name string, namespace string) rbacv1.R
 func (td *OsmTestData) getKubernetesServerVersionNumber() ([]int, error) {
 	version, err := td.Client.Discovery().ServerVersion()
 	if err != nil {
-		return nil, errors.Errorf("Error getting K8s server version: %s", err)
+		return nil, errors.Errorf("error getting K8s server version: %s", err)
 	}
 
 	ver, err := goversion.NewVersion(version.String())
 	if err != nil {
-		return nil, errors.Errorf("Error parsing k8s server version %s: %s", version, err)
+		return nil, errors.Errorf("error parsing k8s server version %s: %s", version, err)
 	}
 
 	return ver.Segments(), nil
@@ -620,7 +620,7 @@ func (td *OsmTestData) GetGrafanaPodHandle(ns string, grafanaPodName string, por
 	}
 	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", port, port))
 	if err != nil {
-		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+		return nil, errors.Errorf("error setting up port forwarding: %s", err)
 	}
 
 	err = portForwarder.Start(func(pf *k8s.PortForwarder) error {
@@ -648,7 +648,7 @@ func (td *OsmTestData) GetPrometheusPodHandle(ns string, prometheusPodName strin
 	}
 	portForwarder, err := k8s.NewPortForwarder(dialer, fmt.Sprintf("%d:%d", port, port))
 	if err != nil {
-		return nil, errors.Errorf("Error setting up port forwarding: %s", err)
+		return nil, errors.Errorf("error setting up port forwarding: %s", err)
 	}
 
 	err = portForwarder.Start(func(pf *k8s.PortForwarder) error {
@@ -727,7 +727,7 @@ func (td *OsmTestData) GetOSMPrometheusHandle() (*Prometheus, error) {
 		},
 	})
 	if err != nil || len(prometheusPod) == 0 {
-		return nil, errors.Errorf("Error getting Prometheus pods: %v (prom pods len: %d)", err, len(prometheusPod))
+		return nil, errors.Errorf("error getting Prometheus pods: %v (prom pods len: %d)", err, len(prometheusPod))
 	}
 	pHandle, err := Td.GetPrometheusPodHandle(prometheusPod[0].Namespace, prometheusPod[0].Name, DefaultOsmPrometheusPort)
 	if err != nil {
@@ -746,7 +746,7 @@ func (td *OsmTestData) GetOSMGrafanaHandle() (*Grafana, error) {
 		},
 	})
 	if err != nil || len(grafanaPod) == 0 {
-		return nil, errors.Errorf("Error getting Grafana pods: %v (graf pods len: %d)", err, len(grafanaPod))
+		return nil, errors.Errorf("error getting Grafana pods: %v (graf pods len: %d)", err, len(grafanaPod))
 	}
 	gHandle, err := Td.GetGrafanaPodHandle(grafanaPod[0].Namespace, grafanaPod[0].Name, DefaultOsmGrafanaPort)
 	if err != nil {


### PR DESCRIPTION
Errors should be handled exactly once. Logging an error and
returning an error is an example of handling errors twice.
This also contributes to disjoint log lines that are hard to tie together.

Also lowercase error messages to comply with lint: https://staticcheck.io/docs/checks#ST1005

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>


-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ x] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No