### PR TITLE
[RFC] feat(k8s): stop sidecars on otherwise completed Jobs

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -17,6 +17,9 @@ rules:
   - apiGroups: [""]
     resources: ["endpoints", "namespaces", "pods", "services", "secrets", "configmaps", "serviceaccounts"]
     verbs: ["list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
 
   # Port forwarding is needed for the OSM pod to be able to connect
   # to participating Envoys and fetch their configuration.

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -321,6 +321,8 @@ func main() {
 		}
 	}
 
+	go k8s.StopJobSidecars(stop, msgBroker, kubeConfig, kubeClient)
+
 	<-stop
 	log.Info().Msgf("Stopping osm-controller %s; %s; %s", version.Version, version.GitCommit, version.BuildDate)
 }

--- a/cmd/osm-healthcheck/osm-healthcheck.go
+++ b/cmd/osm-healthcheck/osm-healthcheck.go
@@ -51,7 +51,7 @@ func main() {
 
 	log.Info().Msgf("Starting OSM healthcheck HTTP server")
 	go func() {
-		if err := server.ListenAndServe(); err != nil {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatal().Err(err).Msg("Failed to start OSM healthcheck HTTP server")
 		}
 	}()

--- a/dockerfiles/Dockerfile.osm-healthcheck
+++ b/dockerfiles/Dockerfile.osm-healthcheck
@@ -10,5 +10,5 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -v -o osm-healthcheck -ldflags "$LDFLAGS" ./cmd/osm-healthcheck
 
-FROM gcr.io/distroless/static
+FROM busybox
 COPY --from=builder /osm/osm-healthcheck /


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This change adds a new long-lived goroutine to osm-controller to explicitly stop sidecar containers on Pods controlled by Jobs. Currently, Jobs never complete because the sidecars run indefinitely. This is the high-level approach:

- For any `pod-updated` event:
  - If the Pod does not belong to a Job, ignore it
  - If the Pod's status indicates the main containers are still running, ignore it
  - For each running sidecar, send `SIGTERM` to PID 1 with the equivalent of `kubectl exec <pod> -c <container> -- kill 1`
    - Based on how https://hub.docker.com/r/zachomedia/kubernetes-sidecar-terminator works

This handles both `envoy` sidecars and `osm-healthcheck` sidecars (for Pods with `tcpSocket` health probes).

The main restriction this introduces is that any sidecar we intend to inject must include a `kill` command. Envoy's images already include busybox which provides a `kill` command. These changes include changing the base image for `osm-healthcheck` to busybox to give it a `kill` command.

Part of #2316

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?