### PR TITLE
envoy: update image and go-control-plane version

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the osm chart and their
 |-----|------|---------|-------------|
 | contour.contour | object | `{"image":{"registry":"docker.io","repository":"projectcontour/contour","tag":"v1.18.0"}}` | Contour controller configuration |
 | contour.enabled | bool | `false` | Enables deployment of Contour control plane and gateway |
-| contour.envoy | object | `{"image":{"registry":"docker.io","repository":"envoyproxy/envoy-alpine","tag":"v1.19.1"}}` | Contour envoy edge proxy configuration |
+| contour.envoy | object | `{"image":{"registry":"docker.io","repository":"envoyproxy/envoy-alpine","tag":"v1.21.1"}}` | Contour envoy edge proxy configuration |
 | osm.caBundleSecretName | string | `"osm-ca-bundle"` | The Kubernetes secret name to store CA bundle for the root CA used in OSM |
 | osm.certificateProvider.certKeyBitSize | int | `2048` | Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS |
 | osm.certificateProvider.kind | string | `"tresor"` | The Certificate manager type: `tresor`, `vault` or `cert-manager` |
@@ -155,8 +155,8 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.prometheus.resources | object | `{"limits":{"cpu":"1","memory":"2G"},"requests":{"cpu":"0.5","memory":"512M"}}` | Prometheus's container resource parameters |
 | osm.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
 | osm.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
-| osm.sidecarImage | string | `"envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"` | Envoy sidecar image for Linux workloads (v1.19.1) |
-| osm.sidecarWindowsImage | string | `"envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"` | Envoy sidecar image for Windows workloads (v1.19.1) |
+| osm.sidecarImage | string | `"envoyproxy/envoy-alpine:v1.21.1@sha256:c2c0b7c136f9daf09c36ef550635eaf5db26465529a1354f725f11390e530879"` | Envoy sidecar image for Linux workloads (v1.21.1) |
+| osm.sidecarWindowsImage | string | `"envoyproxy/envoy-windows:v1.21.1@sha256:04d06653294ac2908885568f78586f7cc337b1d79357d9cf561d9bc7d36bc963"` | Envoy sidecar image for Windows workloads (v1.21.1) |
 | osm.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | osm.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | osm.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |

--- a/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
@@ -39,7 +39,6 @@ spec:
             - "envoy"
           args: [
             "--config-path", "/etc/envoy/bootstrap.yaml",
-            "--bootstrap-version", "3",
             "--service-node", "osm-multicluster-gateway",
             "--service-cluster", "osm-multicluster-gateway",
             "--log-level", {{ .Values.osm.multicluster.gatewayLogLevel }},

--- a/charts/osm/templates/prometheus-configmap.yaml
+++ b/charts/osm/templates/prometheus-configmap.yaml
@@ -130,43 +130,43 @@ data:
           target_label: __address__
         metric_relabel_configs:
         - source_labels: [__name__]
-          regex: 'envoy_.*osm_request_(total|duration_ms_(bucket|count|sum))'
+          regex: '.*osm_request_(total|duration_ms_(bucket|count|sum))'
           action: keep
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_(\d{3})_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_(\d{3})_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: response_code
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_(.*)_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_(.*)_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: source_namespace
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_(.*)_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_(.*)_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: source_kind
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_(.*)_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_(.*)_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: source_name
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_(.*)_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_(.*)_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: source_pod
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_(.*)_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_(.*)_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: destination_namespace
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_(.*)_destination_name_.*_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_(.*)_destination_name_.*_destination_pod_.*_osm_request_total
           target_label: destination_kind
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_(.*)_destination_pod_.*_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_(.*)_destination_pod_.*_osm_request_total
           target_label: destination_name
         - source_labels: [__name__]
           action: replace
-          regex: envoy_response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_(.*)_osm_request_total
+          regex: response_code_\d{3}_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_(.*)_osm_request_total
           target_label: destination_pod
         - source_labels: [__name__]
           action: replace
@@ -175,35 +175,35 @@ data:
 
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_(.*)_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_(.*)_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: source_namespace
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_(.*)_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_(.*)_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: source_kind
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_.*_source_name_(.*)_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_.*_source_name_(.*)_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: source_name
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_(.*)_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_.*_source_name_.*_source_pod_(.*)_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: source_pod
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_(.*)_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_(.*)_destination_kind_.*_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: destination_namespace
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_(.*)_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_(.*)_destination_name_.*_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: destination_kind
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_(.*)_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_(.*)_destination_pod_.*_osm_request_duration_ms_(bucket|sum|count)
           target_label: destination_name
         - source_labels: [__name__]
           action: replace
-          regex: envoy_source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_(.*)_osm_request_duration_ms_(bucket|sum|count)
+          regex: source_namespace_.*_source_kind_.*_source_name_.*_source_pod_.*_destination_namespace_.*_destination_kind_.*_destination_name_.*_destination_pod_(.*)_osm_request_duration_ms_(bucket|sum|count)
           target_label: destination_pod
         - source_labels: [__name__]
           action: replace

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -344,7 +344,7 @@
                     "title": "The sidecarImage schema",
                     "description": "The proxy side car image to run.",
                     "examples": [
-                        "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd"
+                        "envoyproxy/envoy-alpine:v1.21.1@sha256:c2c0b7c136f9daf09c36ef550635eaf5db26465529a1354f725f11390e530879"
                     ]
                 },
                 "curlImage": {
@@ -362,7 +362,7 @@
                     "title": "The sidecarWindowsImage schema",
                     "description": "The proxy side car image to run on Windows payloads.",
                     "examples": [
-                        "envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85"
+                        "envoyproxy/envoy-windows:v1.21.1@sha256:04d06653294ac2908885568f78586f7cc337b1d79357d9cf561d9bc7d36bc963"
                     ]
                 },
                 "certificateProvider": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -31,10 +31,10 @@ osm:
 
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
-  # -- Envoy sidecar image for Linux workloads (v1.19.1)
-  sidecarImage: envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd
-  # -- Envoy sidecar image for Windows workloads (v1.19.1)
-  sidecarWindowsImage: envoyproxy/envoy-windows@sha256:c904fda95891ebbccb9b1f24c1a9482c8d01cbca215dd081fc8c8db36db85f85
+  # -- Envoy sidecar image for Linux workloads (v1.21.1)
+  sidecarImage: envoyproxy/envoy-alpine:v1.21.1@sha256:c2c0b7c136f9daf09c36ef550635eaf5db26465529a1354f725f11390e530879
+  # -- Envoy sidecar image for Windows workloads (v1.21.1)
+  sidecarWindowsImage: envoyproxy/envoy-windows:v1.21.1@sha256:04d06653294ac2908885568f78586f7cc337b1d79357d9cf561d9bc7d36bc963
   # -- Curl image for control plane init container
   curlImage: curlimages/curl
 
@@ -348,7 +348,7 @@ contour:
     image:
       registry: docker.io
       repository: envoyproxy/envoy-alpine
-      tag: v1.19.1
+      tag: v1.21.1
 
 #
 # -- SMI configuration

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -42,7 +42,7 @@ var testPresetMeshConfigMap *corev1.ConfigMap = &corev1.ConfigMap{
 	"enablePrivilegedInitContainer": false,
 	"logLevel": "error",
 	"maxDataPlaneConnections": 0,
-	"envoyImage": "envoyproxy/envoy-alpine@sha256:6502a637c6c5fba4d03d0672d878d12da4bcc7a0d0fb3f1d506982dde0039abd",
+	"envoyImage": "envoyproxy/envoy-alpine:v1.21.1@sha256:c2c0b7c136f9daf09c36ef550635eaf5db26465529a1354f725f11390e530879",
 	"initContainerImage": "openservicemesh/init:latest-main",
 	"configResyncInterval": "2s"
 },

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/envoyproxy/go-control-plane v0.9.9
+	github.com/envoyproxy/go-control-plane v0.10.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.5.0
@@ -94,7 +94,7 @@ require (
 	github.com/bombsimon/wsl/v3 v3.1.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed // indirect
+	github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe // indirect
 	github.com/containerd/continuity v0.1.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/daixiang0/gci v0.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/cloudflare/cloudflare-go v0.13.2/go.mod h1:27kfc1apuifUmJhp069y0+hwlK
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe h1:QJDJubh0OEcpeGjC7/8uF9tt4e39U/Ya1uyK+itnNPQ=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
@@ -412,8 +412,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.9.9 h1:vQLjymTobffN2R0F8eTqw6q7iozfRO5Z0m+/4Vw+/uA=
-github.com/envoyproxy/go-control-plane v0.9.9/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
+github.com/envoyproxy/go-control-plane v0.10.1 h1:cgDRLG7bs59Zd+apAWuzLQL95obVYAymNJek76W3mgw=
+github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=

--- a/pkg/envoy/ads/cache_callbacks.go
+++ b/pkg/envoy/ads/cache_callbacks.go
@@ -34,7 +34,7 @@ func (cb *Callbacks) OnStreamRequest(a int64, req *discovery.DiscoveryRequest) e
 }
 
 // OnStreamResponse is called when a response is being sent to a request
-func (cb *Callbacks) OnStreamResponse(aa int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
+func (cb *Callbacks) OnStreamResponse(_ context.Context, aa int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
 	log.Debug().Msgf("OnStreamResponse REQ: %s, type: %s, v: %s, nonce: %s, resNames: %s", req.Node.Id, req.TypeUrl, req.VersionInfo, req.ResponseNonce, req.ResourceNames)
 	log.Debug().Msgf("OnStreamResponse RESP: type: %s, v: %s, nonce: %s, NumResources: %d", resp.TypeUrl, resp.VersionInfo, resp.Nonce, len(resp.Resources))
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -54,7 +54,7 @@ func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.Aggregat
 	// A nil request indicates a change on mesh configuration, OSM will trigger an update
 	// for all proxy config (we generate a response with no direct request from envoy)
 	osmDrivenUpdate := request == nil
-	cacheResourceMap := map[envoy.TypeURI][]types.Resource{}
+	cacheResourceMap := map[string][]types.Resource{}
 
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
@@ -87,7 +87,7 @@ func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.Aggregat
 
 		if s.cacheEnabled {
 			// Keep a reference to later set the full snapshot in the cache
-			cacheResourceMap[typeURI] = resources
+			cacheResourceMap[typeURI.String()] = resources
 		} else {
 			// If cache disabled, craft and send a reply to the proxy on the stream
 			if err := s.SendDiscoveryResponse(proxy, finalReq, server, resources); err != nil {

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -287,6 +287,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
 					"--service-cluster", "svcacc.namespace",
+					"--drain-time-s", "30",
+					"--drain-strategy", "immediate",
 				},
 				Env: []corev1.EnvVar{
 					{
@@ -413,6 +415,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
 					"--service-cluster", "svcacc.namespace",
+					"--drain-time-s", "30",
+					"--drain-strategy", "immediate",
 				},
 				Env: []corev1.EnvVar{
 					{

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -287,7 +287,6 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
 					"--service-cluster", "svcacc.namespace",
-					"--bootstrap-version 3",
 				},
 				Env: []corev1.EnvVar{
 					{
@@ -414,7 +413,6 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
 					"--service-cluster", "svcacc.namespace",
-					"--bootstrap-version 3",
 				},
 				Env: []corev1.EnvVar{
 					{

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -60,6 +60,11 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),
 			"--service-cluster", clusterID,
+			// Drain time is set to 30s and drain strategy is set to immediate so that connections
+			// are drained sooner when the listener is updated/removed via LDS.
+			// Ref: https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-drain-time-s
+			"--drain-time-s", "30",
+			"--drain-strategy", "immediate",
 		},
 		Env: []corev1.EnvVar{
 			{

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -60,7 +60,6 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),
 			"--service-cluster", clusterID,
-			"--bootstrap-version 3",
 		},
 		Env: []corev1.EnvVar{
 			{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Updates Envoy image to v1.21.1, which is the latest
  release with security patches applied

- Updates go-control-plane module to v0.10.1. This is
  required to use latest changes to the XDS API, e.g.
  to set HTTP MaxRequestsPerConnection as a part of the
  HttpProtocolOptions.
  Resolves snapshot cache (experimental) compatibility
  with new SDK.

- Removes Envoy cmd line argument for bootstrap version
  which is now the only supported version in Envoy. The
  cmd line flag has been removed in Envoy.

- Accounts for the change in envoy where custom metrics from
   WASM extensions are no longer prefixed with `envoy_`. The metrics as
   they exist in Prometheus are unchanged.

- Update drain interval to 30s from 600s and set drain strategy to
   immediate so that connections are drained sooner when the
   listener is removed.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`