### PR TITLE
feat(log): enable Envoy logging on inbound & outbound TCP listeners

### DIFF
--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -42,6 +42,7 @@ func (lb *listenerBuilder) newOutboundListener() (*xds_listener.Listener, error)
 				Name: wellknown.OriginalDestination,
 			},
 		},
+		AccessLog: envoy.GetAccessLog(),
 	}
 
 	// Create a default passthrough filter chain when global egress is enabled.
@@ -122,6 +123,7 @@ func newInboundListener() *xds_listener.Listener {
 				Name: wellknown.OriginalDestination,
 			},
 		},
+		AccessLog: envoy.GetAccessLog(),
 	}
 }
 

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Construct inbound listeners", func() {
 		It("Tests the inbound listener config", func() {
 			listener := newInboundListener()
 			Expect(listener.Address).To(Equal(envoy.GetAddress(constants.WildcardIPAddr, constants.EnvoyInboundListenerPort)))
+			Expect(listener.AccessLog).NotTo(BeEmpty())
 			Expect(len(listener.ListenerFilters)).To(Equal(2)) // TlsInspector, OriginalDestination listener filter
 			Expect(listener.ListenerFilters[0].Name).To(Equal(wellknown.TlsInspector))
 			Expect(listener.TrafficDirection).To(Equal(xds_core.TrafficDirection_INBOUND))
@@ -202,6 +203,7 @@ func TestNewOutboundListener(t *testing.T) {
 	assert.NoError(err)
 
 	assert.Len(listener.ListenerFilters, 3) // OriginalDst, TlsInspector, HttpInspector
+	assert.NotEmpty(listener.AccessLog)
 	assert.Equal(wellknown.TlsInspector, listener.ListenerFilters[1].Name)
 	assert.Equal(&xds_listener.ListenerFilterChainMatchPredicate{
 		Rule: &xds_listener.ListenerFilterChainMatchPredicate_DestinationPortRange{


### PR DESCRIPTION
Signed-off-by: Allen Leigh <allenlsy@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->

Add Envoy access log configuration to inbound & outbound listener for TCP traffic.

Resolves #4530 

**Testing done**:

✅  updated unit tests.

Dev build of OSM is deployed and set up following the egress demo documentation. It is observed that:

* `outbound-listener` has proper `access_log` settings 
* Envoy logs egress HTTPS connection process. Screenshot below shows Envoy logging HTTPS connection to httpbin.org on port 443

![Screen Shot 2022-03-30 at 8 58 55 PM](https://user-images.githubusercontent.com/872876/161101465-a20f659a-fc45-4a98-9292-38485243b27f.png)

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [X] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

Not needed