### PR TITLE
cli/verifier: derive appProtocol from service

### DIFF
--- a/pkg/cli/verifier/connectivity_pod_to_pod.go
+++ b/pkg/cli/verifier/connectivity_pod_to_pod.go
@@ -59,7 +59,7 @@ func NewPodConnectivityVerifier(stdout io.Writer, stderr io.Writer, restConfig *
 
 // Run executes the pod connectivity verifier
 func (v *PodConnectivityVerifier) Run() Result {
-	ctx := fmt.Sprintf("Verify if pod %q can access pod %q for app protocol %q", v.trafficAttr.SrcPod, v.trafficAttr.DstPod, v.trafficAttr.AppProtocol)
+	ctx := fmt.Sprintf("Verify if pod %q can access pod %q for service %q", v.trafficAttr.SrcPod, v.trafficAttr.DstPod, v.trafficAttr.DstService)
 
 	verifiers := Set{
 		//


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Uses the same mechanism as the controller to derive
the app protocol for a service port. This is required
for a service with multiple ports, both serving
different protocols.

The `AppProtocol` in the `TrafficAttribute` struct
will be used for ingress/egress instead.

Part of #4634

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --to-pod httpbin/httpbin-69dc7d545c-hbc6d --service httpbin 
---------------------------------------------
[+] Context: Verify if pod "curl/curl-7bb5845476-5b7wr" can access pod "httpbin/httpbin-69dc7d545c-hbc6d" for service "httpbin/httpbin"
Status: Success

---------------------------------------------
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`