### PR TITLE
apis/UpstreamTrafficSetting: allow setting status

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -61,7 +61,7 @@ rules:
     resources: ["egresses", "ingressbackends", "retries", "upstreamtrafficsettings"]
     verbs: ["list", "get", "watch"]
   - apiGroups: ["policy.openservicemesh.io"]
-    resources: ["ingressbackends/status"]
+    resources: ["ingressbackends/status", "upstreamtrafficsettings/status"]
     verbs: ["update"]
 
   # Used for interacting with cert-manager CertificateRequest resources.

--- a/pkg/apis/policy/v1alpha1/upstreamtrafficsetting.go
+++ b/pkg/apis/policy/v1alpha1/upstreamtrafficsetting.go
@@ -7,7 +7,6 @@ import (
 // UpstreamTrafficSetting defines the settings applicable to traffic destined
 // to an upstream host.
 // +genclient
-// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type UpstreamTrafficSetting struct {
 	// Object's type metadata
@@ -20,6 +19,10 @@ type UpstreamTrafficSetting struct {
 	// Spec is the UpstreamTrafficSetting policy specification
 	// +optional
 	Spec UpstreamTrafficSettingSpec `json:"spec,omitempty"`
+
+	// Status is the status of the UpstreamTrafficSetting resource.
+	// +optional
+	Status UpstreamTrafficSettingStatus `json:"status,omitempty"`
 }
 
 // UpstreamTrafficSettingSpec defines the upstream traffic setting specification.
@@ -35,10 +38,6 @@ type UpstreamTrafficSettingSpec struct {
 	// directed to the upstream host.
 	// +optional
 	ConnectionSettings *ConnectionSettingsSpec `json:"connectionSettings,omitempty"`
-
-	// Status is the status of the UpstreamTrafficSetting resource.
-	// +optional
-	Status UpstreamTrafficSettingStatus `json:"status,omitempty"`
 }
 
 // ConnectionSettingsSpec defines the connection settings for an

--- a/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1alpha1/zz_generated.deepcopy.go
@@ -535,6 +535,7 @@ func (in *UpstreamTrafficSetting) DeepCopyInto(out *UpstreamTrafficSetting) {
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.Spec.DeepCopyInto(&out.Spec)
+	out.Status = in.Status
 	return
 }
 
@@ -597,7 +598,6 @@ func (in *UpstreamTrafficSettingSpec) DeepCopyInto(out *UpstreamTrafficSettingSp
 		*out = new(ConnectionSettingsSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	out.Status = in.Status
 	return
 }
 

--- a/pkg/gen/client/policy/clientset/versioned/typed/policy/v1alpha1/fake/fake_upstreamtrafficsetting.go
+++ b/pkg/gen/client/policy/clientset/versioned/typed/policy/v1alpha1/fake/fake_upstreamtrafficsetting.go
@@ -99,6 +99,18 @@ func (c *FakeUpstreamTrafficSettings) Update(ctx context.Context, upstreamTraffi
 	return obj.(*v1alpha1.UpstreamTrafficSetting), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeUpstreamTrafficSettings) UpdateStatus(ctx context.Context, upstreamTrafficSetting *v1alpha1.UpstreamTrafficSetting, opts v1.UpdateOptions) (*v1alpha1.UpstreamTrafficSetting, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(upstreamtrafficsettingsResource, "status", c.ns, upstreamTrafficSetting), &v1alpha1.UpstreamTrafficSetting{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.UpstreamTrafficSetting), err
+}
+
 // Delete takes name of the upstreamTrafficSetting and deletes it. Returns an error if one occurs.
 func (c *FakeUpstreamTrafficSettings) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.

--- a/pkg/gen/client/policy/clientset/versioned/typed/policy/v1alpha1/upstreamtrafficsetting.go
+++ b/pkg/gen/client/policy/clientset/versioned/typed/policy/v1alpha1/upstreamtrafficsetting.go
@@ -37,6 +37,7 @@ type UpstreamTrafficSettingsGetter interface {
 type UpstreamTrafficSettingInterface interface {
 	Create(ctx context.Context, upstreamTrafficSetting *v1alpha1.UpstreamTrafficSetting, opts v1.CreateOptions) (*v1alpha1.UpstreamTrafficSetting, error)
 	Update(ctx context.Context, upstreamTrafficSetting *v1alpha1.UpstreamTrafficSetting, opts v1.UpdateOptions) (*v1alpha1.UpstreamTrafficSetting, error)
+	UpdateStatus(ctx context.Context, upstreamTrafficSetting *v1alpha1.UpstreamTrafficSetting, opts v1.UpdateOptions) (*v1alpha1.UpstreamTrafficSetting, error)
 	Delete(ctx context.Context, name string, opts v1.DeleteOptions) error
 	DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*v1alpha1.UpstreamTrafficSetting, error)
@@ -125,6 +126,22 @@ func (c *upstreamTrafficSettings) Update(ctx context.Context, upstreamTrafficSet
 		Namespace(c.ns).
 		Resource("upstreamtrafficsettings").
 		Name(upstreamTrafficSetting.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Body(upstreamTrafficSetting).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *upstreamTrafficSettings) UpdateStatus(ctx context.Context, upstreamTrafficSetting *v1alpha1.UpstreamTrafficSetting, opts v1.UpdateOptions) (result *v1alpha1.UpstreamTrafficSetting, err error) {
+	result = &v1alpha1.UpstreamTrafficSetting{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("upstreamtrafficsettings").
+		Name(upstreamTrafficSetting.Name).
+		SubResource("status").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(upstreamTrafficSetting).
 		Do(ctx).

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -333,6 +333,10 @@ func (c client) UpdateStatus(resource interface{}) (metav1.Object, error) {
 		obj := resource.(*policyv1alpha1.IngressBackend)
 		return c.policyClient.PolicyV1alpha1().IngressBackends(obj.Namespace).UpdateStatus(context.Background(), obj, metav1.UpdateOptions{})
 
+	case *policyv1alpha1.UpstreamTrafficSetting:
+		obj := resource.(*policyv1alpha1.UpstreamTrafficSetting)
+		return c.policyClient.PolicyV1alpha1().UpstreamTrafficSettings(obj.Namespace).UpdateStatus(context.Background(), obj, metav1.UpdateOptions{})
+
 	default:
 		return nil, errors.Errorf("Unsupported type: %T", t)
 	}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -644,7 +644,33 @@ func TestUpdateStatus(t *testing.T) {
 					Reason:        "valid",
 				},
 			},
-		}, {
+		},
+		{
+			name: "valid UpstreamTrafficSetting resource",
+			existingResource: &policyv1alpha1.UpstreamTrafficSetting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: policyv1alpha1.UpstreamTrafficSettingSpec{
+					Host: "foo.bar.svc.cluster.local",
+				},
+			},
+			updatedResource: &policyv1alpha1.UpstreamTrafficSetting{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: policyv1alpha1.UpstreamTrafficSettingSpec{
+					Host: "foo.bar.svc.cluster.local",
+				},
+				Status: policyv1alpha1.UpstreamTrafficSettingStatus{
+					CurrentStatus: "valid",
+					Reason:        "valid",
+				},
+			},
+		},
+		{
 			name:             "unsupported resource",
 			existingResource: &policyv1alpha1.Egress{},
 			updatedResource:  &policyv1alpha1.Egress{},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Allows updating the status of the UpstreamTrafficSetting
resource through the status subresource. Also fixes a bug
where the status field was nested under the spec instead
of the top level resource.

Part of #4500

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`