### PR TITLE
rate-limiting: add HTTP local rate limiting capability

### DIFF
--- a/pkg/apis/policy/v1alpha1/upstreamtrafficsetting.go
+++ b/pkg/apis/policy/v1alpha1/upstreamtrafficsetting.go
@@ -182,6 +182,8 @@ type HTTPLocalRateLimitSpec struct {
 	// ResponseStatusCode defines the HTTP status code to use for responses
 	// to rate limited requests. Code must be in the 400-599 (inclusive)
 	// error range. If not specified, a default of 429 (Too Many Requests) is used.
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/v3/http_status.proto#enum-type-v3-statuscode
+	// for the list of HTTP status codes supported by Envoy.
 	// +optional
 	ResponseStatusCode uint32 `json:"responseStatusCode,omitempty"`
 

--- a/pkg/envoy/rds/route/rbac.go
+++ b/pkg/envoy/rds/route/rbac.go
@@ -7,9 +7,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
-
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -21,7 +19,7 @@ const (
 // buildInboundRBACFilterForRule builds an HTTP RBAC per route filter based on the given traffic policy rule.
 // The principals in the RBAC policy are derived from the allowed service accounts specified in the given rule.
 // The permissions in the RBAC policy are implicitly set to ANY (all permissions).
-func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule, trustDomain string) (map[string]*any.Any, error) {
+func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule, trustDomain string) (*any.Any, error) {
 	if rule.AllowedServiceIdentities == nil {
 		return nil, errors.Errorf("traffipolicy.Rule.AllowedServiceIdentities not set")
 	}
@@ -54,5 +52,5 @@ func buildInboundRBACFilterForRule(rule *trafficpolicy.Rule, trustDomain string)
 		return nil, err
 	}
 
-	return map[string]*any.Any{envoy.HTTPRBACFilterName: marshalled}, nil
+	return marshalled, nil
 }

--- a/pkg/envoy/rds/route/rbac_test.go
+++ b/pkg/envoy/rds/route/rbac_test.go
@@ -9,7 +9,6 @@ import (
 	xds_http_rbac "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/rbac/v3"
 	tassert "github.com/stretchr/testify/assert"
 
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/rbac"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/tests"
@@ -99,9 +98,8 @@ func TestBuildInboundRBACFilterForRule(t *testing.T) {
 				return
 			}
 
-			marshalled := rbacFilter[envoy.HTTPRBACFilterName]
 			httpRBACPerRoute := &xds_http_rbac.RBACPerRoute{}
-			err = marshalled.UnmarshalTo(httpRBACPerRoute)
+			err = rbacFilter.UnmarshalTo(httpRBACPerRoute)
 			assert.Nil(err)
 
 			rbacRules := httpRBACPerRoute.Rbac.Rules

--- a/pkg/envoy/rds/route/route_config_test.go
+++ b/pkg/envoy/rds/route/route_config_test.go
@@ -9,6 +9,7 @@ import (
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	tassert "github.com/stretchr/testify/assert"
@@ -41,12 +42,12 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 		expectedRouteConfigFields *xds_route.RouteConfiguration
 	}{
 		{
-			name:                      "no policies provided",
+			name:                      "no inbound policy",
 			inbound:                   &trafficpolicy.InboundMeshTrafficPolicy{},
 			expectedRouteConfigFields: nil,
 		},
 		{
-			name: "inbound policy provided",
+			name: "basic inbound policy ",
 			inbound: &trafficpolicy.InboundMeshTrafficPolicy{
 				HTTPRouteConfigsPerPort: map[int][]*trafficpolicy.InboundTrafficPolicy{
 					80: {
@@ -95,9 +96,19 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 						Routes: []*xds_route.Route{
 							{
 								// corresponds to ingressPolicies[0].Rules[0]
+
+								// Only the filter name is matched, not the marshalled config
+								TypedPerFilterConfig: map[string]*any.Any{
+									envoy.HTTPRBACFilterName: nil,
+								},
 							},
 							{
 								// corresponds to ingressPolicies[0].Rules[1]
+
+								// Only the filter name is matched, not the marshalled config
+								TypedPerFilterConfig: map[string]*any.Any{
+									envoy.HTTPRBACFilterName: nil,
+								},
 							},
 						},
 					},
@@ -107,6 +118,87 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 							{
 								// corresponds to ingressPolicies[1].Rules[0]
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "inbound policy with VirtualHost and Route level local rate limiting",
+			inbound: &trafficpolicy.InboundMeshTrafficPolicy{
+				HTTPRouteConfigsPerPort: map[int][]*trafficpolicy.InboundTrafficPolicy{
+					80: {
+						{
+							Name:      "bookstore-v1-default",
+							Hostnames: []string{"bookstore-v1.default.svc.cluster.local"},
+							Rules: []*trafficpolicy.Rule{
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch:   tests.BookstoreBuyHTTPRoute,
+										WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+										RateLimit: &policyv1alpha1.HTTPPerRouteRateLimitSpec{
+											Local: &policyv1alpha1.HTTPLocalRateLimitSpec{
+												Requests: 10,
+												Unit:     "second",
+											},
+										},
+									},
+									AllowedServiceIdentities: mapset.NewSet(identity.WildcardServiceIdentity),
+								},
+								{
+									Route: trafficpolicy.RouteWeightedClusters{
+										HTTPRouteMatch:   tests.BookstoreSellHTTPRoute,
+										WeightedClusters: mapset.NewSet(tests.BookstoreV1DefaultWeightedCluster),
+										RateLimit: &policyv1alpha1.HTTPPerRouteRateLimitSpec{
+											Local: &policyv1alpha1.HTTPLocalRateLimitSpec{
+												Requests: 10,
+												Unit:     "second",
+											},
+										},
+									},
+									AllowedServiceIdentities: mapset.NewSet(identity.WildcardServiceIdentity),
+								},
+							},
+							RateLimit: &policyv1alpha1.RateLimitSpec{
+								Local: &policyv1alpha1.LocalRateLimitSpec{
+									HTTP: &policyv1alpha1.HTTPLocalRateLimitSpec{
+										Requests: 100,
+										Unit:     "minute",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRouteConfigFields: &xds_route.RouteConfiguration{
+				Name: "rds-inbound.80",
+				VirtualHosts: []*xds_route.VirtualHost{
+					{
+						Name: "inbound_virtual-host|bookstore-v1.default.svc.cluster.local",
+						Routes: []*xds_route.Route{
+							{
+								// corresponds to ingressPolicies[0].Rules[0]
+
+								// Only the filter name is matched, not the marshalled config
+								TypedPerFilterConfig: map[string]*any.Any{
+									envoy.HTTPRBACFilterName:           nil,
+									envoy.HTTPLocalRateLimitFilterName: nil,
+								},
+							},
+							{
+								// corresponds to ingressPolicies[0].Rules[1]
+
+								// Only the filter name is matched, not the marshalled config
+								TypedPerFilterConfig: map[string]*any.Any{
+									envoy.HTTPRBACFilterName:           nil,
+									envoy.HTTPLocalRateLimitFilterName: nil,
+								},
+							},
+						},
+						// Only the filter name is matched, not the marshalled config
+						TypedPerFilterConfig: map[string]*any.Any{
+							envoy.HTTPLocalRateLimitFilterName: nil,
 						},
 					},
 				},
@@ -138,6 +230,18 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 				for i, vh := range routeConfig.VirtualHosts {
 					assert.Len(vh.Routes, len(tc.expectedRouteConfigFields.VirtualHosts[i].Routes))
+
+					// Verify that the expected typed filters on the VirtualHost are present
+					for filter := range tc.expectedRouteConfigFields.VirtualHosts[i].TypedPerFilterConfig {
+						assert.Contains(vh.TypedPerFilterConfig, filter)
+					}
+
+					// Verify that the expected typed filters on the Route are present
+					for j, route := range vh.Routes {
+						for filter := range tc.expectedRouteConfigFields.VirtualHosts[i].Routes[j].TypedPerFilterConfig {
+							assert.Contains(route.TypedPerFilterConfig, filter)
+						}
+					}
 				}
 			}
 		})

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -87,19 +87,22 @@ const (
 )
 
 // Filter names - can be any name (not used by Envoy to determine the filter to use)
-// *Note: HTTP RBAC filter still requires a wellknown name
+// *Note: HTTP typed filters referenced in RDS require a wellknown name
 const (
 	// HTTP filters
 	HTTPConnectionManagerFilterName = "http_connection_manager"
 	HTTPRouterFilterName            = "http_router"
 	HTTPLuaFilterName               = "http_lua"
-	HTTPLocalRateLimitFilterName    = "http_local_rate_limit"
-	HTTPExtAuthzFilterName          = "http_external_authz"
-	HTTPHealthCheckFilterName       = "http_health_check"
 
-	// The HTTP RBAC filter still requires a wellknown name
-	// See https://github.com/envoyproxy/envoy/issues/21759#issuecomment-1159243250
-	HTTPRBACFilterName = "envoy.filters.http.rbac"
+	HTTPExtAuthzFilterName    = "http_external_authz"
+	HTTPHealthCheckFilterName = "http_health_check"
+
+	// The HTTP typed filters referenced in the RDS configuration still need to
+	// use wellknown names. These filters are configured as a map where the key is
+	// the filter name and value is the marshalled filter config.
+	// See https://github.com/envoyproxy/envoy/issues/21759#issuecomment-1163570994
+	HTTPRBACFilterName           = "envoy.filters.http.rbac"
+	HTTPLocalRateLimitFilterName = "envoy.filters.http.local_ratelimit"
 
 	// Network (L4) filters
 	TCPProxyFilterName         = "tcp_proxy"

--- a/tests/e2e/e2e_local_ratelimit_test.go
+++ b/tests/e2e/e2e_local_ratelimit_test.go
@@ -1,0 +1,177 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var _ = OSMDescribe("Test local rate limiting",
+	OSMDescribeInfo{
+		Tier:   1,
+		Bucket: 3,
+		OS:     OSCrossPlatform,
+	},
+	func() {
+		Context("HTTP request rate limiting", func() {
+			testRateLimtiting()
+		})
+	})
+
+func testRateLimtiting() {
+	const sourceName = "client"
+	const destName = "server"
+	var ns = []string{sourceName, destName}
+
+	It("Tests rate limiting of traffic from client pod -> service", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
+
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Get simple pod definitions for the HTTP server
+		svcAccDef, podDef, svcDef, err := Td.GetOSSpecificHTTPBinPod(destName, destName)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = Td.CreateServiceAccount(destName, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(destName, podDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstSvc, err := Td.CreateService(destName, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(destName, 90*time.Second, 1, nil)).To(Succeed())
+
+		srcPod := setupSource(sourceName, false)
+
+		By("Allow traffic via SMI policies")
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    "routes",
+				TrafficTargetName: "test-target",
+
+				SourceNamespace:      sourceName,
+				SourceSVCAccountName: srcPod.Spec.ServiceAccountName,
+
+				DestinationNamespace:      destName,
+				DestinationSvcAccountName: svcAccDef.Name,
+			})
+
+		_, err = Td.CreateHTTPRouteGroup(destName, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(destName, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		clientToServer := HTTPRequestDef{
+			SourceNs:        sourceName,
+			SourcePod:       srcPod.Name,
+			SourceContainer: sourceName,
+
+			Destination: fmt.Sprintf("%s.%s.svc.cluster.local", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", sourceName, srcPod.Name),
+			clientToServer.Destination)
+
+		// Send traffic
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed with status: %d, err: %s",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, Td.ReqSuccessTimeout)
+		Expect(cond).To(BeTrue())
+
+		// Rate limit
+		By("Enforce HTTP rate limit at VirtualHost level")
+
+		upstreamTrafficSetting := &policyv1alpha1.UpstreamTrafficSetting{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dstSvc.Name,
+				Namespace: dstSvc.Namespace,
+			},
+			Spec: policyv1alpha1.UpstreamTrafficSettingSpec{
+				Host: fmt.Sprintf("%s.%s.svc.cluster.local", dstSvc.Name, dstSvc.Namespace),
+				RateLimit: &policyv1alpha1.RateLimitSpec{
+					Local: &policyv1alpha1.LocalRateLimitSpec{
+						HTTP: &policyv1alpha1.HTTPLocalRateLimitSpec{
+							Requests: 1,
+							Unit:     "minute",
+						},
+					},
+				},
+			},
+		}
+
+		upstreamTrafficSetting, err = Td.PolicyClient.PolicyV1alpha1().UpstreamTrafficSettings(upstreamTrafficSetting.Namespace).Create(context.TODO(), upstreamTrafficSetting, metav1.CreateOptions{})
+		Expect(err).ToNot((HaveOccurred()))
+
+		// Expect client to receive 429 (Too Many Requests)
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.StatusCode != 429 {
+				Td.T.Logf("> (%s) HTTP Req did not fail as expected, status: %d, err: %s",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+
+			Td.T.Logf("> (%s) HTTP Req failed as expected with status: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, Td.ReqSuccessTimeout)
+		Expect(cond).To(BeTrue())
+
+		By("Enforce HTTP rate limit at Route level")
+
+		upstreamTrafficSetting.Spec.RateLimit = nil
+		upstreamTrafficSetting.Spec.HTTPRoutes = append(upstreamTrafficSetting.Spec.HTTPRoutes,
+			policyv1alpha1.HTTPRouteSpec{
+				Path: ".*", // Matches the Path allowed by HTTPRouteGroup policy
+				RateLimit: &policyv1alpha1.HTTPPerRouteRateLimitSpec{
+					Local: &policyv1alpha1.HTTPLocalRateLimitSpec{
+						Requests: 1,
+						Unit:     "minute",
+					},
+				},
+			})
+
+		_, err = Td.PolicyClient.PolicyV1alpha1().UpstreamTrafficSettings(upstreamTrafficSetting.Namespace).Update(context.TODO(), upstreamTrafficSetting, metav1.UpdateOptions{})
+		Expect(err).ToNot((HaveOccurred()))
+
+		// Expect client to receive 429 (Too Many Requests)
+		cond = Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+
+			if result.StatusCode != 429 {
+				Td.T.Logf("> (%s) HTTP Req did not fail as expected, status: %d, err: %s",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+
+			Td.T.Logf("> (%s) HTTP Req failed as expected with status: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, Td.ReqSuccessTimeout)
+
+		Expect(cond).To(BeTrue())
+	})
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Adds capability to locally (per sidecar) rate limit
  HTTP traffic

- Adds HTTP rate limit e2e test

- Clarifies allowed HTTP status codes for rate limited
  responses

Part of #2018

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests, e2e tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `will be updated post merge`