### PR TITLE
add more protocols to CLI

### DIFF
--- a/pkg/cli/verifier/envoy_config.go
+++ b/pkg/cli/verifier/envoy_config.go
@@ -330,10 +330,10 @@ func findOutboundFilterChainForServicePort(meshSvc service.MeshService, dstIPRan
 
 func getFilterForProtocol(protocol string) string {
 	switch protocol {
-	case constants.ProtocolHTTP:
+	case constants.ProtocolHTTP, constants.ProtocolGRPC:
 		return envoy.HTTPConnectionManagerFilterName
 
-	case constants.ProtocolTCP, constants.ProtocolHTTPS:
+	case constants.ProtocolTCP, constants.ProtocolHTTPS, constants.ProtocolTCPServerFirst:
 		return envoy.TCPProxyFilterName
 
 	default:


### PR DESCRIPTION
Right now the CLI fails on the demo, because it  can't verify the mysql pod which uses tcp server first