### PR TITLE
ref(test): Improve e2e test framework using Fortio as load test tool

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -113,7 +113,7 @@ go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -ginkgo.focus="\bSimpleCl
 
 #### Setting installType:
 
-The `installType` flag can be used to specify whether the tests should install OSM themselves, or if they will be run on a cluster which already has OSM installed. 
+The `installType` flag can be used to specify whether the tests should install OSM themselves, or if they will be run on a cluster which already has OSM installed.
 
 ```console
 go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=NoInstall
@@ -122,16 +122,16 @@ go test ./tests/e2e -test.v -ginkgo.v -ginkgo.progress -installType=NoInstall
 The different values of installType are as follows:
 
 1. `installType=NoInstall`
-   
+
     The e2es will run on the cluster currently in the user's kubeconfig, which is already expected to have OSM installed prior to the test run. The tests will not install OSM before, or uninstall OSM after any of the tests run. The cluster can be of any CNCF certified distribution (though the k8s version cannot be an outdated version).
 
 1. `installType=KindCluster`
 
-	Each test in the e2e suite will spin up a kind cluster, and run that specific test on that kind cluster. Each test will install OSM via the OSM cli, and then uninstall OSM after the test finishes running. The user is not expected to have created any cluster beforehand. 
+	Each test in the e2e suite will spin up a kind cluster, and run that specific test on that kind cluster. Each test will install OSM via the OSM cli, and then uninstall OSM after the test finishes running. The user is not expected to have created any cluster beforehand.
 
 1. `installType=SelfInstall` (default)
 
-	By default, the e2es will run on the cluster currently in the user's kubeconfig. Each test will install OSM via the OSM cli, and then uninstall OSM after the test finishes running. The cluster can be of any CNCF certified distribution (though the k8s version cannot be an outdated version). The user is should not have OSM installed beforehand. 
+	By default, the e2es will run on the cluster currently in the user's kubeconfig. Each test will install OSM via the OSM cli, and then uninstall OSM after the test finishes running. The cluster can be of any CNCF certified distribution (though the k8s version cannot be an outdated version). The user is should not have OSM installed beforehand.
 
 
 #### Use Kind for testing

--- a/tests/e2e/constants.go
+++ b/tests/e2e/constants.go
@@ -1,0 +1,17 @@
+package e2e
+
+import "github.com/openservicemesh/osm/tests/framework"
+
+const (
+	fortioImageName = "fortio/fortio"
+	fortioHTTPPort  = 8080
+	fortioTCPPort   = 8078
+	fortioGRPCPort  = 8079
+
+	fortioTCPRetCodeSuccess  = "OK"
+	fortioGRPCRetCodeSuccess = "SERVING"
+)
+
+var (
+	fortioSingleCallSpec = framework.FortioLoadTestSpec{Calls: 1}
+)

--- a/tests/e2e/e2e_ip_exclusion_test.go
+++ b/tests/e2e/e2e_ip_exclusion_test.go
@@ -45,8 +45,8 @@ func testIPExclusion() {
 			SimplePodAppDef{
 				PodName:   destName,
 				Namespace: destName,
-				Image:     "kennethreitz/httpbin",
-				Ports:     []int{80},
+				Image:     fortioImageName,
+				Ports:     []int{fortioHTTPPort},
 				OS:        Td.ClusterOS,
 			})
 		Expect(err).NotTo(HaveOccurred())
@@ -76,7 +76,7 @@ func testIPExclusion() {
 			SourcePod:       srcPod.Name,
 			SourceContainer: srcPod.Name,
 
-			Destination: fmt.Sprintf("%s.%s", dstSvc.Name, dstSvc.Namespace),
+			Destination: fmt.Sprintf("%s.%s:%d", dstSvc.Name, dstSvc.Namespace, fortioHTTPPort),
 		}
 
 		srcToDestStr := fmt.Sprintf("%s -> %s",

--- a/tests/e2e/e2e_tcp_client_server_test.go
+++ b/tests/e2e/e2e_tcp_client_server_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -11,6 +10,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/tests/framework"
 	. "github.com/openservicemesh/osm/tests/framework"
 )
@@ -44,19 +44,24 @@ func testTCPTraffic(permissiveMode bool) {
 		installOpts.EnablePermissiveMode = permissiveMode
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-		// Load TCP server image
-		Expect(Td.LoadImagesToKind([]string{"tcp-echo-server"})).To(Succeed())
-
 		// Create Test NS
 		for _, n := range ns {
 			Expect(Td.CreateNs(n, nil)).To(Succeed())
 			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 		}
 
-		destinationPort := 80
+		destinationPort := fortioTCPPort
 
 		// Get simple pod definitions for the TCP server
-		svcAccDef, podDef, svcDef, err := Td.GetOSSpecificTCPEchoPod(framework.RandomNameWithPrefix("pod"), destNs, destinationPort)
+		svcAccDef, podDef, svcDef, err := Td.SimplePodApp(
+			SimplePodAppDef{
+				PodName:     destNs,
+				Namespace:   destNs,
+				Image:       fortioImageName,
+				Ports:       []int{destinationPort},
+				AppProtocol: constants.ProtocolTCP,
+				OS:          Td.ClusterOS,
+			})
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -70,7 +75,7 @@ func testTCPTraffic(permissiveMode bool) {
 		// Expect it to be up and running in it's receiver namespace
 		Expect(Td.WaitForPodsRunningReady(destNs, 120*time.Second, 1, nil)).To(Succeed())
 
-		srcPod := setupSource(sourceNs, false /* no kubernetes service for the client */)
+		srcPod := setupFortioSource(sourceNs, false /* no kubernetes service for the client */)
 
 		trafficTargetName := "test-target"
 		trafficRouteName := "routes"
@@ -100,7 +105,7 @@ func testTCPTraffic(permissiveMode bool) {
 		}
 
 		// All ready. Expect client to reach server
-		requestMsg := "test request"
+		requestMsg := "test-request"
 		clientToServer := TCPRequestDef{
 			SourceNs:        sourceNs,
 			SourcePod:       srcPod.Name,
@@ -116,21 +121,24 @@ func testTCPTraffic(permissiveMode bool) {
 			clientToServer.DestinationHost, clientToServer.DestinationPort)
 
 		cond := Td.WaitForRepeatedSuccess(func() bool {
-			result := Td.TCPRequest(clientToServer)
+			result := Td.FortioTCPLoadTest(FortioTCPLoadTestDef{TCPRequestDef: clientToServer, FortioLoadTestSpec: fortioSingleCallSpec})
 
 			if result.Err != nil {
-				Td.T.Logf("> (%s) TCP Req failed, response: %s, err: %s",
-					srcToDestStr, result.Response, result.Err)
+				Td.T.Logf("> (%s) TCP Req failed, return codes: %v, err: %s",
+					srcToDestStr, result.AllReturnCodes(), result.Err)
 				return false
 			}
 
-			// Ensure the echo response contains request message
-			if !strings.Contains(result.Response, requestMsg) {
-				Td.T.Logf("> (%s) Unexpected response: %s.\n Response expected to contain: %s", srcToDestStr, result.Response, requestMsg)
-				return false
+			// Ensure the correct TCP return code
+			for retCode := range result.ReturnCodes {
+				if retCode != fortioTCPRetCodeSuccess {
+					Td.T.Logf("> (%s) Unexpected return code: %s.\n Return code expected to contain: %s. Skip.", srcToDestStr, retCode, fortioTCPRetCodeSuccess)
+					continue
+				}
+				Td.T.Logf("> (%s) TCP Req succeeded, return code: %s", srcToDestStr, retCode)
+				return true
 			}
-			Td.T.Logf("> (%s) TCP Req succeeded, response: %s", srcToDestStr, result.Response)
-			return true
+			return false
 		}, 5, Td.ReqSuccessTimeout)
 
 		Expect(cond).To(BeTrue(), "Failed testing TCP traffic from %s", srcToDestStr)
@@ -142,14 +150,18 @@ func testTCPTraffic(permissiveMode bool) {
 
 			// Expect client not to reach server
 			cond = Td.WaitForRepeatedSuccess(func() bool {
-				result := Td.TCPRequest(clientToServer)
+				result := Td.FortioTCPLoadTest(FortioTCPLoadTestDef{TCPRequestDef: clientToServer, FortioLoadTestSpec: fortioSingleCallSpec})
 
-				if result.Err == nil {
-					Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail,  response: %s", srcToDestStr, result.Response)
-					return false
+				// Look for failed TCP return code
+				for retCode := range result.ReturnCodes {
+					if retCode != fortioTCPRetCodeSuccess {
+						Td.T.Logf("> (%s) TCP Req failed correctly, return codes: %s, err: %s", srcToDestStr, retCode, result.Err)
+						return true
+					}
 				}
-				Td.T.Logf("> (%s) TCP Req failed correctly, response: %s, err: %s", srcToDestStr, result.Response, result.Err)
-				return true
+
+				Td.T.Logf("> (%s) TCP Req did not fail, expected it to fail, return codes: %v", srcToDestStr, result.AllReturnCodes())
+				return false
 			}, 5, 150*time.Second)
 			Expect(cond).To(BeTrue())
 		}

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1074,11 +1074,8 @@ func (td *OsmTestData) RunRemote(
 		Stdout: &stdout,
 		Stderr: &stderr,
 	})
-	if err != nil {
-		return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
-	}
 
-	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), nil
+	return strings.TrimSpace(stdout.String()), strings.TrimSpace(stderr.String()), err
 }
 
 // WaitForPodsRunningReady waits for a <n> number of pods on an NS to be running and ready

--- a/tests/framework/common_traffic_fortio.go
+++ b/tests/framework/common_traffic_fortio.go
@@ -1,0 +1,241 @@
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+const (
+	fortioResDurationHistKey  = "DurationHistogram"
+	fortioResPercentilesKey   = "Percentiles"
+	fortioResPercentileKey    = "Percentile"
+	fortioResValueKey         = "Value"
+	fortioResReturnCodesKey   = "RetCodes"
+	fortioResRequestsCountKey = "Count"
+)
+
+// FortioLoadTestSpec defines the Fortio load test specification. Request definition is not included.
+type FortioLoadTestSpec struct {
+	// QPS is the number of requests per second. Negative number means no wait maximum rate. The default is 8
+	QPS int
+
+	// Connections is the number of connections/goroutines. The default is 4
+	Connections int
+
+	// Calls is the number of requests. Default is 0, which uses duration.
+	Calls int
+
+	// Duration is the duration of the test. Default is 5 seconds.
+	Duration string
+}
+
+// FortioHTTPLoadTestDef defines a Fortio HTTP load test intent
+type FortioHTTPLoadTestDef struct {
+	HTTPRequestDef
+	FortioLoadTestSpec
+}
+
+// FortioTCPLoadTestDef defines a Fortio TCP load test intent
+type FortioTCPLoadTestDef struct {
+	TCPRequestDef
+	FortioLoadTestSpec
+}
+
+// FortioGRPCLoadTestDef defines a Fortio GRPC load test intent
+type FortioGRPCLoadTestDef struct {
+	GRPCRequestDef
+	FortioLoadTestSpec
+}
+
+// FortioLoadResult represents Fortio load test result
+type FortioLoadResult struct {
+	ReturnCodes   map[string]FortioReturnCodeEntry
+	DurationHist  map[float64]float64
+	TotalRequests int32
+
+	Err error
+}
+
+// FortioReturnCodeEntry is a data entry for a single Fortio load test return code with related stats.
+type FortioReturnCodeEntry struct {
+	ReturnCode string
+	Count      int
+	Percentage float64
+}
+
+// HasFailedHTTPRequests checks if there is return code not smaller than 400. Non-numeric return code will be skipped. This is suitable for checking the result of Fortio HTTP load test.
+func (result *FortioLoadResult) HasFailedHTTPRequests() bool {
+	for statusCodeStr := range result.ReturnCodes {
+		statusCode, err := strconv.Atoi(statusCodeStr)
+		if err != nil {
+			continue
+		}
+
+		if statusCode >= 400 && result.ReturnCodes[statusCodeStr].Count > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// AllReturnCodes returns all the load test return codes as an array of strings.
+func (result *FortioLoadResult) AllReturnCodes() []string {
+	var codes []string
+	for retCode := range result.ReturnCodes {
+		codes = append(codes, retCode)
+	}
+	return codes
+}
+
+// FortioHTTPLoadTest runs a Fortio load test with HTTP protocol according to given FortioHTTPLoadTestDef and returns a FortioLoadResult
+func (td *OsmTestData) FortioHTTPLoadTest(ht FortioHTTPLoadTestDef) FortioLoadResult {
+	var command []string
+	if td.ClusterOS == constants.OSWindows {
+		// -s silent progress, -o output to devnull, '-D -' dump headers to "-" (stdout), -i Status code
+		// -I skip body download, '-w StatusCode:%{http_code}' prints Status code label-like for easy parsing
+		// -L follow redirects
+		command = strings.Fields(fmt.Sprintf("curl.exe -s -o NUL -D - -I -w %s:%%{http_code} -L %s", StatusCodeWord, ht.Destination))
+	} else {
+		command = buildFortioLoadCommandWithArgs(ht.FortioLoadTestSpec)
+		command = append(command, ht.Destination)
+	}
+
+	stdout, stderr, err := td.RunRemote(ht.SourceNs, ht.SourcePod, ht.SourceContainer, command)
+	if err != nil {
+		// Error codes from the execution come through err
+		return FortioLoadResult{
+			Err: fmt.Errorf("Remote exec err: %v | stderr: %s", err, stderr),
+		}
+	}
+	if len(stderr) > 0 {
+		// no error from execution and proper exit code, we got some stderr though
+		td.T.Logf("[warn] Stderr: %v", stderr)
+	}
+
+	return mapFortioOutputToResult(stdout)
+}
+
+// FortioTCPLoadTest runs a Fortio load test with TCP protocol according to given FortioTCPLoadTestDef and returns a FortioLoadResult
+func (td *OsmTestData) FortioTCPLoadTest(req FortioTCPLoadTestDef) FortioLoadResult {
+	var command []string
+	if td.ClusterOS == constants.OSWindows {
+		powershellCommand := fmt.Sprintf("$IP = [System.Net.Dns]::GetHostAddresses('%s');", req.DestinationHost) +
+			fmt.Sprintf("$Socket = New-Object System.Net.Sockets.TCPClient($IP, %d);", req.DestinationPort) +
+			"$Stream = $Socket.GetStream(); $Writer = New-Object System.IO.StreamWriter($Stream);" +
+			fmt.Sprintf(" $Writer.WriteLine('%s'); $Writer.Flush();", req.Message) +
+			"$reader = New-Object System.IO.StreamReader($Stream); Write-Host -NoNewline $reader.ReadLine()"
+		command = []string{"pwsh.exe", "-c", powershellCommand}
+	} else {
+		command = buildFortioLoadCommandWithArgs(req.FortioLoadTestSpec)
+		if req.Message != "" {
+			command = append(command, "-payload", fmt.Sprintf("'%s'", req.Message))
+		}
+		command = append(command, fmt.Sprintf("tcp://%s:%d", req.DestinationHost, req.DestinationPort))
+	}
+
+	stdout, stderr, err := td.RunRemote(req.SourceNs, req.SourcePod, req.SourceContainer, command)
+
+	if err != nil {
+		return FortioLoadResult{
+			Err: fmt.Errorf("Remote exec err: %v | stderr: %s | cmd: %s", err, stderr, command),
+		}
+	}
+	if len(stderr) > 0 {
+		// no error from execution and proper exit code, we got some stderr though
+		td.T.Logf("[warn] Stderr: %v", stderr)
+	}
+
+	return mapFortioOutputToResult(stdout)
+}
+
+// FortioGRPCLoadTest runs a Fortio load test with GRPC protocol according to given FortioGRPCLoadTestDef and returns a FortioLoadResult
+func (td *OsmTestData) FortioGRPCLoadTest(req FortioGRPCLoadTestDef) FortioLoadResult {
+	if req.UseTLS {
+		return FortioLoadResult{Err: fmt.Errorf("UseTLS is not supported for Fortio GRPC load test")}
+	}
+
+	command := buildFortioLoadCommandWithArgs(req.FortioLoadTestSpec)
+	command = append(command, "-grpc", req.Destination)
+
+	stdout, stderr, err := td.RunRemote(req.SourceNs, req.SourcePod, req.SourceContainer, command)
+
+	if err != nil {
+		return FortioLoadResult{
+			Err: fmt.Errorf("Remote exec err: %v | stderr: %s | cmd: %s", err, stderr, command),
+		}
+	}
+	if len(stderr) > 0 {
+		// no error from execution and proper exit code, we got some stderr though
+		td.T.Logf("[warn] Stderr: %v", stderr)
+	}
+
+	return mapFortioOutputToResult(stdout)
+}
+
+// mapFortioOutputToResult maps stdout from single request fortio test
+// output. It expects headers on stdout like "<name>: <value...>"
+func mapFortioOutputToResult(execOut string) FortioLoadResult {
+	var ret = FortioLoadResult{
+		ReturnCodes:  make(map[string]FortioReturnCodeEntry),
+		DurationHist: make(map[float64]float64),
+	}
+
+	var fortioResultJSON map[string]interface{}
+	err := json.Unmarshal([]byte(execOut), &fortioResultJSON)
+	if err != nil {
+		ret.Err = err
+		return ret
+	}
+
+	// Example Fortio HTTP JSON output:
+
+	durationHist := fortioResultJSON[fortioResDurationHistKey].(map[string]interface{})
+	totalRequests := int32(durationHist[fortioResRequestsCountKey].(float64))
+	ret.TotalRequests = totalRequests
+
+	// extract duration histogram
+	for _, stat := range durationHist[fortioResPercentilesKey].([]interface{}) {
+		statObj := stat.(map[string]interface{})
+		percentile := statObj[fortioResPercentileKey].(float64)
+		duration := statObj[fortioResValueKey].(float64)
+
+		ret.DurationHist[percentile] = duration
+	}
+
+	// extract response stats
+	for returnCode, count := range fortioResultJSON[fortioResReturnCodesKey].(map[string]interface{}) {
+		ret.ReturnCodes[returnCode] = FortioReturnCodeEntry{
+			ReturnCode: returnCode,
+			Count:      int(count.(float64)),
+			Percentage: count.(float64) / float64(totalRequests),
+		}
+	}
+
+	return ret
+}
+
+// buildFortioLoadCommandWithArgs builds a fortio load CLI command given the load test spec and returns an array of strings.
+func buildFortioLoadCommandWithArgs(spec FortioLoadTestSpec) []string {
+	cmd := []string{"fortio", "load", "-json", "-"}
+	if spec.QPS != 0 {
+		if spec.QPS < 0 {
+			cmd = append(cmd, "-qps", "0")
+		} else {
+			cmd = append(cmd, "-qps", strconv.Itoa(spec.QPS))
+		}
+	}
+	if spec.Calls != 0 {
+		cmd = append(cmd, "-n", strconv.Itoa(spec.Calls))
+	}
+	if spec.Connections != 0 {
+		cmd = append(cmd, "-c", strconv.Itoa(spec.Connections))
+	}
+	if spec.Duration != "" {
+		cmd = append(cmd, "-t", spec.Duration)
+	}
+	return cmd
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Below is a list of services in the e2e tests that are used to test different web request protocols:

* HTTP: curl
* TCP: tcp-echo-server
* gRPC: grpcurl, grpcbin

They are right now testing in single request mode. As our project develops, we need to a more customizable request sending solution to test various scenarios.

Fortio is a load testing tool that comes with both the server (web UI included) and the load generating client. They are packaged in a single Docker image.

In this PR:

* Using Fortio, e2e test framework is improved by supporting simple load test in HTTP, TCP and gRPC(insecure) protocols. It exposes some common load test configurations such as test duration, number of calls and connections etc.
* Migrated some e2e tests to use Fortio for demonstration and feature verification purposes. It's not the required to migrate all e2e tests to Fortio at this moment. These test cases are updated with Fortio being the Docker image of both client and server sides.

Partially resolves #4621 .

TODO after this PR:

* Secured gRPC request and response is not implemented in this PR. It requires providing Fortio server with certificates in the test.
* Fortio does not have a Windows compatible Docker image. e2e test in Windows is not supported yet

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

✅ Updated unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [x] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?