### PR TITLE
ref(cert): update Manager to support mult clients

### DIFF
--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -30,6 +30,7 @@ func (i *fakeIssuer) GetRootCertificate() *Certificate {
 // FakeCertManager is a testing helper that returns a *certificate.Manager
 func FakeCertManager() (*Manager, error) {
 	cm, err := NewManager(
+		&Certificate{},
 		&fakeIssuer{},
 		validity,
 		nil,

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -30,7 +30,6 @@ func (i *fakeIssuer) GetRootCertificate() *Certificate {
 // FakeCertManager is a testing helper that returns a *certificate.Manager
 func FakeCertManager() (*Manager, error) {
 	cm, err := NewManager(
-		&Certificate{},
 		&fakeIssuer{},
 		validity,
 		nil,

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -23,10 +23,13 @@ func (i *fakeIssuer) IssueCertificate(cn CommonName, validityPeriod time.Duratio
 	}, nil
 }
 
+func (i *fakeIssuer) GetRootCertificate() *Certificate {
+	return caCert
+}
+
 // FakeCertManager is a testing helper that returns a *certificate.Manager
 func FakeCertManager() (*Manager, error) {
 	cm, err := NewManager(
-		caCert,
 		&fakeIssuer{},
 		validity,
 		nil,

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -16,7 +16,6 @@ var errCertNotFound = errors.New("certificate not found")
 
 // NewManager creates a new CertManager
 func NewManager(
-	ca *Certificate,
 	certClient client,
 	serviceCertValidityDuration time.Duration,
 	msgBroker *messaging.Broker) (*Manager, error) {

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -14,8 +14,9 @@ import (
 
 var errCertNotFound = errors.New("certificate not found")
 
-// NewManager creates a new CertManager with the passed CA and CA Private Key
+// NewManager creates a new CertManager
 func NewManager(
+	ca *Certificate,
 	certClient client,
 	serviceCertValidityDuration time.Duration,
 	msgBroker *messaging.Broker) (*Manager, error) {

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Test Certificate Manager", func() {
 
 	Context("Test Getting a certificate from the cache", func() {
 		m, newCertError := NewManager(
-			caCert,
 			&fakeIssuer{},
 			validity,
 			nil)
@@ -63,7 +62,7 @@ func TestRotor(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	msgBroker := messaging.NewBroker(stop)
-	certManager, err := NewManager(&Certificate{}, &fakeIssuer{}, validityPeriod, msgBroker)
+	certManager, err := NewManager(&fakeIssuer{}, validityPeriod, msgBroker)
 	certManager.Start(5*time.Second, stop)
 	assert.NoError(err)
 
@@ -217,10 +216,9 @@ func TestListCertificate(t *testing.T) {
 func TestGetRootCertificate(t *testing.T) {
 	assert := tassert.New(t)
 
-	manager := &Manager{ca: caCert}
+	manager := &Manager{clients: []client{&fakeIssuer{}}}
 
-	got, err := manager.GetRootCertificate()
+	got := manager.GetRootCertificate()
 
-	assert.Nil(err)
 	assert.Equal(caCert, got)
 }

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -37,7 +37,6 @@ var _ = Describe("Test Certificate Manager", func() {
 
 	Context("Test Getting a certificate from the cache", func() {
 		m, newCertError := NewManager(
-			&Certificate{},
 			&fakeIssuer{},
 			validity,
 			nil)
@@ -63,7 +62,7 @@ func TestRotor(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	msgBroker := messaging.NewBroker(stop)
-	certManager, err := NewManager(&Certificate{}, &fakeIssuer{}, validityPeriod, msgBroker)
+	certManager, err := NewManager(&fakeIssuer{}, validityPeriod, msgBroker)
 	certManager.Start(5*time.Second, stop)
 	assert.NoError(err)
 

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Test Certificate Manager", func() {
 
 	Context("Test Getting a certificate from the cache", func() {
 		m, newCertError := NewManager(
+			&Certificate{},
 			&fakeIssuer{},
 			validity,
 			nil)
@@ -62,7 +63,7 @@ func TestRotor(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	msgBroker := messaging.NewBroker(stop)
-	certManager, err := NewManager(&fakeIssuer{}, validityPeriod, msgBroker)
+	certManager, err := NewManager(&Certificate{}, &fakeIssuer{}, validityPeriod, msgBroker)
 	certManager.Start(5*time.Second, stop)
 	assert.NoError(err)
 

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -133,6 +133,11 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	return cert, nil
 }
 
+// GetRootCertificate returns the root certificate.
+func (cm *CertManager) GetRootCertificate() *certificate.Certificate {
+	return cm.ca
+}
+
 // New will construct a new certificate client using Jetstack's cert-manager,
 func New(
 	ca *certificate.Certificate,

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -242,7 +242,7 @@ func (c *Config) getTresorOSMCertificateManager() (*certificate.Manager, debugge
 		return nil, nil, errors.Errorf("Failed to instantiate Tresor as a Certificate Manager")
 	}
 
-	tresorCertManager, err := certificate.NewManager(rootCert, tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	tresorCertManager, err := certificate.NewManager(tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Tresor cert-manager : %w", err)
 	}
@@ -302,12 +302,7 @@ func (c *Config) getHashiVaultOSMCertificateManager(options VaultOptions) (*cert
 		return nil, nil, fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
 	}
 
-	vaultCert, err := vaultClient.GetRootCertificate()
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting Vault Root Certificate, got: %w", err)
-	}
-
-	certManager, err := certificate.NewManager(vaultCert, vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	certManager, err := certificate.NewManager(vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Vault cert-manager : %w", err)
 	}
@@ -351,7 +346,7 @@ func (c *Config) getCertManagerOSMCertificateManager(options CertManagerOptions)
 		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager client: %+v", err)
 	}
 
-	certManager, err := certificate.NewManager(rootCert, cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	certManager, err := certificate.NewManager(cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, errors.Errorf("error instantiating osm certificate.Manager for Jetstack cert-manager : %+v", err)
 	}

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -242,7 +242,7 @@ func (c *Config) getTresorOSMCertificateManager() (*certificate.Manager, debugge
 		return nil, nil, errors.Errorf("Failed to instantiate Tresor as a Certificate Manager")
 	}
 
-	tresorCertManager, err := certificate.NewManager(rootCert, tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	tresorCertManager, err := certificate.NewManager(tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Tresor cert-manager : %w", err)
 	}
@@ -302,7 +302,7 @@ func (c *Config) getHashiVaultOSMCertificateManager(options VaultOptions) (*cert
 		return nil, nil, fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
 	}
 
-	certManager, err := certificate.NewManager(vaultClient.GetRootCertificate(), vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	certManager, err := certificate.NewManager(vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Vault cert-manager : %w", err)
 	}
@@ -346,7 +346,7 @@ func (c *Config) getCertManagerOSMCertificateManager(options CertManagerOptions)
 		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager client: %+v", err)
 	}
 
-	certManager, err := certificate.NewManager(rootCert, cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	certManager, err := certificate.NewManager(cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, errors.Errorf("error instantiating osm certificate.Manager for Jetstack cert-manager : %+v", err)
 	}

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -242,7 +242,7 @@ func (c *Config) getTresorOSMCertificateManager() (*certificate.Manager, debugge
 		return nil, nil, errors.Errorf("Failed to instantiate Tresor as a Certificate Manager")
 	}
 
-	tresorCertManager, err := certificate.NewManager(tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	tresorCertManager, err := certificate.NewManager(rootCert, tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Tresor cert-manager : %w", err)
 	}
@@ -302,7 +302,7 @@ func (c *Config) getHashiVaultOSMCertificateManager(options VaultOptions) (*cert
 		return nil, nil, fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
 	}
 
-	certManager, err := certificate.NewManager(vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	certManager, err := certificate.NewManager(vaultClient.GetRootCertificate(), vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Vault cert-manager : %w", err)
 	}
@@ -346,7 +346,7 @@ func (c *Config) getCertManagerOSMCertificateManager(options CertManagerOptions)
 		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager client: %+v", err)
 	}
 
-	certManager, err := certificate.NewManager(cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
+	certManager, err := certificate.NewManager(rootCert, cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
 	if err != nil {
 		return nil, nil, errors.Errorf("error instantiating osm certificate.Manager for Jetstack cert-manager : %+v", err)
 	}

--- a/pkg/certificate/providers/tresor/certificate_manager.go
+++ b/pkg/certificate/providers/tresor/certificate_manager.go
@@ -129,3 +129,8 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 
 	return cert, nil
 }
+
+// GetRootCertificate returns the root certificate.
+func (cm *CertManager) GetRootCertificate() *certificate.Certificate {
+	return cm.ca
+}

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -25,7 +25,7 @@ func NewFake(msgBroker *messaging.Broker) *certificate.Manager {
 	if err != nil {
 		return nil
 	}
-	tresorCertManager, err := certificate.NewManager(tresorClient, 1*time.Hour, msgBroker)
+	tresorCertManager, err := certificate.NewManager(ca, tresorClient, 1*time.Hour, msgBroker)
 	if err != nil {
 		return nil
 	}

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -25,7 +25,7 @@ func NewFake(msgBroker *messaging.Broker) *certificate.Manager {
 	if err != nil {
 		return nil
 	}
-	tresorCertManager, err := certificate.NewManager(ca, tresorClient, 1*time.Hour, msgBroker)
+	tresorCertManager, err := certificate.NewManager(tresorClient, 1*time.Hour, msgBroker)
 	if err != nil {
 		return nil
 	}

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -35,7 +35,7 @@ func New(vaultAddr, token, role string) (*CertManager, error) {
 		return nil, err
 	}
 
-	vaultCert, err := c.GetRootCA()
+	vaultCert, err := c.getRootCA()
 	if err != nil {
 		return nil, fmt.Errorf("error getting Vault Root Certificate, got: %w", err)
 	}
@@ -88,8 +88,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	return newCert(cn, secret, time.Now().Add(validityPeriod)), nil
 }
 
-// GetRootCA returns the root certificate.
-func (cm *CertManager) GetRootCA() (*certificate.Certificate, error) {
+func (cm *CertManager) getRootCA() (*certificate.Certificate, error) {
 	// Create a temp certificate to determine the public part of the issuing CA
 	cert, err := cm.IssueCertificate("localhost", decade)
 	if err != nil {

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -53,7 +53,18 @@ func New(vaultAddr, token, role string) (*CertManager, error) {
 
 	c.client.SetToken(token)
 
+	vaultCert, err := c.GetRootCA()
+	if err != nil {
+		return nil, fmt.Errorf("error getting Vault Root Certificate, got: %w", err)
+	}
+	c.ca = vaultCert
+
 	return c, nil
+}
+
+// GetRootCertificate returns the root certificate.
+func (cm *CertManager) GetRootCertificate() *certificate.Certificate {
+	return cm.ca
 }
 
 // IssueCertificate requests a new signed certificate from the configured Vault issuer.
@@ -68,8 +79,8 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 	return newCert(cn, secret, time.Now().Add(validityPeriod)), nil
 }
 
-// GetRootCertificate returns the root certificate.
-func (cm *CertManager) GetRootCertificate() (*certificate.Certificate, error) {
+// GetRootCA returns the root certificate.
+func (cm *CertManager) GetRootCA() (*certificate.Certificate, error) {
 	// Create a temp certificate to determine the public part of the issuing CA
 	cert, err := cm.IssueCertificate("localhost", decade)
 	if err != nil {

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -30,6 +30,21 @@ const (
 
 // New constructs a new certificate client using Vault's cert-manager
 func New(vaultAddr, token, role string) (*CertManager, error) {
+	c, err := newClient(vaultAddr, token, role)
+	if err != nil {
+		return nil, err
+	}
+
+	vaultCert, err := c.GetRootCA()
+	if err != nil {
+		return nil, fmt.Errorf("error getting Vault Root Certificate, got: %w", err)
+	}
+	c.ca = vaultCert
+
+	return c, nil
+}
+
+func newClient(vaultAddr, token, role string) (*CertManager, error) {
 	if vaultAddr == "" {
 		return nil, fmt.Errorf("vault address must not be empty")
 	}
@@ -52,12 +67,6 @@ func New(vaultAddr, token, role string) (*CertManager, error) {
 	log.Info().Msgf("Created Vault CertManager, with role=%q at %v", role, vaultAddr)
 
 	c.client.SetToken(token)
-
-	vaultCert, err := c.GetRootCA()
-	if err != nil {
-		return nil, fmt.Errorf("error getting Vault Root Certificate, got: %w", err)
-	}
-	c.ca = vaultCert
 
 	return c, nil
 }

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -102,7 +102,7 @@ func TestNew(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tassert := assert.New(t)
-			_, err := New(tc.vaultaddr, tc.token, tc.role)
+			_, err := newClient(tc.vaultaddr, tc.token, tc.role)
 			if tc.wantErr {
 				tassert.Error(err, "expected error, got nil")
 			} else {
@@ -118,7 +118,7 @@ func TestIssueCertificate(t *testing.T) {
 
 	token, addr := mockVault(t)
 
-	cm, err := New(addr, token, vaultRole)
+	cm, err := newClient(addr, token, vaultRole)
 	if err != nil {
 		t.Fatalf("did not expect error, got %v", err)
 	}

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -3,6 +3,7 @@ package vault
 
 import (
 	"github.com/hashicorp/vault/api"
+	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
 // CertManager implements certificate.Manager and contains a Hashi Vault client instance.
@@ -12,4 +13,7 @@ type CertManager struct {
 
 	// The Vault role configured for OSM and passed as a CLI.
 	role string
+
+	// The Certificate Authority root certificate
+	ca *certificate.Certificate
 }

--- a/pkg/certificate/providers/vault/types.go
+++ b/pkg/certificate/providers/vault/types.go
@@ -3,6 +3,7 @@ package vault
 
 import (
 	"github.com/hashicorp/vault/api"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -58,14 +58,14 @@ type Certificate struct {
 type client interface {
 	// IssueCertificate issues a new certificate.
 	IssueCertificate(CommonName, time.Duration) (*Certificate, error)
+
+	// GetRootCertificate returns the root certificate.
+	GetRootCertificate() *Certificate
 }
 
-// Manager represents all necessary information for the certificate manager.
+// Manager represents all necessary information for the certificate managers.
 type Manager struct {
-	client client
-
-	// The Certificate Authority root certificate to be used by this certificate manager
-	ca *Certificate
+	clients []client
 
 	// Cache for all the certificates issued
 	// Types: map[certificate.CommonName]*certificate.Certificate

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -13,8 +13,7 @@ import (
 func TestNewGrpc(t *testing.T) {
 	assert := tassert.New(t)
 	certManager := tresorFake.NewFake(nil)
-	adsCert, err := certManager.GetRootCertificate()
-	assert.Nil(err)
+	adsCert := certManager.GetRootCertificate()
 
 	certPem := adsCert.GetCertificateChain()
 	keyPem := adsCert.GetPrivateKey()
@@ -52,8 +51,7 @@ func TestGrpcServe(t *testing.T) {
 	assert := tassert.New(t)
 
 	certManager := tresorFake.NewFake(nil)
-	adsCert, err := certManager.GetRootCertificate()
-	assert.Nil(err)
+	adsCert := certManager.GetRootCertificate()
 
 	serverType := "ADS"
 	port := 9999

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -30,8 +30,7 @@ func TestSetupMutualTLS(t *testing.T) {
 	}
 
 	certManager := tresorFake.NewFake(nil)
-	adsCert, err := certManager.GetRootCertificate()
-	assert.Nil(err)
+	adsCert := certManager.GetRootCertificate()
 
 	serverType := "ADS"
 	goodCertPem := adsCert.GetCertificateChain()


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Supports multiple clients in Manager struct. Refactoring
as a part of the root cert rotation work. During root cert
rotation, there will be 2 CertManagers - the CertManager
being rotated in and the CertManager being rotated out as
specified in the MeshRootCertificates.

The ca is moved from the Manager to the CertManagers
for each cert provider.

Part of #4502

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Certificate Management     | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?