### PR TITLE
expose the version information via prometheus

### DIFF
--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -189,6 +189,7 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating crd conversion webhook")
 	}
 
+	version.SetMetric()
 	/*
 	 * Initialize osm-bootstrap's HTTP server
 	 */

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -248,6 +248,8 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error starting the validating webhook server")
 	}
 
+	version.SetMetric()
+
 	// Initialize OSM's http service server
 	httpServer := httpserver.NewHTTPServer(constants.OSMHTTPServerPort)
 	// Health/Liveness probes
@@ -306,6 +308,7 @@ func startMetricsStore() {
 		metricsstore.DefaultMetricsStore.HTTPResponseTotal,
 		metricsstore.DefaultMetricsStore.HTTPResponseDuration,
 		metricsstore.DefaultMetricsStore.FeatureFlagEnabled,
+		metricsstore.DefaultMetricsStore.VersionInfo,
 		metricsstore.DefaultMetricsStore.ProxyXDSRequestCount,
 		metricsstore.DefaultMetricsStore.ProxyMaxConnectionsRejected,
 		metricsstore.DefaultMetricsStore.AdmissionWebhookResponseTotal,

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -181,6 +181,7 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating sidecar injector webhook")
 	}
 
+	version.SetMetric()
 	/*
 	 * Initialize osm-injector's HTTP server
 	 */

--- a/pkg/metricsstore/metricsstore.go
+++ b/pkg/metricsstore/metricsstore.go
@@ -93,6 +93,9 @@ type MetricsStore struct {
 	// disabled (0)
 	FeatureFlagEnabled *prometheus.GaugeVec
 
+	// VersionInfo contains the static version information of OSM as labels. The gauge is always set to 1.
+	VersionInfo *prometheus.GaugeVec
+
 	/*
 	 * MetricsStore internals should be defined below --------------
 	 */
@@ -256,6 +259,12 @@ func init() {
 		Name:      "feature_flag_enabled",
 		Help:      "Represents whether a feature flag is enabled (1) or disabled (0)",
 	}, []string{"feature_flag"})
+
+	defaultMetricsStore.VersionInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: metricsRootNamespace,
+		Name:      "version_info",
+		Help:      "Contains the static information denoting the version of this OSM instance",
+	}, []string{"version", "build_date", "git_commit"})
 
 	defaultMetricsStore.registry = prometheus.NewRegistry()
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/metricsstore"
 )
 
 var log = logger.New("version")
@@ -53,4 +54,9 @@ func GetVersionHandler() http.Handler {
 			_, _ = fmt.Fprint(w, string(jsonVersionInfo))
 		}
 	})
+}
+
+// SetMetric is a one time call to expose the version info via prometheus metrics.
+func SetMetric() {
+	metricsstore.DefaultMetricsStore.VersionInfo.WithLabelValues(Version, BuildDate, GitCommit).Set(1)
 }


### PR DESCRIPTION
Simply expose the OSM version information as a prometheus metric.


Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

