### PR TITLE
Update envoy version to v1.23, and contour to v1.22

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -59,9 +59,9 @@ The following table lists the configurable parameters of the osm chart and their
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| contour.contour | object | `{"image":{"registry":"ghcr.io","repository":"projectcontour/contour","tag":"v1.21.1"}}` | Contour controller configuration |
+| contour.contour | object | `{"image":{"registry":"ghcr.io","repository":"projectcontour/contour","tag":"v1.22.1"}}` | Contour controller configuration |
 | contour.enabled | bool | `false` | Enables deployment of Contour control plane and gateway |
-| contour.envoy | object | `{"image":{"registry":"docker.io","repository":"envoyproxy/envoy-distroless","tag":"v1.22.2"}}` | Contour envoy edge proxy configuration |
+| contour.envoy | object | `{"image":{"registry":"docker.io","repository":"envoyproxy/envoy-distroless","tag":"v1.23.1"}}` | Contour envoy edge proxy configuration |
 | osm.caBundleSecretName | string | `"osm-ca-bundle"` | The Kubernetes secret name to store CA bundle for the root CA used in OSM |
 | osm.certificateProvider.certKeyBitSize | int | `2048` | Certificate key bit size for data plane certificates issued to workloads to communicate over mTLS |
 | osm.certificateProvider.kind | string | `"tresor"` | The Certificate manager type: `tresor`, `vault` or `cert-manager` |
@@ -247,8 +247,8 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.prometheus.retention | object | `{"time":"15d"}` | Prometheus data rentention configuration |
 | osm.prometheus.retention.time | string | `"15d"` | Prometheus data retention time |
 | osm.prometheus.tolerations | list | `[]` | Node tolerations applied to control plane pods. The specified tolerations allow pods to schedule onto nodes with matching taints. |
-| osm.sidecarImage | string | `"envoyproxy/envoy-distroless:v1.22.2@sha256:541d31419b95e3c62d8cc0967db9cdb4ad2782cc08faa6f15f04c081200e324a"` | Envoy sidecar image for Linux workloads |
-| osm.sidecarWindowsImage | string | `"envoyproxy/envoy-windows:v1.22.1@sha256:92733f8e5beae5c45df204a0e13edbd29e99adf962d1b1c7869b197d85c64bd0"` | Envoy sidecar image for Windows workloads |
+| osm.sidecarImage | string | `"envoyproxy/envoy-distroless:v1.23.1@sha256:293ffbe026e50a9463e909d9114278ca0af076b33d59d77a4a369acc6cbc53a0"` | Envoy sidecar image for Linux workloads -- NOTE: This should point to digest of the manifest that points to both the AMD and ARM images, rather than one of the two -- This can be obtained by running "docker inspect envoyproxy/envoy-distroless:<version> -f '{{index .RepoDigests 0}}'" after running "docker pull" |
+| osm.sidecarWindowsImage | string | `"envoyproxy/envoy-windows:v1.23.1@sha256:c1da166a272c0ca02a2ffbe568eadef5e373ed4def1cb156b584cefda44be014"` | Envoy sidecar image for Windows workloads |
 | osm.tracing.address | string | `""` | Address of the tracing collector service (must contain the namespace). When left empty, this is computed in helper template to "jaeger.<osm-namespace>.svc.cluster.local". Please override for BYO-tracing as documented in tracing.md |
 | osm.tracing.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"kubernetes.io/os"` |  |
 | osm.tracing.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"In"` |  |

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -417,7 +417,7 @@
           "title": "The sidecarImage schema",
           "description": "The proxy side car image to run.",
           "examples": [
-            "envoyproxy/envoy-distroless:v1.22.2@sha256:541d31419b95e3c62d8cc0967db9cdb4ad2782cc08faa6f15f04c081200e324a"
+            "envoyproxy/envoy-distroless:v1.23.1@sha256:293ffbe026e50a9463e909d9114278ca0af076b33d59d77a4a369acc6cbc53a0"
           ]
         },
         "curlImage": {
@@ -435,7 +435,7 @@
           "title": "The sidecarWindowsImage schema",
           "description": "The proxy side car image to run on Windows payloads.",
           "examples": [
-            "envoyproxy/envoy-windows:v1.22.1@sha256:92733f8e5beae5c45df204a0e13edbd29e99adf962d1b1c7869b197d85c64bd0"
+            "envoyproxy/envoy-windows:v1.23.1@sha256:c1da166a272c0ca02a2ffbe568eadef5e373ed4def1cb156b584cefda44be014"
           ]
         },
         "trustDomain": {

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -50,9 +50,11 @@ osm:
   # -- `osm-controller` image pull secret
   imagePullSecrets: []
   # -- Envoy sidecar image for Linux workloads
-  sidecarImage: envoyproxy/envoy-distroless:v1.22.2@sha256:541d31419b95e3c62d8cc0967db9cdb4ad2782cc08faa6f15f04c081200e324a
+  # -- NOTE: This should point to digest of the manifest that points to both the AMD and ARM images, rather than one of the two
+  # -- This can be obtained by running "docker inspect envoyproxy/envoy-distroless:<version> -f '{{index .RepoDigests 0}}'" after running "docker pull"
+  sidecarImage: envoyproxy/envoy-distroless:v1.23.1@sha256:293ffbe026e50a9463e909d9114278ca0af076b33d59d77a4a369acc6cbc53a0
   # -- Envoy sidecar image for Windows workloads
-  sidecarWindowsImage: envoyproxy/envoy-windows:v1.22.1@sha256:92733f8e5beae5c45df204a0e13edbd29e99adf962d1b1c7869b197d85c64bd0
+  sidecarWindowsImage: envoyproxy/envoy-windows:v1.23.1@sha256:c1da166a272c0ca02a2ffbe568eadef5e373ed4def1cb156b584cefda44be014
   # -- Curl image for control plane init container
   curlImage: curlimages/curl
 
@@ -614,13 +616,13 @@ contour:
     image:
       registry: ghcr.io
       repository: projectcontour/contour
-      tag: v1.21.1
+      tag: v1.22.1
   # -- Contour envoy edge proxy configuration
   envoy:
     image:
       registry: docker.io
       repository: envoyproxy/envoy-distroless
-      tag: v1.22.2
+      tag: v1.23.1
 
 #
 # -- SMI configuration


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Update envoy version to v1.23.1. To make this compatible with contour, we will also need to bump contour to v1.22.1 

Checked the release notes of envoy v1.23.1, nothing here seems to impact OSM. https://www.envoyproxy.io/docs/envoy/v1.23.1/version_history/v1.23/v1.23.1

Contour v1.22.1 changelog also does not impact OSM: https://github.com/projectcontour/contour/releases/v1.22.1
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Tested OSM installation and sidecar injection on ARM64 machine and ran through contour ingress demo successfully. 

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [X] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?