### PR TITLE
feat(certificate): create a compat layer for provider generation

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -175,6 +175,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.tracing.port | int | `9411` | Port of the tracing collector service |
 | osm.validatorWebhook.webhookConfigurationName | string | `""` | Name of the ValidatingWebhookConfiguration |
 | osm.vault.host | string | `""` | Hashicorp Vault host/service - where Vault is installed |
+| osm.vault.port | int | `8200` | port to use to connect to Vault |
 | osm.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
 | osm.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
 | osm.vault.token | string | `""` | token that should be used to connect to Vault |

--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -85,6 +85,7 @@ spec:
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.osm.vault.host}}",
+            "--vault-port", "{{.Values.osm.vault.port}}",
             "--vault-protocol", "{{.Values.osm.vault.protocol}}",
             "--vault-token", "{{.Values.osm.vault.token}}",
             {{- end }}

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -83,6 +83,7 @@ spec:
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{ required "osm.vault.host is required when osm.certificateProvider.kind==vault" .Values.osm.vault.host }}",
+            "--vault-port", "{{.Values.osm.vault.port}}",
             "--vault-protocol", "{{.Values.osm.vault.protocol}}",
             "--vault-token", "{{ required "osm.vault.token is required when osm.certificateProvider.kind==vault" .Values.osm.vault.token }}",
             {{- end }}

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -80,6 +80,7 @@ spec:
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.osm.vault.host}}",
+            "--vault-port", "{{.Values.osm.vault.port}}",
             "--vault-protocol", "{{.Values.osm.vault.protocol}}",
             "--vault-token", "{{.Values.osm.vault.token}}",
             {{- end }}

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1267,6 +1267,14 @@
                             "description": "Hashicorp Vault host/service - where Vault is installed",
                             "type": "string"
                         },
+                        "port": {
+                            "$id": "#/properties/osm/properties/vault/properties/port",
+                            "title": "Hashicorp Vault's port",
+                            "description": "Port to use to connect to vault",
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535
+                        },
                         "protocol": {
                             "$id": "#/properties/osm/properties/vault/properties/protocol",
                             "title": "Hashicorp Vault's protocol schema",

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -121,6 +121,8 @@ osm:
   vault:
     # --  Hashicorp Vault host/service - where Vault is installed
     host: ""
+    # -- port to use to connect to Vault
+    port: 8200
     # -- protocol to use to connect to Vault
     protocol: http
     # -- token that should be used to connect to Vault

--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -85,6 +85,7 @@ spec:
                       type: object
                       required:
                         - host
+                        - port
                         - role
                         - protocol
                         - token
@@ -92,6 +93,11 @@ spec:
                         host:
                           description: Host name for the Vault server
                           type: string
+                        port:
+                          description: Port for the Vault server
+                          type: integer
+                          minimum: 1
+                          maximum: 65535
                         role:
                           description: Role created on Vault server for the mesh control plane
                           type: string

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -112,6 +112,21 @@ func init() {
 	_ = admissionv1.AddToScheme(scheme)
 }
 
+// TODO(#4502): This function can be deleted once we get rid of cert options.
+func getCertOptions() (providers.Options, error) {
+	switch providers.Kind(certProviderKind) {
+	case providers.TresorKind:
+		tresorOptions.SecretName = caBundleSecretName
+		return tresorOptions, nil
+	case providers.VaultKind:
+		return vaultOptions, nil
+	case providers.CertManagerKind:
+		certManagerOptions.SecretName = caBundleSecretName
+		return certManagerOptions, nil
+	}
+	return nil, fmt.Errorf("unknown certificate provider kind: %s", certProviderKind)
+}
+
 func main() {
 	log.Info().Msgf("Starting osm-bootstrap %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 	if err := parseFlags(); err != nil {
@@ -176,9 +191,13 @@ func main() {
 	// Initialize Configurator to retrieve mesh specific config
 	cfg := configurator.NewConfigurator(configClient, stop, osmNamespace, osmMeshConfigName, msgBroker)
 
+	certOpts, err := getCertOptions()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error getting certificate options")
+	}
 	// Intitialize certificate manager/provider
-	certManager, _, _, err := providers.GenerateCertificateManager(kubeClient, kubeConfig, cfg, providers.Kind(certProviderKind), osmNamespace,
-		caBundleSecretName, tresorOptions, vaultOptions, certManagerOptions, msgBroker)
+	certManager, err := providers.NewCertificateManager(kubeClient, kubeConfig, cfg, osmNamespace,
+		certOpts, msgBroker)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 			"Error initializing certificate manager of kind %s", certProviderKind)
@@ -309,10 +328,6 @@ func parseFlags() error {
 func validateCLIParams() error {
 	if osmNamespace == "" {
 		return errors.New("Please specify the OSM namespace using --osm-namespace")
-	}
-
-	if caBundleSecretName == "" {
-		return errors.Errorf("Please specify the CA bundle secret name using --ca-bundle-secret-name")
 	}
 
 	return nil

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -136,17 +136,6 @@ func TestValidateCLIParams(t *testing.T) {
 				osmNamespace = "valid-ns"
 			},
 			verify: func(err error) {
-				assert.NotNil(err)
-				assert.Contains(err.Error(), "--ca-bundle-secret-name")
-			},
-		},
-		{
-			name: "osm-namespace and ca-bundle-secret-name is valid",
-			setup: func() {
-				osmNamespace = "valid-ns"
-				caBundleSecretName = "valid-ca-bundle"
-			},
-			verify: func(err error) {
 				assert.Nil(err)
 			},
 		},

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -121,6 +121,21 @@ func init() {
 	_ = admissionv1.AddToScheme(scheme)
 }
 
+// TODO(#4502): This function can be deleted once we get rid of cert options.
+func getCertOptions() (providers.Options, error) {
+	switch providers.Kind(certProviderKind) {
+	case providers.TresorKind:
+		tresorOptions.SecretName = caBundleSecretName
+		return tresorOptions, nil
+	case providers.VaultKind:
+		return vaultOptions, nil
+	case providers.CertManagerKind:
+		certManagerOptions.SecretName = caBundleSecretName
+		return certManagerOptions, nil
+	}
+	return nil, fmt.Errorf("unknown certificate provider kind: %s", certProviderKind)
+}
+
 func main() {
 	log.Info().Msgf("Starting osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 	if err := parseFlags(); err != nil {
@@ -176,9 +191,13 @@ func main() {
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating MeshSpec")
 	}
-
-	certManager, certDebugger, _, err := providers.GenerateCertificateManager(kubeClient, kubeConfig, cfg, providers.Kind(certProviderKind), osmNamespace,
-		caBundleSecretName, tresorOptions, vaultOptions, certManagerOptions, msgBroker)
+	certOpts, err := getCertOptions()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error getting certificate options")
+	}
+	// Intitialize certificate manager/provider
+	certManager, err := providers.NewCertificateManager(kubeClient, kubeConfig, cfg, osmNamespace,
+		certOpts, msgBroker)
 
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
@@ -276,7 +295,7 @@ func main() {
 
 	// Create DebugServer and start its config event listener.
 	// Listener takes care to start and stop the debug server as appropriate
-	debugConfig := debugger.NewDebugConfig(certDebugger, xdsServer, meshCatalog, proxyRegistry, kubeConfig, kubeClient, cfg, k8sClient, msgBroker)
+	debugConfig := debugger.NewDebugConfig(certManager, xdsServer, meshCatalog, proxyRegistry, kubeConfig, kubeClient, cfg, k8sClient, msgBroker)
 	go debugConfig.StartDebugServerConfigListener(stop)
 
 	// Start the k8s pod watcher that updates corresponding k8s secrets

--- a/cmd/osm-controller/validate.go
+++ b/cmd/osm-controller/validate.go
@@ -2,16 +2,10 @@ package main
 
 import (
 	"github.com/pkg/errors"
-
-	"github.com/openservicemesh/osm/pkg/certificate/providers"
 )
 
 // validateCLIParams contains all checks necessary that various permutations of the CLI flags are consistent
 func validateCLIParams() error {
-	if err := validateCertificateManagerOptions(); err != nil {
-		return errors.Errorf("Error validating certificate manager options: %s", err)
-	}
-
 	if meshName == "" {
 		return errors.New("Please specify the mesh name using --mesh-name")
 	}
@@ -24,26 +18,5 @@ func validateCLIParams() error {
 		return errors.Errorf("Please specify the webhook configuration name using --validator-webhook-config")
 	}
 
-	if caBundleSecretName == "" {
-		return errors.Errorf("Please specify the CA bundle secret name using --ca-bundle-secret-name")
-	}
-
 	return nil
-}
-
-func validateCertificateManagerOptions() error {
-	switch providers.Kind(certProviderKind) {
-	case providers.TresorKind:
-		return providers.ValidateTresorOptions(tresorOptions)
-
-	case providers.VaultKind:
-		return providers.ValidateVaultOptions(vaultOptions)
-
-	case providers.CertManagerKind:
-		return providers.ValidateCertManagerOptions(certManagerOptions)
-
-	default:
-		return errors.Errorf("Invalid certificate manager kind %s. Please specify a valid certificate manager, one of: [%v]",
-			certProviderKind, providers.ValidCertificateProviders)
-	}
 }

--- a/cmd/osm-controller/validate_test.go
+++ b/cmd/osm-controller/validate_test.go
@@ -4,130 +4,42 @@ import (
 	"testing"
 
 	tassert "github.com/stretchr/testify/assert"
-
-	"github.com/openservicemesh/osm/pkg/certificate/providers"
 )
-
-func TestValidateCertificateManagerOptions(t *testing.T) {
-	testCases := []struct {
-		name               string
-		certProvider       string
-		vaultToken         string
-		caBundleSecretName string
-		issuerName         string
-		expectError        bool
-	}{
-		{
-			name:         "Cert Provider : Tresor",
-			certProvider: providers.TresorKind.String(),
-			expectError:  false,
-		},
-		{
-			name:         "Cert Provider : Vault and token is not empty",
-			certProvider: providers.VaultKind.String(),
-			vaultToken:   "anythinghere",
-			expectError:  false,
-		},
-		{
-			name:         "Cert Provider : Vault and token is empty",
-			certProvider: providers.VaultKind.String(),
-			vaultToken:   "",
-			expectError:  true,
-		},
-		{
-			name:               "Cert Provider : Cert-Manager with valid caBundleSecretName and certmanagerIssuerName",
-			certProvider:       providers.CertManagerKind.String(),
-			caBundleSecretName: "test-secret",
-			issuerName:         "test-issuer",
-			expectError:        false,
-		},
-		{
-			name:               "Cert Provider : Cert-Manager with valid caBundleSecretName and no certmanagerIssuerName",
-			certProvider:       providers.CertManagerKind.String(),
-			caBundleSecretName: "test-secret",
-			issuerName:         "",
-			expectError:        true,
-		},
-		{
-			name:               "Cert Provider : Cert-Manager with no caBundleSecretName and no certmanagerIssuerName",
-			certProvider:       providers.CertManagerKind.String(),
-			issuerName:         "",
-			caBundleSecretName: "",
-			expectError:        true,
-		},
-		{
-			name:         "Cert Provider : InvalidProvider",
-			certProvider: "InvalidProvider",
-			expectError:  true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert := tassert.New(t)
-			certProviderKind = tc.certProvider
-			vaultOptions.VaultToken = tc.vaultToken
-			certManagerOptions.IssuerName = tc.issuerName
-			caBundleSecretName = tc.caBundleSecretName
-			err := validateCertificateManagerOptions()
-			assert.Equal(err != nil, tc.expectError)
-		})
-	}
-}
 
 func TestValidateCLIParams(t *testing.T) {
 	testCases := []struct {
 		name                       string
-		certProvider               string
 		meshName                   string
 		osmNamespace               string
 		validatorWebhookConfigName string
-		caBundleSecretName         string
 		expectError                bool
 	}{
 		{
 			name:                       "none of the necessary CLI params are empty",
-			certProvider:               providers.TresorKind.String(),
 			meshName:                   "test-mesh",
 			osmNamespace:               "test-ns",
 			validatorWebhookConfigName: "test-webhook",
-			caBundleSecretName:         "test-secret",
 			expectError:                false,
 		},
 		{
 			name:                       "mesh name is empty",
-			certProvider:               providers.TresorKind.String(),
 			meshName:                   "",
 			osmNamespace:               "test-ns",
 			validatorWebhookConfigName: "test-webhook",
-			caBundleSecretName:         "test-secret",
 			expectError:                true,
 		},
 		{
 			name:                       "osm namespace is empty",
-			certProvider:               providers.TresorKind.String(),
 			meshName:                   "test-mesh",
 			osmNamespace:               "",
 			validatorWebhookConfigName: "test-webhook",
-			caBundleSecretName:         "test-secret",
 			expectError:                true,
 		},
 		{
 			name:                       "validator webhook is empty",
-			certProvider:               providers.TresorKind.String(),
 			meshName:                   "test-mesh",
 			osmNamespace:               "test-ns",
 			validatorWebhookConfigName: "",
-			caBundleSecretName:         "test-secret",
-			expectError:                true,
-		},
-		{
-			name:                       "cabundle is empty",
-			certProvider:               providers.TresorKind.String(),
-			meshName:                   "test-mesh",
-			osmNamespace:               "test-ns",
-			validatorWebhookConfigName: "test-webhook",
-			caBundleSecretName:         "",
 			expectError:                true,
 		},
 	}
@@ -135,11 +47,9 @@ func TestValidateCLIParams(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
-			certProviderKind = tc.certProvider
 			meshName = tc.meshName
 			osmNamespace = tc.osmNamespace
 			validatorWebhookConfigName = tc.validatorWebhookConfigName
-			caBundleSecretName = tc.caBundleSecretName
 			err := validateCLIParams()
 			assert.Equal(err != nil, tc.expectError)
 		})

--- a/pkg/apis/config/v1alpha2/meshrootcertificate.go
+++ b/pkg/apis/config/v1alpha2/meshrootcertificate.go
@@ -66,6 +66,9 @@ type VaultProviderSpec struct {
 	// Host specifies the name of the Vault server
 	Host string `json:"host"`
 
+	// Port specifies the port of the Vault server
+	Port int `json:"port"`
+
 	// Role specifies the name of the role for use by mesh control plane
 	Role string `json:"role"`
 

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Test Certificate Manager", func() {
 
 	Context("Test Getting a certificate from the cache", func() {
 		m, newCertError := NewManager(
-			&fakeIssuer{},
+			&fakeMRCClient{},
 			validity,
 			nil)
 		It("should get an issued certificate from the cache", func() {
@@ -62,7 +62,7 @@ func TestRotor(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 	msgBroker := messaging.NewBroker(stop)
-	certManager, err := NewManager(&fakeIssuer{}, validityPeriod, msgBroker)
+	certManager, err := NewManager(&fakeMRCClient{}, validityPeriod, msgBroker)
 	certManager.Start(5*time.Second, stop)
 	assert.NoError(err)
 
@@ -216,7 +216,7 @@ func TestListCertificate(t *testing.T) {
 func TestGetRootCertificate(t *testing.T) {
 	assert := tassert.New(t)
 
-	manager := &Manager{clients: []client{&fakeIssuer{}}}
+	manager := &Manager{clients: []Issuer{&fakeIssuer{}}}
 
 	got := manager.GetRootCertificate()
 

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -1,0 +1,20 @@
+package providers
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+)
+
+// List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
+func (c *MRCCompatClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
+	return []*v1alpha2.MeshRootCertificate{
+		c.mrc,
+	}, nil
+}
+
+// AddEventHandler is a no-op for the legacy client. The previous client could not handle changes, but we need this
+// method to implement the certificate.MRCClient interface.
+func (c *MRCCompatClient) AddEventHandler(cache.ResourceEventHandler) {}
+
+// provider.Tresor = &v1alpha2.TresorProviderSpec{SecretName: opts.SecretName}

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/castorage/k8s"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/certmanager"
@@ -18,7 +19,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/providers/vault"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/debugger"
 	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
@@ -29,116 +29,61 @@ const (
 	rootCertOrganization = "Open Service Mesh"
 )
 
-// GenerateCertificateManager returns a new certificate manager and associated config
-func GenerateCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator, providerKind Kind,
-	providerNamespace string, caBundleSecretName string, tresorOptions TresorOptions, vaultOptions VaultOptions,
-	certManagerOptions CertManagerOptions, msgBroker *messaging.Broker) (*certificate.Manager, debugger.CertificateManagerDebugger, *Config, error) {
-	config := &Config{
-		kubeClient:         kubeClient,
-		kubeConfig:         kubeConfig,
-		cfg:                cfg,
-		providerKind:       providerKind,
-		providerNamespace:  providerNamespace,
-		caBundleSecretName: caBundleSecretName,
-
-		tresorOptions:      tresorOptions,
-		vaultOptions:       vaultOptions,
-		certManagerOptions: certManagerOptions,
-
-		msgBroker: msgBroker,
+// NewCertificateManager returns a new certificate manager, with an MRC compat client.
+// TODO(4502): Use an informer behind a feature flag.
+func NewCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator,
+	providerNamespace string, options Options, msgBroker *messaging.Broker) (*certificate.Manager, error) {
+	if err := options.Validate(); err != nil {
+		return nil, err
 	}
 
-	if err := config.Validate(); err != nil {
-		return nil, nil, nil, err
+	// TODO(4502): Switch the compat client to an informer. Might need another struct to compose the informer and
+	// provider generator.
+	mrcClient := &MRCCompatClient{
+		MRCProviderGenerator: MRCProviderGenerator{
+			kubeClient: kubeClient,
+			kubeConfig: kubeConfig,
+			KeyBitSize: cfg.GetCertKeyBitSize(),
+		},
+		mrc: &v1alpha2.MeshRootCertificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "legacy-compat",
+				Namespace: providerNamespace,
+				Annotations: map[string]string{
+					constants.MRCVersionAnnotation: "legacy-compat",
+				},
+			},
+			Spec: v1alpha2.MeshRootCertificateSpec{
+				Provider: options.AsProviderSpec(),
+			},
+			// TODO(#4502): Detect if an actual MRC exists, and set the status accordingly.
+			Status: v1alpha2.MeshRootCertificateStatus{
+				State:         constants.MRCStateValidating,
+				RotationStage: constants.MRCStageComplete,
+			},
+		},
 	}
 
-	certManager, certDebugger, err := config.GetCertificateManager()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
-	return certManager, certDebugger, config, nil
+	return certificate.NewManager(mrcClient, cfg.GetServiceCertValidityPeriod(), msgBroker)
 }
 
-// Validate validates the certificate provider config
-func (c *Config) Validate() error {
-	switch c.providerKind {
-	case TresorKind:
-		// nothing to validate
-		return nil
-
-	case VaultKind:
-		return ValidateVaultOptions(c.vaultOptions)
-
-	case CertManagerKind:
-		return ValidateCertManagerOptions(c.certManagerOptions)
-
+// GetCertIssuerForMRC returns a certificate.Issuer generated from the provided MRC.
+func (c *MRCProviderGenerator) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+	p := mrc.Spec.Provider
+	switch {
+	case p.Tresor != nil:
+		return c.getTresorOSMCertificateManager(mrc)
+	case p.Vault != nil:
+		return c.getHashiVaultOSMCertificateManager(mrc)
+	case p.CertManager != nil:
+		return c.getCertManagerOSMCertificateManager(mrc)
 	default:
-		return errors.Errorf("Invalid certificate manager kind %s. Specify a valid certificate manager, one of: [%v]",
-			c.providerKind, ValidCertificateProviders)
-	}
-}
-
-// ValidateTresorOptions validates the options for Tresor certificate provider
-func ValidateTresorOptions(options TresorOptions) error {
-	// Nothing to validate at the moment
-	return nil
-}
-
-// ValidateVaultOptions validates the options for Hashi Vault certificate provider
-func ValidateVaultOptions(options VaultOptions) error {
-	if options.VaultHost == "" {
-		return errors.New("VaultHost not specified in Hashi Vault options")
-	}
-
-	if options.VaultToken == "" {
-		return errors.New("VaultToken not specified in Hashi Vault options")
-	}
-
-	if options.VaultRole == "" {
-		return errors.New("VaultRole not specified in Hashi Vault options")
-	}
-
-	if _, ok := map[string]interface{}{"http": nil, "https": nil}[options.VaultProtocol]; !ok {
-		return errors.Errorf("VaultProtocol in Hashi Vault options must be one of [http, https], got %s", options.VaultProtocol)
-	}
-
-	return nil
-}
-
-// ValidateCertManagerOptions validates the options for cert-manager.io certificate provider
-func ValidateCertManagerOptions(options CertManagerOptions) error {
-	if options.IssuerName == "" {
-		return errors.New("IssuerName not specified in cert-manager.io options")
-	}
-
-	if options.IssuerKind == "" {
-		return errors.New("IssuerKind not specified in cert-manager.io options")
-	}
-
-	if options.IssuerGroup == "" {
-		return errors.New("IssuerGroup not specified in cert-manager.io options")
-	}
-
-	return nil
-}
-
-// GetCertificateManager returns the certificate manager/provider instance
-func (c *Config) GetCertificateManager() (*certificate.Manager, debugger.CertificateManagerDebugger, error) {
-	switch c.providerKind {
-	case TresorKind:
-		return c.getTresorOSMCertificateManager()
-	case VaultKind:
-		return c.getHashiVaultOSMCertificateManager(c.vaultOptions)
-	case CertManagerKind:
-		return c.getCertManagerOSMCertificateManager(c.certManagerOptions)
-	default:
-		return nil, nil, fmt.Errorf("Unsupported Certificate Manager %s", c.providerKind)
+		return nil, fmt.Errorf("Unknown certificate provider: %+v", p)
 	}
 }
 
 // getTresorOSMCertificateManager returns a certificate manager instance with Tresor as the certificate provider
-func (c *Config) getTresorOSMCertificateManager() (*certificate.Manager, debugger.CertificateManagerDebugger, error) {
+func (c *MRCProviderGenerator) getTresorOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
 	var err error
 	var rootCert *certificate.Certificate
 
@@ -146,110 +91,88 @@ func (c *Config) getTresorOSMCertificateManager() (*certificate.Manager, debugge
 	// Assuming multiple instances of Tresor are instantiated at the same time, only one of them will
 	// succeed to issue a "Create" of the secret. All other Creates will fail with "AlreadyExists".
 	// Regardless of success or failure, all instances can proceed to load the same CA.
-
 	rootCert, err = tresor.NewCA(constants.CertificationAuthorityCommonName, constants.CertificationAuthorityRootValidityPeriod, rootCertCountry, rootCertLocality, rootCertOrganization)
-
 	if err != nil {
-		return nil, nil, errors.Errorf("Failed to create new Certificate Authority with cert issuer %s", c.providerKind)
-	}
-
-	if rootCert == nil {
-		return nil, nil, errors.Errorf("Invalid root certificate created by cert issuer %s", c.providerKind)
+		return nil, errors.New("Failed to create new Certificate Authority with cert issuer tresor")
 	}
 
 	if rootCert.GetPrivateKey() == nil {
-		return nil, nil, errors.Errorf("Root cert does not have a private key")
+		return nil, errors.New("Root cert does not have a private key")
 	}
 
-	rootCert, err = k8s.GetCertificateFromSecret(c.providerNamespace, c.caBundleSecretName, rootCert, c.kubeClient)
+	rootCert, err = k8s.GetCertificateFromSecret(mrc.Namespace, mrc.Spec.Provider.Tresor.SecretName, rootCert, c.kubeClient)
 	if err != nil {
-		return nil, nil, errors.Errorf("Failed to synchronize certificate on Secrets API : %v", err)
+		return nil, fmt.Errorf("Failed to synchronize certificate on Secrets API : %w", err)
 	}
 
 	if rootCert.GetPrivateKey() == nil {
-		return nil, nil, fmt.Errorf("Root cert does not have a private key: %w", certificate.ErrInvalidCertSecret)
+		return nil, fmt.Errorf("Root cert does not have a private key: %w", certificate.ErrInvalidCertSecret)
 	}
 
 	tresorClient, err := tresor.New(
 		rootCert,
 		rootCertOrganization,
-		c.cfg.GetCertKeyBitSize(),
+		c.KeyBitSize,
 	)
 	if err != nil {
-		return nil, nil, errors.Errorf("Failed to instantiate Tresor as a Certificate Manager")
+		return nil, fmt.Errorf("failed to instantiate Tresor as a Certificate Manager: %w", err)
 	}
-
-	tresorCertManager, err := certificate.NewManager(tresorClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Tresor cert-manager : %w", err)
-	}
-	return tresorCertManager, tresorCertManager, nil
+	return tresorClient, nil
 }
 
 // getHashiVaultOSMCertificateManager returns a certificate manager instance with Hashi Vault as the certificate provider
-func (c *Config) getHashiVaultOSMCertificateManager(options VaultOptions) (*certificate.Manager, debugger.CertificateManagerDebugger, error) {
-	if _, ok := map[string]interface{}{"http": nil, "https": nil}[options.VaultProtocol]; !ok {
-		return nil, nil, fmt.Errorf("value %s is not a valid Hashi Vault protocol", options.VaultProtocol)
-	}
+func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+	provider := mrc.Spec.Provider.Vault
 
 	// A Vault address would have the following shape: "http://vault.default.svc.cluster.local:8200"
-	vaultAddr := fmt.Sprintf("%s://%s:%d", options.VaultProtocol, options.VaultHost, options.VaultPort)
+	vaultAddr := fmt.Sprintf("%s://%s:%d", provider.Protocol, provider.Host, provider.Port)
 	vaultClient, err := vault.New(
 		vaultAddr,
-		options.VaultToken,
-		options.VaultRole,
+		provider.Token,
+		provider.Role,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
+		return nil, fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
 	}
-
-	certManager, err := certificate.NewManager(vaultClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error instantiating osm certificate.Manager for Vault cert-manager : %w", err)
-	}
-	return certManager, certManager, nil
+	return vaultClient, nil
 }
 
 // getCertManagerOSMCertificateManager returns a certificate manager instance with cert-manager as the certificate provider
-func (c *Config) getCertManagerOSMCertificateManager(options CertManagerOptions) (*certificate.Manager, debugger.CertificateManagerDebugger, error) {
-	rootCertSecret, err := c.kubeClient.CoreV1().Secrets(c.providerNamespace).Get(context.TODO(), c.caBundleSecretName, metav1.GetOptions{})
+func (c *MRCProviderGenerator) getCertManagerOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+	provider := mrc.Spec.Provider.CertManager
+	rootCertSecret, err := c.kubeClient.CoreV1().Secrets(mrc.Namespace).Get(context.TODO(), provider.SecretName, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to get cert-manager CA secret %s/%s: %s", c.providerNamespace, c.caBundleSecretName, err)
+		return nil, fmt.Errorf("Failed to get cert-manager CA secret %s/%s: %s", mrc.Namespace, provider.SecretName, err)
 	}
 
 	pemCert, ok := rootCertSecret.Data[constants.KubernetesOpaqueSecretCAKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("Opaque k8s secret %s/%s does not have required field %q", c.providerNamespace, c.caBundleSecretName, constants.KubernetesOpaqueSecretCAKey)
+		return nil, fmt.Errorf("Opaque k8s secret %s/%s does not have required field %q", mrc.Namespace, provider.SecretName, constants.KubernetesOpaqueSecretCAKey)
 	}
 
 	rootCert, err := certificate.NewFromPEM(pemCert, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to decode cert-manager CA certificate from secret %s/%s: %s", c.providerNamespace, c.caBundleSecretName, err)
+		return nil, fmt.Errorf("Failed to decode cert-manager CA certificate from secret %s/%s: %s", mrc.Namespace, provider.SecretName, err)
 	}
 
 	client, err := cmversionedclient.NewForConfig(c.kubeConfig)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to build cert-manager client set: %s", err)
+		return nil, fmt.Errorf("Failed to build cert-manager client set: %s", err)
 	}
 
 	cmClient, err := certmanager.New(
 		rootCert,
 		client,
-		c.providerNamespace,
+		mrc.Namespace,
 		cmmeta.ObjectReference{
-			Name:  options.IssuerName,
-			Kind:  options.IssuerKind,
-			Group: options.IssuerGroup,
+			Name:  provider.IssuerName,
+			Kind:  provider.IssuerKind,
+			Group: provider.IssuerGroup,
 		},
-		c.cfg.GetCertKeyBitSize(),
+		c.KeyBitSize,
 	)
 	if err != nil {
-		return nil, nil, errors.Errorf("Error instantiating Jetstack cert-manager client: %+v", err)
+		return nil, fmt.Errorf("error instantiating Jetstack cert-manager client: %w", err)
 	}
-
-	certManager, err := certificate.NewManager(cmClient, c.cfg.GetServiceCertValidityPeriod(), c.msgBroker)
-	if err != nil {
-		return nil, nil, errors.Errorf("error instantiating osm certificate.Manager for Jetstack cert-manager : %+v", err)
-	}
-	return certManager, certManager, nil
+	return cmClient, nil
 }

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -10,62 +10,16 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/messaging"
 	"github.com/openservicemesh/osm/pkg/tests/certificates"
 )
-
-func TestGenerateCertificateManager(t *testing.T) {
-	fakeClient := fake.NewSimpleClientset()
-	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(),
-		&clientcmd.ConfigOverrides{},
-	)
-	kubeConfig, _ := clientConfig.ClientConfig()
-	mockCtrl := gomock.NewController(t)
-	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-
-	mockConfigurator.EXPECT().IsDebugServerEnabled().Return(false).AnyTimes()
-	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
-	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
-
-	testCases := []struct {
-		name           string
-		tresorOpt      TresorOptions
-		vaultOpt       VaultOptions
-		certManagerOpt CertManagerOptions
-		providerKind   Kind
-		expErr         bool
-	}{
-		{
-			name:           "Successfully create certManager and certDebugger",
-			tresorOpt:      TresorOptions{},
-			vaultOpt:       VaultOptions{},
-			certManagerOpt: CertManagerOptions{},
-			providerKind:   TresorKind,
-			expErr:         false,
-		},
-		{
-			name:           "Fail to validate Config",
-			tresorOpt:      TresorOptions{},
-			vaultOpt:       VaultOptions{},
-			certManagerOpt: CertManagerOptions{},
-			providerKind:   VaultKind,
-			expErr:         true,
-		},
-	}
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			assert := tassert.New(t)
-			_, _, _, err := GenerateCertificateManager(fakeClient, kubeConfig, mockConfigurator, tc.providerKind, "osm-system", "osm-ca-bundle", tc.tresorOpt, tc.vaultOpt, tc.certManagerOpt, nil)
-			assert.Equal(tc.expErr, err != nil)
-		})
-	}
-}
 
 func TestGetCertificateManager(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
@@ -77,208 +31,76 @@ func TestGetCertificateManager(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		util        *Config
 		expectError bool
+
+		// params
+		kubeClient        kubernetes.Interface
+		kubeConfig        *rest.Config
+		cfg               configurator.Configurator
+		providerNamespace string
+		options           Options
+		msgBroker         *messaging.Broker
 	}{
 		{
-			name: "tresor as the certificate manager",
-			util: &Config{
-				caBundleSecretName: "osm-ca-bundle",
-				providerKind:       TresorKind,
-				providerNamespace:  "osm-system",
-				cfg:                mockConfigurator,
-				kubeClient:         fake.NewSimpleClientset(),
-			},
-			expectError: false,
+			name:              "tresor as the certificate manager",
+			options:           TresorOptions{SecretName: "osm-ca-bundle"},
+			providerNamespace: "osm-system",
+			cfg:               mockConfigurator,
+			kubeClient:        fake.NewSimpleClientset(),
+			expectError:       false,
 		},
 		{
-			name: "certManager as the certificate manager",
-			util: &Config{
-				kubeClient:         fake.NewSimpleClientset(),
-				kubeConfig:         &rest.Config{},
-				cfg:                mockConfigurator,
-				providerKind:       CertManagerKind,
-				providerNamespace:  "osm-system",
-				caBundleSecretName: "",
-				certManagerOptions: CertManagerOptions{IssuerName: "test-name", IssuerKind: "test-kind", IssuerGroup: "test-group"},
-			},
-			expectError: false,
+			name:              "tresor with no secret",
+			options:           TresorOptions{},
+			providerNamespace: "osm-system",
+			cfg:               mockConfigurator,
+			kubeClient:        fake.NewSimpleClientset(),
+			expectError:       true,
+		},
+		{
+			name:              "certManager as the certificate manager",
+			kubeClient:        fake.NewSimpleClientset(),
+			kubeConfig:        &rest.Config{},
+			cfg:               mockConfigurator,
+			providerNamespace: "osm-system",
+			options:           CertManagerOptions{IssuerName: "test-name", IssuerKind: "test-kind", IssuerGroup: "test-group", SecretName: "test-secret"},
+			expectError:       false,
+		},
+		{
+			name:        "Fail to validate Config",
+			options:     VaultOptions{},
+			expectError: true,
 		},
 	}
 
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
 			assert := tassert.New(t)
 
-			if tc.util.providerKind == CertManagerKind {
+			if opts, ok := tc.options.(CertManagerOptions); ok {
 				secret := corev1.Secret{Data: map[string][]byte{constants.KubernetesOpaqueSecretCAKey: []byte(certificates.SampleCertificatePEM)}}
-				_, err := tc.util.kubeClient.CoreV1().Secrets(tc.util.providerNamespace).Create(context.Background(), &secret, metav1.CreateOptions{})
+				secret.Name = opts.SecretName
+				_, err := tc.kubeClient.CoreV1().Secrets(tc.providerNamespace).Create(context.Background(), &secret, metav1.CreateOptions{})
 				assert.Nil(err)
 			}
 
-			manager, _, err := tc.util.GetCertificateManager()
-			assert.NotNil(manager)
+			manager, err := NewCertificateManager(tc.kubeClient, tc.kubeConfig, tc.cfg, tc.providerNamespace, tc.options, tc.msgBroker)
+			assert.Equal(tc.expectError, manager == nil)
 			assert.Equal(tc.expectError, err != nil)
 
-			if tc.util.providerKind == TresorKind {
-				_, err := tc.util.kubeClient.CoreV1().Secrets(tc.util.providerNamespace).Get(context.TODO(), tc.util.caBundleSecretName, metav1.GetOptions{})
+			if opt, ok := tc.options.(TresorOptions); ok && !tc.expectError {
+				_, err := tc.kubeClient.CoreV1().Secrets(tc.providerNamespace).Get(context.TODO(), opt.SecretName, metav1.GetOptions{})
 				assert.NoError(err)
 			}
 		})
 	}
 }
 
-func TestValidateCertManagerOptions(t *testing.T) {
-	assert := tassert.New(t)
-
-	testCases := []struct {
-		testName  string
-		options   CertManagerOptions
-		expectErr bool
-	}{
-		{
-			testName: "Empty issuer",
-			options: CertManagerOptions{
-				IssuerName:  "",
-				IssuerKind:  "test-kind",
-				IssuerGroup: "test-group",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty kind",
-			options: CertManagerOptions{
-				IssuerName:  "test-name",
-				IssuerKind:  "",
-				IssuerGroup: "test-group",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty group",
-			options: CertManagerOptions{
-				IssuerName:  "test-name",
-				IssuerKind:  "test-kind",
-				IssuerGroup: "",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Valid cert manager opts",
-			options: CertManagerOptions{
-				IssuerName:  "test-name",
-				IssuerKind:  "test-kind",
-				IssuerGroup: "test-group",
-			},
-			expectErr: false,
-		},
-	}
-
-	for _, t := range testCases {
-		err := ValidateCertManagerOptions(t.options)
-		if t.expectErr {
-			assert.Error(err, "test '%s' didn't error as expected", t.testName)
-		} else {
-			assert.NoError(err, "test '%s' didn't succeed as expected", t.testName)
-		}
-	}
-}
-
-func TestValidateVaultOptions(t *testing.T) {
-	assert := tassert.New(t)
-
-	testCases := []struct {
-		testName  string
-		options   VaultOptions
-		expectErr bool
-	}{
-		{
-			testName: "invalid proto",
-			options: VaultOptions{
-				VaultProtocol: "ftp",
-				VaultHost:     "vault-host",
-				VaultToken:    "vault-token",
-				VaultRole:     "vault-role",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty host",
-			options: VaultOptions{
-				VaultProtocol: "http",
-				VaultHost:     "",
-				VaultToken:    "vault-token",
-				VaultRole:     "vault-role",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty token",
-			options: VaultOptions{
-				VaultProtocol: "https",
-				VaultHost:     "vault-host",
-				VaultToken:    "",
-				VaultRole:     "vault-role",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty role",
-			options: VaultOptions{
-				VaultProtocol: "http",
-				VaultHost:     "vault-host",
-				VaultToken:    "vault-token",
-				VaultRole:     "",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty role",
-			options: VaultOptions{
-				VaultProtocol: "https",
-				VaultHost:     "vault-host",
-				VaultToken:    "vault-token",
-				VaultRole:     "",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Valid config",
-			options: VaultOptions{
-				VaultProtocol: "https",
-				VaultHost:     "vault-host",
-				VaultToken:    "vault-token",
-				VaultRole:     "role",
-			},
-			expectErr: false,
-		},
-	}
-
-	for _, t := range testCases {
-		err := ValidateVaultOptions(t.options)
-		if t.expectErr {
-			assert.Error(err, "test '%s' didn't error as expected", t.testName)
-		} else {
-			assert.NoError(err, "test '%s' didn't succeed as expected", t.testName)
-		}
-	}
-}
-
 func TestGetHashiVaultOSMCertificateManager(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-
-	mockConfigurator.EXPECT().IsDebugServerEnabled().Return(false).AnyTimes()
-	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
-	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
-	config := Config{
-		kubeConfig:         &rest.Config{},
-		caBundleSecretName: "",
-		providerKind:       VaultKind,
-		providerNamespace:  "osm-system",
-		cfg:                mockConfigurator,
-		kubeClient:         fake.NewSimpleClientset(),
+	generator := &MRCProviderGenerator{
+		KeyBitSize: 2048,
 	}
+
 	opt := VaultOptions{
 		VaultHost:  "vault.default.svc.cluster.local",
 		VaultToken: "vault-token",
@@ -290,6 +112,7 @@ func TestGetHashiVaultOSMCertificateManager(t *testing.T) {
 		name          string
 		vaultProtocol string
 		expErr        bool
+		errMsg        string // optional error message to validate against
 	}{
 		{
 			name:          "Not a valid Vault protocol",
@@ -297,9 +120,10 @@ func TestGetHashiVaultOSMCertificateManager(t *testing.T) {
 			expErr:        true,
 		},
 		{
-			name:          "Error instantiating Vault as CertManager",
+			name:          "Valid protocol, but can't reach out to vault",
 			vaultProtocol: "http",
 			expErr:        true,
+			errMsg:        "error getting Vault Root Certificate",
 		},
 	}
 
@@ -308,31 +132,53 @@ func TestGetHashiVaultOSMCertificateManager(t *testing.T) {
 			assert := tassert.New(t)
 
 			opt.VaultProtocol = tc.vaultProtocol
-			_, _, err := config.getHashiVaultOSMCertificateManager(opt)
-			assert.Equal(tc.expErr, err != nil)
+
+			mrc := &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mrc",
+					Namespace: "test-namespace",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: opt.AsProviderSpec(),
+				},
+			}
+
+			_, err := generator.getHashiVaultOSMCertificateManager(mrc)
+			if tc.expErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+
+			if tc.errMsg != "" {
+				assert.Contains(err.Error(), tc.errMsg)
+			}
 		})
 	}
 }
 
 func TestGetCertManagerOSMCertificateManager(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
-
-	mockConfigurator.EXPECT().IsDebugServerEnabled().Return(false).AnyTimes()
-	mockConfigurator.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
-	mockConfigurator.EXPECT().GetServiceCertValidityPeriod().Return(1 * time.Hour).AnyTimes()
-	config := Config{
-		kubeConfig:         &rest.Config{},
-		caBundleSecretName: "",
-		providerKind:       CertManagerKind,
-		providerNamespace:  "osm-system",
-		cfg:                mockConfigurator,
-		kubeClient:         fake.NewSimpleClientset(),
+	generator := &MRCProviderGenerator{
+		kubeClient: fake.NewSimpleClientset(),
+		kubeConfig: &rest.Config{},
+		KeyBitSize: 2048,
 	}
+
 	opt := CertManagerOptions{
 		IssuerName:  "test-name",
 		IssuerKind:  "test-kind",
 		IssuerGroup: "test-group",
+		SecretName:  "test-secret",
+	}
+
+	mrc := &v1alpha2.MeshRootCertificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mrc",
+			Namespace: "osm-system",
+		},
+		Spec: v1alpha2.MeshRootCertificateSpec{
+			Provider: opt.AsProviderSpec(),
+		},
 	}
 
 	testCases := []struct {
@@ -371,15 +217,16 @@ func TestGetCertManagerOSMCertificateManager(t *testing.T) {
 		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
 			assert := tassert.New(t)
 			if tc.createSecret {
-				_, err := config.kubeClient.CoreV1().Secrets(config.providerNamespace).Create(context.Background(), &tc.secret, metav1.CreateOptions{})
+				tc.secret.Name = opt.SecretName
+				_, err := generator.kubeClient.CoreV1().Secrets(mrc.Namespace).Create(context.Background(), &tc.secret, metav1.CreateOptions{})
 				assert.Nil(err)
 			}
 
-			_, _, err := config.getCertManagerOSMCertificateManager(opt)
+			_, err := generator.getCertManagerOSMCertificateManager(mrc)
 			assert.Equal(tc.expErr, err != nil)
 
 			if tc.createSecret {
-				err := config.kubeClient.CoreV1().Secrets(config.providerNamespace).Delete(context.Background(), "", metav1.DeleteOptions{})
+				err := generator.kubeClient.CoreV1().Secrets(mrc.Namespace).Delete(context.Background(), opt.SecretName, metav1.DeleteOptions{})
 				assert.Nil(err)
 			}
 		})

--- a/pkg/certificate/providers/options.go
+++ b/pkg/certificate/providers/options.go
@@ -1,0 +1,88 @@
+package providers
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+)
+
+// Validate validates the options for Tresor certificate provider
+func (options TresorOptions) Validate() error {
+	if options.SecretName == "" {
+		return errors.New("tresor CA bundle secret name must be set")
+	}
+	return nil
+}
+
+// AsProviderSpec returns the provider spec generated from the tresor options
+func (options TresorOptions) AsProviderSpec() v1alpha2.ProviderSpec {
+	return v1alpha2.ProviderSpec{
+		Tresor: &v1alpha2.TresorProviderSpec{
+			SecretName: options.SecretName,
+		},
+	}
+}
+
+// Validate validates the options for Hashi Vault certificate provider
+func (options VaultOptions) Validate() error {
+	if options.VaultHost == "" {
+		return errors.New("VaultHost not specified in Hashi Vault options")
+	}
+
+	if options.VaultToken == "" {
+		return errors.New("VaultToken not specified in Hashi Vault options")
+	}
+
+	if options.VaultRole == "" {
+		return errors.New("VaultRole not specified in Hashi Vault options")
+	}
+
+	if _, ok := map[string]interface{}{"http": nil, "https": nil}[options.VaultProtocol]; !ok {
+		return fmt.Errorf("VaultProtocol in Hashi Vault options must be one of [http, https], got %s", options.VaultProtocol)
+	}
+
+	return nil
+}
+
+// AsProviderSpec returns the provider spec generated from the vault options
+func (options VaultOptions) AsProviderSpec() v1alpha2.ProviderSpec {
+	return v1alpha2.ProviderSpec{
+		Vault: &v1alpha2.VaultProviderSpec{
+			Protocol: options.VaultProtocol,
+			Host:     options.VaultHost,
+			Token:    options.VaultToken,
+			Role:     options.VaultRole,
+			Port:     options.VaultPort,
+		},
+	}
+}
+
+// Validate validates the options for cert-manager.io certificate provider
+func (options CertManagerOptions) Validate() error {
+	if options.IssuerName == "" {
+		return errors.New("IssuerName not specified in cert-manager.io options")
+	}
+
+	if options.IssuerKind == "" {
+		return errors.New("IssuerKind not specified in cert-manager.io options")
+	}
+
+	if options.IssuerGroup == "" {
+		return errors.New("IssuerGroup not specified in cert-manager.io options")
+	}
+
+	return nil
+}
+
+// AsProviderSpec returns the provider spec generated from the CertManager options
+func (options CertManagerOptions) AsProviderSpec() v1alpha2.ProviderSpec {
+	return v1alpha2.ProviderSpec{
+		CertManager: &v1alpha2.CertManagerProviderSpec{
+			IssuerName:  options.IssuerName,
+			IssuerKind:  options.IssuerKind,
+			IssuerGroup: options.IssuerGroup,
+			SecretName:  options.SecretName,
+		},
+	}
+}

--- a/pkg/certificate/providers/options_test.go
+++ b/pkg/certificate/providers/options_test.go
@@ -1,0 +1,143 @@
+package providers
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+)
+
+func TestValidateCertManagerOptions(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		testName  string
+		options   CertManagerOptions
+		expectErr bool
+	}{
+		{
+			testName: "Empty issuer",
+			options: CertManagerOptions{
+				IssuerName:  "",
+				IssuerKind:  "test-kind",
+				IssuerGroup: "test-group",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty kind",
+			options: CertManagerOptions{
+				IssuerName:  "test-name",
+				IssuerKind:  "",
+				IssuerGroup: "test-group",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty group",
+			options: CertManagerOptions{
+				IssuerName:  "test-name",
+				IssuerKind:  "test-kind",
+				IssuerGroup: "",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Valid cert manager opts",
+			options: CertManagerOptions{
+				IssuerName:  "test-name",
+				IssuerKind:  "test-kind",
+				IssuerGroup: "test-group",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, t := range testCases {
+		err := t.options.Validate()
+		if t.expectErr {
+			assert.Error(err, "test '%s' didn't error as expected", t.testName)
+		} else {
+			assert.NoError(err, "test '%s' didn't succeed as expected", t.testName)
+		}
+	}
+}
+
+func TestValidateVaultOptions(t *testing.T) {
+	assert := tassert.New(t)
+
+	testCases := []struct {
+		testName  string
+		options   VaultOptions
+		expectErr bool
+	}{
+		{
+			testName: "invalid proto",
+			options: VaultOptions{
+				VaultProtocol: "ftp",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "vault-role",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty host",
+			options: VaultOptions{
+				VaultProtocol: "http",
+				VaultHost:     "",
+				VaultToken:    "vault-token",
+				VaultRole:     "vault-role",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty token",
+			options: VaultOptions{
+				VaultProtocol: "https",
+				VaultHost:     "vault-host",
+				VaultToken:    "",
+				VaultRole:     "vault-role",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty role",
+			options: VaultOptions{
+				VaultProtocol: "http",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Empty role",
+			options: VaultOptions{
+				VaultProtocol: "https",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "",
+			},
+			expectErr: true,
+		},
+		{
+			testName: "Valid config",
+			options: VaultOptions{
+				VaultProtocol: "https",
+				VaultHost:     "vault-host",
+				VaultToken:    "vault-token",
+				VaultRole:     "role",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, t := range testCases {
+		err := t.options.Validate()
+		if t.expectErr {
+			assert.Error(err, "test '%s' didn't error as expected", t.testName)
+		} else {
+			assert.NoError(err, "test '%s' didn't succeed as expected", t.testName)
+		}
+	}
+}

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -3,6 +3,9 @@ package fake
 import (
 	"time"
 
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
@@ -13,19 +16,31 @@ const (
 	rootCertOrganization = "Open Service Mesh Tresor"
 )
 
-// NewFake constructs a fake certificate client using a certificate
-func NewFake(msgBroker *messaging.Broker) *certificate.Manager {
+type fakeMRCClient struct{}
+
+func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
 	rootCertCountry := "US"
 	rootCertLocality := "CA"
 	ca, err := tresor.NewCA("Fake Tresor CN", 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	tresorClient, err := tresor.New(ca, rootCertOrganization, 2048)
-	if err != nil {
-		return nil
-	}
-	tresorCertManager, err := certificate.NewManager(tresorClient, 1*time.Hour, msgBroker)
+	return tresor.New(ca, rootCertOrganization, 2048)
+}
+
+// List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
+func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
+	// return single empty object in the list.
+	return []*v1alpha2.MeshRootCertificate{{}}, nil
+}
+
+// AddEventHandler is a no-op for the legacy client. The previous client could not handle changes, but we need this
+// method to implement the certificate.MRCClient interface.
+func (c *fakeMRCClient) AddEventHandler(cache.ResourceEventHandler) {}
+
+// NewFake constructs a fake certificate client using a certificate
+func NewFake(msgBroker *messaging.Broker) *certificate.Manager {
+	tresorCertManager, err := certificate.NewManager(&fakeMRCClient{}, 1*time.Hour, msgBroker)
 	if err != nil {
 		return nil
 	}

--- a/pkg/certificate/providers/types.go
+++ b/pkg/certificate/providers/types.go
@@ -5,8 +5,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/openservicemesh/osm/pkg/configurator"
-	"github.com/openservicemesh/osm/pkg/messaging"
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 )
 
 // Kind specifies the certificate provider kind
@@ -33,31 +32,19 @@ var (
 	ValidCertificateProviders = []Kind{TresorKind, VaultKind, CertManagerKind}
 )
 
-// Config is a type that stores config related to certificate providers and implements generic utility functions
-type Config struct {
-	kubeClient kubernetes.Interface
-	kubeConfig *rest.Config
-	cfg        configurator.Configurator
+// Options is an interface that contains required fields to convert the old style options to the new style MRC for
+// each provider type.
+// TODO(#4502): Remove this interface, and all of the options below.
+type Options interface {
+	Validate() error
 
-	providerKind       Kind
-	providerNamespace  string
-	caBundleSecretName string
-
-	// tresorOptions is the options for 'Tresor' certificate provider
-	tresorOptions TresorOptions
-
-	// vaultOptions is the options for 'Hashicorp Vault' certificate provider
-	vaultOptions VaultOptions
-
-	// certManagerOptions is the options for 'cert-manager.io' certiticate provider
-	certManagerOptions CertManagerOptions
-
-	msgBroker *messaging.Broker
+	AsProviderSpec() v1alpha2.ProviderSpec
 }
 
 // TresorOptions is a type that specifies 'Tresor' certificate provider options
 type TresorOptions struct {
 	// No options at the moment
+	SecretName string
 }
 
 // VaultOptions is a type that specifies 'Hashicorp Vault' certificate provider options
@@ -74,4 +61,23 @@ type CertManagerOptions struct {
 	IssuerName  string
 	IssuerKind  string
 	IssuerGroup string
+
+	SecretName string
+}
+
+// MRCCompatClient is a backwards compatible client to convert old certificate options into an MRC.
+// It's intent is to match the custom interface that will wrap the MRC k8s informer.
+// TODO(#4502): Remove this entirely once we are fully onboarded to MRC informers.
+type MRCCompatClient struct {
+	MRCProviderGenerator
+	mrc *v1alpha2.MeshRootCertificate
+}
+
+// MRCProviderGenerator knows how to convert a given MRC to its appropriate provider.
+type MRCProviderGenerator struct {
+	kubeClient kubernetes.Interface
+	kubeConfig *rest.Config // used to generate a CertificateManager client.
+
+	// TODO(#4502): move these to the compat client once we have added these fields to the MRC.
+	KeyBitSize int
 }

--- a/pkg/certificate/providers/vault/certificate_manager.go
+++ b/pkg/certificate/providers/vault/certificate_manager.go
@@ -102,7 +102,7 @@ func (cm *CertManager) getRootCA() (*certificate.Certificate, error) {
 		Expiration:   time.Now().Add(decade),
 		CertChain:    cert.CertChain,
 		IssuingCA:    cert.IssuingCA,
-	}, err
+	}, nil
 }
 
 func newCert(cn certificate.CommonName, secret *api.Secret, expiration time.Time) *certificate.Certificate {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -161,6 +161,15 @@ const (
 	MetricsAnnotation = "openservicemesh.io/metrics"
 )
 
+// Annotations and labels used by the MeshRootCertificate
+const (
+	// MRCVersionAnnotation is the annotation used for the version of the MeshRootCertificate
+	MRCVersionAnnotation = "openservicemesh.io/mrc-version"
+
+	MRCStateValidating = "validating"
+	MRCStageComplete   = "complete"
+)
+
 // Labels used by the control plane
 const (
 	// IgnoreLabel is the label used to ignore a resource


### PR DESCRIPTION
The compat layer is used to convert from the old style options
to the new style MRC. This is useful so that we don't have to manage
two implementations of the certificate.Manager.

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

part of #4713