### PR TITLE
ref(pkg/smi): remove unused kubeClient from smi client

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -171,7 +171,7 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Kubernetes Controller")
 	}
 
-	meshSpec, err := smi.NewMeshSpecClient(kubeConfig, kubeClient, osmNamespace, k8sClient, stop, msgBroker)
+	meshSpec, err := smi.NewMeshSpecClient(kubeConfig, osmNamespace, k8sClient, stop, msgBroker)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating MeshSpec")
 	}

--- a/pkg/smi/client.go
+++ b/pkg/smi/client.go
@@ -16,7 +16,6 @@ import (
 	smiTrafficSplitClient "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned"
 	smiTrafficSplitInformers "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/informers/externalversions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
@@ -41,14 +40,13 @@ const (
 )
 
 // NewMeshSpecClient implements mesh.MeshSpec and creates the Kubernetes client, which retrieves SMI specific CRDs.
-func NewMeshSpecClient(smiKubeConfig *rest.Config, kubeClient kubernetes.Interface, osmNamespace string, kubeController k8s.Controller,
+func NewMeshSpecClient(smiKubeConfig *rest.Config, osmNamespace string, kubeController k8s.Controller,
 	stop chan struct{}, msgBroker *messaging.Broker) (MeshSpec, error) {
 	smiTrafficSplitClientSet := smiTrafficSplitClient.NewForConfigOrDie(smiKubeConfig)
 	smiTrafficSpecClientSet := smiTrafficSpecClient.NewForConfigOrDie(smiKubeConfig)
 	smiTrafficTargetClientSet := smiAccessClient.NewForConfigOrDie(smiKubeConfig)
 
 	client, err := newSMIClient(
-		kubeClient,
 		smiTrafficSplitClientSet,
 		smiTrafficSpecClientSet,
 		smiTrafficTargetClientSet,
@@ -99,7 +97,7 @@ func (c *client) run(stop <-chan struct{}) error {
 }
 
 // newClient creates a provider based on a Kubernetes client instance.
-func newSMIClient(kubeClient kubernetes.Interface, smiTrafficSplitClient smiTrafficSplitClient.Interface,
+func newSMIClient(smiTrafficSplitClient smiTrafficSplitClient.Interface,
 	smiTrafficSpecClient smiTrafficSpecClient.Interface, smiAccessClient smiAccessClient.Interface,
 	osmNamespace string, kubeController k8s.Controller, providerIdent string, stop chan struct{},
 	msgBroker *messaging.Broker) (*client, error) {

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -72,7 +72,6 @@ func bootstrapClient(stop chan struct{}) (*client, *fakeKubeClientSet, error) {
 	}
 
 	meshSpec, err := newSMIClient(
-		kubeClient,
 		smiTrafficSplitClientSet,
 		smiTrafficSpecClientSet,
 		smiTrafficTargetClientSet,


### PR DESCRIPTION
**Description**:

This PR removes the unused kubeClient from SMI client in `pkg/smi/client.go`.
Found while navigating the source code.

**Testing done**:

Existing unit tests in `client_tests.go` should be enough for the changeset.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ x ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
 
Not inspired by any external source code.

2. Is this a breaking change?

No

4. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No need for a documentation change, internal refactoring of SMI client.