### PR TITLE
cert changes: Fix GetTrustedCAs; align import names; use component logger

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -3,8 +3,6 @@ package certificate
 import (
 	time "time"
 
-	"github.com/rs/zerolog/log"
-
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/errcode"
 )

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -7,13 +7,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog/log"
-
 	"github.com/openservicemesh/osm/pkg/announcements"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/k8s/events"
+	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/messaging"
+)
+
+var (
+	log = logger.New("certificate")
 )
 
 // NewManager creates a new CertificateManager with the passed MRCClient and options

--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -181,7 +181,7 @@ func updateCrdConfiguration(cert *certificate.Certificate, crdClient apiclient.A
 					Port:      pointer.Int32(constants.CRDConversionWebhookPort),
 					Path:      &crdConversionPath,
 				},
-				CABundle: cert.GetIssuingCA(),
+				CABundle: cert.GetTrustedCAs(),
 			},
 			ConversionReviewVersions: conversionReviewVersions,
 		},

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
@@ -101,7 +101,7 @@ func TestNewResponse(t *testing.T) {
 		return nil, fmt.Errorf("dummy error")
 	}), nil)
 
-	cm := tresorfake.NewFake(nil, 1*time.Hour)
+	cm := tresorFake.NewFake(nil, 1*time.Hour)
 	resources, err := NewResponse(meshCatalog, proxy, nil, mockConfigurator, cm, proxyRegistry)
 	assert.NotNil(err)
 	assert.Nil(resources)

--- a/pkg/envoy/rds/response_test.go
+++ b/pkg/envoy/rds/response_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	testclient "k8s.io/client-go/kubernetes/fake"
 
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
@@ -297,7 +297,7 @@ func TestNewResponse(t *testing.T) {
 				ResourceNames: []string{},
 			}
 
-			mc := tresorfake.NewFake(nil, 1*time.Hour)
+			mc := tresorFake.NewFake(nil, 1*time.Hour)
 
 			resources, err := NewResponse(mockCatalog, proxy, &discoveryRequest, mockConfigurator, mc, proxyRegistry)
 			assert.Nil(err)
@@ -444,7 +444,7 @@ func TestResponseRequestCompletion(t *testing.T) {
 		return []service.MeshService{tests.BookstoreV1Service}, nil
 	}), nil)
 
-	mc := tresorfake.NewFake(nil, 1*time.Hour)
+	mc := tresorFake.NewFake(nil, 1*time.Hour)
 
 	mockCatalog.EXPECT().GetInboundMeshTrafficPolicy(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	mockCatalog.EXPECT().GetOutboundMeshTrafficPolicy(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/ingress/gateway.go
+++ b/pkg/ingress/gateway.go
@@ -76,7 +76,7 @@ func (c *client) createAndStoreGatewayCert(spec configv1alpha2.IngressGatewayCer
 // storeCertInSecret stores the certificate in the specified k8s TLS secret
 func (c *client) storeCertInSecret(cert *certificate.Certificate, secret corev1.SecretReference) error {
 	secretData := map[string][]byte{
-		"ca.crt":  cert.GetIssuingCA(),
+		"ca.crt":  cert.GetTrustedCAs(),
 		"tls.crt": cert.GetCertificateChain(),
 		"tls.key": cert.GetPrivateKey(),
 	}

--- a/pkg/utils/grpc_test.go
+++ b/pkg/utils/grpc_test.go
@@ -19,7 +19,7 @@ func TestNewGrpc(t *testing.T) {
 
 	certPem := adsCert.GetCertificateChain()
 	keyPem := adsCert.GetPrivateKey()
-	rootPem := adsCert.GetIssuingCA()
+	rootPem := adsCert.GetTrustedCAs()
 	var emptyByteArray []byte
 
 	type newGrpcTest struct {
@@ -59,7 +59,7 @@ func TestGrpcServe(t *testing.T) {
 
 	serverType := "ADS"
 	port := 9999
-	grpcServer, lis, err := NewGrpc(serverType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetIssuingCA())
+	grpcServer, lis, err := NewGrpc(serverType, port, adsCert.GetCertificateChain(), adsCert.GetPrivateKey(), adsCert.GetTrustedCAs())
 	assert.Nil(err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -37,7 +37,7 @@ func TestSetupMutualTLS(t *testing.T) {
 	serverType := "ADS"
 	goodCertPem := adsCert.GetCertificateChain()
 	goodKeyPem := adsCert.GetPrivateKey()
-	goodCA := adsCert.GetIssuingCA()
+	goodCA := adsCert.GetTrustedCAs()
 	var emptyByteArray []byte
 
 	setupMutualTLStests := []setupMutualTLStest{

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -76,7 +76,7 @@ func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert *certi
 						Path:      &webhookPath,
 						Port:      &webhookPort,
 					},
-					CABundle: cert.GetIssuingCA()},
+					CABundle: cert.GetTrustedCAs()},
 				FailurePolicy: &failurePolicy,
 				MatchPolicy:   &matchPolicy,
 				NamespaceSelector: &metav1.LabelSelector{

--- a/tests/scenarios/traffic_split_with_apex_service_test.go
+++ b/tests/scenarios/traffic_split_with_apex_service_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 
 	catalogFake "github.com/openservicemesh/osm/pkg/catalog/fake"
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/rds"
@@ -51,7 +51,7 @@ func TestRDSNewResponseWithTrafficSplit(t *testing.T) {
 		EnableEgressPolicy: false,
 	}).AnyTimes()
 
-	mc := tresorfake.NewFake(nil, 1*time.Hour)
+	mc := tresorFake.NewFake(nil, 1*time.Hour)
 	a.NotNil(a)
 
 	resources, err := rds.NewResponse(meshCatalog, proxy, nil, mockConfigurator, mc, proxyRegistry)

--- a/tests/scenarios/traffic_split_with_zero_weight_test.go
+++ b/tests/scenarios/traffic_split_with_zero_weight_test.go
@@ -20,7 +20,7 @@ import (
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
 	"github.com/openservicemesh/osm/pkg/catalog"
-	tresorfake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
+	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	"github.com/openservicemesh/osm/pkg/configurator"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -253,7 +253,7 @@ func TestRDSRespose(t *testing.T) {
 			mockCatalog.EXPECT().GetIngressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 			mockCatalog.EXPECT().GetEgressTrafficPolicy(gomock.Any()).Return(nil, nil).AnyTimes()
 
-			cm := tresorfake.NewFake(nil, 1*time.Hour)
+			cm := tresorFake.NewFake(nil, 1*time.Hour)
 
 			resources, err := rds.NewResponse(mockCatalog, proxy, nil, mockConfigurator, cm, proxyRegistry)
 			assert.Nil(err)


### PR DESCRIPTION
1. align imports on casing for tresorFake
2. use GetTrustedCAs where appropriate
3. use a logger component in certificate package

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>
