### PR TITLE
Update Kubernetes version testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,10 +206,10 @@ jobs:
         focus: [""]
         bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
-          - k8s_version: v1.22.10
+          - k8s_version: v1.22.9
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"
             bucket: ".*"
-          - k8s_version: v1.23.7
+          - k8s_version: v1.23.6
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"
             bucket: ".*"
           - k8s_version: v1.24.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,10 +206,13 @@ jobs:
         focus: [""]
         bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
-          - k8s_version: v1.21.10
+          - k8s_version: v1.22.10
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"
             bucket: ".*"
-          - k8s_version: v1.22.7
+          - k8s_version: v1.23.7
+            focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"
+            bucket: ".*"
+          - k8s_version: v1.24.1
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"
             bucket: ".*"
     env:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Read more about [OSM's high level goals, design, and architecture](DESIGN.md).
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.20.0 or greater
+- Kubernetes cluster running Kubernetes v1.22.10 or greater
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Read more about [OSM's high level goals, design, and architecture](DESIGN.md).
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.22.10 or greater
+- Kubernetes cluster running Kubernetes v1.22.9 or greater
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/charts/osm/Chart.yaml
+++ b/charts/osm/Chart.yaml
@@ -21,7 +21,7 @@ version: 1.1.1
 appVersion: latest-main
 
 # This specifies the minimum Kubernetes version OSM is compatible with.
-kubeVersion: ">= 1.20.0-0"
+kubeVersion: ">= 1.22.9-0"
 
 dependencies:
 - name: contour

--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -6,7 +6,7 @@ A Helm chart to install the [OSM](https://github.com/openservicemesh/osm) contro
 
 ## Prerequisites
 
-- Kubernetes >= 1.20.0-0
+- Kubernetes >= 1.22.9-0
 
 ## Get Repo Info
 

--- a/cmd/cli/install_test.go
+++ b/cmd/cli/install_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -26,12 +27,32 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-var (
+const (
 	testRegistrySecret = "test-registry-secret"
 	testVaultHost      = "vault.osm.svc.cluster.local"
 	testVaultToken     = "token"
 	testChartPath      = "testdata/test-chart"
+	kubeVersionMajor   = 1
+	kubeVersionMinor   = 22
+	kubeVersionPatch   = 9
 )
+
+func helmCapabilities() *chartutil.Capabilities {
+	defaultCapabilities := chartutil.DefaultCapabilities.Copy()
+	// Intentionally avoiding charutil.ParseKubeVersion so we don't have to
+	// deal with error handling when generating the capabilities.
+	defaultCapabilities.KubeVersion = chartutil.KubeVersion{
+		Version: fmt.Sprintf(
+			"v%d.%d.%d",
+			kubeVersionMajor,
+			kubeVersionMinor,
+			kubeVersionPatch,
+		),
+		Major: strconv.Itoa(kubeVersionMajor),
+		Minor: strconv.Itoa(kubeVersionMinor),
+	}
+	return defaultCapabilities
+}
 
 var _ = Describe("Running the install command", func() {
 
@@ -55,7 +76,7 @@ var _ = Describe("Running the install command", func() {
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard,
 				},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 
@@ -117,7 +138,7 @@ var _ = Describe("Running the install command", func() {
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard,
 				},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 
@@ -179,7 +200,7 @@ var _ = Describe("Running the install command", func() {
 				Releases: store,
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 
@@ -254,7 +275,7 @@ var _ = Describe("Running the install command", func() {
 				Releases: store,
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 
@@ -298,7 +319,7 @@ var _ = Describe("Running the install command", func() {
 				Releases: store,
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 
@@ -371,7 +392,7 @@ var _ = Describe("deployPrometheus is true", func() {
 			Releases: store,
 			KubeClient: &kubefake.PrintingKubeClient{
 				Out: ioutil.Discard},
-			Capabilities: chartutil.DefaultCapabilities,
+			Capabilities: helmCapabilities(),
 			Log:          func(format string, v ...interface{}) {},
 		}
 

--- a/cmd/cli/mesh_upgrade_test.go
+++ b/cmd/cli/mesh_upgrade_test.go
@@ -24,7 +24,7 @@ func meshUpgradeConfig() *action.Configuration {
 		KubeClient: &kubefake.PrintingKubeClient{
 			Out: ioutil.Discard,
 		},
-		Capabilities: chartutil.DefaultCapabilities,
+		Capabilities: helmCapabilities(),
 		Log:          func(_ string, _ ...interface{}) {},
 	}
 }

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -11,7 +11,6 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/action"
 	helm "helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage"
@@ -226,7 +225,7 @@ func TestUninstallCmd(t *testing.T) {
 				Releases: store,
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 
@@ -560,7 +559,7 @@ func TestUninstallClusterWideResources(t *testing.T) {
 				Releases: store,
 				KubeClient: &kubefake.PrintingKubeClient{
 					Out: ioutil.Discard},
-				Capabilities: chartutil.DefaultCapabilities,
+				Capabilities: helmCapabilities(),
 				Log:          func(format string, v ...interface{}) {},
 			}
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -7,6 +7,7 @@
 - Root certificate rotation is now supported through the new CRD, MeshRootCertificate.
 - Along with root certificate rotation we support custom trust domains, as well as rotating to new trust domains with no downtime.
 - Envoy has been updated to v1.22 and uses the `envoyproxy/envoy-distroless` image instead of the deprecated `envoyproxy/envoy-alpine` image.
+- Added support for Kubernetes 1.23 and 1.24
 
 ### Breaking Changes
 
@@ -14,7 +15,8 @@
   - `osm_proxy_response_send_success_count`
   - `osm_proxy_response_send_error_count`
   - `osm_proxy_xds_request_count`
-
+- Support for Kubernetes 1.20 and 1.21 has been dropped
+		
 ## Release v1.1.0
 
 ### Notable changes

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/prometheus/common v0.28.0
 	github.com/rs/zerolog v1.18.0
 	github.com/servicemeshinterface/smi-sdk-go v0.5.0
-	github.com/spf13/cobra v1.2.1
+	github.com/spf13/cobra v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	gomodules.xyz/jsonpatch/v2 v2.2.0
@@ -60,7 +60,7 @@ require (
 	k8s.io/code-generator v0.23.5
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
 	sigs.k8s.io/controller-runtime v0.11.1
-	sigs.k8s.io/kind v0.12.0
+	sigs.k8s.io/kind v0.14.0
 )
 
 require (
@@ -76,7 +76,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	golang.org/x/net v0.0.0-20220607020251-c690dde0001d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d // indirect
+	golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 // indirect
 	google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac // indirect
 	honnef.co/go/tools v0.1.1 // indirect
 )
@@ -97,7 +97,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
-	github.com/BurntSushi/toml v0.4.1 // indirect
+	github.com/BurntSushi/toml v1.1.0 // indirect
 	github.com/DataDog/datadog-go v3.2.0+incompatible // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20200511133814-5174e21577d5 // indirect
 	github.com/Jeffail/gabs v1.1.1 // indirect
@@ -295,7 +295,7 @@ require (
 	github.com/oracle/oci-go-sdk v13.1.0+incompatible // indirect
 	github.com/packethost/packngo v0.1.1-0.20180711074735-b9cb5096f54c // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,9 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
 github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
-github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml v1.1.0 h1:ksErzDEI1khOiGPgpwuI7x2ebx/uXQNw7xJpn9Eq1+I=
+github.com/BurntSushi/toml v1.1.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
@@ -516,6 +517,8 @@ github.com/cpu/goacmedns v0.0.3/go.mod h1:4MipLkI+qScwqtVxcNO6okBhbgRrr7/tKXUSgS
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
@@ -1745,8 +1748,9 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
+github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
@@ -1859,6 +1863,7 @@ github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc/go.mod h1:HFLT6
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryancurrah/gomodguard v1.1.0 h1:DWbye9KyMgytn8uYpuHkwf0RHqAYO6Ay/D0TbCpPtVU=
 github.com/ryancurrah/gomodguard v1.1.0/go.mod h1:4O8tr7hBODaGE6VIhfJDHcwzh5GUccKSJBU0UMXJFVM=
 github.com/ryanrolds/sqlclosecheck v0.3.0 h1:AZx+Bixh8zdUBxUA1NxbxVAS78vTPq4rCb8OUZI9xFw=
@@ -1942,8 +1947,10 @@ github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHN
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
-github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/cobra v1.5.0 h1:X+jTBEBqF0bHN+9cSMgmfuvv2VHJ9ezmFNf9Y/XstYU=
+github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -2477,8 +2484,8 @@ golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d h1:Zu/JngovGLVi6t2J3nmAf3AoTDwuzw85YZ3b9o4yU7s=
-golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664 h1:wEZYwx+kK+KlZ0hpvP2Ls1Xr4+RWnlzGFwPP0aiDjIU=
+golang.org/x/sys v0.0.0-20220622161953-175b2fd9d664/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -3031,8 +3038,8 @@ sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eM
 sigs.k8s.io/controller-tools v0.2.9-0.20200414181213-645d44dca7c0/go.mod h1:YKE/iHvcKITCljdnlqHYe+kAt7ZldvtAwUzQff0k1T0=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
 sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6/go.mod h1:p4QtZmO4uMYipTQNzagwnNoseA6OxSUutVw05NhYDRs=
-sigs.k8s.io/kind v0.12.0 h1:LFynXwQkH1MrWI8pM1FQty0oUwEKjU5EkMaVZaPld8E=
-sigs.k8s.io/kind v0.12.0/go.mod h1:EcgDSBVxz8Bvm19fx8xkioFrf9dC30fMJdOTXBSGNoM=
+sigs.k8s.io/kind v0.14.0 h1:cNmI3jGBvp7UegEGbC5we8plDtCUmaNRL+bod7JoSCE=
+sigs.k8s.io/kind v0.14.0/go.mod h1:UrFRPHG+2a5j0Q7qiR4gtJ4rEyn8TuMQwuOPf+m4oHg=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH83nJtY1g=


### PR DESCRIPTION
Update Kerbernetes matrix testing by removing Kubernetes v1.21 and
adding v1.23 and v1.24. Also update the README to include the oldest
supported Kubernetes version.

Signed-off-by: Thomas Stringer <thomas@trstringer.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Tests                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? Updates soon by @zr-msft 