### PR TITLE
docs(README): update minimum kubernetes version to 1.21.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Read more about [OSM's high level goals, design, and architecture](DESIGN.md).
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.20.0 or greater
+- Kubernetes cluster running Kubernetes v1.21.0 or greater
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.1.1
 appVersion: latest-main
 
 # This specifies the minimum Kubernetes version OSM is compatible with.
-kubeVersion: ">= 1.20.0-0"
+kubeVersion: ">= 1.21.0-0"
 
 dependencies:
 - name: contour

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -6,7 +6,7 @@ A Helm chart to install the [OSM](https://github.com/openservicemesh/osm) contro
 
 ## Prerequisites
 
-- Kubernetes >= 1.20.0-0
+- Kubernetes >= 1.21.0-0
 
 ## Get Repo Info
 


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>

**Description**: update minimum version of Kubernetes to use with OSM to 1.21 since 1.20 is EOL

**Testing done**: Verified markdown renders properly.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ x ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? yes