### PR TITLE
owners: mirror code owners file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,6 @@
-#ref: https://github.com/orgs/openservicemesh/teams/osm-maintainers/members
-maintainers:
-  - draychev
-  - eduser25
-  - ksubrmnn
-  - michelleN
-  - nojnhuh
-  - nshankar13
-  - SanyaKochhar
-  - shalier
-  - shashankram
-  - snehachhabria
-  - phillipgibson
-emeritus:
-  -
+# ref: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @shashankram @snehachhabria @nojnhuh @draychev @jaellio
+
+# Emeritus maintainers
+# @michelleN @eduser25


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Mirrors the CODEOWNERS file which reflects
the current set of code owners accurately.
The existing OWNERS file was a placeholder
for anyone with write access to the repo, not
necessarily a code owner. The OWNERS file
must be preserved since it's a requirement
for CNCF.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?