### PR TITLE
cli: extend proxy cmd to set proxy config

### DIFF
--- a/cmd/cli/proxy.go
+++ b/cmd/cli/proxy.go
@@ -1,16 +1,36 @@
 package main
 
 import (
+	"fmt"
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/openservicemesh/osm/pkg/cli"
+	"github.com/openservicemesh/osm/pkg/constants"
 )
 
 const proxyCmdDescription = `
 This command consists of subcommands related to the operations
 of the sidecar proxy on pods.
 `
+
+type proxyAdminCmd struct {
+	out        io.Writer
+	config     *rest.Config
+	clientSet  kubernetes.Interface
+	query      string
+	namespace  string
+	pod        string
+	localPort  uint16
+	outFile    string
+	sigintChan chan os.Signal
+}
 
 func newProxyCmd(config *action.Configuration, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,6 +40,36 @@ func newProxyCmd(config *action.Configuration, out io.Writer) *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 	cmd.AddCommand(newProxyGetCmd(config, out))
+	cmd.AddCommand(newProxySetCmd(config, out))
 
 	return cmd
+}
+
+func (cmd *proxyAdminCmd) run(reqType string) error {
+	response, err := cli.ExecuteEnvoyAdminReq(cmd.clientSet, cmd.config, cmd.namespace, cmd.pod, cmd.localPort, reqType, cmd.query)
+	if err != nil {
+		return fmt.Errorf("error running proxy cmd: %w", err)
+	}
+
+	out := cmd.out // By default, output is written to stdout
+	if cmd.outFile != "" {
+		fd, err := os.Create(cmd.outFile)
+		if err != nil {
+			return fmt.Errorf("Error opening file %s: %w", cmd.outFile, err)
+		}
+		//nolint: errcheck
+		//#nosec G307
+		defer fd.Close()
+		out = fd // write output to file
+	}
+
+	_, err = out.Write(response)
+	return err
+}
+
+// isMeshedPod returns a boolean indicating if the pod is part of a mesh
+func isMeshedPod(pod corev1.Pod) bool {
+	// osm-controller adds a unique label to each pod that belongs to a mesh
+	_, proxyLabelSet := pod.Labels[constants.EnvoyUniqueIDLabelName]
+	return proxyLabelSet
 }

--- a/cmd/cli/proxy_set.go
+++ b/cmd/cli/proxy_set.go
@@ -13,31 +13,28 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
-const getCmdDescription = `
-This command will get the Envoy proxy configuration for the given query and pod.
-The query is forwarded as is to the Envoy proxy sidecar.
+const setCmdDescription = `
+This command will set the Envoy proxy configuration for the given query and pod.
+The query is forwarded as is to the Envoy proxy sidecar as a POST request.
 Refer to https://www.envoyproxy.io/docs/envoy/latest/operations/admin for the
-list of supported GET queries.
+list of supported POST queries.
 `
 
-const getCmdExample = `
-# Get the proxy config dump for the given pod 'bookbuyer-5ccf77f46d-rc5mg' in the 'bookbuyer' namespace
-osm proxy get config_dump bookbuyer-5ccf77f46d-rc5mg -n bookbuyer
-
-# Get the cluster config for the given pod 'bookbuyer-5ccf77f46d-rc5mg' in the 'bookbuyer' namespace and output to file 'clusters.txt'
-osm proxy get clusters bookbuyer-5ccf77f46d-rc5mg -n bookbuyer -f clusters.txt
+const setCmdExample = `
+# Reset the proxy stats counters for the pod 'bookbuyer-5ccf77f46d-rc5mg' in the 'bookbuyer' namespace
+osm proxy set reset_counters bookbuyer-5ccf77f46d-rc5mg -n bookbuyer
 `
 
-func newProxyGetCmd(config *action.Configuration, out io.Writer) *cobra.Command {
+func newProxySetCmd(config *action.Configuration, out io.Writer) *cobra.Command {
 	adminCmd := &proxyAdminCmd{
 		out:        out,
 		sigintChan: make(chan os.Signal, 1),
 	}
 
 	cmd := &cobra.Command{
-		Use:   "get QUERY POD",
-		Short: "get query for proxy",
-		Long:  getCmdDescription,
+		Use:   "set QUERY POD",
+		Short: "set query for proxy",
+		Long:  setCmdDescription,
 		Args:  cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
 			adminCmd.query = args[0]
@@ -53,9 +50,9 @@ func newProxyGetCmd(config *action.Configuration, out io.Writer) *cobra.Command 
 				return fmt.Errorf("Could not access Kubernetes cluster, check kubeconfig: %w", err)
 			}
 			adminCmd.clientSet = clientset
-			return adminCmd.run("GET")
+			return adminCmd.run("POST")
 		},
-		Example: getCmdExample,
+		Example: setCmdExample,
 	}
 
 	//add mesh name flag

--- a/pkg/cli/verifier/envoy_config_parser.go
+++ b/pkg/cli/verifier/envoy_config_parser.go
@@ -66,7 +66,7 @@ type PodConfigGetter struct {
 // Get returns the parsed Envoy config dump
 func (g PodConfigGetter) Get() (*Config, error) {
 	query := "config_dump?include_eds"
-	configBytes, err := cli.GetEnvoyProxyConfig(g.kubeClient, g.restConfig, g.pod.Namespace, g.pod.Name, constants.EnvoyAdminPort, query)
+	configBytes, err := cli.ExecuteEnvoyAdminReq(g.kubeClient, g.restConfig, g.pod.Namespace, g.pod.Name, constants.EnvoyAdminPort, "GET", query)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Extends the `osm proxy` cmd by making it
able to execute `set`(POST) requests as well.

With this change, similar to `osm proxy get`,
`osm proxy set` allows updating the proxy
configuration via the Envoy admin interface.
This is extremely useful for troubleshooting,
when we may want to reset stats counters and
logging levels.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
```
$ osm proxy get stats "$fortio_server" -n demo | grep over_limit
cluster.demo/fortio|8080|local.ratelimit.over_limit: 0

$ osm proxy set reset_counters fortio-c4bd7857f-8kxq5 -n demo
OK
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| CLI Tool                   | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`