### PR TITLE
increase test coverage to look for coverage outside of current package

### DIFF
--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -16,6 +16,7 @@ go test -timeout 120s \
    -failfast \
    -race \
    -v \
+   -coverpkg=./pkg/... \
    -coverprofile=coverage.txt.with_generated_code \
    -covermode atomic $modules | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }
 

--- a/scripts/test-w-coverage.sh
+++ b/scripts/test-w-coverage.sh
@@ -16,7 +16,7 @@ go test -timeout 120s \
    -failfast \
    -race \
    -v \
-   -coverpkg=./pkg/... \
+   -coverpkg=./pkg/...,./cmd/... \
    -coverprofile=coverage.txt.with_generated_code \
    -covermode atomic $modules | tee testoutput.txt || { echo "go test returned non-zero"; exit 1; }
 


### PR DESCRIPTION
Test coverage, by default, only reports the coverage within the package of the unit test. However many of our tests should be considered integration tests, with tests crossing package boundaries. By applying the coverpkg flag each test will now check coverage against all packages in the `pkg` directory. 

This will likely slow down our unit tests, but our tests suite is largely dominated by e2e tests so this should be negligible