### PR TITLE
fix(ci): fix lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,10 @@ jobs:
       - name: go build deps
         run: make embed-files-test
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.41.1
+          version: latest
           skip-pkg-cache: true
-          args: --timeout 10m --skip-dirs pkg/gen --skip-files "zz_generated.deepcopy.go$"
 
   codegen:
     name: Codegen

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ go-vet:
 
 .PHONY: go-lint
 go-lint: embed-files-test
-	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.41.1 golangci-lint run --config .golangci.yml
+	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:latest golangci-lint run --config .golangci.yml
 
 .PHONY: go-fmt
 go-fmt:

--- a/cmd/cli/namespace_add.go
+++ b/cmd/cli/namespace_add.go
@@ -95,7 +95,7 @@ func (a *namespaceAddCmd) run() error {
 			return err
 		}
 		if !exists {
-			return errors.Errorf("Mesh [%s] does not exist. Please specify another mesh using --mesh-name or create a new mesh.", a.meshName)
+			return errors.Errorf("mesh [%s] does not exist, please specify another mesh using --mesh-name or create a new mesh", a.meshName)
 		}
 
 		deploymentsClient := a.clientSet.AppsV1().Deployments(ns)

--- a/cmd/cli/namespace_test.go
+++ b/cmd/cli/namespace_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Running the namespace add command", func() {
 			})
 
 			It("should give error about non-existent mesh", func() {
-				Expect(err.Error()).To(Equal(fmt.Sprintf("Mesh [%s] does not exist. Please specify another mesh using --mesh-name or create a new mesh.", testMeshName)))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("mesh [%s] does not exist, please specify another mesh using --mesh-name or create a new mesh", testMeshName)))
 			})
 		})
 
@@ -372,7 +372,7 @@ var _ = Describe("Running the namespace add command", func() {
 			})
 
 			It("should give error about non-existent mesh", func() {
-				Expect(err.Error()).To(Equal(fmt.Sprintf("Mesh [%s] does not exist. Please specify another mesh using --mesh-name or create a new mesh.", testMeshName)))
+				Expect(err.Error()).To(Equal(fmt.Sprintf("mesh [%s] does not exist, please specify another mesh using --mesh-name or create a new mesh", testMeshName)))
 			})
 		})
 

--- a/cmd/cli/support_err.go
+++ b/cmd/cli/support_err.go
@@ -60,11 +60,11 @@ func (cmd *errInfoCmd) run(errCode string) error {
 		// Print the error code description mapping only for the given error code
 		e, err := errcode.FromStr(errCode)
 		if err != nil {
-			return errors.Errorf("Error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", errCode)
+			return errors.Errorf("error code '%s' is not a valid error code format, should be of the form Exxxx, ex. E1000", errCode)
 		}
 		description, ok := errcode.ErrCodeMap[e]
 		if !ok {
-			return errors.Errorf("Error code '%s' is not a valid error code recognized by OSM", errCode)
+			return errors.Errorf("error code '%s' is not a valid error code recognized by OSM", errCode)
 		}
 		table.Append([]string{errCode, description})
 	} else {

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -77,7 +77,7 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 
 			meshInfoList, err := getMeshInfoList(versionCmd.config, versionCmd.clientset)
 			if err != nil {
-				return errors.Wrapf(err, "Unable to list meshes within the cluster.")
+				return errors.Wrapf(err, "unable to list meshes within the cluster")
 			}
 
 			for _, m := range meshInfoList {

--- a/pkg/bugreport/run.go
+++ b/pkg/bugreport/run.go
@@ -143,7 +143,7 @@ func runCmdAndWriteToFile(cmdList []string, outFile string) error {
 	cmd := exec.Command(cmdList[0], cmdList[1:]...) //#nosec G204
 
 	// open the out file for writing
-	outfile, err := os.Create(outFile)
+	outfile, err := os.Create(filepath.Clean(outFile))
 	if err != nil {
 		return err
 	}

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -21,7 +21,7 @@ func NewManager(
 	ca *Certificate,
 	client client,
 	serviceCertValidityDuration time.Duration,
-	msgBroker *messaging.Broker) (*manager, error) {
+	msgBroker *messaging.Broker) (*manager, error) { //nolint:revive // unexported-return
 	if ca == nil {
 		return nil, errNoIssuingCA
 	}

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
-func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}) {
+func receive(requests chan *xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}) {
 	for {
 		var request *xds_discovery.DiscoveryRequest
 		request, recvErr := (*server).Recv()
@@ -31,7 +31,7 @@ func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery
 			log.Trace().Str("proxy", proxy.String()).Msgf("gRPC stream from proxy terminated")
 			close(quit)
 			return
-		case requests <- *request:
+		case requests <- request:
 		}
 		log.Debug().Str("proxy", proxy.String()).Msgf("Received DiscoveryRequest from proxy")
 	}

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -63,7 +63,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	defer s.proxyRegistry.UnregisterProxy(proxy)
 
 	quit := make(chan struct{})
-	requests := make(chan xds_discovery.DiscoveryRequest)
+	requests := make(chan *xds_discovery.DiscoveryRequest)
 
 	// This helper handles receiving messages from the connected Envoys
 	// and any gRPC error states.
@@ -104,20 +104,20 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 				metricsstore.DefaultMetricsStore.ProxyConnectCount.Dec()
 				return errGrpcClosed
 			}
-			log.Debug().Str("proxy", proxy.String()).Msgf("Processing DiscoveryRequest %s", discoveryReqToStr(&discoveryRequest))
+			log.Debug().Str("proxy", proxy.String()).Msgf("Processing DiscoveryRequest %s", discoveryReqToStr(discoveryRequest))
 
 			metricsstore.DefaultMetricsStore.ProxyXDSRequestCount.WithLabelValues(certCommonName.String(), discoveryRequest.TypeUrl).Inc()
 
 			// This function call runs xDS proto state machine given DiscoveryRequest as input.
 			// It's output is the decision to reply or not to this request.
-			if !respondToRequest(proxy, &discoveryRequest) {
-				log.Debug().Str("proxy", proxy.String()).Msgf("Ignoring DiscoveryRequest %s that does not need to be responded to", discoveryReqToStr(&discoveryRequest))
+			if !respondToRequest(proxy, discoveryRequest) {
+				log.Debug().Str("proxy", proxy.String()).Msgf("Ignoring DiscoveryRequest %s that does not need to be responded to", discoveryReqToStr(discoveryRequest))
 				continue
 			}
 
 			typesRequest := []envoy.TypeURI{envoy.TypeURI(discoveryRequest.TypeUrl)}
 
-			<-s.workqueues.AddJob(newJob(typesRequest, &discoveryRequest))
+			<-s.workqueues.AddJob(newJob(typesRequest, discoveryRequest))
 
 		case <-proxyUpdateChan:
 			log.Info().Str("proxy", proxy.String()).Msg("Broadcast update received")

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -375,7 +375,7 @@ func FromStr(e string) (ErrCode, error) {
 	errStr := strings.TrimLeft(e, "E")
 	errInt, err := strconv.Atoi(errStr)
 	if err != nil {
-		return ErrCode(0), errors.Errorf("Error code '%s' is not a valid error code format. Should be of the form Exxxx, ex. E1000.", e)
+		return ErrCode(0), errors.Errorf("error code '%s' is not a valid error code format, should be of the form Exxxx, ex. E1000", e)
 	}
 	return ErrCode(errInt), nil
 }

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -16,7 +16,7 @@ import (
 )
 
 // WildCardRouteMatch represents a wildcard HTTP route match condition
-var WildCardRouteMatch HTTPRouteMatch = HTTPRouteMatch{
+var WildCardRouteMatch = HTTPRouteMatch{
 	Path:          constants.RegexMatchAll,
 	PathMatchType: PathMatchRegex,
 	Methods:       []string{constants.WildcardHTTPMethod},

--- a/tests/framework/common_metrics.go
+++ b/tests/framework/common_metrics.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -178,7 +179,7 @@ func (g *Grafana) PanelPNGSnapshot(dashboard string, panelID int, fromMinutes in
 	}()
 
 	saveFilepath = fmt.Sprintf("%s%s", saveFilepath, ".png")
-	out, err := os.Create(saveFilepath)
+	out, err := os.Create(filepath.Clean(saveFilepath))
 	if err != nil {
 		return err
 	}

--- a/tests/scale/osm_common_profile_resources.go
+++ b/tests/scale/osm_common_profile_resources.go
@@ -3,6 +3,7 @@ package scale
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -107,7 +108,7 @@ func getOSMTrackResources() []TrackedLabel {
 
 // Get common outputs we are interested to print in (resultsFile and stdout basically)
 func getOSMTestOutputFiles() []*os.File {
-	fName := Td.GetTestFilePath(defaultFilename)
+	fName := filepath.Clean(Td.GetTestFilePath(defaultFilename))
 	f, err := os.Create(fName)
 	if err != nil {
 		fmt.Printf("Failed to open file: %v", err)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates the version of `golangci-lint` used in the Makefile
and CI to the floating `latest` version so we don't have to periodically
update this manually.

Other changes are made based on linter errors thrown by the updated
version of the linter.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
- Did a manual smoke test of `make go-lint`
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A