### PR TITLE
Add openshift SCC zookeeper

### DIFF
--- a/tests/e2e/e2e_statefulsets_test.go
+++ b/tests/e2e/e2e_statefulsets_test.go
@@ -54,6 +54,11 @@ var _ = OSMDescribe("Test traffic among Statefulset members",
 				chart, err := loader.Load(chartPath)
 				Expect(err).NotTo(HaveOccurred())
 
+				if Td.DeployOnOpenShift {
+					err = Td.AddOpenShiftSCC("privileged", saName, testNS)
+					Expect(err).NotTo(HaveOccurred())
+				}
+
 				// Install zookeeper
 				_, err = install.Run(chart, map[string]interface{}{
 					"replicaCount": replicaCount,

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1554,8 +1554,8 @@ func (td *OsmTestData) GrabLogs() error {
 	return nil
 }
 
-// addOpenShiftSCC adds the specified SecurityContextConstraint to the given service account
-func (td *OsmTestData) addOpenShiftSCC(scc, serviceAccount, namespace string) error {
+// AddOpenShiftSCC adds the specified SecurityContextConstraint to the given service account
+func (td *OsmTestData) AddOpenShiftSCC(scc, serviceAccount, namespace string) error {
 	if !td.DeployOnOpenShift {
 		return errors.Errorf("Tests are not configured for OpenShift. Try again with -deployOnOpenShift=true")
 	}

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -79,7 +79,7 @@ func (td *OsmTestData) CreateServiceAccount(ns string, svcAccount *corev1.Servic
 		return nil, err
 	}
 	if Td.DeployOnOpenShift {
-		err = Td.addOpenShiftSCC("privileged", svcAc.Name, svcAc.Namespace)
+		err = Td.AddOpenShiftSCC("privileged", svcAc.Name, svcAc.Namespace)
 		return svcAc, err
 	}
 	return svcAc, nil


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add SecuityContextConstraint for zookeeper SA in e2e_statefulsets_test for OpenShift. 

Resolves https://github.com/openservicemesh/osm/issues/4784

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Tested locally on OpenShift cluster. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [X] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?