### PR TITLE
Consolidate cert rotation chan into cert manager

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -237,9 +237,7 @@ func main() {
 	endpointsProviders := []endpoint.Provider{kubeProvider}
 	serviceProviders := []service.Provider{kubeProvider}
 
-	if err := ingress.Initialize(kubeClient, k8sClient, stop, cfg, certManager, msgBroker); err != nil {
-		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating Ingress client")
-	}
+	ingress.Initialize(kubeClient, k8sClient, stop, cfg, certManager, msgBroker)
 
 	policyController := policy.NewPolicyController(informerCollection, k8sClient, msgBroker)
 

--- a/pkg/announcements/types.go
+++ b/pkg/announcements/types.go
@@ -121,11 +121,6 @@ const (
 	// IngressUpdated is the type of announcement emitted when we observe an update to a Kubernetes Ingress
 	IngressUpdated Kind = "ingress-updated"
 
-	// ---
-
-	// CertificateRotated is the type of announcement emitted when a certificate is rotated by the certificate provider
-	CertificateRotated Kind = "certificate-rotated"
-
 	// --- config.openservicemesh.io API events
 
 	// MeshConfigAdded is the type of announcement emitted when we observe an addition of a Kubernetes MeshConfig

--- a/pkg/catalog/fake/fake.go
+++ b/pkg/catalog/fake/fake.go
@@ -55,7 +55,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient config
 
 	cfg := configurator.NewConfigurator(ic, osmNamespace, osmMeshConfigName, nil)
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 
 	// #1683 tracks potential improvements to the following dynamic mocks
 	mockKubeController.EXPECT().ListServices().DoAndReturn(func() []*corev1.Service {

--- a/pkg/catalog/helpers_test.go
+++ b/pkg/catalog/helpers_test.go
@@ -50,7 +50,7 @@ func newFakeMeshCatalogForRoutes(t *testing.T, testParams testParams) *MeshCatal
 
 	stop := make(chan struct{})
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 
 	// Create a bookstoreV1 pod
 	bookstoreV1Pod := tests.NewPodFixture(tests.BookstoreV1Service.Namespace, tests.BookstoreV1Service.Name, tests.BookstoreServiceAccountName, tests.PodLabels)

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -2013,7 +2013,7 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
-			fakeCertManager := tresorFake.NewFake(nil, 1*time.Hour)
+			fakeCertManager := tresorFake.NewFake(1 * time.Hour)
 
 			mockKubeController := k8s.NewMockController(mockCtrl)
 			mockPolicyController := policy.NewMockController(mockCtrl)

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -96,7 +96,6 @@ func FakeCertManager() (*Manager, error) {
 		&fakeMRCClient{},
 		getCertValidityDuration,
 		getCertValidityDuration,
-		nil,
 		1*time.Hour,
 	)
 	if err != nil {

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -378,6 +378,11 @@ func TestSubscribeRotations(t *testing.T) {
 		pubsub:           pubsub.New(0),
 	}
 
+	ch1, unsub1 := cm.SubscribeRotations(cnPrefix1)
+	ch2, unsub2 := cm.SubscribeRotations(cnPrefix2)
+	defer unsub1()
+	defer unsub2()
+
 	cert, err := cm.IssueCertificate(cnPrefix1, Service)
 	assert.NoError(err)
 	assert.Equal("fake-cert-cn1.fake1.domain.com", cert.GetCommonName().String())
@@ -385,11 +390,6 @@ func TestSubscribeRotations(t *testing.T) {
 	cert, err = cm.IssueCertificate(cnPrefix2, Service)
 	assert.NoError(err)
 	assert.Equal("fake-cert-cn2.fake1.domain.com", cert.GetCommonName().String())
-
-	ch1, unsub1 := cm.SubscribeRotations(cnPrefix1)
-	ch2, unsub2 := cm.SubscribeRotations(cnPrefix2)
-	defer unsub1()
-	defer unsub2()
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -2,18 +2,18 @@ package certificate
 
 import (
 	"context"
+	"sync"
 	"testing"
 	time "time"
 
+	"github.com/cskr/pubsub"
 	tassert "github.com/stretchr/testify/assert"
 	trequire "github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
 func TestShouldRotate(t *testing.T) {
@@ -85,13 +85,13 @@ func TestRotor(t *testing.T) {
 
 	stop := make(chan struct{})
 	defer close(stop)
-	msgBroker := messaging.NewBroker(stop)
-	certManager, err := NewManager(context.Background(), &fakeMRCClient{}, getServiceCertValidityPeriod, getIngressGatewayCertValidityPeriod, msgBroker, 5*time.Second)
+	certManager, err := NewManager(context.Background(), &fakeMRCClient{}, getServiceCertValidityPeriod, getIngressGatewayCertValidityPeriod, 5*time.Second)
 	require.NoError(err)
 
 	certA, err := certManager.IssueCertificate(cnPrefix, Service)
 	require.NoError(err)
-	certRotateChan := msgBroker.GetCertPubSub().Sub(announcements.CertificateRotated.String())
+	certRotateChan, unsub := certManager.SubscribeRotations(cnPrefix)
+	defer unsub()
 
 	// Wait for two certificate rotations to be announced and terminate
 	<-certRotateChan
@@ -182,7 +182,6 @@ func TestIssueCertificate(t *testing.T) {
 
 	stop := make(chan struct{})
 	defer close(stop)
-	msgBroker := messaging.NewBroker(stop)
 
 	t.Run("single key issuer", func(t *testing.T) {
 		cm := &Manager{
@@ -190,7 +189,7 @@ func TestIssueCertificate(t *testing.T) {
 			// The root certificate signing all newly issued certificates
 			signingIssuer:    &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}, CertificateAuthority: pem.RootCertificate("id1"), TrustDomain: "fake1.domain.com"},
 			validatingIssuer: &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}, CertificateAuthority: pem.RootCertificate("id1"), TrustDomain: "fake2.domain.com"},
-			msgBroker:        msgBroker,
+			pubsub:           pubsub.New(0),
 		}
 		// single signingIssuer, not cached
 		cert1, err := cm.IssueCertificate(cnPrefix, Service)
@@ -228,7 +227,7 @@ func TestIssueCertificate(t *testing.T) {
 			// The root certificate signing all newly issued certificates
 			signingIssuer:    &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}, CertificateAuthority: pem.RootCertificate("id1"), TrustDomain: "fake1.domain.com"},
 			validatingIssuer: &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2"}, CertificateAuthority: pem.RootCertificate("id2"), TrustDomain: "fake2.domain.com"},
-			msgBroker:        msgBroker,
+			pubsub:           pubsub.New(0),
 		}
 
 		// Not cached
@@ -286,7 +285,7 @@ func TestIssueCertificate(t *testing.T) {
 			// The root certificate signing all newly issued certificates
 			signingIssuer:    &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1", err: true}, CertificateAuthority: pem.RootCertificate("id1")},
 			validatingIssuer: &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2", err: true}, CertificateAuthority: pem.RootCertificate("id2")},
-			msgBroker:        msgBroker,
+			pubsub:           pubsub.New(0),
 		}
 
 		// bad signingIssuer
@@ -364,4 +363,48 @@ func TestHandleMRCEvent(t *testing.T) {
 			assert.Equal(tt.wantValidatingIssuer, *m.validatingIssuer)
 		})
 	}
+}
+
+func TestSubscribeRotations(t *testing.T) {
+	assert := tassert.New(t)
+	cnPrefix1 := "fake-cert-cn1"
+	cnPrefix2 := "fake-cert-cn2"
+
+	cm := &Manager{
+		serviceCertValidityDuration: func() time.Duration { return time.Hour },
+		// The root certificate signing all newly issued certificates
+		signingIssuer:    &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}, CertificateAuthority: pem.RootCertificate("id1"), TrustDomain: "fake1.domain.com"},
+		validatingIssuer: &issuer{ID: "id1", Issuer: &fakeIssuer{id: "id1"}, CertificateAuthority: pem.RootCertificate("id1"), TrustDomain: "fake1.domain.com"},
+		pubsub:           pubsub.New(0),
+	}
+
+	cert, err := cm.IssueCertificate(cnPrefix1, Service)
+	assert.NoError(err)
+	assert.Equal("fake-cert-cn1.fake1.domain.com", cert.GetCommonName().String())
+
+	cert, err = cm.IssueCertificate(cnPrefix2, Service)
+	assert.NoError(err)
+	assert.Equal("fake-cert-cn2.fake1.domain.com", cert.GetCommonName().String())
+
+	ch1, unsub1 := cm.SubscribeRotations(cnPrefix1)
+	ch2, unsub2 := cm.SubscribeRotations(cnPrefix2)
+	defer unsub1()
+	defer unsub2()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		msg1 := <-ch1
+		msg2 := <-ch2
+
+		assert.Equal("fake-cert-cn1.fake2.domain.com", msg1.(*Certificate).GetCommonName().String())
+		assert.Equal("fake-cert-cn2.fake2.domain.com", msg2.(*Certificate).GetCommonName().String())
+		wg.Done()
+	}()
+
+	// swap the issuer which will trigger a rotation
+	cm.signingIssuer = &issuer{ID: "id2", Issuer: &fakeIssuer{id: "id2"}, CertificateAuthority: pem.RootCertificate("id2"), TrustDomain: "fake2.domain.com"}
+	cm.checkAndRotate()
+
+	wg.Wait()
 }

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -76,7 +76,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 		mrcClient.MRCProviderGenerator.DefaultVaultToken = vaultOption.VaultToken
 	}
 
-	return certificate.NewManager(ctx, mrcClient, cfg.GetServiceCertValidityPeriod, cfg.GetIngressGatewayCertValidityPeriod, msgBroker, checkInterval)
+	return certificate.NewManager(ctx, mrcClient, cfg.GetServiceCertValidityPeriod, cfg.GetIngressGatewayCertValidityPeriod, checkInterval)
 }
 
 // NewCertificateManagerFromMRC returns a new certificate manager.
@@ -100,7 +100,7 @@ func NewCertificateManagerFromMRC(ctx context.Context, kubeClient kubernetes.Int
 		mrcClient.MRCProviderGenerator.DefaultVaultToken = vaultOption.VaultToken
 	}
 
-	return certificate.NewManager(ctx, mrcClient, cfg.GetServiceCertValidityPeriod, cfg.GetIngressGatewayCertValidityPeriod, msgBroker, checkInterval)
+	return certificate.NewManager(ctx, mrcClient, cfg.GetServiceCertValidityPeriod, cfg.GetIngressGatewayCertValidityPeriod, checkInterval)
 }
 
 // GetCertIssuerForMRC returns a certificate.Issuer generated from the provided MRC.

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
 const (
@@ -50,6 +49,7 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					TrustDomain: "cluster.local",
 					Provider: v1alpha2.ProviderSpec{
 						Tresor: &v1alpha2.TresorProviderSpec{
 							CA: v1alpha2.TresorCASpec{
@@ -60,7 +60,6 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 							},
 						},
 					},
-					TrustDomain: "cluster.local",
 				},
 				Status: v1alpha2.MeshRootCertificateStatus{
 					State: constants.MRCStateActive,
@@ -74,14 +73,14 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 }
 
 // NewFake constructs a fake certificate client using a certificate
-func NewFake(msgBroker *messaging.Broker, checkInterval time.Duration) *certificate.Manager {
+func NewFake(checkInterval time.Duration) *certificate.Manager {
 	getValidityDuration := func() time.Duration { return 1 * time.Hour }
-	return NewFakeWithValidityDuration(getValidityDuration, msgBroker, checkInterval)
+	return NewFakeWithValidityDuration(getValidityDuration, checkInterval)
 }
 
 // NewFakeWithValidityDuration constructs a fake certificate manager with specified cert validity duration
-func NewFakeWithValidityDuration(getCertValidityDuration func() time.Duration, msgBroker *messaging.Broker, checkInterval time.Duration) *certificate.Manager {
-	tresorCertManager, err := certificate.NewManager(context.Background(), &fakeMRCClient{}, getCertValidityDuration, getCertValidityDuration, msgBroker, checkInterval)
+func NewFakeWithValidityDuration(getCertValidityDuration func() time.Duration, checkInterval time.Duration) *certificate.Manager {
+	tresorCertManager, err := certificate.NewManager(context.Background(), &fakeMRCClient{}, getCertValidityDuration, getCertValidityDuration, checkInterval)
 	if err != nil {
 		log.Error().Err(err).Msg("error encountered creating fake cert manager")
 		return nil

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -9,9 +9,10 @@ import (
 
 	"golang.org/x/sync/singleflight"
 
+	"github.com/cskr/pubsub"
+
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
-	"github.com/openservicemesh/osm/pkg/messaging"
 )
 
 const (
@@ -107,7 +108,6 @@ type Manager struct {
 	ingressCertValidityDuration func() time.Duration
 	// TODO(#4711): define serviceCertValidityDuration in the MRC
 	serviceCertValidityDuration func() time.Duration
-	msgBroker                   *messaging.Broker
 
 	mu            sync.Mutex // mu syncrhonizes acces to the below resources.
 	signingIssuer *issuer
@@ -115,6 +115,8 @@ type Manager struct {
 	validatingIssuer *issuer
 
 	group singleflight.Group
+
+	pubsub *pubsub.PubSub
 }
 
 // MRCClient is an interface that can watch for changes to the MRC. It is typically backed by a k8s informer.

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -100,7 +100,7 @@ func TestNewConversionWebhook(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	fakeCertManager := tresorFake.NewFake(nil, 1*time.Hour)
+	fakeCertManager := tresorFake.NewFake(1 * time.Hour)
 	osmNamespace := "-osm-namespace-"
 	enablesReconciler := false
 

--- a/pkg/envoy/ads/response_test.go
+++ b/pkg/envoy/ads/response_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 	Context("Test sendAllResponses()", func() {
 
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		certPEM, _ := certManager.IssueCertificate(proxySvcAccount.ToServiceIdentity().String(), certificate.Service)
 		cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 		server, actualResponses := tests.NewFakeXDSServer(cert, nil, nil)
@@ -175,7 +175,7 @@ var _ = Describe("Test ADS response functions", func() {
 
 	Context("Test sendSDSResponse()", func() {
 
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		certCNPrefix := fmt.Sprintf("%s.%s.%s.%s", uuid.New(), envoy.KindSidecar, proxySvcAccount.Name, proxySvcAccount.Namespace)
 		certDuration := 1 * time.Hour
 		certPEM, _ := certManager.IssueCertificate(certCNPrefix, certificate.Service)

--- a/pkg/envoy/ads/stream.go
+++ b/pkg/envoy/ads/stream.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
-	"github.com/openservicemesh/osm/pkg/k8s/events"
 	"github.com/openservicemesh/osm/pkg/messaging"
 	"github.com/openservicemesh/osm/pkg/metricsstore"
 	"github.com/openservicemesh/osm/pkg/utils"
@@ -74,9 +73,8 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 	defer s.msgBroker.Unsub(proxyUpdatePubSub, proxyUpdateChan)
 
 	// Register for certificate rotation updates
-	certPubSub := s.msgBroker.GetCertPubSub()
-	certRotateChan := certPubSub.Sub(announcements.CertificateRotated.String())
-	defer s.msgBroker.Unsub(certPubSub, certRotateChan)
+	certRotateChan, unsub := s.certManager.SubscribeRotations(si.String())
+	defer unsub()
 
 	newJob := func(typeURIs []envoy.TypeURI, discoveryRequest *xds_discovery.DiscoveryRequest) *proxyResponseJob {
 		return &proxyResponseJob{
@@ -133,17 +131,12 @@ func (s *Server) StreamAggregatedResources(server xds_discovery.AggregatedDiscov
 			// Do not send SDS, let envoy figure out what certs does it want.
 			<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeCDS, envoy.TypeEDS, envoy.TypeLDS, envoy.TypeRDS}, nil))
 
-		case certRotateMsg := <-certRotateChan:
-			cert := certRotateMsg.(events.PubSubMessage).NewObj.(*certificate.Certificate)
-			if isCNforProxy(proxy, cert.GetCommonName()) {
-				// The CN whose corresponding certificate was updated (rotated) by the certificate provider is associated
-				// with this proxy, so update the secrets corresponding to this certificate via SDS.
-				log.Debug().Str("proxy", proxy.String()).Msg("Certificate has been updated for proxy")
+		case <-certRotateChan:
+			log.Debug().Str("proxy", proxy.String()).Msg("Certificate has been updated for proxy")
 
-				// Empty DiscoveryRequest should create the SDS specific request
-				// Prepare to queue the SDS proxy response job on the worker pool
-				<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeSDS}, nil))
-			}
+			// Empty DiscoveryRequest should create the SDS specific request
+			// Prepare to queue the SDS proxy response job on the worker pool
+			<-s.workqueues.AddJob(newJob([]envoy.TypeURI{envoy.TypeSDS}, nil))
 		}
 	}
 }
@@ -315,20 +308,6 @@ func getResourceSliceFromMapset(resourceMap mapset.Set) []string {
 	}
 	sort.Strings(resourceSlice)
 	return resourceSlice
-}
-
-// isCNforProxy returns true if the given CN for the workload certificate matches the given proxy's identity.
-// Proxy identity corresponds to the k8s service account, while the workload certificate is of the form
-// <svc-account>.<namespace>.<trust-domain>.
-func isCNforProxy(proxy *envoy.Proxy, cn certificate.CommonName) bool {
-	// Workload certificate CN is of the form <svc-account>.<namespace>.<trust-domain>
-	chunks := strings.Split(cn.String(), constants.DomainDelimiter)
-	if len(chunks) < 3 {
-		return false
-	}
-
-	identityForCN := identity.K8sServiceAccount{Name: chunks[0], Namespace: chunks[1]}
-	return identityForCN == proxy.Identity.ToK8sServiceAccount()
 }
 
 func getCertificateCommonNameMeta(cn certificate.CommonName) (envoy.ProxyKind, uuid.UUID, identity.ServiceIdentity, error) {

--- a/pkg/envoy/ads/stream_test.go
+++ b/pkg/envoy/ads/stream_test.go
@@ -13,45 +13,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 )
 
-func TestIsCNForProxy(t *testing.T) {
-	type testCase struct {
-		name     string
-		cn       certificate.CommonName
-		proxy    *envoy.Proxy
-		expected bool
-	}
-
-	testCases := []testCase{
-		{
-			name: "workload CN belongs to proxy",
-			cn:   certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy: func() *envoy.Proxy {
-				p := envoy.NewProxy(envoy.KindSidecar, uuid.New(), identity.New("svc-acc", "namespace"), nil)
-				return p
-			}(),
-			expected: true,
-		},
-		{
-			name: "workload CN does not belong to proxy",
-			cn:   certificate.CommonName("svc-acc.namespace.cluster.local"),
-			proxy: func() *envoy.Proxy {
-				p := envoy.NewProxy(envoy.KindSidecar, uuid.New(), identity.New("svc-acc-foo", "namespace"), nil)
-				return p
-			}(),
-			expected: false,
-		},
-	}
-
-	for i, tc := range testCases {
-		t.Run(fmt.Sprintf("Testing test case %d: %s", i, tc.name), func(t *testing.T) {
-			assert := tassert.New(t)
-
-			actual := isCNforProxy(tc.proxy, tc.cn)
-			assert.Equal(tc.expected, actual)
-		})
-	}
-}
-
 func findSliceElem(slice []string, elem string) bool {
 	for _, v := range slice {
 		if v == elem {

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -101,7 +101,7 @@ func TestNewResponse(t *testing.T) {
 		return nil, fmt.Errorf("dummy error")
 	}), nil)
 
-	cm := tresorFake.NewFake(nil, 1*time.Hour)
+	cm := tresorFake.NewFake(1 * time.Hour)
 	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, cm, proxyRegistry)
 	assert.NotNil(err)
 	assert.Nil(resources)

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -19,11 +19,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
-
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -297,7 +296,7 @@ func TestNewResponse(t *testing.T) {
 				ResourceNames: []string{},
 			}
 
-			mc := tresorFake.NewFake(nil, 1*time.Hour)
+			mc := tresorFake.NewFake(1 * time.Hour)
 
 			resources, err := NewResponse(mockCatalog, proxy, &discoveryRequest, mockConfigurator, mc, proxyRegistry)
 			assert.Nil(err)
@@ -444,7 +443,7 @@ func TestResponseRequestCompletion(t *testing.T) {
 		return []service.MeshService{tests.BookstoreV1Service}, nil
 	}), nil)
 
-	mc := tresorFake.NewFake(nil, 1*time.Hour)
+	mc := tresorFake.NewFake(1 * time.Hour)
 
 	mockCatalog.EXPECT().GetInboundMeshTrafficPolicy(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockCatalog.EXPECT().GetOutboundMeshTrafficPolicy(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/envoy/sds/response_test.go
+++ b/pkg/envoy/sds/response_test.go
@@ -62,7 +62,7 @@ func TestNewResponse(t *testing.T) {
 	assert.Nil(err)
 
 	cfg := configurator.NewConfigurator(ic, "-osm-namespace-", "-the-mesh-config-name-", nil)
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	meshCatalog := catalogFake.NewFakeMeshCatalog(fakeKubeClient, fakeConfigClient)
 
 	// ----- Test with an properly configured proxy

--- a/pkg/ingress/client.go
+++ b/pkg/ingress/client.go
@@ -1,8 +1,6 @@
 package ingress
 
 import (
-	"fmt"
-
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -13,7 +11,7 @@ import (
 
 // Initialize initializes the client and starts the ingress gateway certificate manager routine
 func Initialize(kubeClient kubernetes.Interface, kubeController k8s.Controller, stop chan struct{},
-	cfg configurator.Configurator, certProvider *certificate.Manager, msgBroker *messaging.Broker) error {
+	cfg configurator.Configurator, certProvider *certificate.Manager, msgBroker *messaging.Broker) {
 	c := &client{
 		kubeClient:     kubeClient,
 		kubeController: kubeController,
@@ -22,9 +20,5 @@ func Initialize(kubeClient kubernetes.Interface, kubeController k8s.Controller, 
 		msgBroker:      msgBroker,
 	}
 
-	if err := c.provisionIngressGatewayCert(stop); err != nil {
-		return fmt.Errorf("Error provisioning ingress gateway certificate: %w", err)
-	}
-
-	return nil
+	go c.provisionIngressGatewayCert(c.cfg.GetMeshConfig().Spec.Certificate.IngressGateway, stop)
 }

--- a/pkg/ingress/gateway.go
+++ b/pkg/ingress/gateway.go
@@ -2,9 +2,8 @@ package ingress
 
 import (
 	"context"
-	"fmt"
 	"reflect"
-	"time"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,66 +16,10 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 )
 
-// provisionIngressGatewayCert does the following:
-// 1. If an ingress gateway certificate spec is specified in the MeshConfig resource, issues a certificate
-//    for it and stores it in the referenced secret.
-// 2. Starts a goroutine to watch for changes to the MeshConfig resource and certificate rotation, and
-//    updates/removes the certificate and secret as necessary.
-func (c *client) provisionIngressGatewayCert(stop <-chan struct{}) error {
-	defaultCertSpec := c.cfg.GetMeshConfig().Spec.Certificate.IngressGateway
-	if defaultCertSpec != nil {
-		// Issue a certificate for the default certificate spec
-		if err := c.createAndStoreGatewayCert(*defaultCertSpec); err != nil {
-			return fmt.Errorf("Error provisioning default ingress gateway cert: %w", err)
-		}
-	}
-
-	// Initialize a watcher to watch for CREATE/UPDATE/DELETE on the ingress gateway cert spec
-	go c.handleCertificateChange(defaultCertSpec, stop)
-
-	return nil
-}
-
-// createAndStoreGatewayCert creates a certificate for the given certificate spec and stores
-// it in the referenced k8s secret if the spec is valid.
-func (c *client) createAndStoreGatewayCert(spec configv1alpha2.IngressGatewayCertSpec) error {
-	if len(spec.SubjectAltNames) == 0 {
-		return fmt.Errorf("Ingress gateway certificate spec must specify at least 1 SAN")
-	}
-
-	// Validate the validity duration
-	if _, err := time.ParseDuration(spec.ValidityDuration); err != nil {
-		return fmt.Errorf("Invalid cert duration '%s' specified: %w", spec.ValidityDuration, err)
-	}
-
-	// Validate the secret ref
-	if spec.Secret.Name == "" || spec.Secret.Namespace == "" {
-		return fmt.Errorf("Ingress gateway cert secret's name and namespace cannot be nil, got %s/%s", spec.Secret.Namespace, spec.Secret.Name)
-	}
-
-	// Issue a certificate
-	// OSM only support configuring a single SAN per cert, so pick the first one
-	certCN := spec.SubjectAltNames[0]
-
-	// A certificate for this CN may be cached already. Delete it before issuing a new certificate.
-	c.certProvider.ReleaseCertificate(certCN)
-	issuedCert, err := c.certProvider.IssueCertificate(certCN, certificate.IngressGateway, certificate.FullCNProvided())
-	if err != nil {
-		return fmt.Errorf("Error issuing a certificate for ingress gateway: %w", err)
-	}
-
-	// Store the certificate in the referenced secret
-	if err := c.storeCertInSecret(issuedCert, spec.Secret); err != nil {
-		return fmt.Errorf("Error storing ingress gateway cert in secret %s/%s: %w", spec.Secret.Namespace, spec.Secret.Name, err)
-	}
-
-	return nil
-}
-
 // storeCertInSecret stores the certificate in the specified k8s TLS secret
 func (c *client) storeCertInSecret(cert *certificate.Certificate, secret corev1.SecretReference) error {
 	secretData := map[string][]byte{
-		"ca.crt":  cert.GetTrustedCAs(),
+		"ca.crt":  cert.GetIssuingCA(),
 		"tls.crt": cert.GetCertificateChain(),
 		"tls.key": cert.GetPrivateKey(),
 	}
@@ -97,16 +40,20 @@ func (c *client) storeCertInSecret(cert *certificate.Certificate, secret corev1.
 	return err
 }
 
-// handleCertificateChange updates the gateway certificate and secret when the MeshConfig resource changes or
-// when the corresponding gateway certificate is rotated.
-func (c *client) handleCertificateChange(currentCertSpec *configv1alpha2.IngressGatewayCertSpec, stop <-chan struct{}) {
+func (c *client) provisionIngressGatewayCert(currentCertSpec *configv1alpha2.IngressGatewayCertSpec, stop <-chan struct{}) {
 	kubePubSub := c.msgBroker.GetKubeEventPubSub()
 	meshConfigUpdateChan := kubePubSub.Sub(announcements.MeshConfigUpdated.String())
 	defer c.msgBroker.Unsub(kubePubSub, meshConfigUpdateChan)
 
-	certPubSub := c.msgBroker.GetCertPubSub()
-	certRotateChan := certPubSub.Sub(announcements.CertificateRotated.String())
-	defer c.msgBroker.Unsub(certPubSub, certRotateChan)
+	// stopWatchingRotations is a function that should be called when the cert rotation is no longer needed on the
+	// specified SAN. This can happen on SAN changes or on the deletion of the ingress gateway spec.
+	// It's set to an empty func so that when a SAN is not specified we can safely call stop without checking for a nil
+	// value.
+	stopWatchingRotations := func() {}
+
+	if currentCertSpec != nil && len(currentCertSpec.SubjectAltNames) > 0 {
+		stopWatchingRotations = c.handleCertChanges(currentCertSpec.SubjectAltNames[0], currentCertSpec.Secret)
+	}
 
 	for {
 		select {
@@ -134,58 +81,89 @@ func (c *client) handleCertificateChange(currentCertSpec *configv1alpha2.Ingress
 				continue
 			}
 			if newCertSpec == nil && currentCertSpec != nil {
+				stopWatchingRotations()
 				// Implies the certificate reference was removed, delete the corresponding secret and certificate
 				if err := c.removeGatewayCertAndSecret(*currentCertSpec); err != nil {
 					log.Error().Err(err).Msg("Error removing stale gateway certificate/secret")
 				}
-			} else if newCertSpec != nil {
-				// New cert spec is not nil and is not the same as the current cert spec, update required
-				err := c.createAndStoreGatewayCert(*newCertSpec)
-				if err != nil {
-					log.Error().Err(err).Msgf("Error updating ingress gateway cert and secret")
-				}
+			} else if shouldRelisten(currentCertSpec, newCertSpec) {
+				stopWatchingRotations()
+				stopWatchingRotations = c.handleCertChanges(newCertSpec.SubjectAltNames[0], newCertSpec.Secret)
 			}
 			currentCertSpec = newCertSpec
 
-		// A certificate was rotated
-		case msg, ok := <-certRotateChan:
-			if !ok {
-				log.Warn().Msg("Notification channel closed for certificate rotation")
-				continue
-			}
-
-			event, ok := msg.(events.PubSubMessage)
-			if !ok {
-				log.Error().Msgf("Received unexpected message %T on channel, expected PubSubMessage", event)
-				continue
-			}
-			cert, ok := event.NewObj.(*certificate.Certificate)
-			if !ok {
-				log.Error().Msgf("Received unexpected message %T on cert rotation channel, expected Certificate", cert)
-				continue
-			}
-
-			// This should never happen, but guarding against a panic due to the usage of a pointer
-			if currentCertSpec == nil {
-				log.Error().Msgf("Current ingress gateway cert spec is nil, but a certificate for it was rotated - unexpected")
-				continue
-			}
-
-			cnInCertSpec := currentCertSpec.SubjectAltNames[0] // Only single SAN is supported in certs
-
-			// Only update the secret if the cert rotated matches the cert spec
-			if cert.GetCommonName() != certificate.CommonName(cnInCertSpec) {
-				continue
-			}
-
-			log.Info().Msg("Ingress gateway certificate was rotated, updating corresponding secret")
-			if err := c.createAndStoreGatewayCert(*currentCertSpec); err != nil {
-				log.Error().Err(err).Msgf("Error updating ingress gateway cert secret after cert rotation")
-			}
-
 		case <-stop:
+			stopWatchingRotations()
 			return
 		}
+	}
+}
+
+func shouldRelisten(oldSpec *configv1alpha2.IngressGatewayCertSpec, newSpec *configv1alpha2.IngressGatewayCertSpec) bool {
+	if newSpec == nil || len(newSpec.SubjectAltNames) == 0 {
+		return false
+	}
+
+	if oldSpec == nil || len(oldSpec.SubjectAltNames) == 0 {
+		return true
+	}
+
+	return oldSpec.SubjectAltNames[0] != newSpec.SubjectAltNames[0]
+}
+
+// handleCertChanges creates and stores a certificate with the given common name into the given secret ref.
+// It then watches for all cert rotations and updates the secret on changes.
+func (c *client) handleCertChanges(cn string, secret corev1.SecretReference) func() {
+	// This is some fanciness to provide the following guarantees:
+	// 1. The subscription is called before a goroutine starts, allowing the subscription creation to be deterministic.
+	//	  This means that the subscription is guaranteed to not miss any rotations in the period between issuance and
+	//    the goroutine starting.
+	// 2. By signalling to stop (instead of just closing it), we guarantee the close func doesn't return before the
+	// 	  goroutine stops. This prevents race conditions where we return before the below goroutine has exited, spawn
+	//	  a new routine due to a changed SAN, and both routines can now race to write out the certificate. This can occur
+	//	  when an update with a new SAN comes through at the same time as a rotation is triggered.
+	// 3. The once allows the close method to be called multiple times.
+	// #1 and #2 are required to prevent
+	var once sync.Once
+	stop := make(chan struct{})
+
+	// must subscribe prior to issuing the cert to guarantee we get all rotations.
+	certRotateChan, unsub := c.certProvider.SubscribeRotations(cn)
+
+	cert, err := c.certProvider.IssueCertificate(cn, certificate.IngressGateway, certificate.FullCNProvided())
+	if err != nil {
+		log.Err(err).Msg("error issuing a certificate for ingress gateway")
+	}
+	if err := c.storeCertInSecret(cert, secret); err != nil {
+		log.Err(err).Msg("Error updating ingress gateway cert secret after cert rotation")
+	}
+
+	go func() {
+		for {
+			select {
+			// A certificate was rotated
+			case msg := <-certRotateChan:
+				cert := msg.(*certificate.Certificate)
+				log.Info().Msgf("Ingress gateway certificate was rotated, updating secret %s/%s", secret.Name, secret.Namespace)
+				if err := c.storeCertInSecret(cert, secret); err != nil {
+					log.Err(err).Msg("Error updating ingress gateway cert secret after cert rotation")
+				}
+
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return func() {
+		// Allow close to be called multiple times by wrapping it in a once.
+		once.Do(func() {
+			// We don't just close the channel because we want to wait for the above goroutine to exit. Since there
+			// is no logic (or race conditions), in the select's stop case we can safely proceed. See the method
+			// comment for more.
+			stop <- struct{}{}
+			unsub()
+			close(stop)
+		})
 	}
 }
 

--- a/pkg/injector/patch_test.go
+++ b/pkg/injector/patch_test.go
@@ -137,7 +137,7 @@ func TestCreatePatch(t *testing.T) {
 			wh := &mutatingWebhook{
 				kubeClient:          client,
 				kubeController:      mockNsController,
-				certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+				certManager:         tresorFake.NewFake(1 * time.Hour),
 				configurator:        mockConfigurator,
 				nonInjectNamespaces: mapset.NewSet(),
 			}
@@ -236,7 +236,7 @@ func TestCreatePatch(t *testing.T) {
 		wh := &mutatingWebhook{
 			kubeClient:          client,
 			kubeController:      mockNsController,
-			certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+			certManager:         tresorFake.NewFake(1 * time.Hour),
 			configurator:        mockConfigurator,
 			nonInjectNamespaces: mapset.NewSet(),
 		}

--- a/pkg/injector/webhook_test.go
+++ b/pkg/injector/webhook_test.go
@@ -563,7 +563,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		stop := make(chan struct{})
 		mockController := gomock.NewController(GinkgoT())
 		cfg := configurator.NewMockConfigurator(mockController)
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 
 		cfg.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
@@ -581,7 +581,7 @@ var _ = Describe("Testing Injector Functions", func() {
 		stop := make(chan struct{})
 		mockController := gomock.NewController(GinkgoT())
 		cfg := configurator.NewMockConfigurator(mockController)
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 
 		cfg.EXPECT().GetCertKeyBitSize().Return(2048).AnyTimes()
 
@@ -836,7 +836,7 @@ func TestWebhookMutate(t *testing.T) {
 		wh := &mutatingWebhook{
 			nonInjectNamespaces: mapset.NewSet(),
 			kubeController:      kubeController,
-			certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+			certManager:         tresorFake.NewFake(1 * time.Hour),
 			kubeClient:          fake.NewSimpleClientset(),
 			configurator:        cfg,
 		}
@@ -882,7 +882,7 @@ func TestWebhookMutate(t *testing.T) {
 		wh := &mutatingWebhook{
 			nonInjectNamespaces: mapset.NewSet(),
 			kubeController:      kubeController,
-			certManager:         tresorFake.NewFake(nil, 1*time.Hour),
+			certManager:         tresorFake.NewFake(1 * time.Hour),
 			kubeClient:          fake.NewSimpleClientset(),
 			configurator:        cfg,
 		}

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -35,7 +35,6 @@ func NewBroker(stopCh <-chan struct{}) *Broker {
 		proxyUpdatePubSub: pubsub.New(0),
 		proxyUpdateCh:     make(chan proxyUpdateEvent),
 		kubeEventPubSub:   pubsub.New(0),
-		certPubSub:        pubsub.New(0),
 	}
 
 	go b.runWorkqueueProcessor(stopCh)
@@ -66,11 +65,6 @@ func (b *Broker) GetProxyUpdatePubSub() *pubsub.PubSub {
 // GetKubeEventPubSub returns the PubSub instance corresponding to k8s events
 func (b *Broker) GetKubeEventPubSub() *pubsub.PubSub {
 	return b.kubeEventPubSub
-}
-
-// GetCertPubSub returns the PubSub instance corresponding to certificate events
-func (b *Broker) GetCertPubSub() *pubsub.PubSub {
-	return b.certPubSub
 }
 
 // GetTotalQProxyEventCount returns the total number of events read from the workqueue

--- a/pkg/messaging/broker_test.go
+++ b/pkg/messaging/broker_test.go
@@ -47,9 +47,6 @@ func TestAllEvents(t *testing.T) {
 	meshCfgChan := c.GetKubeEventPubSub().Sub(announcements.MeshConfigUpdated.String())
 	defer c.Unsub(c.kubeEventPubSub, meshCfgChan)
 
-	certRotateChan := c.GetCertPubSub().Sub(announcements.CertificateRotated.String())
-	defer c.Unsub(c.certPubSub, certRotateChan)
-
 	numEventTriggers := 50
 	// Endpoints add/update/delete will result in proxy update events
 	numProxyUpdatesPerEventTrigger := 3
@@ -108,17 +105,6 @@ func TestAllEvents(t *testing.T) {
 		}
 	}()
 
-	go func() {
-		for i := 0; i < numEventTriggers; i++ {
-			certRotated := events.PubSubMessage{
-				Kind:   announcements.CertificateRotated,
-				OldObj: i,
-				NewObj: i,
-			}
-			c.certPubSub.Pub(certRotated, announcements.CertificateRotated.String())
-		}
-	}()
-
 	doneVerifyingPodEvents := make(chan struct{})
 	go func() {
 		// Verify expected number of pod events
@@ -148,15 +134,6 @@ func TestAllEvents(t *testing.T) {
 		close(doneVerifyingMeshCfgEvents)
 	}()
 
-	doneVerifyingCertEvents := make(chan struct{})
-	go func() {
-		numExpectedCertEvents := numEventTriggers * 1 // 1 == 1 cert rotation event per trigger
-		for i := 0; i < numExpectedCertEvents; i++ {
-			<-certRotateChan
-		}
-		close(doneVerifyingCertEvents)
-	}()
-
 	doneVerifyingProxyEvents := make(chan struct{})
 	go func() {
 		// Verify that atleast 1 proxy update pub-sub is received. We only verify one
@@ -169,7 +146,6 @@ func TestAllEvents(t *testing.T) {
 	<-doneVerifyingPodEvents
 	<-doneVerifyingEndpointEvents
 	<-doneVerifyingMeshCfgEvents
-	<-doneVerifyingCertEvents
 	<-doneVerifyingProxyEvents
 
 	a.EqualValues(c.GetTotalQEventCount(), numEventTriggers*(numProxyUpdatesPerEventTrigger+numNonProxyUpdatesPerEventTrigger))

--- a/pkg/messaging/types.go
+++ b/pkg/messaging/types.go
@@ -20,7 +20,6 @@ type Broker struct {
 	proxyUpdatePubSub              *pubsub.PubSub
 	proxyUpdateCh                  chan proxyUpdateEvent
 	kubeEventPubSub                *pubsub.PubSub
-	certPubSub                     *pubsub.PubSub
 	totalQEventCount               uint64
 	totalQProxyEventCount          uint64
 	totalDispatchedProxyEventCount uint64

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestNewGrpc(t *testing.T) {
 	assert := tassert.New(t)
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	adsCert, err := certManager.IssueCertificate("fake-ads", certificate.Internal)
 	assert.NoError(err)
 
 	certPem := adsCert.GetCertificateChain()
 	keyPem := adsCert.GetPrivateKey()
-	rootPem := adsCert.GetTrustedCAs()
+	rootPem := adsCert.GetIssuingCA()
 	var emptyByteArray []byte
 
 	type newGrpcTest struct {
@@ -52,14 +52,14 @@ func TestNewGrpc(t *testing.T) {
 func TestGrpcServe(t *testing.T) {
 	assert := tassert.New(t)
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	adsCert, err := certManager.IssueCertificate("fake-ads", certificate.Internal)
 
 	assert.NoError(err)
 
 	serverType := "ADS"
 	port := 9999
-	grpcServer, lis, err := NewGrpc(serverType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetTrustedCAs())
+	grpcServer, lis, err := NewGrpc(serverType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetIssuingCA())
 	assert.Nil(err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -30,7 +30,7 @@ func TestSetupMutualTLS(t *testing.T) {
 		expectedError string
 	}
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	adsCert, err := certManager.IssueCertificate("fake-ads", certificate.Internal)
 
 	assert.NoError(err)
@@ -38,7 +38,7 @@ func TestSetupMutualTLS(t *testing.T) {
 	serverType := "ADS"
 	goodCertPem := adsCert.GetCertificateChain()
 	goodKeyPem := adsCert.GetPrivateKey()
-	goodCA := adsCert.GetTrustedCAs()
+	goodCA := adsCert.GetIssuingCA()
 	var emptyByteArray []byte
 
 	setupMutualTLStests := []setupMutualTLStest{
@@ -67,7 +67,7 @@ func TestValidateClient(t *testing.T) {
 		expectedError error
 	}
 
-	certManager := tresorFake.NewFake(nil, 1*time.Hour)
+	certManager := tresorFake.NewFake(1 * time.Hour)
 	cnPrefix := fmt.Sprintf("%s.%s.%s", uuid.New(), tests.BookstoreServiceAccountName, tests.Namespace)
 	certPEM, _ := certManager.IssueCertificate(cnPrefix, certificate.Internal)
 	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -145,7 +145,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 	enableReconciler := false
 	validateTrafficTarget := true
 	t.Run("successful startup", func(t *testing.T) {
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 
 		stop := make(chan struct{})
 		defer close(stop)
@@ -167,7 +167,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 	})
 
 	t.Run("successful startup with reconciler enabled and traffic target validation enabled", func(t *testing.T) {
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		enableReconciler = true
 
 		stop := make(chan struct{})
@@ -183,7 +183,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 	})
 
 	t.Run("successful startup with reconciler enabled and validation for traffic target disabled", func(t *testing.T) {
-		certManager := tresorFake.NewFake(nil, 1*time.Hour)
+		certManager := tresorFake.NewFake(1 * time.Hour)
 		enableReconciler = true
 		validateTrafficTarget = false
 

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -51,7 +51,7 @@ func TestRDSNewResponseWithTrafficSplit(t *testing.T) {
 		EnableEgressPolicy: false,
 	}).AnyTimes()
 
-	mc := tresorFake.NewFake(nil, 1*time.Hour)
+	mc := tresorFake.NewFake(1 * time.Hour)
 	a.NotNil(a)
 
 	resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, mc, proxyRegistry)

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -253,7 +253,7 @@ func TestRDSRespose(t *testing.T) {
 			mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 
-			cm := tresorFake.NewFake(nil, 1*time.Hour)
+			cm := tresorFake.NewFake(1 * time.Hour)
 
 			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, cm, proxyRegistry)
 			assert.Nil(err)


### PR DESCRIPTION
The biggest change is moving the cert rotation pubsub to the cert manager itself, and changing the semantics to subscribe to single certs. This will make future changes that listen for cert rotations much simpler. 

The motivation for this is that every time we subscribe to cert rotation events we filter against the cert CommonName we are interested in.

In addition, with upcoming changes to cert rotation there are several places we need to add a messaging.Broker just to get access to the rotations. This, to me, was a code smell, and meant that the rotations access should be on the manager itself.

In addition the following bugs were fixed

This also fixes the following bugs:
1. Use TrustedCAs instead of IssuingCA where appropriate
2. Prevent missed rotations due to subscribing after IssueCertificate has been called.

Part of https://github.com/openservicemesh/osm/issues/4839

I've added some comments to this PR on specific code lines to provide context of the current change vs the prior context