### PR TITLE
Feature pyroscope

### DIFF
--- a/scripts/pyroscope/install.sh
+++ b/scripts/pyroscope/install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# RUN THIS SCRIPT FROM THE ROOT OF THE REPOSITORY
+
+# shellcheck disable=SC1091
+source .env
+
+kubectl patch meshconfig osm-mesh-config -n "$K8S_NAMESPACE" -p '{"spec":{"observability":{"enableDebugServer":true}}}' --type=merge
+
+kubectl annotate -n "$K8S_NAMESPACE" svc osm-controller "pyroscope.io/scrape=true" "pyroscope.io/application-name=osm-controller" "pyroscope.io/spy-name=gospy" "pyroscope.io/profile-cpu-enabled=true" "pyroscope.io/profile-mem-enabled=true" "pyroscope.io/port=9092"
+
+helm install prof pyroscope-io/pyroscope -f scripts/pyroscope/values.yaml

--- a/scripts/pyroscope/values.yaml
+++ b/scripts/pyroscope/values.yaml
@@ -1,0 +1,103 @@
+---
+# Create Cluster Role and bind it to Pyroscope to enable it watching Kubernetes resources.
+rbac:
+  create: true
+# Pyroscope configuration.
+pyroscopeConfigs:
+  log-level: debug
+  scrape-configs:
+    # Example scrape config for pods
+    #
+    # The relabeling allows the actual pod scrape endpoint to be configured via the
+    # following annotations:
+    #
+    # * `pyroscope.io/scrape`: Only scrape pods that have a value of `true`.
+    # * `pyroscope.io/application-name`: Name of the application being profiled.
+    # * `pyroscope.io/scheme`: If the metrics endpoint is secured then you will need
+    # to set this to `https` & most likely set the `tls_config` of the scrape config.
+    # * `pyroscope.io/port`: Scrape the pod on the indicated port.
+    # * `pyroscope.io/profile-{profile_name}-path`: Specifies URL path exposing pprof profile.
+    # * `pyroscope.io/profile-{profile_name}-param-{param_key}`: Overrides scrape URL parameters.
+    #
+    # Kubernetes labels will be added as Pyroscope labels on metrics via the
+    # `labelmap` relabeling action.
+    - job-name: 'kubernetes-pods'
+      enabled-profiles: [cpu, mem]
+      kubernetes-sd-configs:
+        - role: pod
+      relabel-configs:
+        - source-labels: [__meta_kubernetes_pod_annotation_pyroscope_io_scrape]
+          action: keep
+          regex: true
+        - source-labels:
+            [__meta_kubernetes_pod_annotation_pyroscope_io_application_name]
+          action: replace
+          target-label: __name__
+        - source-labels:
+            [__meta_kubernetes_pod_annotation_pyroscope_io_spy_name]
+          action: replace
+          target-label: __spy_name__
+        - source-labels: [__meta_kubernetes_pod_annotation_pyroscope_io_scheme]
+          action: replace
+          regex: (https?)
+          target-label: __scheme__
+        - source-labels:
+            [__address__, __meta_kubernetes_pod_annotation_pyroscope_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target-label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - source-labels: [__meta_kubernetes_namespace]
+          action: replace
+          target-label: kubernetes_namespace
+        - source-labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target-label: kubernetes_pod_name
+        - source-labels: [__meta_kubernetes_pod_phase]
+          regex: Pending|Succeeded|Failed|Completed
+          action: drop
+        - action: labelmap
+          regex: __meta_kubernetes_pod_annotation_pyroscope_io_profile_(.+)
+          replacement: __profile_$1
+    - job-name: 'kubernetes-svcs'
+      enabled-profiles: [cpu, mem]
+      kubernetes-sd-configs:
+        - role: service
+      relabel-configs:
+        - source-labels: [__meta_kubernetes_service_annotation_pyroscope_io_scrape]
+          action: keep
+          regex: true
+        - source-labels:
+            [__meta_kubernetes_service_annotation_pyroscope_io_application_name]
+          action: replace
+          target-label: __name__
+        - source-labels:
+            [__meta_kubernetes_service_annotation_pyroscope_io_spy_name]
+          action: replace
+          target-label: __spy_name__
+        - source-labels: [__meta_kubernetes_service_annotation_pyroscope_io_scheme]
+          action: replace
+          regex: (https?)
+          target-label: __scheme__
+        - source-labels:
+            [__address__, __meta_kubernetes_service_annotation_pyroscope_io_port]
+          action: replace
+          regex: ([^:]+)(?::\d+)?;(\d+)
+          replacement: $1:$2
+          target-label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+        - source-labels: [__meta_kubernetes_namespace]
+          action: replace
+          target-label: kubernetes_namespace
+        - source-labels: [__meta_kubernetes_service_name]
+          action: replace
+          target-label: kubernetes_service_name
+        - source-labels: [__meta_kubernetes_service_phase]
+          regex: Pending|Succeeded|Failed|Completed
+          action: drop
+        - action: labelmap
+          regex: __meta_kubernetes_service_annotation_pyroscope_io_profile_(.+)
+          replacement: __profile_$1


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This PR adds scripts to install Pyroscope as an online/dynamic profiling tool in OSM namespace. 

Pyroscope is installed in [Golang pull mode](https://pyroscope.io/docs/golang-pull-mode/). It requires the Golang service to have pprof debug web endpoint setup. Therefore right now osm-controller can be profiled. Other components such as osm-bootstrap and osm-injector do not support online profiling.

Resolves https://github.com/openservicemesh/osm/issues/4694

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.


-->
**Testing done**:

Tested the script in development cluster. Pyroscope is properly installed.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [X] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

Yes. The script is modified from [Pyroscope official example](https://github.com/pyroscope-io/pyroscope/tree/main/examples/golang-pull/kubernetes). We didn't inform the maintainer.

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

Documentation task is tracked by https://github.com/openservicemesh/osm-docs/issues/368 