### PR TITLE
feat(injector): add list of ignored network interfaces

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -142,6 +142,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.meshName | string | `"osm"` | Identifier for the instance of a service mesh within a cluster |
 | osm.multicluster | object | `{"gatewayLogLevel":"error"}` | OSM multicluster feature configuration |
 | osm.multicluster.gatewayLogLevel | string | `"error"` | Log level for the multicluster gateway |
+| osm.networkInterfaceExclusionList | list | `[]` | Specifies a global list of network interface names to exclude for inbound and outbound traffic interception by the sidecar proxy. |
 | osm.osmBootstrap.podLabels | object | `{}` | OSM bootstrap's pod labels |
 | osm.osmBootstrap.replicaCount | int | `1` | OSM bootstrap's replica count |
 | osm.osmBootstrap.resource | object | `{"limits":{"cpu":"0.5","memory":"128M"},"requests":{"cpu":"0.3","memory":"128M"}}` | OSM bootstrap's container resource parameters |

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -18,7 +18,8 @@ data:
         "outboundPortExclusionList": {{.Values.osm.outboundPortExclusionList | mustToJson}},
         "inboundPortExclusionList": {{.Values.osm.inboundPortExclusionList | mustToJson}},
         "outboundIPRangeExclusionList": {{.Values.osm.outboundIPRangeExclusionList | mustToJson}},
-        "outboundIPRangeInclusionList": {{.Values.osm.outboundIPRangeInclusionList | mustToJson}}
+        "outboundIPRangeInclusionList": {{.Values.osm.outboundIPRangeInclusionList | mustToJson}},
+        "networkInterfaceExclusionList": {{.Values.osm.networkInterfaceExclusionList | mustToJson}}
       },
       "observability": {
         "enableDebugServer": {{.Values.osm.enableDebugServer | mustToJson}},

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1121,6 +1121,21 @@
                         ]
                     ]
                 },
+                "networkInterfaceExclusionList": {
+                    "$id": "#/properties/osm/properties/networkInterfaceExclusionList",
+                    "type": "array",
+                    "title": "The networkInterfaceExclusionList schema",
+                    "description": "Network interface exluclusion list for sidecar traffic interception",
+                    "items": {
+                        "type": "string"
+                    },
+                    "examples": [
+                        [
+                            "eth0",
+                            "net1"
+                        ]
+                    ]
+                },
                 "grafana": {
                     "$id": "#/properties/osm/properties/grafana",
                     "type": "object",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -259,6 +259,9 @@ osm:
   # If specified, must be a list of positive integers.
   inboundPortExclusionList: []
 
+  # -- Specifies a global list of network interface names to exclude for inbound and outbound traffic interception by the sidecar proxy.
+  networkInterfaceExclusionList: []
+
   #
   # -- OSM's sidecar injector parameters
   injector:

--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -149,6 +149,11 @@ spec:
                         type: integer
                         minimum: 1
                         maximum: 65535
+                    networkInterfaceExclusionList:
+                      description: NetworkInterfaceExclusionList defines a global list of network interface names to exclude from inbound and outbound traffic interception by the sidecar proxy.
+                      type: array
+                      items:
+                        type: string
                     enablePermissiveTrafficPolicyMode:
                       description: True for allowing traffic to flow between client and service pods within the mesh without SMI traffic policies, i.e. no traffic policy enforcement in the mesh. If set to false, enables deny-all traffic policy in mesh i.e. an SMI Traffic Target is necessary for services to communicate.
                       type: boolean

--- a/pkg/apis/config/v1alpha2/mesh_config.go
+++ b/pkg/apis/config/v1alpha2/mesh_config.go
@@ -103,6 +103,11 @@ type TrafficSpec struct {
 	// InboundExternalAuthorization defines a ruleset that, if enabled, will configure a remote external authorization endpoint
 	// for all inbound and ingress traffic in the mesh.
 	InboundExternalAuthorization ExternalAuthzSpec `json:"inboundExternalAuthorization,omitempty"`
+
+	// NetworkInterfaceExclusionList defines a global list of network interface
+	// names to exclude from inbound and outbound traffic interception by the
+	// sidecar proxy.
+	NetworkInterfaceExclusionList []string `json:"networkInterfaceExclusionList"`
 }
 
 // ObservabilitySpec is the type to represent OSM's observability configurations.

--- a/pkg/apis/config/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/config/v1alpha2/zz_generated.deepcopy.go
@@ -521,6 +521,11 @@ func (in *TrafficSpec) DeepCopyInto(out *TrafficSpec) {
 		copy(*out, *in)
 	}
 	out.InboundExternalAuthorization = in.InboundExternalAuthorization
+	if in.NetworkInterfaceExclusionList != nil {
+		in, out := &in.NetworkInterfaceExclusionList, &out.NetworkInterfaceExclusionList
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/injector/init_container.go
+++ b/pkg/injector/init_container.go
@@ -9,8 +9,8 @@ import (
 
 func getInitContainerSpec(containerName string, cfg configurator.Configurator, outboundIPRangeExclusionList []string,
 	outboundIPRangeInclusionList []string, outboundPortExclusionList []int,
-	inboundPortExclusionList []int, enablePrivilegedInitContainer bool, pullPolicy corev1.PullPolicy) corev1.Container {
-	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList)
+	inboundPortExclusionList []int, enablePrivilegedInitContainer bool, pullPolicy corev1.PullPolicy, networkInterfaceExclusionList []string) corev1.Container {
+	iptablesInitCommand := generateIptablesCommands(outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList, networkInterfaceExclusionList)
 
 	return corev1.Container{
 		Name:            containerName,

--- a/pkg/injector/init_container_test.go
+++ b/pkg/injector/init_container_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		It("Creates init container without ip range exclusion list", func() {
 			mockConfigurator.EXPECT().GetInitContainerImage().Return(containerImage).Times(1)
 			privileged := privilegedFalse
-			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, nil, privileged, corev1.PullAlways)
+			actual := getInitContainerSpec(containerName, mockConfigurator, nil, nil, nil, nil, privileged, corev1.PullAlways, nil)
 
 			expected := corev1.Container{
 				Name:            "-container-name-",

--- a/pkg/injector/iptables.go
+++ b/pkg/injector/iptables.go
@@ -76,6 +76,8 @@ func generateIptablesCommands(outboundIPRangeExclusionList []string, outboundIPR
 
 	// Ignore inbound traffic on specified interfaces
 	for _, iface := range networkInterfaceExclusionList {
+		// *Note: it is important to use the insert option '-I' instead of the append option '-A' to ensure the
+		// exclusion of traffic to the network interface happens before the rule that redirects traffic to the proxy
 		cmds = append(cmds, fmt.Sprintf("-I OSM_PROXY_INBOUND -i %s -j RETURN", iface))
 	}
 

--- a/pkg/injector/iptables_test.go
+++ b/pkg/injector/iptables_test.go
@@ -8,12 +8,13 @@ import (
 
 func TestGenerateIptablesCommands(t *testing.T) {
 	testCases := []struct {
-		name                      string
-		outboundIPRangeExclusions []string
-		outboundIPRangeInclusions []string
-		outboundPortExclusions    []int
-		inboundPortExclusions     []int
-		expected                  string
+		name                       string
+		outboundIPRangeExclusions  []string
+		outboundIPRangeInclusions  []string
+		outboundPortExclusions     []int
+		inboundPortExclusions      []int
+		networkInterfaceExclusions []string
+		expected                   string
 	}{
 		{
 			name: "no exclusions or inclusions",
@@ -45,11 +46,12 @@ EOF
 `,
 		},
 		{
-			name:                      "with exclusions and inclusions",
-			outboundIPRangeExclusions: []string{"1.1.1.1/32", "2.2.2.2/32"},
-			outboundIPRangeInclusions: []string{"3.3.3.3/32", "4.4.4.4/32"},
-			outboundPortExclusions:    []int{10, 20},
-			inboundPortExclusions:     []int{30, 40},
+			name:                       "with exclusions and inclusions",
+			outboundIPRangeExclusions:  []string{"1.1.1.1/32", "2.2.2.2/32"},
+			outboundIPRangeInclusions:  []string{"3.3.3.3/32", "4.4.4.4/32"},
+			outboundPortExclusions:     []int{10, 20},
+			inboundPortExclusions:      []int{30, 40},
+			networkInterfaceExclusions: []string{"eth0", "eth1"},
 			expected: `iptables-restore --noflush <<EOF
 # OSM sidecar interception rules
 *nat
@@ -65,6 +67,8 @@ EOF
 -A OSM_PROXY_INBOUND -p tcp --dport 15903 -j RETURN
 -A OSM_PROXY_INBOUND -p tcp --dport 15904 -j RETURN
 -A OSM_PROXY_INBOUND -p tcp -j OSM_PROXY_IN_REDIRECT
+-I OSM_PROXY_INBOUND -i eth0 -j RETURN
+-I OSM_PROXY_INBOUND -i eth1 -j RETURN
 -I OSM_PROXY_INBOUND -p tcp --match multiport --dports 30,40 -j RETURN
 -A OSM_PROXY_OUT_REDIRECT -p tcp -j REDIRECT --to-port 15001
 -A OSM_PROXY_OUT_REDIRECT -p tcp --dport 15000 -j ACCEPT
@@ -73,6 +77,8 @@ EOF
 -A OSM_PROXY_OUTBOUND -o lo -m owner ! --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -m owner --uid-owner 1500 -j RETURN
 -A OSM_PROXY_OUTBOUND -d 127.0.0.1/32 -j RETURN
+-A OSM_PROXY_OUTBOUND -o eth0 -j RETURN
+-A OSM_PROXY_OUTBOUND -o eth1 -j RETURN
 -A OSM_PROXY_OUTBOUND -d 1.1.1.1/32 -j RETURN
 -A OSM_PROXY_OUTBOUND -d 2.2.2.2/32 -j RETURN
 -A OSM_PROXY_OUTBOUND -p tcp --match multiport --dports 10,20 -j RETURN
@@ -88,7 +94,7 @@ EOF
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
-			actual := generateIptablesCommands(tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions)
+			actual := generateIptablesCommands(tc.outboundIPRangeExclusions, tc.outboundIPRangeInclusions, tc.outboundPortExclusions, tc.inboundPortExclusions, tc.networkInterfaceExclusions)
 			a.Equal(tc.expected, actual)
 		})
 	}

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -205,8 +205,10 @@ func (wh *mutatingWebhook) configurePodInit(podOS string, pod *corev1.Pod, names
 	globalOutboundIPRangeInclusionList := wh.configurator.GetMeshConfig().Spec.Traffic.OutboundIPRangeInclusionList
 	outboundIPRangeInclusionList := mergeIPRangeLists(podOutboundIPRangeInclusionList, globalOutboundIPRangeInclusionList)
 
+	networkInterfaceExclusionList := wh.configurator.GetMeshConfig().Spec.Traffic.NetworkInterfaceExclusionList
+
 	// Add the init container to the pod spec
-	initContainer := getInitContainerSpec(constants.InitContainerName, wh.configurator, outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList, wh.configurator.IsPrivilegedInitContainer(), wh.osmContainerPullPolicy)
+	initContainer := getInitContainerSpec(constants.InitContainerName, wh.configurator, outboundIPRangeExclusionList, outboundIPRangeInclusionList, outboundPortExclusionList, inboundPortExclusionList, wh.configurator.IsPrivilegedInitContainer(), wh.osmContainerPullPolicy, networkInterfaceExclusionList)
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, initContainer)
 
 	return nil


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change adds a new configurable list of ignored network interface
names. Traffic received from and sent to those interfaces is not
forwarded to the sidecar container by iptables. When this list is empty
(the default), osm-injector produces the exact same iptables commands as
it did before.

The list is configured in the chart at `osm.networkInterfaceExclusionList`
and in the MeshConfig at `spec.traffic.networkInterfaceExclusionList`.

Fixes #4546

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Updated unit tests

<details>
<summary>Tested manually e2e</summary>

- Installed [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) on an AKS cluster: `kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/master/deployments/multus-daemonset-thick-plugin.yml`
- Created a new network interface `net1`:
  ```yaml
  apiVersion: "k8s.cni.cncf.io/v1"
  kind: NetworkAttachmentDefinition
  metadata:
    name: macvlan-conf
  spec:
    config: '{
        "cniVersion": "0.3.0",
        "type": "macvlan",
        "master": "eth0",
        "mode": "bridge",
        "ipam": {
          "type": "host-local",
          "subnet": "192.168.1.0/24",
          "rangeStart": "192.168.1.200",
          "rangeEnd": "192.168.1.216",
          "routes": [
            { "dst": "0.0.0.0/0" }
          ],
          "gateway": "192.168.1.1"
        }
      }'
  ```
- Created 2 ubuntu pods from deployments named `client` and `server` each running containers defined by:
  ```dockerfile
  FROM ubuntu
  RUN apt update && apt install -y iproute2 curl python3
  ```

  ```yaml
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: client
  spec:
    replicas: 1
    selector:
      matchLabels:
        app: client
    template:
      metadata:
        labels:
          app: client
        annotations:
          k8s.v1.cni.cncf.io/networks: macvlan-conf
      spec:
        nodeName: aks-nodepool2-29838616-vmss000000
        containers:
        - name: client
          command: ["/bin/sh", "-c", "trap : TERM INT; sleep infinity & wait"]
          image: jondev.azurecr.io/nettest
  ```
  - Both pods must be running on the same node
- `kubectl exec -it deploy/server -c server -- bash -c 'ip a && python3 -m http.server'`
  - Note the IP address of the `net1` interface, e.g. 192.168.1.200, which changes each time the pod is recreated
- `kubectl exec -it deploy/client -c client -- curl -I 192.168.1.200:8000`
  ```
    HTTP/1.0 200 OK
    Server: SimpleHTTP/0.6 Python/3.8.10
    Date: Wed, 27 Apr 2022 16:13:02 GMT
    Content-type: text/html; charset=utf-8
    Content-Length: 1018
    ```
- Installed OSM
- `osm namespace add default`
- `kubectl rollout restart deploy client server`
- `kubectl exec -it deploy/server -c server -- bash -c 'ip a && python3 -m http.server'`
- `kubectl exec -it deploy/client -c client -- curl -I 192.168.1.200:8000`
  ```
    curl: (7) Failed to connect to 192.168.1.213 port 8000: Connection refused
    command terminated with exit code 7
    ```
- `kubectl patch meshconfig -n osm-system osm-mesh-config -p '{"spec": {"traffic": {"networkInterfaceExclusionList": ["net1"]}}}' --type=merge`
- `kubectl rollout restart deploy client server`
- `kubectl exec -it deploy/server -c server -- bash -c 'ip a && python3 -m http.server'`
  - Note the IP address of the `net1` interface, e.g. 192.168.1.200
- `kubectl exec -it deploy/client -c client -- curl -I 192.168.1.200:8000`
  ```
    HTTP/1.0 200 OK
    Server: SimpleHTTP/0.6 Python/3.8.10
    Date: Wed, 27 Apr 2022 16:13:02 GMT
    Content-type: text/html; charset=utf-8
    Content-Length: 1018
    ```
- `/stats` Envoy endpoint on either pod didn't show any of that traffic going through Envoy.
</details>

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [X] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [X] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Yes, https://github.com/openservicemesh/osm-docs/pull/361