### PR TITLE
test((benchmark): add Golang benchmark test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ bootstrap.yaml
 
 # Test result folders
 test-[0-9]*/
+bm_profiles/
 
 # hugo static site generator
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ go-test: cmd/cli/chart.tgz
 go-test-coverage: embed-files
 	./scripts/test-w-coverage.sh
 
+.PHONY: go-benchmark
+go-benchmark: embed-files
+	./scripts/go-benchmark.sh
+
 .PHONY: kind-up
 kind-up:
 	./scripts/kind-with-registry.sh

--- a/pkg/certificate/providers/tresor/ca_test.go
+++ b/pkg/certificate/providers/tresor/ca_test.go
@@ -14,7 +14,7 @@ func TestNewCA(t *testing.T) {
 	assert := tassert.New(t)
 	rootCertCountry := "US"
 	rootCertLocality := "CA"
-	rootCertOrganization := "Open Service Mesh Tresor"
+	rootCertOrganization := testCertOrgName
 
 	cert, err := NewCA("Tresor CA for Testing", 2*time.Second, rootCertCountry, rootCertLocality, rootCertOrganization)
 	assert.Nil(err)

--- a/pkg/certificate/providers/tresor/certificate_manager_benchmark_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_benchmark_test.go
@@ -1,0 +1,45 @@
+package tresor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+	"github.com/openservicemesh/osm/pkg/logger"
+)
+
+var bmCert *certificate.Certificate
+
+func BenchmarkIssueCertificate(b *testing.B) {
+	if err := logger.SetLogLevel("error"); err != nil {
+		b.Logf("Failed to set log level to error: %s", err)
+	}
+
+	serviceFQDN := certificate.CommonName("a.b.c")
+	validity := 3 * time.Second
+	cn := certificate.CommonName("Test CA")
+	rootCertCountry := "US"
+	rootCertLocality := "CA"
+	rootCertOrganization := testCertOrgName
+
+	rootCert, err := NewCA(cn, 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
+	if err != nil {
+		b.Fatalf("Error loading CA from files %s and %s: %s", rootCertPem, rootKeyPem, err.Error())
+	}
+
+	m, newCertError := New(
+		rootCert,
+		"org",
+		2048,
+	)
+	if newCertError != nil {
+		b.Fatalf("Error creating new certificate manager: %s", newCertError.Error())
+	}
+
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		bmCert, _ = m.IssueCertificate(serviceFQDN, validity)
+	}
+	b.StopTimer()
+}

--- a/pkg/certificate/providers/tresor/certificate_manager_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Test Certificate Manager", func() {
 		cn := certificate.CommonName("Test CA")
 		rootCertCountry := "US"
 		rootCertLocality := "CA"
-		rootCertOrganization := "Open Service Mesh Tresor"
+		rootCertOrganization := testCertOrgName
 
 		rootCert, err := NewCA(cn, 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
 		if err != nil {

--- a/pkg/certificate/providers/tresor/types.go
+++ b/pkg/certificate/providers/tresor/types.go
@@ -14,6 +14,8 @@ const (
 
 	// How many bits in the certificate serial number
 	certSerialNumberBits = 128
+
+	testCertOrgName = "Open Service Mesh Tresor"
 )
 
 var (

--- a/pkg/envoy/ads/response_benchmark_test.go
+++ b/pkg/envoy/ads/response_benchmark_test.go
@@ -1,0 +1,193 @@
+package ads
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+
+	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/catalog"
+	"github.com/openservicemesh/osm/pkg/endpoint"
+	"github.com/openservicemesh/osm/pkg/k8s/informers"
+	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/messaging"
+	"github.com/openservicemesh/osm/pkg/policy"
+	"github.com/openservicemesh/osm/pkg/providers/kube"
+	"github.com/openservicemesh/osm/pkg/signals"
+	"github.com/openservicemesh/osm/pkg/smi"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+
+	"github.com/openservicemesh/osm/pkg/configurator"
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/registry"
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	policyFake "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+var (
+	proxy           *envoy.Proxy
+	server          xds_discovery.AggregatedDiscoveryService_StreamAggregatedResourcesServer
+	osmConfigurator *configurator.Client
+	adsServer       *Server
+)
+
+func setupTestServer(b *testing.B) {
+	stop := signals.RegisterExitHandlers()
+	msgBroker := messaging.NewBroker(stop)
+	kubeClient := k8sClientFake.NewSimpleClientset()
+	configClient := configFake.NewSimpleClientset()
+	policyClient := policyFake.NewSimpleClientset()
+	informerCollection, err := informers.NewInformerCollection(tests.MeshName, stop,
+		informers.WithKubeClient(kubeClient),
+		informers.WithConfigClient(configClient, tests.OsmMeshConfigName, tests.OsmNamespace),
+	)
+	if err != nil {
+		b.Fatalf("Failed to create informer collection: %s", err)
+	}
+	kubeController := k8s.NewKubernetesController(informerCollection, policyClient, msgBroker)
+	policyController := policy.NewPolicyController(informerCollection, kubeController, msgBroker)
+	osmConfigurator = configurator.NewConfigurator(informerCollection, tests.OsmNamespace, tests.OsmMeshConfigName, msgBroker)
+	kubeProvider := kube.NewClient(kubeController, osmConfigurator)
+
+	meshConfig := configv1alpha2.MeshConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "config.openservicemesh.io",
+			Kind:       "MeshConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: tests.OsmNamespace,
+			Name:      tests.OsmMeshConfigName,
+		}, Spec: configv1alpha2.MeshConfigSpec{
+			Certificate: configv1alpha2.CertificateSpec{
+				CertKeyBitSize:              2048,
+				ServiceCertValidityDuration: "1h",
+			},
+			Traffic: configv1alpha2.TrafficSpec{
+				EnableEgress:                      true,
+				EnablePermissiveTrafficPolicyMode: true,
+			},
+			Observability: configv1alpha2.ObservabilitySpec{
+				EnableDebugServer: false,
+				Tracing: configv1alpha2.TracingSpec{
+					Enable: false,
+				},
+			},
+			FeatureFlags: configv1alpha2.FeatureFlags{
+				EnableWASMStats:    false,
+				EnableEgressPolicy: false,
+			},
+		},
+	}
+	_, err = configClient.ConfigV1alpha2().MeshConfigs(tests.OsmNamespace).Create(context.Background(), &meshConfig, metav1.CreateOptions{})
+	if err != nil {
+		b.Fatalf("Failed to create mesh config: %v", err)
+	}
+
+	certManager, err := certificate.FakeCertManager()
+	if err != nil {
+		b.Fatalf("Failed to create fake cert manager: %v", err)
+	}
+
+	// --- setup
+	namespace := tests.Namespace
+	proxyService := service.MeshService{
+		Name:      tests.BookstoreV1ServiceName,
+		Namespace: namespace,
+	}
+	proxySvcAccount := tests.BookstoreServiceAccount
+
+	certPEM, _ := certManager.IssueCertificate(proxySvcAccount.ToServiceIdentity().String(), certificate.Service)
+	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
+	server, _ = tests.NewFakeXDSServer(cert, nil, nil)
+
+	proxyUUID := uuid.New()
+	labels := map[string]string{constants.EnvoyUniqueIDLabelName: proxyUUID.String()}
+	meshSpec := smi.NewSMIClient(informerCollection, tests.OsmNamespace, kubeController, msgBroker)
+	mc := catalog.NewMeshCatalog(
+		kubeController,
+		meshSpec,
+		certManager,
+		policyController,
+		stop,
+		osmConfigurator,
+		[]service.Provider{kubeProvider},
+		[]endpoint.Provider{kubeProvider},
+		msgBroker,
+	)
+
+	proxyRegistry := registry.NewProxyRegistry(registry.ExplicitProxyServiceMapper(func(*envoy.Proxy) ([]service.MeshService, error) {
+		return nil, nil
+	}), nil)
+
+	pod := tests.NewPodFixture(namespace, fmt.Sprintf("pod-0-%s", proxyUUID), tests.BookstoreServiceAccountName, tests.PodLabels)
+	pod.Labels[constants.EnvoyUniqueIDLabelName] = proxyUUID.String()
+	_, err = kubeClient.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		b.Fatalf("Failed to create pod: %v", err)
+	}
+
+	// monitor namespace
+	nsObj := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   namespace,
+			Labels: map[string]string{constants.OSMKubeResourceMonitorAnnotation: tests.MeshName},
+		},
+	}
+	if err := informerCollection.Add(informers.InformerKeyNamespace, &nsObj, &testing.T{}); err != nil {
+		b.Fatalf("Failed to add namespace to informer collection: %s", err)
+	}
+
+	svc := tests.NewServiceFixture(proxyService.Name, namespace, labels)
+	_, err = kubeClient.CoreV1().Services(namespace).Create(context.Background(), svc, metav1.CreateOptions{})
+	if err != nil {
+		b.Fatalf("Failed to create service: %v", err)
+	}
+
+	proxy = envoy.NewProxy(envoy.KindSidecar, proxyUUID, proxySvcAccount.ToServiceIdentity(), nil)
+
+	adsServer = NewADSServer(mc, proxyRegistry, true, tests.Namespace, osmConfigurator, certManager, kubeController, nil)
+}
+
+func BenchmarkSendXDSResponse(b *testing.B) {
+	// TODO(allenlsy): Add EDS to the list
+	testingXdsTypes := []envoy.TypeURI{
+		envoy.TypeLDS,
+		envoy.TypeSDS,
+		envoy.TypeRDS,
+		envoy.TypeCDS,
+	}
+
+	if err := logger.SetLogLevel("error"); err != nil {
+		b.Logf("Failed to set log level to error: %s", err)
+	}
+
+	for _, xdsType := range testingXdsTypes {
+		b.Run(string(xdsType), func(b *testing.B) {
+			setupTestServer(b)
+
+			// Set subscribed resources
+			proxy.SetSubscribedResources(xdsType, mapset.NewSetWith("service-cert:default/bookstore", "root-cert-for-mtls-inbound:default/bookstore|80"))
+
+			b.ResetTimer()
+			b.StartTimer()
+			for i := 0; i < b.N; i++ {
+				if err := adsServer.sendResponse(proxy, &server, nil, osmConfigurator, xdsType); err != nil {
+					b.Fatalf("Failed to send response: %s", err)
+				}
+			}
+			b.StopTimer()
+		})
+	}
+}

--- a/pkg/envoy/bootstrap/envoy_config_benchmark_test.go
+++ b/pkg/envoy/bootstrap/envoy_config_benchmark_test.go
@@ -1,0 +1,44 @@
+package bootstrap
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
+	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/models"
+)
+
+func BenchmarkBuildEnvoyBootstrapConfig(b *testing.B) {
+	if err := logger.SetLogLevel("error"); err != nil {
+		b.Logf("Failed to set log level to error: %s", err)
+	}
+
+	assert := tassert.New(b)
+
+	cert := tresorFake.NewFakeCertificate()
+	builder := &Builder{
+		NodeID:                cert.GetCommonName().String(),
+		XDSHost:               "osm-controller.osm-system.svc.cluster.local",
+		TLSMinProtocolVersion: "TLSv1_0",
+		TLSMaxProtocolVersion: "TLSv1_2",
+		CipherSuites:          []string{"abc", "xyz"},
+		ECDHCurves:            []string{"ABC", "XYZ"},
+		OriginalHealthProbes: models.HealthProbes{
+			Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true},
+			Readiness: &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true},
+			Startup:   &models.HealthProbe{Path: "/startup", Port: 83, IsHTTP: true},
+		},
+	}
+
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		bootstrapConfig, err := builder.Build()
+		assert.Nil(err)
+		assert.NotNil(bootstrapConfig)
+	}
+
+	b.StopTimer()
+}

--- a/pkg/injector/webhook_benchmark_test.go
+++ b/pkg/injector/webhook_benchmark_test.go
@@ -1,0 +1,123 @@
+package injector
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mapset "github.com/deckarep/golang-set"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclient "k8s.io/client-go/kubernetes/fake"
+
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	policyFake "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/k8s/informers"
+	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/messaging"
+	"github.com/openservicemesh/osm/pkg/signals"
+	"github.com/openservicemesh/osm/pkg/tests"
+)
+
+func BenchmarkPodCreationHandler(b *testing.B) {
+	if err := logger.SetLogLevel("error"); err != nil {
+		b.Logf("Failed to set log level to error: %s", err)
+	}
+
+	admissionRequestBody := `{
+		"kind": "AdmissionReview",
+		"apiVersion": "admission.k8s.io/v1",
+		"request": {
+		  "uid": "11111111-2222-3333-4444-555555555555",
+		  "kind": {
+			"group": "",
+			"version": "v1",
+			"kind": "PodExecOptions"
+		  },
+		  "resource": {
+			"group": "",
+			"version": "v1",
+			"resource": "pods"
+		  },
+		  "subResource": "exec",
+		  "requestKind": {
+			"group": "",
+			"version": "v1",
+			"kind": "PodExecOptions"
+		  },
+		  "requestResource": {
+			"group": "",
+			"version": "v1",
+			"resource": "pods"
+		  },
+		  "requestSubResource": "exec",
+		  "name": "some-pod-1111111111-22222",
+		  "namespace": "default",
+		  "operation": "CONNECT",
+		  "userInfo": {
+			"username": "user",
+			"groups": []
+		  },
+		  "object": {
+			"kind": "PodExecOptions",
+			"apiVersion": "v1",
+			"stdin": true,
+			"stdout": true,
+			"tty": true,
+			"container": "some-pod",
+			"command": ["bin/bash"]
+		  },
+		  "oldObject": null,
+		  "dryRun": false,
+		  "options": null
+		}
+	  }`
+
+	kubeClient := testclient.NewSimpleClientset()
+	configClient := configFake.NewSimpleClientset()
+	policyClient := policyFake.NewSimpleClientset()
+	stop := signals.RegisterExitHandlers()
+	msgBroker := messaging.NewBroker(stop)
+	informerCollection, err := informers.NewInformerCollection(tests.MeshName, stop,
+		informers.WithKubeClient(kubeClient),
+		informers.WithConfigClient(configClient, tests.OsmMeshConfigName, tests.OsmNamespace),
+	)
+	kubeController := k8s.NewKubernetesController(informerCollection, policyClient, msgBroker)
+	if err != nil {
+		b.Fatalf("Failed to create kubeController: %s", err.Error())
+	}
+
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}
+	if _, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), testNamespace, metav1.CreateOptions{}); err != nil {
+		b.Fatalf("Failed to create namespace: %s", err.Error())
+	}
+
+	wh := &mutatingWebhook{
+		kubeClient:          kubeClient,
+		kubeController:      kubeController,
+		nonInjectNamespaces: mapset.NewSet(),
+	}
+
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/a/b/c", strings.NewReader(admissionRequestBody))
+		req.Header = map[string][]string{
+			"Content-Type": {"application/json"},
+		}
+
+		wh.podCreationHandler(w, req)
+		res := w.Result()
+		if res.StatusCode != 200 {
+			b.Fatalf("Expected 200, got %d", res.StatusCode)
+		}
+	}
+	b.StopTimer()
+}

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -26,6 +26,15 @@ import (
 var ErrDecodingPEMBlock = errors.New("failed to decode PEM block containing certificate")
 
 const (
+	// MeshName is the name of the OSM mesh
+	MeshName = "osm"
+
+	// OsmNamespace is the namespace of OSM control plane
+	OsmNamespace = "osm-system"
+
+	// OsmMeshConfigName is the name of OSM MeshConfig resource
+	OsmMeshConfigName = "osm-mesh-config"
+
 	// Namespace is the commonly used namespace.
 	Namespace = "default"
 

--- a/pkg/validator/server_benchmark_test.go
+++ b/pkg/validator/server_benchmark_test.go
@@ -1,0 +1,91 @@
+package validator
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	k8sClientFake "k8s.io/client-go/kubernetes/fake"
+
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
+	smiAccessClientFake "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/access/clientset/versioned/fake"
+	smiSpecClientFake "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/specs/clientset/versioned/fake"
+	smiSplitClientFake "github.com/servicemeshinterface/smi-sdk-go/pkg/gen/client/split/clientset/versioned/fake"
+
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	policyFake "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/k8s/informers"
+	"github.com/openservicemesh/osm/pkg/logger"
+	"github.com/openservicemesh/osm/pkg/messaging"
+	"github.com/openservicemesh/osm/pkg/policy"
+	"github.com/openservicemesh/osm/pkg/signals"
+	"github.com/openservicemesh/osm/pkg/tests"
+	"github.com/openservicemesh/osm/pkg/webhook"
+)
+
+func BenchmarkDoValidation(b *testing.B) {
+	if err := logger.SetLogLevel("error"); err != nil {
+		b.Logf("Failed to set log level to error: %s", err)
+	}
+
+	kubeClient := k8sClientFake.NewSimpleClientset()
+	_, cancel := context.WithCancel(context.Background())
+	stop := signals.RegisterExitHandlers(cancel)
+	msgBroker := messaging.NewBroker(stop)
+	smiTrafficSplitClientSet := smiSplitClientFake.NewSimpleClientset()
+	smiTrafficSpecClientSet := smiSpecClientFake.NewSimpleClientset()
+	smiTrafficTargetClientSet := smiAccessClientFake.NewSimpleClientset()
+	policyClient := policyFake.NewSimpleClientset()
+	configClient := configFake.NewSimpleClientset()
+	informerCollection, err := informers.NewInformerCollection(tests.MeshName, stop,
+		informers.WithKubeClient(kubeClient),
+		informers.WithSMIClients(smiTrafficSplitClientSet, smiTrafficSpecClientSet, smiTrafficTargetClientSet),
+		informers.WithConfigClient(configClient, tests.OsmMeshConfigName, tests.OsmNamespace),
+		informers.WithPolicyClient(policyClient),
+	)
+	if err != nil {
+		b.Fatalf("Failed to create informer collection: %s", err)
+	}
+	k8sClient := k8s.NewKubernetesController(informerCollection, policyClient, msgBroker)
+	policyController := policy.NewPolicyController(informerCollection, k8sClient, msgBroker)
+	kv := &policyValidator{
+		policyClient: policyController,
+	}
+
+	w := httptest.NewRecorder()
+	s := &validatingWebhookServer{
+		validators: map[string]validateFunc{
+			policyv1alpha1.SchemeGroupVersion.WithKind("IngressBackend").String():         kv.ingressBackendValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():                 egressValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("UpstreamTrafficSetting").String(): kv.upstreamTrafficSettingValidator,
+			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():               trafficTargetValidator,
+		},
+	}
+
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		req := &http.Request{
+			Header: map[string][]string{
+				webhook.HTTPHeaderContentType: {webhook.ContentTypeJSON},
+			},
+			Body: io.NopCloser(strings.NewReader(`{
+				"metadata": {
+					"uid": "some-uid"
+				},
+				"request": {}
+			}`)),
+		}
+		s.doValidation(w, req)
+		res := w.Result()
+		if res.StatusCode != http.StatusOK {
+			b.Fatalf("Expected status code %d, got %d", http.StatusOK, res.StatusCode)
+		}
+	}
+	b.StopTimer()
+}

--- a/scripts/go-benchmark.sh
+++ b/scripts/go-benchmark.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+pkgs=(
+   pkg/certificate/providers/tresor
+   pkg/envoy/ads
+   pkg/envoy/bootstrap
+   pkg/validator
+)
+
+date_s=$(date '+%Y-%m-%d-%H-%M-%S')
+bm_dir=bm_profiles/$date_s
+
+output_file=$bm_dir/bm_output_$date_s
+
+mkdir -p "$bm_dir"
+
+for pkg in "${pkgs[@]}"; do
+   echo "Benchmarking $pkg"
+   name=${pkg//\//_}-$date_s
+   go test -benchmem -run=^$ -bench ^Benchmark github.com/openservicemesh/osm/"$pkg" -cpuprofile "$bm_dir"/"$name".cpu.pprof -memprofile "$bm_dir"/"$name".mem.pprof -trace "$bm_dir"/"$name".trace >> "$output_file"
+   go tool pprof -png -output "$bm_dir"/"$name".cpu.png "$bm_dir"/"$name".cpu.pprof
+   go tool pprof -png -output "$bm_dir"/"$name".mem.png "$bm_dir"/"$name".mem.pprof
+done
+
+if [ -d bm_profiles/latest ]; then
+   rm -rf bm_profiles/latest
+fi
+ln -s "$date_s" bm_profiles/latest


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Offline performance profiling is part of issue #4622. This PR adds benchmark test cases that profiles CPU usage, memory usage and program timeline.

* Added `make go-benchmark` make task. It runs all registered packages to be profiled.
* Each `go-benchmark` execution generates profile results which are saved in the `bm_profiles/<execution-timestamp>` folder, which is Git ignored. 
* For the ease of access the results, a symbol link to the latest results is created as `bm_profiles/latest`

TODO after this PR:

* Create a CI job to run benchmark before and after changes and output the performance change. This can be done with [`benchstat` ](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)

Partially resolve #4622 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [X] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No