### PR TITLE
cert rotation now ignores monotonic clock readings when checking expiration

### DIFF
--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -175,10 +175,14 @@ func (m *Manager) shouldRotate(c *Certificate) bool {
 	intNoise := rand.Intn(noiseSeconds) // #nosec G404
 	secondsNoise := time.Duration(intNoise) * time.Second
 	renewBefore := RenewBeforeCertExpires + secondsNoise
-	if time.Until(c.GetExpiration()) <= renewBefore {
+	// Round is called to truncate monotonic clock to the nearest second. This is done to avoid environments where the
+	// CPU clock may stop, resulting in a time measurement that differs significantly from the x509 timestamp.
+	// See https://github.com/openservicemesh/osm/issues/5000#issuecomment-1218539412 for more details.
+	expiration := c.GetExpiration().Round(0)
+	if time.Until(expiration) <= renewBefore {
 		log.Info().Msgf("Cert %s should be rotated; expires in %+v; renewBefore is %+v",
 			c.GetCommonName(),
-			time.Until(c.GetExpiration()),
+			time.Until(expiration),
 			renewBefore)
 		return true
 	}

--- a/pkg/debugger/certificate.go
+++ b/pkg/debugger/certificate.go
@@ -34,7 +34,7 @@ func (ds DebugConfig) getCertHandler() http.Handler {
 
 			_, _ = fmt.Fprintf(w, "---[ %d ]---\n", idx)
 			_, _ = fmt.Fprintf(w, "\t Common Name: %q\n", cert.GetCommonName())
-			_, _ = fmt.Fprintf(w, "\t Valid Until: %+v (%+v remaining)\n", cert.GetExpiration(), time.Until(cert.GetExpiration()))
+			_, _ = fmt.Fprintf(w, "\t Valid Until: %+v (%+v remaining)\n", cert.GetExpiration(), time.Until(cert.GetExpiration().Round(0)))
 			_, _ = fmt.Fprintf(w, "\t Issuing CA (SHA256): %x\n", sha256.Sum256(ca))
 			_, _ = fmt.Fprintf(w, "\t Trusted CAs (SHA256): %x\n", sha256.Sum256(trustedCAs))
 			_, _ = fmt.Fprintf(w, "\t Cert Chain (SHA256): %x\n", sha256.Sum256(chain))
@@ -43,7 +43,7 @@ func (ds DebugConfig) getCertHandler() http.Handler {
 			_, _ = fmt.Fprintf(w, "\t x509.SignatureAlgorithm: %+v\n", x509.SignatureAlgorithm)
 			_, _ = fmt.Fprintf(w, "\t x509.PublicKeyAlgorithm: %+v\n", x509.PublicKeyAlgorithm)
 			_, _ = fmt.Fprintf(w, "\t x509.Version: %+v\n", x509.Version)
-			_, _ = fmt.Fprintf(w, "\t x509.SerialNumber: %x\n", x509.SerialNumber)
+			_, _ = fmt.Fprintf(w, "\t x509.SerialNumber: %s\n", x509.SerialNumber)
 			_, _ = fmt.Fprintf(w, "\t x509.Issuer: %+v\n", x509.Issuer)
 			_, _ = fmt.Fprintf(w, "\t x509.Subject: %+v\n", x509.Subject)
 			_, _ = fmt.Fprintf(w, "\t x509.NotBefore (begin): %+v (%+v ago)\n", x509.NotBefore, time.Since(x509.NotBefore))


### PR DESCRIPTION
Presumed fix for https://github.com/openservicemesh/osm/issues/5000. More details in the comment https://github.com/openservicemesh/osm/issues/5000#issuecomment-1218539412

(even if this is not the issue, this would still be the correct way to check the x509 expiration)

Signed-off-by: Sean Teeling <seanteeling@microsoft.com>

