### PR TITLE
feat(metrics): add cn/type labels to xds response metrics

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## Release v1.1.0
+
+### Notable changes
+
+None
+
+### Breaking changes
+
+The following changes are not backward compatible with the previous release.
+
+- The `osm_proxy_response_send_success_count` and `osm_proxy_response_send_error_count` metrics are now labeled with the proxy certificate's common name and XDS type, so queries to match the previous equivalent need to sum for all values of each of those labels.
+
+### Deprecation notes
+
+None
+
 ## Release v1.0.0
 
 ### Notable changes

--- a/pkg/envoy/ads/response.go
+++ b/pkg/envoy/ads/response.go
@@ -161,7 +161,7 @@ func (s *Server) SendDiscoveryResponse(proxy *envoy.Proxy, request *xds_discover
 
 	// Send the response
 	if err := (*server).Send(response); err != nil {
-		metricsstore.DefaultMetricsStore.ProxyResponseSendErrorCount.Inc()
+		metricsstore.DefaultMetricsStore.ProxyResponseSendErrorCount.WithLabelValues(proxy.GetCertificateCommonName().String(), string(typeURI)).Inc()
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrSendingDiscoveryResponse)).
 			Str("proxy", proxy.String()).Msgf("Error sending response for typeURI %s to proxy", typeURI.Short())
 		return err
@@ -169,7 +169,7 @@ func (s *Server) SendDiscoveryResponse(proxy *envoy.Proxy, request *xds_discover
 
 	// Sending discovery response succeeded, record last resources sent
 	proxy.SetLastResourcesSent(typeURI, resourcesSent)
-	metricsstore.DefaultMetricsStore.ProxyResponseSendSuccessCount.Inc()
+	metricsstore.DefaultMetricsStore.ProxyResponseSendSuccessCount.WithLabelValues(proxy.GetCertificateCommonName().String(), string(typeURI)).Inc()
 
 	return nil
 }

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -19,6 +19,7 @@ import (
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -142,6 +143,8 @@ var _ = Describe("Test ADS response functions", func() {
 			EnableEgressPolicy: false,
 		}).AnyTimes()
 
+		metricsstore.DefaultMetricsStore.Start(metricsstore.DefaultMetricsStore.ProxyResponseSendSuccessCount)
+
 		It("returns Aggregated Discovery Service response", func() {
 			s := NewADSServer(mc, proxyRegistry, true, tests.Namespace, mockConfigurator, mockCertManager, kubectrlMock, nil)
 
@@ -197,6 +200,8 @@ var _ = Describe("Test ADS response functions", func() {
 				Name:     proxySvcAccount.String(),
 				CertType: secrets.ServiceCertType,
 			}.String()))
+
+			Expect(metricsstore.DefaultMetricsStore.Contains(fmt.Sprintf("osm_proxy_response_send_success_count{common_name=%q,type=%q} 1\n", proxy.GetCertificateCommonName(), envoy.TypeCDS))).To(BeTrue())
 		})
 	})
 

--- a/pkg/httpserver/httpserver_test.go
+++ b/pkg/httpserver/httpserver_test.go
@@ -89,17 +89,10 @@ func TestNewHTTPServer(t *testing.T) {
 	respL := recordCall(testServer, fmt.Sprintf("%s%s", url, invalidRoutePath))
 	assert.Equal(http.StatusNotFound, respL.StatusCode)
 
-	//Metrics path Check
-	req := httptest.NewRequest("GET", fmt.Sprintf("%s%s", url, constants.MetricsPath), nil)
-	w := httptest.NewRecorder()
-	testServer.Config.Handler.ServeHTTP(w, req)
-	respM := w.Result()
-	assert.Equal(http.StatusOK, respM.StatusCode)
-
 	// Ensure added metrics are generated based on previous requests in this
 	// test
-	assert.Contains(w.Body.String(), `osm_http_response_total{code="200",method="get",path="/health/alive"} 1`+"\n")
-	assert.Contains(w.Body.String(), `osm_http_response_duration_bucket{code="200",method="get",path="/health/alive",le="+Inf"} 1`+"\n")
+	assert.True(metricsStore.Contains(`osm_http_response_total{code="200",method="get",path="/health/alive"} 1` + "\n"))
+	assert.True(metricsStore.Contains(`osm_http_response_duration_bucket{code="200",method="get",path="/health/alive",le="+Inf"} 1` + "\n"))
 
 	err := httpServ.Start()
 	assert.Nil(err)


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds `common_name` and `type` labels to the existing
`osm_proxy_response_send_success_count` and
`osm_proxy_response_send_error_count` metrics identifying the proxy and
XDS type for the response.

Example:

    osm_proxy_response_send_success_count{common_name="32029594-2980-408e-b92a-3e5ce5174609.sidecar.bookthief.bookthief.cluster.local",type="type.googleapis.com/envoy.config.cluster.v3.Cluster"} 4

Part of #4568 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Updated unit tests
- Did some manual smoke testing in a cluster

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? Technically yes, release notes updated.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Yes, https://github.com/openservicemesh/osm-docs/pull/340