### PR TITLE
Fix lints by removing superfluous var type from var instantiation

### DIFF
--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -20,7 +20,7 @@ import (
 
 var testNamespace = "test-namespace"
 
-var testMeshConfig *configv1alpha2.MeshConfig = &configv1alpha2.MeshConfig{
+var testMeshConfig = &configv1alpha2.MeshConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: testNamespace,
 		Name:      meshConfigName,
@@ -28,7 +28,7 @@ var testMeshConfig *configv1alpha2.MeshConfig = &configv1alpha2.MeshConfig{
 	Spec: configv1alpha2.MeshConfigSpec{},
 }
 
-var testMeshConfigWithLastAppliedAnnotation *configv1alpha2.MeshConfig = &configv1alpha2.MeshConfig{
+var testMeshConfigWithLastAppliedAnnotation = &configv1alpha2.MeshConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: testNamespace,
 		Name:      meshConfigName,
@@ -39,7 +39,7 @@ var testMeshConfigWithLastAppliedAnnotation *configv1alpha2.MeshConfig = &config
 	Spec: configv1alpha2.MeshConfigSpec{},
 }
 
-var testPresetMeshConfigMap *corev1.ConfigMap = &corev1.ConfigMap{
+var testPresetMeshConfigMap = &corev1.ConfigMap{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "ConfigMap",
 		APIVersion: "v1",
@@ -89,7 +89,7 @@ var testPresetMeshConfigMap *corev1.ConfigMap = &corev1.ConfigMap{
 	},
 }
 
-var testMeshRootCertificate *configv1alpha2.MeshRootCertificate = &configv1alpha2.MeshRootCertificate{
+var testMeshRootCertificate = &configv1alpha2.MeshRootCertificate{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: testNamespace,
 		Name:      meshRootCertificateName,
@@ -100,7 +100,7 @@ var testMeshRootCertificate *configv1alpha2.MeshRootCertificate = &configv1alpha
 	},
 }
 
-var testPresetMeshRootCertificate *corev1.ConfigMap = &corev1.ConfigMap{
+var testPresetMeshRootCertificate = &corev1.ConfigMap{
 	TypeMeta: metav1.TypeMeta{
 		Kind:       "ConfigMap",
 		APIVersion: "v1",

--- a/pkg/catalog/fake/fake.go
+++ b/pkg/catalog/fake/fake.go
@@ -97,7 +97,7 @@ func NewFakeMeshCatalog(kubeClient kubernetes.Interface, meshConfigClient config
 			return nil
 		}
 
-		var podRet []*corev1.Pod = []*corev1.Pod{}
+		podRet := []*corev1.Pod{}
 		for idx := range vv.Items {
 			podRet = append(podRet, &vv.Items[idx])
 		}

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -33,7 +33,7 @@ const (
 	rootCertOrganization = "Open Service Mesh"
 )
 
-var getCA func(certificate.Issuer) (pem.RootCertificate, error) = func(i certificate.Issuer) (pem.RootCertificate, error) {
+var getCA = func(i certificate.Issuer) (pem.RootCertificate, error) {
 	cert, err := i.IssueCertificate("init-cert", 1*time.Second)
 	if err != nil {
 		return nil, err

--- a/pkg/tests/fixtures.go
+++ b/pkg/tests/fixtures.go
@@ -553,7 +553,7 @@ var (
 	}
 
 	// WildCardRouteMatch is HTTPRouteMatch with wildcard path and method
-	WildCardRouteMatch trafficpolicy.HTTPRouteMatch = trafficpolicy.HTTPRouteMatch{
+	WildCardRouteMatch = trafficpolicy.HTTPRouteMatch{
 		Path:          constants.RegexMatchAll,
 		PathMatchType: trafficpolicy.PathMatchRegex,
 		Methods:       []string{constants.WildcardHTTPMethod},

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1017,7 +1017,7 @@ func (td *OsmTestData) DeleteNs(nsName string) error {
 		}
 	}
 
-	var backgroundDelete metav1.DeletionPropagation = metav1.DeletePropagationBackground
+	backgroundDelete := metav1.DeletePropagationBackground
 
 	td.T.Logf("Deleting namespace %v", nsName)
 	err := td.Client.CoreV1().Namespaces().Delete(context.Background(), nsName, metav1.DeleteOptions{PropagationPolicy: &backgroundDelete})


### PR DESCRIPTION
Remove unnecessary var types during instantiation to fix lints