### PR TITLE
Allow custom image names for OSM Helm chart

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -114,6 +114,14 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.image.digest.osmInjector | string | `""` | osm-injector's image digest |
 | osm.image.digest.osmPreinstall | string | `""` | osm-preinstall's image digest |
 | osm.image.digest.osmSidecarInit | string | `""` | Sidecar init container's image digest |
+| osm.image.name | object | `{"osmBootstrap":"osm-bootstrap","osmCRDs":"osm-crds","osmController":"osm-controller","osmHealthcheck":"osm-healthcheck","osmInjector":"osm-injector","osmPreinstall":"osm-preinstall","osmSidecarInit":"init"}` | Image name defaults |
+| osm.image.name.osmBootstrap | string | `"osm-bootstrap"` | osm-boostrap's image name |
+| osm.image.name.osmCRDs | string | `"osm-crds"` | osm-crds' image name |
+| osm.image.name.osmController | string | `"osm-controller"` | osm-controller's image name |
+| osm.image.name.osmHealthcheck | string | `"osm-healthcheck"` | osm-healthcheck's image name |
+| osm.image.name.osmInjector | string | `"osm-injector"` | osm-injector's image name |
+| osm.image.name.osmPreinstall | string | `"osm-preinstall"` | osm-preinstall's image name |
+| osm.image.name.osmSidecarInit | string | `"init"` | Sidecar init container's image name |
 | osm.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy for control plane containers |
 | osm.image.registry | string | `"openservicemesh"` | Container image registry for control plane images |
 | osm.image.tag | string | `"latest-main"` | Container image tag for control plane images |

--- a/charts/osm/templates/_helpers.tpl
+++ b/charts/osm/templates/_helpers.tpl
@@ -43,62 +43,62 @@ securityContext:
 {{/* osm-controller image */}}
 {{- define "osmController.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/osm-controller:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmController .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/osm-controller@%s" .Values.osm.image.registry .Values.osm.image.digest.osmController -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmController .Values.osm.image.digest.osmController -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-injector image */}}
 {{- define "osmInjector.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/osm-injector:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmInjector .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/osm-injector@%s" .Values.osm.image.registry .Values.osm.image.digest.osmInjector -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmInjector .Values.osm.image.digest.osmInjector -}}
 {{- end -}}
 {{- end -}}
 
 {{/* Sidecar init image */}}
 {{- define "osmSidecarInit.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/init:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmSidecarInit .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/init@%s" .Values.osm.image.registry .Values.osm.image.digest.osmSidecarInit -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmSidecarInit .Values.osm.image.digest.osmSidecarInit -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-bootstrap image */}}
 {{- define "osmBootstrap.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/osm-bootstrap:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmBootstrap .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/osm-bootstrap@%s" .Values.osm.image.registry .Values.osm.image.digest.osmBootstrap -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmBootstrap .Values.osm.image.digest.osmBootstrap -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-crds image */}}
 {{- define "osmCRDs.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/osm-crds:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmCRDs .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/osm-crds@%s" .Values.osm.image.registry .Values.osm.image.digest.osmCRDs -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmCRDs .Values.osm.image.digest.osmCRDs -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-preinstall image */}}
 {{- define "osmPreinstall.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/osm-preinstall:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmPreinstall .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/osm-preinstall@%s" .Values.osm.image.registry .Values.osm.image.digest.osmPreinstall -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmPreinstall .Values.osm.image.digest.osmPreinstall -}}
 {{- end -}}
 {{- end -}}
 
 {{/* osm-healthcheck image */}}
 {{- define "osmHealthcheck.image" -}}
 {{- if .Values.osm.image.tag -}}
-{{- printf "%s/osm-healthcheck:%s" .Values.osm.image.registry .Values.osm.image.tag -}}
+{{- printf "%s/%s:%s" .Values.osm.image.registry .Values.osm.image.name.osmHealthcheck .Values.osm.image.tag -}}
 {{- else -}}
-{{- printf "%s/osm-healthcheck@%s" .Values.osm.image.registry .Values.osm.image.digest.osmHealthcheck -}}
+{{- printf "%s/%s@%s" .Values.osm.image.registry .Values.osm.image.name.osmHealthcheck .Values.osm.image.digest.osmHealthcheck -}}
 {{- end -}}
 {{- end -}}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -250,6 +250,7 @@
                     ],
                     "required": [
                         "registry",
+                        "name",
                         "pullPolicy",
                         "tag",
                         "digest"
@@ -263,6 +264,65 @@
                             "examples": [
                                 "openservicemesh"
                             ]
+                        },
+                        "name": {
+                            "$id": "#/properties/osm/properties/image/properties/name",
+                            "type": "object",
+                            "title": "Default image names",
+                            "description": "Default image names for control plane.",
+                            "required": [
+                                "osmController",
+                                "osmInjector",
+                                "osmSidecarInit",
+                                "osmBootstrap",
+                                "osmCRDs",
+                                "osmPreinstall",
+                                "osmHealthcheck"
+                            ],
+                            "properties": {
+                                "osmController": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmController",
+                                    "type": "string",
+                                    "title": "osm-controller's image names",
+                                    "description": "osm-controller container's image names."
+                                },
+                                "osmInjector": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmInjector",
+                                    "type": "string",
+                                    "title": "osm-injector's image name",
+                                    "description": "osm-injector container's image name."
+                                },
+                                "osmSidecarInit": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmSidecarInit",
+                                    "type": "string",
+                                    "title": "osm-osmSidecarInit's image name",
+                                    "description": "osm-osmSidecarInit container's image name."
+                                },
+                                "osmBootstrap": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmBootstrap",
+                                    "type": "string",
+                                    "title": "osm-boostrap's image name",
+                                    "description": "osm-bootstrap container's image name."
+                                },
+                                "osmCRDs": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmCRDs",
+                                    "type": "string",
+                                    "title": "osm-crds' image name",
+                                    "description": "osm-crds container's image name."
+                                },
+                                "osmPreinstall": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmPreinstall",
+                                    "type": "string",
+                                    "title": "osm-preinstall's image name",
+                                    "description": "osm-preinstall container's image name."
+                                },
+                                "osmHealthcheck": {
+                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmHealthcheck",
+                                    "type": "string",
+                                    "title": "osm-healthcheck's image name",
+                                    "description": "osm-healthcheck container's image name."
+                                }
+                            }
                         },
                         "pullPolicy": {
                             "$id": "#/properties/osm/properties/image/properties/pullPolicy",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -13,6 +13,22 @@ osm:
     pullPolicy: IfNotPresent
     # -- Container image tag for control plane images
     tag: "latest-main"
+    # -- Image name defaults
+    name:
+      # -- osm-controller's image name
+      osmController: osm-controller
+      # -- osm-injector's image name
+      osmInjector: osm-injector
+      # -- Sidecar init container's image name
+      osmSidecarInit: init
+      # -- osm-boostrap's image name
+      osmBootstrap: osm-bootstrap
+      # -- osm-crds' image name
+      osmCRDs: osm-crds
+      # -- osm-preinstall's image name
+      osmPreinstall: osm-preinstall
+      # -- osm-healthcheck's image name
+      osmHealthcheck: osm-healthcheck
     # -- Image digest (defaults to latest compatible tag)
     digest:
       # -- osm-controller's image digest


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Map image name in values.yaml and resolves #4331

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Install                    | [ x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?