### PR TITLE
feat(certs): update certificate Manager using MRC Status changes

### DIFF
--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -39,7 +39,7 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan MRCEvent, error) {
 	go func() {
 		ch <- MRCEvent{
 			Type: MRCEventAdded,
-			MRC: &v1alpha2.MeshRootCertificate{
+			NewMRC: &v1alpha2.MeshRootCertificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "osm-mesh-root-certificate",
 					Namespace: "osm-system",

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -19,8 +19,8 @@ func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEven
 	ch := make(chan certificate.MRCEvent)
 	go func() {
 		ch <- certificate.MRCEvent{
-			Type: certificate.MRCEventAdded,
-			MRC:  c.mrc,
+			Type:   certificate.MRCEventAdded,
+			NewMRC: c.mrc,
 		}
 		close(ch)
 	}()

--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -48,18 +48,19 @@ func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, e
 			mrc := obj.(*v1alpha2.MeshRootCertificate)
 			log.Debug().Msgf("received MRC add event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
 			eventChan <- certificate.MRCEvent{
-				Type: certificate.MRCEventAdded,
-				MRC:  mrc,
+				Type:   certificate.MRCEventAdded,
+				NewMRC: mrc,
 			}
 		},
-		// We don't really care about the previous version
-		// since the "state machine" of the MRC is well defined
-		UpdateFunc: func(_, newObj interface{}) {
-			mrc := newObj.(*v1alpha2.MeshRootCertificate)
-			log.Debug().Msgf("received MRC update event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
+		// We check if the status was updated to determine if it was a status update or not
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			newMRC := newObj.(*v1alpha2.MeshRootCertificate)
+			oldMRC := oldObj.(*v1alpha2.MeshRootCertificate)
+			log.Debug().Msgf("received MRC update event for MRC %s/%s", newMRC.GetNamespace(), newMRC.GetName())
 			eventChan <- certificate.MRCEvent{
-				Type: certificate.MRCEventUpdated,
-				MRC:  mrc,
+				Type:   certificate.MRCEventUpdated,
+				OldMRC: oldMRC,
+				NewMRC: newMRC,
 			}
 		},
 		// We don't care about deletes because the only deletes that should

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -43,7 +43,7 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 	go func() {
 		ch <- certificate.MRCEvent{
 			Type: certificate.MRCEventAdded,
-			MRC: &v1alpha2.MeshRootCertificate{
+			NewMRC: &v1alpha2.MeshRootCertificate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "osm-mesh-root-certificate",
 					Namespace: "osm-system",

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -134,15 +134,19 @@ type MRCEventType string
 // MRCEvent describes a change event on a given MRC
 type MRCEvent struct {
 	Type MRCEventType
+
+	// The previous observed version of the MRC as of the time of this event
+	OldMRC *v1alpha2.MeshRootCertificate
+
 	// The last observed version of the MRC as of the time of this event
-	MRC *v1alpha2.MeshRootCertificate
+	NewMRC *v1alpha2.MeshRootCertificate
 }
 
 var (
 	// MRCEventAdded is the type of announcement emitted when we observe an addition of a Kubernetes MeshRootCertificate
 	MRCEventAdded MRCEventType = "meshrootcertificate-added"
 
-	// MRCEventUpdated is the type of announcement emitted when we observe an update to a Kubernetes MeshRootCertificate
+	// MRCEventUpdated is the type of announcement emitted when we observe a non status update to a Kubernetes MeshRootCertificate
 	MRCEventUpdated MRCEventType = "meshrootcertificate-updated"
 )
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Updates the Manager in response to MRC state status changes.

Note: This change is not sufficient for OSM to support OSM root
certificate rotation. More updates are required to support root
certificate rotation in non-Envoy service certificates.

Resolves #4815

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |
| Certificate Management     | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No