### PR TITLE
Backport: Add root path ingress e2e test (#4756)

### DIFF
--- a/tests/e2e/e2e_ingressbackend.go
+++ b/tests/e2e/e2e_ingressbackend.go
@@ -79,6 +79,19 @@ func testIngressBackend() {
 						IngressRuleValue: networkingv1.IngressRuleValue{
 							HTTP: &networkingv1.HTTPIngressRuleValue{
 								Paths: []networkingv1.HTTPIngressPath{
+									// Adding root path due to nginx ingress issue: https://github.com/kubernetes/ingress-nginx/issues/8518
+									{
+										Path:     "/",
+										PathType: (*networkingv1.PathType)(pointer.StringPtr(string(networkingv1.PathTypeImplementationSpecific))),
+										Backend: networkingv1.IngressBackend{
+											Service: &networkingv1.IngressServiceBackend{
+												Name: svcDef.Name,
+												Port: networkingv1.ServiceBackendPort{
+													Number: serverPort,
+												},
+											},
+										},
+									},
 									{
 										Path:     "/status/200",
 										PathType: (*networkingv1.PathType)(pointer.StringPtr(string(networkingv1.PathTypeImplementationSpecific))),


### PR DESCRIPTION
Addresses an issue where an ingress without a root path does
not work for some non-kind distributions like AKS:
kubernetes/ingress-nginx#8518.

Adding a wildcard path in addition to the status/200 path resolves
the issue.

Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Cherry pick commit to add wildcard path to ingress in ingress backend e2e. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [X] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?