### PR TITLE
switch back to wellknown http_connection_manager name

### DIFF
--- a/pkg/cli/verifier/testdata/curl_egress.json
+++ b/pkg/cli/verifier/testdata/curl_egress.json
@@ -731,7 +731,7 @@
        "category": "envoy.filters.network"
       },
       {
-       "name": "http_connection_manager",
+       "name": "envoy.filters.network.http_connection_manager",
        "category": "envoy.filters.network"
       },
       {
@@ -1271,7 +1271,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",
@@ -1400,7 +1400,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-egress.80",

--- a/pkg/cli/verifier/testdata/curl_permissive.json
+++ b/pkg/cli/verifier/testdata/curl_permissive.json
@@ -151,7 +151,7 @@
        "category": "envoy.filters.network"
       },
       {
-       "name": "http_connection_manager",
+       "name": "envoy.filters.network.http_connection_manager",
        "category": "envoy.filters.network"
       },
       {
@@ -1195,7 +1195,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",

--- a/pkg/cli/verifier/testdata/httpbin1_permissive.json
+++ b/pkg/cli/verifier/testdata/httpbin1_permissive.json
@@ -63,7 +63,7 @@
        "category": "envoy.filters.network"
       },
       {
-       "name": "http_connection_manager",
+       "name": "envoy.filters.network.http_connection_manager",
        "category": "envoy.filters.network"
       },
       {
@@ -1239,7 +1239,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-inbound.14001",
@@ -1457,7 +1457,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",

--- a/pkg/cli/verifier/testdata/httpbin2_permissive.json
+++ b/pkg/cli/verifier/testdata/httpbin2_permissive.json
@@ -443,7 +443,7 @@
        "category": "envoy.filters.network"
       },
       {
-       "name": "http_connection_manager",
+       "name": "envoy.filters.network.http_connection_manager",
        "category": "envoy.filters.network"
       },
       {
@@ -1239,7 +1239,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-inbound.14001",
@@ -1457,7 +1457,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound.14001",

--- a/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookbuyer.json
+++ b/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookbuyer.json
@@ -289,7 +289,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound",

--- a/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookstore.json
+++ b/pkg/cli/verifier/testdata/sample-envoy-config-dump-bookstore.json
@@ -36,7 +36,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "health_probes_http",
@@ -116,7 +116,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "health_probes_http",
@@ -196,7 +196,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "health_probes_http",
@@ -987,7 +987,7 @@
        {
         "filters": [
          {
-          "name": "http_connection_manager",
+          "name": "envoy.filters.network.http_connection_manager",
           "typed_config": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "stat_prefix": "health_probes_http",
@@ -1071,7 +1071,7 @@
        {
         "filters": [
          {
-          "name": "http_connection_manager",
+          "name": "envoy.filters.network.http_connection_manager",
           "typed_config": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "stat_prefix": "health_probes_http",
@@ -1155,7 +1155,7 @@
        {
         "filters": [
          {
-          "name": "http_connection_manager",
+          "name": "envoy.filters.network.http_connection_manager",
           "typed_config": {
            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
            "stat_prefix": "health_probes_http",
@@ -1253,7 +1253,7 @@
          },
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-outbound",
@@ -1446,7 +1446,7 @@
            }
           },
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "mesh-http-conn-manager.rds-inbound",
@@ -1638,7 +1638,7 @@
         {
          "filters": [
           {
-           "name": "http_connection_manager",
+           "name": "envoy.filters.network.http_connection_manager",
            "typed_config": {
             "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
             "stat_prefix": "prometheus-http-conn-manager",

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -142,7 +142,7 @@ static_resources:
         port_value: 15901
     filter_chains:
     - filters:
-      - name: http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
@@ -195,7 +195,7 @@ static_resources:
         port_value: 15902
     filter_chains:
     - filters:
-      - name: http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:
@@ -248,7 +248,7 @@ static_resources:
         port_value: 15903
     filter_chains:
     - filters:
-      - name: http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
           access_log:

--- a/pkg/envoy/types.go
+++ b/pkg/envoy/types.go
@@ -3,6 +3,8 @@
 package envoy
 
 import (
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -90,7 +92,8 @@ const (
 // *Note: HTTP typed filters referenced in RDS require a wellknown name
 const (
 	// HTTP filters
-	HTTPConnectionManagerFilterName = "http_connection_manager"
+	// TODO: once https://github.com/envoyproxy/go-control-plane/issues/588, we can use any name we want.
+	HTTPConnectionManagerFilterName = wellknown.HTTPConnectionManager
 	HTTPRouterFilterName            = "http_router"
 	HTTPLuaFilterName               = "http_lua"
 


### PR DESCRIPTION
This is purely to make this PR smaller https://github.com/openservicemesh/osm/pull/5056. Once this is in, I can rebase into the other to reduce the diff size and make review a bit easier


Necessary because of https://github.com/envoyproxy/go-control-plane/pull/589