### PR TITLE
docs(CONTRIBUTOR_LADDER): add links for Github Slack and meetings

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -20,7 +20,7 @@ Description: A Community Participant participates in the community and contribut
 * Responsibilities:
     * Must follow the [CNCF Code of Conduct]
 * How users can get involved with the community:
-    * Participating in community discussions in GitHub, Slack, and meetings
+    * Participating in community discussions in [GitHub, Slack, and meetings](https://github.com/openservicemesh/osm#community)
     * Helping other users
     * Submitting bug reports
     * Trying out new releases


### PR DESCRIPTION
Signed-off-by: Wen Lin <linwen1991@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Add links for Github, Slack and Zoom meetings in CONTRIBUTOR_LADDER to help new community members get information easier and quicker. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Testing by manually clicking the links.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [X ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? 
    - No     
    - Did you notify the maintainers and provide attribution?
       - Not Applicable 
   

2. Is this a breaking change?
    - No
3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
    - No (Not applicable)