### PR TITLE
demo: Add scripts for Kafka demo

### DIFF
--- a/demo/deploy-kafka.sh
+++ b/demo/deploy-kafka.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -aueo pipefail
+
+# shellcheck disable=SC1091
+source .env
+DEPLOY_ON_OPENSHIFT="${DEPLOY_ON_OPENSHIFT:-false}"
+USE_PRIVATE_REGISTRY="${USE_PRIVATE_REGISTRY:-false}"
+MESH_NAME="${MESH_NAME:-osm}"
+
+kubectl create ns kafka 
+
+bin/osm namespace add --mesh-name "$MESH_NAME" kafka
+
+bin/osm metrics enable --namespace kafka
+
+helm install kafka bitnami/kafka --set replicaCount=3 --set zookeeper.enabled=false --set zookeeperChrootPath='/kafka-root' --set serviceAccount.create=true --set serviceAccount.name=kafka --namespace kafka --set "externalZookeeper.servers={kafka-zookeeper-0.kafka-zookeeper-headless.zookeeper.svc.cluster.local,kafka-zookeeper-1.kafka-zookeeper-headless.zookeeper.svc.cluster.local,kafka-zookeeper-2.kafka-zookeeper-headless.zookeeper.svc.cluster.local}"
+
+if [ "$DEPLOY_ON_OPENSHIFT" = true ] ; then
+    oc adm policy add-scc-to-user privileged -z "kafka" -n "kafka"
+    if [ "$USE_PRIVATE_REGISTRY" = true ]; then
+        oc secrets link "kafka" "$CTR_REGISTRY_CREDS_NAME" --for=pull -n "kafka"
+    fi
+fi
+
+kubectl apply -nkafka -f - <<EOF
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  matches:
+    ports:
+    - 9092
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: kafka-internal
+  namespace: kafka
+spec:
+  matches:
+    ports:
+    - 9092
+    - 9093
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  destination:
+    kind: ServiceAccount
+    name: kafka
+    namespace: kafka
+  rules:
+  - kind: TCPRoute
+    name: kafka
+  sources:
+  - kind: ServiceAccount
+    name: default
+    namespace: kafka
+---
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
+metadata:
+  name: kafka-internal
+  namespace: kafka
+spec:
+  destination:
+    kind: ServiceAccount
+    name: kafka
+    namespace: kafka
+  rules:
+  - kind: TCPRoute
+    name: kafka-internal
+  sources:
+  - kind: ServiceAccount
+    name: kafka
+    namespace: kafka
+EOF
+
+# Use these commands to test out Kafka
+# kubectl run kafka-client --restart='Never' --image docker.io/bitnami/kafka:3.1.0-debian-10-r60 --namespace kafka --command -- sleep infinity
+# kubectl exec --tty -i kafka-client --namespace kafka -- bash
+# kafka-console-producer.sh --broker-list kafka-0.kafka-headless.kafka.svc.cluster.local:9092 --topic test
+# kafka-console-consumer.sh --bootstrap-server kafka.kafka.svc.cluster.local:9092 --topic test --from-beginning

--- a/demo/deploy-zookeeper.sh
+++ b/demo/deploy-zookeeper.sh
@@ -25,6 +25,30 @@ if [ "$DEPLOY_ON_OPENSHIFT" = true ] ; then
 fi
 
 kubectl apply -nzookeeper -f - <<EOF
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: zookeeper
+  namespace: zookeeper
+spec:
+  matches:
+    ports:
+    - 2181
+    - 3181
+---
+apiVersion: specs.smi-spec.io/v1alpha4
+kind: TCPRoute
+metadata:
+  name: zookeeper-internal
+  namespace: zookeeper
+spec:
+  matches:
+    ports:
+    - 2181
+    - 3181
+    - 2888
+    - 3888
+---
 kind: TrafficTarget
 apiVersion: access.smi-spec.io/v1alpha3
 metadata:
@@ -40,21 +64,25 @@ spec:
     name: zookeeper
   sources:
   - kind: ServiceAccount
-    name: zookeeper
-    namespace: zookeeper
+    name: kafka
+    namespace: kafka
 ---
-apiVersion: specs.smi-spec.io/v1alpha4
-kind: TCPRoute
+kind: TrafficTarget
+apiVersion: access.smi-spec.io/v1alpha3
 metadata:
-  name: zookeeper
+  name: zookeeper-internal
   namespace: zookeeper
 spec:
-  matches:
-    ports:
-    - 2181
-    - 3181
-    - 2888
-    - 3888
-
+  destination:
+    kind: ServiceAccount
+    name: zookeeper
+    namespace: zookeeper
+  rules:
+  - kind: TCPRoute
+    name: zookeeper-internal
+  sources:
+  - kind: ServiceAccount
+    name: zookeeper
+    namespace: zookeeper
 EOF
 


### PR DESCRIPTION
Adding Kafka to our existing Zookeeper demo script makes the
demo more relevant to our customers as Zookeeper is rarely used
as a standalone datastore. This allows us to integrate Kafka into
our demo if we wish (e.g. send a message every time a book is purchased)

Signed-off-by: Keith Mattix II <keithmattix2@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
N/A
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Demo                       | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? 