### PR TITLE
policy: implement UpstreamTrafficSetting API

### DIFF
--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -30,7 +30,7 @@ Uninstalling OSM will:
 (which OSM adds to support multiple CR versions)
 
 The command will not delete:
-(1) the namespace the mesh was installed in unless specified via the 
+(1) the namespace the mesh was installed in unless specified via the
 --delete-namespace flag.
 (2) the cluster-wide resources (i.e. CRDs, mutating and validating webhooks and
 secrets) unless specified via via the --delete-cluster-wide-resources (or -a) flag
@@ -199,6 +199,8 @@ func (d *uninstallMeshCmd) uninstallCustomResourceDefinitions() error {
 		"egresses.policy.openservicemesh.io",
 		"ingressbackends.policy.openservicemesh.io",
 		"meshconfigs.config.openservicemesh.io",
+		"upstreamtrafficsettings.policy.openservicemesh.io",
+		"retries.policy.openservicemesh.io",
 		"multiclusterservices.config.openservicemesh.io",
 		"httproutegroups.specs.smi-spec.io",
 		"tcproutes.specs.smi-spec.io",

--- a/pkg/apis/policy/v1alpha1/upstreamtrafficsetting.go
+++ b/pkg/apis/policy/v1alpha1/upstreamtrafficsetting.go
@@ -59,14 +59,14 @@ type ConnectionSettingsSpec struct {
 type TCPConnectionSettings struct {
 	// MaxConnections specifies the maximum number of TCP connections
 	// allowed to the upstream host.
-	// Defaults to 1024 if not specified.
+	// Defaults to 2147483647 (2^32 - 1) if not specified.
 	// +optional
 	MaxConnections *uint32 `json:"maxConnections,omitempty"`
 
 	// ConnectTimeout specifies the TCP connection timeout.
 	// Defaults to 5s if not specified.
 	// +optional
-	ConnectTimeout metav1.Duration `json:"connectTimeout,omitempty"`
+	ConnectTimeout *metav1.Duration `json:"connectTimeout,omitempty"`
 }
 
 // HTTPConnectionSettings defines the HTTP connection settings for an
@@ -74,7 +74,7 @@ type TCPConnectionSettings struct {
 type HTTPConnectionSettings struct {
 	// MaxRequests specifies the maximum number of parallel requests
 	// allowed to the upstream host.
-	// Defaults to 1024 if not specified.
+	// Defaults to 2147483647 (2^32 - 1) if not specified.
 	// +optional
 	MaxRequests *uint32 `json:"maxRequests,omitempty"`
 
@@ -86,13 +86,13 @@ type HTTPConnectionSettings struct {
 
 	// MaxPendingRequests specifies the maximum number of pending HTTP/1.1
 	// requests allowed to the upstream host.
-	// Defaults to 1024 if not specified.
+	// Defaults to 2147483647 (2^32 - 1) if not specified.
 	// +optional
 	MaxPendingRequests *uint32 `json:"maxPendingRequests,omitempty"`
 
 	// MaxRetries specifies the maximum number of parallel retries
 	// allowed to the upstream host.
-	// Defaults to 3 if not specified.
+	// Defaults to 2147483647 (2^32 - 1) if not specified.
 	// +optional
 	MaxRetries *uint32 `json:"maxRetries,omitempty"`
 }

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -489,7 +490,11 @@ func (in *TCPConnectionSettings) DeepCopyInto(out *TCPConnectionSettings) {
 		*out = new(uint32)
 		**out = **in
 	}
-	out.ConnectTimeout = in.ConnectTimeout
+	if in.ConnectTimeout != nil {
+		in, out := &in.ConnectTimeout, &out.ConnectTimeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/catalog/fake.go
+++ b/pkg/catalog/fake.go
@@ -114,6 +114,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient versio
 
 	mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(nil).AnyTimes()
 	mockPolicyController.EXPECT().GetIngressBackendPolicy(gomock.Any()).Return(nil).AnyTimes()
+	mockPolicyController.EXPECT().GetUpstreamTrafficSetting(gomock.Any()).Return(nil).AnyTimes()
 
 	return NewMeshCatalog(mockKubeController, meshSpec, certManager,
 		mockPolicyController, stop, cfg, serviceProviders, endpointProviders, messaging.NewBroker(stop))

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -2,6 +2,7 @@ package cds
 
 import (
 	"testing"
+	"time"
 
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -9,6 +10,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	tassert "github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -19,6 +24,9 @@ import (
 )
 
 func TestGetUpstreamServiceCluster(t *testing.T) {
+	var thresholdUintVal uint32 = 3
+	thresholdDuration := &metav1.Duration{Duration: time.Duration(1 * time.Second)}
+
 	downstreamSvcAccount := tests.BookbuyerServiceIdentity
 	upstreamSvc := service.MeshService{
 		Namespace: "default",
@@ -26,8 +34,9 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 		Port:      14001,
 	}
 	testCases := []struct {
-		name          string
-		clusterConfig trafficpolicy.MeshClusterConfig
+		name                            string
+		clusterConfig                   trafficpolicy.MeshClusterConfig
+		expectedCircuitBreakerThreshold *xds_cluster.CircuitBreakers
 	}{
 		{
 			name: "EDS based cluster adds health checks when configured",
@@ -45,6 +54,40 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 				EnableEnvoyActiveHealthChecks: false,
 			},
 		},
+		{
+			name: "Cluster with Circuit Breaker",
+			clusterConfig: trafficpolicy.MeshClusterConfig{
+				Name:    "default/bookstore-v1_14001",
+				Service: upstreamSvc,
+				UpstreamTrafficSetting: &policyv1alpha1.UpstreamTrafficSetting{
+					Spec: policyv1alpha1.UpstreamTrafficSettingSpec{
+						ConnectionSettings: &policyv1alpha1.ConnectionSettingsSpec{
+							TCP: &policyv1alpha1.TCPConnectionSettings{
+								MaxConnections: &thresholdUintVal,
+								ConnectTimeout: thresholdDuration,
+							},
+							HTTP: &policyv1alpha1.HTTPConnectionSettings{
+								MaxRequests:              &thresholdUintVal,
+								MaxPendingRequests:       &thresholdUintVal,
+								MaxRetries:               &thresholdUintVal,
+								MaxRequestsPerConnection: &thresholdUintVal,
+							},
+						},
+					},
+				},
+			},
+			expectedCircuitBreakerThreshold: &xds_cluster.CircuitBreakers{
+				Thresholds: []*xds_cluster.CircuitBreakers_Thresholds{
+					{
+						MaxConnections:     wrapperspb.UInt32(thresholdUintVal),
+						MaxRequests:        wrapperspb.UInt32(thresholdUintVal),
+						MaxPendingRequests: wrapperspb.UInt32(thresholdUintVal),
+						MaxRetries:         wrapperspb.UInt32(thresholdUintVal),
+						TrackRemaining:     true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -58,6 +101,10 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 				assert.NotNil(remoteCluster.HealthChecks)
 			} else {
 				assert.Nil(remoteCluster.HealthChecks)
+			}
+
+			if tc.clusterConfig.UpstreamTrafficSetting != nil {
+				assert.Equal(tc.expectedCircuitBreakerThreshold, remoteCluster.CircuitBreakers)
 			}
 		})
 	}
@@ -246,8 +293,9 @@ func TestGetPrometheusCluster(t *testing.T) {
 
 func TestGetOriginalDestinationEgressCluster(t *testing.T) {
 	assert := tassert.New(t)
-	HTTP2ProtocolOptions, err := envoy.GetHTTP2ProtocolOptions()
+	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getDefaultHTTPProtocolOptions())
 	assert.Nil(err)
+
 	testCases := []struct {
 		name        string
 		clusterName string
@@ -262,7 +310,7 @@ func TestGetOriginalDestinationEgressCluster(t *testing.T) {
 					Type: xds_cluster.Cluster_ORIGINAL_DST,
 				},
 				LbPolicy:                      xds_cluster.Cluster_CLUSTER_PROVIDED,
-				TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
+				TypedExtensionProtocolOptions: typedHTTPProtocolOptions,
 			},
 		},
 		{
@@ -274,7 +322,7 @@ func TestGetOriginalDestinationEgressCluster(t *testing.T) {
 					Type: xds_cluster.Cluster_ORIGINAL_DST,
 				},
 				LbPolicy:                      xds_cluster.Cluster_CLUSTER_PROVIDED,
-				TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
+				TypedExtensionProtocolOptions: typedHTTPProtocolOptions,
 			},
 		},
 	}

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -135,7 +135,7 @@ func TestNewResponse(t *testing.T) {
 		actualClusters = append(actualClusters, cl)
 	}
 
-	HTTP2ProtocolOptions, err := envoy.GetHTTP2ProtocolOptions()
+	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getDefaultHTTPProtocolOptions())
 	assert.Nil(err)
 
 	expectedLocalCluster := &xds_cluster.Cluster{
@@ -146,7 +146,7 @@ func TestNewResponse(t *testing.T) {
 		EdsClusterConfig:              nil,
 		RespectDnsTtl:                 true,
 		DnsLookupFamily:               xds_cluster.Cluster_V4_ONLY,
-		TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
+		TypedExtensionProtocolOptions: typedHTTPProtocolOptions,
 		LoadAssignment: &xds_endpoint.ClusterLoadAssignment{
 			ClusterName: "default/bookbuyer|8080|local",
 			Endpoints: []*xds_endpoint.LocalityLbEndpoints{
@@ -187,7 +187,7 @@ func TestNewResponse(t *testing.T) {
 		Name:                          "default/bookstore-v1|80",
 		AltStatName:                   "",
 		ClusterDiscoveryType:          &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_EDS},
-		TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
+		TypedExtensionProtocolOptions: typedHTTPProtocolOptions,
 		EdsClusterConfig: &xds_cluster.Cluster_EdsClusterConfig{
 			EdsConfig: &xds_core.ConfigSource{
 				ConfigSourceSpecifier: &xds_core.ConfigSource_Ads{
@@ -205,6 +205,9 @@ func TestNewResponse(t *testing.T) {
 					Value:   upstreamTLSProto.Value,
 				},
 			},
+		},
+		CircuitBreakers: &xds_cluster.CircuitBreakers{
+			Thresholds: []*xds_cluster.CircuitBreakers_Thresholds{getDefaultCircuitBreakerThreshold()},
 		},
 	}
 
@@ -215,7 +218,7 @@ func TestNewResponse(t *testing.T) {
 		Name:                          "default/bookstore-v2|80",
 		AltStatName:                   "",
 		ClusterDiscoveryType:          &xds_cluster.Cluster_Type{Type: xds_cluster.Cluster_EDS},
-		TypedExtensionProtocolOptions: HTTP2ProtocolOptions,
+		TypedExtensionProtocolOptions: typedHTTPProtocolOptions,
 		EdsClusterConfig: &xds_cluster.Cluster_EdsClusterConfig{
 			EdsConfig: &xds_core.ConfigSource{
 				ConfigSourceSpecifier: &xds_core.ConfigSource_Ads{
@@ -233,6 +236,9 @@ func TestNewResponse(t *testing.T) {
 					Value:   upstreamTLSProto.Value,
 				},
 			},
+		},
+		CircuitBreakers: &xds_cluster.CircuitBreakers{
+			Thresholds: []*xds_cluster.CircuitBreakers_Thresholds{getDefaultCircuitBreakerThreshold()},
 		},
 	}
 

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -8,8 +8,6 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	extensions_upstream_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
-	"github.com/golang/protobuf/ptypes/any"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/uuid"
@@ -230,25 +228,6 @@ func GetUpstreamTLSContext(downstreamIdentity identity.ServiceIdentity, upstream
 		Sni: upstreamSvc.ServerName(),
 	}
 	return tlsConfig
-}
-
-// GetHTTP2ProtocolOptions creates an Envoy http configuration that matches the downstream protocol
-func GetHTTP2ProtocolOptions() (map[string]*any.Any, error) {
-	marshalledHTTPProtocolOptions, err := anypb.New(
-		&extensions_upstream_http_v3.HttpProtocolOptions{
-			UpstreamProtocolOptions: &extensions_upstream_http_v3.HttpProtocolOptions_UseDownstreamProtocolConfig{
-				UseDownstreamProtocolConfig: &extensions_upstream_http_v3.HttpProtocolOptions_UseDownstreamHttpConfig{
-					Http2ProtocolOptions: &xds_core.Http2ProtocolOptions{},
-				},
-			},
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]*any.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": marshalledHTTPProtocolOptions,
-	}, nil
 }
 
 // GetADSConfigSource creates an Envoy ConfigSource struct.

--- a/pkg/policy/mock_client_generated.go
+++ b/pkg/policy/mock_client_generated.go
@@ -50,6 +50,20 @@ func (mr *MockControllerMockRecorder) GetIngressBackendPolicy(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIngressBackendPolicy", reflect.TypeOf((*MockController)(nil).GetIngressBackendPolicy), arg0)
 }
 
+// GetUpstreamTrafficSetting mocks base method.
+func (m *MockController) GetUpstreamTrafficSetting(arg0 UpstreamTrafficSettingGetOpt) *v1alpha1.UpstreamTrafficSetting {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpstreamTrafficSetting", arg0)
+	ret0, _ := ret[0].(*v1alpha1.UpstreamTrafficSetting)
+	return ret0
+}
+
+// GetUpstreamTrafficSetting indicates an expected call of GetUpstreamTrafficSetting.
+func (mr *MockControllerMockRecorder) GetUpstreamTrafficSetting(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpstreamTrafficSetting", reflect.TypeOf((*MockController)(nil).GetUpstreamTrafficSetting), arg0)
+}
+
 // ListEgressPoliciesForSourceIdentity mocks base method.
 func (m *MockController) ListEgressPoliciesForSourceIdentity(arg0 identity.K8sServiceAccount) []*v1alpha1.Egress {
 	m.ctrl.T.Helper()

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -2,9 +2,11 @@
 package policy
 
 import (
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/k8s"
@@ -49,4 +51,18 @@ type Controller interface {
 
 	// ListRetryPolicies returns the Retry policies for the given source identity
 	ListRetryPolicies(identity.K8sServiceAccount) []*policyV1alpha1.Retry
+
+	// GetUpstreamTrafficSetting returns the UpstreamTrafficSetting resource that matches the given options
+	GetUpstreamTrafficSetting(UpstreamTrafficSettingGetOpt) *policyv1alpha1.UpstreamTrafficSetting
+}
+
+// UpstreamTrafficSettingGetOpt specifies the options used to filter UpstreamTrafficSetting objects as a part of its getter
+type UpstreamTrafficSettingGetOpt struct {
+	// MeshService specifies the mesh service known within the cluster
+	// Must be specified when retrieving a resource matching the upstream
+	// mesh service.
+	MeshService *service.MeshService
+
+	// NamespacedName specifies the name and namespace of the resource
+	NamespacedName *types.NamespacedName
 }

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -5,6 +5,8 @@ package trafficpolicy
 import (
 	mapset "github.com/deckarep/golang-set"
 
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
 	"github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -139,6 +141,9 @@ type MeshClusterConfig struct {
 	// EnableEnvoyActiveHealthChecks enables Envoy's active health checks for the cluster
 	// +optional
 	EnableEnvoyActiveHealthChecks bool
+
+	// UpstreamTrafficSetting is the traffic setting for the upstream cluster
+	UpstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
 }
 
 // TrafficMatch is the type used to represent attributes used to match traffic


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Implements the UpstreamTrafficSetting API for
connection related configurations on clients
connecting to an upstream.

Additionally:
- Updates optional field in API to be a pointer
- Refactors cluster related code wrt protocol
  options
- Disables circuit breaking for upstream clusters
  by default by using max values

Part of #4500

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Tested circuit breaking using a load generator
to exceed connection and request thresholds.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`
