### PR TITLE
fix: add missing nosec

### DIFF
--- a/cmd/osm-healthcheck/osm-healthcheck.go
+++ b/cmd/osm-healthcheck/osm-healthcheck.go
@@ -44,7 +44,7 @@ func main() {
 	serverMux := http.NewServeMux()
 	serverMux.HandleFunc("/osm-healthcheck", healthcheckHandler)
 
-	//#nosec G112
+	// #nosec G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	// Initialize osm-healthcheck HTTP server
 	server := &http.Server{
 		Addr:    ":15904",

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Test httpserver with probes", func() {
 			router.Handle(url, handler)
 		}
 		testServer = &httptest.Server{
-			//#nosec G112
+			// #nosec G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 			Config: &http.Server{
 				Addr:    fmt.Sprintf(":%d", testHTTPServerPort),
 				Handler: router,

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -98,6 +98,7 @@ func (s *HTTPServer) Stop() error {
 
 	// Free and reset the server, so it can be started again
 	s.started = false
+	//#nosec G112
 	s.server = &http.Server{
 		Addr:    fmt.Sprintf(":%d", s.port),
 		Handler: s.httpServeMux,

--- a/pkg/httpserver/httpserver.go
+++ b/pkg/httpserver/httpserver.go
@@ -33,7 +33,7 @@ type HTTPServer struct {
 func NewHTTPServer(port uint16) *HTTPServer {
 	serverMux := http.NewServeMux()
 
-	//#nosec G112
+	// #nosec G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	return &HTTPServer{
 		started: false,
 		server: &http.Server{
@@ -98,7 +98,7 @@ func (s *HTTPServer) Stop() error {
 
 	// Free and reset the server, so it can be started again
 	s.started = false
-	//#nosec G112
+	// #nosec G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	s.server = &http.Server{
 		Addr:    fmt.Sprintf(":%d", s.port),
 		Handler: s.httpServeMux,

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -382,7 +382,7 @@ func TestGetSmiClientVersionHTTPHandler(t *testing.T) {
 		router.Handle(path, handler)
 	}
 
-	//#nosec G112
+	// #nosec G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	testServer := &httptest.Server{
 		Config: &http.Server{
 			Addr:    fmt.Sprintf(":%d", testHTTPServerPort),

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -38,7 +38,7 @@ func NewServer(name, namespace string, port int, cm *certificate.Manager, handle
 		cm:           cm,
 		onCertChange: onCertChange,
 	}
-	//#nosec G112
+	// #nosec G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server
 	s.server = &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),
 		Handler: mux,


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds missing nosec causing lint errors on http server
initialization.

Thanks @shalier for finding this!

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [x] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?