### PR TITLE
Replace depreciated MatchSubjectAltNames with MatchTypedSubjectAltNames

### DIFF
--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -158,31 +158,25 @@ func (s *sdsImpl) getRootCert(cert *certificate.Certificate, sdscert secrets.SDS
 	}
 	svcIdentitiesInCertRequest := s.meshCatalog.ListServiceIdentitiesForService(*meshSvc)
 
-	secret.GetValidationContext().MatchSubjectAltNames = getSubjectAltNamesFromSvcIdentities(svcIdentitiesInCertRequest, s.TrustDomain)
+	secret.GetValidationContext().MatchTypedSubjectAltNames = getSubjectAltNamesFromSvcIdentities(svcIdentitiesInCertRequest, s.TrustDomain)
 	return secret, nil
 }
 
 // Note: ServiceIdentity must be in the format "name.namespace" [https://github.com/openservicemesh/osm/issues/3188]
-func getSubjectAltNamesFromSvcIdentities(serviceIdentities []identity.ServiceIdentity, trustDomain string) []*xds_matcher.StringMatcher {
-	var matchSANs []*xds_matcher.StringMatcher
+func getSubjectAltNamesFromSvcIdentities(serviceIdentities []identity.ServiceIdentity, trustDomain string) []*xds_auth.SubjectAltNameMatcher {
+	var matchSANs []*xds_auth.SubjectAltNameMatcher
 
 	for _, si := range serviceIdentities {
-		match := xds_matcher.StringMatcher{
-			MatchPattern: &xds_matcher.StringMatcher_Exact{
-				Exact: si.AsPrincipal(trustDomain),
+		match := xds_auth.SubjectAltNameMatcher{
+			SanType: xds_auth.SubjectAltNameMatcher_DNS,
+			Matcher: &xds_matcher.StringMatcher{
+				MatchPattern: &xds_matcher.StringMatcher_Exact{
+					Exact: si.AsPrincipal(trustDomain),
+				},
 			},
 		}
 		matchSANs = append(matchSANs, &match)
 	}
 
 	return matchSANs
-}
-
-func subjectAltNamesToStr(sanMatchList []*xds_matcher.StringMatcher) []string {
-	var sanStr []string
-
-	for _, sanMatcher := range sanMatchList {
-		sanStr = append(sanStr, sanMatcher.GetExact())
-	}
-	return sanStr
 }


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Replaces `match_subject_alt_names` with `match_typed_subject_alt_names`.  

The match_subject_alt_names is depreciated in favor of `match_typed_subject_alt_names`: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto.html#envoy-v3-api-field-extensions-transport-sockets-tls-v3-certificatevalidationcontext-match-typed-subject-alt-names

This enables using URI SAN for SPIFFE ID eventually (https://github.com/openservicemesh/osm/issues/4750)

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
manual, unit
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [x] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [x] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?n/a