### PR TITLE
feat(metrics): add feature flag metrics

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -305,6 +305,7 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.ErrCodeCounter,
 		metricsstore.DefaultMetricsStore.HTTPResponseTotal,
 		metricsstore.DefaultMetricsStore.HTTPResponseDuration,
+		metricsstore.DefaultMetricsStore.FeatureFlagEnabled,
 	)
 }
 

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -2,6 +2,7 @@ package configurator
 
 import (
 	"fmt"
+	"reflect"
 
 	"k8s.io/client-go/tools/cache"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
 // NewConfigurator implements configurator.Configurator and creates the Kubernetes client to manage namespaces.
@@ -44,6 +46,7 @@ func newConfigurator(meshConfigClientSet versioned.Interface, stop <-chan struct
 		Delete: announcements.MeshConfigDeleted,
 	}
 	informer.AddEventHandler(k8s.GetEventHandlerFuncs(nil, eventTypes, msgBroker))
+	informer.AddEventHandler(c.metricsHandler())
 
 	c.run(stop)
 
@@ -85,4 +88,44 @@ func (c *client) getMeshConfig() configv1alpha2.MeshConfig {
 
 	meshConfig = *item.(*configv1alpha2.MeshConfig)
 	return meshConfig
+}
+
+func (c *client) metricsHandler() cache.ResourceEventHandlerFuncs {
+	handleMetrics := func(obj interface{}) {
+		config := obj.(*configv1alpha2.MeshConfig)
+		if config.Name != c.meshConfigName {
+			return
+		}
+		// This uses reflection to iterate over the feature flags to avoid
+		// enumerating them here individually. This code assumes the following:
+		// - MeshConfig.Spec.FeatureFlags is a struct, not a pointer to a struct
+		// - Each field of the FeatureFlags type is a separate feature flag of
+		//   type bool
+		// - Each field defines a `json` struct tag that only contains an
+		//   alphanumeric field name without any other directive like `omitempty`
+		flags := reflect.ValueOf(config.Spec.FeatureFlags)
+		for i := 0; i < flags.NumField(); i++ {
+			field := flags.Field(i)
+			name := flags.Type().Field(i).Tag.Get("json")
+			var val float64 = 0
+			if field.Bool() {
+				val = 1
+			}
+			metricsstore.DefaultMetricsStore.FeatureFlagEnabled.WithLabelValues(name).Set(val)
+		}
+	}
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: handleMetrics,
+		UpdateFunc: func(_, newObj interface{}) {
+			handleMetrics(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			config := obj.(*configv1alpha2.MeshConfig).DeepCopy()
+			// Ensure metrics reflect however the rest of the control plane
+			// handles when the MeshConfig doesn't exist. If this happens not to
+			// be the "real" MeshConfig, handleMetrics() will simply ignore it.
+			config.Spec.FeatureFlags = c.GetFeatureFlags()
+			handleMetrics(config)
+		},
+	}
 }

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -105,12 +105,11 @@ func (c *client) metricsHandler() cache.ResourceEventHandlerFuncs {
 		//   alphanumeric field name without any other directive like `omitempty`
 		flags := reflect.ValueOf(config.Spec.FeatureFlags)
 		for i := 0; i < flags.NumField(); i++ {
-			field := flags.Field(i)
-			name := flags.Type().Field(i).Tag.Get("json")
-			var val float64 = 0
-			if field.Bool() {
+			var val float64
+			if flags.Field(i).Bool() {
 				val = 1
 			}
+			name := flags.Type().Field(i).Tag.Get("json")
 			metricsstore.DefaultMetricsStore.FeatureFlagEnabled.WithLabelValues(name).Set(val)
 		}
 	}

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -1,12 +1,15 @@
 package configurator
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 )
@@ -39,4 +42,87 @@ func TestGetMeshConfig(t *testing.T) {
 	err := c.cache.Add(newObj)
 	a.Nil(err)
 	a.Equal(*newObj, c.getMeshConfig())
+}
+
+type store struct {
+	cache.Store
+}
+
+func (s *store) GetByKey(_ string) (interface{}, bool, error) {
+	return nil, false, nil
+}
+
+func TestMetricsHandler(t *testing.T) {
+	c := &client{
+		cache:          &store{},
+		meshConfigName: osmMeshConfigName,
+	}
+	handlers := c.metricsHandler()
+	metricsstore.DefaultMetricsStore.Start(metricsstore.DefaultMetricsStore.FeatureFlagEnabled)
+
+	assertMetricsContain := func(metric string) {
+		t.Helper()
+		req := httptest.NewRequest("GET", "http://this.doesnt/matter", nil)
+		w := httptest.NewRecorder()
+		metricsstore.DefaultMetricsStore.Handler().ServeHTTP(w, req)
+		res := w.Body.String()
+
+		assert.Contains(t, res, metric)
+	}
+
+	// Adding a MeshConfig
+	handlers.OnAdd(&configv1alpha2.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: osmMeshConfigName,
+		},
+		Spec: configv1alpha2.MeshConfigSpec{
+			FeatureFlags: configv1alpha2.FeatureFlags{
+				EnableRetryPolicy: true,
+			},
+		},
+	})
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableRetryPolicy"} 1` + "\n")
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableSnapshotCacheMode"} 0` + "\n")
+
+	// Adding a different MeshConfig whose settings are ignored
+	handlers.OnAdd(&configv1alpha2.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "not-" + osmMeshConfigName,
+		},
+		Spec: configv1alpha2.MeshConfigSpec{
+			FeatureFlags: configv1alpha2.FeatureFlags{
+				EnableSnapshotCacheMode: true,
+			},
+		},
+	})
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableRetryPolicy"} 1` + "\n")
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableSnapshotCacheMode"} 0` + "\n")
+
+	// Updating the "real" MeshConfig
+	handlers.OnUpdate(nil, &configv1alpha2.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: osmMeshConfigName,
+		},
+		Spec: configv1alpha2.MeshConfigSpec{
+			FeatureFlags: configv1alpha2.FeatureFlags{
+				EnableSnapshotCacheMode: true,
+			},
+		},
+	})
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableRetryPolicy"} 0` + "\n")
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableSnapshotCacheMode"} 1` + "\n")
+
+	// Deleting the "real" MeshConfig
+	handlers.OnDelete(&configv1alpha2.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: osmMeshConfigName,
+		},
+		Spec: configv1alpha2.MeshConfigSpec{
+			FeatureFlags: configv1alpha2.FeatureFlags{
+				EnableSnapshotCacheMode: true,
+			},
+		},
+	})
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableRetryPolicy"} 0` + "\n")
+	assertMetricsContain(`osm_feature_flag_enabled{feature_flag="enableSnapshotCacheMode"} 0` + "\n")
 }

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -81,6 +81,10 @@ type MetricsStore struct {
 	// HTTP requests
 	HTTPResponseDuration *prometheus.HistogramVec
 
+	// FeatureFlagEnabled represents whether each feature flag is enabled (1) or
+	// disabled (0)
+	FeatureFlagEnabled *prometheus.GaugeVec
+
 	/*
 	 * MetricsStore internals should be defined below --------------
 	 */
@@ -234,6 +238,12 @@ func init() {
 		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		Help:      "Duration in seconds of HTTP responses sent",
 	}, []string{"code", "method", "path"})
+
+	defaultMetricsStore.FeatureFlagEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsRootNamespace,
+		Name:      "feature_flag_enabled",
+		Help:      "Represents whether a feature flag is enabled (1) or disabled (0)",
+	}, []string{"feature_flag"})
 
 	defaultMetricsStore.registry = prometheus.NewRegistry()
 }


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
These changes add the `osm_feature_flag_enabled` metric labeled with
each feature flag name as it appears in the API. The metric is a Gauge
where a value of 0 indicates the flag is disabled and 1 when the flag is
enabled.

Part of #4568

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Added unit tests
- Did some manual smoke testing with the whole control plane running in a cluster

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Yes, https://github.com/openservicemesh/osm-docs/pull/336