### PR TITLE
feat(api/MeshRootCertificate): add informer client

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -41,7 +41,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["config.openservicemesh.io"]
-    resources: ["meshconfigs"]
+    resources: ["meshconfigs", "meshrootcertificates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["config.openservicemesh.io"]
     resources: ["multiclusterservices"]

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -173,8 +173,11 @@ func main() {
 
 	msgBroker := messaging.NewBroker(stop)
 
-	// Initialize Configurator to retrieve mesh specific config
-	cfg := configurator.NewConfigurator(configClient, stop, osmNamespace, osmMeshConfigName, msgBroker)
+	// Initialize Configurator to watch resources in the config.openservicemesh.io API group
+	cfg, err := configurator.NewConfigurator(configClient, stop, osmNamespace, osmMeshConfigName, msgBroker)
+	if err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller for config.openservicemesh.io")
+	}
 
 	// Intitialize certificate manager/provider
 	certManager, _, _, err := providers.GenerateCertificateManager(kubeClient, kubeConfig, cfg, providers.Kind(certProviderKind), osmNamespace,

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -163,9 +163,11 @@ func main() {
 
 	msgBroker := messaging.NewBroker(stop)
 
-	// This component will be watching the OSM MeshConfig and will make it available
-	// to the rest of the components.
-	cfg := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName, msgBroker)
+	// This component will be watching resources in the config.openservicemesh.io API group
+	cfg, err := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName, msgBroker)
+	if err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller for config.openservicemesh.io")
+	}
 
 	k8sClient, err := k8s.NewKubernetesController(kubeClient, policyClient, meshName, stop, msgBroker)
 	if err != nil {

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -161,7 +161,7 @@ func main() {
 	// Initialize Configurator to watch resources in the config.openservicemesh.io API group
 	cfg, err := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName, msgBroker)
 	if err != nil {
-		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller config.openservicemesh.io")
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller for config.openservicemesh.io")
 	}
 
 	// Initialize kubernetes.Controller to watch kubernetes resources

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -158,8 +158,11 @@ func main() {
 
 	msgBroker := messaging.NewBroker(stop)
 
-	// Initialize Configurator to retrieve mesh specific config
-	cfg := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName, msgBroker)
+	// Initialize Configurator to watch resources in the config.openservicemesh.io API group
+	cfg, err := configurator.NewConfigurator(configClientset.NewForConfigOrDie(kubeConfig), stop, osmNamespace, osmMeshConfigName, msgBroker)
+	if err != nil {
+		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating controller config.openservicemesh.io")
+	}
 
 	// Initialize kubernetes.Controller to watch kubernetes resources
 	kubeController, err := k8s.NewKubernetesController(kubeClient, policyClient, meshName, stop, msgBroker, k8s.Namespaces)

--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -126,7 +126,7 @@ const (
 	// CertificateRotated is the type of announcement emitted when a certificate is rotated by the certificate provider
 	CertificateRotated Kind = "certificate-rotated"
 
-	// ---
+	// --- config.openservicemesh.io API events
 
 	// MeshConfigAdded is the type of announcement emitted when we observe an addition of a Kubernetes MeshConfig
 	MeshConfigAdded Kind = "meshconfig-added"
@@ -136,6 +136,15 @@ const (
 
 	// MeshConfigUpdated is the type of announcement emitted when we observe an update to a Kubernetes MeshConfig
 	MeshConfigUpdated Kind = "meshconfig-updated"
+
+	// MeshRootCertificateAdded is the type of announcement emitted when we observe an addition of a Kubernetes MeshRootCertificate
+	MeshRootCertificateAdded Kind = "meshrootcertificate-added"
+
+	// MeshRootCertificateDeleted is the type of announcement emitted when we observe the deletion of a Kubernetes MeshRootCertificate
+	MeshRootCertificateDeleted Kind = "meshrootcertificate-deleted"
+
+	// MeshRootCertificateUpdated is the type of announcement emitted when we observe an update to a Kubernetes MeshRootCertificate
+	MeshRootCertificateUpdated Kind = "meshrootcertificate-updated"
 
 	// --- policy.openservicemesh.io API events
 

--- a/pkg/apis/config/v1alpha2/register.go
+++ b/pkg/apis/config/v1alpha2/register.go
@@ -41,6 +41,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&MeshConfigList{},
 		&MultiClusterService{},
 		&MultiClusterServiceList{},
+		&MeshRootCertificate{},
+		&MeshRootCertificateList{},
 	)
 
 	metav1.AddToGroupVersion(

--- a/pkg/catalog/fake/fake.go
+++ b/pkg/catalog/fake/fake.go
@@ -52,8 +52,10 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient config
 
 	osmNamespace := "-test-osm-namespace-"
 	osmMeshConfigName := "-test-osm-mesh-config-"
-	cfg := configurator.NewConfigurator(meshConfigClient, stop, osmNamespace, osmMeshConfigName, nil)
-
+	cfg, err := configurator.NewConfigurator(meshConfigClient, stop, osmNamespace, osmMeshConfigName, nil)
+	if err != nil {
+		return nil
+	}
 	certManager := tresorFake.NewFake(nil)
 
 	// #1683 tracks potential improvements to the following dynamic mocks

--- a/pkg/configurator/client_test.go
+++ b/pkg/configurator/client_test.go
@@ -23,7 +23,8 @@ func TestGetMeshConfig(t *testing.T) {
 
 	meshConfigClient := fakeConfig.NewSimpleClientset()
 	stop := make(chan struct{})
-	c := newConfigurator(meshConfigClient, stop, osmNamespace, osmMeshConfigName, nil)
+	c, err := newConfigurator(meshConfigClient, stop, osmNamespace, osmMeshConfigName, nil)
+	a.Nil(err)
 
 	// Returns empty MeshConfig if informer cache is empty
 	a.Equal(configv1alpha2.MeshConfig{}, c.getMeshConfig())
@@ -38,7 +39,7 @@ func TestGetMeshConfig(t *testing.T) {
 			Name:      osmMeshConfigName,
 		},
 	}
-	err := c.cache.Add(newObj)
+	err = c.caches.meshConfig.Add(newObj)
 	a.Nil(err)
 	a.Equal(*newObj, c.getMeshConfig())
 }
@@ -55,7 +56,7 @@ func TestMetricsHandler(t *testing.T) {
 	a := assert.New(t)
 
 	c := &client{
-		cache:          &store{},
+		caches:         &cacheCollection{meshConfig: &store{}},
 		meshConfigName: osmMeshConfigName,
 	}
 	handlers := c.metricsHandler()

--- a/pkg/configurator/methods_test.go
+++ b/pkg/configurator/methods_test.go
@@ -30,7 +30,8 @@ func TestCreateUpdateConfig(t *testing.T) {
 		meshConfigClientSet := testclient.NewSimpleClientset()
 
 		stop := make(chan struct{})
-		cfg := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
+		cfg, err := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
+		tassert.Nil(t, err)
 		tassert.Equal(t, configv1alpha2.MeshConfig{}, cfg.getMeshConfig())
 	})
 
@@ -475,7 +476,8 @@ func TestCreateUpdateConfig(t *testing.T) {
 			// Create configurator
 			stop := make(chan struct{})
 			defer close(stop)
-			cfg := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
+			cfg, err := newConfigurator(meshConfigClientSet, stop, osmNamespace, osmMeshConfigName, nil)
+			assert.Nil(err)
 
 			meshConfig := configv1alpha2.MeshConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -485,7 +487,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 				Spec: *test.initialMeshConfigData,
 			}
 
-			err := cfg.cache.Add(&meshConfig)
+			err = cfg.caches.meshConfig.Add(&meshConfig)
 			assert.Nil(err)
 
 			test.checkCreate(assert, cfg)
@@ -495,7 +497,7 @@ func TestCreateUpdateConfig(t *testing.T) {
 			}
 
 			meshConfig.Spec = *test.updatedMeshConfigData
-			err = cfg.cache.Update(&meshConfig)
+			err = cfg.caches.meshConfig.Update(&meshConfig)
 			assert.Nil(err)
 
 			test.checkUpdate(assert, cfg)

--- a/pkg/configurator/types.go
+++ b/pkg/configurator/types.go
@@ -17,11 +17,21 @@ var (
 	log = logger.New("configurator")
 )
 
+type informerCollection struct {
+	meshConfig          cache.SharedIndexInformer
+	meshRootCertificate cache.SharedIndexInformer
+}
+
+type cacheCollection struct {
+	meshConfig          cache.Store
+	meshRootCertificate cache.Store
+}
+
 // client is the type used to represent the Kubernetes client for the config.openservicemesh.io API group
 type client struct {
 	osmNamespace   string
-	informer       cache.SharedIndexInformer
-	cache          cache.Store
+	informers      *informerCollection
+	caches         *cacheCollection
 	meshConfigName string
 }
 

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -63,7 +63,8 @@ func TestNewResponse(t *testing.T) {
 	_, err = envoy.NewProxy("-certificate-common-name-is-invalid-", "-cert-serial-number-is-invalid-", nil)
 	assert.Equal(err, envoy.ErrInvalidCertificateCN)
 
-	cfg := configurator.NewConfigurator(fakeConfigClient, stop, "-osm-namespace-", "-the-mesh-config-name-", nil)
+	cfg, err := configurator.NewConfigurator(fakeConfigClient, stop, "-osm-namespace-", "-the-mesh-config-name-", nil)
+	assert.Nil(err)
 	certManager := tresorFake.NewFake(nil)
 	meshCatalog := catalogFake.NewFakeMeshCatalog(fakeKubeClient, fakeConfigClient)
 

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -154,10 +154,10 @@ const (
 	ErrPubSubMessageFormat ErrCode = iota + 4100
 )
 
-// Range 4150-4200 reserved for MeshConfig related errors
+// Range 4150-4200 reserved for errors related to config.openservicemesh.io resources
 const (
-	// ErrMeshConfigInformerInitCache indicates failed to init cache sync for MeshConfig informer
-	ErrMeshConfigInformerInitCache ErrCode = iota + 4150
+	// ErrConfigInformerInitCache indicates failed to init cache sync for config.openservicemesh.io informers
+	ErrConfigInformerInitCache ErrCode = iota + 4150
 
 	// ErrMeshConfigStructParsing indicates failed to cast object to MeshConfig
 	ErrMeshConfigStructCasting
@@ -589,8 +589,8 @@ Failed parsing object into PubSub message.
 	//
 	// Range 4150-4200
 	//
-	ErrMeshConfigInformerInitCache: `
-Failed initial cache sync for MeshConfig informer.
+	ErrConfigInformerInitCache: `
+Failed initial cache sync for config.openservicemesh.io informer.
 `,
 	ErrMeshConfigStructCasting: `
 Failed to cast object to MeshConfig.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds the MeshRootCertificate informer client. Refactors the
configurator client to watch the MeshRootCertificate and
MeshConfig resources. Attempts to group informer clients for
resources in the same API group, config.openservicemesh.io.

Resolves #4710 
Part of #4502 

Signed-off-by: jaellio <jaellio@microsoft.com>

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
- Demo
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No - need to update the errcode docs