### PR TITLE
update demo to allow multi-arch/multi-os 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BUILD_DATE_VAR := github.com/openservicemesh/osm/pkg/version.BuildDate
 BUILD_VERSION_VAR := github.com/openservicemesh/osm/pkg/version.Version
 BUILD_GITCOMMIT_VAR := github.com/openservicemesh/osm/pkg/version.GitCommit
 DOCKER_GO_VERSION = 1.17
-DOCKER_BUILDX_PLATFORM ?= linux/amd64
+DOCKER_BUILDX_PLATFORM ?= linux/$(shell go env GOARCH)
 # Value for the --output flag on docker buildx build.
 # https://docs.docker.com/engine/reference/commandline/buildx_build/#output
 DOCKER_BUILDX_OUTPUT ?= type=registry

--- a/demo/deploy-bookbuyer.sh
+++ b/demo/deploy-bookbuyer.sh
@@ -50,9 +50,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookbuyer
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
         # Main container with APP
         - name: bookbuyer

--- a/demo/deploy-bookstore-with-same-sa.sh
+++ b/demo/deploy-bookstore-with-same-sa.sh
@@ -75,9 +75,6 @@ spec:
         version: $VERSION
     spec:
       serviceAccountName: bookstore
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always

--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -83,9 +83,6 @@ spec:
         version: $VERSION
     spec:
       serviceAccountName: "$SVC"
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always

--- a/demo/deploy-bookthief.sh
+++ b/demo/deploy-bookthief.sh
@@ -68,9 +68,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookthief
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
         # Main container with APP
         - name: bookthief

--- a/demo/deploy-bookwarehouse.sh
+++ b/demo/deploy-bookwarehouse.sh
@@ -64,9 +64,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: bookwarehouse
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
         # Main container with APP
         - name: bookwarehouse

--- a/demo/deploy-tcp-client.sh
+++ b/demo/deploy-tcp-client.sh
@@ -41,9 +41,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: tcp-client
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
       - name: tcp-client
         image: "${CTR_REGISTRY}/tcp-client:${CTR_TAG}"

--- a/demo/deploy-tcp-echo-service.sh
+++ b/demo/deploy-tcp-echo-service.sh
@@ -59,9 +59,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: tcp-echo
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       containers:
       - name: tcp-echo-server
         image: "${CTR_REGISTRY}/tcp-echo-server:${CTR_TAG}"

--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -27,9 +27,6 @@ spec:
       labels:
         app: vault
     spec:
-      nodeSelector:
-        kubernetes.io/arch: amd64
-        kubernetes.io/os: linux
       terminationGracePeriodSeconds: 10
       containers:
       - name: vault

--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -27,6 +27,24 @@ spec:
       labels:
         app: vault
     spec:
+      ## Affinity settings for pod assignment
+      ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - arm 
+                - 386
       terminationGracePeriodSeconds: 10
       containers:
       - name: vault


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->

Signed-off-by: Whitney Griffith whitney.griffith16@gmail.com

**Description**: The demo has been explicitly set to run on nodes with Linux OS and and AMD64 Architecture. These changes unblock running the demo on clusters with exclusively linux/arm64 nodes. The node selectors were removed for the demo apps and [node affinity](ttps://kubernetes.io/docs/concepts/configuration/assign-pod-node/) added where necessary. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: The demo was run locally with these changes. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Demo                       |  [x] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No
