### PR TITLE
fix(scripts): remove bash 4.0 dependency in coverage script

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -2,22 +2,23 @@
 
 set -aueo pipefail
 
-readarray -t modules < <(go list ./... | \
-                             grep -v tests/framework | \
-                             grep -v tests/e2e | \
-                             grep -v tests/scenarios | \
-                             grep -v tests/scale | \
-                             grep -v ci/ | \
-                             grep -v demo/ | \
-                             grep -v experimental/ | \
-                             grep -v scripts/)
+modules=$(go list ./... | \
+            grep -v tests/framework | \
+            grep -v tests/e2e | \
+            grep -v tests/scenarios | \
+            grep -v tests/scale | \
+            grep -v ci/ | \
+            grep -v demo/ | \
+            grep -v experimental/ | \
+            grep -v scripts/)
 
+# shellcheck disable=SC2086
 go test -timeout 120s \
    -failfast \
    -race \
    -v \
    -coverprofile=coverage.txt.with_generated_code \
-   -covermode atomic "${modules[@]}" | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }
+   -covermode atomic $modules | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }
 
 # shellcheck disable=SC2002
 cat coverage.txt.with_generated_code | grep -v "_generated.go" | grep -v "fake.go" | grep -v "pkg/gen" | grep -v "pkg/apis" > coverage.txt


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
`readarray` is a bash builtin introduced in 4.0. This change removes
its use so `make go-test-coverage` can be run on Macs which only ship
with bash 3.2 preinstalled.

Fixes #2152

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Tested locally on my Mac with bash 3.2
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A