### PR TITLE
Support pod recreation for the kubectl debug command.

### DIFF
--- a/pkg/injector/volumes.go
+++ b/pkg/injector/volumes.go
@@ -4,15 +4,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// getVolumeSpec returns a list of volumes to add to the POD
-func getVolumeSpec(envoyBootstrapConfigName string) []corev1.Volume {
-	return []corev1.Volume{
-		{
-			Name: envoyBootstrapConfigVolume,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: envoyBootstrapConfigName,
-				},
+// getVolumeSpec returns a volume to add to the POD
+func getVolumeSpec(envoyBootstrapConfigName string) corev1.Volume {
+	return corev1.Volume{
+		Name: envoyBootstrapConfigVolume,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: envoyBootstrapConfigName,
 			},
 		},
 	}

--- a/pkg/injector/volumes_test.go
+++ b/pkg/injector/volumes_test.go
@@ -11,14 +11,13 @@ var _ = Describe("Test volume functions", func() {
 	Context("Test getVolumeSpec", func() {
 		It("creates volume spec", func() {
 			actual := getVolumeSpec("-envoy-config-")
-			expected := []v1.Volume{{
+			expected := v1.Volume{
 				Name: "envoy-bootstrap-config-volume",
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
 						SecretName: "-envoy-config-",
 					},
-				},
-			}}
+				}}
 			Expect(actual).To(Equal(expected))
 		})
 	})

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -37,6 +37,8 @@ const (
 
 	// WebhookHealthPath is the HTTP path at which the health of the webhook can be queried
 	WebhookHealthPath = "/healthz"
+
+	bootstrapSecretPrefix = "envoy-bootstrap-config-"
 )
 
 // NewMutatingWebhook starts a new web server handling requests from the injector MutatingWebhookConfiguration
@@ -182,7 +184,6 @@ func (wh *mutatingWebhook) podCreationHandler(w http.ResponseWriter, req *http.R
 	// We use req.Namespace because pod.Namespace is "" at this point
 	// This string uniquely identifies the pod. Ideally this would be the pod.UID, but this is not available at this point.
 	proxyUUID := uuid.New()
-
 	requestForNamespace, admissionResp := wh.getAdmissionReqResp(proxyUUID, admissionRequestBody)
 
 	resp, err := json.Marshal(&admissionResp)

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -845,12 +845,9 @@ func TestWebhookMutate(t *testing.T) {
 
 		cfg := configurator.NewMockConfigurator(mockCtrl)
 		cfg.EXPECT().GetMeshConfig().AnyTimes()
-		cfg.EXPECT().IsPrivilegedInitContainer()
 		cfg.EXPECT().GetInitContainerImage().Return("init-container-image").AnyTimes()
 		cfg.EXPECT().GetEnvoyImage().Return("envoy-linux-image").AnyTimes()
 		cfg.EXPECT().GetEnvoyWindowsImage().Return("envoy-windows-image").AnyTimes()
-		cfg.EXPECT().GetProxyResources()
-		cfg.EXPECT().GetEnvoyLogLevel()
 
 		wh := &mutatingWebhook{
 			nonInjectNamespaces: mapset.NewSet(),

--- a/pkg/utils/proto.go
+++ b/pkg/utils/proto.go
@@ -24,3 +24,17 @@ func ProtoToYAML(m protoreflect.ProtoMessage) ([]byte, error) {
 	}
 	return configYAML, err
 }
+
+// YAMLToProto converts yaml to the provided proto message.
+func YAMLToProto(configYAML []byte, message protoreflect.ProtoMessage) error {
+	configJSON, err := yaml.YAMLToJSON(configYAML)
+	if err != nil {
+		return err
+	}
+
+	if err := protojson.Unmarshal(configJSON, message); err != nil {
+		log.Error().Err(err).Msgf("Error unmarshaling YAML to proto")
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
We do this by mutating the already injected pod's UUID,
and reinserting the UUID & new certificate in the appropriate
locations. This will result in a new bootstrap config as well.

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>