### PR TITLE
cli/verifier: verify presence of secrets

### DIFF
--- a/pkg/cli/verifier/connectivity_pod_to_pod_test.go
+++ b/pkg/cli/verifier/connectivity_pod_to_pod_test.go
@@ -42,6 +42,7 @@ func TestRun(t *testing.T) {
 								Name: constants.EnvoyContainerName,
 							},
 						},
+						ServiceAccountName: "curl",
 					},
 				},
 				&corev1.Pod{
@@ -55,6 +56,7 @@ func TestRun(t *testing.T) {
 								Name: constants.EnvoyContainerName,
 							},
 						},
+						ServiceAccountName: "httpbin",
 					},
 				},
 				&corev1.Namespace{

--- a/pkg/cli/verifier/envoy_config.go
+++ b/pkg/cli/verifier/envoy_config.go
@@ -627,7 +627,7 @@ func (v *EnvoyConfigVerifier) findTLSSecretsOnSource(secrets []*xds_secret.Secre
 	for _, secret := range secrets {
 		actualSecrets.Add(secret.Name)
 	}
-	if !expectedSecrets.IsSubset((actualSecrets)) {
+	if !expectedSecrets.IsSubset(actualSecrets) {
 		diff := expectedSecrets.Difference(actualSecrets)
 		return errors.Errorf("expected secrets %s not found", diff.String())
 	}
@@ -659,7 +659,7 @@ func (v *EnvoyConfigVerifier) findTLSSecretsOnDestination(secrets []*xds_secret.
 	for _, secret := range secrets {
 		actualSecrets.Add(secret.Name)
 	}
-	if !expectedSecrets.IsSubset((actualSecrets)) {
+	if !expectedSecrets.IsSubset(actualSecrets) {
 		diff := expectedSecrets.Difference(actualSecrets)
 		return errors.Errorf("expected secrets %s not found", diff.String())
 	}

--- a/pkg/cli/verifier/envoy_config.go
+++ b/pkg/cli/verifier/envoy_config.go
@@ -10,6 +10,7 @@ import (
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xds_secret "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -22,6 +23,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy/lds"
 	"github.com/openservicemesh/osm/pkg/envoy/rds/route"
+	envoySecrets "github.com/openservicemesh/osm/pkg/envoy/secrets"
+	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -168,7 +171,18 @@ func (v *EnvoyConfigVerifier) verifySource() Result {
 		clusters = append(clusters, cluster)
 	}
 
-	// Next, if the destination service is known, verify it has a matching filter chain and route
+	// Retrieve secrets
+	var secrets []*xds_secret.Secret
+	secretConfigs := config.Secrets.GetDynamicActiveSecrets()
+	for _, s := range secretConfigs {
+		secret := &xds_secret.Secret{}
+		//nolint: errcheck
+		//#nosec G104: Errors unhandled
+		s.GetSecret().UnmarshalTo(secret)
+		secrets = append(secrets, secret)
+	}
+
+	// If the destination service is known, verify it has a matching filter chain and route
 	if v.configAttr.trafficAttr.DstService != nil {
 		dst := v.configAttr.trafficAttr.DstService
 		svc, err := v.kubeClient.CoreV1().Services(dst.Namespace).Get(context.Background(), dst.Name, metav1.GetOptions{})
@@ -192,6 +206,13 @@ func (v *EnvoyConfigVerifier) verifySource() Result {
 		if err := v.findClusterForService(svc, clusters, true); err != nil {
 			result.Status = Failure
 			result.Reason = fmt.Sprintf("Did not find matching outbound cluster for service %q: %s", dst, err)
+			return result
+		}
+
+		// Verify client TLS secret
+		if err := v.findTLSSecretsOnSource(secrets); err != nil {
+			result.Status = Failure
+			result.Reason = fmt.Sprintf("Client TLS secret not found for pod %q: %s", v.configAttr.trafficAttr.SrcPod, err)
 			return result
 		}
 	}
@@ -358,6 +379,17 @@ func (v *EnvoyConfigVerifier) verifyDestination() Result {
 		clusters = append(clusters, cluster)
 	}
 
+	// Retrieve secrets
+	var secrets []*xds_secret.Secret
+	secretConfigs := config.Secrets.GetDynamicActiveSecrets()
+	for _, s := range secretConfigs {
+		secret := &xds_secret.Secret{}
+		//nolint: errcheck
+		//#nosec G104: Errors unhandled
+		s.GetSecret().UnmarshalTo(secret)
+		secrets = append(secrets, secret)
+	}
+
 	// Next, if the destination service is known, verify it has a matching filter chain
 	if v.configAttr.trafficAttr.DstService != nil {
 		dst := v.configAttr.trafficAttr.DstService
@@ -380,6 +412,12 @@ func (v *EnvoyConfigVerifier) verifyDestination() Result {
 		if err := v.findClusterForService(svc, clusters, false); err != nil {
 			result.Status = Failure
 			result.Reason = fmt.Sprintf("Did not find matching inbound cluster for service %q: %s", dst, err)
+			return result
+		}
+		// Verify server TLS secret
+		if err := v.findTLSSecretsOnDestination(secrets); err != nil {
+			result.Status = Failure
+			result.Reason = fmt.Sprintf("Server TLS secret not found for pod %q: %s", v.configAttr.trafficAttr.DstPod, err)
 			return result
 		}
 	}
@@ -560,6 +598,70 @@ func findHTTPRouteConfig(routeConfigs []*xds_route.RouteConfiguration, desireCon
 
 	if virtualHost == nil {
 		return errors.Errorf("virtual host for domain %s not found", desiredDomain)
+	}
+
+	return nil
+}
+
+func (v *EnvoyConfigVerifier) findTLSSecretsOnSource(secrets []*xds_secret.Secret) error {
+	// Look for 2 secrets:
+	// 1. Client TLS secret (based on client's ServiceAccount)
+	// 2. Upstream peer validation secret (based on upstream service)
+	srcPod := v.configAttr.trafficAttr.SrcPod
+	pod, err := v.kubeClient.CoreV1().Pods(srcPod.Namespace).Get(context.Background(), srcPod.Name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Errorf("pod %s not found", srcPod)
+	}
+	downstreamIdentity := identity.K8sServiceAccount{Namespace: pod.Namespace, Name: pod.Spec.ServiceAccountName}.ToServiceIdentity()
+	downstreamSecretName := envoySecrets.SDSCert{
+		Name:     envoySecrets.GetSecretNameForIdentity(downstreamIdentity),
+		CertType: envoySecrets.ServiceCertType,
+	}.String()
+	upstreamPeerValidationSecretName := envoySecrets.SDSCert{
+		Name:     v.configAttr.trafficAttr.DstService.String(),
+		CertType: envoySecrets.RootCertTypeForMTLSOutbound,
+	}.String()
+
+	expectedSecrets := mapset.NewSetWith(downstreamSecretName, upstreamPeerValidationSecretName)
+	actualSecrets := mapset.NewSet()
+	for _, secret := range secrets {
+		actualSecrets.Add(secret.Name)
+	}
+	if !expectedSecrets.IsSubset((actualSecrets)) {
+		diff := expectedSecrets.Difference(actualSecrets)
+		return errors.Errorf("expected secrets %s not found", diff.String())
+	}
+
+	return nil
+}
+
+func (v *EnvoyConfigVerifier) findTLSSecretsOnDestination(secrets []*xds_secret.Secret) error {
+	// Look for 2 secrets:
+	// 1. Server TLS secret (based on upstream ServiceAccount)
+	// 2. Downstream peer validation secret (based on upstream ServiceAccount)
+	dstPod := v.configAttr.trafficAttr.DstPod
+	pod, err := v.kubeClient.CoreV1().Pods(dstPod.Namespace).Get(context.Background(), dstPod.Name, metav1.GetOptions{})
+	if err != nil {
+		return errors.Errorf("pod %s not found", dstPod)
+	}
+	upstreamIdentity := identity.K8sServiceAccount{Namespace: pod.Namespace, Name: pod.Spec.ServiceAccountName}.ToServiceIdentity()
+	upstreamSecretName := envoySecrets.SDSCert{
+		Name:     envoySecrets.GetSecretNameForIdentity(upstreamIdentity),
+		CertType: envoySecrets.ServiceCertType,
+	}.String()
+	downstreamPeerValidationSecretName := envoySecrets.SDSCert{
+		Name:     envoySecrets.GetSecretNameForIdentity(upstreamIdentity),
+		CertType: envoySecrets.RootCertTypeForMTLSInbound,
+	}.String()
+
+	expectedSecrets := mapset.NewSetWith(upstreamSecretName, downstreamPeerValidationSecretName)
+	actualSecrets := mapset.NewSet()
+	for _, secret := range secrets {
+		actualSecrets.Add(secret.Name)
+	}
+	if !expectedSecrets.IsSubset((actualSecrets)) {
+		diff := expectedSecrets.Difference(actualSecrets)
+		return errors.Errorf("expected secrets %s not found", diff.String())
 	}
 
 	return nil

--- a/pkg/cli/verifier/envoy_config_parser.go
+++ b/pkg/cli/verifier/envoy_config_parser.go
@@ -45,8 +45,8 @@ type Config struct {
 	// Listeners is an Envoy xDS proto.
 	Listeners adminv3.ListenersConfigDump
 
-	// SecretsConfigDump is an Envoy xDS proto.
-	SecretsConfigDump adminv3.SecretsConfigDump
+	// Secrets is an Envoy xDS proto.
+	Secrets adminv3.SecretsConfigDump
 
 	// ScopedRoutesConfigDump is an Envoy xDS proto.
 	ScopedRoutesConfigDump adminv3.ScopedRoutesConfigDump
@@ -118,7 +118,7 @@ func parseEnvoyConfig(jsonBytes []byte) (*Config, error) {
 			}
 
 		case "type.googleapis.com/envoy.admin.v3.SecretsConfigDump":
-			if err := configDump.Configs[idx].UnmarshalTo(&cfg.SecretsConfigDump); err != nil {
+			if err := configDump.Configs[idx].UnmarshalTo(&cfg.Secrets); err != nil {
 				return nil, errors.Errorf("error parsing SecretsConfigDump: %s", err)
 			}
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Verifies the presence of client and server side
secrets required for pod-to-pod connectivity.

Part of #4634

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --to-pod httpbin/httpbin-69dc7d545c-hbc6d --service httpbin 
---------------------------------------------
[+] Context: Verify if pod "curl/curl-7bb5845476-5b7wr" can access pod "httpbin/httpbin-69dc7d545c-hbc6d" for service "httpbin/httpbin"
Status: Success

---------------------------------------------
```
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --to-pod httpbin/httpbin-69dc7d545c-hbc6d --service httpbin 
---------------------------------------------
[+] Context: Verify if pod "curl/curl-7bb5845476-5b7wr" can access pod "httpbin/httpbin-69dc7d545c-hbc6d" for service "httpbin/httpbin"
Status: Failure
Reason: A verification step failed
Suggestion: Please follow the suggestions listed in the failed steps below to resolve the issue

[++] Context: Verify if namespace "curl" is monitored
Status: Success

[++] Context: Verify if namespace "httpbin" is monitored
Status: Success

[++] Context: Verify Envoy sidecar on pod "curl/curl-7bb5845476-5b7wr"
Status: Success

[++] Context: Verify Envoy sidecar on pod "httpbin/httpbin-69dc7d545c-hbc6d"
Status: Success

[++] Context: Verify Envoy config for traffic: 
	source pod: curl/curl-7bb5845476-5b7wr
	destination pod: httpbin/httpbin-69dc7d545c-hbc6d
	destination service: httpbin/httpbin
	destination protocol: http
Status: Failure

[+++] Context: Verify Envoy config on source
Status: Success

[+++] Context: Verify Envoy config on destination
Status: Failure
Reason: Server TLS secret not found for pod "httpbin/httpbin-69dc7d545c-hbc6d": expected secrets Set{service-cert:httpbin/httpbinfoo} not found

---------------------------------------------
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`