### PR TITLE
envoy|catalog: use TrafficMatch to build inbound filter config

### DIFF
--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -307,11 +307,15 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 						Name:                "inbound_ns1/mysql-0.mysql_3306_tcp",
 						DestinationPort:     3306,
 						DestinationProtocol: "tcp",
+						ServerNames:         []string{"mysql-0.mysql.ns1.svc.cluster.local"},
+						Cluster:             "ns1/mysql-0.mysql|3306|local",
 					},
 					{
 						Name:                "inbound_ns1/s2_9090_http",
 						DestinationPort:     9090,
 						DestinationProtocol: "http",
+						ServerNames:         []string{"s2.ns1.svc.cluster.local"},
+						Cluster:             "ns1/s2|9090|local",
 					},
 				},
 				ClustersConfigs: []*trafficpolicy.MeshClusterConfig{

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -226,12 +226,10 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 		serviceIdentity: tests.BookbuyerServiceIdentity,
 	}
 
-	proxyService := tests.BookbuyerService
-
 	testCases := []struct {
 		name           string
 		permissiveMode bool
-		port           uint16
+		trafficMatch   *trafficpolicy.TrafficMatch
 
 		expectedFilterChainMatch *xds_listener.FilterChainMatch
 		expectedFilterNames      []string
@@ -240,10 +238,15 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 		{
 			name:           "inbound HTTP filter chain with permissive mode disabled",
 			permissiveMode: false,
-			port:           80,
+			trafficMatch: &trafficpolicy.TrafficMatch{
+				Name:                "inbound_ns1/svc1_80_http",
+				DestinationPort:     80,
+				DestinationProtocol: "http",
+				ServerNames:         []string{"svc1.ns1.svc.cluster.local"},
+			},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:      &wrapperspb.UInt32Value{Value: 80},
-				ServerNames:          []string{proxyService.ServerName()},
+				ServerNames:          []string{"svc1.ns1.svc.cluster.local"},
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
@@ -253,10 +256,15 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 		{
 			name:           "inbound HTTP filter chain with permissive mode enabled",
 			permissiveMode: true,
-			port:           90,
+			trafficMatch: &trafficpolicy.TrafficMatch{
+				Name:                "inbound_ns1/svc1_90_http",
+				DestinationPort:     90,
+				DestinationProtocol: "http",
+				ServerNames:         []string{"svc1.ns1.svc.cluster.local"},
+			},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:      &wrapperspb.UInt32Value{Value: 90},
-				ServerNames:          []string{proxyService.ServerName()},
+				ServerNames:          []string{"svc1.ns1.svc.cluster.local"},
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
@@ -287,8 +295,7 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 				mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(lb.serviceIdentity).Return(trafficTargets, nil).Times(1)
 			}
 
-			proxyService.TargetPort = tc.port
-			filterChain, err := lb.getInboundMeshHTTPFilterChain(proxyService)
+			filterChain, err := lb.getInboundMeshHTTPFilterChain(tc.trafficMatch)
 
 			assert.Equal(err != nil, tc.expectError)
 			assert.Equal(filterChain.FilterChainMatch, tc.expectedFilterChainMatch)
@@ -324,12 +331,10 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 		serviceIdentity: tests.BookbuyerServiceIdentity,
 	}
 
-	proxyService := tests.BookbuyerService
-
 	testCases := []struct {
 		name           string
 		permissiveMode bool
-		port           uint16
+		trafficMatch   *trafficpolicy.TrafficMatch
 
 		expectedFilterChainMatch *xds_listener.FilterChainMatch
 		expectedFilterNames      []string
@@ -338,10 +343,15 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 		{
 			name:           "inbound TCP filter chain with permissive mode disabled",
 			permissiveMode: false,
-			port:           80,
+			trafficMatch: &trafficpolicy.TrafficMatch{
+				Name:                "inbound_ns1/svc1_80_http",
+				DestinationPort:     80,
+				DestinationProtocol: "tcp",
+				ServerNames:         []string{"svc1.ns1.svc.cluster.local"},
+			},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:      &wrapperspb.UInt32Value{Value: 80},
-				ServerNames:          []string{proxyService.ServerName()},
+				ServerNames:          []string{"svc1.ns1.svc.cluster.local"},
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
@@ -352,10 +362,15 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 		{
 			name:           "inbound TCP filter chain with permissive mode enabled",
 			permissiveMode: true,
-			port:           90,
+			trafficMatch: &trafficpolicy.TrafficMatch{
+				Name:                "inbound_ns1/svc1_90_http",
+				DestinationPort:     90,
+				DestinationProtocol: "tcp",
+				ServerNames:         []string{"svc1.ns1.svc.cluster.local"},
+			},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:      &wrapperspb.UInt32Value{Value: 90},
-				ServerNames:          []string{proxyService.ServerName()},
+				ServerNames:          []string{"svc1.ns1.svc.cluster.local"},
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
@@ -386,8 +401,7 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 				mockCatalog.EXPECT().ListInboundTrafficTargetsWithRoutes(lb.serviceIdentity).Return(trafficTargets, nil).Times(1)
 			}
 
-			proxyService.TargetPort = tc.port
-			filterChain, err := lb.getInboundMeshTCPFilterChain(proxyService)
+			filterChain, err := lb.getInboundMeshTCPFilterChain(tc.trafficMatch)
 
 			assert.Equal(err != nil, tc.expectError)
 			assert.Equal(filterChain.FilterChainMatch, tc.expectedFilterChainMatch)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Similar to how outbound filter config is built, this change
relies on the TrafficMatch type to build inbound filter
configs. The TrafficMatch has a 1-1 mapping to an Envoy
filter_chain config. This is necessary to be able to
cleanly apply TrafficMatch based policies (e.g. rate
limiting) without needing to rely on multiple catalog
APIs.

Part of #2018

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests, CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`