### PR TITLE
demo: script to set up vanilla multicluster env

### DIFF
--- a/scripts/multicluster/crd/multicluster.x-k8s.io_serviceexports.yaml
+++ b/scripts/multicluster/crd/multicluster.x-k8s.io_serviceexports.yaml
@@ -1,0 +1,133 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  scope: Namespaced
+  names:
+    plural: serviceexports
+    singular: serviceexport
+    kind: ServiceExport
+    shortNames:
+    - svcex
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    "schema":
+      "openAPIV3Schema":
+        description: ServiceExport declares that the Service with the same name and
+          namespace as this export should be consumable from other clusters.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: status describes the current state of an exported service.
+              Service configuration comes from the Service that had the same name
+              and namespace as this ServiceExport. Populated by the multi-cluster
+              service implementation's controller.
+            type: object
+            properties:
+              conditions:
+                type: array
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
+                  type: object
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      type: string
+                      format: date-time
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                      maxLength: 32768
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      type: integer
+                      format: int64
+                      minimum: 0
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      type: string
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      type: string
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map

--- a/scripts/multicluster/crd/multicluster.x-k8s.io_serviceimports.yaml
+++ b/scripts/multicluster/crd/multicluster.x-k8s.io_serviceimports.yaml
@@ -1,0 +1,161 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceimports.multicluster.x-k8s.io
+spec:
+  group: multicluster.x-k8s.io
+  scope: Namespaced
+  names:
+    plural: serviceimports
+    singular: serviceimport
+    kind: ServiceImport
+    shortNames:
+    - svcim
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The type of this ServiceImport
+      jsonPath: .spec.type
+    - name: IP
+      type: string
+      description: The VIP for this ServiceImport
+      jsonPath: .spec.ips
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp
+    "schema":
+      "openAPIV3Schema":
+        description: ServiceImport describes a service imported from clusters in a
+          ClusterSet.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the behavior of a ServiceImport.
+            type: object
+            required:
+            - ports
+            - type
+            properties:
+              ips:
+                description: ip will be used as the VIP for this service when type
+                  is ClusterSetIP.
+                type: array
+                maxItems: 1
+                items:
+                  type: string
+              ports:
+                type: array
+                items:
+                  description: ServicePort represents the port on which the service
+                    is exposed
+                  type: object
+                  required:
+                  - port
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and http://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                        Field can be enabled with ServiceAppProtocol feature gate.
+                      type: string
+                    name:
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort. Optional
+                        if only one ServicePort is defined on this service.
+                      type: string
+                    port:
+                      description: The port that will be exposed by this service.
+                      type: integer
+                      format: int32
+                    protocol:
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
+                      type: string
+                x-kubernetes-list-type: atomic
+              sessionAffinity:
+                description: 'Supports "ClientIP" and "None". Used to maintain session
+                  affinity. Enable client IP based session affinity. Must be ClientIP
+                  or None. Defaults to None. Ignored when type is Headless More info:
+                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                type: string
+              sessionAffinityConfig:
+                description: sessionAffinityConfig contains session affinity configuration.
+                type: object
+                properties:
+                  clientIP:
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
+                    type: object
+                    properties:
+                      timeoutSeconds:
+                        description: timeoutSeconds specifies the seconds of ClientIP
+                          type session sticky time. The value must be >0 && <=86400(for
+                          1 day) if ServiceAffinity == "ClientIP". Default value is
+                          10800(for 3 hours).
+                        type: integer
+                        format: int32
+              type:
+                description: type defines the type of this service. Must be ClusterSetIP
+                  or Headless.
+                type: string
+                enum:
+                - ClusterSetIP
+                - Headless
+          status:
+            description: status contains information about the exported services that
+              form the multi-cluster service referenced by this ServiceImport.
+            type: object
+            properties:
+              clusters:
+                description: clusters is the list of exporting clusters from which
+                  this service was derived.
+                type: array
+                items:
+                  description: ClusterStatus contains service configuration mapped
+                    to a specific source cluster
+                  type: object
+                  required:
+                  - cluster
+                  properties:
+                    cluster:
+                      description: cluster is the name of the exporting cluster. Must
+                        be a valid RFC-1123 DNS label.
+                      type: string
+                x-kubernetes-list-map-keys:
+                - cluster
+                x-kubernetes-list-type: map

--- a/scripts/multicluster/rbac/role.yaml
+++ b/scripts/multicluster/rbac/role.yaml
@@ -1,0 +1,50 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mcs-derived-service-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/scripts/multicluster/setup.sh
+++ b/scripts/multicluster/setup.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# This script sets up a demo multicluster environment for OSM development.
+# It deploys the sample bookstore application on cluster c1 and c2. C2 exports its
+# bookstore service via ServiceExport and c1 imports it via ServiceImport. A new EndpointSlice
+# resource on c1 is created to store accessible endpoint from c2.
+
+# shellcheck disable=SC2128
+# shellcheck disable=SC2086
+cd "$(dirname ${BASH_SOURCE})"
+set -e
+
+c1=${CLUSTER1:-c1}
+c2=${CLUSTER2:-c2}
+k1="kubectl --context ${c1}"
+k2="kubectl --context ${c2}"
+app_port=14001
+
+# ==== 1. Setup CRDs
+
+${k1} apply -f ./crd -f ./rbac
+${k2} apply -f ./crd -f ./rbac
+
+# ==== 2. Deploy applications
+for ctx in ${c1} ${c2}; do
+    kubectl config use-context "${ctx}"
+
+    echo "[${ctx}] Installing osm"
+    osm install
+
+    echo "[${ctx}] Deploying demo application"
+    kubectl create namespace bookstore
+    kubectl create namespace bookbuyer
+    kubectl create namespace bookthief
+    kubectl create namespace bookwarehouse
+    osm namespace add bookstore bookbuyer bookthief bookwarehouse
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/release-v1.2/manifests/apps/bookbuyer.yaml
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/release-v1.2/manifests/apps/bookstore.yaml
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/release-v1.2/manifests/apps/bookwarehouse.yaml
+    kubectl apply -f https://raw.githubusercontent.com/openservicemesh/osm-docs/release-v1.2/manifests/apps/mysql.yaml
+done
+
+# ==== Deploy a curl client for testing
+${k1} apply -f - <<EOF
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: curl
+  namespace: bookbuyer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: curl
+  template:
+    metadata:
+      labels:
+        app: curl
+    spec:
+      containers:
+      - name: curl
+        image: curlimages/curl
+        command: ["sleep", "1000000"]
+EOF
+
+# ==== 3. Create ServiceExport
+${k2} apply -f - <<EOF
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: bookstore
+  namespace: bookstore
+EOF
+
+# ==== 4. Create ServiceImport
+
+# create a meta-service to get a valid local service IP
+${k1} apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcs-bookstore
+  namespace: bookstore
+spec:
+  type: ClusterIP
+  ports:
+  - port: ${app_port}
+    protocol: TCP
+EOF
+sleep 5
+mcs_ip=$(${k1} get service mcs-bookstore -n bookstore -o jsonpath='{.spec.clusterIP}')
+
+${k1} apply -f - <<EOF
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceImport
+metadata:
+  name: bookstore
+  namespace: bookstore
+spec:
+  ips:
+  - ${mcs_ip}
+  type: ClusterSetIP
+  ports:
+  - name: http
+    protocol: TCP
+    port: ${app_port}
+EOF
+
+# ==== 5. Expose service on c2 and get the IP addresses.
+${k2} patch service bookstore -n bookstore -p '{"spec":{"type":"LoadBalancer"}}'
+for _ in {1..10}; do
+    remote_ip=$(${k2} get service bookstore -n bookstore -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+    if [ -n "${remote_ip}" ]; then
+        break
+    fi
+    sleep 5
+done
+if [ -z "${remote_ip}" ]; then
+    echo "Remote bookstore IP not found"
+    exit 1
+fi
+echo "Remote bookstore IP: ${remote_ip}"
+
+local_ip=$(${k1} get service bookstore -n bookstore -o jsonpath='{.spec.clusterIP}')
+
+# ==== 6. Create remote endpointSlice
+uid=$(${k1} get serviceimport bookstore -n bookstore -o jsonpath='{.metadata.uid}')
+${k1} apply -f - <<EOF
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: imported-bookstore-cluster-c2
+  namespace: bookstore
+  labels:
+    multicluster.kubernetes.io/source-cluster: cluster-c2
+    multicluster.kubernetes.io/service-name: bookstore
+  ownerReferences:
+  - apiVersion: multicluster.k8s.io/v1alpha1
+    controller: false
+    kind: ServiceImport
+    name: bookstore
+    uid: ${uid}
+addressType: IPv4
+ports:
+  - name: http
+    protocol: TCP
+    port: ${app_port}
+endpoints:
+  - addresses:
+    - "${remote_ip}"
+EOF
+
+# ==== 7. Update coreDNS entries
+${k1} apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  mcs-bookstore.server: |
+    bookstore.bookstore.svc.clusterset.local:53 {
+      errors
+      cache 30
+      hosts {
+        ${mcs_ip} bookstore.bookstore.svc.clusterset.local
+        ${local_ip} bookstore.bookstore.svc.clusterset.local
+        fallthrough
+      }
+    }
+EOF
+
+# reload coreDNS
+${k1} delete pod --namespace kube-system -l k8s-app=kube-dns
+

--- a/scripts/multicluster/uninstall.sh
+++ b/scripts/multicluster/uninstall.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script uninstalls the demo multicluster environment for OSM development.
+
+# shellcheck disable=SC2128
+# shellcheck disable=SC2086
+cd "$(dirname ${BASH_SOURCE})"
+set -e
+
+c1=${CLUSTER1:-c1}
+c2=${CLUSTER2:-c2}
+
+# Uninstall from cluster c1
+for ctx in ${c1} ${c2}; do
+    kubectl config use-context "${ctx}"
+    osm uninstall
+    kubectl delete ns bookstore bookbuyer bookthief bookwarehouse
+done


### PR DESCRIPTION
**Description**:

Add a script to set up a demo multicluster environment for OSM development.

It deploys the sample bookstore application on cluster c1 and c2. C2 exports its bookstore service via `ServiceExport` and c1 imports it via `ServiceImport`. A new `EndpointSlice` resource on c1 is created to store accessible endpoint from c2.

The steps listed in the script are:

1. Setup CRDs
2. Deploy applications
3. Create `ServiceExport` in c2
4. Create `ServiceImport` in c1. It will have a ClusterSetIP
5. Expose bookstore on c2 and get service public IP
6. On c1, create `EndpointSlice` containing the remote service IP 
7. (optional) update coreDNS entries of domain `bookstore.bookstore.svc.clusterset.local`

Partially resolves #4974 

**Testing done**:

Script is tested by executing with 2 clusters.

The end result of running the script:

* [c1] Created ServiceImport with MultiClusterService IP
* [c1] Created EndpointSlice with public service IP from c2
* [c2] Created ServiceExport

**Affected area**:

| Functional Area            |     |
| -------------------------- | --- |
| Demo                       | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No.

The demo is inspired by [mcs-api](https://github.com/kubernetes-sigs/mcs-api/tree/master/demo)

8. Is this a breaking change?

No

9. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?

No