### PR TITLE
Certificate issuance state management

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -20,6 +20,19 @@ const (
 	noiseSeconds = 5
 )
 
+// mergeRoot will merge in the provided root CA for future calls to GetIssuingCA. It guarantees to not mutate
+// the underlying IssuingCA field. By doing so, we ensure that we don't need locks.
+// NOTE: this does not return a full copy, mutations to the other byte slices could cause data races.
+func (c *Certificate) newMergedWithRoot(root pem.RootCertificate) *Certificate {
+	cert := *c
+
+	buf := make([]byte, 0, len(root)+len(c.IssuingCA))
+	buf = append(buf, c.IssuingCA...)
+	buf = append(buf, root...)
+	cert.IssuingCA = buf
+	return &cert
+}
+
 // GetCommonName returns the Common Name of the certificate
 func (c *Certificate) GetCommonName() CommonName {
 	return c.CommonName

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
 
 var (
@@ -15,8 +16,8 @@ var (
 
 type fakeMRCClient struct{}
 
-func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (Issuer, error) {
-	return &fakeIssuer{}, nil
+func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (Issuer, string, error) {
+	return &fakeIssuer{}, "fake-issuer-1", nil
 }
 
 // List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
@@ -29,13 +30,22 @@ func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
 // method to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) AddEventHandler(cache.ResourceEventHandler) {}
 
-type fakeIssuer struct{}
+type fakeIssuer struct {
+	err bool
+	id  string
+}
 
 // IssueCertificate is a testing helper to satisfy the certificate client interface
 func (i *fakeIssuer) IssueCertificate(cn CommonName, validityPeriod time.Duration) (*Certificate, error) {
+	if i.err {
+		return nil, fmt.Errorf("%s failed", i.id)
+	}
 	return &Certificate{
 		CommonName: cn,
 		Expiration: time.Now().Add(validityPeriod),
+		// simply used to distinguish the private/public key from other issuers
+		IssuingCA:  pem.RootCertificate(i.id),
+		PrivateKey: pem.PrivateKey(i.id),
 	}, nil
 }
 

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	time "time"
 
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 )
@@ -25,10 +23,6 @@ func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
 	// return single empty object in the list.
 	return []*v1alpha2.MeshRootCertificate{{}}, nil
 }
-
-// AddEventHandler is a no-op for the legacy client. The previous client could not handle changes, but we need this
-// method to implement the certificate.MRCClient interface.
-func (c *fakeMRCClient) AddEventHandler(cache.ResourceEventHandler) {}
 
 type fakeIssuer struct {
 	err bool

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -104,7 +104,6 @@ func (m *Manager) getFromCache(cn CommonName) *Certificate {
 
 // IssueCertificate implements Manager and returns a newly issued certificate from the given client.
 func (m *Manager) IssueCertificate(cn CommonName, validityPeriod time.Duration) (*Certificate, error) {
-	// var additionalRoot pem.RootCertificate
 	var err error
 	cert := m.getFromCache(cn) // Don't call this while holding the lock
 

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -55,6 +55,9 @@ func (m *Manager) Start(checkInterval time.Duration, stop <-chan struct{}) {
 }
 
 func (m *Manager) checkAndRotate() {
+	// NOTE: checkAndRotate can reintroduce a certificate that has been released, thereby creating an unbounded cache.
+	// A certificate can also have been rotated already, leaving the list of issued certs stale, and we re-rotate.
+	// the latter is not a bug, but a source of inefficiency.
 	for _, cert := range m.ListIssuedCertificates() {
 		shouldRotate := cert.ShouldRotate()
 

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -1,7 +1,6 @@
 package certificate
 
 import (
-	"fmt"
 	"testing"
 	time "time"
 
@@ -10,6 +9,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
+	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
@@ -69,11 +69,8 @@ func TestRotor(t *testing.T) {
 	assert.NoError(err)
 	certRotateChan := msgBroker.GetCertPubSub().Sub(announcements.CertificateRotated.String())
 
-	start := time.Now()
-	// Wait for one certificate rotation to be announced and terminate
+	// Wait for two certificate rotations to be announced and terminate
 	<-certRotateChan
-
-	fmt.Printf("It took %+v to rotate certificate %s\n", time.Since(start), cn)
 	newCert, err := certManager.IssueCertificate(cn, validityPeriod)
 	assert.NoError(err)
 	assert.NotEqual(certA.GetExpiration(), newCert.GetExpiration())
@@ -152,4 +149,121 @@ func TestListIssuedCertificate(t *testing.T) {
 			t.Fatalf("Certificate #%v %v does not exist", i, c.GetCommonName())
 		}
 	}
+}
+
+func TestIssueCertificate(t *testing.T) {
+	cn := CommonName("fake-cert-cn")
+	assert := tassert.New(t)
+
+	t.Run("single key issuer", func(t *testing.T) {
+		cm := &Manager{
+			// The root certificate signing all newly issued certificates
+			keyIssuer: &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}},
+			pubIssuer: &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}},
+		}
+		// single keyIssuer, not cached
+		cert1, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotNil(cert1)
+		assert.Equal(cert1.keyIssuerID, "id1")
+		assert.Equal(cert1.pubIssuerID, "id1")
+		assert.Equal(cert1.GetIssuingCA(), pem.RootCertificate("id1"))
+
+		// single keyIssuer cached
+		cert2, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.Equal(cert1, cert2)
+
+		// single key issuer, old version cached
+		// TODO: could use informer logic to test mrc updates instead of just manually making changes.
+		cm.keyIssuer = &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2"}}
+		cm.pubIssuer = &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2"}}
+
+		cert3, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotNil(cert3)
+		assert.Equal(cert3.keyIssuerID, "id2")
+		assert.Equal(cert3.pubIssuerID, "id2")
+		assert.NotEqual(cert2, cert3)
+		assert.Equal(cert3.GetIssuingCA(), pem.RootCertificate("id2"))
+	})
+
+	t.Run("2 issuers", func(t *testing.T) {
+		cm := &Manager{
+			// The root certificate signing all newly issued certificates
+			keyIssuer: &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}},
+			pubIssuer: &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2"}},
+		}
+
+		// Not cached
+		cert1, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotNil(cert1)
+		assert.Equal(cert1.keyIssuerID, "id1")
+		assert.Equal(cert1.pubIssuerID, "id2")
+		assert.Equal(cert1.GetIssuingCA(), pem.RootCertificate("id1id2"))
+
+		// cached
+		cert2, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.Equal(cert1, cert2)
+
+		// cached, but pubIssuer is removed
+		cm.pubIssuer = cm.keyIssuer
+		cert3, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotEqual(cert1, cert3)
+		assert.Equal(cert3.keyIssuerID, "id1")
+		assert.Equal(cert3.pubIssuerID, "id1")
+		assert.Equal(cert3.GetIssuingCA(), pem.RootCertificate("id1"))
+
+		// cached, but keyIssuer is old
+		cm.keyIssuer = &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2"}}
+		cert4, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotEqual(cert3, cert4)
+		assert.Equal(cert4.keyIssuerID, "id2")
+		assert.Equal(cert4.pubIssuerID, "id1")
+		assert.Equal(cert4.GetIssuingCA(), pem.RootCertificate("id2id1"))
+
+		// cached, but pubIssuer is old
+		cm.pubIssuer = &issuer{ID: "id3", Issuer: &fakeIssuer{id: "id3"}}
+		cert5, err := cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotEqual(cert4, cert5)
+		assert.Equal(cert5.keyIssuerID, "id2")
+		assert.Equal(cert5.pubIssuerID, "id3")
+		assert.Equal(cert5.GetIssuingCA(), pem.RootCertificate("id2id3"))
+	})
+
+	t.Run("bad issuers", func(t *testing.T) {
+		cm := &Manager{
+			// The root certificate signing all newly issued certificates
+			keyIssuer: &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1", err: true}},
+			pubIssuer: &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2", err: true}},
+		}
+
+		// bad private key
+		cert, err := cm.IssueCertificate(cn, time.Minute)
+		assert.Nil(cert)
+		assert.EqualError(err, "id1 failed")
+
+		// bad public key
+		cm.keyIssuer = &issuer{ID: "id3", Issuer: &fakeIssuer{id: "id3"}}
+		cert, err = cm.IssueCertificate(cn, time.Minute)
+		assert.Nil(cert)
+		assert.EqualError(err, "id2 failed")
+
+		// insert a cached cert
+		cm.pubIssuer = cm.keyIssuer
+		cert, err = cm.IssueCertificate(cn, time.Minute)
+		assert.NoError(err)
+		assert.NotNil(cert)
+
+		// bad public key on an existing cached cert, because the pubIssuer is new
+		cm.pubIssuer = &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1", err: true}}
+		cert, err = cm.IssueCertificate(cn, time.Minute)
+		assert.EqualError(err, "id1 failed")
+		assert.Nil(cert)
+	})
 }

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -4,53 +4,12 @@ import (
 	"testing"
 	time "time"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	tassert "github.com/stretchr/testify/assert"
 
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/messaging"
 )
-
-var _ = Describe("Test Tresor Debugger", func() {
-	Context("test ListIssuedCertificates()", func() {
-		// Setup:
-		//   1. Create a new (fake) certificate
-		//   2. Reuse the same certificate as the Issuing CA
-		//   3. Populate the CertManager's cache w/ cert
-		cert := &Certificate{CommonName: "fake-cert-for-debugging"}
-		cm := &Manager{}
-		cm.cache.Store("foo", cert)
-
-		It("lists all issued certificates", func() {
-			actual := cm.ListIssuedCertificates()
-			expected := []*Certificate{cert}
-			Expect(actual).To(Equal(expected))
-		})
-	})
-})
-
-var _ = Describe("Test Certificate Manager", func() {
-	defer GinkgoRecover()
-	const serviceFQDN = "a.b.c"
-
-	Context("Test Getting a certificate from the cache", func() {
-		m, newCertError := NewManager(
-			&fakeMRCClient{},
-			validity,
-			nil)
-		It("should get an issued certificate from the cache", func() {
-			Expect(newCertError).ToNot(HaveOccurred())
-			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)
-			Expect(issueCertificateError).ToNot(HaveOccurred())
-			Expect(cert.GetCommonName()).To(Equal(CommonName(serviceFQDN)))
-
-			cachedCert := m.getFromCache(serviceFQDN)
-			Expect(cachedCert).To(Equal(cert))
-		})
-	})
-})
 
 func TestRotor(t *testing.T) {
 	assert := tassert.New(t)

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -1,8 +1,6 @@
 package providers
 
 import (
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 )
 
@@ -12,9 +10,3 @@ func (c *MRCCompatClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
 		c.mrc,
 	}, nil
 }
-
-// AddEventHandler is a no-op for the legacy client. The previous client could not handle changes, but we need this
-// method to implement the certificate.MRCClient interface.
-func (c *MRCCompatClient) AddEventHandler(cache.ResourceEventHandler) {}
-
-// provider.Tresor = &v1alpha2.TresorProviderSpec{SecretName: opts.SecretName}

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -67,7 +67,7 @@ func NewCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Con
 }
 
 // GetCertIssuerForMRC returns a certificate.Issuer generated from the provided MRC.
-func (c *MRCProviderGenerator) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+func (c *MRCProviderGenerator) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, string, error) {
 	p := mrc.Spec.Provider
 	switch {
 	case p.Tresor != nil:
@@ -77,12 +77,19 @@ func (c *MRCProviderGenerator) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertifi
 	case p.CertManager != nil:
 		return c.getCertManagerOSMCertificateManager(mrc)
 	default:
-		return nil, fmt.Errorf("Unknown certificate provider: %+v", p)
+		return nil, "", fmt.Errorf("Unknown certificate provider: %+v", p)
 	}
 }
 
+func getMRCID(mrc *v1alpha2.MeshRootCertificate) (string, error) {
+	if mrc.Annotations == nil || mrc.Annotations[constants.MRCVersionAnnotation] == "" {
+		return "", fmt.Errorf("no annotation found for MRC %s/%s, expected annotation %s", mrc.Namespace, mrc.Name, constants.MRCVersionAnnotation)
+	}
+	return mrc.Annotations[constants.MRCVersionAnnotation], nil
+}
+
 // getTresorOSMCertificateManager returns a certificate manager instance with Tresor as the certificate provider
-func (c *MRCProviderGenerator) getTresorOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+func (c *MRCProviderGenerator) getTresorOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, string, error) {
 	var err error
 	var rootCert *certificate.Certificate
 
@@ -92,20 +99,20 @@ func (c *MRCProviderGenerator) getTresorOSMCertificateManager(mrc *v1alpha2.Mesh
 	// Regardless of success or failure, all instances can proceed to load the same CA.
 	rootCert, err = tresor.NewCA(constants.CertificationAuthorityCommonName, constants.CertificationAuthorityRootValidityPeriod, rootCertCountry, rootCertLocality, rootCertOrganization)
 	if err != nil {
-		return nil, errors.New("Failed to create new Certificate Authority with cert issuer tresor")
+		return nil, "", errors.New("Failed to create new Certificate Authority with cert issuer tresor")
 	}
 
 	if rootCert.GetPrivateKey() == nil {
-		return nil, errors.New("Root cert does not have a private key")
+		return nil, "", errors.New("Root cert does not have a private key")
 	}
 
 	rootCert, err = k8s.GetCertificateFromSecret(mrc.Namespace, mrc.Spec.Provider.Tresor.SecretName, rootCert, c.kubeClient)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to synchronize certificate on Secrets API : %w", err)
+		return nil, "", fmt.Errorf("Failed to synchronize certificate on Secrets API : %w", err)
 	}
 
 	if rootCert.GetPrivateKey() == nil {
-		return nil, fmt.Errorf("Root cert does not have a private key: %w", certificate.ErrInvalidCertSecret)
+		return nil, "", fmt.Errorf("Root cert does not have a private key: %w", certificate.ErrInvalidCertSecret)
 	}
 
 	tresorClient, err := tresor.New(
@@ -114,13 +121,18 @@ func (c *MRCProviderGenerator) getTresorOSMCertificateManager(mrc *v1alpha2.Mesh
 		c.KeyBitSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate Tresor as a Certificate Manager: %w", err)
+		return nil, "", fmt.Errorf("failed to instantiate Tresor as a Certificate Manager: %w", err)
 	}
-	return tresorClient, nil
+
+	id, err := getMRCID(mrc)
+	if err != nil {
+		return nil, "", err
+	}
+	return tresorClient, id, nil
 }
 
 // getHashiVaultOSMCertificateManager returns a certificate manager instance with Hashi Vault as the certificate provider
-func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, string, error) {
 	provider := mrc.Spec.Provider.Vault
 
 	// A Vault address would have the following shape: "http://vault.default.svc.cluster.local:8200"
@@ -131,17 +143,21 @@ func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.
 		provider.Role,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
+		return nil, "", fmt.Errorf("error instantiating Hashicorp Vault as a Certificate Manager: %w", err)
 	}
-	return vaultClient, nil
+	id, err := getMRCID(mrc)
+	if err != nil {
+		return nil, "", err
+	}
+	return vaultClient, id, nil
 }
 
 // getCertManagerOSMCertificateManager returns a certificate manager instance with cert-manager as the certificate provider
-func (c *MRCProviderGenerator) getCertManagerOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+func (c *MRCProviderGenerator) getCertManagerOSMCertificateManager(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, string, error) {
 	provider := mrc.Spec.Provider.CertManager
 	client, err := cmversionedclient.NewForConfig(c.kubeConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to build cert-manager client set: %s", err)
+		return nil, "", fmt.Errorf("Failed to build cert-manager client set: %s", err)
 	}
 
 	cmClient, err := certmanager.New(
@@ -155,7 +171,11 @@ func (c *MRCProviderGenerator) getCertManagerOSMCertificateManager(mrc *v1alpha2
 		c.KeyBitSize,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error instantiating Jetstack cert-manager client: %w", err)
+		return nil, "", fmt.Errorf("error instantiating Jetstack cert-manager client: %w", err)
 	}
-	return cmClient, nil
+	id, err := getMRCID(mrc)
+	if err != nil {
+		return nil, "", err
+	}
+	return cmClient, id, nil
 }

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -3,8 +3,6 @@ package fake
 import (
 	"time"
 
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
@@ -34,10 +32,6 @@ func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
 	// return single empty object in the list.
 	return []*v1alpha2.MeshRootCertificate{{}}, nil
 }
-
-// AddEventHandler is a no-op for the legacy client. The previous client could not handle changes, but we need this
-// method to implement the certificate.MRCClient interface.
-func (c *fakeMRCClient) AddEventHandler(cache.ResourceEventHandler) {}
 
 // NewFake constructs a fake certificate client using a certificate
 func NewFake(msgBroker *messaging.Broker) *certificate.Manager {

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -18,14 +18,15 @@ const (
 
 type fakeMRCClient struct{}
 
-func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, error) {
+func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (certificate.Issuer, string, error) {
 	rootCertCountry := "US"
 	rootCertLocality := "CA"
 	ca, err := tresor.NewCA("Fake Tresor CN", 1*time.Hour, rootCertCountry, rootCertLocality, rootCertOrganization)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return tresor.New(ca, rootCertOrganization, 2048)
+	issuer, err := tresor.New(ca, rootCertOrganization, 2048)
+	return issuer, "issuer-1", err
 }
 
 // List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/client-go/tools/cache"
-
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/messaging"
@@ -89,11 +87,6 @@ type Manager struct {
 
 // MRCClient is an interface that can watch for changes to the MRC. It is typically backed by a k8s informer.
 type MRCClient interface {
-	// List for now.. can add watch and others later
-
-	// AddEventHandler uses the same interface as the k8s ResourceEventHandler, but doesn't require any
-	// hard dependency on K8s. We *do* expect the same semantics as the k8s ResourceEventHandler.
-	AddEventHandler(cache.ResourceEventHandler)
 	List() ([]*v1alpha2.MeshRootCertificate, error)
 
 	// GetCertIssuerForMRC returns an Issuer based on the provided MRC.


### PR DESCRIPTION
State management for certificate rotation

This PR implements certificate state management for rotation, by maintaining 2 `certificate.Issuer`'s (previously `certificate.Provider`). It adds an ID to each issuer, to be extracted from the MRC, to delineate between a prior issued cert, and the current intended issuer.

We then add a combine method on a certificate, which will add in a `pem.RootCertificate`, such that `GetIssuingCA` will now return the combined set of certificates for validation.