### PR TITLE
ref: use builder pattern in EDS resources generation

### DIFF
--- a/pkg/envoy/eds/builder.go
+++ b/pkg/envoy/eds/builder.go
@@ -22,6 +22,17 @@ type endpointsBuilder struct {
 	upstreamSvcEndpoints map[service.MeshService][]endpoint.Endpoint
 }
 
+func newEndpointsBuilder() *endpointsBuilder {
+	return &endpointsBuilder{
+		upstreamSvcEndpoints: make(map[service.MeshService][]endpoint.Endpoint),
+	}
+}
+
+func (b *endpointsBuilder) AddEndpoints(svc service.MeshService, endpoints []endpoint.Endpoint) {
+	b.upstreamSvcEndpoints[svc] = endpoints
+}
+
+// Build generate Envoy endpoint resources based on stored endpoints
 func (b *endpointsBuilder) Build() []types.Resource {
 	var edsResources []types.Resource
 

--- a/pkg/envoy/eds/builder.go
+++ b/pkg/envoy/eds/builder.go
@@ -3,6 +3,7 @@ package eds
 import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 
@@ -16,6 +17,19 @@ const (
 	localClusterPriority  = uint32(0)
 	remoteClusterPriority = uint32(1)
 )
+
+type endpointsBuilder struct {
+	upstreamSvcEndpoints map[service.MeshService][]endpoint.Endpoint
+}
+
+func (b *endpointsBuilder) Build() []types.Resource {
+	var edsResources []types.Resource
+
+	for svc, endpoints := range b.upstreamSvcEndpoints {
+		edsResources = append(edsResources, newClusterLoadAssignment(svc, endpoints))
+	}
+	return edsResources
+}
 
 // newClusterLoadAssignment returns the cluster load assignments for the given service and its endpoints
 func newClusterLoadAssignment(svc service.MeshService, serviceEndpoints []endpoint.Endpoint) *xds_endpoint.ClusterLoadAssignment {


### PR DESCRIPTION
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->

Apply builder pattern on EDS resource generation. 

The purpose of the refactoring is to decouple the external resource fetching, core business logic and intermediate result generation.

Resolves issue #4923 

**Testing done**:

No feature changes. 

- [x] Unit test

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

No

2. Is this a breaking change?

No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No