### PR TITLE
chore: show release version in Grafana boards

### DIFF
--- a/charts/osm/grafana/dashboards/osm-control-plane.json
+++ b/charts/osm/grafana/dashboards/osm-control-plane.json
@@ -60,7 +60,10 @@
         }
       ]
     },
-    "description": "OSM Control Plane Metrics latest",
+    "title": "OSM Control Plane Metrics",
+    "description": "Compatible with OSM v1.0.0. This dashboard provides traffic metrics from the given service to OSM’s control plane.",
+    "uid": "OSMControlPlaneMetrics",
+    "version": 2,
     "editable": true,
     "gnetId": 11776,
     "graphTooltip": 0,
@@ -718,8 +721,5 @@
         "1d"
       ]
     },
-    "timezone": "",
-    "title": "OSM Control Plane Metrics",
-    "uid": "OSMCPMetrics",
-    "version": 1
+    "timezone": ""
   }

--- a/charts/osm/grafana/dashboards/osm-data-plane-performance.json
+++ b/charts/osm/grafana/dashboards/osm-data-plane-performance.json
@@ -60,7 +60,10 @@
         }
       ]
     },
-    "description": "OSM Data Plane Performance Metrics latest",
+    "title": "OSM Data Plane Performance Metrics",
+    "description": "Compatible with OSM v1.0.0. This dashboard lets you view the performance of OSM’s data plane.",
+    "uid": "OSMDataPlanePerformanceMetrics",
+    "version": 3,
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
@@ -576,8 +579,5 @@
         "1d"
       ]
     },
-    "timezone": "",
-    "title": "OSM Data plane Performance Metrics",
-    "uid": "G-Mk07H7z",
-    "version": 2
+    "timezone": ""
   }

--- a/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
+++ b/charts/osm/grafana/dashboards/osm-mesh-envoy-details.json
@@ -66,7 +66,10 @@
       }
     ]
   },
-  "description": "Mesh and Envoy Details latest",
+  "title": "OSM Mesh and Envoy Details",
+  "description": "Compatible with OSM v1.0.0. This dashboard lets you view the performance and behavior of OSM’s control plane.",
+  "uid": "OSMMeshAndEnvoyDetails",
+  "version": 4,
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
@@ -1548,8 +1551,5 @@
       "1d"
     ]
   },
-  "timezone": "",
-  "title": "Mesh and Envoy Details",
-  "uid": "PLyKJcHGz",
-  "version": 3
+  "timezone": ""
 }

--- a/charts/osm/grafana/dashboards/osm-pod-to-service.json
+++ b/charts/osm/grafana/dashboards/osm-pod-to-service.json
@@ -60,7 +60,10 @@
         }
       ]
     },
-    "description": "OSM Pod to Services Metrics latest",
+    "title": "OSM Pod to Service Metrics",
+    "description": "Compatible with OSM v1.0.0. This dashboard lets you investigate the traffic metrics from a pod to all the services it connects/talks to.",
+    "uid": "OSMPodToServiceMetrics",
+    "version": 2,
     "editable": true,
     "gnetId": 11776,
     "graphTooltip": 0,
@@ -903,8 +906,5 @@
         "1d"
       ]
     },
-    "timezone": "",
-    "title": "OSM Pod to Services Metrics",
-    "uid": "OSMpodMetrics",
-    "version": 1
+    "timezone": ""
   }

--- a/charts/osm/grafana/dashboards/osm-service-to-service.json
+++ b/charts/osm/grafana/dashboards/osm-service-to-service.json
@@ -60,7 +60,10 @@
         }
       ]
     },
-    "description": "OSM Service to Service Metrics latest",
+    "title": "OSM Service to Service Metrics",
+    "description": "Compatible with OSM v1.0.0. This dashboard lets you view the traffic metrics from a given source service to a given destination service.",
+    "uid": "OSMServiceToServiceMetrics",
+    "version": 2,
     "editable": true,
     "gnetId": 11776,
     "graphTooltip": 0,
@@ -739,8 +742,5 @@
         "1d"
       ]
     },
-    "timezone": "",
-    "title": "OSM Service to Service Metrics",
-    "uid": "OSMs2sMetrics",
-    "version": 1
+    "timezone": ""
   }

--- a/charts/osm/grafana/dashboards/osm-workload-to-service.json
+++ b/charts/osm/grafana/dashboards/osm-workload-to-service.json
@@ -60,7 +60,10 @@
         }
       ]
     },
-    "description": "OSM Workload to Service Metrics latest",
+    "title": "OSM Workload to Service Metrics",
+    "description": "Compatible with OSM v1.0.0. This dashboard provides the traffic metrics from a workload (deployment, replicaSet) to all the services it connects/talks to.",
+    "uid": "OSMWorkloadToServiceMetrics",
+    "version": 2,
     "editable": true,
     "gnetId": 11776,
     "graphTooltip": 0,
@@ -829,8 +832,5 @@
         "1d"
       ]
     },
-    "timezone": "",
-    "title": "OSM Workload to Service Metrics",
-    "uid": "OSMworkloadMetrics",
-    "version": 1
+    "timezone": ""
   }

--- a/charts/osm/grafana/dashboards/osm-workload-to-workload.json
+++ b/charts/osm/grafana/dashboards/osm-workload-to-workload.json
@@ -60,7 +60,10 @@
         }
       ]
     },
-    "description": "OSM Workload to Workload Metrics latest",
+    "title": "OSM Workload to Workload Metrics",
+    "description": "Compatible with OSM v1.0.0. This dashboard displays the latencies of requests in the mesh from workload to workload.",
+    "uid": "OSMWorkloadToWorkloadMetrics",
+    "version": 2,
     "editable": true,
     "gnetId": 11776,
     "graphTooltip": 0,
@@ -491,8 +494,5 @@
         "1d"
       ]
     },
-    "timezone": "",
-    "title": "OSM Workload to Workload Metrics",
-    "uid": "OSMworkloadToWorkloadMetrics",
-    "version": 1
+    "timezone": ""
 }

--- a/charts/osm/templates/grafana-configmap.yaml
+++ b/charts/osm/templates/grafana-configmap.yaml
@@ -70,13 +70,13 @@ metadata:
     app: osm-grafana
 data:
   osm-pod.json: |
-{{ .Files.Get "grafana/dashboards/osm-pod.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
+{{ .Files.Get "grafana/dashboards/osm-pod-to-service.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
   osm-workload.json: |
-{{ .Files.Get "grafana/dashboards/osm-workload.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
+{{ .Files.Get "grafana/dashboards/osm-workload-to-service.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
   osm-service-to-service.json: |
 {{ .Files.Get "grafana/dashboards/osm-service-to-service.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
   osm-data-plane-container.json: |
-{{ .Files.Get "grafana/dashboards/osm-data-plane-container.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
+{{ .Files.Get "grafana/dashboards/osm-data-plane-performance.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
   osm-workload-to-workload.json: |
 {{ .Files.Get "grafana/dashboards/osm-workload-to-workload.json" | replace "${DS_PROMETHEUS}" "Prometheus" | indent 4 }}
 


### PR DESCRIPTION
Shows the latest osm release version in the description
field of osm's Grafana dashboard manifests. Also shows
a meaningful message describing each Grafana dashboard's
functionality within the same description field.

The description field is used by osm's Grafana.com
dashboard repo at
https://grafana.com/orgs/openservicemesh/dashboards

The description field is displayed prominently as the
sub-header title for each Grafana.com osm dashboard.
It is also the only location (for now) in upstream
Grafana.com to display compatible versions.

Contributes towards #4282.
Resolves #4525.

Signed-off-by: Johnson Shi <Johnson.Shi@microsoft.com>


Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.


**Testing done**: Ran the bookstore demo with Grafana enabled, port-forwarded Grafana, and inspected the validity of Grafana data.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Not yet. Will create separate PR in osm-docs.