### PR TITLE
envoy: update go-control-plane version

### DIFF
--- a/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
+++ b/charts/osm/templates/osm-multicluster-gateway-deployment.yaml
@@ -39,7 +39,6 @@ spec:
             - "envoy"
           args: [
             "--config-path", "/etc/envoy/bootstrap.yaml",
-            "--bootstrap-version", "3",
             "--service-node", "osm-multicluster-gateway",
             "--service-cluster", "osm-multicluster-gateway",
             "--log-level", {{ .Values.osm.multicluster.gatewayLogLevel }},

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible
 	github.com/dustin/go-humanize v1.0.0
-	github.com/envoyproxy/go-control-plane v0.9.9
+	github.com/envoyproxy/go-control-plane v0.10.1
 	github.com/fatih/color v1.10.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.5.0
@@ -94,7 +94,7 @@ require (
 	github.com/bombsimon/wsl/v3 v3.1.0 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
-	github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed // indirect
+	github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe // indirect
 	github.com/containerd/continuity v0.1.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/daixiang0/gci v0.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/cloudflare/cloudflare-go v0.13.2/go.mod h1:27kfc1apuifUmJhp069y0+hwlK
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
-github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe h1:QJDJubh0OEcpeGjC7/8uF9tt4e39U/Ya1uyK+itnNPQ=
+github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
@@ -412,8 +412,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
-github.com/envoyproxy/go-control-plane v0.9.9 h1:vQLjymTobffN2R0F8eTqw6q7iozfRO5Z0m+/4Vw+/uA=
-github.com/envoyproxy/go-control-plane v0.9.9/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
+github.com/envoyproxy/go-control-plane v0.10.1 h1:cgDRLG7bs59Zd+apAWuzLQL95obVYAymNJek76W3mgw=
+github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v0.0.0-20200808040245-162e5629780b/go.mod h1:NAJj0yf/KaRKURN6nyi7A9IZydMivZEm9oQLWNjfKDc=

--- a/pkg/envoy/ads/cache_callbacks.go
+++ b/pkg/envoy/ads/cache_callbacks.go
@@ -34,7 +34,7 @@ func (cb *Callbacks) OnStreamRequest(a int64, req *discovery.DiscoveryRequest) e
 }
 
 // OnStreamResponse is called when a response is being sent to a request
-func (cb *Callbacks) OnStreamResponse(aa int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
+func (cb *Callbacks) OnStreamResponse(_ context.Context, aa int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
 	log.Debug().Msgf("OnStreamResponse REQ: %s, type: %s, v: %s, nonce: %s, resNames: %s", req.Node.Id, req.TypeUrl, req.VersionInfo, req.ResponseNonce, req.ResourceNames)
 	log.Debug().Msgf("OnStreamResponse RESP: type: %s, v: %s, nonce: %s, NumResources: %d", resp.TypeUrl, resp.VersionInfo, resp.Nonce, len(resp.Resources))
 }

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -54,7 +54,7 @@ func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.Aggregat
 	// A nil request indicates a change on mesh configuration, OSM will trigger an update
 	// for all proxy config (we generate a response with no direct request from envoy)
 	osmDrivenUpdate := request == nil
-	cacheResourceMap := map[envoy.TypeURI][]types.Resource{}
+	cacheResourceMap := map[string][]types.Resource{}
 
 	// Order is important: CDS, EDS, LDS, RDS
 	// See: https://github.com/envoyproxy/go-control-plane/issues/59
@@ -87,7 +87,7 @@ func (s *Server) sendResponse(proxy *envoy.Proxy, server *xds_discovery.Aggregat
 
 		if s.cacheEnabled {
 			// Keep a reference to later set the full snapshot in the cache
-			cacheResourceMap[typeURI] = resources
+			cacheResourceMap[typeURI.String()] = resources
 		} else {
 			// If cache disabled, craft and send a reply to the proxy on the stream
 			if err := s.SendDiscoveryResponse(proxy, finalReq, server, resources); err != nil {

--- a/pkg/injector/envoy_config_test.go
+++ b/pkg/injector/envoy_config_test.go
@@ -299,7 +299,6 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
 					"--service-cluster", "svcacc.namespace",
-					"--bootstrap-version 3",
 				},
 				Env: []corev1.EnvVar{
 					{
@@ -426,7 +425,6 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 					"--log-level", "debug",
 					"--config-path", "/etc/envoy/bootstrap.yaml",
 					"--service-cluster", "svcacc.namespace",
-					"--bootstrap-version 3",
 				},
 				Env: []corev1.EnvVar{
 					{

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -60,7 +60,6 @@ func getEnvoySidecarContainerSpec(pod *corev1.Pod, cfg configurator.Configurator
 			"--log-level", cfg.GetEnvoyLogLevel(),
 			"--config-path", strings.Join([]string{envoyProxyConfigPath, envoyBootstrapConfigFile}, "/"),
 			"--service-cluster", clusterID,
-			"--bootstrap-version 3",
 		},
 		Env: []corev1.EnvVar{
 			{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Updates go-control-plane module to v0.10.1. This is
  required to use latest changes to the XDS API, e.g.
  to set HTTP MaxRequestsPerConnection as a part of the
  HttpProtocolOptions.
  Resolves snapshot cache (experimental) compatibility
  with new SDK.

- Removes Envoy cmd line argument for bootstrap version
  which is now the only supported version in Envoy. The
  cmd line flag has been removed in Envoy.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Demo, CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`