### PR TITLE
crd/conversion: only patch CRDs needing conversion

### DIFF
--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -38,16 +38,12 @@ const (
 	retryPolicyConverterPath           = "/convert/retrypolicy"
 )
 
-var crdConversionWebhookConfiguration = map[string]string{
-	"traffictargets.access.smi-spec.io":              trafficAccessConverterPath,
-	"httproutegroups.specs.smi-spec.io":              httpRouteGroupConverterPath,
-	"meshconfigs.config.openservicemesh.io":          meshConfigConverterPath,
-	"multiclusterservices.config.openservicemesh.io": multiclusterServiceConverterPath,
-	"egresses.policy.openservicemesh.io":             egressPolicyConverterPath,
-	"trafficsplits.split.smi-spec.io":                trafficSplitConverterPath,
-	"tcproutes.specs.smi-spec.io":                    tcpRoutesConverterPath,
-	"ingressbackends.policy.openservicemesh.io":      ingressBackendsPolicyConverterPath,
-	"retries.policy.openservicemesh.io":              retryPolicyConverterPath,
+// apiKindToPath maps the resource API kind to the HTTP path at which
+// the webhook server peforms the conversion
+// *Note: only add API kinds for which conversion is necessary so that
+// the webhook is not invoked otherwise.
+var apiKindToPath = map[string]string{
+	"meshconfigs.config.openservicemesh.io": meshConfigConverterPath,
 }
 
 var conversionReviewVersions = []string{"v1beta1", "v1"}
@@ -167,7 +163,7 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func patchCrds(cert *certificate.Certificate, crdClient apiclient.ApiextensionsV1Interface, osmNamespace string, enableReconciler bool) error {
-	for crdName, crdConversionPath := range crdConversionWebhookConfiguration {
+	for crdName, crdConversionPath := range apiKindToPath {
 		if err := updateCrdConfiguration(cert, crdClient, osmNamespace, crdName, crdConversionPath, enableReconciler); err != nil {
 			log.Error().Err(err).Msgf("Error updating conversion webhook configuration for crd : %s", crdName)
 			return err


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the code to only patch CRDs that require
a conversion strategy. This prevents the webhook
from being invoked for resources that do not
require conversion, thereby reducing the load
on the webhook server in large scale environments.
It also removes an additional failure path for
resource CRUDs.

Note: the existing stubs for APIs that do not need
a conversion are still present, in case they need
to be reused later on.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Local run, CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`