### PR TITLE
config/MeshConfig: Update control plane to v1alpha3

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -138,6 +138,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.injector.replicaCount | int | `1` | Sidecar injector's replica count (ignored when autoscale.enable is true) |
 | osm.injector.resource | object | `{"limits":{"cpu":"0.5","memory":"64M"},"requests":{"cpu":"0.3","memory":"64M"}}` | Sidecar injector's container resource parameters |
 | osm.injector.webhookTimeoutSeconds | int | `20` | Mutating webhook timeout |
+| osm.localProxyMode | string | `"Localhost"` | Proxy mode for the Envoy proxy sidecar. Acceptable values are ['Localhost', 'PodIP'] |
 | osm.maxDataPlaneConnections | int | `0` | Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits |
 | osm.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
 | osm.multicluster | object | `{"gatewayLogLevel":"error"}` | OSM multicluster feature configuration |

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -10,7 +10,8 @@ data:
         "enablePrivilegedInitContainer": {{.Values.osm.enablePrivilegedInitContainer | mustToJson}},
         "logLevel": {{.Values.osm.envoyLogLevel | mustToJson}},
         "maxDataPlaneConnections": {{.Values.osm.maxDataPlaneConnections | mustToJson}},
-        "configResyncInterval": {{.Values.osm.configResyncInterval | mustToJson}}
+        "configResyncInterval": {{.Values.osm.configResyncInterval | mustToJson}},
+        "localProxyMode": {{.Values.osm.localProxyMode | mustToJson}}
       },
       "traffic": {
         "enableEgress": {{.Values.osm.enableEgress | mustToJson}},

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -181,6 +181,7 @@
                 "meshName",
                 "maxDataPlaneConnections",
                 "envoyLogLevel",
+                "localProxyMode",
                 "controllerLogLevel",
                 "enforceSingleMesh",
                 "deployJaeger",
@@ -699,6 +700,16 @@
                     "pattern": "^(trace|debug|info|warning|warn|error|critical|off)$",
                     "examples": [
                         "error"
+                    ]
+                },
+                "localProxyMode": {
+                    "$id": "#/properties/osm/properties/localProxyMode",
+                    "type": "string",
+                    "title": "The localProxyMode schema",
+                    "description": "Proxy mode for the Envoy proxy sidecar. Acceptable values are ['Localhost', 'PodIP'].",
+                    "pattern": "^(Localhost|PodIP)$",
+                    "examples": [
+                        "Localhost"
                     ]
                 },
                 "controllerLogLevel": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -204,6 +204,9 @@ osm:
   # -- Log level for the Envoy proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error`
   envoyLogLevel: error
 
+  # -- Proxy mode for the Envoy proxy sidecar. Acceptable values are ['Localhost', 'PodIP']
+  localProxyMode: Localhost
+
   # -- Sets the max data plane connections allowed for an instance of osm-controller, set to 0 to not enforce limits
   maxDataPlaneConnections: 0
 

--- a/cmd/cli/policy_check_pods_test.go
+++ b/cmd/cli/policy_check_pods_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -66,18 +66,18 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 	}
 
 	testCases := []struct {
-		meshConfig  configv1alpha2.MeshConfig
+		meshConfig  configv1alpha3.MeshConfig
 		enabled     bool
 		expectError bool
 	}{
 		{
-			configv1alpha2.MeshConfig{
+			configv1alpha3.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace.Name,
 					Name:      defaultOsmMeshConfigName,
 				},
-				Spec: configv1alpha2.MeshConfigSpec{
-					Traffic: configv1alpha2.TrafficSpec{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						EnablePermissiveTrafficPolicyMode: true,
 					},
 				},
@@ -86,13 +86,13 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 			false,
 		},
 		{
-			configv1alpha2.MeshConfig{
+			configv1alpha3.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace.Name,
 					Name:      defaultOsmMeshConfigName,
 				},
-				Spec: configv1alpha2.MeshConfigSpec{
-					Traffic: configv1alpha2.TrafficSpec{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						EnablePermissiveTrafficPolicyMode: false,
 					},
 				},
@@ -107,7 +107,7 @@ func TestIsPermissiveModeEnabled(t *testing.T) {
 			assert := tassert.New(t)
 
 			// create the MeshConfig
-			_, err := fakeConfigClient.ConfigV1alpha2().MeshConfigs(osmNamespace.Name).Create(context.TODO(), &tc.meshConfig, metav1.CreateOptions{})
+			_, err := fakeConfigClient.ConfigV1alpha3().MeshConfigs(osmNamespace.Name).Create(context.TODO(), &tc.meshConfig, metav1.CreateOptions{})
 			assert.Nil(err)
 
 			enabled, err := cmd.isPermissiveModeEnabled()
@@ -268,19 +268,19 @@ func TestRun(t *testing.T) {
 	assert.Nil(err)
 
 	// Create MeshConfig with permissive mode enabled
-	meshConfig := &configv1alpha2.MeshConfig{
+	meshConfig := &configv1alpha3.MeshConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "osm-system",
 			Name:      defaultOsmMeshConfigName,
 		},
-		Spec: configv1alpha2.MeshConfigSpec{
-			Traffic: configv1alpha2.TrafficSpec{
+		Spec: configv1alpha3.MeshConfigSpec{
+			Traffic: configv1alpha3.TrafficSpec{
 				EnablePermissiveTrafficPolicyMode: true,
 			},
 		},
 	}
 
-	_, err = fakeConfigClient.ConfigV1alpha2().MeshConfigs(osmNamespace.Name).Create(context.TODO(), meshConfig, metav1.CreateOptions{})
+	_, err = fakeConfigClient.ConfigV1alpha3().MeshConfigs(osmNamespace.Name).Create(context.TODO(), meshConfig, metav1.CreateOptions{})
 	assert.Nil(err)
 
 	for i, tc := range testCases {
@@ -331,7 +331,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 		srcPod            corev1.Pod
 		dstPod            corev1.Pod
 		trafficTarget     smiAccess.TrafficTarget
-		meshConfig        configv1alpha2.MeshConfig
+		meshConfig        configv1alpha3.MeshConfig
 		expectError       bool
 		expectedOutSubstr string
 	}{
@@ -379,13 +379,13 @@ func TestCheckTrafficPolicy(t *testing.T) {
 					}},
 				},
 			},
-			configv1alpha2.MeshConfig{
+			configv1alpha3.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "osm-system",
 					Name:      defaultOsmMeshConfigName,
 				},
-				Spec: configv1alpha2.MeshConfigSpec{
-					Traffic: configv1alpha2.TrafficSpec{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						EnablePermissiveTrafficPolicyMode: false,
 					},
 				},
@@ -437,13 +437,13 @@ func TestCheckTrafficPolicy(t *testing.T) {
 					}},
 				},
 			},
-			configv1alpha2.MeshConfig{
+			configv1alpha3.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "osm-system",
 					Name:      defaultOsmMeshConfigName,
 				},
-				Spec: configv1alpha2.MeshConfigSpec{
-					Traffic: configv1alpha2.TrafficSpec{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						EnablePermissiveTrafficPolicyMode: false,
 					},
 				},
@@ -496,13 +496,13 @@ func TestCheckTrafficPolicy(t *testing.T) {
 					}},
 				},
 			},
-			configv1alpha2.MeshConfig{
+			configv1alpha3.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "osm-system",
 					Name:      defaultOsmMeshConfigName,
 				},
-				Spec: configv1alpha2.MeshConfigSpec{
-					Traffic: configv1alpha2.TrafficSpec{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						EnablePermissiveTrafficPolicyMode: true,
 					},
 				},
@@ -548,7 +548,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			assert := tassert.New(t)
 
 			// create MeshConfig
-			_, err := fakeConfigClient.ConfigV1alpha2().MeshConfigs(osmNamespace.Name).Create(context.TODO(), &tc.meshConfig, metav1.CreateOptions{})
+			_, err := fakeConfigClient.ConfigV1alpha3().MeshConfigs(osmNamespace.Name).Create(context.TODO(), &tc.meshConfig, metav1.CreateOptions{})
 			assert.Nil(err)
 
 			// create the traffic target
@@ -560,7 +560,7 @@ func TestCheckTrafficPolicy(t *testing.T) {
 			assert.Contains(out.String(), tc.expectedOutSubstr)
 
 			// delete the MeshConfig for the next test case using the same MeshConfig
-			err = fakeConfigClient.ConfigV1alpha2().MeshConfigs(osmNamespace.Name).Delete(context.TODO(), tc.meshConfig.Name, metav1.DeleteOptions{})
+			err = fakeConfigClient.ConfigV1alpha3().MeshConfigs(osmNamespace.Name).Delete(context.TODO(), tc.meshConfig.Name, metav1.DeleteOptions{})
 			assert.Nil(err)
 
 			// delete the TrafficTarget for the next test case

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -23,7 +23,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/certificate/providers"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -227,7 +227,7 @@ func (b *bootstrap) createDefaultMeshConfig() error {
 
 	// Create a default meshConfig
 	defaultMeshConfig := buildDefaultMeshConfig(presetsConfigMap)
-	if _, err := b.meshConfigClient.ConfigV1alpha2().MeshConfigs(b.namespace).Create(context.TODO(), defaultMeshConfig, metav1.CreateOptions{}); err == nil {
+	if _, err := b.meshConfigClient.ConfigV1alpha3().MeshConfigs(b.namespace).Create(context.TODO(), defaultMeshConfig, metav1.CreateOptions{}); err == nil {
 		log.Info().Msgf("MeshConfig (%s) created in namespace %s", meshConfigName, b.namespace)
 		return nil
 	}
@@ -306,15 +306,15 @@ func validateCLIParams() error {
 	return nil
 }
 
-func buildDefaultMeshConfig(presetMeshConfigMap *corev1.ConfigMap) *configv1alpha2.MeshConfig {
+func buildDefaultMeshConfig(presetMeshConfigMap *corev1.ConfigMap) *configv1alpha3.MeshConfig {
 	presetMeshConfig := presetMeshConfigMap.Data[presetMeshConfigJSONKey]
-	presetMeshConfigSpec := configv1alpha2.MeshConfigSpec{}
+	presetMeshConfigSpec := configv1alpha3.MeshConfigSpec{}
 	err := json.Unmarshal([]byte(presetMeshConfig), &presetMeshConfigSpec)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Error converting preset-mesh-config json string to meshConfig object")
 	}
 
-	return &configv1alpha2.MeshConfig{
+	return &configv1alpha3.MeshConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MeshConfig",
 			APIVersion: "config.openservicemesh.io/configv1alpha3",

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -12,19 +12,19 @@ import (
 	"k8s.io/client-go/kubernetes"
 	fakeKube "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 )
 
 var testNamespace = "test-namespace"
 
-var testMeshConfig *configv1alpha2.MeshConfig = &configv1alpha2.MeshConfig{
+var testMeshConfig *configv1alpha3.MeshConfig = &configv1alpha3.MeshConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: testNamespace,
 		Name:      meshConfigName,
 	},
-	Spec: configv1alpha2.MeshConfigSpec{},
+	Spec: configv1alpha3.MeshConfigSpec{},
 }
 
 var testPresetMeshConfigMap *corev1.ConfigMap = &corev1.ConfigMap{

--- a/pkg/catalog/egress_test.go
+++ b/pkg/catalog/egress_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -446,7 +446,7 @@ func TestGetEgressTrafficPolicy(t *testing.T) {
 				policyController: mockPolicyController,
 			}
 
-			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableEgressPolicy: true}).Times(1)
+			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableEgressPolicy: true}).Times(1)
 
 			actual, err := mc.GetEgressTrafficPolicy(testSourceIdentity)
 			assert.Equal(tc.expectError, err != nil)

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -40,7 +40,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockKubeController := k8s.NewMockController(mockCtrl)
 	mockPolicyController := policy.NewMockController(mockCtrl)
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 	mockConfigurator.EXPECT().GetOSMNamespace().Return("osm-system").AnyTimes()
 
 	provider := kubeFake.NewFakeProvider()

--- a/pkg/catalog/outbound_traffic_policies_test.go
+++ b/pkg/catalog/outbound_traffic_policies_test.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/policy"
 
@@ -596,7 +596,7 @@ func TestGetOutboundMeshTrafficPolicy(t *testing.T) {
 
 			// Mock calls to k8s client caches
 			mockCfg.EXPECT().IsPermissiveTrafficPolicyMode().Return(tc.permissiveMode).AnyTimes()
-			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{}).AnyTimes()
+			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{}).AnyTimes()
 			mockServiceProvider.EXPECT().ListServices().Return(allMeshServices).AnyTimes()
 			mockMeshSpec.EXPECT().ListTrafficTargets().Return(trafficTargets).AnyTimes()
 			mockServiceProvider.EXPECT().GetID().Return("test").AnyTimes()
@@ -774,7 +774,7 @@ func TestListAllowedUpstreamServicesIncludeApex(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockController := k8s.NewMockController(mockCtrl)
 	mockServiceProvider := service.NewMockProvider(mockCtrl)
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 	mockConfigurator.EXPECT().GetOSMNamespace().Return("osm-system").AnyTimes()
 
 	mc := MeshCatalog{

--- a/pkg/catalog/retry_test.go
+++ b/pkg/catalog/retry_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
 
-	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -230,7 +230,7 @@ func TestGetRetryPolicy(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
-			mockCfg.EXPECT().GetFeatureFlags().Return(v1alpha2.FeatureFlags{EnableRetryPolicy: tc.retryPolicyFlag}).Times(1)
+			mockCfg.EXPECT().GetFeatureFlags().Return(v1alpha3.FeatureFlags{EnableRetryPolicy: tc.retryPolicyFlag}).Times(1)
 			mockPolicyController.EXPECT().ListRetryPolicies(gomock.Any()).Return(tc.retryCRDs).Times(1)
 
 			res := mc.getRetryPolicy(retrySrc, tc.destSvc)

--- a/pkg/config/client.go
+++ b/pkg/config/client.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	configV1alpha1Client "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
-	configV1alpha1Informers "github.com/openservicemesh/osm/pkg/gen/client/config/informers/externalversions"
+	configV1alpha3Client "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	configV1alpha3Informers "github.com/openservicemesh/osm/pkg/gen/client/config/informers/externalversions"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/messaging"
 )
@@ -22,11 +22,11 @@ const (
 
 // NewConfigController returns a config.Controller struct related to functionality provided by the resources in the config.openservicemesh.io API group
 func NewConfigController(kubeConfig *rest.Config, kubeController k8s.Controller, stop chan struct{}, msgBroker *messaging.Broker) (Controller, error) {
-	configClient := configV1alpha1Client.NewForConfigOrDie(kubeConfig)
-	informerFactory := configV1alpha1Informers.NewSharedInformerFactory(configClient, k8s.DefaultKubeEventResyncInterval)
+	configClient := configV1alpha3Client.NewForConfigOrDie(kubeConfig)
+	informerFactory := configV1alpha3Informers.NewSharedInformerFactory(configClient, k8s.DefaultKubeEventResyncInterval)
 
 	client := client{
-		informer:       informerFactory.Config().V1alpha2().MultiClusterServices(),
+		informer:       informerFactory.Config().V1alpha3().MultiClusterServices(),
 		kubeController: kubeController,
 	}
 

--- a/pkg/config/mock_client_generated.go
+++ b/pkg/config/mock_client_generated.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	v1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 )
 
 // MockController is a mock of Controller interface.
@@ -35,10 +35,10 @@ func (m *MockController) EXPECT() *MockControllerMockRecorder {
 }
 
 // GetMultiClusterService mocks base method.
-func (m *MockController) GetMultiClusterService(arg0, arg1 string) *v1alpha2.MultiClusterService {
+func (m *MockController) GetMultiClusterService(arg0, arg1 string) *v1alpha3.MultiClusterService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultiClusterService", arg0, arg1)
-	ret0, _ := ret[0].(*v1alpha2.MultiClusterService)
+	ret0, _ := ret[0].(*v1alpha3.MultiClusterService)
 	return ret0
 }
 
@@ -49,10 +49,10 @@ func (mr *MockControllerMockRecorder) GetMultiClusterService(arg0, arg1 interfac
 }
 
 // GetMultiClusterServiceByServiceAccount mocks base method.
-func (m *MockController) GetMultiClusterServiceByServiceAccount(arg0, arg1 string) []v1alpha2.MultiClusterService {
+func (m *MockController) GetMultiClusterServiceByServiceAccount(arg0, arg1 string) []v1alpha3.MultiClusterService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMultiClusterServiceByServiceAccount", arg0, arg1)
-	ret0, _ := ret[0].([]v1alpha2.MultiClusterService)
+	ret0, _ := ret[0].([]v1alpha3.MultiClusterService)
 	return ret0
 }
 
@@ -63,10 +63,10 @@ func (mr *MockControllerMockRecorder) GetMultiClusterServiceByServiceAccount(arg
 }
 
 // ListMultiClusterServices mocks base method.
-func (m *MockController) ListMultiClusterServices() []v1alpha2.MultiClusterService {
+func (m *MockController) ListMultiClusterServices() []v1alpha3.MultiClusterService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMultiClusterServices")
-	ret0, _ := ret[0].([]v1alpha2.MultiClusterService)
+	ret0, _ := ret[0].([]v1alpha3.MultiClusterService)
 	return ret0
 }
 

--- a/pkg/config/multiclusterservice.go
+++ b/pkg/config/multiclusterservice.go
@@ -1,16 +1,16 @@
 package config
 
 import (
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-func (c client) ListMultiClusterServices() []configv1alpha2.MultiClusterService {
-	var services []configv1alpha2.MultiClusterService
+func (c client) ListMultiClusterServices() []configv1alpha3.MultiClusterService {
+	var services []configv1alpha3.MultiClusterService
 
 	for _, obj := range c.informer.Informer().GetStore().List() {
-		mcs := obj.(*configv1alpha2.MultiClusterService)
+		mcs := obj.(*configv1alpha3.MultiClusterService)
 		if c.kubeController.IsMonitoredNamespace(mcs.Namespace) {
 			services = append(services, *mcs)
 		}
@@ -20,8 +20,8 @@ func (c client) ListMultiClusterServices() []configv1alpha2.MultiClusterService 
 	return services
 }
 
-func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []configv1alpha2.MultiClusterService {
-	var services []configv1alpha2.MultiClusterService
+func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []configv1alpha3.MultiClusterService {
+	var services []configv1alpha3.MultiClusterService
 
 	for _, svc := range c.ListMultiClusterServices() {
 		if svc.Spec.ServiceAccount == serviceAccount && svc.Namespace == namespace {
@@ -33,7 +33,7 @@ func (c client) GetMultiClusterServiceByServiceAccount(serviceAccount, namespace
 	return services
 }
 
-func (c client) GetMultiClusterService(name, namespace string) *configv1alpha2.MultiClusterService {
+func (c client) GetMultiClusterService(name, namespace string) *configv1alpha3.MultiClusterService {
 	if !c.kubeController.IsMonitoredNamespace(namespace) {
 		return nil
 	}
@@ -42,5 +42,5 @@ func (c client) GetMultiClusterService(name, namespace string) *configv1alpha2.M
 		log.Error().Str(constants.LogFieldContext, constants.LogContextMulticluster).Err(err).Msgf("Error getting MultiClusterService %s in namespace %s from informer ", name, namespace)
 		return nil
 	}
-	return mcs.(*configv1alpha2.MultiClusterService)
+	return mcs.(*configv1alpha3.MultiClusterService)
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -2,8 +2,8 @@
 package config
 
 import (
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
-	configv1alpha2Client "github.com/openservicemesh/osm/pkg/gen/client/config/informers/externalversions/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
+	configv1alpha3Client "github.com/openservicemesh/osm/pkg/gen/client/config/informers/externalversions/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -15,13 +15,13 @@ var (
 
 // client is the type used to represent the Kubernetes client for the multiclusterservice.openservicemesh.io API group
 type client struct {
-	informer       configv1alpha2Client.MultiClusterServiceInformer
+	informer       configv1alpha3Client.MultiClusterServiceInformer
 	kubeController k8s.Controller
 }
 
 // Controller is the interface for the functionality provided by the resources part of the multiclusterservice.openservicemesh.io API group
 type Controller interface {
-	ListMultiClusterServices() []configv1alpha2.MultiClusterService
-	GetMultiClusterService(name, namespace string) *configv1alpha2.MultiClusterService
-	GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []configv1alpha2.MultiClusterService
+	ListMultiClusterServices() []configv1alpha3.MultiClusterService
+	GetMultiClusterService(name, namespace string) *configv1alpha3.MultiClusterService
+	GetMultiClusterServiceByServiceAccount(serviceAccount, namespace string) []configv1alpha3.MultiClusterService
 }

--- a/pkg/configurator/client.go
+++ b/pkg/configurator/client.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	configInformers "github.com/openservicemesh/osm/pkg/gen/client/config/informers/externalversions"
 
@@ -36,7 +36,7 @@ func newConfigurator(meshConfigClientSet configClientset.Interface, stop <-chan 
 		configInformers.WithNamespace(osmNamespace),
 		listOption,
 	)
-	informer := informerFactory.Config().V1alpha2().MeshConfigs().Informer()
+	informer := informerFactory.Config().V1alpha3().MeshConfigs().Informer()
 	c := &client{
 		informer:       informer,
 		cache:          informer.GetStore(),
@@ -76,8 +76,8 @@ func (c *client) getMeshConfigCacheKey() string {
 }
 
 // Returns the current MeshConfig
-func (c *client) getMeshConfig() configv1alpha2.MeshConfig {
-	var meshConfig configv1alpha2.MeshConfig
+func (c *client) getMeshConfig() configv1alpha3.MeshConfig {
+	var meshConfig configv1alpha3.MeshConfig
 
 	meshConfigCacheKey := c.getMeshConfigCacheKey()
 	item, exists, err := c.cache.GetByKey(meshConfigCacheKey)
@@ -91,13 +91,13 @@ func (c *client) getMeshConfig() configv1alpha2.MeshConfig {
 		return meshConfig
 	}
 
-	meshConfig = *item.(*configv1alpha2.MeshConfig)
+	meshConfig = *item.(*configv1alpha3.MeshConfig)
 	return meshConfig
 }
 
 func (c *client) metricsHandler() cache.ResourceEventHandlerFuncs {
 	handleMetrics := func(obj interface{}) {
-		config := obj.(*configv1alpha2.MeshConfig)
+		config := obj.(*configv1alpha3.MeshConfig)
 
 		// This uses reflection to iterate over the feature flags to avoid
 		// enumerating them here individually. This code assumes the following:
@@ -122,7 +122,7 @@ func (c *client) metricsHandler() cache.ResourceEventHandlerFuncs {
 			handleMetrics(newObj)
 		},
 		DeleteFunc: func(obj interface{}) {
-			config := obj.(*configv1alpha2.MeshConfig).DeepCopy()
+			config := obj.(*configv1alpha3.MeshConfig).DeepCopy()
 			// Ensure metrics reflect however the rest of the control plane
 			// handles when the MeshConfig doesn't exist. If this happens not to
 			// be the "real" MeshConfig, handleMetrics() will simply ignore it.

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -10,7 +10,7 @@ import (
 	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 )
 
 const (
@@ -26,9 +26,9 @@ func TestGetMeshConfig(t *testing.T) {
 	c := newConfigurator(meshConfigClient, stop, osmNamespace, osmMeshConfigName, nil)
 
 	// Returns empty MeshConfig if informer cache is empty
-	a.Equal(configv1alpha2.MeshConfig{}, c.getMeshConfig())
+	a.Equal(configv1alpha3.MeshConfig{}, c.getMeshConfig())
 
-	newObj := &configv1alpha2.MeshConfig{
+	newObj := &configv1alpha3.MeshConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "config.openservicemesh.io",
 			Kind:       "MeshConfig",
@@ -62,12 +62,12 @@ func TestMetricsHandler(t *testing.T) {
 	metricsstore.DefaultMetricsStore.Start(metricsstore.DefaultMetricsStore.FeatureFlagEnabled)
 
 	// Adding the MeshConfig
-	handlers.OnAdd(&configv1alpha2.MeshConfig{
+	handlers.OnAdd(&configv1alpha3.MeshConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: osmMeshConfigName,
 		},
-		Spec: configv1alpha2.MeshConfigSpec{
-			FeatureFlags: configv1alpha2.FeatureFlags{
+		Spec: configv1alpha3.MeshConfigSpec{
+			FeatureFlags: configv1alpha3.FeatureFlags{
 				EnableRetryPolicy: true,
 			},
 		},
@@ -76,12 +76,12 @@ func TestMetricsHandler(t *testing.T) {
 	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_feature_flag_enabled{feature_flag="enableSnapshotCacheMode"} 0` + "\n"))
 
 	// Updating the MeshConfig
-	handlers.OnUpdate(nil, &configv1alpha2.MeshConfig{
+	handlers.OnUpdate(nil, &configv1alpha3.MeshConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: osmMeshConfigName,
 		},
-		Spec: configv1alpha2.MeshConfigSpec{
-			FeatureFlags: configv1alpha2.FeatureFlags{
+		Spec: configv1alpha3.MeshConfigSpec{
+			FeatureFlags: configv1alpha3.FeatureFlags{
 				EnableSnapshotCacheMode: true,
 			},
 		},
@@ -90,12 +90,12 @@ func TestMetricsHandler(t *testing.T) {
 	a.True(metricsstore.DefaultMetricsStore.Contains(`osm_feature_flag_enabled{feature_flag="enableSnapshotCacheMode"} 1` + "\n"))
 
 	// Deleting the MeshConfig
-	handlers.OnDelete(&configv1alpha2.MeshConfig{
+	handlers.OnDelete(&configv1alpha3.MeshConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: osmMeshConfigName,
 		},
-		Spec: configv1alpha2.MeshConfigSpec{
-			FeatureFlags: configv1alpha2.FeatureFlags{
+		Spec: configv1alpha3.MeshConfigSpec{
+			FeatureFlags: configv1alpha3.FeatureFlags{
 				EnableSnapshotCacheMode: true,
 			},
 		},

--- a/pkg/configurator/methods.go
+++ b/pkg/configurator/methods.go
@@ -8,7 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -32,7 +32,7 @@ const (
 // The functions in this file implement the configurator.Configurator interface
 
 // GetMeshConfig returns the MeshConfig resource corresponding to the control plane
-func (c *client) GetMeshConfig() configv1alpha2.MeshConfig {
+func (c *client) GetMeshConfig() configv1alpha3.MeshConfig {
 	return c.getMeshConfig()
 }
 
@@ -41,7 +41,7 @@ func (c *client) GetOSMNamespace() string {
 	return c.osmNamespace
 }
 
-func marshalConfigToJSON(config configv1alpha2.MeshConfigSpec) (string, error) {
+func marshalConfigToJSON(config configv1alpha3.MeshConfigSpec) (string, error) {
 	bytes, err := json.MarshalIndent(&config, "", "    ")
 	if err != nil {
 		return "", err
@@ -121,6 +121,17 @@ func (c *client) GetEnvoyLogLevel() string {
 		return logLevel
 	}
 	return constants.DefaultEnvoyLogLevel
+}
+
+func (c *client) GetEnvoyProxyMode() configv1alpha3.LocalProxyMode {
+	proxyConfig := c.getMeshConfig().Spec.Sidecar.LocalProxyMode
+	switch proxyConfig {
+	case configv1alpha3.LocalProxyModeLocalhost, configv1alpha3.LocalProxyModePodIP:
+		return proxyConfig
+	default:
+		// unrecognized proxy mode; return the default: ProxyModeLocalhost
+		return configv1alpha3.LocalProxyModeLocalhost
+	}
 }
 
 // GetEnvoyImage returns the envoy image
@@ -217,7 +228,7 @@ func (c *client) GetInboundExternalAuthConfig() auth.ExtAuthConfig {
 }
 
 // GetFeatureFlags returns OSM's feature flags
-func (c *client) GetFeatureFlags() configv1alpha2.FeatureFlags {
+func (c *client) GetFeatureFlags() configv1alpha3.FeatureFlags {
 	return c.getMeshConfig().Spec.FeatureFlags
 }
 

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	testclient "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -31,21 +31,21 @@ func TestCreateUpdateConfig(t *testing.T) {
 
 		stop := make(chan struct{})
 		cfg := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
-		tassert.Equal(t, configv1alpha2.MeshConfig{}, cfg.getMeshConfig())
+		tassert.Equal(t, configv1alpha3.MeshConfig{}, cfg.getMeshConfig())
 	})
 
 	tests := []struct {
 		name                  string
-		initialMeshConfigData *configv1alpha2.MeshConfigSpec
+		initialMeshConfigData *configv1alpha3.MeshConfigSpec
 		checkCreate           func(*tassert.Assertions, Configurator)
-		updatedMeshConfigData *configv1alpha2.MeshConfigSpec
+		updatedMeshConfigData *configv1alpha3.MeshConfigSpec
 		checkUpdate           func(*tassert.Assertions, Configurator)
 	}{
 		{
 			name: "default",
 
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					EnablePrivilegedInitContainer: true,
 					LogLevel:                      "error",
 					MaxDataPlaneConnections:       0,
@@ -53,24 +53,24 @@ func TestCreateUpdateConfig(t *testing.T) {
 					EnvoyImage:                    "envoyproxy/envoy-alpine:v0.0.0",
 					InitContainerImage:            "openservicemesh/init:v0.0.0",
 				},
-				Traffic: configv1alpha2.TrafficSpec{
+				Traffic: configv1alpha3.TrafficSpec{
 					EnablePermissiveTrafficPolicyMode: false,
 					EnableEgress:                      true,
 				},
-				Observability: configv1alpha2.ObservabilitySpec{
+				Observability: configv1alpha3.ObservabilitySpec{
 					OSMLogLevel:       constants.DefaultOSMLogLevel,
 					EnableDebugServer: true,
-					Tracing: configv1alpha2.TracingSpec{
+					Tracing: configv1alpha3.TracingSpec{
 						Enable: true,
 					},
 				},
-				Certificate: configv1alpha2.CertificateSpec{
+				Certificate: configv1alpha3.CertificateSpec{
 					ServiceCertValidityDuration: "24h",
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
-				expectedConfig := &configv1alpha2.MeshConfigSpec{
-					Sidecar: configv1alpha2.SidecarSpec{
+				expectedConfig := &configv1alpha3.MeshConfigSpec{
+					Sidecar: configv1alpha3.SidecarSpec{
 						EnablePrivilegedInitContainer: true,
 						LogLevel:                      "error",
 						MaxDataPlaneConnections:       0,
@@ -78,18 +78,18 @@ func TestCreateUpdateConfig(t *testing.T) {
 						EnvoyImage:                    "envoyproxy/envoy-alpine:v0.0.0",
 						InitContainerImage:            "openservicemesh/init:v0.0.0",
 					},
-					Traffic: configv1alpha2.TrafficSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						EnablePermissiveTrafficPolicyMode: false,
 						EnableEgress:                      true,
 					},
-					Observability: configv1alpha2.ObservabilitySpec{
+					Observability: configv1alpha3.ObservabilitySpec{
 						OSMLogLevel:       constants.DefaultOSMLogLevel,
 						EnableDebugServer: true,
-						Tracing: configv1alpha2.TracingSpec{
+						Tracing: configv1alpha3.TracingSpec{
 							Enable: true,
 						},
 					},
-					Certificate: configv1alpha2.CertificateSpec{
+					Certificate: configv1alpha3.CertificateSpec{
 						ServiceCertValidityDuration: "24h",
 					},
 				}
@@ -103,16 +103,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "IsPermissiveTrafficPolicyMode",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Traffic: configv1alpha3.TrafficSpec{
 					EnablePermissiveTrafficPolicyMode: true,
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.True(cfg.IsPermissiveTrafficPolicyMode())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Traffic: configv1alpha3.TrafficSpec{
 					EnablePermissiveTrafficPolicyMode: false,
 				},
 			},
@@ -122,16 +122,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "IsEgressEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Traffic: configv1alpha3.TrafficSpec{
 					EnableEgress: true,
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.True(cfg.IsEgressEnabled())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Traffic: configv1alpha2.TrafficSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Traffic: configv1alpha3.TrafficSpec{
 					EnableEgress: false,
 				},
 			},
@@ -141,16 +141,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "IsDebugServerEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Observability: configv1alpha2.ObservabilitySpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Observability: configv1alpha3.ObservabilitySpec{
 					EnableDebugServer: true,
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.True(cfg.IsDebugServerEnabled())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Observability: configv1alpha2.ObservabilitySpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Observability: configv1alpha3.ObservabilitySpec{
 					EnableDebugServer: false,
 				},
 			},
@@ -160,9 +160,9 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "IsTracingEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Observability: configv1alpha2.ObservabilitySpec{
-					Tracing: configv1alpha2.TracingSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Observability: configv1alpha3.ObservabilitySpec{
+					Tracing: configv1alpha3.TracingSpec{
 						Enable:   true,
 						Address:  "myjaeger",
 						Port:     12121,
@@ -176,9 +176,9 @@ func TestCreateUpdateConfig(t *testing.T) {
 				assert.Equal(uint32(12121), cfg.GetTracingPort())
 				assert.Equal("/my/endpoint", cfg.GetTracingEndpoint())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Observability: configv1alpha2.ObservabilitySpec{
-					Tracing: configv1alpha2.TracingSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Observability: configv1alpha3.ObservabilitySpec{
+					Tracing: configv1alpha3.TracingSpec{
 						Enable:   false,
 						Address:  "myjaeger",
 						Port:     12121,
@@ -192,12 +192,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetEnvoyLogLevel",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal("error", cfg.GetEnvoyLogLevel())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					LogLevel: "info",
 				},
 			},
@@ -207,12 +207,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetEnvoyImage",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal("", cfg.GetEnvoyImage())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					EnvoyImage: "envoyproxy/envoy-alpine:v1.17.1",
 				},
 			},
@@ -222,12 +222,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetEnvoyWindowsImage",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal("", cfg.GetEnvoyWindowsImage())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					EnvoyImage: "envoyproxy/envoy-windows:v1.17.1",
 				},
 			},
@@ -237,12 +237,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetInitContainerImage",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal("", cfg.GetInitContainerImage())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					InitContainerImage: "openservicemesh/init:v0.8.2",
 				},
 			},
@@ -252,16 +252,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "GetServiceCertValidityDuration",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Certificate: configv1alpha2.CertificateSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Certificate: configv1alpha3.CertificateSpec{
 					ServiceCertValidityDuration: "24h",
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(24*time.Hour, cfg.GetServiceCertValidityPeriod())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Certificate: configv1alpha2.CertificateSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Certificate: configv1alpha3.CertificateSpec{
 					ServiceCertValidityDuration: "1h",
 				},
 			},
@@ -271,16 +271,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "GetCertKeyBitSize",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Certificate: configv1alpha2.CertificateSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Certificate: configv1alpha3.CertificateSpec{
 					CertKeyBitSize: 4096,
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(4096, cfg.GetCertKeyBitSize())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Certificate: configv1alpha2.CertificateSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Certificate: configv1alpha3.CertificateSpec{
 					CertKeyBitSize: -10,
 				},
 			},
@@ -290,16 +290,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "IsPrivilegedInitContainer",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					EnablePrivilegedInitContainer: true,
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.True(cfg.IsPrivilegedInitContainer())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					EnablePrivilegedInitContainer: false,
 				},
 			},
@@ -309,13 +309,13 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetResyncInterval",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				interval := cfg.GetConfigResyncInterval()
 				assert.Equal(interval, time.Duration(0))
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					ConfigResyncInterval: "2m",
 				},
 			},
@@ -326,13 +326,13 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "NegativeGetResyncInterval",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				interval := cfg.GetConfigResyncInterval()
 				assert.Equal(interval, time.Duration(0))
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					ConfigResyncInterval: "Non-duration string",
 				},
 			},
@@ -343,12 +343,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetMaxDataplaneConnections",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(0, cfg.GetMaxDataPlaneConnections())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					MaxDataPlaneConnections: 1000,
 				},
 			},
@@ -358,14 +358,14 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "GetProxyResources",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				res := cfg.GetProxyResources()
 				assert.Equal(0, len(res.Limits))
 				assert.Equal(0, len(res.Requests))
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Sidecar: configv1alpha2.SidecarSpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Sidecar: configv1alpha3.SidecarSpec{
 					Resources: v1.ResourceRequirements{
 						Requests: v1.ResourceList{
 							v1.ResourceCPU:    resource.MustParse("1"),
@@ -388,12 +388,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "IsWASMStatsEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(false, cfg.GetFeatureFlags().EnableWASMStats)
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				FeatureFlags: configv1alpha2.FeatureFlags{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				FeatureFlags: configv1alpha3.FeatureFlags{
 					EnableWASMStats: true,
 				},
 			},
@@ -403,12 +403,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "IsEgressPolicyEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(false, cfg.GetFeatureFlags().EnableEgressPolicy)
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				FeatureFlags: configv1alpha2.FeatureFlags{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				FeatureFlags: configv1alpha3.FeatureFlags{
 					EnableEgressPolicy: true,
 				},
 			},
@@ -418,12 +418,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "IsMulticlusterModeEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(false, cfg.GetFeatureFlags().EnableMulticlusterMode)
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				FeatureFlags: configv1alpha2.FeatureFlags{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				FeatureFlags: configv1alpha3.FeatureFlags{
 					EnableMulticlusterMode: true,
 				},
 			},
@@ -433,12 +433,12 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name:                  "IsAsyncProxyServiceMappingEnabled",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{},
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(false, cfg.GetFeatureFlags().EnableAsyncProxyServiceMapping)
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				FeatureFlags: configv1alpha2.FeatureFlags{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				FeatureFlags: configv1alpha3.FeatureFlags{
 					EnableAsyncProxyServiceMapping: true,
 				},
 			},
@@ -448,16 +448,16 @@ func TestCreateUpdateConfig(t *testing.T) {
 		},
 		{
 			name: "OSMLogLevel",
-			initialMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Observability: configv1alpha2.ObservabilitySpec{
+			initialMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Observability: configv1alpha3.ObservabilitySpec{
 					OSMLogLevel: constants.DefaultOSMLogLevel,
 				},
 			},
 			checkCreate: func(assert *tassert.Assertions, cfg Configurator) {
 				assert.Equal(constants.DefaultOSMLogLevel, cfg.GetOSMLogLevel())
 			},
-			updatedMeshConfigData: &configv1alpha2.MeshConfigSpec{
-				Observability: configv1alpha2.ObservabilitySpec{
+			updatedMeshConfigData: &configv1alpha3.MeshConfigSpec{
+				Observability: configv1alpha3.ObservabilitySpec{
 					OSMLogLevel: "warn",
 				},
 			},
@@ -477,7 +477,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			defer close(stop)
 			cfg := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
 
-			meshConfig := configv1alpha2.MeshConfig{
+			meshConfig := configv1alpha3.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: osmNamespace,
 					Name:      osmMeshConfigName,

--- a/pkg/configurator/mock_client_generated.go
+++ b/pkg/configurator/mock_client_generated.go
@@ -9,7 +9,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	v1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	v1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	auth "github.com/openservicemesh/osm/pkg/auth"
 	v1 "k8s.io/api/core/v1"
 )
@@ -93,6 +93,20 @@ func (mr *MockConfiguratorMockRecorder) GetEnvoyLogLevel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvoyLogLevel", reflect.TypeOf((*MockConfigurator)(nil).GetEnvoyLogLevel))
 }
 
+// GetEnvoyProxyMode mocks base method.
+func (m *MockConfigurator) GetEnvoyProxyMode() v1alpha3.LocalProxyMode {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEnvoyProxyMode")
+	ret0, _ := ret[0].(v1alpha3.LocalProxyMode)
+	return ret0
+}
+
+// GetEnvoyProxyMode indicates an expected call of GetEnvoyProxyMode.
+func (mr *MockConfiguratorMockRecorder) GetEnvoyProxyMode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvoyProxyMode", reflect.TypeOf((*MockConfigurator)(nil).GetEnvoyProxyMode))
+}
+
 // GetEnvoyWindowsImage mocks base method.
 func (m *MockConfigurator) GetEnvoyWindowsImage() string {
 	m.ctrl.T.Helper()
@@ -108,10 +122,10 @@ func (mr *MockConfiguratorMockRecorder) GetEnvoyWindowsImage() *gomock.Call {
 }
 
 // GetFeatureFlags mocks base method.
-func (m *MockConfigurator) GetFeatureFlags() v1alpha2.FeatureFlags {
+func (m *MockConfigurator) GetFeatureFlags() v1alpha3.FeatureFlags {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFeatureFlags")
-	ret0, _ := ret[0].(v1alpha2.FeatureFlags)
+	ret0, _ := ret[0].(v1alpha3.FeatureFlags)
 	return ret0
 }
 
@@ -164,10 +178,10 @@ func (mr *MockConfiguratorMockRecorder) GetMaxDataPlaneConnections() *gomock.Cal
 }
 
 // GetMeshConfig mocks base method.
-func (m *MockConfigurator) GetMeshConfig() v1alpha2.MeshConfig {
+func (m *MockConfigurator) GetMeshConfig() v1alpha3.MeshConfig {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMeshConfig")
-	ret0, _ := ret[0].(v1alpha2.MeshConfig)
+	ret0, _ := ret[0].(v1alpha3.MeshConfig)
 	return ret0
 }
 

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -7,7 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/logger"
@@ -28,7 +28,7 @@ type client struct {
 // Configurator is the controller interface for K8s namespaces
 type Configurator interface {
 	// GetMeshConfig returns the MeshConfig resource corresponding to the control plane
-	GetMeshConfig() configv1alpha2.MeshConfig
+	GetMeshConfig() configv1alpha3.MeshConfig
 
 	// GetOSMNamespace returns the namespace in which OSM controller pod resides
 	GetOSMNamespace() string
@@ -66,6 +66,9 @@ type Configurator interface {
 	// GetEnvoyLogLevel returns the envoy log level
 	GetEnvoyLogLevel() string
 
+	// GetProxyMode returns the envoy proxy mode
+	GetEnvoyProxyMode() configv1alpha3.LocalProxyMode
+
 	// GetEnvoyImage returns the envoy image
 	GetEnvoyImage() string
 
@@ -95,5 +98,5 @@ type Configurator interface {
 	GetInboundExternalAuthConfig() auth.ExtAuthConfig
 
 	// GetFeatureFlags returns OSM's feature flags
-	GetFeatureFlags() configv1alpha2.FeatureFlags
+	GetFeatureFlags() configv1alpha3.FeatureFlags
 }

--- a/pkg/crdconversion/config_meshconfig_conversion_test.go
+++ b/pkg/crdconversion/config_meshconfig_conversion_test.go
@@ -60,9 +60,6 @@ func TestConvertMeshConfig(t *testing.T) {
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "config.openservicemesh.io/v1alpha3",
 					Kind:       "MeshConfig",
-				},
-				Spec: configv1alpha3.MeshConfigSpec{
-					Traffic: configv1alpha3.TrafficSpec{
 						OutboundIPRangeInclusionList: []string{"1.1.1.1/32"},
 					},
 					Sidecar: configv1alpha3.SidecarSpec{

--- a/pkg/crdconversion/config_meshconfig_conversion_test.go
+++ b/pkg/crdconversion/config_meshconfig_conversion_test.go
@@ -60,6 +60,9 @@ func TestConvertMeshConfig(t *testing.T) {
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "config.openservicemesh.io/v1alpha3",
 					Kind:       "MeshConfig",
+				},
+				Spec: configv1alpha3.MeshConfigSpec{
+					Traffic: configv1alpha3.TrafficSpec{
 						OutboundIPRangeInclusionList: []string{"1.1.1.1/32"},
 					},
 					Sidecar: configv1alpha3.SidecarSpec{

--- a/pkg/debugger/debugger_config_listener.go
+++ b/pkg/debugger/debugger_config_listener.go
@@ -1,7 +1,7 @@
 package debugger
 
 import (
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -36,8 +36,8 @@ func (d *DebugConfig) StartDebugServerConfigListener(stop chan struct{}) {
 				continue
 			}
 
-			prevSpec := msg.OldObj.(*configv1alpha2.MeshConfig).Spec
-			newSpec := msg.NewObj.(*configv1alpha2.MeshConfig).Spec
+			prevSpec := msg.OldObj.(*configv1alpha3.MeshConfig).Spec
+			newSpec := msg.NewObj.(*configv1alpha3.MeshConfig).Spec
 
 			if prevSpec.Observability.EnableDebugServer == newSpec.Observability.EnableDebugServer {
 				continue

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -17,7 +17,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 
@@ -138,7 +138,7 @@ var _ = Describe("Test ADS response functions", func() {
 		mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(certDuration).AnyTimes()
 		mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 		mockConfigurator.EXPECT().IsDebugServerEnabled().Return(true).AnyTimes()
-		mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+		mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 			EnableWASMStats:    false,
 			EnableEgressPolicy: false,
 		}).AnyTimes()

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -34,7 +34,7 @@ var replacer = strings.NewReplacer(".", "_", ":", "_")
 
 // getUpstreamServiceCluster returns an Envoy Cluster corresponding to the given upstream service
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func getUpstreamServiceCluster(downstreamIdentity identity.ServiceIdentity, config trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha2.SidecarSpec) *xds_cluster.Cluster {
+func getUpstreamServiceCluster(downstreamIdentity identity.ServiceIdentity, config trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha3.SidecarSpec) *xds_cluster.Cluster {
 	httpProtocolOptions := getDefaultHTTPProtocolOptions()
 
 	marshalledUpstreamTLSContext, err := anypb.New(
@@ -332,7 +332,7 @@ func formatAltStatNameForPrometheus(clusterName string) string {
 	return replacer.Replace(clusterName)
 }
 
-func upstreamClustersFromClusterConfigs(downstreamIdentity identity.ServiceIdentity, configs []*trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha2.SidecarSpec) []*xds_cluster.Cluster {
+func upstreamClustersFromClusterConfigs(downstreamIdentity identity.ServiceIdentity, configs []*trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha3.SidecarSpec) []*xds_cluster.Cluster {
 	var clusters []*xds_cluster.Cluster
 
 	for _, c := range configs {

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -97,7 +97,7 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
-			remoteCluster := getUpstreamServiceCluster(downstreamSvcAccount, tc.clusterConfig, configv1alpha2.SidecarSpec{})
+			remoteCluster := getUpstreamServiceCluster(downstreamSvcAccount, tc.clusterConfig, configv1alpha3.SidecarSpec{})
 			assert.NotNil(remoteCluster)
 
 			if tc.clusterConfig.EnableEnvoyActiveHealthChecks {

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -65,9 +65,9 @@ func TestNewResponse(t *testing.T) {
 		TargetPort: 8080,
 	}
 
-	meshConfig := configv1alpha2.MeshConfig{
-		Spec: configv1alpha2.MeshConfigSpec{
-			Sidecar: configv1alpha2.SidecarSpec{
+	meshConfig := configv1alpha3.MeshConfig{
+		Spec: configv1alpha3.MeshConfigSpec{
+			Sidecar: configv1alpha3.SidecarSpec{
 				TLSMinProtocolVersion: "TLSv1_2",
 				TLSMaxProtocolVersion: "TLSv1_3",
 			},
@@ -109,7 +109,7 @@ func TestNewResponse(t *testing.T) {
 	mockConfigurator.EXPECT().IsTracingEnabled().Return(true).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingHost().Return(constants.DefaultTracingHost).AnyTimes()
 	mockConfigurator.EXPECT().GetTracingPort().Return(constants.DefaultTracingPort).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{}).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{}).AnyTimes()
 	mockCatalog.EXPECT().GetKubeController().Return(mockKubeController).AnyTimes()
 	mockConfigurator.EXPECT().GetMeshConfig().Return(meshConfig).AnyTimes()
 
@@ -432,7 +432,7 @@ func TestNewResponseListServicesError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
 	cfg := configurator.NewMockConfigurator(ctrl)
-	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
+	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
 	meshCatalog.EXPECT().GetOutboundMeshTrafficPolicy(proxyIdentity).Return(nil).AnyTimes()
 	cfg.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
@@ -462,7 +462,7 @@ func TestNewResponseGetEgressTrafficPolicyError(t *testing.T) {
 	mockKubeController.EXPECT().ListPods().Return([]*v1.Pod{})
 	cfg.EXPECT().IsEgressEnabled().Return(false).Times(1)
 	cfg.EXPECT().IsTracingEnabled().Return(false).Times(1)
-	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
+	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
 	cfg.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
 	resp, err := NewResponse(meshCatalog, proxy, nil, cfg, nil, proxyRegistry)
@@ -495,7 +495,7 @@ func TestNewResponseGetEgressTrafficPolicyNotEmpty(t *testing.T) {
 	}, nil).Times(1)
 	cfg.EXPECT().IsEgressEnabled().Return(false).Times(1)
 	cfg.EXPECT().IsTracingEnabled().Return(false).Times(1)
-	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
+	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
 	cfg.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
 	resp, err := NewResponse(meshCatalog, proxy, nil, cfg, nil, proxyRegistry)
@@ -518,7 +518,7 @@ func TestNewResponseForMulticlusterGateway(t *testing.T) {
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
 	cfg := configurator.NewMockConfigurator(ctrl)
 
-	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 	cfg.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 	meshCatalog.EXPECT().ListOutboundServicesForMulticlusterGateway().Return([]service.MeshService{
 		tests.BookstoreV1Service,

--- a/pkg/envoy/lds/egress_test.go
+++ b/pkg/envoy/lds/egress_test.go
@@ -10,7 +10,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -57,7 +57,7 @@ func TestGetEgressHTTPFilterChain(t *testing.T) {
 			}
 			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 			mockConfigurator.EXPECT().GetTracingEndpoint().Return("some-endpoint").AnyTimes()
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableEgressPolicy: true,
 				EnableWASMStats:    false}).AnyTimes()
 			actual, err := lb.getEgressHTTPFilterChain(tc.destinationPort)
@@ -153,7 +153,7 @@ func TestGetEgressTCPFilterChain(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableEgressPolicy: true,
 				EnableWASMStats:    false,
 			}).AnyTimes()
@@ -229,7 +229,7 @@ func TestGetEgressFilterChainsForMatches(t *testing.T) {
 			}
 			mockConfigurator.EXPECT().IsTracingEnabled().Return(false).AnyTimes()
 			mockConfigurator.EXPECT().GetTracingEndpoint().Return("some-endpoint").AnyTimes()
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableEgressPolicy: true,
 				EnableWASMStats:    false,
 			}).AnyTimes()

--- a/pkg/envoy/lds/gateway_test.go
+++ b/pkg/envoy/lds/gateway_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	tassert "github.com/stretchr/testify/assert"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -25,7 +25,7 @@ func TestBuildMulticlusterGatewayListeners(t *testing.T) {
 
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 
 	id := identity.K8sServiceAccount{Name: "osm", Namespace: "osm-system"}.ToServiceIdentity()
 	meshServices := []service.MeshService{

--- a/pkg/envoy/lds/ingress.go
+++ b/pkg/envoy/lds/ingress.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -45,7 +45,7 @@ func (lb *listenerBuilder) getIngressFilterChains(svc service.MeshService) []*xd
 	return filterChains
 }
 
-func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *trafficpolicy.IngressTrafficMatch, sidecarSpec configv1alpha2.SidecarSpec) (*xds_listener.FilterChain, error) {
+func (lb *listenerBuilder) getIngressFilterChainFromTrafficMatch(trafficMatch *trafficpolicy.IngressTrafficMatch, sidecarSpec configv1alpha3.SidecarSpec) (*xds_listener.FilterChain, error) {
 	if trafficMatch == nil {
 		return nil, errors.Errorf("Nil IngressTrafficMatch for ingress on proxy with identity %s", lb.serviceIdentity)
 	}

--- a/pkg/envoy/lds/ingress_test.go
+++ b/pkg/envoy/lds/ingress_test.go
@@ -10,7 +10,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -179,7 +179,7 @@ func TestGetIngressFilterChainFromTrafficMatch(t *testing.T) {
 				Enable: false,
 			})
 
-			actual, err := lb.getIngressFilterChainFromTrafficMatch(tc.trafficMatch, configv1alpha2.SidecarSpec{})
+			actual, err := lb.getIngressFilterChainFromTrafficMatch(tc.trafficMatch, configv1alpha3.SidecarSpec{})
 			assert.Equal(tc.expectError, err != nil)
 
 			if err == nil {

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -12,7 +12,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	"github.com/openservicemesh/osm/pkg/catalog"
@@ -37,7 +37,7 @@ func TestGetOutboundHTTPFilterChainForService(t *testing.T) {
 	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
 		Enable: false,
 	}).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableWASMStats: false,
 	}).AnyTimes()
 
@@ -214,7 +214,7 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
 		Enable: false,
 	}).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableWASMStats:        false,
 		EnableMulticlusterMode: true,
 	}).AnyTimes()
@@ -313,7 +313,7 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
 		Enable: false,
 	}).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableMulticlusterMode: true,
 	}).AnyTimes()
 	mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
@@ -614,7 +614,7 @@ func TestGetOutboundHTTPFilter(t *testing.T) {
 	mockConfigurator.EXPECT().GetInboundExternalAuthConfig().Return(auth.ExtAuthConfig{
 		Enable: false,
 	}).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableWASMStats: false,
 	}).AnyTimes()
 

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	tassert "github.com/stretchr/testify/assert"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -192,7 +192,7 @@ func TestNewOutboundListener(t *testing.T) {
 	}).Times(2)
 	cfg := configurator.NewMockConfigurator(mockCtrl)
 	cfg.EXPECT().IsEgressEnabled().Return(false).Times(1)
-	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	cfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableEgressPolicy: true,
 	}).Times(1)
 

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	"github.com/openservicemesh/osm/pkg/auth"
@@ -82,7 +82,7 @@ func TestNewResponse(t *testing.T) {
 	}).AnyTimes()
 	mockConfigurator.EXPECT().GetMeshConfig().AnyTimes()
 
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableWASMStats:        false,
 		EnableEgressPolicy:     true,
 		EnableMulticlusterMode: false,
@@ -165,7 +165,7 @@ func TestNewResponseForMulticlusterGateway(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	meshCatalog := catalog.NewMockMeshCataloger(ctrl)
 
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableMulticlusterMode: true,
 	}).AnyTimes()
 

--- a/pkg/envoy/lds/wasm_test.go
+++ b/pkg/envoy/lds/wasm_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/configurator"
 )
@@ -44,7 +44,7 @@ func TestGetWASMStatsHeaders(t *testing.T) {
 				statsHeaders: tc.statsHeaders,
 			}
 
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableWASMStats: tc.enabled}).Times(1)
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableWASMStats: tc.enabled}).Times(1)
 
 			actual := lb.getWASMStatsHeaders()
 			a.Equal(tc.expected, actual)

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -282,7 +282,7 @@ func TestNewResponse(t *testing.T) {
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableWASMStats: false,
 			}).AnyTimes()
 
@@ -451,7 +451,7 @@ func TestResponseRequestCompletion(t *testing.T) {
 	mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableWASMStats: false,
 	}).AnyTimes()
 

--- a/pkg/envoy/rds/route/route_config_test.go
+++ b/pkg/envoy/rds/route/route_config_test.go
@@ -13,7 +13,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/envoy"
 
@@ -112,7 +112,7 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 			defer mockCtrl.Finish()
 			mockCfg := configurator.NewMockConfigurator(mockCtrl)
 
-			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableWASMStats: false,
 			}).AnyTimes()
 			actual := BuildInboundMeshRouteConfiguration(tc.inbound.HTTPRouteConfigsPerPort, nil, mockCfg)
@@ -186,7 +186,7 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 			mockCfg := configurator.NewMockConfigurator(mockCtrl)
 
-			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockCfg.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableWASMStats: tc.wasmEnabled,
 			}).Times(1)
 			actual := BuildInboundMeshRouteConfiguration(testInbound.HTTPRouteConfigsPerPort, &envoy.Proxy{}, mockCfg)

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	v1 "k8s.io/api/core/v1"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -78,7 +78,7 @@ func GetAddress(address string, port uint32) *xds_core.Address {
 }
 
 // GetTLSParams creates Envoy TlsParameters struct.
-func GetTLSParams(sidecarSpec configv1alpha2.SidecarSpec) *xds_auth.TlsParameters {
+func GetTLSParams(sidecarSpec configv1alpha3.SidecarSpec) *xds_auth.TlsParameters {
 	minVersionInt := xds_auth.TlsParameters_TlsProtocol_value[sidecarSpec.TLSMinProtocolVersion]
 	maxVersionInt := xds_auth.TlsParameters_TlsProtocol_value[sidecarSpec.TLSMaxProtocolVersion]
 	tlsMinVersion := xds_auth.TlsParameters_TlsProtocol(minVersionInt)
@@ -163,7 +163,7 @@ func pbStringValue(v string) *structpb.Value {
 // is used to indicate peer certificate validation should be skipped, and is used when mTLS is disabled (ex. with TLS
 // based ingress).
 // 'sidecarSpec' is the sidecar section of MeshConfig.
-func getCommonTLSContext(tlsSDSCert secrets.SDSCert, peerValidationSDSCert *secrets.SDSCert, sidecarSpec configv1alpha2.SidecarSpec) *xds_auth.CommonTlsContext {
+func getCommonTLSContext(tlsSDSCert secrets.SDSCert, peerValidationSDSCert *secrets.SDSCert, sidecarSpec configv1alpha3.SidecarSpec) *xds_auth.CommonTlsContext {
 	commonTLSContext := &xds_auth.CommonTlsContext{
 		TlsParams: GetTLSParams(sidecarSpec),
 		TlsCertificateSdsSecretConfigs: []*xds_auth.SdsSecretConfig{{
@@ -190,7 +190,7 @@ func getCommonTLSContext(tlsSDSCert secrets.SDSCert, peerValidationSDSCert *secr
 
 // GetDownstreamTLSContext creates a downstream Envoy TLS Context to be configured on the upstream for the given upstream's identity
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func GetDownstreamTLSContext(upstreamIdentity identity.ServiceIdentity, mTLS bool, sidecarSpec configv1alpha2.SidecarSpec) *xds_auth.DownstreamTlsContext {
+func GetDownstreamTLSContext(upstreamIdentity identity.ServiceIdentity, mTLS bool, sidecarSpec configv1alpha3.SidecarSpec) *xds_auth.DownstreamTlsContext {
 	upstreamSDSCert := secrets.SDSCert{
 		Name:     secrets.GetSecretNameForIdentity(upstreamIdentity),
 		CertType: secrets.ServiceCertType,
@@ -222,7 +222,7 @@ func GetDownstreamTLSContext(upstreamIdentity identity.ServiceIdentity, mTLS boo
 
 // GetUpstreamTLSContext creates an upstream Envoy TLS Context for the given downstream identity and upstream service pair
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func GetUpstreamTLSContext(downstreamIdentity identity.ServiceIdentity, upstreamSvc service.MeshService, sidecarSpec configv1alpha2.SidecarSpec) *xds_auth.UpstreamTlsContext {
+func GetUpstreamTLSContext(downstreamIdentity identity.ServiceIdentity, upstreamSvc service.MeshService, sidecarSpec configv1alpha3.SidecarSpec) *xds_auth.UpstreamTlsContext {
 	downstreamSDSCert := secrets.SDSCert{
 		Name:     secrets.GetSecretNameForIdentity(downstreamIdentity),
 		CertType: secrets.ServiceCertType,

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/envoy/secrets"
@@ -70,7 +70,7 @@ func TestGetStdoutAccessLog(t *testing.T) {
 	assert.Equal(resAccessLogger, expAccessLogger)
 }
 
-var sidecarSpec = configv1alpha2.SidecarSpec{
+var sidecarSpec = configv1alpha3.SidecarSpec{
 	TLSMinProtocolVersion: "TLSv1_2",
 	TLSMaxProtocolVersion: "TLSv1_3",
 }

--- a/pkg/ingress/gateway.go
+++ b/pkg/ingress/gateway.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	"github.com/openservicemesh/osm/pkg/k8s/events"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -39,7 +39,7 @@ func (c *client) provisionIngressGatewayCert(stop <-chan struct{}) error {
 
 // createAndStoreGatewayCert creates a certificate for the given certificate spec and stores
 // it in the referenced k8s secret if the spec is valid.
-func (c *client) createAndStoreGatewayCert(spec configv1alpha2.IngressGatewayCertSpec) error {
+func (c *client) createAndStoreGatewayCert(spec configv1alpha3.IngressGatewayCertSpec) error {
 	if len(spec.SubjectAltNames) == 0 {
 		return errors.New("Ingress gateway certificate spec must specify at least 1 SAN")
 	}
@@ -100,7 +100,7 @@ func (c *client) storeCertInSecret(cert *certificate.Certificate, secret corev1.
 
 // handleCertificateChange updates the gateway certificate and secret when the MeshConfig resource changes or
 // when the corresponding gateway certificate is rotated.
-func (c *client) handleCertificateChange(currentCertSpec *configv1alpha2.IngressGatewayCertSpec, stop <-chan struct{}) {
+func (c *client) handleCertificateChange(currentCertSpec *configv1alpha3.IngressGatewayCertSpec, stop <-chan struct{}) {
 	kubePubSub := c.msgBroker.GetKubeEventPubSub()
 	meshConfigUpdateChan := kubePubSub.Sub(announcements.MeshConfigUpdated.String())
 	defer c.msgBroker.Unsub(kubePubSub, meshConfigUpdateChan)
@@ -124,7 +124,7 @@ func (c *client) handleCertificateChange(currentCertSpec *configv1alpha2.Ingress
 				continue
 			}
 
-			updatedMeshConfig, ok := event.NewObj.(*configv1alpha2.MeshConfig)
+			updatedMeshConfig, ok := event.NewObj.(*configv1alpha3.MeshConfig)
 			if !ok {
 				log.Error().Msgf("Received unexpected object %T, expected MeshConfig", updatedMeshConfig)
 				continue
@@ -191,7 +191,7 @@ func (c *client) handleCertificateChange(currentCertSpec *configv1alpha2.Ingress
 }
 
 // removeGatewayCertAndSecret removes the secret and certificate corresponding to the existing cert spec
-func (c *client) removeGatewayCertAndSecret(storedCertSpec configv1alpha2.IngressGatewayCertSpec) error {
+func (c *client) removeGatewayCertAndSecret(storedCertSpec configv1alpha3.IngressGatewayCertSpec) error {
 	err := c.kubeClient.CoreV1().Secrets(storedCertSpec.Secret.Namespace).Delete(context.Background(), storedCertSpec.Secret.Name, metav1.DeleteOptions{})
 	if err != nil {
 		return err

--- a/pkg/ingress/gateway_test.go
+++ b/pkg/ingress/gateway_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -39,15 +39,15 @@ func TestProvisionIngressGatewayCert(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		meshConfig          configv1alpha2.MeshConfig
+		meshConfig          configv1alpha3.MeshConfig
 		expectSecretToExist bool
 		expectErr           bool
 	}{
 		{
 			name: "ingress gateway cert spec does not exist",
-			meshConfig: configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
+			meshConfig: configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
 						IngressGateway: nil,
 					},
 				},
@@ -57,10 +57,10 @@ func TestProvisionIngressGatewayCert(t *testing.T) {
 		},
 		{
 			name: "ingress gateway cert spec exists",
-			meshConfig: configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
-						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{
+			meshConfig: configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
+						IngressGateway: &configv1alpha3.IngressGatewayCertSpec{
 							SubjectAltNames:  []string{"foo.bar.cluster.local"},
 							ValidityDuration: "1h",
 							Secret:           testSecret,
@@ -73,10 +73,10 @@ func TestProvisionIngressGatewayCert(t *testing.T) {
 		},
 		{
 			name: "ingress gateway cert spec has no SAN",
-			meshConfig: configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
-						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{
+			meshConfig: configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
+						IngressGateway: &configv1alpha3.IngressGatewayCertSpec{
 							SubjectAltNames:  nil,
 							ValidityDuration: "1h",
 							Secret:           testSecret,
@@ -142,12 +142,12 @@ func TestCreateAndStoreGatewayCert(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		certSpec  configv1alpha2.IngressGatewayCertSpec
+		certSpec  configv1alpha3.IngressGatewayCertSpec
 		expectErr bool
 	}{
 		{
 			name: "valid spec",
-			certSpec: configv1alpha2.IngressGatewayCertSpec{
+			certSpec: configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "1h",
 				Secret:           testSecret,
@@ -156,7 +156,7 @@ func TestCreateAndStoreGatewayCert(t *testing.T) {
 		},
 		{
 			name: "invalid SAN",
-			certSpec: configv1alpha2.IngressGatewayCertSpec{
+			certSpec: configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  nil,
 				ValidityDuration: "1h",
 				Secret:           testSecret,
@@ -165,7 +165,7 @@ func TestCreateAndStoreGatewayCert(t *testing.T) {
 		},
 		{
 			name: "invalid validity duration",
-			certSpec: configv1alpha2.IngressGatewayCertSpec{
+			certSpec: configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "foobar",
 				Secret:           testSecret,
@@ -174,7 +174,7 @@ func TestCreateAndStoreGatewayCert(t *testing.T) {
 		},
 		{
 			name: "invalid secret, name or namepace not specified",
-			certSpec: configv1alpha2.IngressGatewayCertSpec{
+			certSpec: configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "1h",
 				Secret: corev1.SecretReference{
@@ -212,9 +212,9 @@ func TestHandleCertificateChange(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		previousCertSpec    *configv1alpha2.IngressGatewayCertSpec
-		previousMeshConfig  *configv1alpha2.MeshConfig
-		updatedMeshConfig   *configv1alpha2.MeshConfig
+		previousCertSpec    *configv1alpha3.IngressGatewayCertSpec
+		previousMeshConfig  *configv1alpha3.MeshConfig
+		updatedMeshConfig   *configv1alpha3.MeshConfig
 		stopChan            chan struct{}
 		expectCertRotation  bool
 		expectSecretToExist bool
@@ -223,10 +223,10 @@ func TestHandleCertificateChange(t *testing.T) {
 			name:               "setting spec when not previously set",
 			previousCertSpec:   nil,
 			previousMeshConfig: nil,
-			updatedMeshConfig: &configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
-						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{
+			updatedMeshConfig: &configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
+						IngressGateway: &configv1alpha3.IngressGatewayCertSpec{
 							SubjectAltNames:  []string{"foo.bar.cluster.local"},
 							ValidityDuration: "1h",
 							Secret:           testSecret,
@@ -239,16 +239,16 @@ func TestHandleCertificateChange(t *testing.T) {
 		},
 		{
 			name: "MeshConfig updated but certificate spec remains the same",
-			previousCertSpec: &configv1alpha2.IngressGatewayCertSpec{
+			previousCertSpec: &configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "1h",
 				Secret:           testSecret,
 			},
 			previousMeshConfig: nil,
-			updatedMeshConfig: &configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
-						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{
+			updatedMeshConfig: &configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
+						IngressGateway: &configv1alpha3.IngressGatewayCertSpec{
 							SubjectAltNames:  []string{"foo.bar.cluster.local"},
 							ValidityDuration: "1h",
 							Secret:           testSecret,
@@ -261,16 +261,16 @@ func TestHandleCertificateChange(t *testing.T) {
 		},
 		{
 			name: "MeshConfig and certificate spec updated",
-			previousCertSpec: &configv1alpha2.IngressGatewayCertSpec{
+			previousCertSpec: &configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "1h",
 				Secret:           testSecret,
 			},
 			previousMeshConfig: nil,
-			updatedMeshConfig: &configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
-						IngressGateway: &configv1alpha2.IngressGatewayCertSpec{
+			updatedMeshConfig: &configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
+						IngressGateway: &configv1alpha3.IngressGatewayCertSpec{
 							SubjectAltNames:  []string{"foo.bar.cluster.local"},
 							ValidityDuration: "2h",
 							Secret:           testSecret,
@@ -283,15 +283,15 @@ func TestHandleCertificateChange(t *testing.T) {
 		},
 		{
 			name: "Certificate spec is unset to remove certificate",
-			previousCertSpec: &configv1alpha2.IngressGatewayCertSpec{
+			previousCertSpec: &configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "1h",
 				Secret:           testSecret,
 			},
 			previousMeshConfig: nil,
-			updatedMeshConfig: &configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					Certificate: configv1alpha2.CertificateSpec{
+			updatedMeshConfig: &configv1alpha3.MeshConfig{
+				Spec: configv1alpha3.MeshConfigSpec{
+					Certificate: configv1alpha3.CertificateSpec{
 						IngressGateway: nil,
 					},
 				},
@@ -301,7 +301,7 @@ func TestHandleCertificateChange(t *testing.T) {
 		},
 		{
 			name: "Secret for rotated certificate is updated",
-			previousCertSpec: &configv1alpha2.IngressGatewayCertSpec{
+			previousCertSpec: &configv1alpha3.IngressGatewayCertSpec{
 				SubjectAltNames:  []string{"foo.bar.cluster.local"},
 				ValidityDuration: "5s",
 				Secret:           testSecret,

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -10,7 +10,7 @@ import (
 func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string,
 	outboundIPRangeInclusionList []string, outboundPortExclusionList []int,
 	inboundPortExclusionList []int, enablePrivilegedInitContainer bool, pullPolicy corev1.PullPolicy) corev1.Container {
-	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
+	iptablesInitCommand := generateIptablesCommands(cfg, outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
 
 	return corev1.Container{
 		Name:            containerName,

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -10,7 +10,7 @@ import (
 func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string,
 	outboundIPRangeInclusionList []string, outboundPortExclusionList []int,
 	inboundPortExclusionList []int, enablePrivilegedInitContainer bool, pullPolicy corev1.PullPolicy) corev1.Container {
-	iptablesInitCommand := generateIptablesCommands(cfg, outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
+	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
 
 	return corev1.Container{
 		Name:            containerName,

--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -60,7 +61,7 @@ var iptablesInboundStaticRules = []string{
 }
 
 // generateIptablesCommands generates a list of iptables commands to set up sidecar interception and redirection
-func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundIPRangeInclusionList []string, outboundPortExclusionList []int, inboundPortExclusionList []int) string {
+func generateIptablesCommands(cfg configurator.Configurator, outboundIPRangeExclusionList []string, outboundIPRangeInclusionList []string, outboundPortExclusionList []int, inboundPortExclusionList []int) string {
 	var rules strings.Builder
 
 	fmt.Fprintln(&rules, `# OSM sidecar interception rules

--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -61,7 +60,7 @@ var iptablesInboundStaticRules = []string{
 }
 
 // generateIptablesCommands generates a list of iptables commands to set up sidecar interception and redirection
-func generateIptablesCommands(cfg configurator.Configurator, outboundIPRangeExclusionList []string, outboundIPRangeInclusionList []string, outboundPortExclusionList []int, inboundPortExclusionList []int) string {
+func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundIPRangeInclusionList []string, outboundPortExclusionList []int, inboundPortExclusionList []int) string {
 	var rules strings.Builder
 
 	fmt.Fprintln(&rules, `# OSM sidecar interception rules

--- a/pkg/injector/iptables_test.go
+++ b/pkg/injector/iptables_test.go
@@ -3,12 +3,14 @@ package injector
 import (
 	"testing"
 
+	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateIptablesCommands(t *testing.T) {
 	testCases := []struct {
 		name                      string
+		configurator              configurator.Configurator
 		outboundIPRangeExclusions []string
 		outboundIPRangeInclusions []string
 		outboundPortExclusions    []int
@@ -88,7 +90,7 @@ EOF
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
-			actual := generateIptablesCommands(tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions)
+			actual := generateIptablesCommands(tc.configurator, tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions)
 			a.Equal(tc.expected, actual)
 		})
 	}

--- a/pkg/injector/iptables_test.go
+++ b/pkg/injector/iptables_test.go
@@ -3,14 +3,12 @@ package injector
 import (
 	"testing"
 
-	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateIptablesCommands(t *testing.T) {
 	testCases := []struct {
 		name                      string
-		configurator              configurator.Configurator
 		outboundIPRangeExclusions []string
 		outboundIPRangeInclusions []string
 		outboundPortExclusions    []int
@@ -90,7 +88,7 @@ EOF
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
-			actual := generateIptablesCommands(tc.configurator, tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions)
+			actual := generateIptablesCommands(tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions)
 			a.Equal(tc.expected, actual)
 		})
 	}

--- a/pkg/k8s/announcement_handlers.go
+++ b/pkg/k8s/announcement_handlers.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -96,8 +96,8 @@ func WatchAndUpdateLogLevel(msgBroker *messaging.Broker, stop <-chan struct{}) {
 				continue
 			}
 
-			prevObj, prevOk := msg.OldObj.(*configv1alpha2.MeshConfig)
-			newObj, newOk := msg.NewObj.(*configv1alpha2.MeshConfig)
+			prevObj, prevOk := msg.OldObj.(*configv1alpha3.MeshConfig)
+			newObj, newOk := msg.NewObj.(*configv1alpha3.MeshConfig)
 			if !prevOk || !newOk {
 				log.Error().Msgf("Error casting to *MeshConfig, got type prev=%T, new=%T", prevObj, newObj)
 			}

--- a/pkg/k8s/announcement_handlers_test.go
+++ b/pkg/k8s/announcement_handlers_test.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -114,16 +114,16 @@ func TestWatchAndUpdateLogLevel(t *testing.T) {
 			name: "log level updated to trace",
 			event: events.PubSubMessage{
 				Kind: announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "info",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "trace",
 						},
 					},
@@ -135,16 +135,16 @@ func TestWatchAndUpdateLogLevel(t *testing.T) {
 			name: "log level updated to info",
 			event: events.PubSubMessage{
 				Kind: announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "trace",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "info",
 						},
 					},
@@ -156,16 +156,16 @@ func TestWatchAndUpdateLogLevel(t *testing.T) {
 			name: "log level unchanged",
 			event: events.PubSubMessage{
 				Kind: announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "info",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "info",
 						},
 					},

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -291,8 +291,8 @@ func getProxyUpdateEvent(msg events.PubSubMessage) *proxyUpdateEvent {
 		}
 
 	case announcements.MeshConfigUpdated:
-		prevMeshConfig, okPrevCast := msg.OldObj.(*configv1alpha2.MeshConfig)
-		newMeshConfig, okNewCast := msg.NewObj.(*configv1alpha2.MeshConfig)
+		prevMeshConfig, okPrevCast := msg.OldObj.(*configv1alpha3.MeshConfig)
+		newMeshConfig, okNewCast := msg.NewObj.(*configv1alpha3.MeshConfig)
 		if !okPrevCast || !okNewCast {
 			log.Error().Msgf("Expected MeshConfig type, got previous=%T, new=%T", okPrevCast, okNewCast)
 			return nil

--- a/pkg/messaging/broker_test.go
+++ b/pkg/messaging/broker_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/k8s/events"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
@@ -99,8 +99,8 @@ func TestAllEvents(t *testing.T) {
 
 			meshCfgUpdate := events.PubSubMessage{
 				Kind:   announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{},
-				NewObj: &configv1alpha2.MeshConfig{},
+				OldObj: &configv1alpha3.MeshConfig{},
+				NewObj: &configv1alpha3.MeshConfig{},
 			}
 			c.GetQueue().Add(meshCfgUpdate)
 		}
@@ -193,16 +193,16 @@ func TestGetProxyUpdateEvent(t *testing.T) {
 			name: "MeshConfig updated to enable permissive mode",
 			msg: events.PubSubMessage{
 				Kind: announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Traffic: configv1alpha2.TrafficSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Traffic: configv1alpha3.TrafficSpec{
 							EnablePermissiveTrafficPolicyMode: false,
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Traffic: configv1alpha2.TrafficSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Traffic: configv1alpha3.TrafficSpec{
 							EnablePermissiveTrafficPolicyMode: true,
 						},
 					},
@@ -223,16 +223,16 @@ func TestGetProxyUpdateEvent(t *testing.T) {
 			name: "MeshConfig updated with field that does not result in proxy update",
 			msg: events.PubSubMessage{
 				Kind: announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "trace",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Observability: configv1alpha2.ObservabilitySpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Observability: configv1alpha3.ObservabilitySpec{
 							OSMLogLevel: "info",
 						},
 					},
@@ -244,16 +244,16 @@ func TestGetProxyUpdateEvent(t *testing.T) {
 			name: "MeshConfig update with feature flags results in proxy update",
 			msg: events.PubSubMessage{
 				Kind: announcements.MeshConfigUpdated,
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						FeatureFlags: configv1alpha2.FeatureFlags{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						FeatureFlags: configv1alpha3.FeatureFlags{
 							EnableEgressPolicy: true,
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						FeatureFlags: configv1alpha2.FeatureFlags{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						FeatureFlags: configv1alpha3.FeatureFlags{
 							EnableEgressPolicy: false,
 						},
 					},

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -16,7 +16,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	"github.com/openservicemesh/osm/pkg/config"
@@ -82,7 +82,7 @@ var _ = Describe("Test Kube client Provider (w/o kubecontroller)", func() {
 				},
 			},
 		}, nil)
-		mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
+		mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
 
 		Expect(c.ListEndpointsForService(meshSvc)).To(Equal([]endpoint.Endpoint{
 			{
@@ -121,7 +121,7 @@ var _ = Describe("Test Kube client Provider (w/o kubecontroller)", func() {
 				},
 			},
 		}, nil)
-		mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
+		mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
 
 		Expect(c.ListEndpointsForService(svc)).To(Equal([]endpoint.Endpoint{
 			{
@@ -406,7 +406,7 @@ func TestListEndpointsForIdentity(t *testing.T) {
 			mockKubeController := k8s.NewMockController(mockCtrl)
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 			mockConfigController := config.NewMockController(mockCtrl)
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: false}).AnyTimes()
 
 			provider := NewClient(mockKubeController, mockConfigController, mockConfigurator)
 
@@ -446,16 +446,16 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockConfigController := config.NewMockController(mockCtrl)
 
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 	provider := NewClient(mockKubeController, mockConfigController, mockConfigurator)
 
 	destServiceIdentity := tests.BookstoreServiceIdentity
 	destSA := destServiceIdentity.ToK8sServiceAccount()
 
-	mcServices := []configv1alpha2.MultiClusterService{
+	mcServices := []configv1alpha3.MultiClusterService{
 		{
-			Spec: configv1alpha2.MultiClusterServiceSpec{
-				Clusters: []configv1alpha2.ClusterSpec{
+			Spec: configv1alpha3.MultiClusterServiceSpec{
+				Clusters: []configv1alpha3.ClusterSpec{
 					{
 						Address: "1.2.3.4:8080",
 						Name:    "remote-cluster-1",

--- a/pkg/providers/kube/client_test.go
+++ b/pkg/providers/kube/client_test.go
@@ -475,7 +475,7 @@ func TestGetMultiClusterServiceEndpointsForServiceAccount(t *testing.T) {
 	configClient := fakeConfig.NewSimpleClientset()
 	for _, mcService := range mcServices {
 		mcServicePtr := mcService
-		_, err := configClient.ConfigV1alpha2().MultiClusterServices(tests.Namespace).Create(context.TODO(), &mcServicePtr, metav1.CreateOptions{})
+		_, err := configClient.ConfigV1alpha3().MultiClusterServices(tests.Namespace).Create(context.TODO(), &mcServicePtr, metav1.CreateOptions{})
 		assert.Nil(err)
 	}
 

--- a/pkg/providers/kube/multiclusterservice.go
+++ b/pkg/providers/kube/multiclusterservice.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -62,7 +62,7 @@ func (c *client) getMultiClusterServiceEndpointsForServiceAccount(serviceAccount
 	return endpoints
 }
 
-func getIPPort(cluster configv1alpha2.ClusterSpec) (ip net.IP, port int, err error) {
+func getIPPort(cluster configv1alpha3.ClusterSpec) (ip net.IP, port int, err error) {
 	tokens := strings.Split(cluster.Address, portIPSeparator)
 	if len(tokens) != 2 {
 		log.Error().Err(errParseMulticlusterServiceIP).Str(constants.LogFieldContext, constants.LogContextMulticluster).Msgf("Invalid address format %s. It should have IP address and port number separated by %s", cluster.Address, portIPSeparator)

--- a/pkg/providers/kube/multiclusterservice_test.go
+++ b/pkg/providers/kube/multiclusterservice_test.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/config"
 	"github.com/openservicemesh/osm/pkg/configurator"
@@ -31,7 +31,7 @@ func TestHelperFunctions(t *testing.T) {
 	mockConfigController := config.NewMockController(mockCtrl)
 
 	mockKubeController.EXPECT().IsMonitoredNamespace(tests.BookbuyerService.Namespace).Return(true).AnyTimes()
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{EnableMulticlusterMode: true}).AnyTimes()
 
 	toReturn := &corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{Namespace: tests.BookbuyerService.Namespace},
@@ -55,9 +55,9 @@ func TestHelperFunctions(t *testing.T) {
 		Zone: "alpha",
 	}}
 
-	toReturnServices := []configv1alpha2.MultiClusterService{{
-		Spec: configv1alpha2.MultiClusterServiceSpec{
-			Clusters: []configv1alpha2.ClusterSpec{{
+	toReturnServices := []configv1alpha3.MultiClusterService{{
+		Spec: configv1alpha3.MultiClusterServiceSpec{
+			Clusters: []configv1alpha3.ClusterSpec{{
 				Address: fmt.Sprintf("%s:%d", expectedEndpoint[0].IP, expectedEndpoint[0].Port),
 				Name:    "alpha",
 			}},
@@ -81,7 +81,7 @@ func TestHelperFunctions(t *testing.T) {
 
 	// Test getIPPort()
 	// returns the port number specified in a ClusterSpec
-	clusterSpec := configv1alpha2.ClusterSpec{
+	clusterSpec := configv1alpha3.ClusterSpec{
 		Address: "1.2.3.4:5678",
 	}
 	actualIP, actualPort, err := getIPPort(clusterSpec)

--- a/pkg/ticker/ticker.go
+++ b/pkg/ticker/ticker.go
@@ -4,7 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/k8s/events"
@@ -68,8 +68,8 @@ func (r *ResyncTicker) watchConfig(quit <-chan struct{}) {
 				continue
 			}
 
-			oldMeshSpec, oldOk := event.OldObj.(*configv1alpha2.MeshConfig)
-			newMeshSpec, newOk := event.NewObj.(*configv1alpha2.MeshConfig)
+			oldMeshSpec, oldOk := event.OldObj.(*configv1alpha3.MeshConfig)
+			newMeshSpec, newOk := event.NewObj.(*configv1alpha3.MeshConfig)
 			if !oldOk || !newOk {
 				log.Error().Msgf("Received unexpected message old=%T new=%T on channel, expected *MeshConfig", oldMeshSpec, newMeshSpec)
 				continue

--- a/pkg/ticker/ticker_test.go
+++ b/pkg/ticker/ticker_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/k8s/events"
@@ -41,16 +41,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Start ticker that ticks every 1s",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "1s",
 						},
 					},
@@ -63,16 +63,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Update ticker from 1s to 500ms",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "1s",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "500ms",
 						},
 					},
@@ -85,16 +85,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Stop ticker - 500ms to 0",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "500",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "0",
 						},
 					},
@@ -107,16 +107,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Restart ticker from 0 to 500ms",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "0",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "500ms",
 						},
 					},
@@ -129,16 +129,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Ticker continues to operate when the tick value is unchanged",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "500ms",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "500ms",
 						},
 					},
@@ -151,16 +151,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Set ticker interval below min allowed and verify it is ignored",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "0",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "1ms", // Less than 'minTickerInterval'
 						},
 					},
@@ -174,16 +174,16 @@ func TestResyncTicker(t *testing.T) {
 		{
 			name: "Restart ticker from invalid interval to 500ms",
 			event: events.PubSubMessage{
-				OldObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				OldObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "1ms",
 						},
 					},
 				},
-				NewObj: &configv1alpha2.MeshConfig{
-					Spec: configv1alpha2.MeshConfigSpec{
-						Sidecar: configv1alpha2.SidecarSpec{
+				NewObj: &configv1alpha3.MeshConfig{
+					Spec: configv1alpha3.MeshConfigSpec{
+						Sidecar: configv1alpha3.SidecarSpec{
 							ConfigResyncInterval: "500ms",
 						},
 					},

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -15,7 +15,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -253,7 +253,7 @@ func (kc *policyValidator) upstreamTrafficSettingValidator(req *admissionv1.Admi
 
 // MultiClusterServiceValidator validates the MultiClusterService CRD.
 func MultiClusterServiceValidator(req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
-	config := &configv1alpha2.MultiClusterService{}
+	config := &configv1alpha3.MultiClusterService{}
 	if err := json.NewDecoder(bytes.NewBuffer(req.Object.Raw)).Decode(config); err != nil {
 		return nil, err
 	}

--- a/tests/e2e/e2e_proxy_resource_limits.go
+++ b/tests/e2e/e2e_proxy_resource_limits.go
@@ -67,7 +67,7 @@ var _ = OSMDescribe("Test proxy resource setting",
 						corev1.ResourceMemory: resource.MustParse("64M"),
 					},
 				}
-				_, err = Td.ConfigClient.ConfigV1alpha2().MeshConfigs(Td.OsmNamespace).Update(context.TODO(), meshConfig, v1.UpdateOptions{})
+				_, err = Td.ConfigClient.ConfigV1alpha3().MeshConfigs(Td.OsmNamespace).Update(context.TODO(), meshConfig, v1.UpdateOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
 
 				// Create a new app

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/cluster/nodeutils"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	policyV1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	policyV1alpha1Client "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
@@ -285,7 +285,7 @@ nodeRegistration:
 
 	configClient, err := configClientset.NewForConfig(kubeConfig)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create %s client", configv1alpha2.SchemeGroupVersion)
+		return errors.Wrapf(err, "failed to create %s client", configv1alpha3.SchemeGroupVersion)
 	}
 
 	policyClient, err := policyV1alpha1Client.NewForConfig(kubeConfig)
@@ -415,7 +415,7 @@ func (td *OsmTestData) LoadImagesToKind(imageNames []string) error {
 	return nil
 }
 
-func setMeshConfigToDefault(instOpts InstallOSMOpts, meshConfig *configv1alpha2.MeshConfig) (defaultConfig *configv1alpha2.MeshConfig) {
+func setMeshConfigToDefault(instOpts InstallOSMOpts, meshConfig *configv1alpha3.MeshConfig) (defaultConfig *configv1alpha3.MeshConfig) {
 	meshConfig.Spec.Traffic.EnableEgress = instOpts.EgressEnabled
 	meshConfig.Spec.Traffic.EnablePermissiveTrafficPolicyMode = instOpts.EnablePermissiveMode
 	meshConfig.Spec.Traffic.OutboundPortExclusionList = []int{}
@@ -608,7 +608,7 @@ func (td *OsmTestData) RestartOSMController(instOpts InstallOSMOpts) error {
 }
 
 // GetMeshConfig is a wrapper to get a MeshConfig by name in a particular namespace
-func (td *OsmTestData) GetMeshConfig(namespace string) (*configv1alpha2.MeshConfig, error) {
+func (td *OsmTestData) GetMeshConfig(namespace string) (*configv1alpha3.MeshConfig, error) {
 	meshConfig, err := td.ConfigClient.ConfigV1alpha2().MeshConfigs(namespace).Get(context.TODO(), td.OsmMeshConfigName, v1.GetOptions{})
 
 	if err != nil {
@@ -916,7 +916,7 @@ func (td *OsmTestData) installCertManager(instOpts InstallOSMOpts) error {
 }
 
 // UpdateOSMConfig updates OSM MeshConfig
-func (td *OsmTestData) UpdateOSMConfig(meshConfig *configv1alpha2.MeshConfig) (*configv1alpha2.MeshConfig, error) {
+func (td *OsmTestData) UpdateOSMConfig(meshConfig *configv1alpha3.MeshConfig) (*configv1alpha3.MeshConfig, error) {
 	updated, err := td.ConfigClient.ConfigV1alpha2().MeshConfigs(td.OsmNamespace).Update(context.TODO(), meshConfig, metav1.UpdateOptions{})
 
 	if err != nil {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -609,7 +609,7 @@ func (td *OsmTestData) RestartOSMController(instOpts InstallOSMOpts) error {
 
 // GetMeshConfig is a wrapper to get a MeshConfig by name in a particular namespace
 func (td *OsmTestData) GetMeshConfig(namespace string) (*configv1alpha3.MeshConfig, error) {
-	meshConfig, err := td.ConfigClient.ConfigV1alpha2().MeshConfigs(namespace).Get(context.TODO(), td.OsmMeshConfigName, v1.GetOptions{})
+	meshConfig, err := td.ConfigClient.ConfigV1alpha3().MeshConfigs(namespace).Get(context.TODO(), td.OsmMeshConfigName, v1.GetOptions{})
 
 	if err != nil {
 		return nil, err
@@ -917,7 +917,7 @@ func (td *OsmTestData) installCertManager(instOpts InstallOSMOpts) error {
 
 // UpdateOSMConfig updates OSM MeshConfig
 func (td *OsmTestData) UpdateOSMConfig(meshConfig *configv1alpha3.MeshConfig) (*configv1alpha3.MeshConfig, error) {
-	updated, err := td.ConfigClient.ConfigV1alpha2().MeshConfigs(td.OsmNamespace).Update(context.TODO(), meshConfig, metav1.UpdateOptions{})
+	updated, err := td.ConfigClient.ConfigV1alpha3().MeshConfigs(td.OsmNamespace).Update(context.TODO(), meshConfig, metav1.UpdateOptions{})
 
 	if err != nil {
 		td.T.Logf("UpdateOSMConfig(): %s", err)

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 
 	catalogFake "github.com/openservicemesh/osm/pkg/catalog/fake"
@@ -46,7 +46,7 @@ func TestRDSNewResponseWithTrafficSplit(t *testing.T) {
 	// ---[  Get the config from rds.NewResponse()  ]-------
 	mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+	mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 		EnableWASMStats:    false,
 		EnableEgressPolicy: false,
 	}).AnyTimes()

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	configv1alpha3 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha3"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -236,7 +236,7 @@ func TestRDSRespose(t *testing.T) {
 
 			mockConfigurator.EXPECT().IsPermissiveTrafficPolicyMode().Return(false).AnyTimes()
 
-			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha2.FeatureFlags{
+			mockConfigurator.EXPECT().GetFeatureFlags().Return(configv1alpha3.FeatureFlags{
 				EnableWASMStats: false,
 			}).AnyTimes()
 


### PR DESCRIPTION
Updates the OSM control plane to use the new v1alpha3 version, and
add a couple of convenience methods. Also, add install capabilities
by updating the Helm chart

Part of #4653 

Signed-off-by: Keith Mattix II <keithmattix2@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Update units to reference new control plane version. Actual functionality will be tested in the next PR
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [X] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Not yet applicable