### PR TITLE
Allow websocket upgrade for all http connections

### DIFF
--- a/pkg/envoy/lds/http_connection.go
+++ b/pkg/envoy/lds/http_connection.go
@@ -23,6 +23,7 @@ const (
 	meshHTTPConnManagerStatPrefix       = "mesh-http-conn-manager"
 	prometheusHTTPConnManagerStatPrefix = "prometheus-http-conn-manager"
 	prometheusInboundVirtualHostName    = "prometheus-inbound-virtual-host"
+	websocketUpgradeType                = "websocket"
 
 	// inbound defines in-mesh inbound or ingress traffic driections
 	inbound connectionDirection = "inbound"
@@ -65,6 +66,11 @@ func (options httpConnManagerOptions) build() (*xds_hcm.HttpConnectionManager, e
 			},
 		},
 		AccessLog: envoy.GetAccessLog(),
+		UpgradeConfigs: []*xds_hcm.HttpConnectionManager_UpgradeConfig{
+			{
+				UpgradeType: websocketUpgradeType,
+			},
+		},
 	}
 
 	// For inbound connections, add the Authz filter

--- a/pkg/envoy/lds/http_connection_test.go
+++ b/pkg/envoy/lds/http_connection_test.go
@@ -23,6 +23,14 @@ func TestHTTPConnbuild(t *testing.T) {
 	contains := func(filters []*xds_hcm.HttpFilter, filterName string) bool {
 		return !notContains(filters, filterName)
 	}
+	containsUpgradeType := func(upgradeConfigs []*xds_hcm.HttpConnectionManager_UpgradeConfig, upgradeType string) bool {
+		for _, u := range upgradeConfigs {
+			if u.UpgradeType == upgradeType {
+				return true
+			}
+		}
+		return false
+	}
 
 	testCases := []struct {
 		name       string
@@ -127,6 +135,13 @@ func TestHTTPConnbuild(t *testing.T) {
 			},
 			assertFunc: func(a *assert.Assertions, connManager *xds_hcm.HttpConnectionManager) {
 				a.True(notContains(connManager.HttpFilters, wellknown.HealthCheck))
+			},
+		},
+		{
+			name:   "websocket upgrade config present",
+			option: httpConnManagerOptions{},
+			assertFunc: func(a *assert.Assertions, connManager *xds_hcm.HttpConnectionManager) {
+				a.True(containsUpgradeType(connManager.UpgradeConfigs, websocketUpgradeType))
 			},
 		},
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Allows to set allowed http upgrade type so that envoy will pass the requested upgrade request upstream.
Implements #4725 by allowing to set the `websocket` upgrade type.

Closes #4725 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:  tested end-to-end on a test cluster

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [x] |
| Ingress                    | [x] |
| Install                    | [ ] |
| Networking                 | [x] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

3. Is this a breaking change? no

4. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? no