### PR TITLE
Fix ingressbackend timeout issue non-kind

### DIFF
--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -781,6 +781,14 @@ func (td *OsmTestData) InstallNginxIngress() (string, error) {
 				},
 			},
 		}
+	} else {
+		vals = map[string]interface{}{
+			"controller": map[string]interface{}{
+				"service": map[string]interface{}{
+					"externalTrafficPolicy": "Local",
+				},
+			},
+		}
 	}
 
 	if err := td.CreateNs(NginxIngressSvc.Namespace, nil); err != nil {


### PR DESCRIPTION
@Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Fix ingresstimeout issue on non-kind clusters by setting externalTrafficPolicy to local. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Ran e2e test locally.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [X] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?