### PR TITLE
feat(retry): Add validating webhook for retry policy

### DIFF
--- a/cmd/osm-bootstrap/crds/policy_retry.yaml
+++ b/cmd/osm-bootstrap/crds/policy_retry.yaml
@@ -86,9 +86,6 @@ spec:
                   type: object
                   required:
                     - retryOn
-                    - perTryTimeout
-                    - numRetries
-                    - retryBackoffBaseInterval
                   properties:
                     retryOn:
                       description: Policies to retry on (delimited by commas).

--- a/pkg/apis/policy/v1alpha1/retry.go
+++ b/pkg/apis/policy/v1alpha1/retry.go
@@ -54,15 +54,15 @@ type RetryPolicySpec struct {
 
 	// PerTryTimeout defines the time allowed for a retry before it's considered a failed attempt.
 	// +optional
-	PerTryTimeout *metav1.Duration `json:"perTryTimeout"`
+	PerTryTimeout *metav1.Duration `json:"perTryTimeout,omitempty"`
 
 	// NumRetries defines the max number of retries to attempt.
 	// +optional
-	NumRetries *uint32 `json:"numRetries"`
+	NumRetries *uint32 `json:"numRetries,omitempty"`
 
 	// RetryBackoffBaseInterval defines the base interval for exponential retry backoff.
 	// +optional
-	RetryBackoffBaseInterval *metav1.Duration `json:"retryBackoffBaseInterval"`
+	RetryBackoffBaseInterval *metav1.Duration `json:"retryBackoffBaseInterval,omitempty"`
 }
 
 // RetryList defines the list of Retry objects.

--- a/pkg/catalog/retry.go
+++ b/pkg/catalog/retry.go
@@ -24,10 +24,6 @@ func (mc *MeshCatalog) getRetryPolicy(downstreamIdentity identity.ServiceIdentit
 
 	for _, retryCRD := range retryPolicies {
 		for _, dest := range retryCRD.Spec.Destinations {
-			if dest.Kind != "Service" {
-				log.Error().Msgf("Retry policy destinations must be a service: %s is a %s", dest, dest.Kind)
-				continue
-			}
 			destMeshSvc := service.MeshService{Name: dest.Name, Namespace: dest.Namespace}
 			// we want all statefulset replicas to have the same retry policy regardless of how they're accessed
 			// for the default use-case, this is equivalent to a name + namespace equality check

--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -287,20 +287,16 @@ func buildWeightedCluster(weightedClusters mapset.Set) *xds_route.WeightedCluste
 	return &wc
 }
 
-// TODO: Add validation webhook for retry policy
-// Remove checks when validation webhook is implemented
 func buildRetryPolicy(retry *v1alpha1.RetryPolicySpec) *xds_route.RetryPolicy {
 	if retry == nil {
 		return nil
 	}
 
 	rp := &xds_route.RetryPolicy{}
-
 	rp.RetryOn = retry.RetryOn
+
 	// NumRetries default is set to 1
-	if retry.NumRetries != nil {
-		rp.NumRetries = wrapperspb.UInt32(*retry.NumRetries)
-	}
+	rp.NumRetries = wrapperspb.UInt32(*retry.NumRetries)
 
 	// PerTryTimeout default uses the global route timeout
 	// Disabling route config timeout does not affect perTryTimeout
@@ -309,10 +305,8 @@ func buildRetryPolicy(retry *v1alpha1.RetryPolicySpec) *xds_route.RetryPolicy {
 	}
 
 	// RetryBackOff default base interval is 25 ms
-	if retry.RetryBackoffBaseInterval != nil {
-		rp.RetryBackOff = &xds_route.RetryPolicy_RetryBackOff{
-			BaseInterval: durationpb.New(retry.RetryBackoffBaseInterval.Duration),
-		}
+	rp.RetryBackOff = &xds_route.RetryPolicy_RetryBackOff{
+		BaseInterval: durationpb.New(retry.RetryBackoffBaseInterval.Duration),
 	}
 
 	return rp

--- a/pkg/policy/client.go
+++ b/pkg/policy/client.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	// kindSvcAccount is the ServiceAccount kind
-	kindSvcAccount = "ServiceAccount"
+	// KindSvcAccount is the ServiceAccount kind
+	KindSvcAccount = "ServiceAccount"
 )
 
 // NewPolicyController returns a policy.Controller interface related to functionality provided by the resources in the policy.openservicemesh.io API group
@@ -140,7 +140,7 @@ func (c client) ListEgressPoliciesForSourceIdentity(source identity.K8sServiceAc
 		}
 
 		for _, sourceSpec := range egressPolicy.Spec.Sources {
-			if sourceSpec.Kind == kindSvcAccount && sourceSpec.Name == source.Name && sourceSpec.Namespace == source.Namespace {
+			if sourceSpec.Kind == KindSvcAccount && sourceSpec.Name == source.Name && sourceSpec.Namespace == source.Namespace {
 				policies = append(policies, egressPolicy)
 			}
 		}
@@ -178,7 +178,8 @@ func (c client) ListRetryPolicies(source identity.K8sServiceAccount) []*policyV1
 
 	for _, retryInterface := range c.caches.retry.List() {
 		retry := retryInterface.(*policyV1alpha1.Retry)
-		if retry.Spec.Source.Kind == kindSvcAccount && retry.Spec.Source.Name == source.Name && retry.Spec.Source.Namespace == source.Namespace {
+
+		if retry.Spec.Source.Name == source.Name && retry.Spec.Source.Namespace == source.Namespace {
 			retries = append(retries, retry)
 		}
 	}

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -34,7 +34,7 @@ func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert *certi
 			Rule: admissionregv1.Rule{
 				APIGroups:   []string{"policy.openservicemesh.io"},
 				APIVersions: []string{"v1alpha1"},
-				Resources:   []string{"ingressbackends", "egresses"},
+				Resources:   []string{"ingressbackends", "egresses", "retries"},
 			},
 		},
 	}

--- a/pkg/validator/patch_test.go
+++ b/pkg/validator/patch_test.go
@@ -20,7 +20,7 @@ var (
 		Rule: admissionregv1.Rule{
 			APIGroups:   []string{"policy.openservicemesh.io"},
 			APIVersions: []string{"v1alpha1"},
-			Resources:   []string{"ingressbackends", "egresses"},
+			Resources:   []string{"ingressbackends", "egresses", "retries"},
 		},
 	}
 

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -52,6 +52,7 @@ func NewValidatingWebhook(webhookConfigName, osmNamespace, osmVersion, meshName 
 	v := &validatingWebhookServer{
 		validators: map[string]validateFunc{
 			policyv1alpha1.SchemeGroupVersion.WithKind("IngressBackend").String():         kv.ingressBackendValidator,
+			policyv1alpha1.SchemeGroupVersion.WithKind("Retry").String():                  retryValidator,
 			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():                 egressValidator,
 			policyv1alpha1.SchemeGroupVersion.WithKind("UpstreamTrafficSetting").String(): kv.upstreamTrafficSettingValidator,
 			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():               trafficTargetValidator,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds validating webhook for retry policy and sets PerTryTimeout, RetryBackoffBaseInterval,
 and NumRetries to optional fields.
Resolves #4778

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>
<!--
Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.
-->

**Testing done**:
Added unit test for retryValidator function
<!--
Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?