### PR TITLE
feat(ads): xDS response add TLS config

### DIFF
--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -142,6 +142,7 @@ var _ = Describe("Test ADS response functions", func() {
 			EnableWASMStats:    false,
 			EnableEgressPolicy: false,
 		}).AnyTimes()
+		mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
 		metricsstore.DefaultMetricsStore.Start(metricsstore.DefaultMetricsStore.ProxyResponseSendSuccessCount)
 

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -33,11 +34,11 @@ var replacer = strings.NewReplacer(".", "_", ":", "_")
 
 // getUpstreamServiceCluster returns an Envoy Cluster corresponding to the given upstream service
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func getUpstreamServiceCluster(downstreamIdentity identity.ServiceIdentity, config trafficpolicy.MeshClusterConfig) *xds_cluster.Cluster {
+func getUpstreamServiceCluster(downstreamIdentity identity.ServiceIdentity, config trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha2.SidecarSpec) *xds_cluster.Cluster {
 	httpProtocolOptions := getDefaultHTTPProtocolOptions()
 
 	marshalledUpstreamTLSContext, err := anypb.New(
-		envoy.GetUpstreamTLSContext(downstreamIdentity, config.Service))
+		envoy.GetUpstreamTLSContext(downstreamIdentity, config.Service, sidecarSpec))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error marshalling UpstreamTLSContext for upstream cluster %s", config.Name)
 		return nil
@@ -331,11 +332,11 @@ func formatAltStatNameForPrometheus(clusterName string) string {
 	return replacer.Replace(clusterName)
 }
 
-func upstreamClustersFromClusterConfigs(downstreamIdentity identity.ServiceIdentity, configs []*trafficpolicy.MeshClusterConfig) []*xds_cluster.Cluster {
+func upstreamClustersFromClusterConfigs(downstreamIdentity identity.ServiceIdentity, configs []*trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha2.SidecarSpec) []*xds_cluster.Cluster {
 	var clusters []*xds_cluster.Cluster
 
 	for _, c := range configs {
-		clusters = append(clusters, getUpstreamServiceCluster(downstreamIdentity, *c))
+		clusters = append(clusters, getUpstreamServiceCluster(downstreamIdentity, *c, sidecarSpec))
 	}
 	return clusters
 }

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -96,7 +97,7 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
-			remoteCluster := getUpstreamServiceCluster(downstreamSvcAccount, tc.clusterConfig)
+			remoteCluster := getUpstreamServiceCluster(downstreamSvcAccount, tc.clusterConfig, configv1alpha2.SidecarSpec{})
 			assert.NotNil(remoteCluster)
 
 			if tc.clusterConfig.EnableEnvoyActiveHealthChecks {

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -42,7 +42,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 	// Build upstream clusters based on allowed outbound traffic policies
 	outboundMeshTrafficPolicy := meshCatalog.GetOutboundMeshTrafficPolicy(proxyIdentity)
 	if outboundMeshTrafficPolicy != nil {
-		clusters = append(clusters, upstreamClustersFromClusterConfigs(proxyIdentity, outboundMeshTrafficPolicy.ClustersConfigs)...)
+		clusters = append(clusters, upstreamClustersFromClusterConfigs(proxyIdentity, outboundMeshTrafficPolicy.ClustersConfigs, cfg.GetMeshConfig().Spec.Sidecar)...)
 	}
 
 	// Build local clusters based on allowed inbound traffic policies

--- a/pkg/envoy/lds/ingress_test.go
+++ b/pkg/envoy/lds/ingress_test.go
@@ -10,6 +10,8 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -85,6 +87,7 @@ func TestGetIngressFilterChains(t *testing.T) {
 			mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
 				Enable: false,
 			}).AnyTimes()
+			mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
 			actual := lb.getIngressFilterChains(testSvc)
 			assert.Len(actual, tc.expectedFilterChainCount)
@@ -176,7 +179,7 @@ func TestGetIngressFilterChainFromTrafficMatch(t *testing.T) {
 				Enable: false,
 			})
 
-			actual, err := lb.getIngressFilterChainFromTrafficMatch(tc.trafficMatch)
+			actual, err := lb.getIngressFilterChainFromTrafficMatch(tc.trafficMatch, configv1alpha2.SidecarSpec{})
 			assert.Equal(tc.expectError, err != nil)
 
 			if err == nil {

--- a/pkg/envoy/lds/inmesh.go
+++ b/pkg/envoy/lds/inmesh.go
@@ -114,7 +114,7 @@ func (lb *listenerBuilder) getInboundMeshHTTPFilterChain(proxyService service.Me
 	}
 
 	// Construct downstream TLS context
-	marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */, lb.cfg.GetMeshConfig().Spec.Sidecar))
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)
@@ -167,7 +167,7 @@ func (lb *listenerBuilder) getInboundMeshTCPFilterChain(proxyService service.Mes
 	}
 
 	// Construct downstream TLS context
-	marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */))
+	marshalledDownstreamTLSContext, err := anypb.New(envoy.GetDownstreamTLSContext(lb.serviceIdentity, true /* mTLS */, lb.cfg.GetMeshConfig().Spec.Sidecar))
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrMarshallingXDSResource)).
 			Msgf("Error marshalling DownstreamTLSContext for proxy service %s", proxyService)

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -218,6 +218,7 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 		EnableWASMStats:        false,
 		EnableMulticlusterMode: true,
 	}).AnyTimes()
+	mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
 	lb := &listenerBuilder{
 		meshCatalog:     mockCatalog,
@@ -314,6 +315,7 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
 		EnableMulticlusterMode: true,
 	}).AnyTimes()
+	mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
 	lb := &listenerBuilder{
 		meshCatalog:     mockCatalog,

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -79,6 +79,7 @@ func TestNewResponse(t *testing.T) {
 	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
 		Enable: false,
 	}).AnyTimes()
+	mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
 	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
 		EnableWASMStats:        false,


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This is a follow up PR of https://github.com/openservicemesh/osm/pull/4418. 

The original PR only applies TLS config to Envoy bootstrap config file, which means only the static resources are updated.

This PR applies the config to the dynamic resources in xDS response from control plane. SidecarSpec from MeshConfig is passed to the config generation sections.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

* Unit test
* Manual test with kind cluster. Cipher suite is manually edited in mesh config. Confirmed that both static and dynamic resources are updated accordingly.

![Screen Shot 2022-03-10 at 11 38 51 AM](https://user-images.githubusercontent.com/872876/157741576-f96dee66-2a3b-4104-a41b-9890cd75a732.png)
![Screen Shot 2022-03-10 at 11 38 45 AM](https://user-images.githubusercontent.com/872876/157741579-74794064-c3bf-48cd-9f91-a39c0f4e2202.png)

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [X] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No. It needs to be done later.