### PR TITLE
feat(certs): update Manager using MRC status

### DIFF
--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -213,7 +213,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Error getting certificate options")
 	}
 
-	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace, certOpts, msgBroker, informerCollection, 5*time.Second)
+	certManager, err := providers.NewCertificateManager(ctx, kubeClient, configClient, kubeConfig, cfg, osmNamespace, certOpts, msgBroker, informerCollection, 5*time.Second)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 			"Error initializing certificate manager of kind %s", certProviderKind)
@@ -423,9 +423,6 @@ func buildMeshRootCertificate(presetMeshRootCertificateConfigMap *corev1.ConfigM
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: meshRootCertificateName,
-			Annotations: map[string]string{
-				constants.MRCVersionAnnotation: "0",
-			},
 		},
 		Spec: presetMeshRootCertificateSpec,
 		Status: configv1alpha2.MeshRootCertificateStatus{

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -207,7 +207,7 @@ func main() {
 	}
 
 	// Intitialize certificate manager/provider
-	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace,
+	certManager, err := providers.NewCertificateManager(ctx, kubeClient, configClient, kubeConfig, cfg, osmNamespace,
 		certOpts, msgBroker, informerCollection, 5*time.Second)
 
 	if err != nil {

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -202,8 +202,8 @@ func main() {
 		log.Fatal().Err(err).Msg("Error getting certificate options")
 	}
 	// Intitialize certificate manager/provider
-	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace,
-		certOpts, msgBroker, informerCollection, 5*time.Second)
+	certManager, err := providers.NewCertificateManager(ctx, kubeClient, configClient, kubeConfig, cfg,
+		osmNamespace, certOpts, msgBroker, informerCollection, 5*time.Second)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 			"Error initializing certificate manager of kind %s", certProviderKind)

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -1,7 +1,10 @@
 package providers
 
+/*
 import (
 	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -27,3 +30,11 @@ func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEven
 
 	return ch, nil
 }
+
+func (c *MRCCompatClient) Update(mrc *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	return c.configClient.ConfigV1alpha2().MeshRootCertificates(mrc.Namespace).UpdateStatus(context.Background(), mrc, metav1.UpdateOptions{})
+}
+
+func (m *MRCCompatClient) Get(id string, ns string) (*v1alpha2.MeshRootCertificate, error) {
+	return m.configClient.ConfigV1alpha2().MeshRootCertificates(ns).Get(context.Background(), id, metav1.GetOptions{})
+}*/

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -175,9 +174,6 @@ func TestGetCertificateManager(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "osm-mesh-root-certificate",
 					Namespace: "osm-system",
-					Annotations: map[string]string{
-						constants.MRCVersionAnnotation: "0",
-					},
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
 					Provider: v1alpha2.ProviderSpec{
@@ -207,7 +203,7 @@ func TestGetCertificateManager(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf(tc.name), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			assert := tassert.New(t)
 
 			oldCA := getCA
@@ -226,7 +222,7 @@ func TestGetCertificateManager(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			manager, err := NewCertificateManager(context.Background(), tc.kubeClient, tc.restConfig, tc.cfg, tc.providerNamespace, tc.options, tc.msgBroker, ic, 1*time.Hour)
+			manager, err := NewCertificateManager(context.Background(), tc.kubeClient, tc.configClient, tc.restConfig, tc.cfg, tc.providerNamespace, tc.options, tc.msgBroker, ic, 1*time.Hour)
 			if tc.expectError {
 				assert.Empty(manager)
 				assert.Error(err)

--- a/pkg/certificate/providers/mrc_test.go
+++ b/pkg/certificate/providers/mrc_test.go
@@ -1,0 +1,95 @@
+package providers
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+)
+
+func TestUpdate(t *testing.T) {
+	testCases := []struct {
+		name          string
+		id            string
+		namespace     string
+		status        string
+		mrc           *v1alpha2.MeshRootCertificate
+		configClient  configClientset.Interface
+		expectedError bool
+	}{
+		{
+			name:      "update mrc not provided",
+			id:        "mrc",
+			namespace: "ns",
+			status:    constants.MRCStateIssuingRollback,
+			configClient: fakeConfig.NewSimpleClientset(&v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "mrc",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateActive,
+				},
+			}),
+			expectedError: false,
+		},
+		{
+			name:      "update mrc provided",
+			id:        "mrc",
+			namespace: "ns",
+			status:    constants.MRCStateIssuingRollback,
+			configClient: fakeConfig.NewSimpleClientset(&v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "mrc",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateActive,
+				},
+			}),
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "mrc",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateActive,
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name:          "update mrc not found",
+			id:            "mrc",
+			namespace:     "ns",
+			status:        constants.MRCStateIssuingRollback,
+			configClient:  fakeConfig.NewSimpleClientset(),
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			mrcClient := &MRCComposer{configClient: tc.configClient}
+
+			updatedMRC, err := mrcClient.Update(tc.id, tc.namespace, tc.status, tc.mrc)
+			if tc.expectedError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.NotNil(updatedMRC)
+				assert.Equal(tc.status, updatedMRC.Status.State)
+			}
+		})
+	}
+}

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -44,13 +44,10 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 	go func() {
 		ch <- certificate.MRCEvent{
 			Type: certificate.MRCEventAdded,
-			MRC: &v1alpha2.MeshRootCertificate{
+			NewMRC: &v1alpha2.MeshRootCertificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "osm-mesh-root-certificate",
 					Namespace: "osm-system",
-					Annotations: map[string]string{
-						constants.MRCVersionAnnotation: "0",
-					},
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
 					Provider: v1alpha2.ProviderSpec{
@@ -73,6 +70,20 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 	}()
 
 	return ch, nil
+}
+
+func (c *fakeMRCClient) Update(id, ns, status string, mrc *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	if mrc != nil {
+		mrc.Status.State = status
+		return mrc, nil
+	}
+	return &v1alpha2.MeshRootCertificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: ns,
+		},
+		Spec:   v1alpha2.MeshRootCertificateSpec{TrustDomain: "fake.example.com"},
+		Status: v1alpha2.MeshRootCertificateStatus{State: status}}, nil
 }
 
 // NewFake constructs a fake certificate client using a certificate

--- a/pkg/certificate/providers/types.go
+++ b/pkg/certificate/providers/types.go
@@ -74,10 +74,11 @@ type CertManagerOptions struct {
 // MRCCompatClient is a backwards compatible client to convert old certificate options into an MRC.
 // It's intent is to match the custom interface that will wrap the MRC k8s informer.
 // TODO(#4502): Remove this entirely once we are fully onboarded to MRC informers.
-type MRCCompatClient struct {
+/*type MRCCompatClient struct {
 	MRCProviderGenerator
-	mrc *v1alpha2.MeshRootCertificate
-}
+	configClient configClientset.Interface
+	mrc          *v1alpha2.MeshRootCertificate
+}*/
 
 // MRCProviderGenerator knows how to convert a given MRC to its appropriate provider.
 type MRCProviderGenerator struct {

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -92,6 +92,7 @@ type Issuer interface {
 
 type issuer struct {
 	Issuer
+	// name of the associated MRC
 	ID          string
 	TrustDomain string
 	// memoized once the first certificate is issued
@@ -124,6 +125,9 @@ type MRCClient interface {
 
 	// GetCertIssuerForMRC returns an Issuer based on the provided MRC.
 	GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (Issuer, pem.RootCertificate, string, error)
+
+	// Update updates an MRC with the provided MRC. Returns the updated MRC.
+	Update(id, ns, status string, mrc *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error)
 }
 
 // MRCEventType is a type alias for a string describing the type of MRC event
@@ -132,8 +136,10 @@ type MRCEventType string
 // MRCEvent describes a change event on a given MRC
 type MRCEvent struct {
 	Type MRCEventType
+	// The previous observed version of the MRC as of the time of this event
+	OldMRC *v1alpha2.MeshRootCertificate
 	// The last observed version of the MRC as of the time of this event
-	MRC *v1alpha2.MeshRootCertificate
+	NewMRC *v1alpha2.MeshRootCertificate
 }
 
 var (
@@ -150,4 +156,8 @@ type MRCEventBroker interface {
 	// MRCs. Watch returns a channel that emits events, and
 	// an error if the subscription goes awry.
 	Watch(context.Context) (<-chan MRCEvent, error)
+}
+
+type MRCUpdater interface {
+	Update(context.Context)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -163,9 +163,6 @@ const (
 
 // Annotations and labels used by the MeshRootCertificate
 const (
-	// MRCVersionAnnotation is the annotation used for the version of the MeshRootCertificate
-	MRCVersionAnnotation = "openservicemesh.io/mrc-version"
-
 	// MRCStateValidatingRollout is the validating rollout status option for the State of the MeshRootCertificate
 	MRCStateValidatingRollout = "validatingRollout"
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updates the Manager in response to MRC state status changes.

On an MRCUpdateEvent the following steps occur:
- validate the update was related to the MRC's status
- validate the status change was valid. This should also be
validated by the validating webhook, but it included as an
additional check
- based on status change, update the Manager's issuers
- if applicable, update the status the MRC being rolled back

Additional changes:
- uses the MRC name for the issuer ID removing the need for a
version annotation on the MRC
- removes the MRCCompatClient

Resolves #4815 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |
| Certificate Management     | [x] |
| Tests                      | [x] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?