### PR TITLE
feat(metrics): add conversion webhook metrics

### DIFF
--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -163,6 +163,9 @@ func main() {
 	// Start the default metrics store
 	metricsstore.DefaultMetricsStore.Start(
 		metricsstore.DefaultMetricsStore.ErrCodeCounter,
+		metricsstore.DefaultMetricsStore.HTTPResponseTotal,
+		metricsstore.DefaultMetricsStore.HTTPResponseDuration,
+		metricsstore.DefaultMetricsStore.ConversionWebhookResourceTotal,
 	)
 
 	msgBroker := messaging.NewBroker(stop)

--- a/pkg/crdconversion/framework_test.go
+++ b/pkg/crdconversion/framework_test.go
@@ -14,6 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
 func TestServe(t *testing.T) {
@@ -36,6 +38,8 @@ func TestServe(t *testing.T) {
 
 		return w, res
 	}
+
+	metricsstore.DefaultMetricsStore.Start(metricsstore.DefaultMetricsStore.ConversionWebhookResourceTotal)
 
 	req := &v1beta1.ConversionRequest{
 		DesiredAPIVersion: "any.group/v1",
@@ -79,6 +83,9 @@ func TestServe(t *testing.T) {
 	a.Equal(metav1.StatusSuccess, res.Response.Result.Status)
 	a.Len(res.Response.ConvertedObjects, 2)
 
+	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_conversion_webhook_resource_total{from_version="any.group/v2",kind="SomeKind",success="true",to_version="any.group/v1"} 1` + "\n"))
+	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_conversion_webhook_resource_total{from_version="any.group/v3",kind="SomeKind",success="true",to_version="any.group/v1"} 1` + "\n"))
+
 	// failing conversion
 	w, res = runServe(req, failConvert)
 
@@ -87,6 +94,9 @@ func TestServe(t *testing.T) {
 	a.Len(res.Response.ConvertedObjects, 0)
 	a.Equal("fail; fail", res.Response.Result.Message)
 
+	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_conversion_webhook_resource_total{from_version="any.group/v2",kind="SomeKind",success="false",to_version="any.group/v1"} 1` + "\n"))
+	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_conversion_webhook_resource_total{from_version="any.group/v3",kind="SomeKind",success="false",to_version="any.group/v1"} 1` + "\n"))
+
 	// partially successful conversion
 	w, res = runServe(req, v2FailV3OkConvert)
 
@@ -94,4 +104,36 @@ func TestServe(t *testing.T) {
 	a.Equal(metav1.StatusFailure, res.Response.Result.Status)
 	a.Len(res.Response.ConvertedObjects, 0)
 	a.Equal("fail", res.Response.Result.Message)
+
+	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_conversion_webhook_resource_total{from_version="any.group/v2",kind="SomeKind",success="false",to_version="any.group/v1"} 2` + "\n"))
+	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_conversion_webhook_resource_total{from_version="any.group/v3",kind="SomeKind",success="false",to_version="any.group/v1"} 2` + "\n"))
+}
+
+func TestDoConversionBadObjectJSON(t *testing.T) {
+	req := &v1beta1.ConversionRequest{
+		DesiredAPIVersion: "any.group/v1",
+		Objects: []runtime.RawExtension{
+			{
+				Raw: []byte(`{`),
+			},
+			{
+				Raw: []byte(`{
+						"apiVersion": "any.group/v3",
+						"kind": "SomeKind"
+					}`),
+			},
+		},
+	}
+	okConvert := func(in *unstructured.Unstructured, _ string) (*unstructured.Unstructured, error) {
+		return in.DeepCopy(), nil
+	}
+
+	res := doConversion(req, okConvert)
+
+	a := assert.New(t)
+
+	a.Equal(metav1.StatusFailure, res.Result.Status)
+	a.Contains(res.Result.Message, "unexpected EOF")
+	// Remaining objects still get parsed
+	a.NotNil(req.Objects[1].Object)
 }

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -62,6 +62,10 @@ type MetricsStore struct {
 	// generated for both validating and mutating webhooks
 	AdmissionWebhookResponseTotal *prometheus.CounterVec
 
+	// ConversionWebhookResponseTotal counts the resources converted by
+	// conversion webhooks
+	ConversionWebhookResourceTotal *prometheus.CounterVec
+
 	/*
 	 * Certificate metrics
 	 */
@@ -194,6 +198,12 @@ func init() {
 		Name:      "admission_webhook_response_total",
 		Help:      "Counter for responses sent by admission webhooks",
 	}, []string{"kind", "success"})
+
+	defaultMetricsStore.ConversionWebhookResourceTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: metricsRootNamespace,
+		Name:      "conversion_webhook_resource_total",
+		Help:      "Counter for resources converted by conversion webhooks",
+	}, []string{"kind", "from_version", "to_version", "success"})
 
 	/*
 	 * Certificate metrics


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds the `osm_conversion_webhook_resource_total` metric to
count custom resource conversions between API versions.

Part of #4568

Example:

    osm_conversion_webhook_resource_total{from_version="config.openservicemesh.io/v1alpha1",kind="MeshConfig",success="true",to_version="config.openservicemesh.io/v1alpha2"} 1

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Updated unit tests
- Did some manual smoke testing with the whole control plane running and creating/updating/deleting a v1alpha1 MeshConfig
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Yes, https://github.com/openservicemesh/osm-docs/pull/344