### PR TITLE
crds: add MeshRootCertificate CRD

### DIFF
--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/name : "openservicemesh.io"
 spec:
-  group: conifg.openservicemesh.io
+  group: config.openservicemesh.io
   scope: Namespaced
   names:
     kind: MeshRootCertificate
@@ -53,12 +53,17 @@ spec:
                 - provider
               properties:
                 provider:
-                  description: Provider used by the mesh control plane.
+                  description: Certificate provider used by the mesh control plane
                   type: object
                   properties:
                     certManager:
                       description: Cert-manager provider configuration
                       type: object
+                      required:
+                        - secretName
+                        - issuerName
+                        - issuerKind
+                        - issuerGroup
                       properties:
                         secretName:
                           description: The name of the kubernetes secret containing the root certificate
@@ -67,12 +72,11 @@ spec:
                           description: The name of the Issuer or ClusterIssuer resource
                           type: string
                         issuerKind:
-                          description: The kind of issuer resource. Defaults to Issuer
+                          description: The kind of issuer resource
                           type: string
                           enum:
                             - ClusterIssuer
                             - Issuer
-                          default: Issuer
                         issuerGroup:
                           description: The group that the issuer belongs to
                           type: string
@@ -88,14 +92,14 @@ spec:
                         host:
                           description: Host name for the Vault server
                           type: string
-                        role: Role created on Vault server for the mesh control plane
-                          description:
+                        role:
+                          description: Role created on Vault server for the mesh control plane
                           type: string
-                        protocol: Protocol for the Vault connection
-                          description:
+                        protocol:
+                          description: Protocol for the Vault connection
                           type: string
-                        token: Token used by the mesh control plane
-                          description:
+                        token:
+                          description: Token used by the mesh control plane
                           type: string
                     tresor:
                       description: Tresor provider configuration
@@ -107,27 +111,12 @@ spec:
                           description: Name of the kubernetes secret storing the root certificate
                           type: string
                   oneOf:
-                    - required: ['tresor']
-                      allOf:
-                        - not:
-                          - required: ['certManager']
-                        - not:
-                          - required: ['vault']
                     - required: ['certManager']
-                      allOf:
-                        - not:
-                          - required: ['tresor']
-                        - not:
-                          - required: ['vault']
                     - required: ['vault']
-                      allOf:
-                        - not:
-                          - required: ['certManager']
-                        - not:
-                          - required: ['tresor']
-          status:
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-    subresources:
-      # status enables the status subresource
-      status: {}
+                    - required: ['tresor']
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        # status enables the status subresource
+        status: {}

--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -1,0 +1,118 @@
+# Custom Resource Definition (CRD) for OSM's config specification.
+#
+# Copyright Open Service Mesh authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: meshrootcertificate.config.openservicemesh.io
+  labels:
+    app.kubernetes.io/name : "openservicemesh.io"
+spec:
+  group: conifg.openservicemesh.io
+  scope: Namespaced
+  names:
+    kind: MeshRootCertificate
+    listKind: MeshRootCertificateList
+    shortNames:
+      - mrc
+    singular: meshrootcertificate
+    plural: meshrootcertificate
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+      - description: Current state of the MeshRootCertificate config
+        jsonPath: .status.currentState
+        name: State
+        type: string
+      - description: Current rotationStage of the MeshRootCertificate config
+        jsonPath: .status.currentRotationStage
+        name: RotationStage
+        type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - provider
+              properties:
+                provider:
+                  description: Provider used by the mesh control plane.
+                  type: object
+                  properties:
+                    tresor:
+                      description: Configuration of the Tresor provider
+                      type: object
+                      required:
+                        - secretName
+                      properties:
+                        secretName:
+                          description: Name of the kubernetes secret storing the root certificate
+                          type: string
+                    vault:
+                      description: Configuration of the Vault provider
+                      type: object
+                      required:
+                        - host
+                        - role
+                        - protocol
+                        - token
+                      properties:
+                        host:
+                          description: Host name for the Vault server
+                          type: string
+                        role: Role created on Vault server for the mesh control plane
+                          description:
+                          type: string
+                        protocol: Protocol for the Vault connection
+                          description:
+                          type: string
+                        token: Token used by the mesh control plane
+                          description:
+                          type: string
+                    certManager:
+                      description: Configuration of the cert-manager provider
+                      type: object
+                      properties:
+                        secretName:
+                          description: The name of the kubernetes secret containing the root certificate
+                          type: string
+                        issuerName:
+                          description: The name of the Issuer or ClusterIssuer resource
+                          type: string
+                        issuerKind:
+                          description: The kind of issuer resource. Defaults to Issuer
+                          type: string
+                          enum:
+                            - ClusterIssuer
+                            - Issuer
+                          default: Issuer
+                        issuerGroup:
+                          description: The group that the issuer belongs to
+                          type: string
+                      oneOf:
+                        - required: ['tresor']
+                        - required: ['certManager']
+                        - required: ['vault']
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      # status enables the status subresource
+      status: {}

--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -17,7 +17,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: meshrootcertificate.config.openservicemesh.io
+  name: meshrootcertificates.config.openservicemesh.io
   labels:
     app.kubernetes.io/name : "openservicemesh.io"
 spec:
@@ -29,9 +29,9 @@ spec:
     shortNames:
       - mrc
     singular: meshrootcertificate
-    plural: meshrootcertificate
+    plural: meshrootcertificates
   versions:
-    - name: v1alpha1
+    - name: v1alpha2
       served: true
       storage: true
       additionalPrinterColumns:
@@ -56,17 +56,28 @@ spec:
                   description: Provider used by the mesh control plane.
                   type: object
                   properties:
-                    tresor:
-                      description: Configuration of the Tresor provider
+                    certManager:
+                      description: Cert-manager provider configuration
                       type: object
-                      required:
-                        - secretName
                       properties:
                         secretName:
-                          description: Name of the kubernetes secret storing the root certificate
+                          description: The name of the kubernetes secret containing the root certificate
+                          type: string
+                        issuerName:
+                          description: The name of the Issuer or ClusterIssuer resource
+                          type: string
+                        issuerKind:
+                          description: The kind of issuer resource. Defaults to Issuer
+                          type: string
+                          enum:
+                            - ClusterIssuer
+                            - Issuer
+                          default: Issuer
+                        issuerGroup:
+                          description: The group that the issuer belongs to
                           type: string
                     vault:
-                      description: Configuration of the Vault provider
+                      description: Vault provider configuration
                       type: object
                       required:
                         - host
@@ -86,30 +97,34 @@ spec:
                         token: Token used by the mesh control plane
                           description:
                           type: string
-                    certManager:
-                      description: Configuration of the cert-manager provider
+                    tresor:
+                      description: Tresor provider configuration
                       type: object
+                      required:
+                        - secretName
                       properties:
                         secretName:
-                          description: The name of the kubernetes secret containing the root certificate
+                          description: Name of the kubernetes secret storing the root certificate
                           type: string
-                        issuerName:
-                          description: The name of the Issuer or ClusterIssuer resource
-                          type: string
-                        issuerKind:
-                          description: The kind of issuer resource. Defaults to Issuer
-                          type: string
-                          enum:
-                            - ClusterIssuer
-                            - Issuer
-                          default: Issuer
-                        issuerGroup:
-                          description: The group that the issuer belongs to
-                          type: string
-                      oneOf:
-                        - required: ['tresor']
-                        - required: ['certManager']
-                        - required: ['vault']
+                  oneOf:
+                    - required: ['tresor']
+                      allOf:
+                        - not:
+                          - required: ['certManager']
+                        - not:
+                          - required: ['vault']
+                    - required: ['certManager']
+                      allOf:
+                        - not:
+                          - required: ['tresor']
+                        - not:
+                          - required: ['vault']
+                    - required: ['vault']
+                      allOf:
+                        - not:
+                          - required: ['certManager']
+                        - not:
+                          - required: ['tresor']
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds the CRD for MeshRootCertificate API.

Part of #4502

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?