### PR TITLE
feat(certs): get Vault token from Secret

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -176,9 +176,9 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.vault.port | int | `8200` | port to use to connect to Vault |
 | osm.vault.protocol | string | `"http"` | protocol to use to connect to Vault |
 | osm.vault.role | string | `"openservicemesh"` | Vault role to be used by Open Service Mesh |
-| osm.vault.secret | object | `{"key":"token","name":"osm-vault-token"}` | The Kubernetes secret storing the Vault token used in OSM |
-| osm.vault.secret.key | string | `"token"` | The Kubernetes secret key with the value bring the Vault token |
-| osm.vault.secret.name | string | `"osm-vault-token"` | The Kubernetes secret name storing the Vault token used in OSM |
+| osm.vault.secret | object | `{"key":"","name":""}` | The Kubernetes secret storing the Vault token used in OSM |
+| osm.vault.secret.key | string | `""` | The Kubernetes secret key with the value bring the Vault token |
+| osm.vault.secret.name | string | `""` | The Kubernetes secret name storing the Vault token used in OSM |
 | osm.vault.token | string | `""` | token that should be used to connect to Vault |
 | osm.webhookConfigNamePrefix | string | `"osm-webhook"` | Prefix used in name of the webhook configuration resources |
 | smi.validateTrafficTarget | bool | `true` | Enables validation of SMI Traffic Target |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -135,9 +135,9 @@ osm:
     # -- The Kubernetes secret storing the Vault token used in OSM
     secret:
       # -- The Kubernetes secret name storing the Vault token used in OSM
-      name: osm-vault-token
+      name: ""
       # -- The Kubernetes secret key with the value bring the Vault token
-      key: token
+      key: ""
 
   #
   # -- cert-manager.io configuration

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -193,6 +193,7 @@ func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.
 	var err error
 	vaultToken := c.DefaultVaultToken
 	if vaultToken == "" {
+		log.Debug().Msgf("Attempting to get Vault token from secret %s", provider.Token.SecretKeyRef.Name)
 		vaultToken, err = getHashiVaultOSMToken(&provider.Token.SecretKeyRef, c.kubeClient)
 		if err != nil {
 			return nil, "", err
@@ -214,7 +215,7 @@ func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.
 	return vaultClient, id, nil
 }
 
-// getHashiVaultOSMToken returns the Hashi Vault token
+// getHashiVaultOSMToken returns the Hashi Vault token from the secret specified in the provided secret key reference
 func getHashiVaultOSMToken(secretKeyRef *v1alpha2.SecretKeyReferenceSpec, kubeClient kubernetes.Interface) (string, error) {
 	tokenSecret, err := kubeClient.CoreV1().Secrets(secretKeyRef.Namespace).Get(context.TODO(), secretKeyRef.Name, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -223,7 +223,7 @@ func getHashiVaultOSMToken(secretKeyRef *v1alpha2.SecretKeyReferenceSpec, kubeCl
 
 	token, ok := tokenSecret.Data[secretKeyRef.Key]
 	if !ok {
-		return "", fmt.Errorf("failed to get Hashi Vault token with key %s from secret %s/%s", secretKeyRef.Key, secretKeyRef.Namespace, secretKeyRef.Name)
+		return "", fmt.Errorf("key %s not found in Hashi Vault token secret %s/%s", secretKeyRef.Key, secretKeyRef.Namespace, secretKeyRef.Name)
 	}
 
 	return string(token), nil

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -251,8 +251,13 @@ func TestGetHashiVaultOSMToken(t *testing.T) {
 			assert := tassert.New(t)
 
 			token, err := getHashiVaultOSMToken(tc.secretKeyRef, tc.kubeClient)
-			assert.Equal(tc.expectError, token == "")
-			assert.Equal(tc.expectError, err != nil)
+			if tc.expectError {
+				assert.Empty(token)
+				assert.Error(err)
+			} else {
+				assert.NotEmpty(token)
+				assert.NoError(err)
+			}
 		})
 	}
 }

--- a/pkg/certificate/providers/options.go
+++ b/pkg/certificate/providers/options.go
@@ -9,8 +9,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 )
 
-const vaultTokenSecretName = "osm-vault-token" // #nosec G101: Potential hardcoded credentials
-
 // Validate validates the options for Tresor certificate provider
 func (options TresorOptions) Validate() error {
 	if options.SecretName == "" {
@@ -61,7 +59,9 @@ func (options VaultOptions) AsProviderSpec() v1alpha2.ProviderSpec {
 			Host:     options.VaultHost,
 			Token: v1alpha2.VaultTokenSpec{
 				SecretKeyRef: v1alpha2.SecretKeyReferenceSpec{
-					Name: vaultTokenSecretName,
+					Name:      options.VaultTokenSecretName,
+					Namespace: options.VaultTokenSecretNamespace,
+					Key:       options.VaultTokenSecretKey,
 				},
 			},
 			Role: options.VaultRole,

--- a/pkg/certificate/providers/options.go
+++ b/pkg/certificate/providers/options.go
@@ -37,7 +37,7 @@ func (options VaultOptions) Validate() error {
 	}
 
 	if options.VaultToken == "" {
-		return errors.New("VaultToken not specified in Hashi Vault options")
+		log.Warn().Msg("VaultToken is not specified in Hashi Vault options. The token secret reference option must be specified.")
 	}
 
 	if options.VaultRole == "" {

--- a/pkg/certificate/providers/options_test.go
+++ b/pkg/certificate/providers/options_test.go
@@ -98,7 +98,7 @@ func TestValidateVaultOptions(t *testing.T) {
 				VaultToken:    "",
 				VaultRole:     "vault-role",
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			testName: "Empty role",

--- a/pkg/certificate/providers/options_test.go
+++ b/pkg/certificate/providers/options_test.go
@@ -103,16 +103,6 @@ func TestValidateVaultOptions(t *testing.T) {
 		{
 			testName: "Empty role",
 			options: VaultOptions{
-				VaultProtocol: "http",
-				VaultHost:     "vault-host",
-				VaultToken:    "vault-token",
-				VaultRole:     "",
-			},
-			expectErr: true,
-		},
-		{
-			testName: "Empty role",
-			options: VaultOptions{
 				VaultProtocol: "https",
 				VaultHost:     "vault-host",
 				VaultToken:    "vault-token",

--- a/pkg/certificate/providers/types.go
+++ b/pkg/certificate/providers/types.go
@@ -51,11 +51,14 @@ type TresorOptions struct {
 
 // VaultOptions is a type that specifies 'Hashicorp Vault' certificate provider options
 type VaultOptions struct {
-	VaultProtocol string
-	VaultHost     string
-	VaultToken    string // TODO(#4745): Remove after deprecating the osm.vault.token option. Replace with VaultTokenSecretName
-	VaultRole     string
-	VaultPort     int
+	VaultProtocol             string
+	VaultHost                 string
+	VaultToken                string // TODO(#4745): Remove after deprecating the osm.vault.token option. Replace with VaultTokenSecretName
+	VaultRole                 string
+	VaultPort                 int
+	VaultTokenSecretNamespace string
+	VaultTokenSecretName      string
+	VaultTokenSecretKey       string
 }
 
 // CertManagerOptions is a type that specifies 'cert-manager.io' certificate provider options

--- a/pkg/certificate/providers/types.go
+++ b/pkg/certificate/providers/types.go
@@ -8,7 +8,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/logger"
 )
+
+var log = logger.New("certificate/provider")
 
 // Kind specifies the certificate provider kind
 type Kind string


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

If the Vault token option is not set, the token will be obtained
from the secret referenced in the SecretKeyRef. Currently, the
Vault token must still be set as an option if Vault is the cert
provider. In a subsequent change, all cert provider flags will be
removed from the osm-bootstrap, osm-controller, and osm-injector.
These values will instead be obtained from the MRC created by the
osm-bootstrap and populated using the preset-mesh-root-certificate.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |
| Certificate Management     | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No