### PR TITLE
Fix linter issues and clean up unused param

### DIFF
--- a/cmd/cli/env.go
+++ b/cmd/cli/env.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Copyright 2020 The OSM contributors
+Copyright 2020 The OSM contributors.
 
 Licensed under the MIT License
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/cmd/cli/install.go
+++ b/cmd/cli/install.go
@@ -57,6 +57,7 @@ const (
 
 // chartTGZSource is the `helm package`d representation of the default Helm chart.
 // Its value is embedded at build time.
+//
 //go:embed chart.tgz
 var chartTGZSource []byte
 

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -242,7 +242,7 @@ func main() {
 	}
 
 	// Initialize the crd conversion webhook server to support the conversion of OSM's CRDs
-	if err := crdconversion.NewConversionWebhook(ctx, kubeClient, crdClient, certManager, osmNamespace, enableReconciler); err != nil {
+	if err := crdconversion.NewConversionWebhook(ctx, crdClient, certManager, osmNamespace, enableReconciler); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating crd conversion webhook")
 	}
 
@@ -327,8 +327,8 @@ func (b *bootstrap) ensureMeshConfig() error {
 }
 
 // initiatilizeKubernetesEventsRecorder initializes the generic Kubernetes event recorder and associates it with
-//	the osm-bootstrap pod resource. The events recorder allows the osm-bootstap to publish Kubernets events to
-// 	report fatal errors with initializing this application. These events will show up in the output of `kubectl get events`
+// the osm-bootstrap pod resource. The events recorder allows the osm-bootstap to publish Kubernets events to
+// report fatal errors with initializing this application. These events will show up in the output of `kubectl get events`
 func (b *bootstrap) initiatilizeKubernetesEventsRecorder() error {
 	bootstrapPod, err := b.getBootstrapPod()
 	if err != nil {

--- a/pkg/catalog/inbound_traffic_policies.go
+++ b/pkg/catalog/inbound_traffic_policies.go
@@ -202,7 +202,7 @@ func (mc *MeshCatalog) getRoutingRulesFromTrafficTarget(trafficTarget access.Tra
 }
 
 // routesFromRules takes a set of traffic target rules and the namespace of the traffic target and returns a list of
-//	http route matches (trafficpolicy.HTTPRouteMatch)
+// http route matches (trafficpolicy.HTTPRouteMatch)
 func (mc *MeshCatalog) routesFromRules(rules []access.TrafficTargetRule, trafficTargetNamespace string) ([]trafficpolicy.HTTPRouteMatch, error) {
 	var routes []trafficpolicy.HTTPRouteMatch
 

--- a/pkg/catalog/outbound_traffic_policies.go
+++ b/pkg/catalog/outbound_traffic_policies.go
@@ -17,12 +17,12 @@ import (
 // GetOutboundMeshTrafficPolicy returns the outbound mesh traffic policy for the given downstream identity
 //
 // The function works as follows:
-// 1. If permissive mode is enabled, builds outbound mesh traffic policies to reach every upstream service
-//    discovered using service discovery, using wildcard routes.
-// 2. In SMI mode, builds outbound mesh traffic policies to reach every upstream service corresponding
-//    to every upstream service account that this downstream is authorized to access using SMI TrafficTarget
-//    policies.
-// 3. Process TraficSplit policies and update the weights for the upstream services based on the policies.
+//  1. If permissive mode is enabled, builds outbound mesh traffic policies to reach every upstream service
+//     discovered using service discovery, using wildcard routes.
+//  2. In SMI mode, builds outbound mesh traffic policies to reach every upstream service corresponding
+//     to every upstream service account that this downstream is authorized to access using SMI TrafficTarget
+//     policies.
+//  3. Process TraficSplit policies and update the weights for the upstream services based on the policies.
 //
 // The route configurations are consolidated per port, such that upstream services using the same port are a part
 // of the same route configuration. This is required to avoid route conflicts that can occur when the same hostname

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -8,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Copyright 2020 The OSM contributors
+Copyright 2020 The OSM contributors.
 
 Licensed under the MIT License
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/pkg/crdconversion/crdconversion.go
+++ b/pkg/crdconversion/crdconversion.go
@@ -7,7 +7,6 @@ import (
 	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -38,7 +37,7 @@ var apiKindToPath = map[string]string{
 var conversionReviewVersions = []string{"v1beta1", "v1"}
 
 // NewConversionWebhook starts a new web server handling requests from the CRD's
-func NewConversionWebhook(ctx context.Context, kubeClient kubernetes.Interface, crdClient apiclient.ApiextensionsV1Interface, certManager *certificate.Manager, osmNamespace string, enableReconciler bool) error {
+func NewConversionWebhook(ctx context.Context, crdClient apiclient.ApiextensionsV1Interface, certManager *certificate.Manager, osmNamespace string, enableReconciler bool) error {
 	srv, err := webhook.NewServer(constants.OSMBootstrapName, osmNamespace, constants.CRDConversionWebhookPort, certManager, map[string]http.HandlerFunc{
 		meshConfigConverterPath:            serveMeshConfigConversion,
 		trafficAccessConverterPath:         serveTrafficAccessConversion,

--- a/pkg/crdconversion/crdconversion_test.go
+++ b/pkg/crdconversion/crdconversion_test.go
@@ -10,7 +10,6 @@ import (
 	apiv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
@@ -96,7 +95,6 @@ func TestUpdateCrdConfiguration(t *testing.T) {
 func TestNewConversionWebhook(t *testing.T) {
 	assert := tassert.New(t)
 	crdClient := fake.NewSimpleClientset()
-	kubeClient := k8sfake.NewSimpleClientset()
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -104,6 +102,6 @@ func TestNewConversionWebhook(t *testing.T) {
 	osmNamespace := "-osm-namespace-"
 	enablesReconciler := false
 
-	actualErr := NewConversionWebhook(context.Background(), kubeClient, crdClient.ApiextensionsV1(), fakeCertManager, osmNamespace, enablesReconciler)
+	actualErr := NewConversionWebhook(context.Background(), crdClient.ApiextensionsV1(), fakeCertManager, osmNamespace, enablesReconciler)
 	assert.NotNil(actualErr)
 }

--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -247,7 +247,7 @@ func BuildEgressRouteConfiguration(portSpecificRouteConfigs map[int][]*trafficpo
 	return routeConfigs
 }
 
-//NewRouteConfigurationStub creates the route configuration placeholder
+// NewRouteConfigurationStub creates the route configuration placeholder
 func NewRouteConfigurationStub(routeConfigName string) *xds_route.RouteConfiguration {
 	routeConfiguration := xds_route.RouteConfiguration{
 		Name: routeConfigName,

--- a/pkg/tests/stream.go
+++ b/pkg/tests/stream.go
@@ -53,9 +53,9 @@ func (s *XDSServer) Recv() (*xds_discovery.DiscoveryRequest, error) {
 // SetHeader sets the header metadata. It may be called multiple times.
 // When call multiple times, all the provided metadata will be merged.
 // All the metadata will be sent out when one of the following happens:
-//  - ServerStream.SendHeader() is called;
-//  - The first response is sent out;
-//  - An RPC status is sent out (error or success).
+//   - ServerStream.SendHeader() is called;
+//   - The first response is sent out;
+//   - An RPC status is sent out (error or success).
 func (s *XDSServer) SetHeader(metadata.MD) error {
 	return nil
 }

--- a/pkg/trafficpolicy/trafficpolicy.go
+++ b/pkg/trafficpolicy/trafficpolicy.go
@@ -83,9 +83,10 @@ func (rwc *RouteWeightedClusters) TotalClustersWeight() int {
 	return totalWeight
 }
 
-// AddRoute adds a route to an OutboundTrafficPolicy given an HTTP route match and weighted cluster. If a Route with the given HTTP route match
-//	already exists, an error will be returned. If a Route with the given HTTP route match does not exist,
-//	a Route with the given HTTP route match and weighted clusters will be added to the Routes on the OutboundTrafficPolicy
+// AddRoute adds a route to an OutboundTrafficPolicy given an HTTP route match and weighted cluster.
+// If a Route with the given HTTP route match already exists, an error will be returned.
+// If a Route with the given HTTP route match does not exist,
+// a Route with the given HTTP route match and weighted clusters will be added to the Routes on the OutboundTrafficPolicy
 func (out *OutboundTrafficPolicy) AddRoute(httpRouteMatch HTTPRouteMatch, retryPolicy *policyv1alpha1.RetryPolicySpec, weightedClusters ...service.WeightedCluster) error {
 	wc := mapset.NewSet()
 	for _, c := range weightedClusters {
@@ -137,7 +138,7 @@ func MergeInboundPolicies(original []*InboundTrafficPolicy, latest ...*InboundTr
 }
 
 // MergeRules merges the give slices of rules such that there is one Rule for a Route with all allowed service accounts listed in the
-//	returned slice of rules
+// returned slice of rules
 func MergeRules(originalRules, latestRules []*Rule) []*Rule {
 	for _, latest := range latestRules {
 		foundRoute := false
@@ -156,8 +157,8 @@ func MergeRules(originalRules, latestRules []*Rule) []*Rule {
 }
 
 // mergeRoutesWeightedClusters merges two slices of RouteWeightedClusters and returns a slice where there is one RouteWeightedCluster
-//	for any HTTPRouteMatch. Where there is an overlap in HTTPRouteMatch between the originalRoutes and latestRoutes, the WeightedClusters
-//  will be unioned as there can only be one set of WeightedClusters per HTTPRouteMatch.
+// for any HTTPRouteMatch. Where there is an overlap in HTTPRouteMatch between the originalRoutes and latestRoutes, the WeightedClusters
+// will be unioned as there can only be one set of WeightedClusters per HTTPRouteMatch.
 func mergeRoutesWeightedClusters(originalRoutes, latestRoutes []*RouteWeightedClusters) []*RouteWeightedClusters {
 	for _, latest := range latestRoutes {
 		foundRoute := false

--- a/tests/framework/common_apps.go
+++ b/tests/framework/common_apps.go
@@ -851,7 +851,7 @@ func (td *OsmTestData) InstallNginxIngress() (string, error) {
 }
 
 // RandomNameWithPrefix generates a random string with the given prefix.
-// 	If the prefix is empty, the default prefix "test" will be used
+// If the prefix is empty, the default prefix "test" will be used
 func RandomNameWithPrefix(prefix string) string {
 	if prefix == "" || len(prefix) > 100 {
 		prefix = "test"

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -140,7 +140,7 @@ type InstallOsmOpt func(*InstallOSMOpts)
 // CleanupType identifies what triggered the cleanup
 type CleanupType string
 
-//DockerConfig and other configs are docker-specific container registry secret structures.
+// DockerConfig and other configs are docker-specific container registry secret structures.
 // Most of it is taken or referenced from kubectl source itself
 type DockerConfig map[string]DockerConfigEntry
 


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
The PRs started to fail when CI `golangci-lint` was bumped to 1.48.0: https://github.com/golangci/golangci-lint/releases

This fixes the linter issues and also cleans up an unused parameter 
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [x] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?