### PR TITLE
cli/verifier: use pod status conditions for readiness check

### DIFF
--- a/pkg/cli/verifier/control_plane_test.go
+++ b/pkg/cli/verifier/control_plane_test.go
@@ -22,7 +22,7 @@ func TestControlPlane(t *testing.T) {
 		expected  Result
 	}{
 		{
-			name: "all control plane pods are running",
+			name: "all control plane pods are ready",
 			resources: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -31,7 +31,24 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-controller"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodInitialized,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
 					},
 				},
 				&corev1.Pod{
@@ -41,7 +58,24 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-controller"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodInitialized,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
 					},
 				},
 				&corev1.Pod{
@@ -51,7 +85,24 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-injector"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodInitialized,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
 					},
 				},
 				&corev1.Pod{
@@ -61,7 +112,24 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-bootstrap"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodInitialized,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
 					},
 				},
 			},
@@ -70,7 +138,7 @@ func TestControlPlane(t *testing.T) {
 			},
 		},
 		{
-			name: "control plane pod is not running",
+			name: "control plane pods are not ready",
 			resources: []runtime.Object{
 				&corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -79,7 +147,24 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-controller"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodFailed, // not running
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodInitialized,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodReady,
+								Status: corev1.ConditionFalse, // not ready
+							},
+						},
 					},
 				},
 				&corev1.Pod{
@@ -89,7 +174,20 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-injector"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.PodInitialized,
+								Status: corev1.ConditionFalse, // init-container pending
+							},
+						},
 					},
 				},
 				&corev1.Pod{
@@ -99,7 +197,16 @@ func TestControlPlane(t *testing.T) {
 						Labels:    map[string]string{constants.AppLabel: "osm-bootstrap"},
 					},
 					Status: corev1.PodStatus{
-						Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{
+							{
+								Type:   corev1.PodScheduled,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   corev1.ContainersReady,
+								Status: corev1.ConditionFalse, // containers not ready
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The pod status `phase` does not accurately convey whether
a pod is ready to serve requests, as intended by the
verifier. The `running` phase only implies:
"The Pod has been bound to a node, and all of the
containers have been created. At least one container
is still running, or is in the process of starting or
restarting."

This change updates the verifier to examine the
more granular pod status conditions.

Part of #4634

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Pod state:
```
NAME                              READY   STATUS     RESTARTS         AGE
osm-bootstrap-688fc78778-r55kr    1/1     Running    1 (4d ago)       11d
osm-controller-5f5f7d95c9-kcjln   0/1     Init:0/1   52 (5m28s ago)   11d
osm-injector-7f4d46649b-b5ms2     0/1     Init:0/1   52 (6m40s ago)   11d
```

Verification:
```
$ osm verify control-plane-health
---------------------------------------------
[+] Context: Verify the health of OSM control plane
Status: Failure
Reason: A verification step failed
Suggestion: Please follow the suggestions listed in the failed steps below to resolve the issue

[++] Context: Verify status of pod for app osm-system/osm-controller
Status: Failure
Reason: Pod not ready: osm-system/osm-controller-5f5f7d95c9-kcjln init-containers pending completion

[++] Context: Verify status of pod for app osm-system/osm-injector
Status: Failure
Reason: Pod not ready: osm-system/osm-injector-7f4d46649b-b5ms2 init-containers pending completion

[++] Context: Verify status of pod for app osm-system/osm-bootstrap
Status: Success

---------------------------------------------
```

Before this change, the verifier would return `Success`.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`