### PR TITLE
envoy/cds: add nil check for ConnectionSettings

### DIFF
--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -394,7 +394,7 @@ func applyUpstreamTrafficSetting(upstreamTrafficSetting *policyv1alpha1.Upstream
 		Thresholds: []*xds_cluster.CircuitBreakers_Thresholds{threshold},
 	}
 
-	if upstreamTrafficSetting == nil {
+	if upstreamTrafficSetting == nil || upstreamTrafficSetting.Spec.ConnectionSettings == nil {
 		return
 	}
 

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -91,6 +91,16 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Cluster without circuit breaker but with valid UpstreamTrafficSetting should not error/panic",
+			clusterConfig: trafficpolicy.MeshClusterConfig{
+				Name:    "default/bookstore-v1_14001",
+				Service: upstreamSvc,
+				UpstreamTrafficSetting: &policyv1alpha1.UpstreamTrafficSetting{
+					Spec: policyv1alpha1.UpstreamTrafficSettingSpec{},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -106,7 +116,7 @@ func TestGetUpstreamServiceCluster(t *testing.T) {
 				assert.Nil(remoteCluster.HealthChecks)
 			}
 
-			if tc.clusterConfig.UpstreamTrafficSetting != nil {
+			if tc.expectedCircuitBreakerThreshold != nil {
 				assert.Equal(tc.expectedCircuitBreakerThreshold, remoteCluster.CircuitBreakers)
 			}
 		})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
With the addition of rate limiting to the
UpstreamTrafficSetting spec, it is possible
for the UpstreamTrafficSetting object to be non
nil while having its ConnectionSettings as nil.
Add nil check so the code doesn't panic when
ConnectionSettings is nil and RateLimit is configured.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`