### PR TITLE
cli/verifier: add stubs for egress checks

### DIFF
--- a/pkg/cli/verifier/connectivity_egress.go
+++ b/pkg/cli/verifier/connectivity_egress.go
@@ -4,41 +4,28 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 )
 
-// TrafficAttribute describes the attributes of the traffic
-type TrafficAttribute struct {
-	SrcPod      *types.NamespacedName
-	DstPod      *types.NamespacedName
-	DstService  *types.NamespacedName
-	DstHost     string
-	DstPort     uint16
-	AppProtocol string
-	Egress      bool
-}
-
-// PodConnectivityVerifier implements the Verifier interface for pod connectivity
-type PodConnectivityVerifier struct {
+// EgressConnectivityVerifier implements the Verifier interface for egress connectivity
+type EgressConnectivityVerifier struct {
 	stdout             io.Writer
 	stderr             io.Writer
 	kubeClient         kubernetes.Interface
 	meshConfig         *configv1alpha2.MeshConfig
 	trafficAttr        TrafficAttribute
 	srcPodConfigGetter ConfigGetter
-	dstPodConfigGetter ConfigGetter
 	meshName           string
 }
 
-// NewPodConnectivityVerifier implements verification for pod connectivity
-func NewPodConnectivityVerifier(stdout io.Writer, stderr io.Writer, restConfig *rest.Config, kubeClient kubernetes.Interface,
+// NewEgressConnectivityVerifier implements verification for egress connectivity
+func NewEgressConnectivityVerifier(stdout io.Writer, stderr io.Writer, restConfig *rest.Config, kubeClient kubernetes.Interface,
 	meshConfig *configv1alpha2.MeshConfig, trafficAttr TrafficAttribute,
 	meshName string) Verifier {
-	return &PodConnectivityVerifier{
+	return &EgressConnectivityVerifier{
 		stdout:      stdout,
 		stderr:      stderr,
 		kubeClient:  kubeClient,
@@ -49,34 +36,26 @@ func NewPodConnectivityVerifier(stdout io.Writer, stderr io.Writer, restConfig *
 			kubeClient: kubeClient,
 			pod:        *trafficAttr.SrcPod,
 		},
-		dstPodConfigGetter: &PodConfigGetter{
-			restConfig: restConfig,
-			kubeClient: kubeClient,
-			pod:        *trafficAttr.DstPod,
-		},
 		meshName: meshName,
 	}
 }
 
 // Run executes the pod connectivity verifier
-func (v *PodConnectivityVerifier) Run() Result {
-	ctx := fmt.Sprintf("Verify if pod %q can access pod %q for service %q", v.trafficAttr.SrcPod, v.trafficAttr.DstPod, v.trafficAttr.DstService)
+func (v *EgressConnectivityVerifier) Run() Result {
+	ctx := fmt.Sprintf("Verify if pod %q can access external service %q", v.trafficAttr.SrcPod, v.trafficAttr.DstService)
 
 	verifiers := Set{
 		//
 		// Namespace monitor verification
 		NewNamespaceMonitorVerifier(v.stdout, v.stderr, v.kubeClient, v.trafficAttr.SrcPod.Namespace, v.meshName),
-		NewNamespaceMonitorVerifier(v.stdout, v.stderr, v.kubeClient, v.trafficAttr.DstPod.Namespace, v.meshName),
 		//
 		// Envoy sidecar verification
 		NewSidecarVerifier(v.stdout, v.stderr, v.kubeClient, *v.trafficAttr.SrcPod),
-		NewSidecarVerifier(v.stdout, v.stderr, v.kubeClient, *v.trafficAttr.DstPod),
 		//
 		// Envoy config verification
 		NewEnvoyConfigVerifier(v.stdout, v.stderr, v.kubeClient, v.meshConfig, configAttribute{
 			trafficAttr:     v.trafficAttr,
 			srcConfigGetter: v.srcPodConfigGetter,
-			dstConfigGetter: v.dstPodConfigGetter,
 		}),
 	}
 

--- a/pkg/cli/verifier/envoy_config.go
+++ b/pkg/cli/verifier/envoy_config.go
@@ -217,6 +217,11 @@ func (v *EnvoyConfigVerifier) verifySource() Result {
 		}
 	}
 
+	// TODO(#4634): verify egress configs
+	// if v.configAttr.trafficAttr.Egress {
+	// 	// Verify egress configs
+	// }
+
 	result.Status = Success
 	return result
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds the stubs necessary to perform egress
config verification on a pod.
A subsequent change will add additional
validations that perform the actual checks.

Part of #4634

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --to-pod httpbin/httpbin-69dc7d545c-hbc6d --service httpbin 
---------------------------------------------
[+] Context: Verify if pod "curl/curl-7bb5845476-5b7wr" can access pod "httpbin/httpbin-69dc7d545c-hbc6d" for service "httpbin/httpbin"
Status: Success

---------------------------------------------
```
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --service httpbin 
Error: one of --to-pod|--egress must be set for connectivity verification
```
```
$ osm verify connectivity --from-pod curl/curl-7bb5845476-5b7wr --to-pod httpbin/httpbin-69dc7d545c-hbc6d --service httpbin --egress
Error: --to-pod cannot be set with --egress
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`