### PR TITLE
fix(*): update broken docs links

### DIFF
--- a/charts/osm/templates/cleanup-hook.yaml
+++ b/charts/osm/templates/cleanup-hook.yaml
@@ -76,7 +76,7 @@ spec:
         - name: garbage-collector
           image: "{{ include "osmCRDs.image" . }}"
           imagePullPolicy: {{ .Values.osm.image.pullPolicy }}
-          # NOTE: any changes to resources being cleaned up should be updated in the lists/commands in the uninstall guide (https://github.com/openservicemesh/osm-docs/blob/main/content/docs/guides/uninstall.md#uninstall-osm-control-plane-and-remove-user-provided-resources) and the uninstall troubleshooting guide (https://github.com/openservicemesh/osm-docs/blob/main/content/docs/guides/troubleshooting/uninstall.md)
+          # NOTE: any changes to resources being cleaned up should be updated in the lists/commands in the uninstall guide (https://github.com/openservicemesh/osm-docs/blob/main/content/en/docs/guides/uninstall.md#uninstall-osm-control-plane-and-remove-user-provided-resources) and the uninstall troubleshooting guide (https://github.com/openservicemesh/osm-docs/blob/main/content/en/docs/guides/troubleshooting/uninstall.md)
           command:
             - sh
             - -c

--- a/docs/api_reference/README.md
+++ b/docs/api_reference/README.md
@@ -19,7 +19,7 @@ From the root of the `osm` repository, use the `gen-crd-api-reference-docs` bina
 
 For example, to generate API reference docs for the `MeshConfig` custom API defined in `/pkg/apis/config/v1alpha1/`:
 ```bash
-<path to api doc generator repo>/gen-crd-api-reference-docs -config `pwd`/docs/api_reference/config.json -api-dir "github.com/openservicemesh/osm/pkg/apis/config/v1alpha1" -template-dir <full path to api doc generator repo>/template/ -out-file <path to osm-docs repo>/content/docs/api_reference/config/v1alpha1.md
+<path to api doc generator repo>/gen-crd-api-reference-docs -config `pwd`/docs/api_reference/config.json -api-dir "github.com/openservicemesh/osm/pkg/apis/config/v1alpha1" -template-dir <full path to api doc generator repo>/template/ -out-file <path to osm-docs repo>/content/en/docs/api_reference/config/v1alpha1.md
 ```
 
 ## 4. Customize the generated doc for the website

--- a/docs/release_guide.md
+++ b/docs/release_guide.md
@@ -130,7 +130,7 @@ Follow the [Generating API Reference Documentation](/docs/api_reference/README.m
 
 ### 4. Update error code documentation
 
-On the docs site's main branch, edit the file [https://github.com/openservicemesh/osm-docs/blob/main/content/docs/guides/troubleshooting/control_plane_error_codes.md](https://github.com/openservicemesh/osm-docs/blob/main/content/docs/guides/troubleshooting/control_plane_error_codes.md) to update the OSM error code table.
+On the docs site's main branch, edit the file [https://github.com/openservicemesh/osm-docs/blob/main/content/en/docs/guides/troubleshooting/control_plane_error_codes.md](https://github.com/openservicemesh/osm-docs/blob/main/content/en/docs/guides/troubleshooting/control_plane_error_codes.md) to update the OSM error code table.
 
 1. Build OSM on the release branch.
 1. Generate the mapping of OSM error codes and their descriptions using the `osm support` cli tool.
@@ -146,7 +146,7 @@ On the docs site's main branch, edit the file [https://github.com/openservicemes
     | E1001      | The specified log level could not be set in the system.                          |
    ```
 
-1. Copy the table and replace the existing table in the file [https://github.com/openservicemesh/osm-docs/blob/main/content/docs/guides/troubleshooting/control_plane_error_codes.md](https://github.com/openservicemesh/osm-docs/blob/main/content/docs/guides/troubleshooting/control_plane_error_codes.md).
+1. Copy the table and replace the existing table in the file [https://github.com/openservicemesh/osm-docs/blob/main/content/en/docs/guides/troubleshooting/control_plane_error_codes.md](https://github.com/openservicemesh/osm-docs/blob/main/content/en/docs/guides/troubleshooting/control_plane_error_codes.md).
 1. If there were updates to the table, make a PR in the OSM docs repository.
 
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates links to `/content/docs/` on the docs site to
`/content/en/docs/`.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- Manually checked links
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [X] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A