### PR TITLE
switch to envoy wellknown types for config names

### DIFF
--- a/pkg/cli/verifier/envoy_config.go
+++ b/pkg/cli/verifier/envoy_config.go
@@ -11,13 +11,13 @@ import (
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_secret "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -331,10 +331,10 @@ func findOutboundFilterChainForServicePort(meshSvc service.MeshService, dstIPRan
 func getFilterForProtocol(protocol string) string {
 	switch protocol {
 	case constants.ProtocolHTTP:
-		return envoy.HTTPConnectionManagerFilterName
+		return wellknown.HTTPConnectionManager
 
 	case constants.ProtocolTCP, constants.ProtocolHTTPS:
-		return envoy.TCPProxyFilterName
+		return wellknown.TCPProxy
 
 	default:
 		return ""

--- a/pkg/cli/verifier/testdata/curl_egress.json
+++ b/pkg/cli/verifier/testdata/curl_egress.json
@@ -1271,7 +1271,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",
@@ -1400,7 +1400,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-egress.80",
@@ -1527,7 +1527,7 @@
          },
          "filters": [
           {
-           "name": "tcp_proxy",
+           "name": "envoy.filters.network.tcp_proxy",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy",
             "stat_prefix": "egress-tcp-proxy.443",

--- a/pkg/cli/verifier/testdata/curl_permissive.json
+++ b/pkg/cli/verifier/testdata/curl_permissive.json
@@ -1195,7 +1195,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",

--- a/pkg/cli/verifier/testdata/httpbin1_permissive.json
+++ b/pkg/cli/verifier/testdata/httpbin1_permissive.json
@@ -1239,7 +1239,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-inbound.14001",
@@ -1457,7 +1457,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",

--- a/pkg/cli/verifier/testdata/httpbin2_permissive.json
+++ b/pkg/cli/verifier/testdata/httpbin2_permissive.json
@@ -1239,7 +1239,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-inbound.14001",
@@ -1457,7 +1457,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",

--- a/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookbuyer.json
+++ b/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookbuyer.json
@@ -289,7 +289,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound",

--- a/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookstore.json
+++ b/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookstore.json
@@ -36,7 +36,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "health_probes_http",
@@ -116,7 +116,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "health_probes_http",
@@ -196,7 +196,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "health_probes_http",
@@ -987,7 +987,7 @@
        {
         "filters": [
          {
-          "name": "http_connection_manager",
+          "name": "envoy.filters.network.http_connection_manager",
           "typed_config": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "stat_prefix": "health_probes_http",
@@ -1071,7 +1071,7 @@
        {
         "filters": [
          {
-          "name": "http_connection_manager",
+          "name": "envoy.filters.network.http_connection_manager",
           "typed_config": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "stat_prefix": "health_probes_http",
@@ -1155,7 +1155,7 @@
        {
         "filters": [
          {
-          "name": "http_connection_manager",
+          "name": "envoy.filters.network.http_connection_manager",
           "typed_config": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "stat_prefix": "health_probes_http",
@@ -1253,7 +1253,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound",
@@ -1446,7 +1446,7 @@
            }
           },
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-inbound",
@@ -1638,7 +1638,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "prometheus-http-conn-manager",

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -142,7 +142,7 @@ static_resources:
         port_value: 15901
     filter_chains:
     - filters:
-      - name: http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
@@ -171,7 +171,7 @@ static_resources:
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
           http_filters:
-          - name: http_router
+          - name: envoy.filters.http.router
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
@@ -195,7 +195,7 @@ static_resources:
         port_value: 15902
     filter_chains:
     - filters:
-      - name: http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
@@ -224,7 +224,7 @@ static_resources:
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
           http_filters:
-          - name: http_router
+          - name: envoy.filters.http.router
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
@@ -248,7 +248,7 @@ static_resources:
         port_value: 15903
     filter_chains:
     - filters:
-      - name: http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
@@ -277,7 +277,7 @@ static_resources:
                   user_agent: '%REQ(USER-AGENT)%'
                   x_forwarded_for: '%REQ(X-FORWARDED-FOR)%'
           http_filters:
-          - name: http_router
+          - name: envoy.filters.http.router
             typed_config:
               '@type': type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:

--- a/pkg/envoy/bootstrap/envoy_config_health_probes.go
+++ b/pkg/envoy/bootstrap/envoy_config_health_probes.go
@@ -12,6 +12,7 @@ import (
 	xds_accesslog "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/stream/v3"
 	xds_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -133,7 +134,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 			},
 			HttpFilters: []*xds_http_connection_manager.HttpFilter{
 				{
-					Name: envoy.HTTPRouterFilterName,
+					Name: wellknown.Router,
 					ConfigType: &xds_http_connection_manager.HttpFilter_TypedConfig{
 						TypedConfig: &any.Any{
 							TypeUrl: envoy.HTTPRouterFilterTypeURL,
@@ -151,7 +152,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 		filterChain = &xds_listener.FilterChain{
 			Filters: []*xds_listener.Filter{
 				{
-					Name: envoy.HTTPConnectionManagerFilterName,
+					Name: wellknown.HTTPConnectionManager,
 					ConfigType: &xds_listener.Filter_TypedConfig{
 						TypedConfig: pbHTTPConnectionManager,
 					},
@@ -181,7 +182,7 @@ func getProbeListener(listenerName, clusterName, newPath string, port int32, ori
 		filterChain = &xds_listener.FilterChain{
 			Filters: []*xds_listener.Filter{
 				{
-					Name: envoy.TCPProxyFilterName,
+					Name: wellknown.TCPProxy,
 					ConfigType: &xds_listener.Filter_TypedConfig{
 						TypedConfig: pbTCPProxy,
 					},

--- a/pkg/envoy/lds/auth.go
+++ b/pkg/envoy/lds/auth.go
@@ -6,11 +6,11 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_ext_authz "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/openservicemesh/osm/pkg/auth"
-	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
@@ -45,7 +45,7 @@ func getExtAuthzHTTPFilter(extAuthConfig *auth.ExtAuthConfig) *xds_hcm.HttpFilte
 	}
 
 	return &xds_hcm.HttpFilter{
-		Name: envoy.HTTPExtAuthzFilterName,
+		Name: wellknown.HTTPExternalAuthorization,
 		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
 			TypedConfig: extAuthMarshalled,
 		},

--- a/pkg/envoy/lds/egress.go
+++ b/pkg/envoy/lds/egress.go
@@ -6,6 +6,7 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -84,7 +85,7 @@ func (lb *listenerBuilder) buildEgressTCPFilterChain(match trafficpolicy.Traffic
 	}
 
 	tcpFilter := &xds_listener.Filter{
-		Name:       envoy.TCPProxyFilterName,
+		Name:       wellknown.TCPProxy,
 		ConfigType: &xds_listener.Filter_TypedConfig{TypedConfig: marshalledTCPProxy},
 	}
 

--- a/pkg/envoy/lds/egress_test.go
+++ b/pkg/envoy/lds/egress_test.go
@@ -5,10 +5,9 @@ import (
 
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-
-	"github.com/openservicemesh/osm/pkg/envoy"
 
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
@@ -54,7 +53,7 @@ func TestGetEgressHTTPFilterChain(t *testing.T) {
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedFilterChainMatch, actual.FilterChainMatch)
 			assert.Len(actual.Filters, 1) // Single HTTPConnectionManager filter
-			assert.Equal(envoy.HTTPConnectionManagerFilterName, actual.Filters[0].Name)
+			assert.Equal(wellknown.HTTPConnectionManager, actual.Filters[0].Name)
 		})
 	}
 }
@@ -144,7 +143,7 @@ func TestGetEgressTCPFilterChain(t *testing.T) {
 			assert.Equal(tc.expectError, err != nil)
 			assert.Equal(tc.expectedFilterChainMatch, actual.FilterChainMatch)
 			assert.Len(actual.Filters, 1) // Single TCPProxy filter
-			assert.Equal(envoy.TCPProxyFilterName, actual.Filters[0].Name)
+			assert.Equal(wellknown.TCPProxy, actual.Filters[0].Name)
 		})
 	}
 }

--- a/pkg/envoy/lds/healthcheck.go
+++ b/pkg/envoy/lds/healthcheck.go
@@ -6,6 +6,7 @@ import (
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_health_check "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -38,7 +39,7 @@ func getHealthCheckFilter() (*xds_hcm.HttpFilter, error) {
 	}
 
 	return &xds_hcm.HttpFilter{
-		Name: envoy.HTTPHealthCheckFilterName,
+		Name: wellknown.HealthCheck,
 		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
 			TypedConfig: hcAny,
 		},

--- a/pkg/envoy/lds/http_connection.go
+++ b/pkg/envoy/lds/http_connection.go
@@ -3,6 +3,7 @@ package lds
 import (
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/any"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -20,7 +21,7 @@ func getPrometheusConnectionManager() *xds_hcm.HttpConnectionManager {
 		CodecType:  xds_hcm.HttpConnectionManager_AUTO,
 		HttpFilters: []*xds_hcm.HttpFilter{
 			{
-				Name: envoy.HTTPRouterFilterName,
+				Name: wellknown.Router,
 				ConfigType: &xds_hcm.HttpFilter_TypedConfig{
 					TypedConfig: &any.Any{
 						TypeUrl: envoy.HTTPRouterFilterTypeURL,

--- a/pkg/envoy/lds/ingress_test.go
+++ b/pkg/envoy/lds/ingress_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/auth"
-	"github.com/openservicemesh/osm/pkg/envoy"
 
 	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
@@ -96,7 +96,7 @@ func TestGetIngressFilterChainFromTrafficMatch(t *testing.T) {
 				Port:     80,
 				Protocol: "http",
 			},
-			expectedEnvoyFilters: []string{envoy.HTTPConnectionManagerFilterName},
+			expectedEnvoyFilters: []string{wellknown.HTTPConnectionManager},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:   &wrapperspb.UInt32Value{Value: 80},
 				TransportProtocol: "",
@@ -111,7 +111,7 @@ func TestGetIngressFilterChainFromTrafficMatch(t *testing.T) {
 				Protocol:    "https",
 				ServerNames: []string{"foo.bar.svc.cluster.local"},
 			},
-			expectedEnvoyFilters: []string{envoy.HTTPConnectionManagerFilterName},
+			expectedEnvoyFilters: []string{wellknown.HTTPConnectionManager},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:   &wrapperspb.UInt32Value{Value: 80},
 				TransportProtocol: "tls",
@@ -126,7 +126,7 @@ func TestGetIngressFilterChainFromTrafficMatch(t *testing.T) {
 				Port:     80,
 				Protocol: "https",
 			},
-			expectedEnvoyFilters: []string{envoy.HTTPConnectionManagerFilterName},
+			expectedEnvoyFilters: []string{wellknown.HTTPConnectionManager},
 			expectedFilterChainMatch: &xds_listener.FilterChainMatch{
 				DestinationPort:   &wrapperspb.UInt32Value{Value: 80},
 				TransportProtocol: "tls",
@@ -160,7 +160,7 @@ func TestGetIngressFilterChainFromTrafficMatch(t *testing.T) {
 			if err == nil {
 				assert.Equal(tc.expectedFilterChainMatch, actual.FilterChainMatch)
 				assert.Len(actual.Filters, 1) // Single HTTPConnectionManager filter
-				assert.Equal(envoy.HTTPConnectionManagerFilterName, actual.Filters[0].Name)
+				assert.Equal(wellknown.HTTPConnectionManager, actual.Filters[0].Name)
 			}
 		})
 	}

--- a/pkg/envoy/lds/inmesh_test.go
+++ b/pkg/envoy/lds/inmesh_test.go
@@ -7,6 +7,7 @@ import (
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/stretchr/testify/assert"
 	tassert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -89,7 +90,7 @@ func TestBuildOutboundHTTPFilterChain(t *testing.T) {
 				assert.Len(httpFilterChain.FilterChainMatch.PrefixRanges, len(tc.trafficMatch.DestinationIPRanges))
 
 				for _, filter := range httpFilterChain.Filters {
-					assert.Equal(envoy.HTTPConnectionManagerFilterName, filter.Name)
+					assert.Equal(wellknown.HTTPConnectionManager, filter.Name)
 				}
 			}
 		})
@@ -165,7 +166,7 @@ func TestBuildOutboundTCPFIlterChain(t *testing.T) {
 				assert.Len(tcpFilterChain.FilterChainMatch.PrefixRanges, len(tc.destinationIPRanges))
 
 				for _, filter := range tcpFilterChain.Filters {
-					assert.Equal(envoy.TCPProxyFilterName, filter.Name)
+					assert.Equal(wellknown.TCPProxy, filter.Name)
 				}
 			}
 		})
@@ -202,7 +203,7 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.L4RBACFilterName, envoy.HTTPConnectionManagerFilterName},
+			expectedFilterNames: []string{envoy.L4RBACFilterName, wellknown.HTTPConnectionManager},
 			expectError:         false,
 		},
 		{
@@ -220,7 +221,7 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.HTTPConnectionManagerFilterName},
+			expectedFilterNames: []string{wellknown.HTTPConnectionManager},
 			expectError:         false,
 		},
 		{
@@ -246,7 +247,7 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.L4LocalRateLimitFilterName, envoy.HTTPConnectionManagerFilterName},
+			expectedFilterNames: []string{envoy.L4LocalRateLimitFilterName, wellknown.HTTPConnectionManager},
 			expectError:         false,
 		},
 		{
@@ -284,7 +285,7 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.L4GlobalRateLimitFilterName, envoy.HTTPConnectionManagerFilterName},
+			expectedFilterNames: []string{envoy.L4GlobalRateLimitFilterName, wellknown.HTTPConnectionManager},
 			expectError:         false,
 		},
 		{
@@ -312,8 +313,8 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.HTTPConnectionManagerFilterName},
-			expectedHTTPFilters: []string{envoy.HTTPLocalRateLimitFilterName, envoy.HTTPGlobalRateLimitFilterName, envoy.HTTPRouterFilterName},
+			expectedFilterNames: []string{wellknown.HTTPConnectionManager},
+			expectedHTTPFilters: []string{envoy.HTTPLocalRateLimitFilterName, envoy.HTTPGlobalRateLimitFilterName, wellknown.Router},
 			expectError:         false,
 		},
 		{
@@ -335,7 +336,7 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 			wasmStatsHeaders:        map[string]string{"k1": "v1", "k2": "v2"},
 			enableActiveHealthCheck: true,
 			extAuthzConfig:          &auth.ExtAuthConfig{Enable: true},
-			expectedFilterNames:     []string{envoy.HTTPConnectionManagerFilterName},
+			expectedFilterNames:     []string{wellknown.HTTPConnectionManager},
 			expectError:             false,
 		},
 	}
@@ -384,7 +385,7 @@ func TestBuildInboundHTTPFilterChain(t *testing.T) {
 
 			var httpFilters []*xds_hcm.HttpFilter
 			for _, f := range filterChain.Filters {
-				if f.Name != envoy.HTTPConnectionManagerFilterName {
+				if f.Name != wellknown.HTTPConnectionManager {
 					continue
 				}
 				hcm := &xds_hcm.HttpConnectionManager{}
@@ -427,7 +428,7 @@ func TestBuildInboundTCPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.L4RBACFilterName, envoy.TCPProxyFilterName},
+			expectedFilterNames: []string{envoy.L4RBACFilterName, wellknown.TCPProxy},
 			expectError:         false,
 		},
 		{
@@ -446,7 +447,7 @@ func TestBuildInboundTCPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.TCPProxyFilterName},
+			expectedFilterNames: []string{wellknown.TCPProxy},
 			expectError:         false,
 		},
 		{
@@ -473,7 +474,7 @@ func TestBuildInboundTCPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.L4LocalRateLimitFilterName, envoy.TCPProxyFilterName},
+			expectedFilterNames: []string{envoy.L4LocalRateLimitFilterName, wellknown.TCPProxy},
 			expectError:         false,
 		},
 		{
@@ -512,7 +513,7 @@ func TestBuildInboundTCPFilterChain(t *testing.T) {
 				TransportProtocol:    "tls",
 				ApplicationProtocols: []string{"osm"},
 			},
-			expectedFilterNames: []string{envoy.L4GlobalRateLimitFilterName, envoy.TCPProxyFilterName},
+			expectedFilterNames: []string{envoy.L4GlobalRateLimitFilterName, wellknown.TCPProxy},
 			expectError:         false,
 		},
 	}

--- a/pkg/envoy/lds/listener.go
+++ b/pkg/envoy/lds/listener.go
@@ -9,6 +9,7 @@ import (
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	xds_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -46,7 +47,7 @@ func buildPrometheusListener(connManager *xds_hcm.HttpConnectionManager) (*xds_l
 			{
 				Filters: []*xds_listener.Filter{
 					{
-						Name: envoy.HTTPConnectionManagerFilterName,
+						Name: wellknown.HTTPConnectionManager,
 						ConfigType: &xds_listener.Filter_TypedConfig{
 							TypedConfig: marshalledConnManager,
 						},
@@ -69,7 +70,7 @@ func getDefaultPassthroughFilterChain() *xds_listener.FilterChain {
 		Name: outboundEgressFilterChainName,
 		Filters: []*xds_listener.Filter{
 			{
-				Name:       envoy.TCPProxyFilterName,
+				Name:       wellknown.TCPProxy,
 				ConfigType: &xds_listener.Filter_TypedConfig{TypedConfig: protobuf.MustMarshalAny(tcpProxy)},
 			},
 		},

--- a/pkg/envoy/lds/response_test.go
+++ b/pkg/envoy/lds/response_test.go
@@ -6,6 +6,7 @@ import (
 
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	tassert "github.com/stretchr/testify/assert"
@@ -109,7 +110,7 @@ func TestNewResponse(t *testing.T) {
 	assert.Equal(listener.Name, OutboundListenerName)
 	assert.Equal(listener.TrafficDirection, xds_core.TrafficDirection_OUTBOUND)
 	assert.Len(listener.ListenerFilters, 3) // Test has egress policy feature enabled, so 3 filters are expected: OriginalDst, TlsInspector, HttpInspector
-	assert.Equal(envoy.OriginalDstFilterName, listener.ListenerFilters[0].Name)
+	assert.Equal(wellknown.OriginalDestination, listener.ListenerFilters[0].Name)
 	assert.NotNil(listener.FilterChains)
 	// There are 3 filter chains configured on the outbound-listener based on the configuration:
 	// 1. Filter chain for bookstore-v1
@@ -124,7 +125,7 @@ func TestNewResponse(t *testing.T) {
 	assert.Len(listener.FilterChains, 3)
 	assert.NotNil(listener.DefaultFilterChain)
 	assert.Equal(listener.DefaultFilterChain.Name, outboundEgressFilterChainName)
-	assert.Equal(listener.DefaultFilterChain.Filters[0].Name, envoy.TCPProxyFilterName)
+	assert.Equal(listener.DefaultFilterChain.Filters[0].Name, wellknown.TCPProxy)
 
 	// validating inbound listener
 	listener, ok = resources[1].(*xds_listener.Listener)
@@ -132,8 +133,8 @@ func TestNewResponse(t *testing.T) {
 	assert.Equal(listener.Name, InboundListenerName)
 	assert.Equal(listener.TrafficDirection, xds_core.TrafficDirection_INBOUND)
 	assert.Len(listener.ListenerFilters, 2)
-	assert.Equal(listener.ListenerFilters[0].Name, envoy.TLSInspectorFilterName)
-	assert.Equal(listener.ListenerFilters[1].Name, envoy.OriginalDstFilterName)
+	assert.Equal(listener.ListenerFilters[0].Name, wellknown.TLSInspector)
+	assert.Equal(listener.ListenerFilters[1].Name, wellknown.OriginalDestination)
 	assert.NotNil(listener.FilterChains)
 	// There is 1 filter chains configured on the inbound-listner based on the configuration:
 	// 1. Filter chanin for bookbuyer

--- a/pkg/envoy/lds/wasm.go
+++ b/pkg/envoy/lds/wasm.go
@@ -11,10 +11,9 @@ import (
 	xds_wasm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/wasm/v3"
 	xds_hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	xds_wasm_ext "github.com/envoyproxy/go-control-plane/envoy/extensions/wasm/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 
 	"google.golang.org/protobuf/types/known/anypb"
-
-	"github.com/openservicemesh/osm/pkg/envoy"
 )
 
 //go:embed stats.wasm
@@ -91,7 +90,7 @@ func getAddHeadersFilter(headers map[string]string) (*xds_hcm.HttpFilter, error)
 	}
 
 	return &xds_hcm.HttpFilter{
-		Name: envoy.HTTPLuaFilterName,
+		Name: wellknown.Lua,
 		ConfigType: &xds_hcm.HttpFilter_TypedConfig{
 			TypedConfig: luaAny,
 		},

--- a/pkg/envoy/rds/route/route_config.go
+++ b/pkg/envoy/rds/route/route_config.go
@@ -12,6 +12,7 @@ import (
 	xds_http_local_ratelimit "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/local_ratelimit/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	xds_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -425,7 +426,7 @@ func applyInboundRouteConfig(route *xds_route.Route, rbacConfig *any.Any, rateLi
 	perFilterConfig := make(map[string]*any.Any)
 
 	// Apply RBACPerRoute policy
-	perFilterConfig[envoy.HTTPRBACFilterName] = rbacConfig
+	perFilterConfig[wellknown.HTTPRoleBasedAccessControl] = rbacConfig
 
 	// Apply local rate limit policy
 	if rateLimit != nil && rateLimit.Local != nil {

--- a/pkg/envoy/rds/route/route_config_test.go
+++ b/pkg/envoy/rds/route/route_config_test.go
@@ -8,6 +8,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	xds_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/duration"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -97,7 +98,7 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 								// Only the filter name is matched, not the marshalled config
 								TypedPerFilterConfig: map[string]*any.Any{
-									envoy.HTTPRBACFilterName: nil,
+									wellknown.HTTPRoleBasedAccessControl: nil,
 								},
 							},
 							{
@@ -105,7 +106,7 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 								// Only the filter name is matched, not the marshalled config
 								TypedPerFilterConfig: map[string]*any.Any{
-									envoy.HTTPRBACFilterName: nil,
+									wellknown.HTTPRoleBasedAccessControl: nil,
 								},
 							},
 						},
@@ -180,8 +181,8 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 								// Only the filter name is matched, not the marshalled config
 								TypedPerFilterConfig: map[string]*any.Any{
-									envoy.HTTPRBACFilterName:           nil,
-									envoy.HTTPLocalRateLimitFilterName: nil,
+									wellknown.HTTPRoleBasedAccessControl: nil,
+									envoy.HTTPLocalRateLimitFilterName:   nil,
 								},
 							},
 							{
@@ -189,8 +190,8 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 								// Only the filter name is matched, not the marshalled config
 								TypedPerFilterConfig: map[string]*any.Any{
-									envoy.HTTPRBACFilterName:           nil,
-									envoy.HTTPLocalRateLimitFilterName: nil,
+									wellknown.HTTPRoleBasedAccessControl: nil,
+									envoy.HTTPLocalRateLimitFilterName:   nil,
 								},
 							},
 						},
@@ -297,7 +298,7 @@ func TestBuildInboundMeshRouteConfiguration(t *testing.T) {
 
 								// Only the filter name is matched, not the marshalled config
 								TypedPerFilterConfig: map[string]*any.Any{
-									envoy.HTTPRBACFilterName: nil,
+									wellknown.HTTPRoleBasedAccessControl: nil,
 								},
 
 								Action: &xds_route.Route_Route{

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -89,32 +89,17 @@ const (
 // Filter names - can be any name (not used by Envoy to determine the filter to use)
 // *Note: HTTP typed filters referenced in RDS require a wellknown name
 const (
-	// HTTP filters
-	HTTPConnectionManagerFilterName = "http_connection_manager"
-	HTTPRouterFilterName            = "http_router"
-	HTTPLuaFilterName               = "http_lua"
-
-	HTTPExtAuthzFilterName    = "http_external_authz"
-	HTTPHealthCheckFilterName = "http_health_check"
-
 	// The HTTP typed filters referenced in the RDS configuration still need to
 	// use wellknown names. These filters are configured as a map where the key is
 	// the filter name and value is the marshalled filter config.
 	// See https://github.com/envoyproxy/envoy/issues/21759#issuecomment-1163570994
-	HTTPRBACFilterName            = "envoy.filters.http.rbac"
 	HTTPLocalRateLimitFilterName  = "envoy.filters.http.local_ratelimit"
 	HTTPGlobalRateLimitFilterName = "envoy.filters.http.ratelimit"
 
 	// Network (L4) filters
-	TCPProxyFilterName          = "tcp_proxy"
 	L4LocalRateLimitFilterName  = "l4_local_rate_limit"
 	L4GlobalRateLimitFilterName = "l4_global_rate_limit"
 	L4RBACFilterName            = "l4_rbac"
-
-	// Listener filters
-	OriginalDstFilterName   = "original_dst"
-	TLSInspectorFilterName  = "tls_inspector"
-	HTTPInspectorFilterName = "http_inspector"
 )
 
 // Filter TypeURLs - used by Envoy to determine the filter to use

--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -1,9 +1,7 @@
 package envoy
 
 import (
-	"fmt"
 	"net"
-	"strings"
 
 	xds_accesslog_filter "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -17,7 +15,6 @@ import (
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -231,47 +228,6 @@ func GetADSConfigSource() *xds_core.ConfigSource {
 		},
 		ResourceApiVersion: xds_core.ApiVersion_V3,
 	}
-}
-
-// GetEnvoyServiceNodeID creates the string for Envoy's "--service-node" CLI argument for the Kubernetes sidecar container Command/Args
-func GetEnvoyServiceNodeID(nodeID, workloadKind, workloadName string) string {
-	items := []string{
-		"$(POD_UID)",
-		"$(POD_NAMESPACE)",
-		"$(POD_IP)",
-		"$(SERVICE_ACCOUNT)",
-		nodeID,
-		"$(POD_NAME)",
-		workloadKind,
-		workloadName,
-	}
-
-	return strings.Join(items, constants.EnvoyServiceNodeSeparator)
-}
-
-// ParseEnvoyServiceNodeID parses the given Envoy service node ID and returns the encoded metadata
-func ParseEnvoyServiceNodeID(serviceNodeID string) (*PodMetadata, error) {
-	chunks := strings.Split(serviceNodeID, constants.EnvoyServiceNodeSeparator)
-
-	if len(chunks) < 5 {
-		return nil, fmt.Errorf("invalid envoy service node id format")
-	}
-
-	meta := &PodMetadata{
-		UID:            chunks[0],
-		Namespace:      chunks[1],
-		IP:             chunks[2],
-		ServiceAccount: identity.K8sServiceAccount{Name: chunks[3], Namespace: chunks[1]},
-		EnvoyNodeID:    chunks[4],
-	}
-
-	if len(chunks) >= 8 {
-		meta.Name = chunks[5]
-		meta.WorkloadKind = chunks[6]
-		meta.WorkloadName = chunks[7]
-	}
-
-	return meta, nil
 }
 
 // GetCIDRRangeFromStr converts the given CIDR as a string to an XDS CidrRange object

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -308,53 +308,6 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(actual).To(Equal(expected))
 		})
 	})
-
-	Context("Test GetEnvoyServiceNodeID()", func() {
-		It("", func() {
-			actual := GetEnvoyServiceNodeID("-nodeID-", "-workload-kind-", "-workload-name-")
-			expected := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-/$(POD_NAME)/-workload-kind-/-workload-name-"
-			Expect(actual).To(Equal(expected))
-		})
-	})
-
-	Context("Test ParseEnvoyServiceNodeID()", func() {
-		It("", func() {
-			serviceNodeID := GetEnvoyServiceNodeID("-nodeID-", "-workload-kind-", "-workload-name-")
-			meta, err := ParseEnvoyServiceNodeID(serviceNodeID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(meta.UID).To(Equal("$(POD_UID)"))
-			Expect(meta.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.IP).To(Equal("$(POD_IP)"))
-			Expect(meta.ServiceAccount.Name).To(Equal("$(SERVICE_ACCOUNT)"))
-			Expect(meta.ServiceAccount.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.EnvoyNodeID).To(Equal("-nodeID-"))
-			Expect(meta.Name).To(Equal("$(POD_NAME)"))
-			Expect(meta.WorkloadKind).To(Equal("-workload-kind-"))
-			Expect(meta.WorkloadName).To(Equal("-workload-name-"))
-		})
-
-		It("handles when not all fields are defined", func() {
-			serviceNodeID := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-"
-			meta, err := ParseEnvoyServiceNodeID(serviceNodeID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(meta.UID).To(Equal("$(POD_UID)"))
-			Expect(meta.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.IP).To(Equal("$(POD_IP)"))
-			Expect(meta.ServiceAccount.Name).To(Equal("$(SERVICE_ACCOUNT)"))
-			Expect(meta.ServiceAccount.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.EnvoyNodeID).To(Equal("-nodeID-"))
-			Expect(meta.Name).To(Equal(""))
-			Expect(meta.WorkloadKind).To(Equal(""))
-			Expect(meta.WorkloadName).To(Equal(""))
-		})
-
-		It("should error when there are less than 5 chunks in the serviceNodeID string", func() {
-			// this 'serviceNodeID' will yield 2 chunks
-			serviceNodeID := "$(POD_UID)/$(POD_NAMESPACE)"
-			_, err := ParseEnvoyServiceNodeID(serviceNodeID)
-			Expect(err).To(HaveOccurred())
-		})
-	})
 })
 
 func TestGetCIDRRangeFromStr(t *testing.T) {


### PR DESCRIPTION
The snapshot cache implementation requires a "consistent cache", meaning references to other config objects require the referenced config is present.

It traces these configs through the wellknown names. While the envoy sidecar itself does not care about most of these wellknown names, the snapshot cache implementation does.

I also fix a nil pointer dereference and remove some unused code