### PR TITLE
docs: update SUPPORT with OSM and K8s version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Read more about [OSM's high level goals, design, and architecture](DESIGN.md).
 ## Install
 
 ### Prerequisites
-- Kubernetes cluster running Kubernetes v1.22.9 or greater
+- Kubernetes cluster running an [active Kubernetes releases](https://kubernetes.io/releases/). The range of supported Kubernetes versions is defined in the [OSM Helm chart](https://github.com/openservicemesh/osm/blob/main/charts/osm/Chart.yaml#L24).
 - kubectl current context is configured for the target cluster install
   - ```kubectl config current-context```
 

--- a/SUPPORT
+++ b/SUPPORT
@@ -1,3 +1,7 @@
 # Support
 
 [Please search open issues on GitHub](https://github.com/openservicemesh/osm/issues), and if your issue isn't already represented please [open a new one](https://github.com/openservicemesh/osm/issues/new/choose). The OSM project maintainers will respond to the best of their abilities.
+
+## Supported versions of OSM
+
+The OSM project maintainers will respond to the best of their abilities to issues on the current and two previous minor versions of OSM running on Kubernetes v1.22.9 or greater.

--- a/SUPPORT
+++ b/SUPPORT
@@ -4,4 +4,4 @@
 
 ## Supported versions of OSM
 
-The OSM project maintainers will respond to the best of their abilities to issues on the current and two previous minor versions of OSM running on Kubernetes v1.22.9 or greater.
+The OSM project maintainers will respond to the best of their abilities to issues on the current and two previous minor versions of OSM running on [active Kubernetes releases](https://kubernetes.io/releases/). The range of supported Kubernetes versions is defined in the [OSM Helm chart](https://github.com/openservicemesh/osm/blob/main/charts/osm/Chart.yaml#L24).


### PR DESCRIPTION
Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>

**Description**: Provide details on which versions of OSM are supported on which versions of Kubernetes in support file.


**Testing done**: Verified file displays correctly.

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ x ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? yes