### PR TITLE
Pin the alpine image to a minor version (3.16)

### DIFF
--- a/dockerfiles/Dockerfile.init
+++ b/dockerfiles/Dockerfile.init
@@ -1,2 +1,2 @@
-FROM alpine:3
+FROM alpine:3.16
 RUN apk add --no-cache iptables


### PR DESCRIPTION
Prior to this change the alpine image was using the sliding tag of `3`.
This PR introduces are stricter pin to the minor version to keep the
version drift to a minimum, so that we pull in patch updates but not
minor updates.

Signed-off-by: Thomas Stringer <thomas@trstringer.com>


**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A.