### PR TITLE
ref(ptypes): update deprecated ptypes functions

### DIFF
--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -8,7 +8,8 @@ import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -128,7 +129,7 @@ func (s *Server) SendDiscoveryResponse(proxy *envoy.Proxy, request *xds_discover
 	resourcesSent := mapset.NewSet()
 	subscribedResources := proxy.GetSubscribedResources(typeURI)
 	for _, res := range resourcesToSend {
-		proto, err := ptypes.MarshalAny(res)
+		proto, err := anypb.New(res.(proto.Message))
 		if err != nil {
 			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 				Msgf("Error marshalling resource %s for proxy %s", typeURI, proxy.GetCertificateSerialNumber())

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -12,7 +12,6 @@ import (
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -183,7 +182,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 			proxyServiceCert := xds_auth.Secret{}
 			tmpResource = (*actualResponses)[4].Resources[0]
-			err = ptypes.UnmarshalAny(tmpResource, &proxyServiceCert)
+			err = tmpResource.UnmarshalTo(&proxyServiceCert)
 			Expect(err).To(BeNil())
 			Expect(proxyServiceCert.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
@@ -192,7 +191,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 			serverRootCertTypeForMTLSInbound := xds_auth.Secret{}
 			tmpResource = (*actualResponses)[4].Resources[1]
-			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForMTLSInbound)
+			err = tmpResource.UnmarshalTo(&serverRootCertTypeForMTLSInbound)
 			Expect(err).To(BeNil())
 			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
@@ -249,7 +248,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 			proxyServiceCert := xds_auth.Secret{}
 			tmpResource = sdsResponse.Resources[0]
-			err = ptypes.UnmarshalAny(tmpResource, &proxyServiceCert)
+			err = tmpResource.UnmarshalTo(&proxyServiceCert)
 			Expect(err).To(BeNil())
 			Expect(proxyServiceCert.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),
@@ -258,7 +257,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 			serverRootCertTypeForMTLSInbound := xds_auth.Secret{}
 			tmpResource = sdsResponse.Resources[1]
-			err = ptypes.UnmarshalAny(tmpResource, &serverRootCertTypeForMTLSInbound)
+			err = tmpResource.UnmarshalTo(&serverRootCertTypeForMTLSInbound)
 			Expect(err).To(BeNil())
 			Expect(serverRootCertTypeForMTLSInbound.Name).To(Equal(secrets.SDSCert{
 				Name:     proxySvcAccount.String(),

--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -9,8 +9,8 @@ import (
 	xds_accesslog_stream "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_transport_sockets "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	xds_upstream_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -26,7 +26,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 			},
 		},
 	}
-	pbHTTPProtocolOptions, err := ptypes.MarshalAny(httpProtocolOptions)
+	pbHTTPProtocolOptions, err := anypb.New(httpProtocolOptions)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling HttpProtocolOptions struct into an anypb.Any message")
@@ -34,7 +34,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 	}
 
 	accessLogger := &xds_accesslog_stream.StdoutAccessLog{}
-	pbAccessLog, err := ptypes.MarshalAny(accessLogger)
+	pbAccessLog, err := anypb.New(accessLogger)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling StdoutAccessLog struct into an anypb.Any message")
@@ -75,7 +75,7 @@ func BuildFromConfig(config Config) (*xds_bootstrap.Bootstrap, error) {
 			},
 		},
 	}
-	pbUpstreamTLSContext, err := ptypes.MarshalAny(upstreamTLSContext)
+	pbUpstreamTLSContext, err := anypb.New(upstreamTLSContext)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshaling UpstreamTlsContext struct into an anypb.Any message")

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -8,9 +8,9 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -35,7 +35,7 @@ func getUpstreamServiceCluster(downstreamIdentity identity.ServiceIdentity, conf
 		return nil
 	}
 
-	marshalledUpstreamTLSContext, err := ptypes.MarshalAny(
+	marshalledUpstreamTLSContext, err := anypb.New(
 		envoy.GetUpstreamTLSContext(downstreamIdentity, config.Service))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling UpstreamTLSContext for upstream cluster %s", config.Name)

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
@@ -21,6 +20,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	trequire "github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -179,7 +179,7 @@ func TestNewResponse(t *testing.T) {
 		},
 	}
 
-	upstreamTLSProto, err := ptypes.MarshalAny(envoy.GetUpstreamTLSContext(tests.BookbuyerServiceIdentity, tests.BookstoreV1Service))
+	upstreamTLSProto, err := anypb.New(envoy.GetUpstreamTLSContext(tests.BookbuyerServiceIdentity, tests.BookstoreV1Service))
 	require.Nil(err)
 
 	expectedBookstoreV1Cluster := &xds_cluster.Cluster{
@@ -208,7 +208,7 @@ func TestNewResponse(t *testing.T) {
 		},
 	}
 
-	upstreamTLSProto, err = ptypes.MarshalAny(envoy.GetUpstreamTLSContext(tests.BookbuyerServiceIdentity, tests.BookstoreV2Service))
+	upstreamTLSProto, err = anypb.New(envoy.GetUpstreamTLSContext(tests.BookbuyerServiceIdentity, tests.BookstoreV2Service))
 	require.Nil(err)
 	expectedBookstoreV2Cluster := &xds_cluster.Cluster{
 		TransportSocketMatches:        nil,
@@ -355,7 +355,7 @@ func TestNewResponse(t *testing.T) {
 			assert.Truef(cmp.Equal(expectedBookstoreV1Cluster, a, protocmp.Transform()), cmp.Diff(expectedBookstoreV1Cluster, a, protocmp.Transform()))
 
 			upstreamTLSContext := xds_auth.UpstreamTlsContext{}
-			err = ptypes.UnmarshalAny(a.TransportSocket.GetTypedConfig(), &upstreamTLSContext)
+			err = a.TransportSocket.GetTypedConfig().UnmarshalTo(&upstreamTLSContext)
 			require.Nil(err)
 
 			assert.Equal(expectedBookstoreV1TLSContext.CommonTlsContext.TlsParams, upstreamTLSContext.CommonTlsContext.TlsParams)
@@ -370,7 +370,7 @@ func TestNewResponse(t *testing.T) {
 			assert.Truef(cmp.Equal(expectedBookstoreV2Cluster, a, protocmp.Transform()), cmp.Diff(expectedBookstoreV1Cluster, a, protocmp.Transform()))
 
 			upstreamTLSContext := xds_auth.UpstreamTlsContext{}
-			err = ptypes.UnmarshalAny(a.TransportSocket.GetTypedConfig(), &upstreamTLSContext)
+			err = a.TransportSocket.GetTypedConfig().UnmarshalTo(&upstreamTLSContext)
 			require.Nil(err)
 
 			assert.Equal(expectedBookstoreV2TLSContext.CommonTlsContext.TlsParams, upstreamTLSContext.CommonTlsContext.TlsParams)

--- a/pkg/envoy/lds/auth.go
+++ b/pkg/envoy/lds/auth.go
@@ -7,7 +7,8 @@ import (
 	xds_ext_authz "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/errcode"
@@ -34,7 +35,7 @@ func getExtAuthzHTTPFilter(extAuthConfig *auth.ExtAuthConfig) *xds_hcm.HttpFilte
 						StatPrefix: extAuthConfig.StatPrefix,
 					},
 				},
-				Timeout: ptypes.DurationProto(extAuthConfig.AuthzTimeout),
+				Timeout: durationpb.New(extAuthConfig.AuthzTimeout),
 			},
 		},
 		TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
@@ -45,7 +46,7 @@ func getExtAuthzHTTPFilter(extAuthConfig *auth.ExtAuthConfig) *xds_hcm.HttpFilte
 		FailureModeAllow: extAuthConfig.FailureModeAllow,
 	}
 
-	extAuthMarshalled, err := ptypes.MarshalAny(extAuth)
+	extAuthMarshalled, err := anypb.New(extAuth)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msg("Failed to marshal External Authorization config")

--- a/pkg/envoy/lds/egress.go
+++ b/pkg/envoy/lds/egress.go
@@ -7,7 +7,7 @@ import (
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -83,7 +83,7 @@ func (lb *listenerBuilder) getEgressTCPFilterChain(match trafficpolicy.TrafficMa
 		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: match.Cluster},
 	}
 
-	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	marshalledTCPProxy, err := anypb.New(tcpProxy)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy for TrafficMatch %v", match)

--- a/pkg/envoy/lds/gateway.go
+++ b/pkg/envoy/lds/gateway.go
@@ -6,7 +6,7 @@ import (
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -49,7 +49,7 @@ func getMulticlusterGatewayFilterChains(upstreamServices []service.MeshService) 
 			AccessLog:        envoy.GetAccessLog(),
 		}
 
-		marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+		marshalledTCPProxy, err := anypb.New(tcpProxy)
 		if err != nil {
 			log.Error().Err(err).Msgf("[Multicluster] Error marshalling tcpProxy object for gateway filter chain service %s", upstreamSvc.String())
 			continue

--- a/pkg/envoy/lds/healthcheck.go
+++ b/pkg/envoy/lds/healthcheck.go
@@ -5,8 +5,8 @@ import (
 	xds_health_check "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -31,7 +31,7 @@ func getHealthCheckFilter() (*xds_hcm.HttpFilter, error) {
 		},
 	}
 
-	hcAny, err := ptypes.MarshalAny(hc)
+	hcAny, err := anypb.New(hc)
 	if err != nil {
 		return nil, errors.Wrap(err, "error marshaling health check filter")
 	}

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -6,8 +6,8 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -65,7 +65,7 @@ func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *t
 		return nil, errors.Errorf("Error building inbound HTTP connection manager for proxy with identity %s, traffic match: %v ", lb.serviceIdentity, trafficMatch)
 	}
 
-	marshalledIngressConnManager, err := ptypes.MarshalAny(ingressConnManager)
+	marshalledIngressConnManager, err := anypb.New(ingressConnManager)
 	if err != nil {
 		return nil, errors.Errorf("Error marshalling ingress HttpConnectionManager object for proxy with identity %s", lb.serviceIdentity)
 	}
@@ -113,7 +113,7 @@ func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *t
 		filterChain.FilterChainMatch.TransportProtocol = envoy.TransportProtocolTLS
 		filterChain.FilterChainMatch.ServerNames = trafficMatch.ServerNames
 
-		marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.serviceIdentity, !trafficMatch.SkipClientCertValidation))
+		marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, !trafficMatch.SkipClientCertValidation))
 		if err != nil {
 			return nil, errors.Errorf("Error marshalling DownstreamTLSContext in ingress filter chain for proxy with identity %s", lb.serviceIdentity)
 		}

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -8,9 +8,9 @@ import (
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -90,7 +90,7 @@ func (lb *listenerBuilder) getInboundHTTPFilters(proxyService service.MeshServic
 		return nil, errors.Wrapf(err, "Error building inbound HTTP connection manager for proxy with identity %s and service %s", lb.serviceIdentity, proxyService)
 	}
 
-	marshalledInboundConnManager, err := ptypes.MarshalAny(inboundConnManager)
+	marshalledInboundConnManager, err := anypb.New(inboundConnManager)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error marshalling inbound HTTP connection manager for proxy with identity %s and service %s", lb.serviceIdentity, proxyService)
 	}
@@ -114,7 +114,7 @@ func (lb *listenerBuilder) getInboundMeshHTTPFilterChain(proxyService service.Me
 	}
 
 	// Construct downstream TLS context
-	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
@@ -167,7 +167,7 @@ func (lb *listenerBuilder) getInboundMeshTCPFilterChain(proxyService service.Mes
 	}
 
 	// Construct downstream TLS context
-	marshalledDownstreamTLSContext, err := ptypes.MarshalAny(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
@@ -225,7 +225,7 @@ func (lb *listenerBuilder) getInboundTCPFilters(proxyService service.MeshService
 		StatPrefix:       fmt.Sprintf("%s.%s", inboundMeshTCPProxyStatPrefix, proxyService.EnvoyLocalClusterName()),
 		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: proxyService.EnvoyLocalClusterName()},
 	}
-	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	marshalledTCPProxy, err := anypb.New(tcpProxy)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy object for egress HTTPS filter chain")
@@ -262,7 +262,7 @@ func (lb *listenerBuilder) getOutboundHTTPFilter(routeConfigName string) (*xds_l
 		return nil, errors.Wrapf(err, "Error building outbound HTTP connection manager for proxy identity %s", lb.serviceIdentity)
 	}
 
-	marshalledFilter, err = ptypes.MarshalAny(outboundConnManager)
+	marshalledFilter, err = anypb.New(outboundConnManager)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error marshalling outbound HTTP connection manager for proxy identity %s", lb.serviceIdentity)
 	}
@@ -372,7 +372,7 @@ func (lb *listenerBuilder) getOutboundTCPFilter(trafficMatch trafficpolicy.Traff
 		}
 	}
 
-	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	marshalledTCPProxy, err := anypb.New(tcpProxy)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy object needed by outbound TCP filter for traffic match %s", trafficMatch.Name)

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -9,7 +9,6 @@ import (
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/ptypes"
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -585,7 +584,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 			assert.Equal(tc.expectError, err != nil)
 
 			actualConfig := &xds_tcp_proxy.TcpProxy{}
-			err = ptypes.UnmarshalAny(filter.GetTypedConfig(), actualConfig)
+			err = filter.GetTypedConfig().UnmarshalTo(actualConfig)
 			assert.Nil(err)
 			assert.Equal(wellknown.TCPProxy, filter.Name)
 

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -10,7 +10,7 @@ import (
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	xds_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -126,7 +126,7 @@ func newInboundListener() *xds_listener.Listener {
 }
 
 func buildPrometheusListener(connManager *xds_hcm.HttpConnectionManager) (*xds_listener.Listener, error) {
-	marshalledConnManager, err := ptypes.MarshalAny(connManager)
+	marshalledConnManager, err := anypb.New(connManager)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling HttpConnectionManager object")
@@ -159,7 +159,7 @@ func getDefaultPassthroughFilterChain() (*xds_listener.FilterChain, error) {
 		StatPrefix:       fmt.Sprintf("%s.%s", egressTCPProxyStatPrefix, envoy.OutboundPassthroughCluster),
 		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{Cluster: envoy.OutboundPassthroughCluster},
 	}
-	marshalledTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+	marshalledTCPProxy, err := anypb.New(tcpProxy)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling TcpProxy object for egress HTTPS filter chain")

--- a/pkg/envoy/lds/rbac.go
+++ b/pkg/envoy/lds/rbac.go
@@ -7,7 +7,7 @@ import (
 	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	xds_network_rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/rbac/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
 	"github.com/openservicemesh/osm/pkg/errcode"
@@ -24,7 +24,7 @@ func (lb *listenerBuilder) buildRBACFilter() (*xds_listener.Filter, error) {
 		return nil, err
 	}
 
-	marshalledNetworkRBACPolicy, err := ptypes.MarshalAny(networkRBACPolicy)
+	marshalledNetworkRBACPolicy, err := anypb.New(networkRBACPolicy)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling RBAC policy: %v", networkRBACPolicy)

--- a/pkg/envoy/lds/tracing.go
+++ b/pkg/envoy/lds/tracing.go
@@ -3,7 +3,7 @@ package lds
 import (
 	xds_tracing "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
@@ -17,7 +17,7 @@ func getHTTPTracingConfig(apiEndpoint string) (*xds_hcm.HttpConnectionManager_Tr
 		CollectorEndpointVersion: xds_tracing.ZipkinConfig_HTTP_JSON,
 	}
 
-	zipkinConfMarshalled, err := ptypes.MarshalAny(zipkinTracingConf)
+	zipkinConfMarshalled, err := anypb.New(zipkinTracingConf)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling Zipkin config")

--- a/pkg/envoy/lds/wasm.go
+++ b/pkg/envoy/lds/wasm.go
@@ -14,7 +14,7 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/pkg/errors"
 
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 //go:embed stats.wasm
@@ -93,7 +93,7 @@ func getAddHeadersFilter(headers map[string]string) (*xds_hcm.HttpFilter, error)
 		InlineCode: addCallsReq.String(),
 	}
 
-	luaAny, err := ptypes.MarshalAny(lua)
+	luaAny, err := anypb.New(lua)
 	if err != nil {
 		return nil, errors.Wrap(err, "error marshaling Lua filter")
 	}
@@ -131,7 +131,7 @@ func getStatsWASMFilter() (*xds_hcm.HttpFilter, error) {
 		},
 	}
 
-	wasmAny, err := ptypes.MarshalAny(wasmPlug)
+	wasmAny, err := anypb.New(wasmPlug)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error marshalling Wasm config")
 	}

--- a/pkg/envoy/rds/route/rbac.go
+++ b/pkg/envoy/rds/route/rbac.go
@@ -4,9 +4,9 @@ import (
 	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	xds_http_rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
 
@@ -74,7 +74,7 @@ func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule) (map[string]*any.An
 		Rbac: httpRBAC,
 	}
 
-	marshalled, err := ptypes.MarshalAny(httpRBACPerRoute)
+	marshalled, err := anypb.New(httpRBACPerRoute)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/rds/route/rbac_test.go
+++ b/pkg/envoy/rds/route/rbac_test.go
@@ -8,7 +8,6 @@ import (
 	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	xds_http_rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
@@ -118,7 +117,7 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 
 			marshalled := rbacFilter[wellknown.HTTPRoleBasedAccessControl]
 			httpRBACPerRoute := &xds_http_rbac.RBACPerRoute{}
-			err = ptypes.UnmarshalAny(marshalled, httpRBACPerRoute)
+			err = marshalled.UnmarshalTo(httpRBACPerRoute)
 			assert.Nil(err)
 
 			rbacRules := httpRBACPerRoute.Rbac.Rules

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -9,12 +9,12 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	v1 "k8s.io/api/core/v1"
 
@@ -87,7 +87,7 @@ func GetTLSParams() *xds_auth.TlsParameters {
 
 // GetAccessLog creates an Envoy AccessLog struct.
 func GetAccessLog() []*xds_accesslog_filter.AccessLog {
-	accessLog, err := ptypes.MarshalAny(getStdoutAccessLog())
+	accessLog, err := anypb.New(getStdoutAccessLog())
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling AccessLog object")
@@ -234,7 +234,7 @@ func GetUpstreamTLSContext(downstreamIdentity identity.ServiceIdentity, upstream
 
 // GetHTTP2ProtocolOptions creates an Envoy http configuration that matches the downstream protocol
 func GetHTTP2ProtocolOptions() (map[string]*any.Any, error) {
-	marshalledHTTPProtocolOptions, err := ptypes.MarshalAny(
+	marshalledHTTPProtocolOptions, err := anypb.New(
 		&extensions_upstream_http_v3.HttpProtocolOptions{
 			UpstreamProtocolOptions: &extensions_upstream_http_v3.HttpProtocolOptions_UseDownstreamProtocolConfig{
 				UseDownstreamProtocolConfig: &extensions_upstream_http_v3.HttpProtocolOptions_UseDownstreamHttpConfig{

--- a/pkg/injector/envoy_config_health_probes.go
+++ b/pkg/injector/envoy_config_health_probes.go
@@ -4,7 +4,8 @@ import (
 	"time"
 
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -136,7 +137,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 				},
 			},
 		}
-		pbHTTPConnectionManager, err := ptypes.MarshalAny(httpConnectionManager)
+		pbHTTPConnectionManager, err := anypb.New(httpConnectionManager)
 		if err != nil {
 			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 				Msgf("Error marshaling HttpConnectionManager struct into an anypb.Any message")
@@ -166,7 +167,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 				Cluster: clusterName,
 			},
 		}
-		pbTCPProxy, err := ptypes.MarshalAny(tcpProxy)
+		pbTCPProxy, err := anypb.New(tcpProxy)
 		if err != nil {
 			log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 				Msgf("Error marshaling TcpProxy struct into an anypb.Any message")
@@ -227,7 +228,7 @@ func getVirtualHost(newPath, clusterName, originalProbePath string, routeTimeout
 							Cluster: clusterName,
 						},
 						PrefixRewrite: originalProbePath,
-						Timeout:       ptypes.DurationProto(routeTimeout),
+						Timeout:       durationpb.New(routeTimeout),
 					},
 				},
 			},
@@ -237,7 +238,7 @@ func getVirtualHost(newPath, clusterName, originalProbePath string, routeTimeout
 
 // getHTTPAccessLog creates an Envoy AccessLog struct.
 func getHTTPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
-	accessLog, err := ptypes.MarshalAny(getStdoutAccessLog())
+	accessLog, err := anypb.New(getStdoutAccessLog())
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msg("Error marshalling AccessLog object")
@@ -253,7 +254,7 @@ func getHTTPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
 
 // getTCPAccessLog creates an Envoy AccessLog struct.
 func getTCPAccessLog() (*xds_accesslog_filter.AccessLog, error) {
-	accessLog, err := ptypes.MarshalAny(getTCPStdoutAccessLog())
+	accessLog, err := anypb.New(getTCPStdoutAccessLog())
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msg("Error marshalling tcp AccessLog object")


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Replaces `ptypes.MarshalAny`, `ptypes.DurationProto` and `ptypes.UnmarshalAny(src, dst)` 
with `anypb.New`, `durationpb.New`, and `src.UnmarshalTo(dst)` respectively. Specialized
functionality is injected directly into the generated packages for each message
type.

Deprecation Messages:

```
ptypes.MarshalAny on pkg.go.dev

MarshalAny marshals the given message m into an anypb.Any message.

Deprecated: Call the anypb.New function instead.
```

```
ptypes.UnmarshalAny on pkg.go.dev

...

Deprecated: Call the any.UnmarshalTo method instead.
```

```
ptypes.DurationProto on pkg.go.dev

DurationProto converts a time.Duration to a durationpb.Duration.

Deprecated: Call the durationpb.New function instead.
```

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI and automated demo
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs] No (https://github.com/openservicemesh/osm-docs) repo (if applicable)?