### PR TITLE
contrib/ladder: remove duplicate approvers section

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -76,11 +76,6 @@ Process of becoming a maintainer:
 2. The nominee will add a comment to the PR testifying that they agree to all requirements of becoming a Maintainer.
 3. A majority of the current Maintainers must then approve the PR.
 
-## Approvers
-
-All pull requests must be reviewed and approved by at least 2 members in the [approvers list](https://github.com/openservicemesh/osm/blob/main/CODEOWNERS).
-
-An approver may nominate a current contributor who has shown significant understanding in one or more areas of the project by adding the nominee to the [CODEOWNERS file](https://github.com/openservicemesh/osm/blob/main/CODEOWNERS) by opening a PR. The nominee must add a comment to the PR testifying they agree to become a code approver. A majority of the current approvers must then approve the PR for the nomination to succeed.
 
 ## Inactivity
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Resolve ambiguity by removing duplicate approvers
section, as both code maintainers and approvers
are the same and listed in the CODEOWNERS file.

Resolves #4559

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Documentation              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`