### PR TITLE
Use Go 1.17 in GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: go build deps
         run: make embed-files-test
       - name: golangci-lint
@@ -59,10 +59,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: go mod tidy
         run: make go-mod-tidy
       - name: Codegen checks
@@ -74,10 +74,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: go mod tidy
         run: make go-mod-tidy
       - name: gomock checks
@@ -110,10 +110,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Go Build
         run: make build-ci
 
@@ -136,10 +136,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: go mod tidy
         run: make go-mod-tidy
       - name: Test
@@ -167,10 +167,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Test
         run: |
           touch .env
@@ -182,7 +182,7 @@ jobs:
     name: Scan images for security vulnerabilities
     runs-on: ubuntu-latest
     needs: build
-    env: 
+    env:
       CTR_TAG: ${{ github.sha }}
       CTR_REGISTRY: "localhost:5000"
     steps:
@@ -200,10 +200,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Build docker images
         run: make docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-bootstrap docker-build-init
       - name: Scan docker images for vulnerabilities
@@ -234,10 +234,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Build test dependencies
         run: make docker-build-osm-controller docker-build-osm-injector docker-build-osm-crds docker-build-osm-bootstrap docker-build-init build-osm docker-build-tcp-echo-server
       # PR Tests
@@ -323,10 +323,10 @@ jobs:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
 
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
 
       - name: Run Simulation w/ Tresor, SMI policies, egress disabled and reconciler disabled
@@ -368,10 +368,10 @@ jobs:
         with:
           path: ~/.cache/go-build
           key: ${{ runner.os }}-gobuild-${{ hashFiles('**/*.go') }}
-      - name: Setup Go 1.16
+      - name: Setup Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
       - name: Docker Login
         run: docker login --username "$DOCKER_USER" --password-stdin <<< "$DOCKER_PASS"
       - name: Push images with git sha tag


### PR DESCRIPTION
Bumping Go to v1.17 in GitHub's workflow