### PR TITLE
validator: validate HTTP rate limiting status code

### DIFF
--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -1147,6 +1147,126 @@ func TestUpstreamTrafficSettingValidator(t *testing.T) {
 			expResp:   nil,
 			expErrStr: "",
 		},
+		{
+			name: "UpstreamTrafficSetting with valid rate limiting config",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "UpstreamTrafficSetting",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "policy.openservicemesh.io/v1alpha1",
+						"kind": "UpstreamTrafficSetting",
+						"metadata": {
+							"name": "httpbin",
+							"namespace": "test"
+						},
+						"spec": {
+							"host": "httpbin.test.svc.cluster.local",
+							"rateLimit": {
+								"local": {
+									"http": {
+										"responseStatusCode": 429
+									}
+								}
+							},
+							"httpRoutes": [
+								{
+								"rateLimit": {
+									"local": {
+										"responseStatusCode": 503
+									}
+								}
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "",
+		},
+		{
+			name: "UpstreamTrafficSetting with invalid vhost rate limiting HTTP status code",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "UpstreamTrafficSetting",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "policy.openservicemesh.io/v1alpha1",
+						"kind": "UpstreamTrafficSetting",
+						"metadata": {
+							"name": "httpbin",
+							"namespace": "test"
+						},
+						"spec": {
+							"host": "httpbin.test.svc.cluster.local",
+							"rateLimit": {
+								"local": {
+									"http": {
+										"responseStatusCode": 1
+									}
+								}
+							}
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "Invalid responseStatusCode 1. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/v3/http_status.proto#enum-type-v3-statuscode for allowed values",
+		},
+		{
+			name: "UpstreamTrafficSetting with invalid HTTP route rate limiting status code",
+			input: &admissionv1.AdmissionRequest{
+				Kind: metav1.GroupVersionKind{
+					Group:   "v1alpha1",
+					Version: "policy.openservicemesh.io",
+					Kind:    "UpstreamTrafficSetting",
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(`
+					{
+						"apiVersion": "policy.openservicemesh.io/v1alpha1",
+						"kind": "UpstreamTrafficSetting",
+						"metadata": {
+							"name": "httpbin",
+							"namespace": "test"
+						},
+						"spec": {
+							"host": "httpbin.test.svc.cluster.local",
+							"rateLimit": {
+								"local": {
+									"http": {
+										"responseStatusCode": 429
+									}
+								}
+							},
+							"httpRoutes": [
+								{
+								"rateLimit": {
+									"local": {
+										"responseStatusCode": 1
+									}
+								}
+								}
+							]
+						}
+					}
+					`),
+				},
+			},
+			expResp:   nil,
+			expErrStr: "Invalid responseStatusCode 1. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/type/v3/http_status.proto#enum-type-v3-statuscode for allowed values",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds logic to validate the HTTP status code is
among a list of status codes supported by Envoy.

Part of #2018

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? yes