### PR TITLE
egress: add UpstreamTrafficSetting support

### DIFF
--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -6,15 +6,24 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
+	"github.com/pkg/errors"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
+	"k8s.io/apimachinery/pkg/types"
 
-	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/policy"
+
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+)
+
+const (
+	// upstreamTrafficSettingKind is the upstreamTrafficSettingKind API kind
+	upstreamTrafficSettingKind = "UpstreamTrafficSetting"
 )
 
 // GetEgressTrafficPolicy returns the Egress traffic policy associated with the given service identity
@@ -29,12 +38,18 @@ func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceId
 	egressResources := mc.policyController.ListEgressPoliciesForSourceIdentity(serviceIdentity.ToK8sServiceAccount())
 
 	for _, egress := range egressResources {
+		upstreamTrafficSetting, err := mc.getUpstreamTrafficSettingForEgress(egress)
+		if err != nil {
+			log.Error().Err(err).Msg("Ignoring invalid Egress policy")
+			continue
+		}
+
 		for _, portSpec := range egress.Spec.Ports {
 			switch strings.ToLower(portSpec.Protocol) {
 			case constants.ProtocolHTTP:
 				// ---
 				// Build the HTTP route configs for the given Egress policy
-				httpRouteConfigs, httpClusterConfigs := mc.buildHTTPRouteConfigs(egress, portSpec.Number)
+				httpRouteConfigs, httpClusterConfigs := mc.buildHTTPRouteConfigs(egress, portSpec.Number, upstreamTrafficSetting)
 				portToRouteConfigMap[portSpec.Number] = append(portToRouteConfigMap[portSpec.Number], httpRouteConfigs...)
 				clusterConfigs = append(clusterConfigs, httpClusterConfigs...)
 
@@ -48,8 +63,9 @@ func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceId
 				// ---
 				// Build the TCP cluster config for this port
 				clusterConfigs = append(clusterConfigs, &trafficpolicy.EgressClusterConfig{
-					Name: fmt.Sprintf("%d", portSpec.Number),
-					Port: portSpec.Number,
+					Name:                   fmt.Sprintf("%d", portSpec.Number),
+					Port:                   portSpec.Number,
+					UpstreamTrafficSetting: upstreamTrafficSetting,
 				})
 
 				// Configure port + IP range TrafficMatches
@@ -65,8 +81,9 @@ func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceId
 				// Build the HTTPS cluster config for this port
 				// HTTPS is TLS encrypted, so will be proxied as a TCP stream
 				clusterConfigs = append(clusterConfigs, &trafficpolicy.EgressClusterConfig{
-					Name: fmt.Sprintf("%d", portSpec.Number),
-					Port: portSpec.Number,
+					Name:                   fmt.Sprintf("%d", portSpec.Number),
+					Port:                   portSpec.Number,
+					UpstreamTrafficSetting: upstreamTrafficSetting,
 				})
 
 				// Configure port + IP range TrafficMatches
@@ -105,7 +122,34 @@ func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceId
 	}, nil
 }
 
-func (mc *MeshCatalog) buildHTTPRouteConfigs(egressPolicy *policyV1alpha1.Egress, port int) ([]*trafficpolicy.EgressHTTPRouteConfig, []*trafficpolicy.EgressClusterConfig) {
+func (mc *MeshCatalog) getUpstreamTrafficSettingForEgress(egressPolicy *policyv1alpha1.Egress) (*policyv1alpha1.UpstreamTrafficSetting, error) {
+	if egressPolicy == nil {
+		return nil, nil
+	}
+
+	for _, match := range egressPolicy.Spec.Matches {
+		if match.APIGroup != nil && *match.APIGroup == policyv1alpha1.SchemeGroupVersion.String() && match.Kind == upstreamTrafficSettingKind {
+			namespacedName := types.NamespacedName{
+				Namespace: egressPolicy.Namespace,
+				Name:      match.Name,
+			}
+			upstreamtrafficSetting := mc.policyController.GetUpstreamTrafficSetting(
+				policy.UpstreamTrafficSettingGetOpt{NamespacedName: &namespacedName})
+
+			if upstreamtrafficSetting == nil {
+				return nil, errors.Errorf("UpstreamTrafficSetting %s specified in Egress policy %s/%s could not be found, ignoring it",
+					namespacedName.String(), egressPolicy.Namespace, egressPolicy.Name)
+			}
+
+			return upstreamtrafficSetting, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (mc *MeshCatalog) buildHTTPRouteConfigs(egressPolicy *policyv1alpha1.Egress, port int,
+	upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting) ([]*trafficpolicy.EgressHTTPRouteConfig, []*trafficpolicy.EgressClusterConfig) {
 	if egressPolicy == nil {
 		return nil, nil
 	}
@@ -170,9 +214,10 @@ func (mc *MeshCatalog) buildHTTPRouteConfigs(egressPolicy *policyV1alpha1.Egress
 		// Create cluster config for this host and port combination
 		clusterName := hostnameWithPort
 		clusterConfig := &trafficpolicy.EgressClusterConfig{
-			Name: clusterName,
-			Host: host,
-			Port: port,
+			Name:                   clusterName,
+			Host:                   host,
+			Port:                   port,
+			UpstreamTrafficSetting: upstreamTrafficSetting,
 		}
 		clusterConfigs = append(clusterConfigs, clusterConfig)
 

--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -11,11 +11,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
-	"github.com/openservicemesh/osm/pkg/policy"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
+	"github.com/openservicemesh/osm/pkg/policy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"

--- a/pkg/catalog/egress_test.go
+++ b/pkg/catalog/egress_test.go
@@ -32,13 +32,21 @@ func TestGetEgressTrafficPolicy(t *testing.T) {
 
 	defer mockCtrl.Finish()
 
+	upstreamTrafficSetting := &policyv1alpha1.UpstreamTrafficSetting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "u1",
+			Namespace: "ns1",
+		},
+	}
+
 	testCases := []struct {
-		name                 string
-		egressPolicies       []*policyv1alpha1.Egress
-		egressPort           int
-		httpRouteGroups      []*specs.HTTPRouteGroup
-		expectedEgressPolicy *trafficpolicy.EgressTrafficPolicy
-		expectError          bool
+		name                   string
+		egressPolicies         []*policyv1alpha1.Egress
+		egressPort             int
+		httpRouteGroups        []*specs.HTTPRouteGroup
+		upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
+		expectedEgressPolicy   *trafficpolicy.EgressTrafficPolicy
+		expectError            bool
 	}{
 		{
 			name: "multiple egress policies for HTTP ports",
@@ -335,6 +343,88 @@ func TestGetEgressTrafficPolicy(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "policy with valid UpstreamTrafficSetting match is processed",
+			egressPolicies: []*policyv1alpha1.Egress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: upstreamTrafficSetting.Namespace,
+					},
+					Spec: policyv1alpha1.EgressSpec{
+						Hosts: []string{
+							"foo.com",
+						},
+						Ports: []policyv1alpha1.PortSpec{
+							{
+								Number:   100,
+								Protocol: "https",
+							},
+						},
+						Matches: []corev1.TypedLocalObjectReference{
+							{
+								APIGroup: pointer.StringPtr("policy.openservicemesh.io/v1alpha1"),
+								Kind:     "UpstreamTrafficSetting",
+								Name:     upstreamTrafficSetting.Name,
+							},
+						},
+					},
+				},
+			},
+			httpRouteGroups:        nil, // no SMI HTTP route matches
+			upstreamTrafficSetting: upstreamTrafficSetting,
+			expectedEgressPolicy: &trafficpolicy.EgressTrafficPolicy{
+				TrafficMatches: []*trafficpolicy.TrafficMatch{
+					{
+						DestinationPort:     100,
+						DestinationProtocol: "https",
+						ServerNames:         []string{"foo.com"},
+						Cluster:             "100",
+					},
+				},
+				HTTPRouteConfigsPerPort: map[int][]*trafficpolicy.EgressHTTPRouteConfig{},
+				ClustersConfigs: []*trafficpolicy.EgressClusterConfig{
+					{
+						// Same cluster used for both HTTPS and TCP on port 100
+						Name:                   "100",
+						Port:                   100,
+						UpstreamTrafficSetting: upstreamTrafficSetting,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "policy with invalid UpstreamTrafficSetting match is ignored",
+			egressPolicies: []*policyv1alpha1.Egress{
+				{
+					Spec: policyv1alpha1.EgressSpec{
+						Hosts: []string{
+							"foo.com",
+						},
+						Ports: []policyv1alpha1.PortSpec{
+							{
+								Number:   100,
+								Protocol: "https",
+							},
+						},
+						Matches: []corev1.TypedLocalObjectReference{
+							{
+								APIGroup: pointer.StringPtr("policy.openservicemesh.io/v1alpha1"),
+								Kind:     "UpstreamTrafficSetting",
+								Name:     "invalid",
+							},
+						},
+					},
+				},
+			},
+			httpRouteGroups: nil, // no SMI HTTP route matches
+			expectedEgressPolicy: &trafficpolicy.EgressTrafficPolicy{
+				TrafficMatches:          nil,
+				HTTPRouteConfigsPerPort: map[int][]*trafficpolicy.EgressHTTPRouteConfig{},
+				ClustersConfigs:         nil,
+			},
+			expectError: false,
+		},
 	}
 
 	testSourceIdentity := identity.ServiceIdentity("foo.bar.cluster.local")
@@ -348,6 +438,7 @@ func TestGetEgressTrafficPolicy(t *testing.T) {
 				mockMeshSpec.EXPECT().GetHTTPRouteGroup(fmt.Sprintf("%s/%s", rg.Namespace, rg.Name)).Return(rg).AnyTimes()
 			}
 			mockPolicyController.EXPECT().ListEgressPoliciesForSourceIdentity(gomock.Any()).Return(tc.egressPolicies).Times(1)
+			mockPolicyController.EXPECT().GetUpstreamTrafficSetting(gomock.Any()).Return(tc.upstreamTrafficSetting).AnyTimes()
 
 			mc := &MeshCatalog{
 				meshSpec:         mockMeshSpec,
@@ -371,11 +462,19 @@ func TestBuildHTTPRouteConfigs(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	upstreamTrafficSetting := &policyv1alpha1.UpstreamTrafficSetting{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "u1",
+			Namespace: "ns1",
+		},
+	}
+
 	testCases := []struct {
 		name                   string
 		egressPolicy           *policyv1alpha1.Egress
 		egressPort             int
 		httpRouteGroups        []*specs.HTTPRouteGroup
+		upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
 		expectedRouteConfigs   []*trafficpolicy.EgressHTTPRouteConfig
 		expectedClusterConfigs []*trafficpolicy.EgressClusterConfig
 	}{
@@ -649,21 +748,95 @@ func TestBuildHTTPRouteConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "egress policy with UpstreamTrafficSetting match specified",
+			egressPolicy: &policyv1alpha1.Egress{
+				Spec: policyv1alpha1.EgressSpec{
+					Hosts: []string{
+						"foo.com",
+						"bar.com",
+					},
+					Ports: []policyv1alpha1.PortSpec{
+						{
+							Number:   80,
+							Protocol: "http",
+						},
+					},
+				},
+			},
+			egressPort:             80,
+			httpRouteGroups:        nil, // no matches specified in the egress policy via Spec.Matches
+			upstreamTrafficSetting: upstreamTrafficSetting,
+			expectedRouteConfigs: []*trafficpolicy.EgressHTTPRouteConfig{
+				{
+					Name: "foo.com",
+					Hostnames: []string{
+						"foo.com",
+						"foo.com:80",
+					},
+					RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("foo.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: nil,
+						},
+					},
+				},
+				{
+					Name: "bar.com",
+					Hostnames: []string{
+						"bar.com",
+						"bar.com:80",
+					},
+					RoutingRules: []*trafficpolicy.EgressHTTPRoutingRule{
+						{
+							Route: trafficpolicy.RouteWeightedClusters{
+								HTTPRouteMatch: trafficpolicy.WildCardRouteMatch,
+								WeightedClusters: mapset.NewSetFromSlice([]interface{}{
+									service.WeightedCluster{ClusterName: service.ClusterName("bar.com:80"), Weight: 100},
+								}),
+							},
+							AllowedDestinationIPRanges: nil,
+						},
+					},
+				},
+			},
+			expectedClusterConfigs: []*trafficpolicy.EgressClusterConfig{
+				{
+					Name:                   "foo.com:80",
+					Host:                   "foo.com",
+					Port:                   80,
+					UpstreamTrafficSetting: upstreamTrafficSetting,
+				},
+				{
+					Name:                   "bar.com:80",
+					Host:                   "bar.com",
+					Port:                   80,
+					UpstreamTrafficSetting: upstreamTrafficSetting,
+				},
+			},
+		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
 			mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
+			mockPolicyController := policy.NewMockController(mockCtrl)
 
 			for _, rg := range tc.httpRouteGroups {
 				mockMeshSpec.EXPECT().GetHTTPRouteGroup(fmt.Sprintf("%s/%s", rg.Namespace, rg.Name)).Return(rg).AnyTimes()
 			}
 
 			mc := &MeshCatalog{
-				meshSpec: mockMeshSpec,
+				meshSpec:         mockMeshSpec,
+				policyController: mockPolicyController,
 			}
 
-			routeConfigs, clusterConfigs := mc.buildHTTPRouteConfigs(tc.egressPolicy, tc.egressPort)
+			routeConfigs, clusterConfigs := mc.buildHTTPRouteConfigs(tc.egressPolicy, tc.egressPort, tc.upstreamTrafficSetting)
 			assert.ElementsMatch(tc.expectedRouteConfigs, routeConfigs)
 			assert.ElementsMatch(tc.expectedClusterConfigs, clusterConfigs)
 		})

--- a/pkg/catalog/egress_test.go
+++ b/pkg/catalog/egress_test.go
@@ -825,15 +825,13 @@ func TestBuildHTTPRouteConfigs(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("Running test case %d: %s", i, tc.name), func(t *testing.T) {
 			mockMeshSpec := smi.NewMockMeshSpec(mockCtrl)
-			mockPolicyController := policy.NewMockController(mockCtrl)
 
 			for _, rg := range tc.httpRouteGroups {
 				mockMeshSpec.EXPECT().GetHTTPRouteGroup(fmt.Sprintf("%s/%s", rg.Namespace, rg.Name)).Return(rg).AnyTimes()
 			}
 
 			mc := &MeshCatalog{
-				meshSpec:         mockMeshSpec,
-				policyController: mockPolicyController,
+				meshSpec: mockMeshSpec,
 			}
 
 			routeConfigs, clusterConfigs := mc.buildHTTPRouteConfigs(tc.egressPolicy, tc.egressPort, tc.upstreamTrafficSetting)

--- a/pkg/envoy/cds/response.go
+++ b/pkg/envoy/cds/response.go
@@ -66,7 +66,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, _ *xds_d
 		}
 	}
 
-	outboundPassthroughCluser, err := getOriginalDestinationEgressCluster(envoy.OutboundPassthroughCluster)
+	outboundPassthroughCluser, err := getOriginalDestinationEgressCluster(envoy.OutboundPassthroughCluster, nil)
 	if err != nil {
 		log.Error().Err(err).Str(errcode.Kind, errcode.ErrGettingOrgDstEgressCluster.String()).
 			Msgf("Failed to passthrough cluster for egress for proxy %s", envoy.OutboundPassthroughCluster)

--- a/pkg/trafficpolicy/egress_types.go
+++ b/pkg/trafficpolicy/egress_types.go
@@ -1,5 +1,9 @@
 package trafficpolicy
 
+import (
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+)
+
 // EgressTrafficPolicy is the type used to represent the different egress traffic policy configurations
 // applicable to a client of Egress destinations.
 type EgressTrafficPolicy struct {
@@ -37,6 +41,9 @@ type EgressClusterConfig struct {
 
 	// Port defines the port number of the external cluster's endpoint
 	Port int
+
+	// UpstreamTrafficSetting is the traffic setting for the upstream cluster
+	UpstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
 }
 
 // EgressHTTPRouteConfig is the type used to represent an HTTP route configuration along with associated routing rules

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -8,7 +8,8 @@ import (
 	hashstructure "github.com/mitchellh/hashstructure/v2"
 	"github.com/pkg/errors"
 
-	"github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
@@ -83,7 +84,7 @@ func (in *InboundTrafficPolicy) AddRule(route RouteWeightedClusters, allowedServ
 // AddRoute adds a route to an OutboundTrafficPolicy given an HTTP route match and weighted cluster. If a Route with the given HTTP route match
 //	already exists, an error will be returned. If a Route with the given HTTP route match does not exist,
 //	a Route with the given HTTP route match and weighted clusters will be added to the Routes on the OutboundTrafficPolicy
-func (out *OutboundTrafficPolicy) AddRoute(httpRouteMatch HTTPRouteMatch, retryPolicy *v1alpha1.RetryPolicySpec, weightedClusters ...service.WeightedCluster) error {
+func (out *OutboundTrafficPolicy) AddRoute(httpRouteMatch HTTPRouteMatch, retryPolicy *policyv1alpha1.RetryPolicySpec, weightedClusters ...service.WeightedCluster) error {
 	wc := mapset.NewSet()
 	for _, c := range weightedClusters {
 		wc.Add(c)

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -157,7 +157,7 @@ func egressValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionR
 				// no additional validation
 
 			default:
-				return nil, errors.Errorf("Expected 'Matches.Kind' for match '%s' to be 'HTTPRouteGroup', got: %s", m.Name, m.Kind)
+				return nil, errors.Errorf("Expected 'matches.kind' for match '%s' to be 'HTTPRouteGroup', got: %s", m.Name, m.Kind)
 			}
 
 		case policyv1alpha1.SchemeGroupVersion.String():
@@ -166,11 +166,11 @@ func egressValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionR
 				upstreamTrafficSettingMatchCount++
 
 			default:
-				return nil, errors.Errorf("Expected 'Matches.Kind' for match '%s' to be 'UpstreamTrafficSetting', got: %s", m.Name, m.Kind)
+				return nil, errors.Errorf("Expected 'matches.kind' for match '%s' to be 'UpstreamTrafficSetting', got: %s", m.Name, m.Kind)
 			}
 
 		default:
-			return nil, errors.Errorf("Expected 'Matches.APIGroup' to be one of %v, got: %s", allowedAPIGroups, *m.APIGroup)
+			return nil, errors.Errorf("Expected 'matches.apiGroup' to be one of %v, got: %s", allowedAPIGroups, *m.APIGroup)
 		}
 	}
 

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -493,9 +493,8 @@ func TestEgressValidator(t *testing.T) {
 					`),
 				},
 			},
-
 			expResp:   nil,
-			expErrStr: "Expected 'Matches.Kind' to be 'HTTPRouteGroup', got: BadHttpRoute",
+			expErrStr: "Expected 'Matches.APIGroup' to be one of [specs.smi-spec.io/v1alpha4 policy.openservicemesh.io/v1alpha1], got: v1alpha1",
 		},
 		{
 			name: "Egress with bad API group fails",
@@ -523,9 +522,8 @@ func TestEgressValidator(t *testing.T) {
 					`),
 				},
 			},
-
 			expResp:   nil,
-			expErrStr: "Expected 'Matches.APIGroup' to be 'specs.smi-spec.io/v1alpha4', got: test",
+			expErrStr: "Expected 'Matches.APIGroup' to be one of [specs.smi-spec.io/v1alpha4 policy.openservicemesh.io/v1alpha1], got: test",
 		},
 		{
 			name: "Egress with valid http route and API group passes",
@@ -553,9 +551,71 @@ func TestEgressValidator(t *testing.T) {
 					`),
 				},
 			},
-
 			expResp:   nil,
 			expErrStr: "",
+		},
+		{
+			name: "Egress with valid UpstreamTrafficSetting match",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "Egress",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"matches": [
+								{
+								"apiGroup": "policy.openservicemesh.io/v1alpha1",
+								"kind": "UpstreamTrafficSetting",
+								"name": "foo"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "",
+		},
+		{
+			name: "Egress with multiple UpstreamTrafficSetting matches is invalid",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "Egress",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "v1alpha1",
+						"kind": "Egress",
+						"spec": {
+							"matches": [
+								{
+								"apiGroup": "policy.openservicemesh.io/v1alpha1",
+								"kind": "UpstreamTrafficSetting",
+								"name": "foo"
+								},
+								{
+								"apiGroup": "policy.openservicemesh.io/v1alpha1",
+								"kind": "UpstreamTrafficSetting",
+								"name": "bar"
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "Cannot have more than 1 UpstreamTrafficSetting match",
 		},
 	}
 

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -468,7 +468,7 @@ func TestEgressValidator(t *testing.T) {
 		expErrStr string
 	}{
 		{
-			name: "Egress with bad http route fails",
+			name: "matches.apiGroup is invalid",
 			input: &admissionv1.AdmissionRequest{
 				Kind: metav1.GroupVersionKind{
 					Group:   "v1alpha1",
@@ -483,7 +483,7 @@ func TestEgressValidator(t *testing.T) {
 						"spec": {
 							"matches": [
 								{
-								"apiGroup": "v1alpha1",
+								"apiGroup": "invalid",
 								"kind": "BadHttpRoute",
 								"name": "Name"
 								}
@@ -494,36 +494,7 @@ func TestEgressValidator(t *testing.T) {
 				},
 			},
 			expResp:   nil,
-			expErrStr: "Expected 'Matches.APIGroup' to be one of [specs.smi-spec.io/v1alpha4 policy.openservicemesh.io/v1alpha1], got: v1alpha1",
-		},
-		{
-			name: "Egress with bad API group fails",
-			input: &admissionv1.AdmissionRequest{
-				Kind: metav1.GroupVersionKind{
-					Group:   "v1alpha1",
-					Version: "policy.openservicemesh.io",
-					Kind:    "Egress",
-				},
-				Object: runtime.RawExtension{
-					Raw: []byte(`
-					{
-						"apiVersion": "v1alpha1",
-						"kind": "Egress",
-						"spec": {
-							"matches": [
-								{
-								"apiGroup": "test",
-								"kind": "HTTPRouteGroup",
-								"name": "Name"
-								}
-							]
-						}
-					}
-					`),
-				},
-			},
-			expResp:   nil,
-			expErrStr: "Expected 'Matches.APIGroup' to be one of [specs.smi-spec.io/v1alpha4 policy.openservicemesh.io/v1alpha1], got: test",
+			expErrStr: "Expected 'matches.apiGroup' to be one of [specs.smi-spec.io/v1alpha4 policy.openservicemesh.io/v1alpha1], got: invalid",
 		},
 		{
 			name: "Egress with valid http route and API group passes",


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Implements capability to apply UpstreamTrafficSetting
  configuration to an Egress destination.

- Refactors CDS to reuse code related to connection
  settings.

- Updates validation webhook for Egress API

Part of #4500

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Testing circuit breaker for Egress traffic. 
Sample config:
```
apiVersion: policy.openservicemesh.io/v1alpha1
kind: UpstreamTrafficSetting
metadata:
  name: httpbin-http
  namespace: fortio
spec:
  host: httpbin.org
  connectionSettings:
    tcp:
      maxConnections: 1
    http:
      maxPendingRequests: 1
      maxRequestsPerConnection: 1
---
kind: Egress
apiVersion: policy.openservicemesh.io/v1alpha1
metadata:
  name: httpbin-ext
  namespace: fortio
spec:
  sources:
  - kind: ServiceAccount
    name: default
    namespace: fortio
  hosts:
  - httpbin.org
  ports:
  - number: 14001
    protocol: http
  matches:
  - apiGroup: policy.openservicemesh.io/v1alpha1
    kind: UpstreamTrafficSetting
    name: httpbin-http
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`