### PR TITLE
bug(cmd/cli): Fixes letter casing for meshRootCertificate CRD

### DIFF
--- a/cmd/cli/uninstall_mesh.go
+++ b/cmd/cli/uninstall_mesh.go
@@ -291,7 +291,7 @@ func (d *uninstallMeshCmd) uninstallCustomResourceDefinitions() error {
 		"egresses.policy.openservicemesh.io",
 		"ingressbackends.policy.openservicemesh.io",
 		"meshconfigs.config.openservicemesh.io",
-		"meshRootCertificate.config.openservicemesh.io",
+		"meshrootcertificates.config.openservicemesh.io",
 		"upstreamtrafficsettings.policy.openservicemesh.io",
 		"retries.policy.openservicemesh.io",
 		"httproutegroups.specs.smi-spec.io",

--- a/cmd/cli/uninstall_mesh_test.go
+++ b/cmd/cli/uninstall_mesh_test.go
@@ -366,6 +366,21 @@ func TestUninstallClusterWideResources(t *testing.T) {
 					},
 					Spec: apiv1.CustomResourceDefinitionSpec{},
 				},
+				// OSM CRD
+				&apiv1.CustomResourceDefinition{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "CustomResourceDefinition",
+						APIVersion: "apiextensions.k8s.io/v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "meshrootcertificates.config.openservicemesh.io",
+						Labels: map[string]string{
+							constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue,
+							constants.ReconcileLabel:     strconv.FormatBool(true),
+						},
+					},
+					Spec: apiv1.CustomResourceDefinitionSpec{},
+				},
 				// SMI CRD
 				&apiv1.CustomResourceDefinition{
 					TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
osm uninstall was not removing meshRootCertificate CRD when -a flag was used, fixes letter casing
and adds meshRootCertificate to TestUninstallClusterWideResources()
Resolves #4943 

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Previously: 
![image](https://user-images.githubusercontent.com/69616256/181125316-0a0ea0e7-9661-4184-b699-e34710331f89.png)

Fixed:
![image](https://user-images.githubusercontent.com/69616256/181125392-2529a77e-17bc-46f0-bfe9-d9bb4b0eada9.png)


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?