### PR TITLE
fix(demo): remove unneeded port-forward for bookstore

### DIFF
--- a/scripts/port-forward-all.sh
+++ b/scripts/port-forward-all.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 ./scripts/port-forward-bookbuyer-ui.sh &
-./scripts/port-forward-bookstore-ui.sh &
 ./scripts/port-forward-bookstore-ui-v2.sh &
 ./scripts/port-forward-bookstore-ui-v1.sh &
 ./scripts/port-forward-bookthief-ui.sh &


### PR DESCRIPTION

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Since the port-forward-all.sh script is no longer referred to on the
docs site for the demo there, it no longer needs to port-forward the
`bookstore` deployment which is not expected to exist in the automated
demo here.

Fixes #3521

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Ran the script against the automated demo and saw no errors.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [X] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A