### PR TITLE
injector: Simplify test

### DIFF
--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -42,10 +43,11 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		directoryForYAMLFiles = "test_fixtures"
 	)
 
-	isTrue := true
+	serviceAccountName := uuid.New().String()
+	namespace := uuid.New().String()
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "namespace",
+			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name: "not-me",
@@ -54,12 +56,12 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				{
 					Name:       "workload-name",
 					Kind:       "workload-kind",
-					Controller: &isTrue,
+					Controller: pointer.BoolPtr(true),
 				},
 			},
 		},
 		Spec: corev1.PodSpec{
-			ServiceAccountName: "svcacc",
+			ServiceAccountName: serviceAccountName,
 		},
 	}
 
@@ -286,7 +288,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				Args: []string{
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
-					"--service-cluster", "svcacc.namespace",
+					"--service-cluster", fmt.Sprintf("%s.%s", serviceAccountName, namespace),
 					"--bootstrap-version 3",
 				},
 				Env: []corev1.EnvVar{
@@ -413,7 +415,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 				Args: []string{
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
-					"--service-cluster", "svcacc.namespace",
+					"--service-cluster", fmt.Sprintf("%s.%s", serviceAccountName, namespace),
 					"--bootstrap-version 3",
 				},
 				Env: []corev1.EnvVar{


### PR DESCRIPTION
This PR is a tiny simplification of a unit test.

1. Uses a UUID (different one for each run) for the namespace of the k8s primitives used in the test
2. Uses a UUID for the service account
3. Leverages `pointer.BoolPtr` package instead of `isTrue := true`