### PR TITLE
Move certificate pubsub/broker implementation onto the manager.

### DIFF
--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -213,7 +213,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Error getting certificate options")
 	}
 
-	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace, certOpts, msgBroker, informerCollection, 5*time.Second)
+	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace, certOpts, informerCollection, 5*time.Second)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 			"Error initializing certificate manager of kind %s", certProviderKind)

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -208,7 +208,7 @@ func main() {
 
 	// Intitialize certificate manager/provider
 	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace,
-		certOpts, msgBroker, informerCollection, 5*time.Second)
+		certOpts, informerCollection, 5*time.Second)
 
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -203,7 +203,7 @@ func main() {
 	}
 	// Intitialize certificate manager/provider
 	certManager, err := providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace,
-		certOpts, msgBroker, informerCollection, 5*time.Second)
+		certOpts, informerCollection, 5*time.Second)
 	if err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 			"Error initializing certificate manager of kind %s", certProviderKind)

--- a/pkg/catalog/fake/fake.go
+++ b/pkg/catalog/fake/fake.go
@@ -55,7 +55,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient config
 
 	cfg := configurator.NewConfigurator(ic, osmNamespace, osmMeshConfigName, nil)
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -50,7 +50,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 
 	stop := make(chan struct{})
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 
 	// Create a bookstoreV1 pod
 	bookstoreV1Pod := tests.NewPodFixture(tests.BookstoreV1Service.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName, tests.PodLabels)

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -98,7 +98,6 @@ func FakeCertManager() (*Manager, error) {
 		&fakeMRCClient{},
 		getCertValidityDuration,
 		getCertValidityDuration,
-		nil,
 		1*time.Hour,
 	)
 	if err != nil {

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/k8s/informers"
-	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
 const (
@@ -44,7 +43,7 @@ var getCA func(certificate.Issuer) (pem.RootCertificate, error) = func(i certifi
 // NewCertificateManager returns a new certificate manager, with an MRC compat client.
 // TODO(4713): Use an informer behind a feature flag.
 func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator,
-	providerNamespace string, options Options, msgBroker *messaging.Broker, ic *informers.InformerCollection, checkInterval time.Duration) (*certificate.Manager, error) {
+	providerNamespace string, options Options, ic *informers.InformerCollection, checkInterval time.Duration) (*certificate.Manager, error) {
 	if err := options.Validate(); err != nil {
 		return nil, err
 	}
@@ -100,7 +99,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 		mrcClient = c
 	}
 
-	return certificate.NewManager(ctx, mrcClient, cfg.GetServiceCertValidityPeriod, cfg.GetIngressGatewayCertValidityPeriod, msgBroker, checkInterval)
+	return certificate.NewManager(ctx, mrcClient, cfg.GetServiceCertValidityPeriod, cfg.GetIngressGatewayCertValidityPeriod, checkInterval)
 }
 
 // GetCertIssuerForMRC returns a certificate.Issuer generated from the provided MRC.

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
 const (
@@ -76,14 +75,14 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 }
 
 // NewFake constructs a fake certificate client using a certificate
-func NewFake(msgBroker *messaging.Broker, checkInterval time.Duration) *certificate.Manager {
+func NewFake(checkInterval time.Duration) *certificate.Manager {
 	getValidityDuration := func() time.Duration { return 1 * time.Hour }
-	return NewFakeWithValidityDuration(getValidityDuration, msgBroker, checkInterval)
+	return NewFakeWithValidityDuration(getValidityDuration, checkInterval)
 }
 
 // NewFakeWithValidityDuration constructs a fake certificate manager with specified cert validity duration
-func NewFakeWithValidityDuration(getCertValidityDuration func() time.Duration, msgBroker *messaging.Broker, checkInterval time.Duration) *certificate.Manager {
-	tresorCertManager, err := certificate.NewManager(context.Background(), &fakeMRCClient{}, getCertValidityDuration, getCertValidityDuration, msgBroker, checkInterval)
+func NewFakeWithValidityDuration(getCertValidityDuration func() time.Duration, checkInterval time.Duration) *certificate.Manager {
+	tresorCertManager, err := certificate.NewManager(context.Background(), &fakeMRCClient{}, getCertValidityDuration, getCertValidityDuration, checkInterval)
 	if err != nil {
 		log.Error().Err(err).Msg("error encountered creating fake cert manager")
 		return nil

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -9,9 +9,10 @@ import (
 
 	"golang.org/x/sync/singleflight"
 
+	"github.com/cskr/pubsub"
+
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
-	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
 const (
@@ -107,7 +108,6 @@ type Manager struct {
 	ingressCertValidityDuration func() time.Duration
 	// TODO(#4711): define serviceCertValidityDuration in the MRC
 	serviceCertValidityDuration func() time.Duration
-	msgBroker                   *messaging.Broker
 
 	mu            sync.Mutex // mu syncrhonizes acces to the below resources.
 	signingIssuer *issuer
@@ -115,6 +115,8 @@ type Manager struct {
 	validatingIssuer *issuer
 
 	group singleflight.Group
+
+	pubsub *pubsub.PubSub
 }
 
 // MRCClient is an interface that can watch for changes to the MRC. It is typically backed by a k8s informer.

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -101,7 +101,7 @@ func TestNewConversionWebhook(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	fakeCertManager := tresorFake.NewFake(nil, 1*time.Hour)
+	fakeCertManager := tresorFake.NewFake(1 * time.Hour)
 	osmNamespace := "-osm-namespace-"
 	enablesReconciler := false
 	stop := make(<-chan struct{})

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 	Context("Test sendAllResponses()", func() {
 
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		certPEM, _ := certManager.IssueCertificate(proxySvcAccount.ToServiceIdentity().String(), certificate.Service)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 		server, actualResponses := tests.NewFakeXDSServer(cert, nil, nil)
@@ -175,7 +175,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 	Context("Test sendSDSResponse()", func() {
 
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		certCNPrefix := fmt.Sprintf("%s.%s.%s.%s", uuid.New(), envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace)
 		certDuration := 1 * time.Hour
 		certPEM, _ := certManager.IssueCertificate(certCNPrefix, certificate.Service)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/k8s/events"
 	"github.com/openservicemesh/osm/pkg/messaging"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 	"github.com/openservicemesh/osm/pkg/utils"
@@ -75,9 +74,8 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	defer s.msgBroker.Unsub(proxyUpdatePubSub, proxyUpdateChan)
 
 	// Register for certificate rotation updates
-	certPubSub := s.msgBroker.GetCertPubSub()
-	certRotateChan := certPubSub.Sub(announcements.CertificateRotated.String())
-	defer s.msgBroker.Unsub(certPubSub, certRotateChan)
+	certRotateChan, unsub := s.certManager.WatchRotations(proxy.Identity.String())
+	defer unsub()
 
 	newJob := func(typeURIs []envoy.TypeURI, discoveryRequest *xds_discovery.DiscoveryRequest) *proxyResponseJob {
 		return &proxyResponseJob{
@@ -134,17 +132,14 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			// Do not send SDS, let envoy figure out what certs does it want.
 			<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeCDS, envoy.TypeEDS, envoy.TypeLDS, envoy.TypeRDS}, nil))
 
-		case certRotateMsg := <-certRotateChan:
-			cert := certRotateMsg.(events.PubSubMessage).NewObj.(*certificate.Certificate)
-			if isCNforProxy(proxy, cert.GetCommonName()) {
-				// The CN whose corresponding certificate was updated (rotated) by the certificate provider is associated
-				// with this proxy, so update the secrets corresponding to this certificate via SDS.
-				log.Debug().Str("proxy", proxy.String()).Msg("Certificate has been updated for proxy")
+		case <-certRotateChan:
+			// The CN whose corresponding certificate was updated (rotated) by the certificate provider is associated
+			// with this proxy, so update the secrets corresponding to this certificate via SDS.
+			log.Debug().Str("proxy", proxy.String()).Msg("Certificate has been updated for proxy")
 
-				// Empty DiscoveryRequest should create the SDS specific request
-				// Prepare to queue the SDS proxy response job on the worker pool
-				<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeSDS}, nil))
-			}
+			// Empty DiscoveryRequest should create the SDS specific request
+			// Prepare to queue the SDS proxy response job on the worker pool
+			<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeSDS}, nil))
 		}
 	}
 }
@@ -316,20 +311,6 @@ func getResourceSliceFromMapset(resourceMap mapset.Set) []string {
 	}
 	sort.Strings(resourceSlice)
 	return resourceSlice
-}
-
-// isCNforProxy returns true if the given CN for the workload certificate matches the given proxy's identity.
-// Proxy identity corresponds to the k8s service account, while the workload certificate is of the form
-// <svc-account>.<namespace>.<trust-domain>.
-func isCNforProxy(proxy *envoy.Proxy, cn certificate.CommonName) bool {
-	// Workload certificate CN is of the form <svc-account>.<namespace>.<trust-domain>
-	chunks := strings.Split(cn.String(), constants.DomainDelimiter)
-	if len(chunks) < 3 {
-		return false
-	}
-
-	identityForCN := identity.K8sServiceAccount{Name: chunks[0], Namespace: chunks[1]}
-	return identityForCN == proxy.Identity.ToK8sServiceAccount()
 }
 
 func getCertificateCommonNameMeta(cn certificate.CommonName) (envoy.ProxyKind, uuid.UUID, identity.ServiceIdentity, error) {

--- a/pkg/envoy/ads/stream_test.go
+++ b/pkg/envoy/ads/stream_test.go
@@ -13,45 +13,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 )
 
-func TestIsCNForProxy(t *testing.T) {
-	type testCase struct {
-		name     string
-		cn       certificate.CommonName
-		proxy    *envoy.Proxy
-		expected bool
-	}
-
-	testCases := []testCase{
-		{
-			name: "workload CN belongs to proxy",
-			cn:   certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy: func() *envoy.Proxy {
-				p := envoy.NewProxy(envoy.KindSidecar, uuid.New(), identity.New("svc-acc", "namespace"), nil)
-				return p
-			}(),
-			expected: true,
-		},
-		{
-			name: "workload CN does not belong to proxy",
-			cn:   certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy: func() *envoy.Proxy {
-				p := envoy.NewProxy(envoy.KindSidecar, uuid.New(), identity.New("svc-acc-foo", "namespace"), nil)
-				return p
-			}(),
-			expected: false,
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			assert := tassert.New(t)
-
-			actual := isCNforProxy(tc.proxy, tc.cn)
-			assert.Equal(tc.expected, actual)
-		})
-	}
-}
-
 func findSliceElem(slice []string, elem string) bool {
 	for _, v := range slice {
 		if v == elem {

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -16,8 +16,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
-
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -25,6 +23,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/auth"
 	catalogFake "github.com/openservicemesh/osm/pkg/catalog/fake"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -101,7 +100,7 @@ func TestNewResponse(t *testing.T) {
 		return nil, fmt.Errorf("dummy error")
 	}), nil)
 
-	cm := tresorfake.NewFake(nil, 1*time.Hour)
+	cm := tresorFake.NewFake(1 * time.Hour)
 	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, cm, proxyRegistry)
 	assert.NotNil(err)
 	assert.Nil(resources)

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -19,11 +19,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
-
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -297,7 +296,7 @@ func TestNewResponse(t *testing.T) {
 				ResourceNames: []string{},
 			}
 
-			mc := tresorfake.NewFake(nil, 1*time.Hour)
+			mc := tresorFake.NewFake(1 * time.Hour)
 
 			resources, err := NewResponse(mockCatalog, proxy, &discoveryRequest, mockConfigurator, mc, proxyRegistry)
 			assert.Nil(err)
@@ -444,7 +443,7 @@ func TestResponseRequestCompletion(t *testing.T) {
 		return []service.MeshService{tests.BookstoreV1Service}, nil
 	}), nil)
 
-	mc := tresorfake.NewFake(nil, 1*time.Hour)
+	mc := tresorFake.NewFake(1 * time.Hour)
 
 	mockCatalog.EXPECT().GetInboundMeshTrafficPolicy(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockCatalog.EXPECT().GetOutboundMeshTrafficPolicy(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -62,7 +62,7 @@ func TestNewResponse(t *testing.T) {
 	assert.Nil(err)
 
 	cfg := configurator.NewConfigurator(ic, "-osm-namespace-", "-the-mesh-config-name-", nil)
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	meshCatalog := catalogFake.NewFakeMeshCatalog(fakeKubeClient, fakeConfigClient)
 
 	// ----- Test with an properly configured proxy

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -12,12 +12,12 @@ import (
 
 // Initialize initializes the client and starts the ingress gateway certificate manager routine
 func Initialize(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{},
-	cfg configurator.Configurator, certProvider *certificate.Manager, msgBroker *messaging.Broker) error {
+	cfg configurator.Configurator, cm *certificate.Manager, msgBroker *messaging.Broker) error {
 	c := &client{
 		kubeClient:     kubeClient,
 		kubeController: kubeController,
 		cfg:            cfg,
-		certProvider:   certProvider,
+		certManager:    cm,
 		msgBroker:      msgBroker,
 	}
 

--- a/pkg/ingress/types.go
+++ b/pkg/ingress/types.go
@@ -20,6 +20,6 @@ type client struct {
 	kubeClient     kubernetes.Interface
 	kubeController k8s.Controller
 	cfg            configurator.Configurator
-	certProvider   *certificate.Manager
+	certManager    *certificate.Manager
 	msgBroker      *messaging.Broker
 }

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -137,7 +137,7 @@ func TestCreatePatch(t *testing.T) {
 			wh := &mutatingWebhook{
 				kubeClient:          client,
 				kubeController:      mockNsController,
-				certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+				certManager:         tresorFake.NewFake(1 * time.Hour),
 				configurator:        mockConfigurator,
 				nonInjectNamespaces: mapset.NewSet(),
 			}
@@ -236,7 +236,7 @@ func TestCreatePatch(t *testing.T) {
 		wh := &mutatingWebhook{
 			kubeClient:          client,
 			kubeController:      mockNsController,
-			certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+			certManager:         tresorFake.NewFake(1 * time.Hour),
 			configurator:        mockConfigurator,
 			nonInjectNamespaces: mapset.NewSet(),
 		}

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -563,7 +563,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		stop := make(chan struct{})
 		mockController := gomock.NewController(GinkgoT())
 		cfg := configurator.NewMockConfigurator(mockController)
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 
 		cfg.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
@@ -581,7 +581,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		stop := make(chan struct{})
 		mockController := gomock.NewController(GinkgoT())
 		cfg := configurator.NewMockConfigurator(mockController)
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 
 		cfg.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
@@ -853,7 +853,7 @@ func TestWebhookMutate(t *testing.T) {
 		wh := &mutatingWebhook{
 			nonInjectNamespaces: mapset.NewSet(),
 			kubeController:      kubeController,
-			certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+			certManager:         tresorFake.NewFake(1 * time.Hour),
 			kubeClient:          fake.NewSimpleClientset(),
 			configurator:        cfg,
 		}
@@ -899,7 +899,7 @@ func TestWebhookMutate(t *testing.T) {
 		wh := &mutatingWebhook{
 			nonInjectNamespaces: mapset.NewSet(),
 			kubeController:      kubeController,
-			certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+			certManager:         tresorFake.NewFake(1 * time.Hour),
 			kubeClient:          fake.NewSimpleClientset(),
 			configurator:        cfg,
 		}

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -68,11 +68,6 @@ func (b *Broker) GetKubeEventPubSub() *pubsub.PubSub {
 	return b.kubeEventPubSub
 }
 
-// GetCertPubSub returns the PubSub instance corresponding to certificate events
-func (b *Broker) GetCertPubSub() *pubsub.PubSub {
-	return b.certPubSub
-}
-
 // GetTotalQProxyEventCount returns the total number of events read from the workqueue
 // pertaining to proxy updates
 func (b *Broker) GetTotalQProxyEventCount() uint64 {

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewGrpc(t *testing.T) {
 	assert := tassert.New(t)
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	adsCert, err := certManager.IssueCertificate("fake-ads", certificate.Internal)
 	assert.NoError(err)
 
@@ -52,7 +52,7 @@ func TestNewGrpc(t *testing.T) {
 func TestGrpcServe(t *testing.T) {
 	assert := tassert.New(t)
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	adsCert, err := certManager.IssueCertificate("fake-ads", certificate.Internal)
 
 	assert.NoError(err)

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -29,7 +29,7 @@ func TestSetupMutualTLS(t *testing.T) {
 		expectedError string
 	}
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	adsCert, err := certManager.IssueCertificate("fake-ads", certificate.Internal)
 
 	assert.NoError(err)
@@ -66,7 +66,7 @@ func TestValidateClient(t *testing.T) {
 		expectedError error
 	}
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	cnPrefix := fmt.Sprintf("%s.%s.%s", uuid.New(), tests.BookstoreServiceAccountName, tests.Namespace)
 	certPEM, _ := certManager.IssueCertificate(cnPrefix, certificate.Internal)
 	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -145,7 +145,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 	enableReconciler := false
 	validateTrafficTarget := true
 	t.Run("successful startup", func(t *testing.T) {
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 
 		port := 41414
 		stop := make(chan struct{})
@@ -167,7 +167,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 	})
 
 	t.Run("successful startup with reconciler enabled and traffic target validation enabled", func(t *testing.T) {
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		enableReconciler = true
 
 		port := 41414
@@ -184,7 +184,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 	})
 
 	t.Run("successful startup with reconciler enabled and validation for traffic target disabled", func(t *testing.T) {
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		enableReconciler = true
 		validateTrafficTarget = false
 

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 
 	catalogFake "github.com/openservicemesh/osm/pkg/catalog/fake"
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/rds"
@@ -51,7 +50,7 @@ func TestRDSNewResponseWithTrafficSplit(t *testing.T) {
 		EnableEgressPolicy: false,
 	}).AnyTimes()
 
-	mc := tresorfake.NewFake(nil, 1*time.Hour)
+	mc := tresorFake.NewFake(1 * time.Hour)
 	a.NotNil(a)
 
 	resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, mc, proxyRegistry)

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -20,7 +20,6 @@ import (
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -253,7 +252,7 @@ func TestRDSRespose(t *testing.T) {
 			mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 
-			cm := tresorfake.NewFake(nil, 1*time.Hour)
+			cm := tresorFake.NewFake(1 * time.Hour)
 
 			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, cm, proxyRegistry)
 			assert.Nil(err)


### PR DESCRIPTION
This further changes the pubsub usage to be keyed by the cnPrefix, such that notifications will be about a single cert

This is done to allow more performant notifications, and to allow for cert rotations in the http servers