### PR TITLE
IngressBackend UpstreamTrafficSetting validations

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -244,7 +244,7 @@ func main() {
 
 	clientset := extensionsClientset.NewForConfigOrDie(kubeConfig)
 
-	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, osmNamespace, osmVersion, meshName, enableReconciler, validateTrafficTarget, constants.ValidatorWebhookPort, certManager, kubeClient, stop); err != nil {
+	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, osmNamespace, osmVersion, meshName, enableReconciler, validateTrafficTarget, constants.ValidatorWebhookPort, certManager, kubeClient, policyClient, stop); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error starting the validating webhook server")
 	}
 

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -244,7 +244,7 @@ func main() {
 
 	clientset := extensionsClientset.NewForConfigOrDie(kubeConfig)
 
-	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, osmNamespace, osmVersion, meshName, enableReconciler, validateTrafficTarget, constants.ValidatorWebhookPort, certManager, kubeClient, policyClient, stop); err != nil {
+	if err := validator.NewValidatingWebhook(validatorWebhookConfigName, osmNamespace, osmVersion, meshName, enableReconciler, validateTrafficTarget, constants.ValidatorWebhookPort, certManager, kubeClient, policyController, stop); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error starting the validating webhook server")
 	}
 

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -163,7 +163,7 @@ func (c client) GetIngressBackendPolicy(svc service.MeshService) *policyV1alpha1
 		// using a validating webhook.
 		for _, backend := range ingressBackend.Spec.Backends {
 			// we need to check ports to allow ingress to multiple ports on the same svc
-			if backend.Name == svc.Name && backend.Port.Number == int(svc.Port) && backend.Port.Protocol == svc.Protocol {
+			if backend.Name == svc.Name && backend.Port.Number == int(svc.TargetPort) && backend.Port.Protocol == svc.Protocol {
 				return ingressBackend
 			}
 		}
@@ -208,6 +208,10 @@ func (c client) GetUpstreamTrafficSetting(options UpstreamTrafficSettingGetOpt) 
 	// Filter by MeshService
 	for _, resource := range c.caches.upstreamTrafficSetting.List() {
 		upstreamTrafficSetting := resource.(*policyV1alpha1.UpstreamTrafficSetting)
+
+		if upstreamTrafficSetting.Spec.Host == options.Host {
+			return upstreamTrafficSetting
+		}
 
 		if upstreamTrafficSetting.Namespace == options.MeshService.Namespace &&
 			upstreamTrafficSetting.Spec.Host == options.MeshService.FQDN() {

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -163,7 +163,7 @@ func (c client) GetIngressBackendPolicy(svc service.MeshService) *policyV1alpha1
 		// using a validating webhook.
 		for _, backend := range ingressBackend.Spec.Backends {
 			// we need to check ports to allow ingress to multiple ports on the same svc
-			if backend.Name == svc.Name && backend.Port.Number == int(svc.TargetPort) && backend.Port.Protocol == svc.Protocol {
+			if backend.Name == svc.Name && backend.Port.Number == int(svc.TargetPort) {
 				return ingressBackend
 			}
 		}
@@ -191,7 +191,7 @@ func (c client) ListRetryPolicies(source identity.K8sServiceAccount) []*policyV1
 
 // GetUpstreamTrafficSetting returns the UpstreamTrafficSetting resource that matches the given options
 func (c client) GetUpstreamTrafficSetting(options UpstreamTrafficSettingGetOpt) *policyV1alpha1.UpstreamTrafficSetting {
-	if options.MeshService == nil && options.NamespacedName == nil {
+	if options.MeshService == nil && options.NamespacedName == nil && options.Host == "" {
 		log.Error().Msgf("No option specified to get UpstreamTrafficSetting resource")
 		return nil
 	}

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -162,7 +162,8 @@ func (c client) GetIngressBackendPolicy(svc service.MeshService) *policyV1alpha1
 		// Multiple IngressBackend policies for the same backend will be prevented
 		// using a validating webhook.
 		for _, backend := range ingressBackend.Spec.Backends {
-			if backend.Name == svc.Name {
+			// we need to check ports to allow ingress to multiple ports on the same svc
+			if backend.Name == svc.Name && backend.Port.Number == int(svc.Port) && backend.Port.Protocol == svc.Protocol {
 				return ingressBackend
 			}
 		}

--- a/pkg/policy/client_test.go
+++ b/pkg/policy/client_test.go
@@ -202,7 +202,7 @@ func TestGetIngressBackendPolicy(t *testing.T) {
 					Spec: policyV1alpha1.IngressBackendSpec{
 						Backends: []policyV1alpha1.BackendSpec{
 							{
-								Name: "backend2", // does not match the backend specified in the test case
+								Name: "backend3", // does not match the backend specified in the test case
 								Port: policyV1alpha1.PortSpec{
 									Number:   80,
 									Protocol: "http",
@@ -219,7 +219,7 @@ func TestGetIngressBackendPolicy(t *testing.T) {
 					},
 				},
 			},
-			backend: service.MeshService{Name: "backend1", Namespace: "test"},
+			backend: service.MeshService{Name: "backend1", Namespace: "test", TargetPort: 80, Protocol: "http"},
 			expectedIngressBackend: &policyV1alpha1.IngressBackend{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-backend-1",

--- a/pkg/policy/conflicts.go
+++ b/pkg/policy/conflicts.go
@@ -13,17 +13,29 @@ func DetectIngressBackendConflicts(x policyv1alpha1.IngressBackend, y policyv1al
 
 	// Check if the backends conflict
 	xSet := mapset.NewSet()
+	type setKey struct {
+		name string
+		port int
+	}
 	for _, backend := range x.Spec.Backends {
-		xSet.Add(backend.Name)
+		key := setKey{
+			name: backend.Name,
+			port: backend.Port.Number,
+		}
+		xSet.Add(key)
 	}
 	ySet := mapset.NewSet()
 	for _, backend := range y.Spec.Backends {
-		ySet.Add(backend.Name)
+		key := setKey{
+			name: backend.Name,
+			port: backend.Port.Number,
+		}
+		ySet.Add(key)
 	}
 
 	duplicates := xSet.Intersect(ySet)
 	for b := range duplicates.Iter() {
-		err := errors.Errorf("Backend %s specified in %s and %s conflicts", b.(string), x.Name, y.Name)
+		err := errors.Errorf("Backend %s specified in %s and %s conflicts", b.(setKey).name, x.Name, y.Name)
 		conflicts = append(conflicts, err)
 	}
 

--- a/pkg/policy/types.go
+++ b/pkg/policy/types.go
@@ -65,4 +65,10 @@ type UpstreamTrafficSettingGetOpt struct {
 
 	// NamespacedName specifies the name and namespace of the resource
 	NamespacedName *types.NamespacedName
+
+	// Host specifies the host field of matching UpstreamTrafficSettings
+	// This field is not qualified by namespace because, by definition,
+	// a properly formatted Host includes a namespace and UpstreamTrafficSetting
+	// resources should not target services in different namespaces.
+	Host string
 }

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
+	policyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
 	"github.com/openservicemesh/osm/pkg/webhook"
 )
 
@@ -35,7 +36,7 @@ type validatingWebhookServer struct {
 }
 
 // NewValidatingWebhook returns a validatingWebhookServer with the defaultValidators that were previously registered.
-func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName string, enableReconciler, validateTrafficTarget bool, port int, certManager certificate.Manager, kubeClient kubernetes.Interface, stop <-chan struct{}) error {
+func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName string, enableReconciler, validateTrafficTarget bool, port int, certManager certificate.Manager, kubeClient kubernetes.Interface, policyClient policyClientset.Interface, stop <-chan struct{}) error {
 	// This is a certificate issued for the webhook handler
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned with the ValidatingWebhookConfiguration
@@ -46,9 +47,13 @@ func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName 
 		return errors.Errorf("Error issuing certificate for the validating webhook: %+v", err)
 	}
 
+	kv := &policyValidator{
+		policyClient: policyClient,
+	}
+
 	v := &validatingWebhookServer{
 		validators: map[string]validateFunc{
-			policyv1alpha1.SchemeGroupVersion.WithKind("IngressBackend").String(): ingressBackendValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("IngressBackend").String(): kv.ingressBackendValidator,
 			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():         egressValidator,
 			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():       trafficTargetValidator,
 		},

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -14,10 +14,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	"github.com/openservicemesh/osm/pkg/policy"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
-	policyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
 	"github.com/openservicemesh/osm/pkg/webhook"
 )
 
@@ -36,7 +37,7 @@ type validatingWebhookServer struct {
 }
 
 // NewValidatingWebhook returns a validatingWebhookServer with the defaultValidators that were previously registered.
-func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName string, enableReconciler, validateTrafficTarget bool, port int, certManager certificate.Manager, kubeClient kubernetes.Interface, policyClient policyClientset.Interface, stop <-chan struct{}) error {
+func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName string, enableReconciler, validateTrafficTarget bool, port int, certManager certificate.Manager, kubeClient kubernetes.Interface, policyClient policy.Controller, stop <-chan struct{}) error {
 	// This is a certificate issued for the webhook handler
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned with the ValidatingWebhookConfiguration
@@ -53,9 +54,10 @@ func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName 
 
 	v := &validatingWebhookServer{
 		validators: map[string]validateFunc{
-			policyv1alpha1.SchemeGroupVersion.WithKind("IngressBackend").String(): kv.ingressBackendValidator,
-			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():         egressValidator,
-			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():       trafficTargetValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("IngressBackend").String():         kv.ingressBackendValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():                 egressValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("UpstreamTrafficSetting").String(): kv.upstreamTrafficSettingValidator,
+			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():               trafficTargetValidator,
 		},
 	}
 

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	fakePolicyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
 	"github.com/pkg/errors"
 	tassert "github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -19,6 +18,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
+	fakePolicyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/messaging"
+	"github.com/openservicemesh/osm/pkg/policy"
+
 	"github.com/openservicemesh/osm/pkg/webhook"
 )
 
@@ -146,15 +149,17 @@ func TestNewValidatingWebhook(t *testing.T) {
 		port := 41414
 		stop := make(chan struct{})
 		defer close(stop)
+		broker := messaging.NewBroker(stop)
 		webhook := &admissionregv1.ValidatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "my-webhook",
 			},
 		}
-		kube := fake.NewSimpleClientset(webhook)
-		policy := fakePolicyClientset.NewSimpleClientset()
 
-		err := NewValidatingWebhook(webhook.Name, testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policy, nil)
+		kube := fake.NewSimpleClientset(webhook)
+		policyClient, _ := policy.NewPolicyController(nil, fakePolicyClientset.NewSimpleClientset(), stop, broker)
+
+		err := NewValidatingWebhook(webhook.Name, testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policyClient, nil)
 		tassert.NoError(t, err)
 	})
 
@@ -165,10 +170,11 @@ func TestNewValidatingWebhook(t *testing.T) {
 		port := 41414
 		stop := make(chan struct{})
 		defer close(stop)
+		broker := messaging.NewBroker(stop)
 		kube := fake.NewSimpleClientset()
-		policy := fakePolicyClientset.NewSimpleClientset()
+		policyClient, _ := policy.NewPolicyController(nil, fakePolicyClientset.NewSimpleClientset(), stop, broker)
 
-		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policy, nil)
+		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policyClient, nil)
 		tassert.NoError(t, err)
 	})
 
@@ -180,10 +186,12 @@ func TestNewValidatingWebhook(t *testing.T) {
 		port := 41414
 		stop := make(chan struct{})
 		defer close(stop)
-		kube := fake.NewSimpleClientset()
-		policy := fakePolicyClientset.NewSimpleClientset()
+		broker := messaging.NewBroker(stop)
 
-		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policy, nil)
+		kube := fake.NewSimpleClientset()
+		policyClient, _ := policy.NewPolicyController(nil, fakePolicyClientset.NewSimpleClientset(), stop, broker)
+
+		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policyClient, nil)
 		tassert.NoError(t, err)
 	})
 }

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	fakePolicyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
 	"github.com/pkg/errors"
 	tassert "github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -151,8 +152,9 @@ func TestNewValidatingWebhook(t *testing.T) {
 			},
 		}
 		kube := fake.NewSimpleClientset(webhook)
+		policy := fakePolicyClientset.NewSimpleClientset()
 
-		err := NewValidatingWebhook(webhook.Name, testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, nil)
+		err := NewValidatingWebhook(webhook.Name, testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policy, nil)
 		tassert.NoError(t, err)
 	})
 
@@ -164,8 +166,9 @@ func TestNewValidatingWebhook(t *testing.T) {
 		stop := make(chan struct{})
 		defer close(stop)
 		kube := fake.NewSimpleClientset()
+		policy := fakePolicyClientset.NewSimpleClientset()
 
-		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, nil)
+		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policy, nil)
 		tassert.NoError(t, err)
 	})
 
@@ -178,8 +181,9 @@ func TestNewValidatingWebhook(t *testing.T) {
 		stop := make(chan struct{})
 		defer close(stop)
 		kube := fake.NewSimpleClientset()
+		policy := fakePolicyClientset.NewSimpleClientset()
 
-		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, nil)
+		err := NewValidatingWebhook("my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, port, certManager, kube, policy, nil)
 		tassert.NoError(t, err)
 	})
 }

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -2,6 +2,9 @@ package validator
 
 import (
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/pkg/errors"
 )
 
 var log = logger.New(ValidatorWebhookSvc)
+
+var ErrIngressBackendDuplicateBackends = errors.New("error: duplicate backends detected")

--- a/pkg/validator/types.go
+++ b/pkg/validator/types.go
@@ -2,9 +2,6 @@ package validator
 
 import (
 	"github.com/openservicemesh/osm/pkg/logger"
-	"github.com/pkg/errors"
 )
 
 var log = logger.New(ValidatorWebhookSvc)
-
-var ErrIngressBackendDuplicateBackends = errors.New("error: duplicate backends detected")

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -2,25 +2,25 @@ package validator
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net"
 	"strconv"
 	"strings"
 
-	policyClientset "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
-	"github.com/openservicemesh/osm/pkg/policy"
+	mapset "github.com/deckarep/golang-set"
 	"github.com/pkg/errors"
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/policy"
+	"github.com/openservicemesh/osm/pkg/service"
 )
 
 // validateFunc is a function type that accepts an AdmissionRequest and returns an AdmissionResponse.
@@ -68,7 +68,7 @@ type validateFunc func(req *admissionv1.AdmissionRequest) (*admissionv1.Admissio
 
 // policyValidator is a validator that has access to a policy
 type policyValidator struct {
-	policyClient policyClientset.Interface
+	policyClient policy.Controller
 }
 
 func trafficTargetValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
@@ -91,18 +91,39 @@ func (kc *policyValidator) ingressBackendValidator(req *admissionv1.AdmissionReq
 	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(ingressBackend); err != nil {
 		return nil, err
 	}
+	ns := ingressBackend.Namespace
 
-	type backendCacheKey struct {
+	type setEntry struct {
 		name string
 		port int
 	}
 
-	backends := make(map[backendCacheKey]struct{}, len(ingressBackend.Spec.Backends))
+	backends := mapset.NewSet()
+	var conflictString strings.Builder
+	conflictingIngressBackends := mapset.NewSet()
 	for _, backend := range ingressBackend.Spec.Backends {
-		cacheKey := backendCacheKey{backend.Name, backend.Port.Number}
-		_, exists := backends[cacheKey]
-		if exists {
+		if unique := backends.Add(setEntry{backend.Name, backend.Port.Number}); !unique {
 			return nil, errors.Errorf("Duplicate backends detected with service name: %s and port: %d", backend.Name, backend.Port.Number)
+		}
+
+		fakeMeshSvc := service.MeshService{
+			Name:       backend.Name,
+			TargetPort: uint16(backend.Port.Number),
+			Protocol:   backend.Port.Protocol,
+		}
+
+		if matchingPolicy := kc.policyClient.GetIngressBackendPolicy(fakeMeshSvc); matchingPolicy != nil && matchingPolicy.Name != ingressBackend.Name {
+			// we've found a duplicate
+			if unique := conflictingIngressBackends.Add(matchingPolicy); !unique {
+				// we've already found the conflicts for this resource
+				continue
+			}
+			conflicts := policy.DetectIngressBackendConflicts(*ingressBackend, *matchingPolicy)
+			fmt.Fprintf(&conflictString, "[+] IngressBackend %s/%s conflicts with %s/%s:\n", ns, ingressBackend.ObjectMeta.GetName(), ns, matchingPolicy.ObjectMeta.GetName())
+			for _, err := range conflicts {
+				fmt.Fprintf(&conflictString, "%s\n", err)
+			}
+			fmt.Fprintf(&conflictString, "\n")
 		}
 
 		// Validate port
@@ -128,8 +149,10 @@ func (kc *policyValidator) ingressBackendValidator(req *admissionv1.AdmissionReq
 		default:
 			return nil, errors.Errorf("Expected 'port.protocol' to be 'http' or 'https', got: %s", backend.Port.Protocol)
 		}
+	}
 
-		backends[cacheKey] = struct{}{}
+	if conflictString.Len() != 0 {
+		return nil, fmt.Errorf("duplicate backends detected\n%s", conflictString.String())
 	}
 
 	// Validate sources
@@ -160,50 +183,7 @@ func (kc *policyValidator) ingressBackendValidator(req *admissionv1.AdmissionReq
 		}
 	}
 
-	err := kc.checkDuplicateBackends(ingressBackend)
-	if errors.Is(err, ErrIngressBackendDuplicateBackends) {
-		return nil, err
-	}
-
-	// Fail open for transient errors, but log
-	if err != nil {
-		log.Error().Err(err).Msg("transient error encountered checking duplicate IngressBackend backends")
-	}
-
 	return nil, nil
-}
-
-// checkDuplicateBackends checks to see if the backends present in the given
-// ingressBackend conflict with existing ingressBackends
-func (kc *policyValidator) checkDuplicateBackends(candidateIngressBackend *policyv1alpha1.IngressBackend, existingIngressBackends ...policyv1alpha1.IngressBackend) error {
-	if candidateIngressBackend == nil {
-		return errors.New("candidateIngressBackend is nil")
-	}
-	ns := candidateIngressBackend.GetObjectMeta().GetNamespace()
-	if len(existingIngressBackends) == 0 {
-		ingressBackendList, err := kc.policyClient.PolicyV1alpha1().IngressBackends(ns).List(context.Background(), metav1.ListOptions{})
-		if err != nil {
-			return errors.Wrapf(err, "Error listing IngressBackend resources in namespace %s", ns)
-		}
-		existingIngressBackends = ingressBackendList.Items
-	}
-
-	var conflictString strings.Builder
-	for _, ib := range existingIngressBackends {
-		if conflicts := policy.DetectIngressBackendConflicts(*candidateIngressBackend, ib); len(conflicts) > 0 {
-			fmt.Fprintf(&conflictString, "[+] IngressBackend %s/%s conflicts with %s/%s:\n", ns, candidateIngressBackend.ObjectMeta.GetName(), ns, ib.ObjectMeta.GetName())
-			for _, err := range conflicts {
-				fmt.Fprintf(&conflictString, "%s\n", err)
-			}
-			fmt.Fprintf(&conflictString, "\n")
-		}
-	}
-
-	if conflictString.Len() != 0 {
-		return fmt.Errorf("%w\n%s", ErrIngressBackendDuplicateBackends, conflictString.String())
-	}
-
-	return nil
 }
 
 // egressValidator validates the Egress custom resource
@@ -244,6 +224,28 @@ func egressValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionR
 	// Can't have more than 1 UpstreamTrafficSetting match for an Egress policy
 	if upstreamTrafficSettingMatchCount > 1 {
 		return nil, errors.New("Cannot have more than 1 UpstreamTrafficSetting match")
+	}
+
+	return nil, nil
+}
+
+// upstreamTrafficSettingValidator validates the UpstreamTrafficSetting custom resource
+func (kc *policyValidator) upstreamTrafficSettingValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	upstreamTrafficSetting := &policyv1alpha1.UpstreamTrafficSetting{}
+	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(upstreamTrafficSetting); err != nil {
+		return nil, err
+	}
+
+	ns := upstreamTrafficSetting.Namespace
+	hostComponents := strings.Split(upstreamTrafficSetting.Spec.Host, ".")
+	if len(hostComponents) < 2 {
+		return nil, field.Invalid(field.NewPath("spec").Child("host"), upstreamTrafficSetting.Spec.Host, "invalid FQDN specified as host")
+	}
+
+	opt := policy.UpstreamTrafficSettingGetOpt{Host: upstreamTrafficSetting.Spec.Host}
+	if matchingUpstreamTrafficSetting := kc.policyClient.GetUpstreamTrafficSetting(opt); matchingUpstreamTrafficSetting != nil && matchingUpstreamTrafficSetting.Name != upstreamTrafficSetting.Name {
+		// duplicate detected
+		return nil, errors.Errorf("UpstreamTrafficSetting %s/%s conflicts with %s/%s since they have the same host %s", ns, upstreamTrafficSetting.ObjectMeta.GetName(), ns, matchingUpstreamTrafficSetting.ObjectMeta.GetName(), matchingUpstreamTrafficSetting.Spec.Host)
 	}
 
 	return nil, nil


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes #4638. Adds stricter validatingWebhook validations for IngressBackend and UpstreamTrafficSetting (duplicate backends and hosts respectively). This PR also changes MeshService -> IngressBackend retrieval process to match on port as well as service name. This appears to have been an accidental omission from the original design since one would expect to be able to create an IngressBackend that allows access to the same service on different ports.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Additional unit tests added in the appropriate Golang packages
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A