### PR TITLE
cli/verifier: verify basic HTTP route configs

### DIFF
--- a/pkg/cli/verifier/connectivity_pod_to_pod_test.go
+++ b/pkg/cli/verifier/connectivity_pod_to_pod_test.go
@@ -89,6 +89,21 @@ func TestRun(t *testing.T) {
 						ClusterIP: "10.96.15.1",
 					},
 				},
+				&corev1.Endpoints{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "httpbin",
+						Namespace: "httpbin",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Ports: []corev1.EndpointPort{
+								{
+									Port: 14001,
+								},
+							},
+						},
+					},
+				},
 			},
 			trafficAttr: TrafficAttribute{
 				SrcPod:      &types.NamespacedName{Namespace: "curl", Name: "curl"},

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -359,7 +359,7 @@ func ServiceToMeshServices(c Controller, svc corev1.Service) []service.MeshServi
 		// us to retrieve the TargetPort for the MeshService.
 		endpoints, _ := c.GetEndpoints(meshSvc)
 		if endpoints != nil {
-			meshSvc.TargetPort = getTargetPortFromEndpoints(portSpec.Name, *endpoints)
+			meshSvc.TargetPort = GetTargetPortFromEndpoints(portSpec.Name, *endpoints)
 		} else {
 			log.Warn().Msgf("k8s service %s/%s does not have endpoints but is being represented as a MeshService", svc.Namespace, svc.Name)
 		}
@@ -368,7 +368,8 @@ func ServiceToMeshServices(c Controller, svc corev1.Service) []service.MeshServi
 	return meshServices
 }
 
-func getTargetPortFromEndpoints(endpointName string, endpoints corev1.Endpoints) (endpointPort uint16) {
+// GetTargetPortFromEndpoints returns the endpoint port corresponding to the given endpoint name and endpoints
+func GetTargetPortFromEndpoints(endpointName string, endpoints corev1.Endpoints) (endpointPort uint16) {
 	// Per https://pkg.go.dev/k8s.io/api/core/v1#ServicePort and
 	// https://pkg.go.dev/k8s.io/api/core/v1#EndpointPort, if a service has multiple
 	// ports, then ServicePort.Name must match EndpointPort.Name when considering


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Verifies HTTP inbound and outbound route
  configs and top level service domain

- Updates code to correctly translate k8s
  service to MeshService. Previously this
  would break when a named TargetPort is
  used for the service port.

- Exports reusable code in k8s pkg

Part of #4634

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- curl -> httpbin test in permissive mode
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --to-pod httpbin/httpbin-69dc7d545c-hbc6d --service httpbin --app-protocol http
W0422 10:12:19.574556   27135 warnings.go:70] config.openservicemesh.io/v1alpha2 MeshConfig is deprecated; use config.openservicemesh.io/v1alpha3 MeshConfig
---------------------------------------------
[+] Context: Verify if pod "curl/curl-7bb5845476-5b7wr" can access pod "httpbin/httpbin-69dc7d545c-hbc6d" for app protocol "http"
Status: Success

---------------------------------------------
```

- Unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`