### PR TITLE
egress: deprecate EgressPolicy feature flag

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -94,7 +94,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.enforceSingleMesh | bool | `true` | Enforce only deploying one mesh in the cluster |
 | osm.envoyLogLevel | string | `"error"` | Log level for the Envoy proxy sidecar. Non developers should generally never set this value. In production environments the LogLevel should be set to `error` |
 | osm.featureFlags.enableAsyncProxyServiceMapping | bool | `false` | Enable async proxy-service mapping |
-| osm.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API. When enabled, fine grained control over Egress (external) traffic is enforced DEPRECATED. To use EgressPolicy, disable global mesh-wide egress using '--set osm.enableEgress=false'. |
+| osm.featureFlags.enableEgressPolicy | bool | `true` | Enable OSM's Egress policy API. When enabled, fine grained control over Egress (external) traffic is enforced DEPRECATED, do not use. To use EgressPolicy API, disable global mesh-wide egress using '--set osm.enableEgress=false'. |
 | osm.featureFlags.enableEnvoyActiveHealthChecks | bool | `false` | Enable Envoy active health checks |
 | osm.featureFlags.enableIngressBackendPolicy | bool | `true` | Enables OSM's IngressBackend policy API. When enabled, OSM will use the IngressBackend API allow ingress traffic to mesh backends |
 | osm.featureFlags.enableMeshRootCertificate | bool | `false` | Enable the MeshRootCertificate to configure the OSM certificate provider |

--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -50,7 +50,6 @@ data:
       },
       "featureFlags": {
         "enableWASMStats": {{.Values.osm.featureFlags.enableWASMStats | mustToJson}},
-        "enableEgressPolicy": {{.Values.osm.featureFlags.enableEgressPolicy | mustToJson}},
         "enableSnapshotCacheMode": {{.Values.osm.featureFlags.enableSnapshotCacheMode | mustToJson}},
         "enableAsyncProxyServiceMapping": {{.Values.osm.featureFlags.enableAsyncProxyServiceMapping | mustToJson}},
         "enableIngressBackendPolicy": {{.Values.osm.featureFlags.enableIngressBackendPolicy | mustToJson}},

--- a/charts/osm/values.schema.json
+++ b/charts/osm/values.schema.json
@@ -1,1529 +1,1527 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
-    "type": "object",
-    "title": "The OSM Helm chart values schema",
-    "required": [
-        "osm",
-        "contour",
-        "smi"
-    ],
-    "definitions": {
-        "containerResources": {
-            "$id": "#/properties/definitions/properties/containerResources",
-            "type": "object",
-            "title": "The containerResources schema definition",
-            "description": "The container's resource configuration",
-            "required": [
-                "limits",
-                "requests"
-            ],
-            "properties": {
-                "limits": {
-                    "$id": "#/properties/definitions/properties/containerResources/properties/limits",
-                    "type": "object",
-                    "title": "The containerResources' limits schema",
-                    "description": "The container's resource limits",
-                    "required": [
-                        "cpu",
-                        "memory"
-                    ],
-                    "properties": {
-                        "cpu": {
-                            "$id": "#/properties/definitions/properties/containerResources/properties/limits/properties/cpu",
-                            "type": "string",
-                            "title": "The containerResources' CPU limit schema",
-                            "description": "The container's CPU limit"
-                        },
-                        "memory": {
-                            "$id": "#/properties/definitions/properties/containerResources/properties/limits/properties/memory",
-                            "type": "string",
-                            "title": "The containerResources' memory limit schema",
-                            "description": "The container's memory limit"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "requests": {
-                    "$id": "#/properties/definitions/properties/containerResources/properties/requests",
-                    "type": "object",
-                    "title": "The containerResources' requests schema",
-                    "description": "The container's request limits",
-                    "required": [
-                        "cpu",
-                        "memory"
-                    ],
-                    "properties": {
-                        "cpu": {
-                            "$id": "#/properties/definitions/properties/containerResources/properties/requests/properties/cpu",
-                            "type": "string",
-                            "title": "The containerResources' CPU request schema",
-                            "description": "The container's CPU request limit"
-                        },
-                        "memory": {
-                            "$id": "#/properties/definitions/properties/containerResources/properties/requests/properties/memory",
-                            "type": "string",
-                            "title": "The containerResources' memory request schema",
-                            "description": "The container's memory request limit"
-                        }
-                    },
-                    "additionalProperties": false
-                }
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "The OSM Helm chart values schema",
+  "required": [
+    "osm",
+    "contour",
+    "smi"
+  ],
+  "definitions": {
+    "containerResources": {
+      "$id": "#/properties/definitions/properties/containerResources",
+      "type": "object",
+      "title": "The containerResources schema definition",
+      "description": "The container's resource configuration",
+      "required": [
+        "limits",
+        "requests"
+      ],
+      "properties": {
+        "limits": {
+          "$id": "#/properties/definitions/properties/containerResources/properties/limits",
+          "type": "object",
+          "title": "The containerResources' limits schema",
+          "description": "The container's resource limits",
+          "required": [
+            "cpu",
+            "memory"
+          ],
+          "properties": {
+            "cpu": {
+              "$id": "#/properties/definitions/properties/containerResources/properties/limits/properties/cpu",
+              "type": "string",
+              "title": "The containerResources' CPU limit schema",
+              "description": "The container's CPU limit"
+            },
+            "memory": {
+              "$id": "#/properties/definitions/properties/containerResources/properties/limits/properties/memory",
+              "type": "string",
+              "title": "The containerResources' memory limit schema",
+              "description": "The container's memory limit"
             }
+          },
+          "additionalProperties": false
         },
-        "autoScale": {
-            "$id": "#/properties/definitions/properties/autoScale",
-            "type": "object",
-            "title": "The autoScale schema",
-            "description": "Autoscale configuration parameters",
-            "required": [
-                "enable"
-            ],
-            "properties": {
-                "enable": {
-                    "$id": "#/properties/definitions/properties/autoScale/properties/enable",
-                    "type": "boolean",
-                    "title": "Autoscale enable",
-                    "description": "Indicates whether autoscale should be enabled or not.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "minReplicas": {
-                    "$id": "#/properties/definitions/properties/autoScale/properties/minReplicas",
-                    "type": "integer",
-                    "title": "Autoscale minimum replicas",
-                    "description": "Indicates the minimum replicas for autoscale.",
-                    "minimum": 1,
-                    "maximum": 10,
-                    "examples": [
-                        1
-                    ]
-                },
-                "maxReplicas": {
-                    "$id": "#/properties/definitions/properties/autoScale/properties/maxReplicas",
-                    "type": "integer",
-                    "title": "Autoscale maximum replicase",
-                    "description": "Indicates the maximum replicas for autoscale.",
-                    "minimum": 1,
-                    "maximum": 10,
-                    "examples": [
-                        5
-                    ]
-                },
-                "cpu": {
-                    "$id": "#/properties/definitions/properties/autoScale/properties/cpu",
-                    "type": "object",
-                    "title": "Autoscale CPU resource schema",
-                    "description": "Autoscale CPU configuration",
-                    "required": [
-                        "targetAverageUtilization"
-                    ],
-                    "properties": {
-                        "targetAverageUtilization": {
-                            "$id": "#/properties/definitions/properties/autoScale/properties/cpu/properties/targetAverageUtilization",
-                            "type": "integer",
-                            "title": "Autoscale cpu targetAverageUtilization",
-                            "description": "Indicates average target cpu utilization (percentage) for autoscale.",
-                            "minimum": 0,
-                            "maximum": 100,
-                            "examples": [
-                                80
-                            ]
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "memory": {
-                    "$id": "#/properties/definitions/properties/autoScale/properties/memory",
-                    "type": "object",
-                    "title": "Autoscale memory resource schema",
-                    "description": "Autoscale memory configuration",
-                    "required": [
-                        "targetAverageUtilization"
-                    ],
-                    "properties": {
-                        "targetAverageUtilization": {
-                            "$id": "#/properties/definitions/properties/autoScale/properties/memory/properties/targetAverageUtilization",
-                            "type": "integer",
-                            "title": "Autoscale memory targetAverageUtilization",
-                            "description": "Indicates average target memory utilization (percentage) for autoscale.",
-                            "minimum": 0,
-                            "maximum": 100,
-                            "examples": [
-                                80
-                            ]
-                        }
-                    },
-                    "additionalProperties": false
-                }
+        "requests": {
+          "$id": "#/properties/definitions/properties/containerResources/properties/requests",
+          "type": "object",
+          "title": "The containerResources' requests schema",
+          "description": "The container's request limits",
+          "required": [
+            "cpu",
+            "memory"
+          ],
+          "properties": {
+            "cpu": {
+              "$id": "#/properties/definitions/properties/containerResources/properties/requests/properties/cpu",
+              "type": "string",
+              "title": "The containerResources' CPU request schema",
+              "description": "The container's CPU request limit"
+            },
+            "memory": {
+              "$id": "#/properties/definitions/properties/containerResources/properties/requests/properties/memory",
+              "type": "string",
+              "title": "The containerResources' memory request schema",
+              "description": "The container's memory request limit"
             }
+          },
+          "additionalProperties": false
         }
+      }
     },
-    "properties": {
-        "osm": {
-            "$id": "#/properties/osm",
-            "type": "object",
-            "title": "The OpenServiceMesh schema",
-            "description": "The top level required key in the values file.",
-            "required": [
-                "image",
-                "sidecarImage",
-                "curlImage",
-                "caBundleSecretName",
-                "enableDebugServer",
-                "enablePermissiveTrafficPolicy",
-                "enableEgress",
-                "enableReconciler",
-                "deployPrometheus",
-                "deployGrafana",
-                "enableFluentbit",
-                "fluentBit",
-                "meshName",
-                "maxDataPlaneConnections",
-                "envoyLogLevel",
-                "controllerLogLevel",
-                "enforceSingleMesh",
-                "deployJaeger",
-                "tracing",
-                "webhookConfigNamePrefix",
+    "autoScale": {
+      "$id": "#/properties/definitions/properties/autoScale",
+      "type": "object",
+      "title": "The autoScale schema",
+      "description": "Autoscale configuration parameters",
+      "required": [
+        "enable"
+      ],
+      "properties": {
+        "enable": {
+          "$id": "#/properties/definitions/properties/autoScale/properties/enable",
+          "type": "boolean",
+          "title": "Autoscale enable",
+          "description": "Indicates whether autoscale should be enabled or not.",
+          "examples": [
+            false
+          ]
+        },
+        "minReplicas": {
+          "$id": "#/properties/definitions/properties/autoScale/properties/minReplicas",
+          "type": "integer",
+          "title": "Autoscale minimum replicas",
+          "description": "Indicates the minimum replicas for autoscale.",
+          "minimum": 1,
+          "maximum": 10,
+          "examples": [
+            1
+          ]
+        },
+        "maxReplicas": {
+          "$id": "#/properties/definitions/properties/autoScale/properties/maxReplicas",
+          "type": "integer",
+          "title": "Autoscale maximum replicase",
+          "description": "Indicates the maximum replicas for autoscale.",
+          "minimum": 1,
+          "maximum": 10,
+          "examples": [
+            5
+          ]
+        },
+        "cpu": {
+          "$id": "#/properties/definitions/properties/autoScale/properties/cpu",
+          "type": "object",
+          "title": "Autoscale CPU resource schema",
+          "description": "Autoscale CPU configuration",
+          "required": [
+            "targetAverageUtilization"
+          ],
+          "properties": {
+            "targetAverageUtilization": {
+              "$id": "#/properties/definitions/properties/autoScale/properties/cpu/properties/targetAverageUtilization",
+              "type": "integer",
+              "title": "Autoscale cpu targetAverageUtilization",
+              "description": "Indicates average target cpu utilization (percentage) for autoscale.",
+              "minimum": 0,
+              "maximum": 100,
+              "examples": [
+                80
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "memory": {
+          "$id": "#/properties/definitions/properties/autoScale/properties/memory",
+          "type": "object",
+          "title": "Autoscale memory resource schema",
+          "description": "Autoscale memory configuration",
+          "required": [
+            "targetAverageUtilization"
+          ],
+          "properties": {
+            "targetAverageUtilization": {
+              "$id": "#/properties/definitions/properties/autoScale/properties/memory/properties/targetAverageUtilization",
+              "type": "integer",
+              "title": "Autoscale memory targetAverageUtilization",
+              "description": "Indicates average target memory utilization (percentage) for autoscale.",
+              "minimum": 0,
+              "maximum": 100,
+              "examples": [
+                80
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "properties": {
+    "osm": {
+      "$id": "#/properties/osm",
+      "type": "object",
+      "title": "The OpenServiceMesh schema",
+      "description": "The top level required key in the values file.",
+      "required": [
+        "image",
+        "sidecarImage",
+        "curlImage",
+        "caBundleSecretName",
+        "enableDebugServer",
+        "enablePermissiveTrafficPolicy",
+        "enableEgress",
+        "enableReconciler",
+        "deployPrometheus",
+        "deployGrafana",
+        "enableFluentbit",
+        "fluentBit",
+        "meshName",
+        "maxDataPlaneConnections",
+        "envoyLogLevel",
+        "controllerLogLevel",
+        "enforceSingleMesh",
+        "deployJaeger",
+        "tracing",
+        "webhookConfigNamePrefix",
+        "osmController",
+        "enablePrivilegedInitContainer",
+        "injector",
+        "osmBootstrap",
+        "featureFlags"
+      ],
+      "properties": {
+        "osmController": {
+          "$id": "#/properties/osm/properties/osmController",
+          "type": "object",
+          "title": "The osmController schema",
+          "description": "The details of the osmController.",
+          "required": [
+            "resource"
+          ],
+          "properties": {
+            "replicaCount": {
+              "$id": "#/properties/osm/properties/osmController/properties/replicaCount",
+              "type": "integer",
+              "title": "The replicaCount schema",
+              "description": "The number of replicas of the osm-controller pod",
+              "examples": [
+                1
+              ]
+            },
+            "resource": {
+              "$ref": "#/definitions/containerResources"
+            },
+            "podLabels": {
+              "$id": "#/properties/osm/properties/osmController/properties/podLabels",
+              "type": "object",
+              "title": "The podLabels schema",
+              "description": "Labels for the osmController pod.",
+              "default": {}
+            },
+            "enablePodDisruptionBudget": {
+              "$id": "#/properties/osm/properties/osmController/properties/enablePodDisruptionBudget",
+              "type": "boolean",
+              "title": "The enablePodDisruptionBudget schema",
+              "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
+              "examples": [
+                false
+              ]
+            },
+            "autoScale": {
+              "$ref": "#/definitions/autoScale"
+            },
+            "affinity": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "image": {
+          "$id": "#/properties/osm/properties/image",
+          "type": "object",
+          "title": "The image schema",
+          "description": "The details of the images to run.",
+          "examples": [
+            {
+              "registry": "openservicemesh",
+              "pullPolicy": "IfNotPresent",
+              "tag": "v0.4.2"
+            }
+          ],
+          "required": [
+            "registry",
+            "name",
+            "pullPolicy",
+            "tag",
+            "digest"
+          ],
+          "properties": {
+            "registry": {
+              "$id": "#/properties/osm/properties/image/properties/registry",
+              "type": "string",
+              "title": "The registry schema",
+              "description": "The registry of the images to run.",
+              "examples": [
+                "openservicemesh"
+              ]
+            },
+            "name": {
+              "$id": "#/properties/osm/properties/image/properties/name",
+              "type": "object",
+              "title": "Default image names",
+              "description": "Default image names for control plane.",
+              "required": [
                 "osmController",
-                "enablePrivilegedInitContainer",
-                "injector",
+                "osmInjector",
+                "osmSidecarInit",
                 "osmBootstrap",
-                "featureFlags"
-            ],
-            "properties": {
+                "osmCRDs",
+                "osmPreinstall",
+                "osmHealthcheck"
+              ],
+              "properties": {
                 "osmController": {
-                    "$id": "#/properties/osm/properties/osmController",
-                    "type": "object",
-                    "title": "The osmController schema",
-                    "description": "The details of the osmController.",
-                    "required": [
-                        "resource"
-                    ],
-                    "properties": {
-                        "replicaCount": {
-                            "$id": "#/properties/osm/properties/osmController/properties/replicaCount",
-                            "type": "integer",
-                            "title": "The replicaCount schema",
-                            "description": "The number of replicas of the osm-controller pod",
-                            "examples": [
-                                1
-                            ]
-                        },
-                        "resource": {
-                            "$ref": "#/definitions/containerResources"
-                        },
-                        "podLabels": {
-                            "$id": "#/properties/osm/properties/osmController/properties/podLabels",
-                            "type": "object",
-                            "title": "The podLabels schema",
-                            "description": "Labels for the osmController pod.",
-                            "default": {}
-                        },
-                        "enablePodDisruptionBudget": {
-                            "$id": "#/properties/osm/properties/osmController/properties/enablePodDisruptionBudget",
-                            "type": "boolean",
-                            "title": "The enablePodDisruptionBudget schema",
-                            "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "autoScale": {
-                            "$ref": "#/definitions/autoScale"
-                        },
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmController",
+                  "type": "string",
+                  "title": "osm-controller's image names",
+                  "description": "osm-controller container's image names."
                 },
-                "image": {
-                    "$id": "#/properties/osm/properties/image",
-                    "type": "object",
-                    "title": "The image schema",
-                    "description": "The details of the images to run.",
-                    "examples": [
-                        {
-                            "registry": "openservicemesh",
-                            "pullPolicy": "IfNotPresent",
-                            "tag": "v0.4.2"
-                        }
-                    ],
-                    "required": [
-                        "registry",
-                        "name",
-                        "pullPolicy",
-                        "tag",
-                        "digest"
-                    ],
-                    "properties": {
-                        "registry": {
-                            "$id": "#/properties/osm/properties/image/properties/registry",
-                            "type": "string",
-                            "title": "The registry schema",
-                            "description": "The registry of the images to run.",
-                            "examples": [
-                                "openservicemesh"
-                            ]
-                        },
-                        "name": {
-                            "$id": "#/properties/osm/properties/image/properties/name",
-                            "type": "object",
-                            "title": "Default image names",
-                            "description": "Default image names for control plane.",
-                            "required": [
-                                "osmController",
-                                "osmInjector",
-                                "osmSidecarInit",
-                                "osmBootstrap",
-                                "osmCRDs",
-                                "osmPreinstall",
-                                "osmHealthcheck"
-                            ],
-                            "properties": {
-                                "osmController": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmController",
-                                    "type": "string",
-                                    "title": "osm-controller's image names",
-                                    "description": "osm-controller container's image names."
-                                },
-                                "osmInjector": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmInjector",
-                                    "type": "string",
-                                    "title": "osm-injector's image name",
-                                    "description": "osm-injector container's image name."
-                                },
-                                "osmSidecarInit": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmSidecarInit",
-                                    "type": "string",
-                                    "title": "osm-osmSidecarInit's image name",
-                                    "description": "osm-osmSidecarInit container's image name."
-                                },
-                                "osmBootstrap": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmBootstrap",
-                                    "type": "string",
-                                    "title": "osm-boostrap's image name",
-                                    "description": "osm-bootstrap container's image name."
-                                },
-                                "osmCRDs": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmCRDs",
-                                    "type": "string",
-                                    "title": "osm-crds' image name",
-                                    "description": "osm-crds container's image name."
-                                },
-                                "osmPreinstall": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmPreinstall",
-                                    "type": "string",
-                                    "title": "osm-preinstall's image name",
-                                    "description": "osm-preinstall container's image name."
-                                },
-                                "osmHealthcheck": {
-                                    "$id": "#/properties/osm/properties/image/properties/name/properties/osmHealthcheck",
-                                    "type": "string",
-                                    "title": "osm-healthcheck's image name",
-                                    "description": "osm-healthcheck container's image name."
-                                }
-                            }
-                        },
-                        "pullPolicy": {
-                            "$id": "#/properties/osm/properties/image/properties/pullPolicy",
-                            "type": "string",
-                            "title": "The pullPolicy schema",
-                            "description": "The image pull policy.",
-                            "pattern": "^(Always|Never|IfNotPresent)?$",
-                            "examples": [
-                                "IfNotPresent"
-                            ]
-                        },
-                        "tag": {
-                            "$id": "#/properties/osm/properties/image/properties/tag",
-                            "type": "string",
-                            "title": "The tag schema",
-                            "description": "The image tag to run.",
-                            "examples": [
-                                "v0.4.2"
-                            ]
-                        },
-                        "digest": {
-                            "$id": "#/properties/osm/properties/image/properties/digest",
-                            "type": "object",
-                            "title": "Default image digests",
-                            "description": "Default image digests for control plane.",
-                            "required": [
-                                "osmController",
-                                "osmInjector",
-                                "osmSidecarInit",
-                                "osmCRDs",
-                                "osmBootstrap",
-                                "osmPreinstall",
-                                "osmHealthcheck"
-                            ],
-                            "properties": {
-                                "osmController": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmController",
-                                    "type": "string",
-                                    "title": "osm-controller's image digest",
-                                    "description": "osm-controller container's image digest."
-                                },
-                                "osmInjector": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmInjector",
-                                    "type": "string",
-                                    "title": "osm-injector's image digest",
-                                    "description": "osm-injector container's image digest."
-                                },
-                                "osmSidecarInit": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmSidecarInit",
-                                    "type": "string",
-                                    "title": "osm-osmSidecarInit's image digest",
-                                    "description": "osm-osmSidecarInit container's image digest."
-                                },
-                                "osmCRDs": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmCRDs",
-                                    "type": "string",
-                                    "title": "osm-crds' image digest",
-                                    "description": "osm-crds container's image digest."
-                                },
-                                "osmBootstrap": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmBootstrap",
-                                    "type": "string",
-                                    "title": "osm-boostrap's image digest",
-                                    "description": "osm-bootstrap container's image digest."
-                                },
-                                "osmPreinstall": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmPreinstall",
-                                    "type": "string",
-                                    "title": "osm-preinstall's image digest",
-                                    "description": "osm-preinstall container's image digest."
-                                },
-                                "osmHealthcheck": {
-                                    "$id": "#/properties/osm/properties/image/properties/digest/properties/osmHealthcheck",
-                                    "type": "string",
-                                    "title": "osm-healthcheck's image digest",
-                                    "description": "osm-healthcheck container's image digest."
-                                }
-                            }
-                        }
-                    },
-                    "additionalProperties": false
+                "osmInjector": {
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmInjector",
+                  "type": "string",
+                  "title": "osm-injector's image name",
+                  "description": "osm-injector container's image name."
                 },
-                "sidecarImage": {
-                    "$id": "#/properties/osm/properties/sidecarImage",
-                    "type": "string",
-                    "title": "The sidecarImage schema",
-                    "description": "The proxy side car image to run.",
-                    "examples": [
-                        "envoyproxy/envoy-distroless:v1.22.2@sha256:541d31419b95e3c62d8cc0967db9cdb4ad2782cc08faa6f15f04c081200e324a"
-                    ]
-                },
-                "curlImage": {
-                    "$id": "#/properties/osm/properties/curlImage",
-                    "type": "string",
-                    "title": "The curlImage schema",
-                    "description": "The curl image for control plane init containers.",
-                    "examples": [
-                        "curlimages/curl"
-                    ]
-                },
-                "sidecarWindowsImage": {
-                    "$id": "#/properties/osm/properties/sidecarWindowsImage",
-                    "type": "string",
-                    "title": "The sidecarWindowsImage schema",
-                    "description": "The proxy side car image to run on Windows payloads.",
-                    "examples": [
-                        "envoyproxy/envoy-windows:v1.22.1@sha256:92733f8e5beae5c45df204a0e13edbd29e99adf962d1b1c7869b197d85c64bd0"
-                    ]
-                },
-                "trustDomain": {
-                    "$id": "#/properties/osm/properties/trustDomain",
-                    "type": "string",
-                    "title": "The certificate issuance Trust Domain",
-                    "description": "The trust domain to use as part of the common name when requesting new certificates.",
-                    "examples": [
-                        "cluster.local",
-                        "example.com"
-                    ]
-                },
-                "certificateProvider": {
-                    "$id": "#/properties/osm/properties/certificateProvider",
-                    "type": "object",
-                    "title": "The certificate provider schema",
-                    "description": "Certificate provider configuration parameters",
-                    "required": [
-                        "kind",
-                        "serviceCertValidityDuration",
-                        "certKeyBitSize"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                        "kind": {
-                            "$id": "#/properties/osm/properties/certificateProvider/properties/kind",
-                            "type": "string",
-                            "title": "The certificate provider kind schema",
-                            "description": "The certificate manager osm-controller should use.",
-                            "pattern": "^(tresor|vault|cert-manager)$",
-                            "examples": [
-                                "tresor"
-                            ]
-                        },
-                        "serviceCertValidityDuration": {
-                            "$id": "#/properties/osm/properties/certificateProvider/properties/serviceCertValidityDuration",
-                            "type": "string",
-                            "title": "The serviceCertValidityDuration schema",
-                            "description": "The service certificate validity duration.",
-                            "examples": [
-                                "24h"
-                            ]
-                        },
-                        "certKeyBitSize": {
-                            "$id": "#/properties/osm/properties/certificateProvider/properties/certKeyBitSize",
-                            "type": "integer",
-                            "title": "The certKeyBitSize schema",
-                            "description": "The key size for data plane certificates.",
-                            "examples": [
-                                2048
-                            ]
-                        }
-                    }
-                },
-                "caBundleSecretName": {
-                    "$id": "#/properties/osm/properties/caBundleSecretName",
-                    "type": "string",
-                    "title": "The caBundleSecretName schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "examples": [
-                        "osm-ca-bundle"
-                    ]
-                },
-                "enableDebugServer": {
-                    "$id": "#/properties/osm/properties/enableDebugServer",
-                    "type": "boolean",
-                    "title": "The enableDebugServer schema",
-                    "description": "Indicates whether the Debug Server should be enabled or not.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "enablePermissiveTrafficPolicy": {
-                    "$id": "#/properties/osm/properties/enablePermissiveTrafficPolicy",
-                    "type": "boolean",
-                    "title": "The enablePermissiveTrafficPolicy schema",
-                    "description": "Indicates whether permissive traffic policy should be enabled or not.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "enableEgress": {
-                    "$id": "#/properties/osm/properties/enableEgress",
-                    "type": "boolean",
-                    "title": "The enableEgress schema",
-                    "description": "Indicates whether egress should be enabled or not.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "enableReconciler": {
-                    "$id": "#/properties/osm/properties/enableReconciler",
-                    "type": "boolean",
-                    "title": "The enableReconciler schema",
-                    "description": "Indicates whether OSM's reconciler should be enabled or not.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "deployPrometheus": {
-                    "$id": "#/properties/osm/properties/deployPrometheus",
-                    "type": "boolean",
-                    "title": "The deployPrometheus schema",
-                    "description": "Indicates whether Prometheus should be installed and configured as part of the osm control plane.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "deployGrafana": {
-                    "$id": "#/properties/osm/properties/deployGrafana",
-                    "type": "boolean",
-                    "title": "The deployGrafana schema",
-                    "description": "Indicates whether Grafana should be installed and configured as part of the osm control plane.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "enableFluentbit": {
-                    "$id": "#/properties/osm/properties/enableFluentbit",
-                    "type": "boolean",
-                    "title": "The enableFluentbit schema",
-                    "description": "Indicates whether Fluent Bit log forwarding should be enabled",
-                    "examples": [
-                        false
-                    ]
-                },
-                "fluentBit": {
-                    "$id": "#/properties/osm/properties/fluentBit",
-                    "type": "object",
-                    "title": "The Fluent Bit schema",
-                    "description": "The default details of the Fluent Bit sidecar if enabled.",
-                    "examples": [
-                        {
-                            "name": "fluentbit-logger",
-                            "registry": "fluent",
-                            "tag": "1.6.4",
-                            "pullPolicy": "IfNotPresent",
-                            "outputPlugin": "stdout",
-                            "enableProxySupport": "false",
-                            "httpProxy": "",
-                            "httpsProxy": ""
-                        }
-                    ],
-                    "required": [
-                        "name",
-                        "registry",
-                        "tag",
-                        "pullPolicy",
-                        "outputPlugin",
-                        "workspaceId",
-                        "primaryKey",
-                        "enableProxySupport",
-                        "httpProxy",
-                        "httpsProxy"
-                    ],
-                    "properties": {
-                        "name": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/name",
-                            "type": "string",
-                            "title": "The name schema",
-                            "description": "The name of the Fluent Bit container",
-                            "examples": [
-                                "fluentbit-logger"
-                            ]
-                        },
-                        "registry": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/registry",
-                            "type": "string",
-                            "title": "The registry schema",
-                            "description": "The registry of the image to run.",
-                            "examples": [
-                                "fluent"
-                            ]
-                        },
-                        "tag": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/tag",
-                            "type": "string",
-                            "title": "The tag schema",
-                            "description": "The image tag to run.",
-                            "examples": [
-                                "1.6.4"
-                            ]
-                        },
-                        "pullPolicy": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/pullPolicy",
-                            "type": "string",
-                            "title": "The pullPolicy schema",
-                            "description": "The image pull policy.",
-                            "pattern": "^(Always|Never|IfNotPresent)$",
-                            "examples": [
-                                "IfNotPresent"
-                            ]
-                        },
-                        "outputPlugin": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/outputPlugin",
-                            "type": "string",
-                            "title": "The output plugin for Fluent Bit",
-                            "description": "The log forwarding destination plugin for Fluent Bit",
-                            "examples": [
-                                "stdout"
-                            ]
-                        },
-                        "workspaceId": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/workspaceId",
-                            "type": "string",
-                            "title": "The Fluent Bit workspaceId schema",
-                            "description": "The workspace ID for Fluent Bit output plugin to Log Analytics"
-                        },
-                        "primaryKey": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/primaryKey",
-                            "type": "string",
-                            "title": "The Fluent Bit primaryKey schema",
-                            "description": "The primary key for Fluent Bit output plugin to Log Analytics"
-                        },
-                        "enableProxySupport": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/enableProxySupport",
-                            "type": "boolean",
-                            "title": "The enableProxySupport output schema",
-                            "description": "Indicates whether outbound proxy support should be configured for Fluent Bit",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "httpProxy": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/httpProxy",
-                            "type": "string",
-                            "title": "The httpProxy schema",
-                            "description": "http proxy endpoint",
-                            "examples": [
-                                "http://<host>:<port>"
-                            ]
-                        },
-                        "httpsProxy": {
-                            "$id": "#/properties/osm/properties/fluentBit/properties/httpsProxy",
-                            "type": "string",
-                            "title": "The httpsProxy schema",
-                            "description": "https proxy endpoint",
-                            "examples": [
-                                "http://<host>:<port>"
-                            ]
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "meshName": {
-                    "$id": "#/properties/osm/properties/meshName",
-                    "type": "string",
-                    "title": "The meshName schema",
-                    "description": "The name associated with the control plane being installed.",
-                    "examples": [
-                        "osm"
-                    ]
-                },
-                "maxDataPlaneConnections": {
-                    "$id": "#/properties/osm/properties/maxDataPlaneConnections",
-                    "type": "integer",
-                    "title": "The maxDataPlaneConnections schema",
-                    "description": "Sets the Max Data Plane Connections",
-                    "examples": [
-                        "1000"
-                    ]
-                },
-                "configResyncInterval": {
-                    "$id": "#/properties/osm/properties/configResyncInterval",
-                    "type": "string",
-                    "title": "The configResyncInterval schema",
-                    "description": "Sets the resync interval for regular proxy broadcast updates",
-                    "examples": [
-                        "30s"
-                    ]
-                },
-                "envoyLogLevel": {
-                    "$id": "#/properties/osm/properties/envoyLogLevel",
-                    "type": "string",
-                    "title": "The envoyLogLevel schema",
-                    "description": "Envoy log level.",
-                    "pattern": "^(trace|debug|info|warning|warn|error|critical|off)$",
-                    "examples": [
-                        "error"
-                    ]
-                },
-                "localProxyMode": {
-                    "$id": "#/properties/osm/properties/localProxyMode",
-                    "type": "string",
-                    "title": "The localProxyMode schema",
-                    "description": "Proxy mode for the Envoy proxy sidecar. Acceptable values are ['Localhost', 'PodIP'].",
-                    "enum": [
-                        "Localhost",
-                        "PodIP"
-                    ],
-                    "examples": [
-                        "Localhost"
-                    ]
-                },
-                "controllerLogLevel": {
-                    "$id": "#/properties/osm/properties/controllerLogLevel",
-                    "type": "string",
-                    "title": "The controllerLogLevel schema",
-                    "description": "OSM Controller log level.",
-                    "pattern": "^(debug|info|warn|error|fatal|panic|disabled|trace)$",
-                    "examples": [
-                        "error"
-                    ]
-                },
-                "enforceSingleMesh": {
-                    "$id": "#/properties/osm/properties/enforceSingleMesh",
-                    "type": "boolean",
-                    "title": "The enforceSingleMesh schema",
-                    "description": "Enforce only running a single control plane within a cluster.",
-                    "examples": [
-                        false
-                    ]
-                },
-                "deployJaeger": {
-                    "$id": "#/properties/osm/properties/deployJaeger",
-                    "type": "boolean",
-                    "title": "The deployJaeger schema",
-                    "description": "Indicates whether Jaeger should be installed and configured as part of the control plane.",
-                    "examples": [
-                        true
-                    ]
-                },
-                "tracing": {
-                    "$id": "#/properties/osm/properties/tracing",
-                    "type": "object",
-                    "title": "The tracing schema",
-                    "description": "An explanation about the purpose of this instance.",
-                    "examples": [
-                        {
-                            "enable": true
-                        }
-                    ],
-                    "required": [
-                        "enable",
-                        "address",
-                        "port",
-                        "endpoint",
-                        "image"
-                    ],
-                    "properties": {
-                        "enable": {
-                            "$id": "#/properties/osm/properties/tracing/properties/enable",
-                            "type": "boolean",
-                            "title": "The enable schema for tracing",
-                            "description": "Indicates whether tracing is enabled or not",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "address": {
-                            "$id": "#/properties/osm/properties/tracing/properties/address",
-                            "type": "string",
-                            "title": "The address schema for tracing",
-                            "description": "Address of the tracing collector",
-                            "examples": [
-                                "jaeger.<osm-namespace>.svc.cluster.local"
-                            ]
-                        },
-                        "port": {
-                            "$id": "#/properties/osm/properties/tracing/properties/port",
-                            "type": "integer",
-                            "title": "The port schema for tracing",
-                            "description": "Port of the tracing collector",
-                            "minimum": 1,
-                            "maximum": 65535,
-                            "examples": [
-                                9411
-                            ]
-                        },
-                        "endpoint": {
-                            "$id": "#/properties/osm/properties/tracing/properties/endpoint",
-                            "type": "string",
-                            "title": "The endpoint schema for tracing",
-                            "description": "API path of the collector",
-                            "examples": [
-                                "/api/v2/spans"
-                            ]
-                        },
-                        "image": {
-                            "$id": "#/properties/osm/properties/tracing/properties/image",
-                            "type": "string",
-                            "title": "Jaeger's image schema",
-                            "description": "Image used for jaeger",
-                            "examples": [
-                                "jaegertracing/all-in-one"
-                            ]
-                        },
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "webhookConfigNamePrefix": {
-                    "$id": "#/properties/osm/properties/webhookConfigNamePrefix",
-                    "type": "string",
-                    "title": "Webhook Config Name Prefix",
-                    "description": "Prefix for the webhook name, which uses the format <webhook-prefix>-<mesh-name>",
-                    "examples": [
-                        ""
-                    ]
-                },
-                "osmNamespace": {
-                    "$id": "#/properties/osm/properties/osmNamespace",
-                    "type": "string",
-                    "title": "The namespace of the OSM control plane components",
-                    "description": "Indicates the namespace in which the OSM control plane components will be installed",
-                    "examples": [
-                        "osm-system"
-                    ]
-                },
-                "enablePrivilegedInitContainer": {
-                    "$id": "#/properties/osm/properties/enablePrivilegedInitContainer",
-                    "type": "boolean",
-                    "title": "The enablePrivilegedInitContainer schema",
-                    "description": "Indicates whether the init container for pods in the mesh should be privileged",
-                    "examples": [
-                        false
-                    ]
-                },
-                "injector": {
-                    "$id": "#/properties/osm/properties/injector",
-                    "type": "object",
-                    "title": "The sidecar injector schema",
-                    "description": "Sidecar injector configurations",
-                    "required": [
-                        "replicaCount",
-                        "resource"
-                    ],
-                    "properties": {
-                        "replicaCount": {
-                            "$id": "#/properties/osm/properties/injector/properties/replicaCount",
-                            "type": "integer",
-                            "title": "The replicaCount schema",
-                            "description": "The number of replicas of the osm-injector pod.",
-                            "examples": [
-                                1
-                            ]
-                        },
-                        "resource": {
-                            "$ref": "#/definitions/containerResources"
-                        },
-                        "podLabels": {
-                            "$id": "#/properties/osm/properties/injector/properties/podLabels",
-                            "type": "object",
-                            "title": "The podLabels schema",
-                            "description": "Labels for the osm-injector pod.",
-                            "default": {}
-                        },
-                        "enablePodDisruptionBudget": {
-                            "$id": "#/properties/osm/properties/injector/properties/enablePodDisruptionBudget",
-                            "type": "boolean",
-                            "title": "The enablePodDisruptionBudget schema",
-                            "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
-                            "examples": [
-                                false
-                            ]
-                        },
-                        "autoScale": {
-                            "$ref": "#/definitions/autoScale"
-                        },
-                        "webhookTimeoutSeconds": {
-                            "$id": "#/properties/osm/properties/webhookTimeout",
-                            "type": "integer",
-                            "title": "Webhook Timeout Seconds",
-                            "description": "Timeout for the mutating webhook in seconds",
-                            "examples": [
-                                20
-                            ]
-                        },
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
+                "osmSidecarInit": {
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmSidecarInit",
+                  "type": "string",
+                  "title": "osm-osmSidecarInit's image name",
+                  "description": "osm-osmSidecarInit container's image name."
                 },
                 "osmBootstrap": {
-                    "$id": "#/properties/osm/properties/osmBootstrap",
-                    "type": "object",
-                    "title": "The OSM bootstrap schema",
-                    "description": "OSM bootstrap's configurations",
-                    "required": [
-                        "replicaCount",
-                        "resource"
-                    ],
-                    "properties": {
-                        "replicaCount": {
-                            "$id": "#/properties/osm/properties/osmBootstrap/properties/replicaCount",
-                            "type": "integer",
-                            "title": "The replicaCount schema",
-                            "description": "The number of replicas of the OSM bootstrap pod.",
-                            "examples": [
-                                1
-                            ]
-                        },
-                        "resource": {
-                            "$ref": "#/definitions/containerResources"
-                        },
-                        "podLabels": {
-                            "$id": "#/properties/osm/properties/osmBootstrap/properties/podLabels",
-                            "type": "object",
-                            "title": "The podLabels schema",
-                            "description": "Labels for the OSM bootstrap pod.",
-                            "default": {}
-                        },
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmBootstrap",
+                  "type": "string",
+                  "title": "osm-boostrap's image name",
+                  "description": "osm-bootstrap container's image name."
                 },
-                "featureFlags": {
-                    "$id": "#/properties/osm/properties/featureFlags",
-                    "type": "object",
-                    "title": "Feature flags",
-                    "description": "Feature flags",
-                    "examples": [
-                        {
-                            "enableWASMStats": true,
-                            "enableEgressPolicy": true
-                        }
-                    ],
-                    "required": [
-                        "enableWASMStats",
-                        "enableEgressPolicy",
-                        "enableAsyncProxyServiceMapping",
-                        "enableIngressBackendPolicy",
-                        "enableEnvoyActiveHealthChecks",
-                        "enableSnapshotCacheMode",
-                        "enableRetryPolicy",
-                        "enableMeshRootCertificate"
-                    ],
-                    "properties": {
-                        "enableWASMStats": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableWASMStats",
-                            "type": "boolean",
-                            "title": "Enable WASM stats",
-                            "description": "Enable extra Envoy statistics generated by a custom WASM extension",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableEgressPolicy": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableEgressPolicy",
-                            "type": "boolean",
-                            "title": "Enable OSM's Egress policy",
-                            "description": "Enable OSM's Egress policy for fine grained control over egress (external) traffic",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableAsyncProxyServiceMapping": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableAsyncProxyServiceMapping",
-                            "type": "boolean",
-                            "title": "Enable async proxy-service mapping",
-                            "description": "Enable async proxy-service mapping",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableIngressBackendPolicy": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableIngressBackendPolicy",
-                            "type": "boolean",
-                            "title": "Enable OSM to use the IngressBackend API",
-                            "description": "Enable OSM to use the IngressBackend API for allowing ingress to mesh backends",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableEnvoyActiveHealthChecks": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableEnvoyActiveHealthChecks",
-                            "type": "boolean",
-                            "title": "Enable Envoy active health checks",
-                            "description": "EnableEnvoyActiveHealthChecks defines if OSM will Envoy active health checks between services allowed to communicate",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableSnapshotCacheMode": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableSnapshotCacheMode",
-                            "type": "boolean",
-                            "title": "Enable SnapshotCache feature for Envoy xDS server",
-                            "description": "Enable SnapshotCache feature in OSM controller to cache snapshots for Envoy xDS configurations.",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableRetryPolicy": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableRetryPolicy",
-                            "type": "boolean",
-                            "title": "Enable Retry Policy",
-                            "description": "Enable automatic request retries.",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "enableMeshRootCertificate": {
-                            "$id": "#/properties/osm/properties/featureFlags/properties/enableMeshRootCertificate",
-                            "type": "boolean",
-                            "title": "Enable the MeshRootCertificate",
-                            "description": "Enable the MeshRootCertificate to configure the OSM certificate provider.",
-                            "examples": [
-                                false
-                            ]
-                        }
-                    },
-                    "additionalProperties": false
+                "osmCRDs": {
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmCRDs",
+                  "type": "string",
+                  "title": "osm-crds' image name",
+                  "description": "osm-crds container's image name."
                 },
-                "pspEnabled": {
-                    "$id": "#/properties/osm/properties/pspEnabled",
-                    "type": "boolean",
-                    "title": "The pspEnabled schema",
-                    "description": "Indicates whether OSM should run with PodSecurityPolicies",
-                    "examples": [
-                        false
-                    ]
+                "osmPreinstall": {
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmPreinstall",
+                  "type": "string",
+                  "title": "osm-preinstall's image name",
+                  "description": "osm-preinstall container's image name."
                 },
-                "controlPlaneTolerations": {
-                    "$id": "#/properties/osm/properties/controlPlaneTolerations",
-                    "type": "array",
-                    "title": "The controlPlaneTolerations schema",
-                    "description": "Node tolerations applied to control plane pods to schedule onto nodes with matching taints",
-                    "items": {
-                        "type": "object"
-                    },
-                    "examples": [
-                        [
-                            {
-                                "key": "key1",
-                                "operator": "Equal",
-                                "value": "value1",
-                                "effect": "NoSchedule"
-                            }
-                        ]
-                    ]
-                },
-                "outboundIPRangeExclusionList": {
-                    "$id": "#/properties/osm/properties/outboundIPRangeExclusionList",
-                    "type": "array",
-                    "title": "The outboundIPRangeExclusionList schema",
-                    "description": "Outbound IP range exluclusion list for sidecar traffic interception",
-                    "items": {
-                        "type": "string",
-                        "pattern": "((?:\\d{1,3}\\.){3}\\d{1,3})\\/(\\d{1,2})$"
-                    },
-                    "examples": [
-                        [
-                            "8.8.8.8/32",
-                            "10.0.0.0/24"
-                        ]
-                    ]
-                },
-                "outboundIPRangeInclusionList": {
-                    "$id": "#/properties/osm/properties/outboundIPRangeInclusionList",
-                    "type": "array",
-                    "title": "The outboundIPRangeInclusionList schema",
-                    "description": "Outbound IP range inclusion list for sidecar traffic interception",
-                    "items": {
-                        "type": "string",
-                        "pattern": "((?:\\d{1,3}\\.){3}\\d{1,3})\\/(\\d{1,2})$"
-                    },
-                    "examples": [
-                        [
-                            "8.8.8.8/32",
-                            "10.0.0.0/24"
-                        ]
-                    ]
-                },
-                "outboundPortExclusionList": {
-                    "$id": "#/properties/osm/properties/outboundPortExclusionList",
-                    "type": "array",
-                    "title": "The outboundPortExclusionList schema",
-                    "description": "Outbound port exluclusion list for sidecar traffic interception",
-                    "items": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 65535
-                    },
-                    "examples": [
-                        [
-                            6379,
-                            3315
-                        ]
-                    ]
-                },
-                "inboundPortExclusionList": {
-                    "$id": "#/properties/osm/properties/inboundPortExclusionList",
-                    "type": "array",
-                    "title": "The inboundPortExclusionList schema",
-                    "description": "Inbound port exluclusion list for sidecar traffic interception",
-                    "items": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 65535
-                    },
-                    "examples": [
-                        [
-                            6379,
-                            3315
-                        ]
-                    ]
-                },
-                "networkInterfaceExclusionList": {
-                    "$id": "#/properties/osm/properties/networkInterfaceExclusionList",
-                    "type": "array",
-                    "title": "The networkInterfaceExclusionList schema",
-                    "description": "Network interface exluclusion list for sidecar traffic interception",
-                    "items": {
-                        "type": "string"
-                    },
-                    "examples": [
-                        [
-                            "eth0",
-                            "net1"
-                        ]
-                    ]
-                },
-                "grafana": {
-                    "$id": "#/properties/osm/properties/grafana",
-                    "type": "object",
-                    "title": "The grafana schema",
-                    "description": "Grafana configuration parameters",
-                    "required": [
-                        "port",
-                        "enableRemoteRendering",
-                        "image",
-                        "rendererImage"
-                    ],
-                    "properties": {
-                        "port": {
-                            "$id": "#/properties/osm/properties/grafana/properties/port",
-                            "title": "Grafana's port schema",
-                            "description": "Grafana's port number",
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 65535,
-                            "examples": [
-                                3000
-                            ]
-                        },
-                        "enableRemoteRendering": {
-                            "$id": "#/properties/osm/properties/grafana/properties/enableRemoteRendering",
-                            "type": "boolean",
-                            "title": "Grafana's enableRemoteRendering schema",
-                            "description": "Enable remote rendering of Grafana's dashboards",
-                            "examples": [
-                                true
-                            ]
-                        },
-                        "image": {
-                            "$id": "#/properties/osm/properties/grafana/properties/image",
-                            "type": "string",
-                            "title": "Grafana's image schema",
-                            "description": "Image used for Grafana",
-                            "examples": [
-                                "grafana/grafana:8.2.2"
-                            ]
-                        },
-                        "rendererImage": {
-                            "$id": "#/properties/osm/properties/grafana/properties/rendererImage",
-                            "type": "string",
-                            "title": "Grafana's rendererImage schema",
-                            "description": "Renderer image used for Grafana",
-                            "examples": [
-                                "grafana/grafana-image-renderer:3.2.1"
-                            ]
-                        },
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "examples": [
-                        {
-                            "port": 3000,
-                            "enableRemoteRendering": true,
-                            "image": "grafana/grafana:8.2.2",
-                            "rendererImage": "grafana/grafana-image-renderer:3.2.1"
-                        }
-                    ],
-                    "additionalProperties": false
-                },
-                "certmanager": {
-                    "$id": "#/properties/osm/properties/certmanager",
-                    "type": "object",
-                    "title": "The certmanager schema",
-                    "description": "cert-manager.io configuration parameters",
-                    "required": [
-                        "issuerName",
-                        "issuerKind",
-                        "issuerGroup"
-                    ],
-                    "properties": {
-                        "issuerName": {
-                            "$id": "#/properties/osm/properties/certmanager/properties/issuerName",
-                            "title": "Cert-manager's issuerName schema",
-                            "description": "Cert-manager's certificate issuer name",
-                            "type": "string",
-                            "examples": [
-                                "osm-ca"
-                            ]
-                        },
-                        "issuerKind": {
-                            "$id": "#/properties/osm/properties/certmanager/properties/issuerKind",
-                            "title": "Cert-manager's issuerKind schema",
-                            "description": "Cert-manager's certificate issuer kind",
-                            "type": "string",
-                            "examples": [
-                                "Issuer"
-                            ]
-                        },
-                        "issuerGroup": {
-                            "$id": "#/properties/osm/properties/certmanager/properties/issuerGroup",
-                            "title": "Cert-manager's issuerGroup schema",
-                            "description": "Cert-manager's certificate issuer group",
-                            "type": "string",
-                            "examples": [
-                                "cert-manager"
-                            ]
-                        }
-                    },
-                    "examples": [
-                        {
-                            "issuerName": "osm-ca",
-                            "issuerKind": "Issuer",
-                            "issuerGroup": "cert-manager"
-                        }
-                    ],
-                    "additionalProperties": false
-                },
-                "vault": {
-                    "$id": "#/properties/osm/properties/vault",
-                    "type": "object",
-                    "title": "The Hashicorp Vault schema",
-                    "description": "Hashicorp Vault configuration parameters",
-                    "properties": {
-                        "host": {
-                            "$id": "#/properties/osm/properties/vault/properties/host",
-                            "title": "Hashicorp Vault's host schema",
-                            "description": "Hashicorp Vault host/service - where Vault is installed",
-                            "type": "string"
-                        },
-                        "port": {
-                            "$id": "#/properties/osm/properties/vault/properties/port",
-                            "title": "Hashicorp Vault's port",
-                            "description": "Port to use to connect to vault",
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 65535
-                        },
-                        "protocol": {
-                            "$id": "#/properties/osm/properties/vault/properties/protocol",
-                            "title": "Hashicorp Vault's protocol schema",
-                            "description": "Protocol to use to connect to Vault",
-                            "type": "string"
-                        },
-                        "token": {
-                            "$id": "#/properties/osm/properties/vault/properties/token",
-                            "title": "Hashicorp Vault's token schema",
-                            "description": "Token to use to connect to Vault",
-                            "type": "string"
-                        },
-                        "role": {
-                            "$id": "#/properties/osm/properties/vault/properties/role",
-                            "title": "Hashicorp Vault's role schema",
-                            "description": "Role to use with Vault",
-                            "type": "string"
-                        },
-                        "secret": {
-                            "$id": "#/properties/osm/properties/vault/properties/secret",
-                            "type": "object",
-                            "title": "Vault token secret schema",
-                            "description": "Vault token secret reference parameters",
-                            "properties": {
-                                "name": {
-                                    "$id": "#/properties/osm/properties/vault/properties/secret/properties/name",
-                                    "title": "Vault token secret name schema",
-                                    "description": "Name of the Kubernetes Secret to store the vault token",
-                                    "type": "string"
-                                },
-                                "key": {
-                                    "$id": "#/properties/osm/properties/vault/properties/secret/properties/key",
-                                    "title": "Vault token secret key schema",
-                                    "description": "Name of the Kubernetes Secret key with the value of the vault token",
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "examples": [
-                        {
-                            "host": "vault.default.svc.cluster.local",
-                            "protocol": "http",
-                            "token": "some-token",
-                            "role": "openservicemesh"
-                        }
-                    ],
-                    "additionalProperties": false
-                },
-                "prometheus": {
-                    "$id": "#/properties/osm/properties/prometheus",
-                    "type": "object",
-                    "title": "The prometheus schema",
-                    "description": "Prometheus configurations",
-                    "required": [
-                        "resources",
-                        "port",
-                        "retention",
-                        "image"
-                    ],
-                    "properties": {
-                        "resources": {
-                            "$ref": "#/definitions/containerResources"
-                        },
-                        "port": {
-                            "$id": "#/properties/osm/properties/prometheus/properties/port",
-                            "title": "Prometheus' port schema",
-                            "description": "Prometheus' port number",
-                            "type": "integer",
-                            "minimum": 1,
-                            "maximum": 65535,
-                            "examples": [
-                                7070
-                            ]
-                        },
-                        "retention": {
-                            "$id": "#/properties/osm/properties/prometheus/properties/rentention",
-                            "type": "object",
-                            "title": "The Prometheus retention schema",
-                            "description": "Prometheus data retention configurations",
-                            "required": [
-                                "time"
-                            ],
-                            "properties": {
-                                "time": {
-                                    "$id": "#/properties/osm/properties/prometheus/properties/retention/properties/time",
-                                    "title": "Prometheus' data retention time schema",
-                                    "description": "Prometheus' data retention time",
-                                    "type": "string",
-                                    "examples": [
-                                        "15d"
-                                    ]
-                                }
-                            }
-                        },
-                        "image": {
-                            "$id": "#/properties/osm/properties/prometheus/properties/image",
-                            "type": "string",
-                            "title": "Prometheus's image schema",
-                            "description": "Image used for Prometheus",
-                            "examples": [
-                                "prom/prometheus:v2.18.1"
-                            ]
-                        },
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "imagePullSecrets": {
-                    "$id": "#/properties/osm/properties/imagePullSecrets",
-                    "type": "array",
-                    "title": "The imagePullSecrets schema",
-                    "description": "ImagePullSecrets for the control plane pod",
-                    "items": {
-                        "type": "object"
-                    },
-                    "examples": [
-                        [
-                            {
-                                "name": "secret-name"
-                            }
-                        ]
-                    ]
-                },
-                "validatorWebhook": {
-                    "$id": "#/properties/osm/properties/validatorWebhook",
-                    "type": "object",
-                    "title": "The validatorWebhook schema",
-                    "description": "Resource validator webhook configuration",
-                    "properties": {
-                        "webhookConfigurationName": {
-                            "$id": "#/properties/osm/properties/validatorWebhook/properties/webhookConfigurationName",
-                            "title": "Validator webhook configuration schema",
-                            "description": "Validator's ValidatingWebhookConfigurationName",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "preinstall": {
-                    "$id": "#/properties/osm/properties/preinstall",
-                    "type": "object",
-                    "title": "The preinstall schema",
-                    "description": "Preinstall configurations",
-                    "required": [],
-                    "properties": {
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
-                },
-                "cleanup": {
-                    "$id": "#/properties/osm/properties/preinstall",
-                    "type": "object",
-                    "title": "The preinstall schema",
-                    "description": "Preinstall configurations",
-                    "required": [],
-                    "properties": {
-                        "affinity": {
-                            "type": "object"
-                        },
-                        "nodeSelector": {
-                            "type": "object"
-                        },
-                        "tolerations": {
-                            "type": "array"
-                        }
-                    },
-                    "additionalProperties": false
+                "osmHealthcheck": {
+                  "$id": "#/properties/osm/properties/image/properties/name/properties/osmHealthcheck",
+                  "type": "string",
+                  "title": "osm-healthcheck's image name",
+                  "description": "osm-healthcheck container's image name."
                 }
+              }
             },
-            "additionalProperties": false
-        },
-        "contour": {
-            "$id": "#/properties/contour",
-            "type": "object",
-            "title": "Contour Ingress",
-            "description": "Contour Ingress configuration",
-            "properties": {
-                "enabled": {
-                    "$id": "#/properties/contour/enabled",
-                    "title": "Enable Contour",
-                    "description": "Enables Contour control plane and gateway",
-                    "type": "boolean"
+            "pullPolicy": {
+              "$id": "#/properties/osm/properties/image/properties/pullPolicy",
+              "type": "string",
+              "title": "The pullPolicy schema",
+              "description": "The image pull policy.",
+              "pattern": "^(Always|Never|IfNotPresent)?$",
+              "examples": [
+                "IfNotPresent"
+              ]
+            },
+            "tag": {
+              "$id": "#/properties/osm/properties/image/properties/tag",
+              "type": "string",
+              "title": "The tag schema",
+              "description": "The image tag to run.",
+              "examples": [
+                "v0.4.2"
+              ]
+            },
+            "digest": {
+              "$id": "#/properties/osm/properties/image/properties/digest",
+              "type": "object",
+              "title": "Default image digests",
+              "description": "Default image digests for control plane.",
+              "required": [
+                "osmController",
+                "osmInjector",
+                "osmSidecarInit",
+                "osmCRDs",
+                "osmBootstrap",
+                "osmPreinstall",
+                "osmHealthcheck"
+              ],
+              "properties": {
+                "osmController": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmController",
+                  "type": "string",
+                  "title": "osm-controller's image digest",
+                  "description": "osm-controller container's image digest."
+                },
+                "osmInjector": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmInjector",
+                  "type": "string",
+                  "title": "osm-injector's image digest",
+                  "description": "osm-injector container's image digest."
+                },
+                "osmSidecarInit": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmSidecarInit",
+                  "type": "string",
+                  "title": "osm-osmSidecarInit's image digest",
+                  "description": "osm-osmSidecarInit container's image digest."
+                },
+                "osmCRDs": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmCRDs",
+                  "type": "string",
+                  "title": "osm-crds' image digest",
+                  "description": "osm-crds container's image digest."
+                },
+                "osmBootstrap": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmBootstrap",
+                  "type": "string",
+                  "title": "osm-boostrap's image digest",
+                  "description": "osm-bootstrap container's image digest."
+                },
+                "osmPreinstall": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmPreinstall",
+                  "type": "string",
+                  "title": "osm-preinstall's image digest",
+                  "description": "osm-preinstall container's image digest."
+                },
+                "osmHealthcheck": {
+                  "$id": "#/properties/osm/properties/image/properties/digest/properties/osmHealthcheck",
+                  "type": "string",
+                  "title": "osm-healthcheck's image digest",
+                  "description": "osm-healthcheck container's image digest."
                 }
+              }
             }
+          },
+          "additionalProperties": false
         },
-        "smi": {
-            "$id": "#/properties/smi",
-            "type": "object",
-            "title": "SMI Configuration",
-            "description": "SMI configuration",
-            "properties": {
-                "validateTrafficTarget": {
-                    "$id": "#/properties/contour/validateTrafficTarget",
-                    "title": "Validate Traffic Target",
-                    "description": "Enables validation of SMI Traffic Target",
-                    "type": "boolean"
-                }
+        "sidecarImage": {
+          "$id": "#/properties/osm/properties/sidecarImage",
+          "type": "string",
+          "title": "The sidecarImage schema",
+          "description": "The proxy side car image to run.",
+          "examples": [
+            "envoyproxy/envoy-distroless:v1.22.2@sha256:541d31419b95e3c62d8cc0967db9cdb4ad2782cc08faa6f15f04c081200e324a"
+          ]
+        },
+        "curlImage": {
+          "$id": "#/properties/osm/properties/curlImage",
+          "type": "string",
+          "title": "The curlImage schema",
+          "description": "The curl image for control plane init containers.",
+          "examples": [
+            "curlimages/curl"
+          ]
+        },
+        "sidecarWindowsImage": {
+          "$id": "#/properties/osm/properties/sidecarWindowsImage",
+          "type": "string",
+          "title": "The sidecarWindowsImage schema",
+          "description": "The proxy side car image to run on Windows payloads.",
+          "examples": [
+            "envoyproxy/envoy-windows:v1.22.1@sha256:92733f8e5beae5c45df204a0e13edbd29e99adf962d1b1c7869b197d85c64bd0"
+          ]
+        },
+        "trustDomain": {
+          "$id": "#/properties/osm/properties/trustDomain",
+          "type": "string",
+          "title": "The certificate issuance Trust Domain",
+          "description": "The trust domain to use as part of the common name when requesting new certificates.",
+          "examples": [
+            "cluster.local",
+            "example.com"
+          ]
+        },
+        "certificateProvider": {
+          "$id": "#/properties/osm/properties/certificateProvider",
+          "type": "object",
+          "title": "The certificate provider schema",
+          "description": "Certificate provider configuration parameters",
+          "required": [
+            "kind",
+            "serviceCertValidityDuration",
+            "certKeyBitSize"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "$id": "#/properties/osm/properties/certificateProvider/properties/kind",
+              "type": "string",
+              "title": "The certificate provider kind schema",
+              "description": "The certificate manager osm-controller should use.",
+              "pattern": "^(tresor|vault|cert-manager)$",
+              "examples": [
+                "tresor"
+              ]
+            },
+            "serviceCertValidityDuration": {
+              "$id": "#/properties/osm/properties/certificateProvider/properties/serviceCertValidityDuration",
+              "type": "string",
+              "title": "The serviceCertValidityDuration schema",
+              "description": "The service certificate validity duration.",
+              "examples": [
+                "24h"
+              ]
+            },
+            "certKeyBitSize": {
+              "$id": "#/properties/osm/properties/certificateProvider/properties/certKeyBitSize",
+              "type": "integer",
+              "title": "The certKeyBitSize schema",
+              "description": "The key size for data plane certificates.",
+              "examples": [
+                2048
+              ]
             }
+          }
+        },
+        "caBundleSecretName": {
+          "$id": "#/properties/osm/properties/caBundleSecretName",
+          "type": "string",
+          "title": "The caBundleSecretName schema",
+          "description": "An explanation about the purpose of this instance.",
+          "examples": [
+            "osm-ca-bundle"
+          ]
+        },
+        "enableDebugServer": {
+          "$id": "#/properties/osm/properties/enableDebugServer",
+          "type": "boolean",
+          "title": "The enableDebugServer schema",
+          "description": "Indicates whether the Debug Server should be enabled or not.",
+          "examples": [
+            false
+          ]
+        },
+        "enablePermissiveTrafficPolicy": {
+          "$id": "#/properties/osm/properties/enablePermissiveTrafficPolicy",
+          "type": "boolean",
+          "title": "The enablePermissiveTrafficPolicy schema",
+          "description": "Indicates whether permissive traffic policy should be enabled or not.",
+          "examples": [
+            false
+          ]
+        },
+        "enableEgress": {
+          "$id": "#/properties/osm/properties/enableEgress",
+          "type": "boolean",
+          "title": "The enableEgress schema",
+          "description": "Indicates whether egress should be enabled or not.",
+          "examples": [
+            false
+          ]
+        },
+        "enableReconciler": {
+          "$id": "#/properties/osm/properties/enableReconciler",
+          "type": "boolean",
+          "title": "The enableReconciler schema",
+          "description": "Indicates whether OSM's reconciler should be enabled or not.",
+          "examples": [
+            false
+          ]
+        },
+        "deployPrometheus": {
+          "$id": "#/properties/osm/properties/deployPrometheus",
+          "type": "boolean",
+          "title": "The deployPrometheus schema",
+          "description": "Indicates whether Prometheus should be installed and configured as part of the osm control plane.",
+          "examples": [
+            false
+          ]
+        },
+        "deployGrafana": {
+          "$id": "#/properties/osm/properties/deployGrafana",
+          "type": "boolean",
+          "title": "The deployGrafana schema",
+          "description": "Indicates whether Grafana should be installed and configured as part of the osm control plane.",
+          "examples": [
+            false
+          ]
+        },
+        "enableFluentbit": {
+          "$id": "#/properties/osm/properties/enableFluentbit",
+          "type": "boolean",
+          "title": "The enableFluentbit schema",
+          "description": "Indicates whether Fluent Bit log forwarding should be enabled",
+          "examples": [
+            false
+          ]
+        },
+        "fluentBit": {
+          "$id": "#/properties/osm/properties/fluentBit",
+          "type": "object",
+          "title": "The Fluent Bit schema",
+          "description": "The default details of the Fluent Bit sidecar if enabled.",
+          "examples": [
+            {
+              "name": "fluentbit-logger",
+              "registry": "fluent",
+              "tag": "1.6.4",
+              "pullPolicy": "IfNotPresent",
+              "outputPlugin": "stdout",
+              "enableProxySupport": "false",
+              "httpProxy": "",
+              "httpsProxy": ""
+            }
+          ],
+          "required": [
+            "name",
+            "registry",
+            "tag",
+            "pullPolicy",
+            "outputPlugin",
+            "workspaceId",
+            "primaryKey",
+            "enableProxySupport",
+            "httpProxy",
+            "httpsProxy"
+          ],
+          "properties": {
+            "name": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/name",
+              "type": "string",
+              "title": "The name schema",
+              "description": "The name of the Fluent Bit container",
+              "examples": [
+                "fluentbit-logger"
+              ]
+            },
+            "registry": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/registry",
+              "type": "string",
+              "title": "The registry schema",
+              "description": "The registry of the image to run.",
+              "examples": [
+                "fluent"
+              ]
+            },
+            "tag": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/tag",
+              "type": "string",
+              "title": "The tag schema",
+              "description": "The image tag to run.",
+              "examples": [
+                "1.6.4"
+              ]
+            },
+            "pullPolicy": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/pullPolicy",
+              "type": "string",
+              "title": "The pullPolicy schema",
+              "description": "The image pull policy.",
+              "pattern": "^(Always|Never|IfNotPresent)$",
+              "examples": [
+                "IfNotPresent"
+              ]
+            },
+            "outputPlugin": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/outputPlugin",
+              "type": "string",
+              "title": "The output plugin for Fluent Bit",
+              "description": "The log forwarding destination plugin for Fluent Bit",
+              "examples": [
+                "stdout"
+              ]
+            },
+            "workspaceId": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/workspaceId",
+              "type": "string",
+              "title": "The Fluent Bit workspaceId schema",
+              "description": "The workspace ID for Fluent Bit output plugin to Log Analytics"
+            },
+            "primaryKey": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/primaryKey",
+              "type": "string",
+              "title": "The Fluent Bit primaryKey schema",
+              "description": "The primary key for Fluent Bit output plugin to Log Analytics"
+            },
+            "enableProxySupport": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/enableProxySupport",
+              "type": "boolean",
+              "title": "The enableProxySupport output schema",
+              "description": "Indicates whether outbound proxy support should be configured for Fluent Bit",
+              "examples": [
+                false
+              ]
+            },
+            "httpProxy": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/httpProxy",
+              "type": "string",
+              "title": "The httpProxy schema",
+              "description": "http proxy endpoint",
+              "examples": [
+                "http://<host>:<port>"
+              ]
+            },
+            "httpsProxy": {
+              "$id": "#/properties/osm/properties/fluentBit/properties/httpsProxy",
+              "type": "string",
+              "title": "The httpsProxy schema",
+              "description": "https proxy endpoint",
+              "examples": [
+                "http://<host>:<port>"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "meshName": {
+          "$id": "#/properties/osm/properties/meshName",
+          "type": "string",
+          "title": "The meshName schema",
+          "description": "The name associated with the control plane being installed.",
+          "examples": [
+            "osm"
+          ]
+        },
+        "maxDataPlaneConnections": {
+          "$id": "#/properties/osm/properties/maxDataPlaneConnections",
+          "type": "integer",
+          "title": "The maxDataPlaneConnections schema",
+          "description": "Sets the Max Data Plane Connections",
+          "examples": [
+            "1000"
+          ]
+        },
+        "configResyncInterval": {
+          "$id": "#/properties/osm/properties/configResyncInterval",
+          "type": "string",
+          "title": "The configResyncInterval schema",
+          "description": "Sets the resync interval for regular proxy broadcast updates",
+          "examples": [
+            "30s"
+          ]
+        },
+        "envoyLogLevel": {
+          "$id": "#/properties/osm/properties/envoyLogLevel",
+          "type": "string",
+          "title": "The envoyLogLevel schema",
+          "description": "Envoy log level.",
+          "pattern": "^(trace|debug|info|warning|warn|error|critical|off)$",
+          "examples": [
+            "error"
+          ]
+        },
+        "localProxyMode": {
+          "$id": "#/properties/osm/properties/localProxyMode",
+          "type": "string",
+          "title": "The localProxyMode schema",
+          "description": "Proxy mode for the Envoy proxy sidecar. Acceptable values are ['Localhost', 'PodIP'].",
+          "enum": [
+            "Localhost",
+            "PodIP"
+          ],
+          "examples": [
+            "Localhost"
+          ]
+        },
+        "controllerLogLevel": {
+          "$id": "#/properties/osm/properties/controllerLogLevel",
+          "type": "string",
+          "title": "The controllerLogLevel schema",
+          "description": "OSM Controller log level.",
+          "pattern": "^(debug|info|warn|error|fatal|panic|disabled|trace)$",
+          "examples": [
+            "error"
+          ]
+        },
+        "enforceSingleMesh": {
+          "$id": "#/properties/osm/properties/enforceSingleMesh",
+          "type": "boolean",
+          "title": "The enforceSingleMesh schema",
+          "description": "Enforce only running a single control plane within a cluster.",
+          "examples": [
+            false
+          ]
+        },
+        "deployJaeger": {
+          "$id": "#/properties/osm/properties/deployJaeger",
+          "type": "boolean",
+          "title": "The deployJaeger schema",
+          "description": "Indicates whether Jaeger should be installed and configured as part of the control plane.",
+          "examples": [
+            true
+          ]
+        },
+        "tracing": {
+          "$id": "#/properties/osm/properties/tracing",
+          "type": "object",
+          "title": "The tracing schema",
+          "description": "An explanation about the purpose of this instance.",
+          "examples": [
+            {
+              "enable": true
+            }
+          ],
+          "required": [
+            "enable",
+            "address",
+            "port",
+            "endpoint",
+            "image"
+          ],
+          "properties": {
+            "enable": {
+              "$id": "#/properties/osm/properties/tracing/properties/enable",
+              "type": "boolean",
+              "title": "The enable schema for tracing",
+              "description": "Indicates whether tracing is enabled or not",
+              "examples": [
+                true
+              ]
+            },
+            "address": {
+              "$id": "#/properties/osm/properties/tracing/properties/address",
+              "type": "string",
+              "title": "The address schema for tracing",
+              "description": "Address of the tracing collector",
+              "examples": [
+                "jaeger.<osm-namespace>.svc.cluster.local"
+              ]
+            },
+            "port": {
+              "$id": "#/properties/osm/properties/tracing/properties/port",
+              "type": "integer",
+              "title": "The port schema for tracing",
+              "description": "Port of the tracing collector",
+              "minimum": 1,
+              "maximum": 65535,
+              "examples": [
+                9411
+              ]
+            },
+            "endpoint": {
+              "$id": "#/properties/osm/properties/tracing/properties/endpoint",
+              "type": "string",
+              "title": "The endpoint schema for tracing",
+              "description": "API path of the collector",
+              "examples": [
+                "/api/v2/spans"
+              ]
+            },
+            "image": {
+              "$id": "#/properties/osm/properties/tracing/properties/image",
+              "type": "string",
+              "title": "Jaeger's image schema",
+              "description": "Image used for jaeger",
+              "examples": [
+                "jaegertracing/all-in-one"
+              ]
+            },
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "webhookConfigNamePrefix": {
+          "$id": "#/properties/osm/properties/webhookConfigNamePrefix",
+          "type": "string",
+          "title": "Webhook Config Name Prefix",
+          "description": "Prefix for the webhook name, which uses the format <webhook-prefix>-<mesh-name>",
+          "examples": [
+            ""
+          ]
+        },
+        "osmNamespace": {
+          "$id": "#/properties/osm/properties/osmNamespace",
+          "type": "string",
+          "title": "The namespace of the OSM control plane components",
+          "description": "Indicates the namespace in which the OSM control plane components will be installed",
+          "examples": [
+            "osm-system"
+          ]
+        },
+        "enablePrivilegedInitContainer": {
+          "$id": "#/properties/osm/properties/enablePrivilegedInitContainer",
+          "type": "boolean",
+          "title": "The enablePrivilegedInitContainer schema",
+          "description": "Indicates whether the init container for pods in the mesh should be privileged",
+          "examples": [
+            false
+          ]
+        },
+        "injector": {
+          "$id": "#/properties/osm/properties/injector",
+          "type": "object",
+          "title": "The sidecar injector schema",
+          "description": "Sidecar injector configurations",
+          "required": [
+            "replicaCount",
+            "resource"
+          ],
+          "properties": {
+            "replicaCount": {
+              "$id": "#/properties/osm/properties/injector/properties/replicaCount",
+              "type": "integer",
+              "title": "The replicaCount schema",
+              "description": "The number of replicas of the osm-injector pod.",
+              "examples": [
+                1
+              ]
+            },
+            "resource": {
+              "$ref": "#/definitions/containerResources"
+            },
+            "podLabels": {
+              "$id": "#/properties/osm/properties/injector/properties/podLabels",
+              "type": "object",
+              "title": "The podLabels schema",
+              "description": "Labels for the osm-injector pod.",
+              "default": {}
+            },
+            "enablePodDisruptionBudget": {
+              "$id": "#/properties/osm/properties/injector/properties/enablePodDisruptionBudget",
+              "type": "boolean",
+              "title": "The enablePodDisruptionBudget schema",
+              "description": "Indicates whether Pod Disruption Budget should be enabled or not.",
+              "examples": [
+                false
+              ]
+            },
+            "autoScale": {
+              "$ref": "#/definitions/autoScale"
+            },
+            "webhookTimeoutSeconds": {
+              "$id": "#/properties/osm/properties/webhookTimeout",
+              "type": "integer",
+              "title": "Webhook Timeout Seconds",
+              "description": "Timeout for the mutating webhook in seconds",
+              "examples": [
+                20
+              ]
+            },
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "osmBootstrap": {
+          "$id": "#/properties/osm/properties/osmBootstrap",
+          "type": "object",
+          "title": "The OSM bootstrap schema",
+          "description": "OSM bootstrap's configurations",
+          "required": [
+            "replicaCount",
+            "resource"
+          ],
+          "properties": {
+            "replicaCount": {
+              "$id": "#/properties/osm/properties/osmBootstrap/properties/replicaCount",
+              "type": "integer",
+              "title": "The replicaCount schema",
+              "description": "The number of replicas of the OSM bootstrap pod.",
+              "examples": [
+                1
+              ]
+            },
+            "resource": {
+              "$ref": "#/definitions/containerResources"
+            },
+            "podLabels": {
+              "$id": "#/properties/osm/properties/osmBootstrap/properties/podLabels",
+              "type": "object",
+              "title": "The podLabels schema",
+              "description": "Labels for the OSM bootstrap pod.",
+              "default": {}
+            },
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "featureFlags": {
+          "$id": "#/properties/osm/properties/featureFlags",
+          "type": "object",
+          "title": "Feature flags",
+          "description": "Feature flags",
+          "examples": [
+            {
+              "enableWASMStats": true
+            }
+          ],
+          "required": [
+            "enableWASMStats",
+            "enableAsyncProxyServiceMapping",
+            "enableIngressBackendPolicy",
+            "enableEnvoyActiveHealthChecks",
+            "enableSnapshotCacheMode",
+            "enableRetryPolicy",
+            "enableMeshRootCertificate"
+          ],
+          "properties": {
+            "enableWASMStats": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableWASMStats",
+              "type": "boolean",
+              "title": "Enable WASM stats",
+              "description": "Enable extra Envoy statistics generated by a custom WASM extension",
+              "examples": [
+                true
+              ]
+            },
+            "enableEgressPolicy": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableEgressPolicy",
+              "type": "boolean",
+              "title": "Enable OSM's Egress policy",
+              "description": "Enable OSM's Egress policy for fine grained control over egress (external) traffic",
+              "examples": [
+                true
+              ]
+            },
+            "enableAsyncProxyServiceMapping": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableAsyncProxyServiceMapping",
+              "type": "boolean",
+              "title": "Enable async proxy-service mapping",
+              "description": "Enable async proxy-service mapping",
+              "examples": [
+                true
+              ]
+            },
+            "enableIngressBackendPolicy": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableIngressBackendPolicy",
+              "type": "boolean",
+              "title": "Enable OSM to use the IngressBackend API",
+              "description": "Enable OSM to use the IngressBackend API for allowing ingress to mesh backends",
+              "examples": [
+                true
+              ]
+            },
+            "enableEnvoyActiveHealthChecks": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableEnvoyActiveHealthChecks",
+              "type": "boolean",
+              "title": "Enable Envoy active health checks",
+              "description": "EnableEnvoyActiveHealthChecks defines if OSM will Envoy active health checks between services allowed to communicate",
+              "examples": [
+                true
+              ]
+            },
+            "enableSnapshotCacheMode": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableSnapshotCacheMode",
+              "type": "boolean",
+              "title": "Enable SnapshotCache feature for Envoy xDS server",
+              "description": "Enable SnapshotCache feature in OSM controller to cache snapshots for Envoy xDS configurations.",
+              "examples": [
+                true
+              ]
+            },
+            "enableRetryPolicy": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableRetryPolicy",
+              "type": "boolean",
+              "title": "Enable Retry Policy",
+              "description": "Enable automatic request retries.",
+              "examples": [
+                true
+              ]
+            },
+            "enableMeshRootCertificate": {
+              "$id": "#/properties/osm/properties/featureFlags/properties/enableMeshRootCertificate",
+              "type": "boolean",
+              "title": "Enable the MeshRootCertificate",
+              "description": "Enable the MeshRootCertificate to configure the OSM certificate provider.",
+              "examples": [
+                false
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "pspEnabled": {
+          "$id": "#/properties/osm/properties/pspEnabled",
+          "type": "boolean",
+          "title": "The pspEnabled schema",
+          "description": "Indicates whether OSM should run with PodSecurityPolicies",
+          "examples": [
+            false
+          ]
+        },
+        "controlPlaneTolerations": {
+          "$id": "#/properties/osm/properties/controlPlaneTolerations",
+          "type": "array",
+          "title": "The controlPlaneTolerations schema",
+          "description": "Node tolerations applied to control plane pods to schedule onto nodes with matching taints",
+          "items": {
+            "type": "object"
+          },
+          "examples": [
+            [
+              {
+                "key": "key1",
+                "operator": "Equal",
+                "value": "value1",
+                "effect": "NoSchedule"
+              }
+            ]
+          ]
+        },
+        "outboundIPRangeExclusionList": {
+          "$id": "#/properties/osm/properties/outboundIPRangeExclusionList",
+          "type": "array",
+          "title": "The outboundIPRangeExclusionList schema",
+          "description": "Outbound IP range exluclusion list for sidecar traffic interception",
+          "items": {
+            "type": "string",
+            "pattern": "((?:\\d{1,3}\\.){3}\\d{1,3})\\/(\\d{1,2})$"
+          },
+          "examples": [
+            [
+              "8.8.8.8/32",
+              "10.0.0.0/24"
+            ]
+          ]
+        },
+        "outboundIPRangeInclusionList": {
+          "$id": "#/properties/osm/properties/outboundIPRangeInclusionList",
+          "type": "array",
+          "title": "The outboundIPRangeInclusionList schema",
+          "description": "Outbound IP range inclusion list for sidecar traffic interception",
+          "items": {
+            "type": "string",
+            "pattern": "((?:\\d{1,3}\\.){3}\\d{1,3})\\/(\\d{1,2})$"
+          },
+          "examples": [
+            [
+              "8.8.8.8/32",
+              "10.0.0.0/24"
+            ]
+          ]
+        },
+        "outboundPortExclusionList": {
+          "$id": "#/properties/osm/properties/outboundPortExclusionList",
+          "type": "array",
+          "title": "The outboundPortExclusionList schema",
+          "description": "Outbound port exluclusion list for sidecar traffic interception",
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "examples": [
+            [
+              6379,
+              3315
+            ]
+          ]
+        },
+        "inboundPortExclusionList": {
+          "$id": "#/properties/osm/properties/inboundPortExclusionList",
+          "type": "array",
+          "title": "The inboundPortExclusionList schema",
+          "description": "Inbound port exluclusion list for sidecar traffic interception",
+          "items": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+          },
+          "examples": [
+            [
+              6379,
+              3315
+            ]
+          ]
+        },
+        "networkInterfaceExclusionList": {
+          "$id": "#/properties/osm/properties/networkInterfaceExclusionList",
+          "type": "array",
+          "title": "The networkInterfaceExclusionList schema",
+          "description": "Network interface exluclusion list for sidecar traffic interception",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "eth0",
+              "net1"
+            ]
+          ]
+        },
+        "grafana": {
+          "$id": "#/properties/osm/properties/grafana",
+          "type": "object",
+          "title": "The grafana schema",
+          "description": "Grafana configuration parameters",
+          "required": [
+            "port",
+            "enableRemoteRendering",
+            "image",
+            "rendererImage"
+          ],
+          "properties": {
+            "port": {
+              "$id": "#/properties/osm/properties/grafana/properties/port",
+              "title": "Grafana's port schema",
+              "description": "Grafana's port number",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "examples": [
+                3000
+              ]
+            },
+            "enableRemoteRendering": {
+              "$id": "#/properties/osm/properties/grafana/properties/enableRemoteRendering",
+              "type": "boolean",
+              "title": "Grafana's enableRemoteRendering schema",
+              "description": "Enable remote rendering of Grafana's dashboards",
+              "examples": [
+                true
+              ]
+            },
+            "image": {
+              "$id": "#/properties/osm/properties/grafana/properties/image",
+              "type": "string",
+              "title": "Grafana's image schema",
+              "description": "Image used for Grafana",
+              "examples": [
+                "grafana/grafana:8.2.2"
+              ]
+            },
+            "rendererImage": {
+              "$id": "#/properties/osm/properties/grafana/properties/rendererImage",
+              "type": "string",
+              "title": "Grafana's rendererImage schema",
+              "description": "Renderer image used for Grafana",
+              "examples": [
+                "grafana/grafana-image-renderer:3.2.1"
+              ]
+            },
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "examples": [
+            {
+              "port": 3000,
+              "enableRemoteRendering": true,
+              "image": "grafana/grafana:8.2.2",
+              "rendererImage": "grafana/grafana-image-renderer:3.2.1"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "certmanager": {
+          "$id": "#/properties/osm/properties/certmanager",
+          "type": "object",
+          "title": "The certmanager schema",
+          "description": "cert-manager.io configuration parameters",
+          "required": [
+            "issuerName",
+            "issuerKind",
+            "issuerGroup"
+          ],
+          "properties": {
+            "issuerName": {
+              "$id": "#/properties/osm/properties/certmanager/properties/issuerName",
+              "title": "Cert-manager's issuerName schema",
+              "description": "Cert-manager's certificate issuer name",
+              "type": "string",
+              "examples": [
+                "osm-ca"
+              ]
+            },
+            "issuerKind": {
+              "$id": "#/properties/osm/properties/certmanager/properties/issuerKind",
+              "title": "Cert-manager's issuerKind schema",
+              "description": "Cert-manager's certificate issuer kind",
+              "type": "string",
+              "examples": [
+                "Issuer"
+              ]
+            },
+            "issuerGroup": {
+              "$id": "#/properties/osm/properties/certmanager/properties/issuerGroup",
+              "title": "Cert-manager's issuerGroup schema",
+              "description": "Cert-manager's certificate issuer group",
+              "type": "string",
+              "examples": [
+                "cert-manager"
+              ]
+            }
+          },
+          "examples": [
+            {
+              "issuerName": "osm-ca",
+              "issuerKind": "Issuer",
+              "issuerGroup": "cert-manager"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "vault": {
+          "$id": "#/properties/osm/properties/vault",
+          "type": "object",
+          "title": "The Hashicorp Vault schema",
+          "description": "Hashicorp Vault configuration parameters",
+          "properties": {
+            "host": {
+              "$id": "#/properties/osm/properties/vault/properties/host",
+              "title": "Hashicorp Vault's host schema",
+              "description": "Hashicorp Vault host/service - where Vault is installed",
+              "type": "string"
+            },
+            "port": {
+              "$id": "#/properties/osm/properties/vault/properties/port",
+              "title": "Hashicorp Vault's port",
+              "description": "Port to use to connect to vault",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "protocol": {
+              "$id": "#/properties/osm/properties/vault/properties/protocol",
+              "title": "Hashicorp Vault's protocol schema",
+              "description": "Protocol to use to connect to Vault",
+              "type": "string"
+            },
+            "token": {
+              "$id": "#/properties/osm/properties/vault/properties/token",
+              "title": "Hashicorp Vault's token schema",
+              "description": "Token to use to connect to Vault",
+              "type": "string"
+            },
+            "role": {
+              "$id": "#/properties/osm/properties/vault/properties/role",
+              "title": "Hashicorp Vault's role schema",
+              "description": "Role to use with Vault",
+              "type": "string"
+            },
+            "secret": {
+              "$id": "#/properties/osm/properties/vault/properties/secret",
+              "type": "object",
+              "title": "Vault token secret schema",
+              "description": "Vault token secret reference parameters",
+              "properties": {
+                "name": {
+                  "$id": "#/properties/osm/properties/vault/properties/secret/properties/name",
+                  "title": "Vault token secret name schema",
+                  "description": "Name of the Kubernetes Secret to store the vault token",
+                  "type": "string"
+                },
+                "key": {
+                  "$id": "#/properties/osm/properties/vault/properties/secret/properties/key",
+                  "title": "Vault token secret key schema",
+                  "description": "Name of the Kubernetes Secret key with the value of the vault token",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "examples": [
+            {
+              "host": "vault.default.svc.cluster.local",
+              "protocol": "http",
+              "token": "some-token",
+              "role": "openservicemesh"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "prometheus": {
+          "$id": "#/properties/osm/properties/prometheus",
+          "type": "object",
+          "title": "The prometheus schema",
+          "description": "Prometheus configurations",
+          "required": [
+            "resources",
+            "port",
+            "retention",
+            "image"
+          ],
+          "properties": {
+            "resources": {
+              "$ref": "#/definitions/containerResources"
+            },
+            "port": {
+              "$id": "#/properties/osm/properties/prometheus/properties/port",
+              "title": "Prometheus' port schema",
+              "description": "Prometheus' port number",
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "examples": [
+                7070
+              ]
+            },
+            "retention": {
+              "$id": "#/properties/osm/properties/prometheus/properties/rentention",
+              "type": "object",
+              "title": "The Prometheus retention schema",
+              "description": "Prometheus data retention configurations",
+              "required": [
+                "time"
+              ],
+              "properties": {
+                "time": {
+                  "$id": "#/properties/osm/properties/prometheus/properties/retention/properties/time",
+                  "title": "Prometheus' data retention time schema",
+                  "description": "Prometheus' data retention time",
+                  "type": "string",
+                  "examples": [
+                    "15d"
+                  ]
+                }
+              }
+            },
+            "image": {
+              "$id": "#/properties/osm/properties/prometheus/properties/image",
+              "type": "string",
+              "title": "Prometheus's image schema",
+              "description": "Image used for Prometheus",
+              "examples": [
+                "prom/prometheus:v2.18.1"
+              ]
+            },
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "imagePullSecrets": {
+          "$id": "#/properties/osm/properties/imagePullSecrets",
+          "type": "array",
+          "title": "The imagePullSecrets schema",
+          "description": "ImagePullSecrets for the control plane pod",
+          "items": {
+            "type": "object"
+          },
+          "examples": [
+            [
+              {
+                "name": "secret-name"
+              }
+            ]
+          ]
+        },
+        "validatorWebhook": {
+          "$id": "#/properties/osm/properties/validatorWebhook",
+          "type": "object",
+          "title": "The validatorWebhook schema",
+          "description": "Resource validator webhook configuration",
+          "properties": {
+            "webhookConfigurationName": {
+              "$id": "#/properties/osm/properties/validatorWebhook/properties/webhookConfigurationName",
+              "title": "Validator webhook configuration schema",
+              "description": "Validator's ValidatingWebhookConfigurationName",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "preinstall": {
+          "$id": "#/properties/osm/properties/preinstall",
+          "type": "object",
+          "title": "The preinstall schema",
+          "description": "Preinstall configurations",
+          "required": [],
+          "properties": {
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
+        },
+        "cleanup": {
+          "$id": "#/properties/osm/properties/preinstall",
+          "type": "object",
+          "title": "The preinstall schema",
+          "description": "Preinstall configurations",
+          "required": [],
+          "properties": {
+            "affinity": {
+              "type": "object"
+            },
+            "nodeSelector": {
+              "type": "object"
+            },
+            "tolerations": {
+              "type": "array"
+            }
+          },
+          "additionalProperties": false
         }
+      },
+      "additionalProperties": false
+    },
+    "contour": {
+      "$id": "#/properties/contour",
+      "type": "object",
+      "title": "Contour Ingress",
+      "description": "Contour Ingress configuration",
+      "properties": {
+        "enabled": {
+          "$id": "#/properties/contour/enabled",
+          "title": "Enable Contour",
+          "description": "Enables Contour control plane and gateway",
+          "type": "boolean"
+        }
+      }
+    },
+    "smi": {
+      "$id": "#/properties/smi",
+      "type": "object",
+      "title": "SMI Configuration",
+      "description": "SMI configuration",
+      "properties": {
+        "validateTrafficTarget": {
+          "$id": "#/properties/contour/validateTrafficTarget",
+          "title": "Validate Traffic Target",
+          "description": "Enables validation of SMI Traffic Target",
+          "type": "boolean"
+        }
+      }
     }
+  }
 }

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -470,7 +470,7 @@ osm:
     enableWASMStats: true
     # -- Enable OSM's Egress policy API.
     # When enabled, fine grained control over Egress (external) traffic is enforced
-    # DEPRECATED. To use EgressPolicy, disable global mesh-wide egress using '--set osm.enableEgress=false'.
+    # DEPRECATED, do not use. To use EgressPolicy API, disable global mesh-wide egress using '--set osm.enableEgress=false'.
     enableEgressPolicy: true
     # -- Enable async proxy-service mapping
     enableAsyncProxyServiceMapping: false

--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -267,7 +267,7 @@ spec:
                       type: boolean
                     enableEgressPolicy:
                       type: boolean
-                      description: DEPRECATED. Set 'taffic.enableEgress' to 'false' to use EgressPolicy API.
+                      description: DEPRECATED, do not use. Set 'taffic.enableEgress' to 'false' to use EgressPolicy API.
                     enableMulticlusterMode:
                       type: boolean
                       description: DEPRECATED, no longer used

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -78,7 +78,6 @@ var testPresetMeshConfigMap = &corev1.ConfigMap{
 },
 "featureFlags": {
 	"enableWASMStats": false,
-	"enableEgressPolicy": true,
 	"enableAsyncProxyServiceMapping": false,
 	"enableIngressBackendPolicy": true,
 	"enableEnvoyActiveHealthChecks": true,

--- a/pkg/apis/config/v1alpha2/mesh_config.go
+++ b/pkg/apis/config/v1alpha2/mesh_config.go
@@ -212,7 +212,10 @@ type FeatureFlags struct {
 	// EnableWASMStats defines if WASM Stats are enabled.
 	EnableWASMStats bool `json:"enableWASMStats"`
 
-	// EnableEgressPolicy defines if OSM's Egress policy is enabled.
+	// EnableEgressPolicy defines if OSM's EgressPolicy API is enabled.
+	// DEPRECATED, do not use.
+	// Disable mesh-wide global egress by setting 'spec.traffic.enableEgress'
+	// to 'false' to implicitly enable the usage of EgressPolicy API.
 	EnableEgressPolicy bool `json:"enableEgressPolicy"`
 
 	// EnableSnapshotCacheMode defines if XDS server starts with snapshot cache.

--- a/pkg/catalog/egress.go
+++ b/pkg/catalog/egress.go
@@ -27,7 +27,8 @@ const (
 
 // GetEgressTrafficPolicy returns the Egress traffic policy associated with the given service identity
 func (mc *MeshCatalog) GetEgressTrafficPolicy(serviceIdentity identity.ServiceIdentity) (*trafficpolicy.EgressTrafficPolicy, error) {
-	if !mc.configurator.GetMeshConfig().Spec.FeatureFlags.EnableEgressPolicy {
+	if mc.configurator.GetMeshConfig().Spec.Traffic.EnableEgress {
+		// Mesh-wide global egress is enabled, so EgressPolicy is implicitly disabled
 		return nil, nil
 	}
 

--- a/pkg/catalog/egress_test.go
+++ b/pkg/catalog/egress_test.go
@@ -452,11 +452,7 @@ func TestGetEgressTrafficPolicy(t *testing.T) {
 				policyController: mockPolicyController,
 			}
 
-			mockCfg.EXPECT().GetMeshConfig().Return(configv1alpha2.MeshConfig{
-				Spec: configv1alpha2.MeshConfigSpec{
-					FeatureFlags: configv1alpha2.FeatureFlags{EnableEgressPolicy: true},
-				},
-			}).Times(1)
+			mockCfg.EXPECT().GetMeshConfig().Return(configv1alpha2.MeshConfig{Spec: configv1alpha2.MeshConfigSpec{Traffic: configv1alpha2.TrafficSpec{EnableEgress: false}}}).Times(1) // Enables EgressPolicy
 
 			actual, err := mc.GetEgressTrafficPolicy(testSourceIdentity)
 			assert.Equal(tc.expectError, err != nil)

--- a/pkg/envoy/ads/response_benchmark_test.go
+++ b/pkg/envoy/ads/response_benchmark_test.go
@@ -84,8 +84,7 @@ func setupTestServer(b *testing.B) {
 				},
 			},
 			FeatureFlags: configv1alpha2.FeatureFlags{
-				EnableWASMStats:    false,
-				EnableEgressPolicy: false,
+				EnableWASMStats: false,
 			},
 		},
 	}

--- a/pkg/messaging/broker_test.go
+++ b/pkg/messaging/broker_test.go
@@ -230,14 +230,14 @@ func TestGetProxyUpdateEvent(t *testing.T) {
 				OldObj: &configv1alpha2.MeshConfig{
 					Spec: configv1alpha2.MeshConfigSpec{
 						FeatureFlags: configv1alpha2.FeatureFlags{
-							EnableEgressPolicy: true,
+							EnableWASMStats: true,
 						},
 					},
 				},
 				NewObj: &configv1alpha2.MeshConfig{
 					Spec: configv1alpha2.MeshConfigSpec{
 						FeatureFlags: configv1alpha2.FeatureFlags{
-							EnableEgressPolicy: false,
+							EnableWASMStats: false,
 						},
 					},
 				},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
After 87fd049d, EgressPolicy API is implicitly
enabled when global mesh-wide egress is disabled
by setting `traffic.enableEgress=false` in MeshConfig.

This change updates the remaining changes pertaining
to the now deprecated EgressPolicy feature flag.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |
| Egress                     | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `yes, release noted for v1.3`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `pending`