### PR TITLE
Plumb trust domain through to helm chart

### DIFF
--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             "--osm-version", "{{ .Chart.AppVersion }}",
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
+            "--trustDomain", "{{.Values.osm.trustDomain}}",
             "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.osm.vault.host}}",

--- a/charts/osm/templates/osm-bootstrap-deployment.yaml
+++ b/charts/osm/templates/osm-bootstrap-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             "--osm-version", "{{ .Chart.AppVersion }}",
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
-            "--trustDomain", "{{.Values.osm.trustDomain}}",
+            "--trust-domain", "{{.Values.osm.trustDomain}}",
             "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.osm.vault.host}}",

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             "--validator-webhook-config", "{{ include "osm.validatorWebhookConfigName" . }}",
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
+            "--trustDomain", "{{.Values.osm.trustDomain}}",
             "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{ required "osm.vault.host is required when osm.certificateProvider.kind==vault" .Values.osm.vault.host }}",

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             "--validator-webhook-config", "{{ include "osm.validatorWebhookConfigName" . }}",
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
-            "--trustDomain", "{{.Values.osm.trustDomain}}",
+            "--trust-domain", "{{.Values.osm.trustDomain}}",
             "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{ required "osm.vault.host is required when osm.certificateProvider.kind==vault" .Values.osm.vault.host }}",

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -58,7 +58,7 @@ spec:
             "--webhook-timeout", "{{.Values.osm.injector.webhookTimeoutSeconds}}",
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
-            "--trustDomain", "{{.Values.osm.trustDomain}}",
+            "--trust-domain", "{{.Values.osm.trustDomain}}",
             "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.osm.vault.host}}",

--- a/charts/osm/templates/osm-injector-deployment.yaml
+++ b/charts/osm/templates/osm-injector-deployment.yaml
@@ -58,6 +58,7 @@ spec:
             "--webhook-timeout", "{{.Values.osm.injector.webhookTimeoutSeconds}}",
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
+            "--trustDomain", "{{.Values.osm.trustDomain}}",
             "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{.Values.osm.vault.host}}",

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -92,7 +92,7 @@ func init() {
 	flags.StringVar(&meshName, "mesh-name", "", "OSM mesh name")
 	flags.StringVarP(&verbosity, "verbosity", "v", "info", "Set log verbosity level")
 	flags.StringVar(&osmNamespace, "osm-namespace", "", "Namespace to which OSM belongs to.")
-	flags.StringVar(&osmMeshConfigName, "osm-config-name", "osm-mesh-config", "Nam;e of the OSM MeshConfig")
+	flags.StringVar(&osmMeshConfigName, "osm-config-name", "osm-mesh-config", "Name of the OSM MeshConfig")
 	flags.StringVar(&osmVersion, "osm-version", "", "Version of OSM")
 
 	// Generic certificate manager/provider options
@@ -100,8 +100,8 @@ func init() {
 	flags.BoolVar(&enableMeshRootCertificate, "enable-mesh-root-certificate", false, "Enable unsupported MeshRootCertificate to create the OSM Certificate Manager")
 	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
 
-	// TODO: Remove when we add full MRC support
-	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates.")
+	// TODO (#4502): Remove when we add full MRC support
+	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates")
 
 	// Vault certificate manager/provider options
 	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -63,6 +63,7 @@ var (
 	osmMeshConfigName  string
 	meshName           string
 	osmVersion         string
+	trustDomain        string
 
 	certProviderKind          string
 	enableMeshRootCertificate bool
@@ -91,13 +92,16 @@ func init() {
 	flags.StringVar(&meshName, "mesh-name", "", "OSM mesh name")
 	flags.StringVarP(&verbosity, "verbosity", "v", "info", "Set log verbosity level")
 	flags.StringVar(&osmNamespace, "osm-namespace", "", "Namespace to which OSM belongs to.")
-	flags.StringVar(&osmMeshConfigName, "osm-config-name", "osm-mesh-config", "Name of the OSM MeshConfig")
+	flags.StringVar(&osmMeshConfigName, "osm-config-name", "osm-mesh-config", "Nam;e of the OSM MeshConfig")
 	flags.StringVar(&osmVersion, "osm-version", "", "Version of OSM")
 
 	// Generic certificate manager/provider options
 	flags.StringVar(&certProviderKind, "certificate-manager", providers.TresorKind.String(), fmt.Sprintf("Certificate manager, one of [%v]", providers.ValidCertificateProviders))
 	flags.BoolVar(&enableMeshRootCertificate, "enable-mesh-root-certificate", false, "Enable unsupported MeshRootCertificate to create the OSM Certificate Manager")
 	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
+
+	// TODO: Remove when we add full MRC support
+	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates.")
 
 	// Vault certificate manager/provider options
 	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")
@@ -230,7 +234,7 @@ func main() {
 				"Error initializing certificate manager of kind %s from MRC", certProviderKind)
 		}
 	} else {
-		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace, certOpts, msgBroker, 5*time.Second)
+		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace, certOpts, msgBroker, 5*time.Second, trustDomain)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error initializing certificate manager of kind %s", certProviderKind)

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -73,6 +73,7 @@ var (
 	caBundleSecretName         string
 	osmMeshConfigName          string
 	osmVersion                 string
+	trustDomain                string
 
 	certProviderKind          string
 	enableMeshRootCertificate bool
@@ -105,6 +106,9 @@ func init() {
 	flags.StringVar(&certProviderKind, "certificate-manager", providers.TresorKind.String(), fmt.Sprintf("Certificate manager, one of [%v]", providers.ValidCertificateProviders))
 	flags.BoolVar(&enableMeshRootCertificate, "enable-mesh-root-certificate", false, "Enable unsupported MeshRootCertificate to create the OSM Certificate Manager")
 	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
+
+	// TODO: Remove when we add full MRC support
+	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates.")
 
 	// Vault certificate manager/provider options
 	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")
@@ -222,7 +226,7 @@ func main() {
 		}
 	} else {
 		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace,
-			certOpts, msgBroker, 5*time.Second)
+			certOpts, msgBroker, 5*time.Second, trustDomain)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error fetching certificate manager of kind %s", certProviderKind)

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -107,8 +107,8 @@ func init() {
 	flags.BoolVar(&enableMeshRootCertificate, "enable-mesh-root-certificate", false, "Enable unsupported MeshRootCertificate to create the OSM Certificate Manager")
 	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
 
-	// TODO: Remove when we add full MRC support
-	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates.")
+	// TODO (#4502): Remove when we add full MRC support
+	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates")
 
 	// Vault certificate manager/provider options
 	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -57,6 +57,7 @@ var (
 	osmMeshConfigName  string
 	webhookTimeout     int32
 	osmVersion         string
+	trustDomain        string
 
 	certProviderKind          string
 	enableMeshRootCertificate bool
@@ -91,6 +92,9 @@ func init() {
 	flags.StringVar(&certProviderKind, "certificate-manager", providers.TresorKind.String(), fmt.Sprintf("Certificate manager, one of [%v]", providers.ValidCertificateProviders))
 	flags.BoolVar(&enableMeshRootCertificate, "enable-mesh-root-certificate", false, "Enable unsupported MeshRootCertificate to create the OSM Certificate Manager")
 	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
+
+	// TODO: Remove when we add full MRC support
+	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates.")
 
 	// Vault certificate manager/provider options
 	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")
@@ -216,7 +220,7 @@ func main() {
 		}
 	} else {
 		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, cfg, osmNamespace,
-			certOpts, msgBroker, 5*time.Second)
+			certOpts, msgBroker, 5*time.Second, trustDomain)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error initializing certificate manager of kind %s", certProviderKind)

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -93,8 +93,8 @@ func init() {
 	flags.BoolVar(&enableMeshRootCertificate, "enable-mesh-root-certificate", false, "Enable unsupported MeshRootCertificate to create the OSM Certificate Manager")
 	flags.StringVar(&caBundleSecretName, "ca-bundle-secret-name", "", "Name of the Kubernetes Secret for the OSM CA bundle")
 
-	// TODO: Remove when we add full MRC support
-	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates.")
+	// TODO (#4502): Remove when we add full MRC support
+	flags.StringVar(&trustDomain, "trust-domain", "cluster.local", "The trust domain to use as part of the common name when requesting new certificates")
 
 	// Vault certificate manager/provider options
 	flags.StringVar(&vaultOptions.VaultProtocol, "vault-protocol", "http", "Host name of the Hashi Vault")

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -45,6 +45,7 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan MRCEvent, error) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					TrustDomain: "fake.domain.com",
 					Provider: v1alpha2.ProviderSpec{
 						Tresor: &v1alpha2.TresorProviderSpec{
 							CA: v1alpha2.TresorCASpec{

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -129,7 +129,7 @@ func (m *Manager) handleMRCEvent(mrcClient MRCClient, event MRCEvent) error {
 			return err
 		}
 
-		c := &issuer{Issuer: client, ID: mrc.Name, CertificateAuthority: ca}
+		c := &issuer{Issuer: client, ID: mrc.Name, CertificateAuthority: ca, TrustDomain: mrc.Spec.TrustDomain}
 		switch {
 		case mrc.Status.State == constants.MRCStateActive:
 			m.mu.Lock()

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -44,7 +44,7 @@ var getCA func(certificate.Issuer) (pem.RootCertificate, error) = func(i certifi
 // NewCertificateManager returns a new certificate manager with a MRC compat client.
 // TODO(4713): Remove and use NewCertificateManagerFromMRC
 func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface, kubeConfig *rest.Config, cfg configurator.Configurator,
-	providerNamespace string, option Options, msgBroker *messaging.Broker, checkInterval time.Duration) (*certificate.Manager, error) {
+	providerNamespace string, option Options, msgBroker *messaging.Broker, checkInterval time.Duration, trustDomain string) (*certificate.Manager, error) {
 	if err := option.Validate(); err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 			},
 			Spec: v1alpha2.MeshRootCertificateSpec{
 				Provider:    option.AsProviderSpec(),
-				TrustDomain: "cluster.local",
+				TrustDomain: trustDomain,
 			},
 			Status: v1alpha2.MeshRootCertificateStatus{
 				State: constants.MRCStateActive,

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -143,7 +143,7 @@ func TestGetCertificateManager(t *testing.T) {
 				getCA = oldCA
 			}()
 
-			manager, err := NewCertificateManager(context.Background(), tc.kubeClient, tc.restConfig, tc.cfg, tc.providerNamespace, tc.options, tc.msgBroker, 1*time.Hour)
+			manager, err := NewCertificateManager(context.Background(), tc.kubeClient, tc.restConfig, tc.cfg, tc.providerNamespace, tc.options, tc.msgBroker, 1*time.Hour, "cluster.local")
 			if tc.expectError {
 				assert.Empty(manager)
 				assert.Error(err)


### PR DESCRIPTION
Signed-off-by: Keith Mattix II <keithmattix2@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Since we're not releasing full MRC support in v1.2, this PR allows users to set a custom trust domain by plumbing it through the helm chart as a command line flag to the 3 binaries (controller, bootstrap, and injector).
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Add test to make sure trust domain is set on the issuers

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Certificate Management     | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? 