### PR TITLE
feat(dockerfile): better caching for docker

### DIFF
--- a/dockerfiles/Dockerfile.osm-controller
+++ b/dockerfiles/Dockerfile.osm-controller
@@ -11,8 +11,9 @@ ARG TARGETOS
 ARG TARGETARCH
 
 WORKDIR /osm
+COPY --from=wasm /wasm/stats.wasm pkg/envoy/lds/
 COPY . .
-COPY --from=wasm /wasm/stats.wasm pkg/envoy/lds
+
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o osm-controller -ldflags "$LDFLAGS" ./cmd/osm-controller


### PR DESCRIPTION
Docker buildx lazy loads a lot of things. Because of this
the second `COPY . .` invalidates the cache for the wasm
base image, which is a 1GB file that docker.io loves to throttle.

This change greatly speeds up rebuilds when making edits.

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?