### PR TITLE
Ignore CODEOWNERS and OWNERS for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ on:
       - "docs/**"
       - "**.md"
       - "scripts/cleanup/**"
+      - "CODEOWNERS"
+      - "OWNERS"
   pull_request:
     branches:
       - main
@@ -16,6 +18,8 @@ on:
       - "docs/**"
       - "**.md"
       - "scripts/cleanup/**"
+      - "CODEOWNERS"
+      - "OWNERS"
 env:
   CI_WAIT_FOR_OK_SECONDS: 60
   CI_MAX_ITERATIONS_THRESHOLD: 60


### PR DESCRIPTION
Currently when CODEOWNERS and OWNERS files are modified this will cause
the CI pipeline to be triggered. There is no reason for CI to run when
these two files are modified, so this change ignores them.

Signed-off-by: Thomas Stringer <thomas@trstringer.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CI System                  | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A