### PR TITLE
docs: update release notes for v1.1.0

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,7 +4,7 @@
 
 ### Notable changes
 
-None
+- Circuit breaking support for traffic directed to in-mesh and external destinations
 
 ### Breaking changes
 
@@ -17,6 +17,7 @@ The following changes are not backward compatible with the previous release.
 The following capabilities have been deprecated and cannot be used.
 
 - The `osm_injector_injector_sidecar_count` and `osm_injector_injector_rq_time` metrics have been removed. The `osm_admission_webhook_response_total` and `osm_http_response_duration` metrics should be used instead.
+- OSM will no longer support installation on Kubernetes version v1.19.
 
 ## Release v1.0.0
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates the release notes corresponding
to the following changes:
- 97c6395b: regarding k8s version v1.19
- fe049570, 7ecd8e9e: circuit breaking

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Documentation              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `yet to be done`