### PR TITLE
ref(install): move namespace controller check to chart

### DIFF
--- a/charts/osm/templates/preinstall-hook.yaml
+++ b/charts/osm/templates/preinstall-hook.yaml
@@ -71,6 +71,7 @@ spec:
           args:
             - --verbosity={{ .Values.osm.controllerLogLevel }}
             - --enforce-single-mesh={{ .Values.osm.enforceSingleMesh }}
+            - --namespace={{ include "osm.namespace" . }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -414,67 +414,6 @@ var _ = Describe("Running the install command", func() {
 		})
 	})
 
-	Describe("when a mesh already exists in the given namespace and enforceSingleMesh is false", func() {
-		var (
-			out           *bytes.Buffer
-			store         *storage.Storage
-			config        *helm.Configuration
-			installCmd    installCmd
-			err           error
-			fakeClientSet kubernetes.Interface
-		)
-
-		BeforeEach(func() {
-			out = new(bytes.Buffer)
-			store = storage.Init(driver.NewMemory())
-			if mem, ok := store.Driver.(*driver.Memory); ok {
-				mem.SetNamespace(settings.Namespace())
-			}
-
-			config = &helm.Configuration{
-				Releases: store,
-				KubeClient: &kubefake.PrintingKubeClient{
-					Out: ioutil.Discard,
-				},
-				Capabilities: chartutil.DefaultCapabilities,
-				Log:          func(format string, v ...interface{}) {},
-			}
-
-			fakeClientSet = fake.NewSimpleClientset()
-			deploymentSpec := createDeploymentSpec(settings.Namespace(), defaultMeshName)
-			_, err = fakeClientSet.AppsV1().Deployments(settings.Namespace()).Create(context.TODO(), deploymentSpec, metav1.CreateOptions{})
-			Expect(err).To(BeNil())
-
-			installCmd = getDefaultInstallCmd(out)
-			installCmd.meshName = defaultMeshName + "-2" //use different name than pre-existing mesh
-			installCmd.clientSet = fakeClientSet
-			installCmd.enforceSingleMesh = false
-
-			// Create pre-existing mesh
-			err = config.Releases.Create(&release.Release{
-				Namespace: settings.Namespace(), // should be found in any namespace
-				Config: map[string]interface{}{
-					"osm": map[string]interface{}{
-						"meshName": defaultMeshName,
-					},
-				},
-				Info: &release.Info{
-					// helm list only shows deployed and failed releases by default
-					Status: release.StatusDeployed,
-				},
-			})
-			if err != nil {
-				panic(err)
-			}
-
-			err = installCmd.run(config)
-		})
-
-		It("should error", func() {
-			Expect(err.Error()).To(Equal(errNamespaceAlreadyHasController(settings.Namespace()).Error()))
-		})
-	})
-
 	Describe("when a mesh name is invalid", func() {
 		var (
 			out        *bytes.Buffer

--- a/cmd/osm-preinstall/osm-preinstall_test.go
+++ b/cmd/osm-preinstall/osm-preinstall_test.go
@@ -105,3 +105,75 @@ func TestSingleMeshOK(t *testing.T) {
 		})
 	}
 }
+
+func TestNamespaceHasNoMesh(t *testing.T) {
+	tests := []struct {
+		name       string
+		namespace  string
+		resources  []runtime.Object
+		expectedOK bool
+	}{
+		{
+			name:       "no existing resources",
+			namespace:  "osm-system",
+			expectedOK: true,
+		},
+		{
+			name:      "existing controller outside namespace",
+			namespace: "osm-system",
+			resources: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "not-osm-system",
+						Labels: map[string]string{
+							constants.AppLabel: constants.OSMControllerName,
+						},
+					},
+				},
+			},
+			expectedOK: true,
+		},
+		{
+			name:      "existing controller in namespace",
+			namespace: "osm-system",
+			resources: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "osm-system",
+						Labels: map[string]string{
+							constants.AppLabel: constants.OSMControllerName,
+						},
+					},
+				},
+			},
+			expectedOK: false,
+		},
+		{
+			name:      "existing non-controller in namespace",
+			namespace: "osm-system",
+			resources: []runtime.Object{
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "osm-system",
+						Labels: map[string]string{
+							constants.AppLabel: "not-" + constants.OSMControllerName,
+						},
+					},
+				},
+			},
+			expectedOK: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := namespaceHasNoMesh(fake.NewSimpleClientset(test.resources...), test.namespace)()
+			if test.expectedOK {
+				assert.NoError(t, err)
+			} else {
+				t.Log(err)
+				assert.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change moves the validation that no meshes exist in the namespace
where OSM is to be installed from the CLI to the chart so using Helm
directly will have the same validation performed.

Part of #2147

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Added unit tests
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [X] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A