### PR TITLE
chore(cmd/cli): Reduce cyclomatic complexity of uninstall command

### DIFF
--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -119,10 +119,12 @@ func (d *uninstallMeshCmd) run() error {
 			return nil
 		}
 
-		// Searches for the mesh specified by the mesh-name flag if specified
-		specifiedMeshFound := d.findSpecifiedMesh(meshInfoList)
-		if !specifiedMeshFound {
-			return nil
+		if d.meshSpecified() {
+			// Searches for the mesh specified by the mesh-name flag if specified
+			specifiedMeshFound := d.findSpecifiedMesh(meshInfoList)
+			if !specifiedMeshFound {
+				return nil
+			}
 		}
 
 		// Adds the mesh to be force uninstalled
@@ -193,10 +195,6 @@ func (d *uninstallMeshCmd) meshSpecified() bool {
 }
 
 func (d *uninstallMeshCmd) findSpecifiedMesh(meshInfoList []meshInfo) bool {
-	if !d.meshSpecified() {
-		return false
-	}
-
 	specifiedMeshFound := d.findMesh(meshInfoList)
 	if !specifiedMeshFound {
 		fmt.Fprintf(d.out, "Did not find mesh [%s] in namespace [%s]\n", d.meshName, d.meshNamespace)

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -617,12 +617,12 @@ func TestUninstallClusterWideResources(t *testing.T) {
 	}
 }
 
-func TestFindFlagSpecifiedMesh(t *testing.T) {
+func TestFindSpecifiedMesh(t *testing.T) {
 	tests := []struct {
 		name                  string
 		specifiedMesh         string
 		meshList              []meshInfo
-		expMeshFlagSpecified  bool
+		meshFlagSpecified     bool
 		expSpecifiedMeshFound bool
 	}{
 		{
@@ -634,7 +634,7 @@ func TestFindFlagSpecifiedMesh(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			expMeshFlagSpecified:  false,
+			meshFlagSpecified:     false,
 			expSpecifiedMeshFound: false,
 		},
 		{
@@ -646,7 +646,7 @@ func TestFindFlagSpecifiedMesh(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			expMeshFlagSpecified:  true,
+			meshFlagSpecified:     true,
 			expSpecifiedMeshFound: false,
 		},
 		{
@@ -658,7 +658,7 @@ func TestFindFlagSpecifiedMesh(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			expMeshFlagSpecified:  true,
+			meshFlagSpecified:     true,
 			expSpecifiedMeshFound: true,
 		},
 	}
@@ -703,11 +703,7 @@ func TestFindFlagSpecifiedMesh(t *testing.T) {
 				deleteClusterWideResources: true,
 				actionConfig:               new(action.Configuration),
 			}
-			meshFlagSpecified, specifiedMeshFound := uninstall.findFlagSpecifiedMesh(test.meshList)
-			fmt.Println("meshFlagSpecified ", meshFlagSpecified)
-			fmt.Println("specifiedMeshFound ", specifiedMeshFound)
-
-			assert.Equal(meshFlagSpecified, test.expMeshFlagSpecified)
+			specifiedMeshFound := uninstall.findSpecifiedMesh(test.meshFlagSpecified, test.meshList)
 			assert.Equal(specifiedMeshFound, test.expSpecifiedMeshFound)
 		})
 	}

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -11,6 +11,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/action"
 	helm "helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -623,7 +623,6 @@ func TestFindSpecifiedMesh(t *testing.T) {
 		name                  string
 		specifiedMesh         string
 		meshList              []meshInfo
-		meshFlagSpecified     bool
 		expSpecifiedMeshFound bool
 	}{
 		{
@@ -635,7 +634,6 @@ func TestFindSpecifiedMesh(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified:     false,
 			expSpecifiedMeshFound: false,
 		},
 		{
@@ -647,7 +645,6 @@ func TestFindSpecifiedMesh(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified:     true,
 			expSpecifiedMeshFound: false,
 		},
 		{
@@ -659,7 +656,6 @@ func TestFindSpecifiedMesh(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified:     true,
 			expSpecifiedMeshFound: true,
 		},
 	}
@@ -704,7 +700,7 @@ func TestFindSpecifiedMesh(t *testing.T) {
 				deleteClusterWideResources: true,
 				actionConfig:               new(action.Configuration),
 			}
-			specifiedMeshFound := uninstall.findSpecifiedMesh(test.meshFlagSpecified, test.meshList)
+			specifiedMeshFound := uninstall.findSpecifiedMesh(test.meshList)
 			assert.Equal(specifiedMeshFound, test.expSpecifiedMeshFound)
 		})
 	}
@@ -715,7 +711,6 @@ func TestPromptMeshUninstall(t *testing.T) {
 		name                 string
 		userPromptsYes       bool
 		meshInfoList         []meshInfo
-		meshFlagSpecified    bool
 		specifiedMeshName    string
 		expMeshesToUninstall []meshInfo
 	}{
@@ -728,7 +723,6 @@ func TestPromptMeshUninstall(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified:    false,
 			specifiedMeshName:    "",
 			expMeshesToUninstall: []meshInfo{},
 		},
@@ -741,7 +735,6 @@ func TestPromptMeshUninstall(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified: false,
 			specifiedMeshName: "",
 			expMeshesToUninstall: []meshInfo{
 				{
@@ -759,7 +752,6 @@ func TestPromptMeshUninstall(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified:    true,
 			specifiedMeshName:    testMeshName,
 			expMeshesToUninstall: []meshInfo{},
 		},
@@ -772,7 +764,6 @@ func TestPromptMeshUninstall(t *testing.T) {
 					namespace: testNamespace,
 				},
 			},
-			meshFlagSpecified: true,
 			specifiedMeshName: testMeshName,
 			expMeshesToUninstall: []meshInfo{
 				{
@@ -832,7 +823,7 @@ func TestPromptMeshUninstall(t *testing.T) {
 				actionConfig:               new(action.Configuration),
 			}
 
-			meshList, err := uninstall.promptMeshUninstall(test.meshInfoList, meshesToUninstall, test.meshFlagSpecified)
+			meshList, err := uninstall.promptMeshUninstall(test.meshInfoList, meshesToUninstall)
 			assert.Nil(err)
 			assert.ElementsMatch(test.expMeshesToUninstall, meshList)
 		})


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Separate code into functions to reduce the cyclomatic complexity
Helps unblock #4555

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

Reduces cyclomatic complexity 30->19
![image](https://user-images.githubusercontent.com/69616256/173988738-f9d2b735-8f41-4e49-9022-d9ea378b1d56.png)

![image](https://user-images.githubusercontent.com/69616256/174674545-57920560-4f3d-43dd-baad-70437fd2d10e.png)


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [x ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?