### PR TITLE
feat(metrics): add proxy XDS request metric

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -306,6 +306,7 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.HTTPResponseTotal,
 		metricsstore.DefaultMetricsStore.HTTPResponseDuration,
 		metricsstore.DefaultMetricsStore.FeatureFlagEnabled,
+		metricsstore.DefaultMetricsStore.ProxyXDSRequestCount,
 	)
 }
 

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -116,6 +116,8 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 
 			<-s.workqueues.AddJob(newJob(typesRequest, &discoveryRequest))
 
+			metricsstore.DefaultMetricsStore.ProxyXDSRequestCount.WithLabelValues(certCommonName.String(), discoveryRequest.TypeUrl).Inc()
+
 		case <-proxyUpdateChan:
 			log.Info().Str("proxy", proxy.String()).Msg("Broadcast update received")
 

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -105,6 +105,8 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			}
 			log.Debug().Str("proxy", proxy.String()).Msgf("Processing DiscoveryRequest %s", discoveryReqToStr(&discoveryRequest))
 
+			metricsstore.DefaultMetricsStore.ProxyXDSRequestCount.WithLabelValues(certCommonName.String(), discoveryRequest.TypeUrl).Inc()
+
 			// This function call runs xDS proto state machine given DiscoveryRequest as input.
 			// It's output is the decision to reply or not to this request.
 			if !respondToRequest(proxy, &discoveryRequest) {
@@ -115,8 +117,6 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			typesRequest := []envoy.TypeURI{envoy.TypeURI(discoveryRequest.TypeUrl)}
 
 			<-s.workqueues.AddJob(newJob(typesRequest, &discoveryRequest))
-
-			metricsstore.DefaultMetricsStore.ProxyXDSRequestCount.WithLabelValues(certCommonName.String(), discoveryRequest.TypeUrl).Inc()
 
 		case <-proxyUpdateChan:
 			log.Info().Str("proxy", proxy.String()).Msg("Broadcast update received")

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -49,6 +49,9 @@ type MetricsStore struct {
 	// ProxyResponseSendErrorCount is the metric for the total number of errors encountered while sending responses to proxies
 	ProxyResponseSendErrorCount prometheus.Counter
 
+	// ProxyXDSRequestCount counts XDS requests made by proxies
+	ProxyXDSRequestCount *prometheus.CounterVec
+
 	/*
 	 * Injector metrics
 	 */
@@ -170,6 +173,13 @@ func init() {
 		Name:      "broadcast_event_count",
 		Help:      "Represents the number of ProxyBroadcast events published by the OSM controller",
 	})
+
+	defaultMetricsStore.ProxyXDSRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "xds_request_count",
+		Help:      "Represents the number of XDS requests made by proxies",
+	}, []string{"common_name", "type"})
 
 	/*
 	 * Injector metrics


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a new `osm_proxy_xds_request_count` metric to count XDS
requests made by proxies, labeled with the proxy's certificate CN and
the XDS type.

Example:

    osm_proxy_xds_request_count{common_name="369c9347-5b8f-42ff-ab1b-427ced15ee68.sidecar.bookbuyer.bookbuyer.cluster.local",type="type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"} 4

Part of #4568

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- This part of the codebase doesn't have unit tests, but I did some manual smoke testing.
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Yes, https://github.com/openservicemesh/osm-docs/pull/337