### PR TITLE
cli/verifier: add control-plane-health command

### DIFF
--- a/cmd/cli/verify.go
+++ b/cmd/cli/verify.go
@@ -19,6 +19,7 @@ func newVerifyCmd(stdout io.Writer, stderr io.Writer) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	cmd.AddCommand(newVerifyConnectivityCmd(stdout, stderr))
+	cmd.AddCommand(newVerifyControlPlaneCmd(stdout, stderr))
 
 	return cmd
 }

--- a/cmd/cli/verify_control_plane.go
+++ b/cmd/cli/verify_control_plane.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openservicemesh/osm/pkg/cli/verifier"
+)
+
+const verifyControlPlaneDescription = `
+This command verifies the health of the OSM control plane.
+`
+
+const verifyControlPlaneExample = `
+osm verify control-plane-health
+`
+
+type verifyControlPlaneCmd struct {
+	stdout     io.Writer
+	stderr     io.Writer
+	restConfig *rest.Config
+	kubeClient kubernetes.Interface
+}
+
+func newVerifyControlPlaneCmd(stdout io.Writer, stderr io.Writer) *cobra.Command {
+	verifyCmd := &verifyControlPlaneCmd{
+		stdout: stdout,
+		stderr: stderr,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "control-plane-health",
+		Short:   "verify the health of the OSM control plane",
+		Long:    verifyControlPlaneDescription,
+		Args:    cobra.NoArgs,
+		Example: verifyControlPlaneExample,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return errors.Errorf("Error fetching kubeconfig: %s", err)
+			}
+			verifyCmd.restConfig = config
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return errors.Errorf("error initializing client: %s", err)
+			}
+			verifyCmd.kubeClient = clientset
+
+			return verifyCmd.run()
+		},
+	}
+
+	return cmd
+}
+
+func (cmd *verifyControlPlaneCmd) run() error {
+	v := verifier.NewControlPlaneHealthVerifier(cmd.stdout, cmd.stderr, cmd.kubeClient, settings.Namespace())
+	result := v.Run()
+
+	fmt.Fprintln(cmd.stdout, "---------------------------------------------")
+	verifier.Print(result, cmd.stdout, 1)
+	fmt.Fprintln(cmd.stdout, "---------------------------------------------")
+
+	return nil
+}

--- a/pkg/cli/verifier/connectivity_egress_test.go
+++ b/pkg/cli/verifier/connectivity_egress_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestEgressRun(t *testing.T) {
-	testMeshName := "test"
+	const testMeshName = "test"
 
 	testCases := []struct {
 		name            string

--- a/pkg/cli/verifier/control_plane.go
+++ b/pkg/cli/verifier/control_plane.go
@@ -1,0 +1,42 @@
+package verifier
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+// ControlPlaneHealthVerifier implements the Verifier interface for control plane health
+type ControlPlaneHealthVerifier struct {
+	stdout     io.Writer
+	stderr     io.Writer
+	kubeClient kubernetes.Interface
+	namespace  string
+}
+
+// NewControlPlaneHealthVerifier implements verification for control plane health
+func NewControlPlaneHealthVerifier(stdout io.Writer, stderr io.Writer, kubeClient kubernetes.Interface, namespace string) Verifier {
+	return &ControlPlaneHealthVerifier{
+		stdout:     stdout,
+		stderr:     stderr,
+		kubeClient: kubeClient,
+		namespace:  namespace,
+	}
+}
+
+// Run executes the control plane health verifier
+func (v *ControlPlaneHealthVerifier) Run() Result {
+	ctx := "Verify the health of OSM control plane"
+
+	verifiers := Set{
+		// Pod status verification
+		NewPodStatusVerifier(v.stdout, v.stderr, v.kubeClient, types.NamespacedName{Namespace: v.namespace, Name: constants.OSMControllerName}),
+		NewPodStatusVerifier(v.stdout, v.stderr, v.kubeClient, types.NamespacedName{Namespace: v.namespace, Name: constants.OSMInjectorName}),
+		NewPodStatusVerifier(v.stdout, v.stderr, v.kubeClient, types.NamespacedName{Namespace: v.namespace, Name: constants.OSMBootstrapName}),
+	}
+
+	return verifiers.Run(ctx)
+}

--- a/pkg/cli/verifier/control_plane_test.go
+++ b/pkg/cli/verifier/control_plane_test.go
@@ -1,0 +1,128 @@
+package verifier
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func TestControlPlane(t *testing.T) {
+	testNs := "test"
+
+	testCases := []struct {
+		name      string
+		resources []runtime.Object
+		expected  Result
+	}{
+		{
+			name: "all control plane pods are running",
+			resources: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-controller-1",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-controller"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-controller-2",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-controller"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-injector-1",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-injector"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-bootstrap-1",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-bootstrap"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			expected: Result{
+				Status: Success,
+			},
+		},
+		{
+			name: "control plane pod is not running",
+			resources: []runtime.Object{
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-controller-1",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-controller"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed, // not running
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-injector-1",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-injector"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "osm-bootstrap-1",
+						Namespace: testNs,
+						Labels:    map[string]string{constants.AppLabel: "osm-bootstrap"},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodRunning,
+					},
+				},
+			},
+			expected: Result{
+				Status: Failure,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			fakeClient := fake.NewSimpleClientset(tc.resources...)
+			v := &ControlPlaneHealthVerifier{
+				kubeClient: fakeClient,
+				namespace:  testNs,
+			}
+
+			actual := v.Run()
+			out := new(bytes.Buffer)
+			Print(actual, out, 1)
+			a.Equal(tc.expected.Status, actual.Status, out)
+		})
+	}
+}

--- a/pkg/cli/verifier/pod.go
+++ b/pkg/cli/verifier/pod.go
@@ -1,0 +1,72 @@
+package verifier
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+// PodStatusVerifier implements the Verifier interface for control plane health
+type PodStatusVerifier struct {
+	stdout     io.Writer
+	stderr     io.Writer
+	kubeClient kubernetes.Interface
+	app        types.NamespacedName
+}
+
+// NewPodStatusVerifier implements verification for control plane health
+func NewPodStatusVerifier(stdout io.Writer, stderr io.Writer, kubeClient kubernetes.Interface, app types.NamespacedName) Verifier {
+	return &PodStatusVerifier{
+		stdout:     stdout,
+		stderr:     stderr,
+		kubeClient: kubeClient,
+		app:        app,
+	}
+}
+
+// Run executes the pod status verifier
+func (v *PodStatusVerifier) Run() Result {
+	result := Result{
+		Context: fmt.Sprintf("Verify status of pod for app %s", v.app),
+	}
+
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{constants.AppLabel: v.app.Name}}
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+	podList, err := v.kubeClient.CoreV1().Pods(v.app.Namespace).List(context.TODO(), listOptions)
+	if err != nil || podList == nil {
+		result.Status = Unknown
+		result.Reason = fmt.Sprintf("Error fetching pods for app %s, err: %s", v.app, err)
+		return result
+	}
+
+	if len(podList.Items) == 0 {
+		result.Status = Failure
+		result.Reason = fmt.Sprintf("No pods found for app %s", v.app)
+		return result
+	}
+
+	var notRunning []string
+	for _, pod := range podList.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			notRunning = append(notRunning, fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+		}
+	}
+	if len(notRunning) > 0 {
+		result.Status = Failure
+		result.Reason = fmt.Sprintf("Some pods are not running: %v", notRunning)
+		return result
+	}
+
+	result.Status = Success
+	return result
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds a `verify control-plane-health` command.
Currently this check is limited to verifying
that the control plane pods are running.
This will be extended to perform additional
checks pertaining to the health of the
control plane, such as looking for fatal/error
events reported, probe failures, etc.

Part of #4634

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
When all control plane pods are running
```
$ osm verify control-plane-health
---------------------------------------------
[+] Context: Verify the health of OSM control plane
Status: Success

---------------------------------------------
```

When the pod is not found
```
$ osm verify control-plane-health
checking pods
---------------------------------------------
[+] Context: Verify the health of OSM control plane
Status: Failure
Reason: A verification step failed
Suggestion: Please follow the suggestions listed in the failed steps below to resolve the issue

[++] Context: Verify status of pod for app osm-system/osm-controller
Status: Failure
Reason: No pods found for app osm-system/osm-controller

---------------------------------------------
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`