### PR TITLE
[backport] demo/scripts: fix bookstore app label and container name (#4910)

### DIFF
--- a/demo/deploy-bookstore.sh
+++ b/demo/deploy-bookstore.sh
@@ -90,7 +90,7 @@ spec:
       containers:
         - image: "${CTR_REGISTRY}/bookstore:${CTR_TAG}"
           imagePullPolicy: Always
-          name: $SVC
+          name: bookstore
           ports:
             - containerPort: 14001
               name: web
@@ -133,10 +133,10 @@ spec:
         - name: $CTR_REGISTRY_CREDS_NAME
 EOF
 
-kubectl get pods      --no-headers -o wide --selector app="$SVC" -n "$BOOKSTORE_NAMESPACE"
-kubectl get endpoints --no-headers -o wide --selector app="$SVC" -n "$BOOKSTORE_NAMESPACE"
+kubectl get pods      --no-headers -o wide --selector app=bookstore,version="$VERSION" -n "$BOOKSTORE_NAMESPACE"
+kubectl get endpoints --no-headers -o wide --selector app=bookstore,version="$VERSION" -n "$BOOKSTORE_NAMESPACE"
 kubectl get service                -o wide                       -n "$BOOKSTORE_NAMESPACE"
 
-for x in $(kubectl get service -n "$BOOKSTORE_NAMESPACE" --selector app="$SVC" --no-headers | awk '{print $1}'); do
+for x in $(kubectl get service -n "$BOOKSTORE_NAMESPACE" --selector app=bookstore,version="$VERSION" --no-headers | awk '{print $1}'); do
     kubectl get service "$x" -n "$BOOKSTORE_NAMESPACE" -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
 done

--- a/demo/tail-bookstore-envoy.sh
+++ b/demo/tail-bookstore-envoy.sh
@@ -3,14 +3,14 @@
 # shellcheck disable=SC1091
 source .env
 
-backend="$1"
+selector="$1"
 thisScript="$(dirname "$0")/$(basename "$0")"
 
-if [ -z "$backend" ]; then
-    echo "Usage: $thisScript <backend-name>"
+if [ -z "$selector" ]; then
+    echo "Usage: $thisScript <selector>"
     exit 1
 fi
 
-POD="$(kubectl get pods -n "$BOOKSTORE_NAMESPACE" --show-labels --selector app="$backend" --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
+POD="$(kubectl get pods -n "$BOOKSTORE_NAMESPACE" --show-labels --selector "$selector" --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
 
 kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c envoy --tail=100 -f

--- a/demo/tail-bookstore.sh
+++ b/demo/tail-bookstore.sh
@@ -3,14 +3,14 @@
 # shellcheck disable=SC1091
 source .env
 
-backend="$1"
+selector="$1"
 thisScript="$(dirname "$0")/$(basename "$0")"
 
-if [ -z "$backend" ]; then
-    echo "Usage: $thisScript <backend-name>"
+if [ -z "$selector" ]; then
+    echo "Usage: $thisScript <selector>"
     exit 1
 fi
 
-POD="$(kubectl get pods -n "$BOOKSTORE_NAMESPACE" --show-labels --selector app="$backend" --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
+POD="$(kubectl get pods -n "$BOOKSTORE_NAMESPACE" --show-labels --selector "$selector" --no-headers | grep -v 'Terminating' | awk '{print $1}' | head -n1)"
 
-kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c "$backend" --tail=100
+kubectl logs "$POD" -n "$BOOKSTORE_NAMESPACE" -c bookstore --tail=100

--- a/scripts/port-forward-bookstore-ui-v1.sh
+++ b/scripts/port-forward-bookstore-ui-v1.sh
@@ -7,15 +7,7 @@
 # shellcheck disable=SC1091
 source .env
 
-backend="${1:-bookstore-v1}"
-thisScript="$(dirname "$0")/$(basename "$0")"
-
-if [ -z "$backend" ]; then
-    echo "Usage: $thisScript <backend-name>"
-    exit 1
-fi
-
 BOOKSTOREv1_LOCAL_PORT="${BOOKSTOREv1_LOCAL_PORT:-8081}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore,version=v1 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv1_LOCAL_PORT":14001

--- a/scripts/port-forward-bookstore-ui-v2.sh
+++ b/scripts/port-forward-bookstore-ui-v2.sh
@@ -7,15 +7,7 @@
 # shellcheck disable=SC1091
 source .env
 
-backend="${1:-bookstore-v2}"
-thisScript="$(dirname "$0")/$(basename "$0")"
-
-if [ -z "$backend" ]; then
-    echo "Usage: $thisScript <backend-name>"
-    exit 1
-fi
-
 BOOKSTOREv2_LOCAL_PORT="${BOOKSTOREv2_LOCAL_PORT:-8082}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector app=bookstore,version=v2 -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTOREv2_LOCAL_PORT":14001

--- a/scripts/port-forward-bookstore-ui.sh
+++ b/scripts/port-forward-bookstore-ui.sh
@@ -7,15 +7,15 @@
 # shellcheck disable=SC1091
 source .env
 
-backend="${1:-bookstore}"
+selector="$1"
 thisScript="$(dirname "$0")/$(basename "$0")"
 
-if [ -z "$backend" ]; then
-    echo "Usage: $thisScript <backend-name>"
+if [ -z "$selector" ]; then
+    echo "Usage: $thisScript <selector>"
     exit 1
 fi
 
 BOOKSTORE_LOCAL_PORT="${BOOKSTORE_LOCAL_PORT:-8084}"
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector "$selector" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" "$BOOKSTORE_LOCAL_PORT":14001

--- a/scripts/port-forward-bookstore.sh
+++ b/scripts/port-forward-bookstore.sh
@@ -2,14 +2,14 @@
 # shellcheck disable=SC1091
 source .env
 
-backend="$1"
+selector="$1"
 thisScript="$(dirname "$0")/$(basename "$0")"
 
-if [ -z "$backend" ]; then
-    echo "Usage: $thisScript <backend-name>"
+if [ -z "$selector" ]; then
+    echo "Usage: $thisScript <selector>"
     exit 1
 fi
 
-POD="$(kubectl get pods --selector app="$backend" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
+POD="$(kubectl get pods --selector "$selector" -n "$BOOKSTORE_NAMESPACE" --no-headers | grep 'Running' | awk 'NR==1{print $1}')"
 kubectl port-forward "$POD" -n "$BOOKSTORE_NAMESPACE" 15000:15000
 


### PR DESCRIPTION
Backports e94c48b5 to release-v1.2
---
Updates the scripts to be in sync with the manifests
used in the manual demo documented on the website and
to be compatible with changes made to the bookstore app
labels in 5f54056b.

Also fixes #4906 and updates the release notes for
v1.2.


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `yes`