### PR TITLE
[backport] fix: update v1.2 release notes (#4916)

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -4,10 +4,8 @@
 
 ### Notable changes
 
-- OSM certificate provider is now configured using the new CRD, MeshRootCertificate
-  - Custom trust domains (i.e. certificate CommonNames) are now supported
+- Custom trust domains (i.e. certificate CommonNames) are now supported
 - The authentication token used to configure the Hashicorp Vault certificate provider can now be passed in using a secretRef
-- Along with root certificate rotation we support custom trust domains, as well as rotating to new trust domains with no downtime.
 - Envoy has been updated to v1.22 and uses the `envoyproxy/envoy-distroless` image instead of the deprecated `envoyproxy/envoy-alpine` image.
   - This means that `kubectl exec -c envoy ... -- sh` will no longer work for the Envoy sidecar
 - Added support for Kubernetes 1.23 and 1.24


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Backports #4916

Adds suggestion from #4865 and removes root certificate
rotation.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Documentation              | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No