### PR TITLE
feat(metrics): add proxy rejected max connections metric

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -307,6 +307,7 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.HTTPResponseDuration,
 		metricsstore.DefaultMetricsStore.FeatureFlagEnabled,
 		metricsstore.DefaultMetricsStore.ProxyXDSRequestCount,
+		metricsstore.DefaultMetricsStore.ProxyMaxConnectionsRejected,
 	)
 }
 

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -34,6 +34,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 
 	// If maxDataPlaneConnections is enabled i.e. not 0, then check that the number of Envoy connections is less than maxDataPlaneConnections
 	if s.cfg.GetMaxDataPlaneConnections() != 0 && s.proxyRegistry.GetConnectedProxyCount() >= s.cfg.GetMaxDataPlaneConnections() {
+		metricsstore.DefaultMetricsStore.ProxyMaxConnectionsRejected.Inc()
 		return errTooManyConnections
 	}
 

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -52,6 +52,10 @@ type MetricsStore struct {
 	// ProxyXDSRequestCount counts XDS requests made by proxies
 	ProxyXDSRequestCount *prometheus.CounterVec
 
+	// ProxyMaxConnectionsRejected counts the number of proxy connections
+	// rejected due to the max connections limit being reached
+	ProxyMaxConnectionsRejected prometheus.Counter
+
 	/*
 	 * Injector metrics
 	 */
@@ -180,6 +184,13 @@ func init() {
 		Name:      "xds_request_count",
 		Help:      "Represents the number of XDS requests made by proxies",
 	}, []string{"common_name", "type"})
+
+	defaultMetricsStore.ProxyMaxConnectionsRejected = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Subsystem: "proxy",
+		Name:      "max_connections_rejected",
+		Help:      "Represents the number of proxy connections rejected due to the configured max connections limit",
+	})
 
 	/*
 	 * Injector metrics


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the `osm_proxy_max_connections_rejected` metric which
counts the number of proxy connections rejected because of the limit
defined by the MeshConfig's spec.sidecar.maxDataPlaneConnections having
been reached.

Part of #4568 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
This part of the codebase isn't covered by unit tests but I did some manual smoke testing with the whole control plane running.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Yes, https://github.com/openservicemesh/osm-docs/pull/339