### PR TITLE
docs(README): move support to a community support file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ OSM is under active development and is ready for production workloads.
 
 ### Support
 
-[Please search open issues on GitHub](https://github.com/openservicemesh/osm/issues), and if your issue isn't already represented please [open a new one](https://github.com/openservicemesh/osm/issues/new/choose). The OSM project maintainers will respond to the best of their abilities.
+See [SUPPORT](SUPPORT)
 
 ### SMI Specification support
 

--- a/SUPPORT
+++ b/SUPPORT
@@ -1,0 +1,3 @@
+# Support
+
+[Please search open issues on GitHub](https://github.com/openservicemesh/osm/issues), and if your issue isn't already represented please [open a new one](https://github.com/openservicemesh/osm/issues/new/choose). The OSM project maintainers will respond to the best of their abilities.


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>



**Description**: relocated support content to SUPPORT file per [Github docs](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/adding-support-resources-to-your-project).

**Testing done**: Change made to markdown file so verified render looks correct

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ x ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? NO
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? NO

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A