### PR TITLE
rate-limiting: add global L4 rate limiting capability

### DIFF
--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -310,7 +310,7 @@ func (mc *MeshCatalog) getUpstreamServicesIncludeApex(upstreamServices []service
 	return allServices
 }
 
-// getRateLimitServiceClusters returns a list MeshClusterConfig objects corresponding to the global
+// getRateLimitServiceClusters returns a list of MeshClusterConfig objects corresponding to the global
 // rate limit service instance. It ensures only a single cluster config if the same rate limit service
 // is used for both TCP and HTTP rate limiting.
 func getRateLimitServiceClusters(upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting, clusterSet mapset.Set) []*trafficpolicy.MeshClusterConfig {

--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -46,6 +46,10 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 		upstreamSvcSet.Add(svc)
 	}
 
+	// Used to avoid duplicate clusters that can arise when multiple
+	// upstream services reference the same global rate limit service
+	rlsClusterSet := mapset.NewSet()
+
 	// A policy (traffic match, route, cluster) must be built for each upstream service. This
 	// includes apex/root services associated with the given upstream service.
 	allUpstreamServices := mc.getUpstreamServicesIncludeApex(upstreamServices)
@@ -66,6 +70,7 @@ func (mc *MeshCatalog) GetInboundMeshTrafficPolicy(upstreamIdentity identity.Ser
 
 		upstreamTrafficSetting := mc.policyController.GetUpstreamTrafficSetting(
 			policy.UpstreamTrafficSettingGetOpt{MeshService: &upstreamSvc})
+		clusterConfigs = append(clusterConfigs, getRateLimitServiceClusters(upstreamTrafficSetting, rlsClusterSet)...)
 
 		// ---
 		// Create a TrafficMatch for this upstream servic.
@@ -303,4 +308,46 @@ func (mc *MeshCatalog) getUpstreamServicesIncludeApex(upstreamServices []service
 	}
 
 	return allServices
+}
+
+// getRateLimitServiceClusters returns a list MeshClusterConfig objects corresponding to the global
+// rate limit service instance. It ensures only a single cluster config if the same rate limit service
+// is used for both TCP and HTTP rate limiting.
+func getRateLimitServiceClusters(upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting, clusterSet mapset.Set) []*trafficpolicy.MeshClusterConfig {
+	if upstreamTrafficSetting == nil || upstreamTrafficSetting.Spec.RateLimit == nil || upstreamTrafficSetting.Spec.RateLimit.Global == nil {
+		return nil
+	}
+
+	rateLimit := upstreamTrafficSetting.Spec.RateLimit
+	var clusters []*trafficpolicy.MeshClusterConfig
+
+	if rateLimit.Global.TCP != nil {
+		clusterName := service.RateLimitServiceClusterName(rateLimit.Global.TCP.RateLimitService)
+		if !clusterSet.Contains(clusterName) {
+			clusters = append(clusters, &trafficpolicy.MeshClusterConfig{
+				Name:     clusterName,
+				Address:  rateLimit.Global.TCP.RateLimitService.Host,
+				Port:     uint32(rateLimit.Global.TCP.RateLimitService.Port),
+				Protocol: constants.ProtocolH2C,
+			})
+			clusterSet.Add(clusterName)
+		}
+	}
+
+	if rateLimit.Global.HTTP != nil {
+		clusterName := service.RateLimitServiceClusterName(rateLimit.Global.HTTP.RateLimitService)
+		// Only configure an HTTP rate limiting cluster if the same cluster is not already
+		// referenced by a TCP rate limiting config
+		if !clusterSet.Contains(clusterName) {
+			clusters = append(clusters, &trafficpolicy.MeshClusterConfig{
+				Name:     clusterName,
+				Address:  rateLimit.Global.HTTP.RateLimitService.Host,
+				Port:     uint32(rateLimit.Global.HTTP.RateLimitService.Port),
+				Protocol: constants.ProtocolH2C,
+			})
+			clusterSet.Add(clusterName)
+		}
+	}
+
+	return clusters
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -264,6 +264,18 @@ const (
 	ProtocolTCPServerFirst = "tcp-server-first"
 )
 
+// HTTPProtocolVersion defines the HTTP protocol version to use
+const (
+	// ProtocolH2c refers to the H2C protocol
+	ProtocolH2C = "h2c"
+
+	// ProtocolHTTP2 refers to HTTP2 protocol
+	ProtocolHTTP2 = "http2"
+
+	// ProtocolHTTP1 refers to HTTP1 protocol
+	ProtocolHTTP1 = "http1"
+)
+
 // Operating systems.
 const (
 	// OSWindows is the name for Windows operating system.

--- a/pkg/envoy/cds/cluster.go
+++ b/pkg/envoy/cds/cluster.go
@@ -34,7 +34,7 @@ var replacer = strings.NewReplacer(".", "_", ":", "_")
 // getUpstreamServiceCluster returns an Envoy Cluster corresponding to the given upstream service
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
 func getUpstreamServiceCluster(downstreamIdentity identity.ServiceIdentity, config trafficpolicy.MeshClusterConfig, sidecarSpec configv1alpha2.SidecarSpec) *xds_cluster.Cluster {
-	httpProtocolOptions := getDefaultHTTPProtocolOptions()
+	httpProtocolOptions := getHTTPProtocolOptions("")
 
 	marshalledUpstreamTLSContext, err := anypb.New(
 		envoy.GetUpstreamTLSContext(downstreamIdentity, config.Service, sidecarSpec))
@@ -254,7 +254,7 @@ func getDNSResolvableEgressCluster(config *trafficpolicy.EgressClusterConfig) (*
 		return nil, fmt.Errorf("Invalid egress cluster config: Port unspecified")
 	}
 
-	httpProtocolOptions := getDefaultHTTPProtocolOptions()
+	httpProtocolOptions := getHTTPProtocolOptions("")
 
 	upstreamCluster := &xds_cluster.Cluster{
 		Name:        config.Name,
@@ -297,7 +297,7 @@ func getDNSResolvableEgressCluster(config *trafficpolicy.EgressClusterConfig) (*
 // getOriginalDestinationEgressCluster returns an Envoy cluster that routes traffic to its original destination.
 // The original destination is the original IP address and port prior to being redirected to the sidecar proxy.
 func getOriginalDestinationEgressCluster(name string, upstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting) (*xds_cluster.Cluster, error) {
-	httpProtocolOptions := getDefaultHTTPProtocolOptions()
+	httpProtocolOptions := getHTTPProtocolOptions("")
 
 	upstreamCluster := &xds_cluster.Cluster{
 		Name: name,
@@ -309,7 +309,7 @@ func getOriginalDestinationEgressCluster(name string, upstreamTrafficSetting *po
 
 	applyUpstreamTrafficSetting(upstreamTrafficSetting, upstreamCluster, httpProtocolOptions)
 
-	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getDefaultHTTPProtocolOptions())
+	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getHTTPProtocolOptions(""))
 	if err != nil {
 		return nil, err
 	}
@@ -342,10 +342,6 @@ func localClustersFromClusterConfigs(configs []*trafficpolicy.MeshClusterConfig)
 		clusters = append(clusters, getLocalServiceCluster(*c))
 	}
 	return clusters
-}
-
-func getDefaultHTTPProtocolOptions() *extensions_upstream_http.HttpProtocolOptions {
-	return getHTTPProtocolOptions("")
 }
 
 func getTypedHTTPProtocolOptions(httpProtocolOptions *extensions_upstream_http.HttpProtocolOptions) (map[string]*any.Any, error) {

--- a/pkg/envoy/cds/cluster_test.go
+++ b/pkg/envoy/cds/cluster_test.go
@@ -231,7 +231,7 @@ func TestGetPrometheusCluster(t *testing.T) {
 
 func TestGetOriginalDestinationEgressCluster(t *testing.T) {
 	assert := tassert.New(t)
-	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getDefaultHTTPProtocolOptions())
+	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getHTTPProtocolOptions(""))
 	assert.Nil(err)
 
 	var thresholdUintVal uint32 = 3
@@ -375,7 +375,7 @@ func TestGetEgressClusters(t *testing.T) {
 }
 
 func TestGetDNSResolvableEgressCluster(t *testing.T) {
-	typedHTTPProtocolOptions, _ := getTypedHTTPProtocolOptions(getDefaultHTTPProtocolOptions())
+	typedHTTPProtocolOptions, _ := getTypedHTTPProtocolOptions(getHTTPProtocolOptions(""))
 
 	testCases := []struct {
 		name            string

--- a/pkg/envoy/cds/response_test.go
+++ b/pkg/envoy/cds/response_test.go
@@ -139,7 +139,7 @@ func TestNewResponse(t *testing.T) {
 		actualClusters = append(actualClusters, cl)
 	}
 
-	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getDefaultHTTPProtocolOptions())
+	typedHTTPProtocolOptions, err := getTypedHTTPProtocolOptions(getHTTPProtocolOptions(""))
 	assert.Nil(err)
 
 	expectedLocalCluster := &xds_cluster.Cluster{

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -272,7 +272,7 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 			expectError:         false,
 		},
 		{
-			name:           "inbound HTTP filter chain with rate limiting enabled",
+			name:           "inbound HTTP filter chain with local rate limiting enabled",
 			permissiveMode: true,
 			trafficMatch: &trafficpolicy.TrafficMatch{
 				Name:                "inbound_ns1/svc1_90_http",
@@ -295,6 +295,34 @@ func TestGetInboundMeshHTTPFilterChain(t *testing.T) {
 				ApplicationProtocols: []string{"osm"},
 			},
 			expectedFilterNames: []string{envoy.L4LocalRateLimitFilterName, envoy.HTTPConnectionManagerFilterName},
+			expectError:         false,
+		},
+		{
+			name:           "inbound HTTP filter chain with global rate limiting enabled",
+			permissiveMode: true,
+			trafficMatch: &trafficpolicy.TrafficMatch{
+				Name:                "inbound_ns1/svc1_90_http",
+				DestinationPort:     90,
+				DestinationProtocol: "http",
+				ServerNames:         []string{"svc1.ns1.svc.cluster.local"},
+				RateLimit: &policyv1alpha1.RateLimitSpec{
+					Global: &policyv1alpha1.GlobalRateLimitSpec{
+						TCP: &policyv1alpha1.TCPGlobalRateLimitSpec{
+							RateLimitService: policyv1alpha1.RateLimitServiceSpec{
+								Host: "foo.bar",
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort:      &wrapperspb.UInt32Value{Value: 90},
+				ServerNames:          []string{"svc1.ns1.svc.cluster.local"},
+				TransportProtocol:    "tls",
+				ApplicationProtocols: []string{"osm"},
+			},
+			expectedFilterNames: []string{envoy.L4GlobalRateLimitFilterName, envoy.HTTPConnectionManagerFilterName},
 			expectError:         false,
 		},
 	}
@@ -423,6 +451,34 @@ func TestGetInboundMeshTCPFilterChain(t *testing.T) {
 				ApplicationProtocols: []string{"osm"},
 			},
 			expectedFilterNames: []string{envoy.L4LocalRateLimitFilterName, envoy.TCPProxyFilterName},
+			expectError:         false,
+		},
+		{
+			name:           "inbound HTTP filter chain with global rate limiting enabled",
+			permissiveMode: true,
+			trafficMatch: &trafficpolicy.TrafficMatch{
+				Name:                "inbound_ns1/svc1_90_http",
+				DestinationPort:     90,
+				DestinationProtocol: "http",
+				ServerNames:         []string{"svc1.ns1.svc.cluster.local"},
+				RateLimit: &policyv1alpha1.RateLimitSpec{
+					Global: &policyv1alpha1.GlobalRateLimitSpec{
+						TCP: &policyv1alpha1.TCPGlobalRateLimitSpec{
+							RateLimitService: policyv1alpha1.RateLimitServiceSpec{
+								Host: "foo.bar",
+								Port: 8080,
+							},
+						},
+					},
+				},
+			},
+			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
+				DestinationPort:      &wrapperspb.UInt32Value{Value: 90},
+				ServerNames:          []string{"svc1.ns1.svc.cluster.local"},
+				TransportProtocol:    "tls",
+				ApplicationProtocols: []string{"osm"},
+			},
+			expectedFilterNames: []string{envoy.L4GlobalRateLimitFilterName, envoy.TCPProxyFilterName},
 			expectError:         false,
 		},
 	}

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -105,9 +105,10 @@ const (
 	HTTPLocalRateLimitFilterName = "envoy.filters.http.local_ratelimit"
 
 	// Network (L4) filters
-	TCPProxyFilterName         = "tcp_proxy"
-	L4LocalRateLimitFilterName = "l4_local_rate_limit"
-	L4RBACFilterName           = "l4_rbac"
+	TCPProxyFilterName          = "tcp_proxy"
+	L4LocalRateLimitFilterName  = "l4_local_rate_limit"
+	L4GlobalRateLimitFilterName = "l4_global_rate_limit"
+	L4RBACFilterName            = "l4_rbac"
 
 	// Listener filters
 	OriginalDstFilterName   = "original_dst"

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
+
 	"github.com/openservicemesh/osm/pkg/identity"
 )
 
@@ -119,6 +121,11 @@ func (ms MeshService) IngressTrafficMatchName() string {
 // IngressTrafficMatchName returns the ingress traffic match name
 func IngressTrafficMatchName(name, namespace string, targetPort uint16, protocol string) string {
 	return fmt.Sprintf("ingress_%s/%s_%d_%s", namespace, name, targetPort, protocol)
+}
+
+// RateLimitServiceClusterName returns the cluster name used for the global rate limit service
+func RateLimitServiceClusterName(svc policyv1alpha1.RateLimitServiceSpec) string {
+	return fmt.Sprintf("%s|%d", svc.Host, svc.Port)
 }
 
 // ClusterName is a type for a service name

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -154,7 +154,12 @@ type MeshClusterConfig struct {
 	EnableEnvoyActiveHealthChecks bool
 
 	// UpstreamTrafficSetting is the traffic setting for the upstream cluster
+	// +optional
 	UpstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
+
+	// Protocol to use for the cluster
+	// +optional
+	Protocol string
 }
 
 // TrafficMatch is the type used to represent attributes used to match traffic

--- a/pkg/trafficpolicy/types.go
+++ b/pkg/trafficpolicy/types.go
@@ -158,6 +158,7 @@ type MeshClusterConfig struct {
 	UpstreamTrafficSetting *policyv1alpha1.UpstreamTrafficSetting
 
 	// Protocol to use for the cluster
+	// One of http1, http2, h2c
 	// +optional
 	Protocol string
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds the capability to enable global L4 rate limiting
for traffic to upstream services. The rate limiting
config is applied via the L4 network global rate
limit filter on the upstream listener.

Part of #2018

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Tested rate limiting using an external rate limit service. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? https://github.com/openservicemesh/osm-docs/pull/425