### PR TITLE
ref(webhook): remove leaf cert from webhook cabundles

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -83,7 +83,7 @@ spec:
             - >
              kubectl replace -f /osm-crds;
              kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
-             kubectl delete --ignore-not-found secret -n '{{ include "osm.namespace" . }}' {{ .Values.osm.caBundleSecretName }} mutating-webhook-cert-secret validating-webhook-cert-secret crd-converter-cert-secret;
+             kubectl delete --ignore-not-found secret -n '{{ include "osm.namespace" . }}' {{ .Values.osm.caBundleSecretName }};
              kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found;
              kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-controller --ignore-not-found;
       nodeSelector:

--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -331,9 +331,6 @@ func (d *uninstallMeshCmd) uninstallValidatingWebhookConfigurations() error {
 func (d *uninstallMeshCmd) uninstallSecrets() error {
 	secrets := []string{
 		d.caBundleSecretName,
-		constants.CrdConverterCertificateSecretName,
-		constants.MutatingWebhookCertificateSecretName,
-		constants.ValidatingWebhookCertificateSecretName,
 	}
 
 	var failedDeletions []string

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -451,27 +451,6 @@ func TestUninstallClusterWideResources(t *testing.T) {
 						Namespace: testNamespace,
 					},
 				},
-				// OSM Secret
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.CrdConverterCertificateSecretName,
-						Namespace: testNamespace,
-					},
-				},
-				// OSM Secret
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.MutatingWebhookCertificateSecretName,
-						Namespace: testNamespace,
-					},
-				},
-				// OSM Secret
-				&corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      constants.ValidatingWebhookCertificateSecretName,
-						Namespace: testNamespace,
-					},
-				},
 				// non-OSM Secret
 				&corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -100,15 +100,6 @@ const (
 	// DefaultCABundleSecretName is the default name of the secret for the OSM CA bundle
 	DefaultCABundleSecretName = "osm-ca-bundle" // #nosec G101: Potential hardcoded credentials
 
-	// MutatingWebhookCertificateSecretName is the default value for mutating webhook secret name
-	MutatingWebhookCertificateSecretName = "mutating-webhook-cert-secret"
-
-	// ValidatingWebhookCertificateSecretName is the default value for validating webhook secret name
-	ValidatingWebhookCertificateSecretName = "validating-webhook-cert-secret" // #nosec G101: Potential hardcoded credentials
-
-	// CrdConverterCertificateSecretName is the default value for conversion webhook secret name
-	CrdConverterCertificateSecretName = "crd-converter-cert-secret" // #nosec G101: Potential hardcoded credentials
-
 	// RegexMatchAll is a regex pattern match for all
 	RegexMatchAll = ".*"
 

--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/certificate/providers"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -58,13 +57,6 @@ func NewConversionWebhook(config Config, kubeClient kubernetes.Interface, crdCli
 		constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing certificate for the crd-converter: %+v", err)
-	}
-
-	// The following function ensures to atomically create or get the certificate from Kubernetes
-	// secret API store. Multiple instances should end up with the same crdConversionwebhookHandlerCert after this function executed.
-	crdConversionWebhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.CrdConverterCertificateSecretName, crdConversionWebhookHandlerCert, kubeClient)
-	if err != nil {
-		return errors.Errorf("Error fetching crd-converter certificate from k8s secret: %s", err)
 	}
 
 	crdWh := crdConversionWebhook{
@@ -189,7 +181,7 @@ func updateCrdConfiguration(cert *certificate.Certificate, crdClient apiclient.A
 					Port:      pointer.Int32(constants.CRDConversionWebhookPort),
 					Path:      &crdConversionPath,
 				},
-				CABundle: cert.GetCertificateChain(),
+				CABundle: cert.GetIssuingCA(),
 			},
 			ConversionReviewVersions: conversionReviewVersions,
 		},

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -88,7 +88,7 @@ func TestUpdateCrdConfiguration(t *testing.T) {
 
 			crd := crds.Items[0]
 			assert.Equal(crd.Spec.Conversion.Strategy, apiv1.WebhookConverter)
-			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, []byte("chain"))
+			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, []byte("ca"))
 			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Namespace, tests.Namespace)
 			assert.Equal(crd.Spec.Conversion.Webhook.ClientConfig.Service.Name, constants.OSMBootstrapName)
 			assert.Equal(crd.Spec.Conversion.Webhook.ConversionReviewVersions, conversionReviewVersions)

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -77,7 +77,7 @@ func TestCreateMutatingWebhook(t *testing.T) {
 	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Name, constants.OSMInjectorName)
 	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Path, &webhookPath)
 	assert.Equal(wh.Webhooks[0].ClientConfig.Service.Port, &webhookPort)
-	assert.Equal(wh.Webhooks[0].ClientConfig.CABundle, []byte("chain"))
+	assert.Equal(wh.Webhooks[0].ClientConfig.CABundle, []byte("ca"))
 
 	assert.Equal(wh.Webhooks[0].NamespaceSelector.MatchLabels[constants.OSMKubeResourceMonitorAnnotation], meshName)
 	assert.EqualValues(wh.Webhooks[0].NamespaceSelector.MatchExpressions, []metav1.LabelSelectorRequirement{

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -76,7 +76,7 @@ func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert *certi
 						Path:      &webhookPath,
 						Port:      &webhookPort,
 					},
-					CABundle: cert.GetCertificateChain()},
+					CABundle: cert.GetIssuingCA()},
 				FailurePolicy: &failurePolicy,
 				MatchPolicy:   &matchPolicy,
 				NamespaceSelector: &metav1.LabelSelector{

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -15,7 +15,6 @@ import (
 
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/certificate/providers"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/webhook"
@@ -45,13 +44,6 @@ func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName 
 		constants.XDSCertificateValidityPeriod)
 	if err != nil {
 		return errors.Errorf("Error issuing certificate for the validating webhook: %+v", err)
-	}
-
-	// The following function ensures to atomically create or get the certificate from Kubernetes
-	// secret API store. Multiple instances should end up with the same webhookHandlerCert after this function executed.
-	webhookHandlerCert, err = providers.GetCertificateFromSecret(osmNamespace, constants.ValidatingWebhookCertificateSecretName, webhookHandlerCert, kubeClient)
-	if err != nil {
-		return errors.Errorf("Error fetching webhook certificate from k8s secret: %s", err)
 	}
 
 	v := &validatingWebhookServer{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Currently, the `CABundles` in the Validating, Conversion, and Mutating Webhook Configurations are set to the cert chains of the webhook certificates. The cert chains include the root, intermediate, and leaf certificates and the cabundles typically only include the root and intermediate certificates.

As described in #2650, Kubernetes secrets for the webhook certs were used to resolve a race condition on webhook certificate creation. Since the `CABundles` included the leaf certificates and each webhook had its own certificate, the Kubernetes API would only be able to successfully validate one webhook server instance of each type. All other webhook instances would receive no requests.

This change sets the `CABundle` for each Webhook Configuration to be the IssuingCA rather than the CertChain. As a result, the Kubernetes secrets for the webhook certificates are no longer necessary.

Resolves #4602 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- verified that the conversion and admission requests successfully go to multiple webhook instances when the `CABundle` is set to `cert.GetIssuingCA()`
- verified that the race condition scenario described in #2650
  - when the `CABundle` on the Webhook Configuration is set to `cert.GetCertificateChain()` and no Kubernetes secrets are created for the webhook certificates
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [x] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No, must update `certificate.md` in the osm-docs repo and `certificate_management.md` in the osm repo