### PR TITLE
envoy/ads: Simplify unit test

### DIFF
--- a/pkg/envoy/ads/health_test.go
+++ b/pkg/envoy/ads/health_test.go
@@ -19,5 +19,5 @@ func TestReadiness(t *testing.T) {
 func TestServerGetID(t *testing.T) {
 	assert := tassert.New(t)
 	actual := (&Server{}).GetID()
-	assert.Equal(actual, ServerType)
+	assert.Equal(ServerType, actual)
 }

--- a/pkg/envoy/ads/health_test.go
+++ b/pkg/envoy/ads/health_test.go
@@ -8,27 +8,16 @@ import (
 
 func TestLiveness(t *testing.T) {
 	assert := tassert.New(t)
-
-	exp := true
-	res := (&Server{}).Liveness()
-	assert.Equal(res, exp)
+	assert.True((&Server{}).Liveness())
 }
 
 func TestReadiness(t *testing.T) {
 	assert := tassert.New(t)
-
-	s := Server{
-		ready: true,
-	}
-	exp := true
-	res := s.Readiness()
-	assert.Equal(res, exp)
+	assert.True((&Server{ready: true}).Readiness())
 }
 
 func TestServerGetID(t *testing.T) {
 	assert := tassert.New(t)
-
-	expected := ServerType
 	actual := (&Server{}).GetID()
-	assert.Equal(actual, expected)
+	assert.Equal(actual, ServerType)
 }


### PR DESCRIPTION
This PR is a tiny simplification of a unit test. 

This uses `assert.True(x)` instead of `assert.Equal(x, true)`