### PR TITLE
ci: Use GitHub action checkout@v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: ShellCheck
         run: shellcheck -x $(find . -name '*.sh')
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Go 1.17
         uses: actions/setup-go@v2
         with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Go 1.17
         uses: actions/setup-go@v2
         with:
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Go 1.17
         uses: actions/setup-go@v2
         with:
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: chart checks
         run: make chart-checks
 
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Restore Module Cache
         uses: actions/cache@v2
         with:
@@ -123,7 +123,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Restore Module Cache
         uses: actions/cache@v2
         with:
@@ -156,7 +156,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Restore Module Cache
         uses: actions/cache@v2
         with:
@@ -187,7 +187,7 @@ jobs:
       CTR_REGISTRY: "localhost:5000"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Build docker images
         env:
           DOCKER_BUILDX_OUTPUT: type=docker
@@ -209,7 +209,7 @@ jobs:
       CTR_REGISTRY: "localhost:5000" # unused for kind, but currently required in framework
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Restore Module Cache
         uses: actions/cache@v2
         with:
@@ -278,7 +278,7 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Restore Module Cache
         uses: actions/cache@v2

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -56,7 +56,7 @@ jobs:
       CTR_TAG: ${{ needs.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Setup Trivy
         run: make trivy-ci-setup
       - name: Scan docker images for vulnerabilities


### PR DESCRIPTION
This PR bumps the OSM GitHub workflow from using `actions/checkout@v1` to `v2`