### PR TITLE
fix(logs): add missing Msg calls to logs

### DIFF
--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -77,14 +77,16 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csr, certPrivKey)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrCreatingCertReq))
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrCreatingCertReq)).
+			Msg("error creating certificate request")
 		return nil, fmt.Errorf("error creating x509 certificate request: %s", err)
 	}
 
 	csrPEM, err := certificate.EncodeCertReqDERtoPEM(csrDER)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
-		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM))
+		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM)).
+			Msg("error encoding cert request DER to PEM")
 		return nil, fmt.Errorf("failed to encode certificate request DER to PEM CN=%s: %s", cn, err)
 	}
 

--- a/pkg/debugger/policy.go
+++ b/pkg/debugger/policy.go
@@ -23,7 +23,7 @@ func (ds DebugConfig) getOSMConfigHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		confJSON, err := ds.configurator.GetMeshConfigJSON()
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Msg("error getting MeshConfig JSON")
 			return
 		}
 		_, _ = fmt.Fprint(w, confJSON)

--- a/pkg/debugger/port_forward.go
+++ b/pkg/debugger/port_forward.go
@@ -37,7 +37,7 @@ func (ds DebugConfig) forwardPort(req portForward) {
 
 	transport, upgrader, err := spdy.RoundTripperFor(ds.kubeConfig)
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Msg("error getting spdy RoundTripper")
 	}
 
 	client := &http.Client{Transport: transport}
@@ -52,10 +52,10 @@ func (ds DebugConfig) forwardPort(req portForward) {
 		streams.ErrOut,
 	)
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Msg("error initializing port forward")
 	}
 
 	if err = fw.ForwardPorts(); err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Msgf("error starting port forward")
 	}
 }


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Log calls that don't include `.Msg()` or `.Msgf()` never get logged.
This change adds these where I could find they were missing.

Demo: https://go.dev/play/p/zaZ58Teo7y3

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- See Go playground link above
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A