### PR TITLE
Add GitHub Action to require size and kind labels

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,0 +1,26 @@
+name: Require labels
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  labels:
+    name: Require labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require size
+        uses: trstringer/require-label-prefix@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          prefix: size
+          addLabel: true
+          defaultLabe: "size/needed"
+          onlyMilestone: true
+      - name: Require kind
+        uses: trstringer/require-label-prefix@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          prefix: kind
+          addLabel: true
+          defaultLabe: "kind/needed"
+          onlyMilestone: true

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -14,7 +14,7 @@ jobs:
           secret: ${{ github.TOKEN }}
           prefix: size
           addLabel: true
-          defaultLabe: "size/needed"
+          defaultLabel: "size/needed"
           onlyMilestone: true
       - name: Require kind
         uses: trstringer/require-label-prefix@v1
@@ -22,5 +22,5 @@ jobs:
           secret: ${{ github.TOKEN }}
           prefix: kind
           addLabel: true
-          defaultLabe: "kind/needed"
+          defaultLabel: "kind/needed"
           onlyMilestone: true


### PR DESCRIPTION
Currently there is no enforcement of adding `size/*` or `kind/*` labels
to issues. This will help the project and collaborators understand the
type of issue, as well as a rough estimate of how long it is projected
to take to resolve.

This PR adds the workflow to mark issues with `size/needed` in the
absence of `size/*` labels, and `kind/needed` in the absence of `kind/*`
labels. This will only consider issues that are part of a milestone.

Signed-off-by: Thomas Stringer <thomas@trstringer.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? Yes, this change uses a custom GitHub action, [trstringer/require-label-prefix](https://github.com/marketplace/actions/require-label-prefix).
    -   Did you notify the maintainers and provide attribution? I am the maintainer of the project.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A