### PR TITLE
rate-limiting: plumb config into inbound policies

### DIFF
--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -6,10 +6,13 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	access "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/policy"
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -44,6 +47,8 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 
 	// Build configurations per upstream service
 	for _, upstreamSvc := range allUpstreamServices {
+		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop
+
 		// ---
 		// Create local cluster configs for this upstram service
 		clusterConfigForSvc := &trafficpolicy.MeshClusterConfig{
@@ -64,6 +69,13 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 			DestinationPort:     int(upstreamSvc.TargetPort),
 			DestinationProtocol: upstreamSvc.Protocol,
 		}
+
+		upstreamTrafficSetting := mc.policyController.GetUpstreamTrafficSetting(
+			policy.UpstreamTrafficSettingGetOpt{MeshService: &upstreamSvc})
+		if upstreamTrafficSetting != nil {
+			trafficMatchForUpstreamSvc.RateLimit = upstreamTrafficSetting.Spec.RateLimit
+		}
+
 		trafficMatches = append(trafficMatches, trafficMatchForUpstreamSvc)
 
 		// Build the HTTP route configs for this service and port combination.
@@ -77,7 +89,7 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 		// The routes are derived from SMI TrafficTarget and TrafficSplit policies in SMI mode,
 		// and are wildcarded in permissive mode. The downstreams that can access this upstream
 		// on the configured routes is also determined based on the traffic policy mode.
-		inboundTrafficPolicies := mc.getInboundTrafficPoliciesForUpstream(upstreamSvc, permissiveMode, trafficTargets)
+		inboundTrafficPolicies := mc.getInboundTrafficPoliciesForUpstream(upstreamSvc, permissiveMode, trafficTargets, upstreamTrafficSetting)
 		routeConfigPerPort[int(upstreamSvc.TargetPort)] = append(routeConfigPerPort[int(upstreamSvc.TargetPort)], inboundTrafficPolicies)
 	}
 
@@ -88,13 +100,14 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 	}
 }
 
-func (mc *MeshCatalog) getInboundTrafficPoliciesForUpstream(upstreamSvc service.MeshService, permissiveMode bool, trafficTargets []*access.TrafficTarget) *trafficpolicy.InboundTrafficPolicy {
+func (mc *MeshCatalog) getInboundTrafficPoliciesForUpstream(upstreamSvc service.MeshService, permissiveMode bool,
+	trafficTargets []*access.TrafficTarget, upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting) *trafficpolicy.InboundTrafficPolicy {
 	var inboundPolicyForUpstreamSvc *trafficpolicy.InboundTrafficPolicy
 
 	if permissiveMode {
 		// Add a wildcard HTTP route that allows any downstream client to access the upstream service
 		hostnames := k8s.GetHostnamesForService(upstreamSvc, true /* local namespace FQDN should always be allowed for inbound routes*/)
-		inboundPolicyForUpstreamSvc = trafficpolicy.NewInboundTrafficPolicy(upstreamSvc.FQDN(), hostnames)
+		inboundPolicyForUpstreamSvc = trafficpolicy.NewInboundTrafficPolicy(upstreamSvc.FQDN(), hostnames, upstreamTrafficSetting)
 		localCluster := service.WeightedCluster{
 			ClusterName: service.ClusterName(upstreamSvc.EnvoyLocalClusterName()),
 			Weight:      constants.ClusterWeightAcceptAll,
@@ -102,21 +115,23 @@ func (mc *MeshCatalog) getInboundTrafficPoliciesForUpstream(upstreamSvc service.
 		// Only a single rule for permissive mode.
 		inboundPolicyForUpstreamSvc.Rules = []*trafficpolicy.Rule{
 			{
-				Route:                    *trafficpolicy.NewRouteWeightedCluster(trafficpolicy.WildCardRouteMatch, []service.WeightedCluster{localCluster}),
+				Route:                    *trafficpolicy.NewRouteWeightedCluster(trafficpolicy.WildCardRouteMatch, []service.WeightedCluster{localCluster}, upstreamTrafficSetting),
 				AllowedServiceIdentities: mapset.NewSetWith(identity.WildcardServiceIdentity),
 			},
 		}
 	} else {
 		// Build the HTTP routes from SMI TrafficTarget and HTTPRouteGroup configurations
-		inboundPolicyForUpstreamSvc = mc.buildInboundHTTPPolicyFromTrafficTarget(upstreamSvc, trafficTargets)
+		inboundPolicyForUpstreamSvc = mc.buildInboundHTTPPolicyFromTrafficTarget(upstreamSvc, trafficTargets, upstreamTrafficSetting)
 	}
 
 	return inboundPolicyForUpstreamSvc
 }
 
-func (mc *MeshCatalog) buildInboundHTTPPolicyFromTrafficTarget(upstreamSvc service.MeshService, trafficTargets []*access.TrafficTarget) *trafficpolicy.InboundTrafficPolicy {
+func (mc *MeshCatalog) buildInboundHTTPPolicyFromTrafficTarget(upstreamSvc service.MeshService, trafficTargets []*access.TrafficTarget,
+	upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting) *trafficpolicy.InboundTrafficPolicy {
 	hostnames := k8s.GetHostnamesForService(upstreamSvc, true /* local namespace FQDN should always be allowed for inbound routes*/)
-	inboundPolicy := trafficpolicy.NewInboundTrafficPolicy(upstreamSvc.FQDN(), hostnames)
+	inboundPolicy := trafficpolicy.NewInboundTrafficPolicy(upstreamSvc.FQDN(), hostnames, upstreamTrafficSetting)
+
 	localCluster := service.WeightedCluster{
 		ClusterName: service.ClusterName(upstreamSvc.EnvoyLocalClusterName()),
 		Weight:      constants.ClusterWeightAcceptAll,
@@ -125,7 +140,7 @@ func (mc *MeshCatalog) buildInboundHTTPPolicyFromTrafficTarget(upstreamSvc servi
 	var routingRules []*trafficpolicy.Rule
 	// From each TrafficTarget and HTTPRouteGroup configuration associated with this service, build routes for it.
 	for _, trafficTarget := range trafficTargets {
-		rules := mc.getRoutingRulesFromTrafficTarget(*trafficTarget, localCluster)
+		rules := mc.getRoutingRulesFromTrafficTarget(*trafficTarget, localCluster, upstreamTrafficSetting)
 		// Multiple TrafficTarget objects can reference the same route, in which case such routes
 		// need to be merged to create a single route that includes all the downstream client identities
 		// this route is authorized for.
@@ -136,7 +151,8 @@ func (mc *MeshCatalog) buildInboundHTTPPolicyFromTrafficTarget(upstreamSvc servi
 	return inboundPolicy
 }
 
-func (mc *MeshCatalog) getRoutingRulesFromTrafficTarget(trafficTarget access.TrafficTarget, routingCluster service.WeightedCluster) []*trafficpolicy.Rule {
+func (mc *MeshCatalog) getRoutingRulesFromTrafficTarget(trafficTarget access.TrafficTarget, routingCluster service.WeightedCluster,
+	upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting) []*trafficpolicy.Rule {
 	// Compute the HTTP route matches associated with the given TrafficTarget object
 	httpRouteMatches, err := mc.routesFromRules(trafficTarget.Spec.Rules, trafficTarget.Namespace)
 	if err != nil {
@@ -155,7 +171,7 @@ func (mc *MeshCatalog) getRoutingRulesFromTrafficTarget(trafficTarget access.Tra
 	var routingRules []*trafficpolicy.Rule
 	for _, httpRouteMatch := range httpRouteMatches {
 		rule := &trafficpolicy.Rule{
-			Route:                    *trafficpolicy.NewRouteWeightedCluster(httpRouteMatch, []service.WeightedCluster{routingCluster}),
+			Route:                    *trafficpolicy.NewRouteWeightedCluster(httpRouteMatch, []service.WeightedCluster{routingCluster}, upstreamTrafficSetting),
 			AllowedServiceIdentities: allowedDownstreamIdentities,
 		}
 		routingRules = append(routingRules, rule)

--- a/pkg/trafficpolicy/trafficpolicy_test.go
+++ b/pkg/trafficpolicy/trafficpolicy_test.go
@@ -8,7 +8,8 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -71,7 +72,7 @@ func TestAddRoute(t *testing.T) {
 		expectedRoutes        []*RouteWeightedClusters
 		givenRouteMatch       HTTPRouteMatch
 		givenWeightedClusters []service.WeightedCluster
-		givenRetryPolicy      *v1alpha1.RetryPolicySpec
+		givenRetryPolicy      *policyv1alpha1.RetryPolicySpec
 		expectedErr           bool
 	}{
 		{
@@ -79,12 +80,12 @@ func TestAddRoute(t *testing.T) {
 			existingRoutes:        []*RouteWeightedClusters{},
 			givenRouteMatch:       testHTTPRouteMatch,
 			givenWeightedClusters: []service.WeightedCluster{testWeightedCluster},
-			givenRetryPolicy:      &v1alpha1.RetryPolicySpec{},
+			givenRetryPolicy:      &policyv1alpha1.RetryPolicySpec{},
 			expectedRoutes: []*RouteWeightedClusters{
 				{
 					HTTPRouteMatch:   testHTTPRouteMatch,
 					WeightedClusters: mapset.NewSet(testWeightedCluster),
-					RetryPolicy:      &v1alpha1.RetryPolicySpec{},
+					RetryPolicy:      &policyv1alpha1.RetryPolicySpec{},
 				},
 			},
 			expectedErr: false,
@@ -99,7 +100,7 @@ func TestAddRoute(t *testing.T) {
 			},
 			givenRouteMatch:       testHTTPRouteMatch2,
 			givenWeightedClusters: []service.WeightedCluster{testWeightedCluster2},
-			givenRetryPolicy: &v1alpha1.RetryPolicySpec{
+			givenRetryPolicy: &policyv1alpha1.RetryPolicySpec{
 				RetryOn: "5xx",
 			},
 			expectedRoutes: []*RouteWeightedClusters{
@@ -110,7 +111,7 @@ func TestAddRoute(t *testing.T) {
 				{
 					HTTPRouteMatch:   testHTTPRouteMatch2,
 					WeightedClusters: mapset.NewSet(testWeightedCluster2),
-					RetryPolicy: &v1alpha1.RetryPolicySpec{
+					RetryPolicy: &policyv1alpha1.RetryPolicySpec{
 						RetryOn: "5xx",
 					},
 				},
@@ -127,7 +128,7 @@ func TestAddRoute(t *testing.T) {
 			},
 			givenRouteMatch:       testHTTPRouteMatch2,
 			givenWeightedClusters: []service.WeightedCluster{testWeightedCluster, testWeightedCluster2},
-			givenRetryPolicy: &v1alpha1.RetryPolicySpec{
+			givenRetryPolicy: &policyv1alpha1.RetryPolicySpec{
 				RetryOn:       "5xx",
 				PerTryTimeout: &thresholdTimeoutDuration,
 			},
@@ -139,7 +140,7 @@ func TestAddRoute(t *testing.T) {
 				{
 					HTTPRouteMatch:   testHTTPRouteMatch2,
 					WeightedClusters: mapset.NewSet(testWeightedCluster, testWeightedCluster2),
-					RetryPolicy: &v1alpha1.RetryPolicySpec{
+					RetryPolicy: &policyv1alpha1.RetryPolicySpec{
 						RetryOn:       "5xx",
 						PerTryTimeout: &thresholdTimeoutDuration,
 					},
@@ -157,7 +158,7 @@ func TestAddRoute(t *testing.T) {
 			},
 			givenRouteMatch:       testHTTPRouteMatch,
 			givenWeightedClusters: []service.WeightedCluster{testWeightedCluster},
-			givenRetryPolicy: &v1alpha1.RetryPolicySpec{
+			givenRetryPolicy: &policyv1alpha1.RetryPolicySpec{
 				RetryOn:       "5xx",
 				NumRetries:    &thresholdUintVal,
 				PerTryTimeout: &thresholdTimeoutDuration,
@@ -166,7 +167,7 @@ func TestAddRoute(t *testing.T) {
 				{
 					HTTPRouteMatch:   testHTTPRouteMatch,
 					WeightedClusters: mapset.NewSet(testWeightedCluster),
-					RetryPolicy: &v1alpha1.RetryPolicySpec{
+					RetryPolicy: &policyv1alpha1.RetryPolicySpec{
 						RetryOn:       "5xx",
 						NumRetries:    &thresholdUintVal,
 						PerTryTimeout: &thresholdTimeoutDuration,
@@ -185,7 +186,7 @@ func TestAddRoute(t *testing.T) {
 			},
 			givenRouteMatch:       testHTTPRouteMatch,
 			givenWeightedClusters: []service.WeightedCluster{testWeightedCluster2},
-			givenRetryPolicy: &v1alpha1.RetryPolicySpec{
+			givenRetryPolicy: &policyv1alpha1.RetryPolicySpec{
 				RetryOn:                  "5xx",
 				RetryBackoffBaseInterval: &thresholdBackoffDuration,
 			},
@@ -422,20 +423,65 @@ func TestMergeRouteWeightedClusters(t *testing.T) {
 func TestNewInboundTrafficPolicy(t *testing.T) {
 	assert := tassert.New(t)
 
-	name := "name"
-	hostnames := []string{"hostname1", "hostname2"}
-	expected := &InboundTrafficPolicy{Name: name, Hostnames: hostnames}
+	rateLimitSpec := &policyv1alpha1.RateLimitSpec{
+		Local: &policyv1alpha1.LocalRateLimitSpec{},
+	}
 
-	actual := NewInboundTrafficPolicy(name, hostnames)
-	assert.Equal(expected, actual)
+	testCases := []struct {
+		name                   string
+		policyName             string
+		hostnames              []string
+		upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
+		expected               *InboundTrafficPolicy
+	}{
+		{
+			name:       "basic inbound policy",
+			policyName: "foo",
+			hostnames:  []string{"foo.com", "bar.com"},
+			expected: &InboundTrafficPolicy{
+				Name:      "foo",
+				Hostnames: []string{"foo.com", "bar.com"},
+			},
+		},
+		{
+			name:       "inbound policy with rate limit configured",
+			policyName: "foo",
+			hostnames:  []string{"foo.com", "bar.com"},
+			upstreamTrafficSetting: &policyv1alpha1.UpstreamTrafficSetting{
+				Spec: policyv1alpha1.UpstreamTrafficSettingSpec{
+					RateLimit: rateLimitSpec,
+				},
+			},
+			expected: &InboundTrafficPolicy{
+				Name:      "foo",
+				Hostnames: []string{"foo.com", "bar.com"},
+				RateLimit: rateLimitSpec,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := NewInboundTrafficPolicy(tc.policyName, tc.hostnames, tc.upstreamTrafficSetting)
+			assert.Equal(tc.expected, actual)
+		})
+	}
 }
 
 func TestNewRouteWeightedCluster(t *testing.T) {
+	perRouteRateLimitConfig := &policyv1alpha1.HTTPPerRouteRateLimitSpec{
+		Local: &policyv1alpha1.HTTPLocalRateLimitSpec{
+			Requests: 10,
+			Unit:     "second",
+		},
+	}
+
 	testCases := []struct {
-		name             string
-		route            HTTPRouteMatch
-		weightedClusters []service.WeightedCluster
-		expected         *RouteWeightedClusters
+		name                   string
+		route                  HTTPRouteMatch
+		weightedClusters       []service.WeightedCluster
+		upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
+		expected               *RouteWeightedClusters
 	}{
 		{
 			name:             "single weighted cluster in set",
@@ -443,13 +489,33 @@ func TestNewRouteWeightedCluster(t *testing.T) {
 			weightedClusters: []service.WeightedCluster{testWeightedCluster},
 			expected:         &RouteWeightedClusters{HTTPRouteMatch: testHTTPRouteMatch, WeightedClusters: mapset.NewSet(testWeightedCluster)},
 		},
+		{
+			name:             "per route rate limiting",
+			route:            testHTTPRouteMatch,
+			weightedClusters: []service.WeightedCluster{testWeightedCluster},
+			upstreamTrafficSetting: &policyv1alpha1.UpstreamTrafficSetting{
+				Spec: policyv1alpha1.UpstreamTrafficSettingSpec{
+					HTTPRoutes: []policyv1alpha1.HTTPRouteSpec{
+						{
+							Path:      testHTTPRouteMatch.Path, // matches path on HTTPRouteMatch
+							RateLimit: perRouteRateLimitConfig,
+						},
+					},
+				},
+			},
+			expected: &RouteWeightedClusters{
+				HTTPRouteMatch:   testHTTPRouteMatch,
+				WeightedClusters: mapset.NewSet(testWeightedCluster),
+				RateLimit:        perRouteRateLimitConfig,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
-			actual := NewRouteWeightedCluster(tc.route, tc.weightedClusters)
+			actual := NewRouteWeightedCluster(tc.route, tc.weightedClusters, tc.upstreamTrafficSetting)
 			assert.Equal(tc.expected, actual)
 		})
 	}

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -7,7 +7,6 @@ import (
 
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 
-	"github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/service"
 )
@@ -47,9 +46,14 @@ type TCPRouteMatch struct {
 
 // RouteWeightedClusters is a struct of an HTTPRoute, associated weighted clusters and the domains
 type RouteWeightedClusters struct {
-	HTTPRouteMatch   HTTPRouteMatch            `json:"http_route_match:omitempty"`
-	WeightedClusters mapset.Set                `json:"weighted_clusters:omitempty"`
-	RetryPolicy      *v1alpha1.RetryPolicySpec `json:"retry_policy:omitempty"`
+	HTTPRouteMatch   HTTPRouteMatch                  `json:"http_route_match:omitempty"`
+	WeightedClusters mapset.Set                      `json:"weighted_clusters:omitempty"`
+	RetryPolicy      *policyv1alpha1.RetryPolicySpec `json:"retry_policy:omitempty"`
+
+	// RateLimit defines the rate limit settings applied at the route level
+	// for the given HTTPRouteMatch
+	// +optional
+	RateLimit *policyv1alpha1.HTTPPerRouteRateLimitSpec `json:"rate_limit:omitempty"`
 }
 
 // InboundTrafficPolicy is a struct that associates incoming traffic on a set of Hostnames with a list of Rules
@@ -57,6 +61,11 @@ type InboundTrafficPolicy struct {
 	Name      string   `json:"name:omitempty"`
 	Hostnames []string `json:"hostnames"`
 	Rules     []*Rule  `json:"rules:omitempty"`
+
+	// RateLimit defines the rate limit settings applied at the virtual_host level
+	// for the given set of hostnames (domains) corresponding to the virtual_host
+	// +optional
+	RateLimit *policyv1alpha1.RateLimitSpec `json:"rate_limit:omitempty"`
 }
 
 // Rule is a struct that represents which service identities (authenticated principals) can access a Route
@@ -179,4 +188,8 @@ type TrafficMatch struct {
 	// route traffic to. This is used by TCP based mesh clusters.
 	// +optional
 	WeightedClusters []service.WeightedCluster
+
+	// RateLimit defines the rate limiting policy applied for this TrafficMatch
+	// +optional
+	RateLimit *policyv1alpha1.RateLimitSpec
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Plumbs the tcp, virtual_host and per route rate limiting
configs into the inbound traffic policy objects.

Next, they will be mapped to Envoy listener and route
configs.

Part of #2018

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`