### PR TITLE
feat(certs): create MRC on install

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -179,6 +179,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
 | osm.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
 | osm.vault.token | string | `""` | token that should be used to connect to Vault |
+| osm.vault.tokenSecretName | string | `"osm-vault-token"` | The Kubernetes secret name to store the Vault token used in OSM |
 | osm.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
 | smi.validateTrafficTarget | bool | `true` | Enables validation of SMI Traffic Target |
 

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -179,6 +179,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
 | osm.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
 | osm.vault.token | string | `""` | token that should be used to connect to Vault |
+| osm.vault.tokenSecretKey | string | `"token"` | The Kubernetes secret key with the value bring the Vault token |
 | osm.vault.tokenSecretName | string | `"osm-vault-token"` | The Kubernetes secret name to store the Vault token used in OSM |
 | osm.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
 | smi.validateTrafficTarget | bool | `true` | Enables validation of SMI Traffic Target |

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -178,9 +178,10 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.vault.port | int | `8200` | port to use to connect to Vault |
 | osm.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
 | osm.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
+| osm.vault.secret | object | `{"key":"token","name":"osm-vault-token"}` | The Kubernetes secret storing the Vault token used in OSM |
+| osm.vault.secret.key | string | `"token"` | The Kubernetes secret key with the value bring the Vault token |
+| osm.vault.secret.name | string | `"osm-vault-token"` | The Kubernetes secret name storing the Vault token used in OSM |
 | osm.vault.token | string | `""` | token that should be used to connect to Vault |
-| osm.vault.tokenSecretKey | string | `"token"` | The Kubernetes secret key with the value bring the Vault token |
-| osm.vault.tokenSecretName | string | `"osm-vault-token"` | The Kubernetes secret name to store the Vault token used in OSM |
 | osm.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
 | smi.validateTrafficTarget | bool | `true` | Enables validation of SMI Traffic Target |
 

--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -84,6 +84,7 @@ spec:
              kubectl replace -f /osm-crds;
              kubectl delete --ignore-not-found meshconfig -n '{{ include "osm.namespace" . }}' osm-mesh-config;
              kubectl delete --ignore-not-found secret -n '{{ include "osm.namespace" . }}' {{ .Values.osm.caBundleSecretName }};
+             kubectl delete --ignore-not-found meshrootcertificate -n '{{ include "osm.namespace" . }}' osm-mesh-root-certificate;
              kubectl delete mutatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-injector --ignore-not-found;
              kubectl delete validatingwebhookconfiguration -l app.kubernetes.io/name=openservicemesh.io,app.kubernetes.io/instance={{ .Values.osm.meshName }},app.kubernetes.io/version={{ .Chart.AppVersion }},app=osm-controller --ignore-not-found;
       nodeSelector:

--- a/charts/osm/templates/preset-mesh-root-certificate.yaml
+++ b/charts/osm/templates/preset-mesh-root-certificate.yaml
@@ -17,19 +17,19 @@ data:
           }
         }
         {{- end}}
-        {{- if eq (.Values.osm.certificateProvider.kind | lower) "certmanager"}}
+        {{- if eq (.Values.osm.certificateProvider.kind | lower) "cert-manager"}}
         "certManager": {
-          "issuerName": {{.Values.osm.certManager.issuerName | mustToJson}},
-          "issuerKind": {{.Values.osm.certManager.issuerKind | mustToJson}},
-          "issuerGroup": {{.Values.osm.certManager.issuerGroup | mustToJson}}
+          "issuerName": {{.Values.osm.certmanager.issuerName | mustToJson}},
+          "issuerKind": {{.Values.osm.certmanager.issuerKind | mustToJson}},
+          "issuerGroup": {{.Values.osm.certmanager.issuerGroup | mustToJson}}
         }
         {{- end}}
         {{- if eq (.Values.osm.certificateProvider.kind | lower) "vault"}}
         "vault": {
           "token": {
             "secretKeyRef": {
-              "name": {{.Values.osm.vault.tokenSecretName | mustToJson}},
-              "key": {{.Values.osm.vault.tokenSecretKey | mustToJson}},
+              "name": {{.Values.osm.vault.secret.name | mustToJson}},
+              "key": {{.Values.osm.vault.secret.key | mustToJson}},
               "namespace": "{{include "osm.namespace" .}}"
             }
           },

--- a/charts/osm/templates/preset-mesh-root-certificate.yaml
+++ b/charts/osm/templates/preset-mesh-root-certificate.yaml
@@ -27,14 +27,16 @@ data:
         {{- if eq (.Values.osm.certificateProvider.kind | lower) "vault"}}
         "vault": {
           "token": {
-            "secretRef": {
+            "secretKeyRef": {
               "name": {{.Values.osm.vault.tokenSecretName | mustToJson}},
+              "key": {{.Values.osm.vault.tokenSecretKey | mustToJson}},
               "namespace": "{{include "osm.namespace" .}}"
             }
           },
           "host": {{.Values.osm.vault.host | mustToJson}},
           "role": {{.Values.osm.vault.role | mustToJson}},
-          "protocol": {{.Values.osm.vault.protocol | mustToJson}}
+          "protocol": {{.Values.osm.vault.protocol | mustToJson}},
+          "port": {{.Values.osm.vault.port | mustToJson}}
         }
         {{- end}}
       }

--- a/charts/osm/templates/preset-mesh-root-certificate.yaml
+++ b/charts/osm/templates/preset-mesh-root-certificate.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: preset-mesh-root-certificate
+  namespace: {{ include "osm.namespace" . }}
+data:
+  preset-mesh-root-certificate.json: |
+    {
+      "provider": {
+        {{- if eq (.Values.osm.certificateProvider.kind | lower) "tresor"}}
+        "tresor": {
+          "ca": {
+            "secretRef": {
+              "name": {{.Values.osm.caBundleSecretName | mustToJson}},
+              "namespace": "{{include "osm.namespace" .}}"
+            }
+          }
+        }
+        {{- end}}
+        {{- if eq (.Values.osm.certificateProvider.kind | lower) "certmanager"}}
+        "certManager": {
+          "issuerName": {{.Values.osm.certManager.issuerName | mustToJson}},
+          "issuerKind": {{.Values.osm.certManager.issuerKind | mustToJson}},
+          "issuerGroup": {{.Values.osm.certManager.issuerGroup | mustToJson}}
+        }
+        {{- end}}
+        {{- if eq (.Values.osm.certificateProvider.kind | lower) "vault"}}
+        "vault": {
+          "token": {
+            "secretRef": {
+              "name": {{.Values.osm.vault.tokenSecretName | mustToJson}},
+              "namespace": "{{include "osm.namespace" .}}"
+            }
+          },
+          "host": {{.Values.osm.vault.host | mustToJson}},
+          "role": {{.Values.osm.vault.role | mustToJson}},
+          "protocol": {{.Values.osm.vault.protocol | mustToJson}}
+        }
+        {{- end}}
+      }
+    }

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1292,6 +1292,12 @@
                             "title": "Hashicorp Vault's role schema",
                             "description": "Role to use with Vault",
                             "type": "string"
+                        },
+                        "tokenSecretName": {
+                            "$id": "#/properties/osm/properties/vault/properties/tokenSecretName",
+                            "title": "Vault token secret name schema",
+                            "description": "Name of the Kubernetes Secret to store the vault token",
+                            "type": "string"
                         }
                     },
                     "examples": [

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1293,17 +1293,25 @@
                             "description": "Role to use with Vault",
                             "type": "string"
                         },
-                        "tokenSecretName": {
-                            "$id": "#/properties/osm/properties/vault/properties/tokenSecretName",
-                            "title": "Vault token secret name schema",
-                            "description": "Name of the Kubernetes Secret to store the vault token",
-                            "type": "string"
-                        },
-                        "tokenSecretKey": {
-                            "$id": "#/properties/osm/properties/vault/properties/tokenSecretKey",
-                            "title": "Vault token secret key schema",
-                            "description": "Name of the Kubernetes Secret key with the value of the vault token",
-                            "type": "string"
+                        "secret": {
+                            "$id": "#/properties/osm/properties/vault/properties/secret",
+                            "type": "object",
+                            "title": "Vault token secret schema",
+                            "description": "Vault token secret reference parameters",
+                            "properties": {
+                                "name": {
+                                    "$id": "#/properties/osm/properties/vault/properties/secret/properties/name",
+                                    "title": "Vault token secret name schema",
+                                    "description": "Name of the Kubernetes Secret to store the vault token",
+                                    "type": "string"
+                                },
+                                "key": {
+                                    "$id": "#/properties/osm/properties/vault/properties/secret/properties/key",
+                                    "title": "Vault token secret key schema",
+                                    "description": "Name of the Kubernetes Secret key with the value of the vault token",
+                                    "type": "string"
+                                }
+                            }
                         }
                     },
                     "examples": [

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1298,6 +1298,12 @@
                             "title": "Vault token secret name schema",
                             "description": "Name of the Kubernetes Secret to store the vault token",
                             "type": "string"
+                        },
+                        "tokenSecretKey": {
+                            "$id": "#/properties/osm/properties/vault/properties/tokenSecretKey",
+                            "title": "Vault token secret key schema",
+                            "description": "Name of the Kubernetes Secret key with the value of the vault token",
+                            "type": "string"
                         }
                     },
                     "examples": [

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -129,10 +129,12 @@ osm:
     token: ""
     # -- Vault role to be used by Open Service Mesh
     role: openservicemesh
-    # -- The Kubernetes secret name to store the Vault token used in OSM
-    tokenSecretName: osm-vault-token
-    # -- The Kubernetes secret key with the value bring the Vault token
-    tokenSecretKey: token
+    # -- The Kubernetes secret storing the Vault token used in OSM
+    secret:
+      # -- The Kubernetes secret name storing the Vault token used in OSM
+      name: osm-vault-token
+      # -- The Kubernetes secret key with the value bring the Vault token
+      key: token
 
   #
   # -- cert-manager.io configuration

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -129,6 +129,8 @@ osm:
     token: ""
     # -- Vault role to be used by Open Service Mesh
     role: openservicemesh
+    # -- The Kubernetes secret name to store the Vault token used in OSM
+    tokenSecretName: osm-vault-token
 
   #
   # -- cert-manager.io configuration

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -131,6 +131,8 @@ osm:
     role: openservicemesh
     # -- The Kubernetes secret name to store the Vault token used in OSM
     tokenSecretName: osm-vault-token
+    # -- The Kubernetes secret key with the value bring the Vault token
+    tokenSecretKey: token
 
   #
   # -- cert-manager.io configuration

--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -251,6 +251,7 @@ func (d *uninstallMeshCmd) uninstallCustomResourceDefinitions() error {
 		"egresses.policy.openservicemesh.io",
 		"ingressbackends.policy.openservicemesh.io",
 		"meshconfigs.config.openservicemesh.io",
+		"meshRootCertificate.config.openservicemesh.io",
 		"upstreamtrafficsettings.policy.openservicemesh.io",
 		"retries.policy.openservicemesh.io",
 		"multiclusterservices.config.openservicemesh.io",

--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -60,14 +60,10 @@ spec:
                       description: Cert-manager provider configuration
                       type: object
                       required:
-                        - secretName
                         - issuerName
                         - issuerKind
                         - issuerGroup
                       properties:
-                        secretName:
-                          description: The name of the kubernetes secret containing the root certificate
-                          type: string
                         issuerName:
                           description: The name of the Issuer or ClusterIssuer resource
                           type: string

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -370,20 +370,15 @@ func (b *bootstrap) ensureMeshRootCertificate() error {
 	if err != nil {
 		return err
 	}
-	var foundIssuingAndCompleteMRC bool
+
 	for _, mrc := range meshRootCertificateList.Items {
 		if mrc.Status.RotationStage == constants.MRCStageIssuing && mrc.Status.State == constants.MRCStateComplete {
-			foundIssuingAndCompleteMRC = true
-			break
+			return nil
 		}
 	}
 
-	if !foundIssuingAndCompleteMRC {
-		// create a MeshRootCertificate since none were found in the complete state and issuing rotationStage
-		return b.createMeshRootCertificate()
-	}
-
-	return nil
+	// create a MeshRootCertificate since none were found in the complete state and issuing rotationStage
+	return b.createMeshRootCertificate()
 }
 
 func (b *bootstrap) createMeshRootCertificate() error {
@@ -434,5 +429,5 @@ func buildMeshRootCertificate(presetMeshRootCertificateConfigMap *corev1.ConfigM
 		},
 	}
 
-	return config, nil
+	return config, util.CreateApplyAnnotation(config, unstructured.UnstructuredJSONScheme)
 }

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -172,7 +172,7 @@ func main() {
 
 	err = bootstrap.ensureMeshRootCertificate()
 	if err != nil {
-		log.Fatal().Err(err).Msgf("Error setting up default MeshRootCertificate %s from Secret %s", meshRootCertificateName, presetMeshRootCertificateName)
+		log.Fatal().Err(err).Msgf("Error setting up default MeshRootCertificate %s from ConfigMap %s", meshRootCertificateName, presetMeshRootCertificateName)
 		return
 	}
 
@@ -372,7 +372,7 @@ func (b *bootstrap) ensureMeshRootCertificate() error {
 	meshRootCertificateList, err := b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).List(context.TODO(), listOptions)
 
 	if len(meshRootCertificateList.Items) == 0 {
-		// create a MeshRootCertificate since none were found in the complete state and issuing rotationState
+		// create a MeshRootCertificate since none were found in the complete state and issuing rotationStage
 		return b.createMeshRootCertificate()
 	}
 	if err != nil {
@@ -436,8 +436,8 @@ func buildMeshRootCertificate(presetMeshRootCertificateConfigMap *corev1.ConfigM
 		},
 		Spec: presetMeshRootCertificateSpec,
 		Status: configv1alpha2.MeshRootCertificateStatus{
-			State:         "complete",
-			RotationStage: "issuing",
+			State:         constants.MRCStateComplete,
+			RotationStage: constants.MRCStageIssuing,
 		},
 	}
 

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -44,9 +44,12 @@ import (
 )
 
 const (
-	meshConfigName          = "osm-mesh-config"
-	presetMeshConfigName    = "preset-mesh-config"
-	presetMeshConfigJSONKey = "preset-mesh-config.json"
+	meshConfigName                   = "osm-mesh-config"
+	presetMeshConfigName             = "preset-mesh-config"
+	presetMeshConfigJSONKey          = "preset-mesh-config.json"
+	meshRootCertificateName          = "osm-mesh-root-certificate"
+	presetMeshRootCertificateName    = "preset-mesh-root-certificate"
+	presetMeshRootCertificateJSONKey = "preset-mesh-root-certificate.json"
 )
 
 var (
@@ -76,9 +79,9 @@ var (
 )
 
 type bootstrap struct {
-	kubeClient       kubernetes.Interface
-	meshConfigClient configClientset.Interface
-	namespace        string
+	kubeClient   kubernetes.Interface
+	configClient configClientset.Interface
+	namespace    string
 }
 
 func init() {
@@ -156,14 +159,20 @@ func main() {
 	}
 
 	bootstrap := bootstrap{
-		kubeClient:       kubeClient,
-		meshConfigClient: configClient,
-		namespace:        osmNamespace,
+		kubeClient:   kubeClient,
+		configClient: configClient,
+		namespace:    osmNamespace,
 	}
 
 	err = bootstrap.ensureMeshConfig()
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Error setting up default MeshConfig %s from ConfigMap %s", meshConfigName, presetMeshConfigName)
+		return
+	}
+
+	err = bootstrap.ensureMeshRootCertificate()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Error setting up default MeshRootCertificate %s from Secret %s", meshRootCertificateName, presetMeshRootCertificateName)
 		return
 	}
 
@@ -253,7 +262,7 @@ func (b *bootstrap) createDefaultMeshConfig() error {
 	if err != nil {
 		return err
 	}
-	if _, err := b.meshConfigClient.ConfigV1alpha2().MeshConfigs(b.namespace).Create(context.TODO(), defaultMeshConfig, metav1.CreateOptions{}); err == nil {
+	if _, err := b.configClient.ConfigV1alpha2().MeshConfigs(b.namespace).Create(context.TODO(), defaultMeshConfig, metav1.CreateOptions{}); err == nil {
 		log.Info().Msgf("MeshConfig (%s) created in namespace %s", meshConfigName, b.namespace)
 		return nil
 	}
@@ -267,7 +276,7 @@ func (b *bootstrap) createDefaultMeshConfig() error {
 }
 
 func (b *bootstrap) ensureMeshConfig() error {
-	config, err := b.meshConfigClient.ConfigV1alpha2().MeshConfigs(b.namespace).Get(context.TODO(), meshConfigName, metav1.GetOptions{})
+	config, err := b.configClient.ConfigV1alpha2().MeshConfigs(b.namespace).Get(context.TODO(), meshConfigName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		// create a default mesh config since it was not found
 		return b.createDefaultMeshConfig()
@@ -281,7 +290,7 @@ func (b *bootstrap) ensureMeshConfig() error {
 		if err := util.CreateApplyAnnotation(config, unstructured.UnstructuredJSONScheme); err != nil {
 			return err
 		}
-		if _, err := b.meshConfigClient.ConfigV1alpha2().MeshConfigs(b.namespace).Update(context.TODO(), config, metav1.UpdateOptions{}); err != nil {
+		if _, err := b.configClient.ConfigV1alpha2().MeshConfigs(b.namespace).Update(context.TODO(), config, metav1.UpdateOptions{}); err != nil {
 			return err
 		}
 	}
@@ -351,6 +360,85 @@ func buildDefaultMeshConfig(presetMeshConfigMap *corev1.ConfigMap) (*configv1alp
 			Name: meshConfigName,
 		},
 		Spec: presetMeshConfigSpec,
+	}
+
+	return config, util.CreateApplyAnnotation(config, unstructured.UnstructuredJSONScheme)
+}
+
+func (b *bootstrap) ensureMeshRootCertificate() error {
+	listOptions := metav1.ListOptions{
+		FieldSelector: "status.state=complete,status.rotationStage=issuing",
+	}
+	meshRootCertificateList, err := b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).List(context.TODO(), listOptions)
+
+	if len(meshRootCertificateList.Items) == 0 {
+		// create a MeshRootCertificate since none were found in the complete state and issuing rotationState
+		return b.createMeshRootCertificate()
+	}
+	if err != nil {
+		return err
+	}
+
+	meshRootCertificate := meshRootCertificateList.Items[0]
+	if _, exists := meshRootCertificate.Annotations[corev1.LastAppliedConfigAnnotation]; !exists {
+		// MeshRootCertificate was found, but may not have the last applied annotation.
+		if err := util.CreateApplyAnnotation(&meshRootCertificate, unstructured.UnstructuredJSONScheme); err != nil {
+			return err
+		}
+		if _, err := b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Update(context.TODO(), &meshRootCertificate, metav1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *bootstrap) createMeshRootCertificate() error {
+	// find preset config map to build the MeshRootCertificate from
+	presetMeshRootCertificate, err := b.kubeClient.CoreV1().ConfigMaps(b.namespace).Get(context.TODO(), presetMeshRootCertificateName, metav1.GetOptions{})
+	// If the preset MeshRootCertificate could not be loaded return the error
+	if err != nil {
+		return err
+	}
+
+	// Create a MeshRootCertificate
+	defaultMeshConfig, err := buildMeshRootCertificate(presetMeshRootCertificate)
+	if err != nil {
+		return err
+	}
+	if _, err := b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Create(context.TODO(), defaultMeshConfig, metav1.CreateOptions{}); err == nil {
+		log.Info().Msgf("MeshRootCertificate (%s) created in namespace %s", meshConfigName, b.namespace)
+		return nil
+	}
+
+	if apierrors.IsAlreadyExists(err) {
+		log.Info().Msgf("MeshRootCertificate already exists in %s. Skip creating.", b.namespace)
+		return nil
+	}
+
+	return err
+}
+
+func buildMeshRootCertificate(presetMeshRootCertificateConfigMap *corev1.ConfigMap) (*configv1alpha2.MeshRootCertificate, error) {
+	presetMeshRootCertificate := presetMeshRootCertificateConfigMap.Data[presetMeshRootCertificateJSONKey]
+	presetMeshRootCertificateSpec := configv1alpha2.MeshRootCertificateSpec{}
+	err := json.Unmarshal([]byte(presetMeshRootCertificate), &presetMeshRootCertificateSpec)
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Error converting preset-mesh-root-certificate json string to MeshRootCertificate object")
+	}
+
+	config := &configv1alpha2.MeshRootCertificate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MeshRootCertificate",
+			APIVersion: "config.openservicemesh.io/configv1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: meshRootCertificateName,
+		},
+		Spec: presetMeshRootCertificateSpec,
+		Status: configv1alpha2.MeshRootCertificateStatus{
+			State:         "complete",
+			RotationStage: "issuing",
+		},
 	}
 
 	return config, util.CreateApplyAnnotation(config, unstructured.UnstructuredJSONScheme)

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -129,9 +129,11 @@ var testPresetMeshRootCertificate *corev1.ConfigMap = &corev1.ConfigMap{
 		presetMeshRootCertificateJSONKey: `{
 "provider": {
 	"tresor": {
-	 "secretRef": {
-	   "name": "osm-ca-bundle",
-	   "namespace": "test-namespace"
+	 "ca": {
+	  "secretRef": {
+		"name": "osm-ca-bundle",
+		"namespace": "test-namespace"
+	  }
 	 }
 	}
 	}
@@ -166,8 +168,8 @@ func TestBuildMeshRootCertificate(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(meshRootCertificate.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	assert.Equal(meshRootCertificate.Name, meshRootCertificateName)
-	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.SecretRef.Name, "osm-ca-bundle")
-	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.SecretRef.Namespace, testNamespace)
+	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.CA.SecretRef.Name, "osm-ca-bundle")
+	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.CA.SecretRef.Namespace, testNamespace)
 	assert.Nil(meshRootCertificate.Spec.Provider.Vault)
 	assert.Nil(meshRootCertificate.Spec.Provider.CertManager)
 }

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -151,6 +151,7 @@ func TestBuildMeshRootCertificate(t *testing.T) {
 	assert := tassert.New(t)
 
 	meshRootCertificate, err := buildMeshRootCertificate(testPresetMeshRootCertificate)
+	assert.Contains(meshRootCertificate.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	assert.NoError(err)
 	assert.Equal(meshRootCertificate.Name, meshRootCertificateName)
 	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.CA.SecretRef.Name, "osm-ca-bundle")
@@ -312,7 +313,7 @@ func TestEnsureMeshConfig(t *testing.T) {
 	}
 }
 
-func TestCreateMeshRootCertificateConfig(t *testing.T) {
+func TestCreateMeshRootCertificate(t *testing.T) {
 	tests := []struct {
 		name                             string
 		namespace                        string
@@ -338,7 +339,7 @@ func TestCreateMeshRootCertificateConfig(t *testing.T) {
 			expectErr:                        true,
 		},
 		{
-			name:                             "default MeshRootCertificate already exists",
+			name:                             "MeshRootCertificate already exists",
 			namespace:                        testNamespace,
 			kubeClient:                       fakeKube.NewSimpleClientset([]runtime.Object{testPresetMeshRootCertificate}...),
 			configClient:                     fakeConfig.NewSimpleClientset([]runtime.Object{testMeshRootCertificate}...),

--- a/pkg/apis/config/v1alpha2/meshrootcertificate.go
+++ b/pkg/apis/config/v1alpha2/meshrootcertificate.go
@@ -49,9 +49,6 @@ type ProviderSpec struct {
 
 // CertManagerProviderSpec defines the configuration of the cert-manager provider
 type CertManagerProviderSpec struct {
-	// SecretName specifies the name of the k8s secret containing the root certificate
-	SecretName string `json:"secretName"`
-
 	// IssuerName specifies the name of the Issuer resource
 	IssuerName string `json:"issuerName"`
 

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -57,8 +57,8 @@ func NewCertificateManager(kubeClient kubernetes.Interface, kubeConfig *rest.Con
 			},
 			// TODO(#4502): Detect if an actual MRC exists, and set the status accordingly.
 			Status: v1alpha2.MeshRootCertificateStatus{
-				State:         constants.MRCStateValidating,
-				RotationStage: constants.MRCStageComplete,
+				State:         constants.MRCStateComplete,
+				RotationStage: constants.MRCStageIssuing,
 			},
 		},
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -166,8 +166,14 @@ const (
 	// MRCVersionAnnotation is the annotation used for the version of the MeshRootCertificate
 	MRCVersionAnnotation = "openservicemesh.io/mrc-version"
 
-	MRCStateValidating = "validating"
-	MRCStageComplete   = "complete"
+	// MRCStageValidating is the validating status option for the rotation stage of the MeshRootCertificate
+	MRCStageValidating = "validating"
+
+	// MRCStageIssuing is the issuing status option for the rotation stage of the MeshRootCertificate
+	MRCStageIssuing = "issuing"
+
+	// MRCStateComplete is the complete status option for the state of the MeshRootCertificate
+	MRCStateComplete = "complete"
 )
 
 // Labels used by the control plane

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -354,10 +354,13 @@ func (td *OsmTestData) GetOSMInstallOpts(options ...InstallOsmOpt) InstallOSMOpt
 		DeployFluentbit:         false,
 		EnableReconciler:        false,
 
-		VaultHost:     "vault." + td.OsmNamespace + ".svc.cluster.local",
-		VaultProtocol: "http",
-		VaultRole:     "openservicemesh",
-		VaultToken:    "token",
+		VaultHost:            "vault." + td.OsmNamespace + ".svc.cluster.local",
+		VaultProtocol:        "http",
+		VaultPort:            8200,
+		VaultRole:            "openservicemesh",
+		VaultToken:           "token",
+		VaultTokenSecretName: "osm-vault-token",
+		VaultTokenSecretKey:  "token-key",
 
 		CertmanagerIssuerGroup: "cert-manager.io",
 		CertmanagerIssuerKind:  "Issuer",
@@ -519,7 +522,9 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 			fmt.Sprintf("osm.vault.host=%s", instOpts.VaultHost),
 			fmt.Sprintf("osm.vault.role=%s", instOpts.VaultRole),
 			fmt.Sprintf("osm.vault.protocol=%s", instOpts.VaultProtocol),
-			fmt.Sprintf("osm.vault.token=%s", instOpts.VaultToken))
+			fmt.Sprintf("osm.vault.token=%s", instOpts.VaultToken),
+			fmt.Sprintf("osm.vault.port=%d", instOpts.VaultPort),
+		)
 		// Wait for the vault pod
 		if err := td.WaitForPodsRunningReady(instOpts.ControlPlaneNS, 60*time.Second, 1, nil); err != nil {
 			return errors.Wrap(err, "failed waiting for vault pod to become ready")

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -106,10 +106,13 @@ type InstallOSMOpts struct {
 	DeployFluentbit         bool
 	EnableReconciler        bool
 
-	VaultHost     string
-	VaultProtocol string
-	VaultToken    string
-	VaultRole     string
+	VaultHost            string
+	VaultProtocol        string
+	VaultPort            int
+	VaultToken           string
+	VaultRole            string
+	VaultTokenSecretName string
+	VaultTokenSecretKey  string
 
 	CertmanagerIssuerGroup string
 	CertmanagerIssuerKind  string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updates the osm-bootstrap to create a default MeshRootCertificate
on osm install. Adds a preset-mesh-root-certificate ConfigMap to
the Helm templates. The osm-bootstrap will obtain the MRC spec
from the ConfigMap and attempt to create a default MRC. If an MRC
already exists with a complete state and issuing rotation stage then
the osm-bootstrap will not create the default MRC.

Additional changes:
- adds MeshRootCertificate CRD to uninstall list
- adds the tokenSecretName and tokenSecretKey values to the
osm.vault values
- removes SecretName from the certManager provider in the mesh
root certificate
- cleans up MeshConfig tests

Part of #4712 

Note: This change does not include creating the Vault token
secret. The MRC created is not used at this point by the OSM
control plane. This will come in a later PR.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI 
- Demo

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Certificate Management     | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No