### PR TITLE
feat: add pyroscope profiling

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/pyroscope-io/client/pyroscope"
 	"github.com/spf13/pflag"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -121,6 +122,29 @@ func init() {
 }
 
 func main() {
+	pyroscope.Start(pyroscope.Config{
+		ApplicationName: "osm-controller",
+
+		// replace this with the address of pyroscope server
+		ServerAddress:   "http://pyroscope:4040",
+
+		// you can disable logging by setting this to nil
+		Logger:          pyroscope.StandardLogger,
+
+		// optionally, if authentication is enabled, specify the API key:
+		// AuthToken: os.Getenv("PYROSCOPE_AUTH_TOKEN"),
+
+		// by default all profilers are enabled,
+		// but you can select the ones you want to use:
+		ProfileTypes: []pyroscope.ProfileType{
+			pyroscope.ProfileCPU,
+			pyroscope.ProfileAllocObjects,
+			pyroscope.ProfileAllocSpace,
+			pyroscope.ProfileInuseObjects,
+			pyroscope.ProfileInuseSpace,
+		},
+	})
+
 	log.Info().Msgf("Starting osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 	if err := parseFlags(); err != nil {
 		log.Fatal().Err(err).Str(errcode.Kind, errcode.ErrInvalidCLIArgument.String()).Msg("Error parsing cmd line arguments")

--- a/go.mod
+++ b/go.mod
@@ -301,6 +301,7 @@ require (
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/pyroscope-io/client v0.2.1 // indirect
 	github.com/quasilyte/go-ruleguard v0.2.0 // indirect
 	github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 // indirect
 	github.com/rboyer/safeio v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1821,6 +1821,8 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pyroscope-io/client v0.2.1 h1:GUyrncANOCuFhnmgURnpJ90o9z/uwZMx+1l9RMJUuKk=
+github.com/pyroscope-io/client v0.2.1/go.mod h1:zRdQXIGxy0H2QbKEkCmZBR6KOLLIFYLWsdzVI0MRm2E=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.2.0 h1:UOVMyH2EKkxIfzrULvA9n/tO+HtEhqD9mrLSWMr5FwU=
 github.com/quasilyte/go-ruleguard v0.2.0/go.mod h1:2RT/tf0Ce0UDj5y243iWKosQogJd8+1G3Rs2fxmlYnw=

--- a/pkg/certificate/providers/tresor/certificate_manager_benchmark_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_benchmark_test.go
@@ -1,0 +1,35 @@
+package tresor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/certificate"
+)
+
+
+func BenchmarkIssueCertificate(b *testing.B) {
+	serviceFQDN := certificate.CommonName("a.b.c")
+	validity := 3 * time.Second
+	cn := certificate.CommonName("Test CA")
+	rootCertCountry := "US"
+	rootCertLocality := "CA"
+	rootCertOrganization := "Open Service Mesh Tresor"
+
+	rootCert, err := NewCA(cn, 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
+	if err != nil {
+		b.Fatalf("Error loading CA from files %s and %s: %s", rootCertPem, rootKeyPem, err.Error())
+	}
+
+	for i := 0; i < b.N; i++ {
+		m, newCertError := New(
+			rootCert,
+			"org",
+			2048,
+		)
+		if newCertError != nil {
+			b.Fatalf("Error creating new certificate manager: %s", newCertError.Error())
+		}
+		m.IssueCertificate(serviceFQDN, validity)
+	}
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Pyroscope is a continuous profiling software. By installing it in the Kubernetes cluster, we can periodically profile OSM control plane and explore performance optimizations. 


This PR is part of https://github.com/openservicemesh/osm/issues/4622 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?