### PR TITLE
fix potential bug in where we copy a lock value

### DIFF
--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
-func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}) {
+func receive(requests chan *xds_discovery.DiscoveryRequest, server *xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer, proxy *envoy.Proxy, quit chan struct{}) {
 	for {
 		var request *xds_discovery.DiscoveryRequest
 		request, recvErr := (*server).Recv()
@@ -31,7 +31,7 @@ func receive(requests chan xds_discovery.DiscoveryRequest, server *xds_discovery
 			log.Trace().Str("proxy", proxy.String()).Msgf("gRPC stream from proxy terminated")
 			close(quit)
 			return
-		case requests <- *request:
+		case requests <- request:
 		}
 		log.Debug().Str("proxy", proxy.String()).Msgf("Received DiscoveryRequest from proxy")
 	}

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -63,7 +63,7 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	defer s.proxyRegistry.UnregisterProxy(proxy)
 
 	quit := make(chan struct{})
-	requests := make(chan xds_discovery.DiscoveryRequest)
+	requests := make(chan *xds_discovery.DiscoveryRequest)
 
 	// This helper handles receiving messages from the connected Envoys
 	// and any gRPC error states.
@@ -104,20 +104,20 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 				metricsstore.DefaultMetricsStore.ProxyConnectCount.Dec()
 				return errGrpcClosed
 			}
-			log.Debug().Str("proxy", proxy.String()).Msgf("Processing DiscoveryRequest %s", discoveryReqToStr(&discoveryRequest))
+			log.Debug().Str("proxy", proxy.String()).Msgf("Processing DiscoveryRequest %s", discoveryReqToStr(discoveryRequest))
 
 			metricsstore.DefaultMetricsStore.ProxyXDSRequestCount.WithLabelValues(certCommonName.String(), discoveryRequest.TypeUrl).Inc()
 
 			// This function call runs xDS proto state machine given DiscoveryRequest as input.
 			// It's output is the decision to reply or not to this request.
-			if !respondToRequest(proxy, &discoveryRequest) {
-				log.Debug().Str("proxy", proxy.String()).Msgf("Ignoring DiscoveryRequest %s that does not need to be responded to", discoveryReqToStr(&discoveryRequest))
+			if !respondToRequest(proxy, discoveryRequest) {
+				log.Debug().Str("proxy", proxy.String()).Msgf("Ignoring DiscoveryRequest %s that does not need to be responded to", discoveryReqToStr(discoveryRequest))
 				continue
 			}
 
 			typesRequest := []envoy.TypeURI{envoy.TypeURI(discoveryRequest.TypeUrl)}
 
-			<-s.workqueues.AddJob(newJob(typesRequest, &discoveryRequest))
+			<-s.workqueues.AddJob(newJob(typesRequest, discoveryRequest))
 
 		case <-proxyUpdateChan:
 			log.Info().Str("proxy", proxy.String()).Msg("Broadcast update received")


### PR DESCRIPTION
My linter just picked up the issue that we're passing around a proto by value vs pointer. This has the issue that protos have locks embedded in them which we shouldn't copy.

https://github.com/golang/tools/blob/master/go/analysis/passes/copylock/copylock.go