### PR TITLE
Set (empty) trust domain on listener builder

### DIFF
--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -56,6 +56,13 @@ func (m *Manager) Start(checkInterval time.Duration, stop <-chan struct{}) {
 	}()
 }
 
+// GetTrustDomain returns the trust domain from the configured signingkey issuer.
+// Note that the CRD uses a default, so this value will always be set.
+func (m *Manager) GetTrustDomain() string {
+	// TODO(4754): implement
+	return ""
+}
+
 func (m *Manager) checkAndRotate() {
 	// NOTE: checkAndRotate can reintroduce a certificate that has been released, thereby creating an unbounded cache.
 	// A certificate can also have been rotated already, leaving the list of issued certs stale, and we re-rotate.

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -72,7 +72,8 @@ type Issuer interface {
 
 type issuer struct {
 	Issuer
-	ID string
+	ID          string
+	TrustDomain string
 	// memoized once the first certificate is issued
 	CertificateAuthority pem.RootCertificate
 }

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -406,7 +406,7 @@ func TestGetOutboundFilterChainMatchForService(t *testing.T) {
 	mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 	mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
 
-	lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceIdentity, mockConfigurator, nil)
+	lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceIdentity, mockConfigurator, nil, "cluster.local")
 
 	testCases := []struct {
 		name                     string
@@ -581,7 +581,7 @@ func TestGetOutboundTCPFilter(t *testing.T) {
 			mockCatalog := catalog.NewMockMeshCataloger(mockCtrl)
 			mockConfigurator := configurator.NewMockConfigurator(mockCtrl)
 
-			lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceIdentity, mockConfigurator, nil)
+			lb := newListenerBuilder(mockCatalog, tests.BookbuyerServiceIdentity, mockConfigurator, nil, "cluster.local")
 			filter, err := lb.getOutboundTCPFilter(tc.trafficMatch)
 
 			assert := tassert.New(t)

--- a/pkg/envoy/lds/listener_test.go
+++ b/pkg/envoy/lds/listener_test.go
@@ -196,7 +196,7 @@ func TestNewOutboundListener(t *testing.T) {
 		EnableEgressPolicy: true,
 	}).Times(1)
 
-	lb := newListenerBuilder(meshCatalog, identity, cfg, nil)
+	lb := newListenerBuilder(meshCatalog, identity, cfg, nil, "cluster.local")
 
 	assert := tassert.New(t)
 	listener, err := lb.newOutboundListener()

--- a/pkg/envoy/lds/rbac_test.go
+++ b/pkg/envoy/lds/rbac_test.go
@@ -89,7 +89,7 @@ func TestBuildRBACPolicyFromTrafficTarget(t *testing.T) {
 			assert := tassert.New(t)
 
 			// Test the RBAC policies
-			policy := buildRBACPolicyFromTrafficTarget(tc.trafficTarget)
+			policy := buildRBACPolicyFromTrafficTarget(tc.trafficTarget, "cluster.local")
 
 			assert.Equal(tc.expectedPolicy, policy)
 		})

--- a/pkg/envoy/lds/types.go
+++ b/pkg/envoy/lds/types.go
@@ -19,4 +19,5 @@ type listenerBuilder struct {
 	meshCatalog     catalog.MeshCataloger
 	cfg             configurator.Configurator
 	statsHeaders    map[string]string
+	trustDomain     string
 }

--- a/pkg/envoy/rbac/policy.go
+++ b/pkg/envoy/rbac/policy.go
@@ -3,17 +3,20 @@ package rbac
 import (
 	xds_rbac "github.com/envoyproxy/go-control-plane/envoy/config/rbac/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+
+	"github.com/openservicemesh/osm/pkg/identity"
 )
 
 // PolicyBuilder is a utility for constructing *xds_rbac.Policy's
 type PolicyBuilder struct {
 	allowedPorts       []uint32
-	allowedPrincipals  []string
+	allowedIdentities  []identity.ServiceIdentity
 	allowAllPrincipals bool
 
 	// All permissions are applied using OR semantics by default. If applyPermissionsAsAnd is set to true, then
 	// permissions are applied using AND semantics.
 	applyPermissionsAsAnd bool
+	trustDomain           string
 }
 
 // Build constructs an RBAC policy for the policy object on which this method is called
@@ -21,9 +24,9 @@ func (p *PolicyBuilder) Build() *xds_rbac.Policy {
 	policy := &xds_rbac.Policy{}
 
 	// Each RuleList follows OR semantics with other RuleList in the list of RuleList
-	prinicipals := make([]*xds_rbac.Principal, 0, len(p.allowedPrincipals))
-	for _, principal := range p.allowedPrincipals {
-		prinicipals = append(prinicipals, GetAuthenticatedPrincipal(principal))
+	prinicipals := make([]*xds_rbac.Principal, 0, len(p.allowedIdentities))
+	for _, svcIdentity := range p.allowedIdentities {
+		prinicipals = append(prinicipals, GetAuthenticatedPrincipal(svcIdentity.AsPrincipal(p.trustDomain)))
 	}
 	if len(prinicipals) == 0 {
 		// No principals specified for this policy, allow ANY
@@ -62,21 +65,21 @@ func (p *PolicyBuilder) UseANDForPermissions(val bool) {
 	p.applyPermissionsAsAnd = val
 }
 
-// AddPrincipal adds a principal to the list of allowed principals
-func (p *PolicyBuilder) AddPrincipal(principal string) {
+// AddIdentity adds an identity, later to be converted to a principal, to the list of allowed identities.
+func (p *PolicyBuilder) AddIdentity(svcIdentity identity.ServiceIdentity) {
 	// We need this extra defense in depth because it is currently possible to configure a wildcard principal
 	// in addition to specific principals. Future changes may look to avoid this.
-	if principal == "*" {
-		p.AllowAnyPrincipal()
+	if svcIdentity.IsWildcard() {
+		p.AllowAnyIdentity()
 	}
 	if !p.allowAllPrincipals {
-		p.allowedPrincipals = append(p.allowedPrincipals, principal)
+		p.allowedIdentities = append(p.allowedIdentities, svcIdentity)
 	}
 }
 
-// AllowAnyPrincipal allows any principal to access the permissions.
-func (p *PolicyBuilder) AllowAnyPrincipal() {
-	p.allowedPrincipals = nil
+// AllowAnyIdentity allows any principal to access the permissions.
+func (p *PolicyBuilder) AllowAnyIdentity() {
+	p.allowedIdentities = nil
 	p.allowAllPrincipals = true
 }
 
@@ -84,6 +87,11 @@ func (p *PolicyBuilder) AllowAnyPrincipal() {
 func (p *PolicyBuilder) AddAllowedDestinationPort(port uint16) {
 	// envoy uses uint32 for ports.
 	p.allowedPorts = append(p.allowedPorts, uint32(port))
+}
+
+// SetTrustDomain sets the trust domain for the policy, which is used when converting a ServiceIdentity to a Principal.
+func (p *PolicyBuilder) SetTrustDomain(td string) {
+	p.trustDomain = td
 }
 
 // GetAuthenticatedPrincipal returns an authenticated RBAC principal object for the given principal

--- a/pkg/envoy/rds/route/rbac.go
+++ b/pkg/envoy/rds/route/rbac.go
@@ -30,7 +30,7 @@ func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule) (map[string]*any.An
 
 	// Create the list of principals for this policy
 	for downstream := range rule.AllowedServiceIdentities.Iter() {
-		pb.AddPrincipal(downstream.(identity.ServiceIdentity).String())
+		pb.AddIdentity(downstream.(identity.ServiceIdentity))
 	}
 
 	// A single RBAC policy per route


### PR DESCRIPTION
This PR has 2 main changes:

1. I set the policy builder's AddPrincipal method to AddIdentity. Following my own advice, the builders should accept inputs in terms of OSM concepts, and return envoy configs. A principal is an envoy concept, and so should be constructed internally, and not leak into its parameters.
2. I set the trust domain (currently an empty string) on the listenerbuilder so that it is used on the policy builder.

The final PR will be to simultaneously remove the trustDomain from service.Identity, while populating the trust domain within the cert manager.