### PR TITLE
The docs walkthrough wants a default when starting port forwarding the UI

### DIFF
--- a/scripts/port-forward-bookstore-ui.sh
+++ b/scripts/port-forward-bookstore-ui.sh
@@ -7,7 +7,7 @@
 # shellcheck disable=SC1091
 source .env
 
-selector="$1"
+selector="${1:-app=bookstore,version=v1}"
 thisScript="$(dirname "$0")/$(basename "$0")"
 
 if [ -z "$selector" ]; then


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
When going through the walk through at I wasn't able to view the `bookstore-ui` application.  The doc at https://release-v1-2.docs.openservicemesh.io/docs/getting_started/install_apps/#view-the-application-uis shows to do:

```
cp .env.example .env
bash <<EOF
./scripts/port-forward-bookbuyer-ui.sh &
./scripts/port-forward-bookstore-ui.sh &
./scripts/port-forward-bookthief-ui.sh &
wait
EOF
```

but I get the following (nothing fails have to run it manually)  so the UI isn't visible.  

```
❯ ./scripts/port-forward-bookstore-ui.sh
Usage: ./scripts/port-forward-bookstore-ui.sh <selector>
```

this just sets a default.  I thought about  changing the docs but it was mentioned in multiple ways and this seemed easier.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [x] |
| Documentation              | [x] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

This fixes the docs...