### PR TITLE
refactor(cmd/cli): update uninstall cmd

### DIFF
--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -94,7 +94,7 @@ func newUninstallMeshCmd(config *action.Configuration, in io.Reader, out io.Writ
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&uninstall.meshName, "mesh-name", defaultMeshName, "Name of the service mesh")
+	f.StringVar(&uninstall.meshName, "mesh-name", "", "Name of the service mesh")
 	f.BoolVarP(&uninstall.force, "force", "f", false, "Attempt to uninstall the osm control plane instance without prompting for confirmation.")
 	f.BoolVarP(&uninstall.deleteClusterWideResources, "delete-cluster-wide-resources", "a", false, "Cluster wide resources (such as osm CRDs, mutating webhook configurations, validating webhook configurations and osm secrets) are fully deleted from the cluster after control plane components are deleted.")
 	f.BoolVar(&uninstall.deleteNamespace, "delete-namespace", false, "Attempt to delete the namespace after control plane components are deleted")
@@ -118,9 +118,9 @@ func (d *uninstallMeshCmd) run() error {
 			fmt.Fprintf(d.out, "No OSM control planes found\n")
 			return nil
 		}
-		specifiedMeshFound := false
 		// Searches for the mesh specified by the mesh-name flag if specified
-		if d.meshName != defaultMeshName {
+		specifiedMeshFound := false
+		if d.meshName != "" {
 			specifiedMeshFound = d.findMesh(meshInfoList)
 			if !specifiedMeshFound {
 				return nil
@@ -174,6 +174,8 @@ func (d *uninstallMeshCmd) run() error {
 				if !d.deleteClusterWideResources && !d.deleteNamespace {
 					return err
 				}
+
+				fmt.Fprintf(d.out, "Error %v when trying to uninstall mesh name [%s] in namespace [%s] - continuing to deleteClusterWideResources and/or deleteNamespace\n", err, m.name, m.namespace)
 			}
 
 			if err == nil {

--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -33,7 +33,7 @@ The command will not delete:
 (1) the namespace the mesh was installed in unless specified via the
 --delete-namespace flag.
 (2) the cluster-wide resources (i.e. CRDs, mutating and validating webhooks and
-secrets) unless specified via via the --delete-cluster-wide-resources (or -a) flag
+secrets) unless specified via the --delete-cluster-wide-resources (or -a) flag
 
 Be careful when using this command as it is destructive and will
 disrupt traffic to applications left running with sidecar proxies.
@@ -53,6 +53,7 @@ type uninstallMeshCmd struct {
 	localPort                  uint16
 	deleteClusterWideResources bool
 	extensionsClientset        extensionsClientset.Interface
+	actionConfig               *action.Configuration
 }
 
 func newUninstallMeshCmd(config *action.Configuration, in io.Reader, out io.Writer) *cobra.Command {
@@ -67,6 +68,7 @@ func newUninstallMeshCmd(config *action.Configuration, in io.Reader, out io.Writ
 		Long:  uninstallMeshDescription,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(_ *cobra.Command, args []string) error {
+			uninstall.actionConfig = config
 			uninstall.client = action.NewUninstall(config)
 
 			// get kubeconfig and initialize k8s client
@@ -105,92 +107,140 @@ func newUninstallMeshCmd(config *action.Configuration, in io.Reader, out io.Writ
 func (d *uninstallMeshCmd) run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	meshesToUninstall := []meshInfo{}
 
 	if !settings.IsManaged() {
-		if !d.force {
-			// print a list of meshes within the cluster for a better user experience
-			fmt.Fprintf(d.out, "\nList of meshes present in the cluster:\n")
-
-			listCmd := &meshListCmd{
-				out:       d.out,
-				config:    d.config,
-				clientSet: d.clientSet,
-				localPort: d.localPort,
+		meshInfoList, err := getMeshInfoList(d.config, d.clientSet)
+		if err != nil {
+			return errors.Wrapf(err, "unable to list meshes within the cluster")
+		}
+		if len(meshInfoList) == 0 {
+			fmt.Fprintf(d.out, "No OSM control planes found\n")
+			return nil
+		}
+		specifiedMeshFound := false
+		// Searches for the mesh specified by the mesh-name flag if specified
+		if d.meshName != defaultMeshName {
+			specifiedMeshFound = d.findMesh(meshInfoList)
+			if !specifiedMeshFound {
+				return nil
 			}
+		}
 
-			err := listCmd.run()
+		// Adds the mesh to be force uninstalled
+		if d.force {
+			// For force uninstall, if single mesh in cluster, set default to that mesh
+			if len(meshInfoList) == 1 {
+				d.meshName = meshInfoList[0].name
+				d.meshNamespace = meshInfoList[0].namespace
+			}
+			forceMesh := meshInfo{name: d.meshName, namespace: d.meshNamespace}
+			meshesToUninstall = append(meshesToUninstall, forceMesh)
+		} else {
+			// print a list of meshes within the cluster for a better user experience
+			err := d.printMeshes()
+			if err != nil {
+				return err
+			}
+			// Prompts user on whether to uninstall each OSM mesh in the cluster
+			for _, mesh := range meshInfoList {
+				// Only prompt for specified mesh if `mesh-name` is specified
+				if specifiedMeshFound && mesh.name != d.meshName {
+					continue
+				}
+				confirm, err := confirm(d.in, d.out, fmt.Sprintf("\nUninstall OSM [mesh name: %s] in namespace [%s] and/or OSM resources?", mesh.name, mesh.namespace), 3)
+				if err != nil {
+					return err
+				}
+				if confirm {
+					meshesToUninstall = append(meshesToUninstall, mesh)
+				}
+			}
+		}
 
-			// Unable to list meshes in the cluster
+		for _, m := range meshesToUninstall {
+			// Re-initializes uninstall config with the namespace of the mesh to be uninstalled
+			err := d.actionConfig.Init(settings.RESTClientGetter(), m.namespace, "secret", debug)
 			if err != nil {
 				return err
 			}
 
-			confirm, err := confirm(d.in, d.out, fmt.Sprintf("\nUninstall OSM [mesh name: %s] in namespace [%s] and/or OSM resources ?", d.meshName, d.meshNamespace), 3)
-			if !confirm || err != nil {
-				return err
+			_, err = d.client.Run(m.name)
+			if err != nil {
+				if errors.Cause(err) == helmStorage.ErrReleaseNotFound {
+					fmt.Fprintf(d.out, "No OSM control plane with mesh name [%s] found in namespace [%s]\n", m.name, m.namespace)
+				}
+
+				if !d.deleteClusterWideResources && !d.deleteNamespace {
+					return err
+				}
 			}
-		}
 
-		_, err := d.client.Run(d.meshName)
-		if err != nil && errors.Cause(err) == helmStorage.ErrReleaseNotFound {
-			fmt.Fprintf(d.out, "No OSM control plane with mesh name [%s] found in namespace [%s]\n", d.meshName, d.meshNamespace)
-
-			if !d.deleteClusterWideResources && !d.deleteNamespace {
-				return err
+			if err == nil {
+				fmt.Fprintf(d.out, "OSM [mesh name: %s] in namespace [%s] uninstalled\n", m.name, m.namespace)
 			}
-		}
 
-		if err == nil {
-			fmt.Fprintf(d.out, "OSM [mesh name: %s] in namespace [%s] uninstalled\n", d.meshName, d.meshNamespace)
+			if d.deleteNamespace {
+				if err := d.clientSet.CoreV1().Namespaces().Delete(ctx, m.namespace, v1.DeleteOptions{}); err != nil {
+					if k8sApiErrors.IsNotFound(err) {
+						fmt.Fprintf(d.out, "OSM namespace [%s] not found\n", m.namespace)
+						return nil
+					}
+					return errors.Errorf("Error occurred while deleting OSM namespace [%s] - %v", m.namespace, err)
+				}
+				fmt.Fprintf(d.out, "OSM namespace [%s] deleted successfully\n", m.namespace)
+			}
 		}
 	} else {
-		fmt.Fprintf(d.out, "OSM [mesh name: %s] in namespace [%s] CANNOT be uninstalled in a managed environment\n", d.meshName, d.meshNamespace)
+		fmt.Fprintf(d.out, "OSM CANNOT be uninstalled in a managed environment\n")
+		if d.deleteNamespace {
+			fmt.Fprintf(d.out, "OSM namespace CANNOT be deleted in a managed environment\n")
+		}
 	}
-
 	if d.deleteClusterWideResources {
-		var failedDeletions []string
-
-		err := d.uninstallCustomResourceDefinitions()
+		meshInfoList, err := getMeshInfoList(d.config, d.clientSet)
 		if err != nil {
-			failedDeletions = append(failedDeletions, "CustomResourceDefinitions")
+			return errors.Wrapf(err, "unable to list meshes within the cluster")
+		}
+		if len(meshInfoList) != 0 {
+			fmt.Fprintf(d.out, "Deleting cluster resources will affect current mesh(es) in cluster:\n")
+			for _, m := range meshInfoList {
+				fmt.Fprintf(d.out, "[%s] mesh in namespace [%s]\n", m.name, m.namespace)
+			}
 		}
 
-		err = d.uninstallMutatingWebhookConfigurations()
-		if err != nil {
-			failedDeletions = append(failedDeletions, "MutatingWebhookConfigurations")
-		}
-
-		err = d.uninstallValidatingWebhookConfigurations()
-		if err != nil {
-			failedDeletions = append(failedDeletions, "ValidatingWebhookConfigurations")
-		}
-
-		err = d.uninstallSecrets()
-		if err != nil {
-			failedDeletions = append(failedDeletions, "Secrets")
-		}
-
+		failedDeletions := d.uninstallClusterResources()
 		if len(failedDeletions) != 0 {
 			return errors.Errorf("Failed to completely delete the following OSM resource types: %+v", failedDeletions)
 		}
 	}
 
-	if d.deleteNamespace {
-		if !settings.IsManaged() {
-			if err := d.clientSet.CoreV1().Namespaces().Delete(ctx, d.meshNamespace, v1.DeleteOptions{}); err != nil {
-				if k8sApiErrors.IsNotFound(err) {
-					fmt.Fprintf(d.out, "OSM namespace [%s] not found\n", d.meshNamespace)
-					return nil
-				}
-				return errors.Errorf("Error occurred while deleting OSM namespace [%s] - %v", d.meshNamespace, err)
-			}
-			fmt.Fprintf(d.out, "OSM namespace [%s] deleted successfully\n", d.meshNamespace)
-		} else {
-			fmt.Fprintf(d.out, "OSM namespace [%s] CANNOT be deleted in a managed environment\n", d.meshNamespace)
-		}
+	return nil
+}
+
+// uninstallClusterResources uninstalls all osm and smi-related cluster resources
+func (d *uninstallMeshCmd) uninstallClusterResources() []string {
+	var failedDeletions []string
+	err := d.uninstallCustomResourceDefinitions()
+	if err != nil {
+		failedDeletions = append(failedDeletions, "CustomResourceDefinitions")
 	}
 
-	return nil
+	err = d.uninstallMutatingWebhookConfigurations()
+	if err != nil {
+		failedDeletions = append(failedDeletions, "MutatingWebhookConfigurations")
+	}
+
+	err = d.uninstallValidatingWebhookConfigurations()
+	if err != nil {
+		failedDeletions = append(failedDeletions, "ValidatingWebhookConfigurations")
+	}
+
+	err = d.uninstallSecrets()
+	if err != nil {
+		failedDeletions = append(failedDeletions, "Secrets")
+	}
+	return failedDeletions
 }
 
 // uninstallCustomResourceDefinitions uninstalls osm and smi-related crds from the cluster.
@@ -358,5 +408,46 @@ func (d *uninstallMeshCmd) uninstallSecrets() error {
 		return errors.Errorf("Found but failed to delete the following OSM secrets in namespace %s: %+v", d.meshNamespace, failedDeletions)
 	}
 
+	return nil
+}
+
+// findMesh looks for specified `mesh-name` mesh from the meshes in the cluster
+func (d *uninstallMeshCmd) findMesh(meshInfoList []meshInfo) bool {
+	found := false
+	for _, m := range meshInfoList {
+		if m.name == d.meshName {
+			found = true
+			break
+		}
+	}
+	if found {
+		return true
+	}
+
+	fmt.Fprintf(d.out, "Did not find mesh [%s] in namespace [%s]\n", d.meshName, d.meshNamespace)
+	// print a list of meshes within the cluster for a better user experience
+	err := d.printMeshes()
+	if err != nil {
+		fmt.Fprintf(d.out, "Unable to list meshes in the cluster - [%v]", err)
+	}
+	return false
+}
+
+// printMeshes prints list of meshes within the cluster for a better user experience
+func (d *uninstallMeshCmd) printMeshes() error {
+	fmt.Fprintf(d.out, "List of meshes present in the cluster:\n")
+
+	listCmd := &meshListCmd{
+		out:       d.out,
+		config:    d.config,
+		clientSet: d.clientSet,
+		localPort: d.localPort,
+	}
+
+	err := listCmd.run()
+	// Unable to list meshes in the cluster
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -134,7 +134,6 @@ func TestUninstallCmd(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		RegisterFailHandler(ginkgo.Fail)
 		t.Run(test.name, func(t *testing.T) {
 			assert := tassert.New(t)
 			out := new(bytes.Buffer)

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	tassert "github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/action"
 	helm "helm.sh/helm/v3/pkg/action"
@@ -537,7 +535,6 @@ func TestUninstallClusterWideResources(t *testing.T) {
 		},
 	}
 
-	RegisterFailHandler(ginkgo.Fail)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert := tassert.New(t)
@@ -557,7 +554,7 @@ func TestUninstallClusterWideResources(t *testing.T) {
 
 			rel := release.Mock(&release.MockReleaseOptions{Name: testMeshName})
 			err := store.Create(rel)
-			Expect(err).To(BeNil())
+			assert.Nil(err)
 
 			testConfig := &helm.Configuration{
 				Releases: store,
@@ -569,7 +566,7 @@ func TestUninstallClusterWideResources(t *testing.T) {
 
 			fakeClientSet := fake.NewSimpleClientset(existingKubeClientsetObjects...)
 			_, err = addDeployment(fakeClientSet, "osm-controller-1", testMeshName, testNamespace, osmTestVersion, true)
-			Expect(err).NotTo(HaveOccurred())
+			assert.Nil(err)
 
 			uninstall := uninstallMeshCmd{
 				in:                 in,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Updates `uninstall mesh` command so that user is prompted on whether they want to uninstall an existing mesh. Also, adds a warning for `delete-cluster-wide-resources` if there are remaining meshes in the cluster, before deleting cluster resources. Resolves #4613

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.
-->
**Testing done**:
Uninstall mesh now prompts with existing mesh:
![prompts_existing_mesh](https://user-images.githubusercontent.com/69616256/163934320-59e3e51b-7748-4b4f-8f45-b4c1c5b01032.jpg)
Can also uninstall specific mesh with `mesh-name` flag:
![specify_mesh_with_mesh_name](https://user-images.githubusercontent.com/69616256/163934565-d579d5d9-b358-4c09-9141-8e59be90c747.jpg)
Informs when mesh doesn't exist (including when trying to force uninstall):
![doesntExist_plus_force_flag](https://user-images.githubusercontent.com/69616256/163934682-ca0a6719-1491-47fc-853b-0b46b7443264.jpg)
`delete-namespace` flag:
![delete_namespace_flag](https://user-images.githubusercontent.com/69616256/163934761-188302c4-b8d3-44bb-af2f-583e8dd33fa2.jpg)
`delete-cluster-wide-resources` flag:
![delete_cluster_wide_resources](https://user-images.githubusercontent.com/69616256/163934937-3321dbc1-59aa-476e-b6b4-bac70979b283.jpg)
warning when deleting cluster resources and there are still meshes in the cluster (updated):
![uninstallCmd_cluster_wide_resources](https://user-images.githubusercontent.com/69616256/165161730-155f3499-5f19-4778-a62a-a75d0a60a69e.jpg)
`force` flag uninstalls existing mesh [only one mesh in cluster]:
![single_mesh_force](https://user-images.githubusercontent.com/69616256/163935069-bf056ad6-df72-43b0-922c-0c65cb404dd7.jpg)
`force` flag uninstalls the default mesh+namespace (osm+osm-system) unless `mesh-name` and `osm-namespace` are specified [multiple meshes]:
![multi_mesh_force](https://user-images.githubusercontent.com/69616256/163935121-1c624a79-725d-4184-96b8-8d0bc457287c.jpg)


<!--
Please mark with X for applicable areas.
-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ x] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs] (https://github.com/openservicemesh/osm-docs) repo (if applicable)?