### PR TITLE
feat(certs): define loops to reconcile MRC status

### DIFF
--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -62,7 +62,6 @@ spec:
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
             "--trust-domain", "{{.Values.osm.trustDomain}}",
-            "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{ required "osm.vault.host is required when osm.certificateProvider.kind==vault" .Values.osm.vault.host }}",
             "--vault-port", "{{.Values.osm.vault.port}}",

--- a/charts/osm/templates/osm-deployment.yaml
+++ b/charts/osm/templates/osm-deployment.yaml
@@ -62,6 +62,7 @@ spec:
             "--ca-bundle-secret-name", "{{.Values.osm.caBundleSecretName}}",
             "--certificate-manager", "{{.Values.osm.certificateProvider.kind}}",
             "--trust-domain", "{{.Values.osm.trustDomain}}",
+            "--enable-mesh-root-certificate={{.Values.osm.featureFlags.enableMeshRootCertificate}}",
             {{ if eq .Values.osm.certificateProvider.kind "vault" }}
             "--vault-host", "{{ required "osm.vault.host is required when osm.certificateProvider.kind==vault" .Values.osm.vault.host }}",
             "--vault-port", "{{.Values.osm.vault.port}}",

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -215,7 +215,7 @@ func main() {
 		}
 	} else {
 		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, osmNamespace,
-			certOpts, k8sClient, 5*time.Second, trustDomain)
+			certOpts, computeClient, 5*time.Second, trustDomain)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error fetching certificate manager of kind %s", certProviderKind)

--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -197,6 +197,8 @@ func main() {
 
 	meshSpec := smi.NewSMIClient(informerCollection, osmNamespace, k8sClient, msgBroker)
 
+	computeClient := kube.NewClient(k8sClient)
+
 	certOpts, err := getCertOptions()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error getting certificate options")
@@ -206,7 +208,7 @@ func main() {
 	var certManager *certificate.Manager
 	if enableMeshRootCertificate {
 		certManager, err = providers.NewCertificateManagerFromMRC(ctx, kubeClient, kubeConfig, osmNamespace,
-			certOpts, k8sClient, informerCollection, 5*time.Second)
+			certOpts, computeClient, informerCollection, 5*time.Second)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error fetching certificate manager of kind %s from MRC", certProviderKind)
@@ -219,8 +221,6 @@ func main() {
 				"Error fetching certificate manager of kind %s", certProviderKind)
 		}
 	}
-
-	computeClient := kube.NewClient(k8sClient)
 
 	ingress.Initialize(kubeClient, k8sClient, stop, certManager, msgBroker)
 

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -218,7 +218,7 @@ func main() {
 		}
 	} else {
 		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, osmNamespace,
-			certOpts, k8sClient, 5*time.Second, trustDomain)
+			certOpts, computeClient, 5*time.Second, trustDomain)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error initializing certificate manager of kind %s", certProviderKind)

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -19,6 +19,7 @@ import (
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	types "k8s.io/apimachinery/pkg/types"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface.
@@ -42,6 +43,18 @@ func NewMockMeshCataloger(ctrl *gomock.Controller) *MockMeshCataloger {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMeshCataloger) EXPECT() *MockMeshCatalogerMockRecorder {
 	return m.recorder
+}
+
+// AddMRCEventsHandler mocks base method.
+func (m *MockMeshCataloger) AddMRCEventsHandler(arg0 cache.ResourceEventHandlerFuncs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMRCEventsHandler", arg0)
+}
+
+// AddMRCEventsHandler indicates an expected call of AddMRCEventsHandler.
+func (mr *MockMeshCatalogerMockRecorder) AddMRCEventsHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMRCEventsHandler", reflect.TypeOf((*MockMeshCataloger)(nil).AddMRCEventsHandler), arg0)
 }
 
 // GetEgressTrafficPolicy mocks base method.

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -9,7 +9,7 @@ var errEncodeCert = errors.New("encode cert")
 var errMarshalPrivateKey = errors.New("marshal private key")
 var errNoPrivateKeyInPEM = errors.New("no private Key in PEM")
 
-// ErrNoCertificateInPEM is the errror for no certificate in PEM
+// ErrNoCertificateInPEM is the error for no certificate in PEM
 var ErrNoCertificateInPEM = errors.New("no certificate in PEM")
 
 // All of the below errors should be returned by the StorageEngine for each described scenario. The errors may be
@@ -20,3 +20,11 @@ var ErrInvalidCertSecret = errors.New("invalid secret for certificate")
 
 // ErrSecretNotFound should be returned if the secret isn't present in the underlying infra, on a Get
 var ErrSecretNotFound = errors.New("secret not found")
+
+// ErrUnexpectedMRCStatusInReconciler is the error that should be returned if a MRC has an unexpected (not error)
+// status in the MRC reconciliation loop
+var ErrUnexpectedMRCStatusInReconciler = errors.New("unexpected MRC status in reconciler")
+
+// ErrUnexpectedMRCStatusInReconciler is the error that should be returned if a MRC is in an error state
+// in the MRC reconciliation loop
+var ErrMRCErrorStatusInReconciler = errors.New("MRC error status in reconciler")

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
-	fakeConfigClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	"github.com/openservicemesh/osm/pkg/compute"
 
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -20,34 +20,11 @@ var (
 )
 
 type fakeMRCClient struct {
-	fakeConfigClient *fakeConfigClientset.Clientset
+	compute.Interface
 }
 
 func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (Issuer, pem.RootCertificate, error) {
 	return &fakeIssuer{}, pem.RootCertificate("rootCA"), nil
-}
-
-// List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
-func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
-	// return single empty object in the list.
-	return []*v1alpha2.MeshRootCertificate{{
-		Spec: v1alpha2.MeshRootCertificateSpec{
-			TrustDomain: "fake.domain.com",
-		},
-	}}, nil
-}
-
-func (c *fakeMRCClient) Get(name string) *v1alpha2.MeshRootCertificate {
-	mrc, _ := c.fakeConfigClient.ConfigV1alpha2().MeshRootCertificates("osm-system").Get(context.Background(), name, metav1.GetOptions{})
-	return mrc
-}
-
-func (c *fakeMRCClient) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return c.fakeConfigClient.ConfigV1alpha2().MeshRootCertificates("osm-system").Update(context.Background(), obj, metav1.UpdateOptions{})
-}
-
-func (c *fakeMRCClient) UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return c.fakeConfigClient.ConfigV1alpha2().MeshRootCertificates("osm-system").UpdateStatus(context.Background(), obj, metav1.UpdateOptions{})
 }
 
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan MRCEvent, error) {

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -14,21 +14,6 @@ func (c *MRCCompatClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
 	}, nil
 }
 
-// Get returns the pre-generated MRC.
-func (c *MRCCompatClient) Get(name string) *v1alpha2.MeshRootCertificate {
-	return c.mrc
-}
-
-// UpdateStatus returns the updated MRC. Should never be called when using the MRCCompatClient.
-func (c *MRCCompatClient) UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return c.mrc, nil
-}
-
-// Update returns the updated MRC. Should never be called when using the MRCCompatClient.
-func (c *MRCCompatClient) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return c.mrc, nil
-}
-
 // Watch is a basic Watch implementation for the MRC attached to the compat client
 func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	ch := make(chan certificate.MRCEvent)

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -14,6 +14,21 @@ func (c *MRCCompatClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
 	}, nil
 }
 
+// Get returns the pre-generated MRC.
+func (c *MRCCompatClient) Get(name string) *v1alpha2.MeshRootCertificate {
+	return c.mrc
+}
+
+// UpdateStatus returns the updated MRC. Should never be called when using the MRCCompatClient.
+func (c *MRCCompatClient) UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	return c.mrc, nil
+}
+
+// Update returns the updated MRC. Should never be called when using the MRCCompatClient.
+func (c *MRCCompatClient) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	return c.mrc, nil
+}
+
 // Watch is a basic Watch implementation for the MRC attached to the compat client
 func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	ch := make(chan certificate.MRCEvent)

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/constants"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	fakeConfigClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
@@ -151,8 +152,8 @@ func TestGetCertificateManager(t *testing.T) {
 
 func TestGetCertificateManagerFromMRC(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	k8sMock := k8s.NewMockController(mockCtrl)
-	k8sMock.EXPECT().GetMeshConfig().AnyTimes()
+	mockCompute := compute.NewMockInterface(mockCtrl)
+	mockCompute.EXPECT().GetMeshConfig().AnyTimes()
 
 	type testCase struct {
 		name        string
@@ -690,7 +691,7 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 			assert.NoError(err)
 			assert.NotNil(ic)
 
-			manager, err := NewCertificateManagerFromMRC(context.Background(), tc.kubeClient, tc.restConfig, tc.providerNamespace, tc.options, k8sMock, ic, 1*time.Hour)
+			manager, err := NewCertificateManagerFromMRC(context.Background(), tc.kubeClient, tc.restConfig, tc.providerNamespace, tc.options, mockCompute, ic, 1*time.Hour)
 			if tc.expectError {
 				assert.Empty(manager)
 				assert.Error(err)

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/compute"
+	"github.com/openservicemesh/osm/pkg/compute/kube"
 	"github.com/openservicemesh/osm/pkg/constants"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	fakeConfigClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
@@ -30,6 +31,7 @@ import (
 func TestGetCertificateManager(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	k8sMock := k8s.NewMockController(mockCtrl)
+	compute := kube.NewClient(k8sMock)
 	k8sMock.EXPECT().GetMeshConfig().AnyTimes()
 
 	type testCase struct {
@@ -133,7 +135,7 @@ func TestGetCertificateManager(t *testing.T) {
 				getCA = oldCA
 			}()
 
-			manager, err := NewCertificateManager(context.Background(), tc.kubeClient, tc.restConfig, tc.providerNamespace, tc.options, k8sMock, 1*time.Hour, "cluster.local")
+			manager, err := NewCertificateManager(context.Background(), tc.kubeClient, tc.restConfig, tc.providerNamespace, tc.options, compute, 1*time.Hour, "cluster.local")
 			if tc.expectError {
 				assert.Empty(manager)
 				assert.Error(err)

--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -15,31 +15,11 @@ import (
 // to observe MRCs (via List() and Watch()) as well as generate
 // `certificate.Provider`s from those MRCs
 type MRCComposer struct {
-	computeClient compute.Interface
+	compute.Interface
 	// TODO(#4863): remove this once informer is collapsed into k8s.client
 	informerCollection *informers.InformerCollection
 
 	MRCProviderGenerator
-}
-
-// List returns the MRCs in the mesh
-func (m *MRCComposer) List() ([]*v1alpha2.MeshRootCertificate, error) {
-	return m.computeClient.ListMeshRootCertificates()
-}
-
-// Get returns the specified MRC
-func (m *MRCComposer) Get(name string) *v1alpha2.MeshRootCertificate {
-	return m.computeClient.GetMeshRootCertificate(name)
-}
-
-// UpdateStatus updates the status of the MRC and returns the updated MRC
-func (m *MRCComposer) UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return m.computeClient.UpdateMeshRootCertificateStatus(obj)
-}
-
-// Update updates the spec of the MRC and returns the updated MRC
-func (m *MRCComposer) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return m.computeClient.UpdateMeshRootCertificate(obj)
 }
 
 // Watch returns a channel that receives events whenever MRCs are added, updated, and deleted
@@ -48,7 +28,7 @@ func (m *MRCComposer) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshR
 // to be ordered for any particular resources, but NOT across different resources.
 func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	eventChan := make(chan certificate.MRCEvent)
-	m.informerCollection.AddEventHandler(informers.InformerKeyMeshRootCertificate, cache.ResourceEventHandlerFuncs{
+	m.AddMRCEventsHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			mrc := obj.(*v1alpha2.MeshRootCertificate)
 			log.Debug().Msgf("received MRC add event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -134,6 +134,21 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 	return c.mrcChannel, nil
 }
 
+// Get returns the pre-generated MRC
+func (c *fakeMRCClient) Get(name string) *v1alpha2.MeshRootCertificate {
+	return &v1alpha2.MeshRootCertificate{Spec: v1alpha2.MeshRootCertificateSpec{TrustDomain: "fake.example.com"}}
+}
+
+// Update returns the updated MRC
+func (c *fakeMRCClient) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	return obj, nil
+}
+
+// UpdateStatus returns the updated MRC
+func (c *fakeMRCClient) UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	return obj, nil
+}
+
 // NewFake constructs a fake certificate client using a certificate
 func NewFake(checkInterval time.Duration) *certificate.Manager {
 	getValidityDuration := func() time.Duration { return 1 * time.Hour }

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -22,6 +23,7 @@ const (
 )
 
 type fakeMRCClient struct {
+	compute.Interface
 	mrcChannel chan certificate.MRCEvent
 }
 
@@ -119,12 +121,6 @@ func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (
 	return issuer, cert.GetTrustedCAs(), nil
 }
 
-// List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
-func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
-	// return single empty object in the list.
-	return []*v1alpha2.MeshRootCertificate{{Spec: v1alpha2.MeshRootCertificateSpec{TrustDomain: "fake.example.com"}}}, nil
-}
-
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	// send event for first CA created
 	go func() {
@@ -132,21 +128,6 @@ func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent,
 	}()
 
 	return c.mrcChannel, nil
-}
-
-// Get returns the pre-generated MRC
-func (c *fakeMRCClient) Get(name string) *v1alpha2.MeshRootCertificate {
-	return &v1alpha2.MeshRootCertificate{Spec: v1alpha2.MeshRootCertificateSpec{TrustDomain: "fake.example.com"}}
-}
-
-// Update returns the updated MRC
-func (c *fakeMRCClient) Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return obj, nil
-}
-
-// UpdateStatus returns the updated MRC
-func (c *fakeMRCClient) UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
-	return obj, nil
 }
 
 // NewFake constructs a fake certificate client using a certificate

--- a/pkg/certificate/providers/types.go
+++ b/pkg/certificate/providers/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -75,6 +76,7 @@ type CertManagerOptions struct {
 // It's intent is to match the custom interface that will wrap the MRC k8s informer.
 // TODO(#4502): Remove this entirely once we are fully onboarded to MRC informers.
 type MRCCompatClient struct {
+	compute.Interface
 	MRCProviderGenerator
 	mrc *v1alpha2.MeshRootCertificate
 }

--- a/pkg/certificate/reconciler.go
+++ b/pkg/certificate/reconciler.go
@@ -1,0 +1,48 @@
+package certificate
+
+import (
+	"context"
+	"time"
+)
+
+// CheckAndUpdate checks for a MRC to reach a desired condition and when the condition is met,
+// it updates the status and terminates the loop
+func (r *MRCReconciler) CheckAndUpdate(ctx context.Context, mrcClient MRCClient, checkInterval time.Duration) {
+	ticker := time.NewTicker(checkInterval)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				log.Info().Msgf("Stopping status reconciliation loop for MRC %s", r.mrcName)
+				return
+			case <-ticker.C:
+				mrc := mrcClient.Get(r.mrcName)
+				if mrc == nil {
+					log.Error().Msgf("failed to get MRC %s in status reconciliation loop", r.mrcName)
+					continue
+				}
+
+				meetsCondition, err := r.checkStatus(ctx, mrc)
+				// checkStatus will return an error if the MRC is no longer in the expected rotation state
+				// i.e. prior to this reconciliation loop, another component has already moved the rotation
+				// to the next state after seeing the valid status condition without this check, the MRC
+				// reconciliation loop might never terminate
+				if err != nil {
+					return
+				}
+				if !meetsCondition {
+					continue
+				}
+
+				// update status does not need to implement its own retry logic. Updating the status will
+				// be retried in the MRC reconciler's next iteration
+				if err := r.updateStatus(ctx, mrc); err != nil {
+					log.Warn().Err(err).Msgf("failed to update status of MRC %s in status reconciliation loop. Condition was met", r.mrcName)
+					continue
+				}
+				return
+			}
+		}
+	}()
+}

--- a/pkg/certificate/reconciler.go
+++ b/pkg/certificate/reconciler.go
@@ -17,7 +17,7 @@ func (r *MRCReconciler) CheckAndUpdate(ctx context.Context, mrcClient MRCClient,
 				log.Info().Msgf("Stopping status reconciliation loop for MRC %s", r.mrcName)
 				return
 			case <-ticker.C:
-				mrc := mrcClient.Get(r.mrcName)
+				mrc := mrcClient.GetMeshRootCertificate(r.mrcName)
 				if mrc == nil {
 					log.Error().Msgf("failed to get MRC %s in status reconciliation loop", r.mrcName)
 					continue

--- a/pkg/certificate/reconciler.go
+++ b/pkg/certificate/reconciler.go
@@ -3,6 +3,8 @@ package certificate
 import (
 	"context"
 	"time"
+
+	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
 // CheckAndUpdate checks for a MRC to reach a desired condition and when the condition is met,
@@ -38,7 +40,8 @@ func (r *MRCReconciler) CheckAndUpdate(ctx context.Context, mrcClient MRCClient,
 				// update status does not need to implement its own retry logic. Updating the status will
 				// be retried in the MRC reconciler's next iteration
 				if err := r.updateStatus(ctx, mrc); err != nil {
-					log.Warn().Err(err).Msgf("failed to update status of MRC %s in status reconciliation loop. Condition was met", r.mrcName)
+					log.Warn().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrUpdatingMRCStatus)).
+						Msgf("failed to update status of MRC %s in status reconciliation loop. Condition was met", r.mrcName)
 					continue
 				}
 				return

--- a/pkg/certificate/reconciler_test.go
+++ b/pkg/certificate/reconciler_test.go
@@ -1,0 +1,199 @@
+package certificate
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	tassert "github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+	fakeConfigClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+)
+
+func TestCheckAndUpdate(t *testing.T) {
+	a := tassert.New(t)
+
+	mrcClient := fakeMRCClient{}
+	checkStatus := func(ctx context.Context, mrc *v1alpha2.MeshRootCertificate) (bool, error) {
+		if mrc.Status.State != constants.MRCStatePending {
+			return false, fmt.Errorf("incorrect rotation state")
+		}
+		return (mrc.Status.ComponentStatuses.Bootstrap == constants.MRCComponentStatusValidating &&
+				mrc.Status.ComponentStatuses.Gateway == constants.MRCComponentStatusValidating &&
+				mrc.Status.ComponentStatuses.Sidecar == constants.MRCComponentStatusValidating &&
+				mrc.Status.ComponentStatuses.XDSControlPlane == constants.MRCComponentStatusValidating &&
+				mrc.Status.ComponentStatuses.Webhooks == constants.MRCComponentStatusValidating),
+			nil
+	}
+	updateStatus := func(ctx context.Context, mrc *v1alpha2.MeshRootCertificate) error {
+		mrc.Status.State = constants.MRCStateValidating
+		mrc.Status.Conditions = append(mrc.Status.Conditions, v1alpha2.MeshRootCertificateCondition{
+			Type:   constants.MRCConditionTypeValidatingRollout,
+			Status: "True",
+			Reason: "CertificatePassivelyInUse",
+		})
+		_, err := mrcClient.UpdateStatus(mrc)
+		a.NoError(err)
+		return nil
+	}
+	mrcName := "osm-mesh-root-certificate"
+
+	// TODO: Add check for fails to meet condition
+	testCases := []struct {
+		name             string
+		currentResource  v1alpha2.MeshRootCertificate
+		expectedResource v1alpha2.MeshRootCertificate
+	}{
+		{
+			name: "successfully updated MRC",
+			currentResource: v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStatePending,
+					ComponentStatuses: v1alpha2.MeshRootCertificateComponentStatuses{
+						Webhooks:        constants.MRCComponentStatusValidating,
+						XDSControlPlane: constants.MRCComponentStatusValidating,
+						Sidecar:         constants.MRCComponentStatusValidating,
+						Bootstrap:       constants.MRCComponentStatusValidating,
+						Gateway:         constants.MRCComponentStatusValidating,
+					},
+				},
+			},
+			expectedResource: v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateValidating,
+					ComponentStatuses: v1alpha2.MeshRootCertificateComponentStatuses{
+						Webhooks:        constants.MRCComponentStatusValidating,
+						XDSControlPlane: constants.MRCComponentStatusValidating,
+						Sidecar:         constants.MRCComponentStatusValidating,
+						Bootstrap:       constants.MRCComponentStatusValidating,
+						Gateway:         constants.MRCComponentStatusValidating,
+					},
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: "True",
+							Reason: "CertificatePassivelyInUse",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "MRC not updated. checkStatus errors",
+			currentResource: v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateValidating,
+					ComponentStatuses: v1alpha2.MeshRootCertificateComponentStatuses{
+						Webhooks:        constants.MRCComponentStatusValidating,
+						XDSControlPlane: constants.MRCComponentStatusValidating,
+						Sidecar:         constants.MRCComponentStatusValidating,
+						Bootstrap:       constants.MRCComponentStatusValidating,
+						Gateway:         constants.MRCComponentStatusValidating,
+					},
+				},
+			},
+			expectedResource: v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateValidating,
+					ComponentStatuses: v1alpha2.MeshRootCertificateComponentStatuses{
+						Webhooks:        constants.MRCComponentStatusValidating,
+						XDSControlPlane: constants.MRCComponentStatusValidating,
+						Sidecar:         constants.MRCComponentStatusValidating,
+						Bootstrap:       constants.MRCComponentStatusValidating,
+						Gateway:         constants.MRCComponentStatusValidating,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mrcClient.fakeConfigClient = fakeConfigClientset.NewSimpleClientset(&tc.currentResource)
+			mrcReconciler := MRCReconciler{mrcName, updateStatus, checkStatus}
+			ctx, cancel := context.WithCancel(context.Background())
+			// TODO: Does this cancel after each loop?
+			defer cancel()
+			// Start mrc reconciliation loop
+			mrcReconciler.CheckAndUpdate(ctx, &mrcClient, 5*time.Millisecond)
+			time.Sleep(1 * time.Second)
+
+			updatedMRC, err := mrcClient.fakeConfigClient.ConfigV1alpha2().MeshRootCertificates("osm-system").Get(ctx, mrcName, metav1.GetOptions{})
+			a.NoError(err)
+			a.Equal(&tc.expectedResource, updatedMRC)
+		})
+	}
+}

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/compute"
 )
 
 const (
@@ -123,10 +124,7 @@ type Manager struct {
 
 // MRCClient is an interface that can watch for changes to the MRC. It is typically backed by a k8s informer.
 type MRCClient interface {
-	List() ([]*v1alpha2.MeshRootCertificate, error)
-	Get(name string) *v1alpha2.MeshRootCertificate
-	UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error)
-	Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error)
+	compute.Interface
 	MRCEventBroker
 
 	// GetCertIssuerForMRC returns an Issuer based on the provided MRC.

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -124,6 +124,9 @@ type Manager struct {
 // MRCClient is an interface that can watch for changes to the MRC. It is typically backed by a k8s informer.
 type MRCClient interface {
 	List() ([]*v1alpha2.MeshRootCertificate, error)
+	Get(name string) *v1alpha2.MeshRootCertificate
+	UpdateStatus(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error)
+	Update(obj *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error)
 	MRCEventBroker
 
 	// GetCertIssuerForMRC returns an Issuer based on the provided MRC.
@@ -154,4 +157,17 @@ type MRCEventBroker interface {
 	// MRCs. Watch returns a channel that emits events, and
 	// an error if the subscription goes awry.
 	Watch(context.Context) (<-chan MRCEvent, error)
+}
+
+// UpdateMRCStatus updates the status of an MRC to the desired state
+type UpdateMRCStatus func(ctx context.Context, mrc *v1alpha2.MeshRootCertificate) error
+
+// CheckMRCStatus checks if the MRC status is in the desired state
+type CheckMRCStatus func(ctx context.Context, mrc *v1alpha2.MeshRootCertificate) (bool, error)
+
+// MRCReconciler defines the actions of a reconciler used to determine when and how to update an MRC's status
+type MRCReconciler struct {
+	mrcName      string
+	updateStatus UpdateMRCStatus
+	checkStatus  CheckMRCStatus
 }

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -122,6 +122,8 @@ type Manager struct {
 	pubsub *pubsub.PubSub
 }
 
+const mrcShortName string = "mrc"
+
 // MRCClient is an interface that can watch for changes to the MRC. It is typically backed by a k8s informer.
 type MRCClient interface {
 	compute.Interface

--- a/pkg/compute/mock_compute_client_generated.go
+++ b/pkg/compute/mock_compute_client_generated.go
@@ -15,6 +15,7 @@ import (
 	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	types "k8s.io/apimachinery/pkg/types"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -38,6 +39,18 @@ func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
+}
+
+// AddMRCEventsHandler mocks base method.
+func (m *MockInterface) AddMRCEventsHandler(arg0 cache.ResourceEventHandlerFuncs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMRCEventsHandler", arg0)
+}
+
+// AddMRCEventsHandler indicates an expected call of AddMRCEventsHandler.
+func (mr *MockInterfaceMockRecorder) AddMRCEventsHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMRCEventsHandler", reflect.TypeOf((*MockInterface)(nil).AddMRCEventsHandler), arg0)
 }
 
 // GetHostnamesForService mocks base method.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -211,6 +211,9 @@ const (
 	// MRCStateError is the error status option for the State of the MeshRootCertificate
 	MRCStateError = "error"
 
+	// MRCStateValidating is the validating status option for the State of the MeshRootCertificate
+	MRCStateValidating = "validating"
+
 	// MRCIntentPassive is the passive option for the Intent of the MeshRootCertificate
 	MRCIntentPassive = "passive"
 
@@ -219,6 +222,9 @@ const (
 
 	// MRCComponentStatusUnknown is the unknown status option for the component status of the MeshRootCertificate
 	MRCComponentStatusUnknown = "Unknown"
+
+	// MRCComponentStatusValidating is the validating status option for the component status of the MeshRootCertificate
+	MRCComponentStatusValidating = "Validating"
 
 	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
 	MRCConditionStatusUnknown = "Unknown"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -226,6 +226,12 @@ const (
 	// MRCComponentStatusValidating is the validating status option for the component status of the MeshRootCertificate
 	MRCComponentStatusValidating = "Validating"
 
+	// MRCComponentStatusIssuing is the issuing status option for the component status of the MeshRootCertificate
+	MRCComponentStatusIssuing = "Issuing"
+
+	// MRCComponentStatusError is the error status option for the component status of the MeshRootCertificate
+	MRCComponentStatusError = "Error"
+
 	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
 	MRCConditionStatusUnknown = "Unknown"
 

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -147,6 +147,9 @@ const (
 
 	// ErrUpdatingMRCStatus indicates the MeshRootCertificate status could not be updated
 	ErrUpdatingMRCStatus
+
+	// ErrCheckingMRCStatus indicates the MeshRootCertificate status could not be checked
+	ErrCheckingMRCStatus
 )
 
 // Range 4100-4150 reserved for PubSub system

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -144,6 +144,9 @@ const (
 
 	// ErrRotatingCert indicates a certificate could not be rotated
 	ErrRotatingCert
+
+	// ErrUpdatingMRCStatus indicates the MeshRootCertificate status could not be updated
+	ErrUpdatingMRCStatus
 )
 
 // Range 4100-4150 reserved for PubSub system
@@ -564,6 +567,10 @@ The certificate authority privided when issuing a certificate was invalid.
 
 	ErrRotatingCert: `
 The specified certificate could not be rotated.
+`,
+
+	ErrUpdatingMRCStatus: `
+The specified MeshRootCertificate could not be updated.
 `,
 
 	//

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
@@ -428,4 +429,9 @@ func (c *Client) ListMeshRootCertificates() ([]*configv1alpha2.MeshRootCertifica
 	}
 
 	return mrcs, nil
+}
+
+// AddMRCEventsHandler adds the event handler for MRCEvents
+func (c *Client) AddMRCEventsHandler(handlerFuncs cache.ResourceEventHandlerFuncs) {
+	c.informers.AddEventHandler(osminformers.InformerKeyMeshRootCertificate, handlerFuncs)
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -627,9 +627,8 @@ func TestConfigUpdateStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := tassert.New(t)
-			kubeClient := testclient.NewSimpleClientset()
 			configClient := fakeConfigClient.NewSimpleClientset(tc.existingResource.(runtime.Object))
-			ic, err := informers.NewInformerCollection(tests.MeshName, nil, informers.WithKubeClient(kubeClient))
+			ic, err := informers.NewInformerCollection(tests.MeshName, nil)
 			a.Nil(err)
 			c := NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, configClient, nil)
 			switch v := tc.updatedResource.(type) {

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -13,6 +13,7 @@ import (
 	envoy "github.com/openservicemesh/osm/pkg/envoy"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // MockController is a mock of Controller interface.
@@ -36,6 +37,18 @@ func NewMockController(ctrl *gomock.Controller) *MockController {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockController) EXPECT() *MockControllerMockRecorder {
 	return m.recorder
+}
+
+// AddMRCEventsHandler mocks base method.
+func (m *MockController) AddMRCEventsHandler(arg0 cache.ResourceEventHandlerFuncs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMRCEventsHandler", arg0)
+}
+
+// AddMRCEventsHandler indicates an expected call of AddMRCEventsHandler.
+func (mr *MockControllerMockRecorder) AddMRCEventsHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMRCEventsHandler", reflect.TypeOf((*MockController)(nil).AddMRCEventsHandler), arg0)
 }
 
 // GetEndpoints mocks base method.

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
@@ -149,4 +150,6 @@ type PassthroughInterface interface {
 
 	// GetUpstreamTrafficSetting returns the UpstreamTrafficSetting resources with namespaced name
 	GetUpstreamTrafficSetting(*types.NamespacedName) *policyv1alpha1.UpstreamTrafficSetting
+
+	AddMRCEventsHandler(cache.ResourceEventHandlerFuncs)
 }


### PR DESCRIPTION
<!--
Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Resolves #5046 

Creates an `MRCReconciler` to define how to check and update the status of a specified MRC. There are multiple reconciliation loops that will be created during root certificate rotation. The details for the following loops can be found [here](https://docs.google.com/document/d/1QF7wL1su4CUzwo3Yo2_vFL90XG2d-wUhBU6uifNrkws/edit#heading=h.tix4uddk7ofj).

1. Watch for all `status.CertificateStatus` fields to be **Validating**
2. Watch for all `status.CertificateStatus` fields to be **Issuing**
3. Watch for the conditions `Provisioning`, `IssuingRollout`, and `ValidatingRollout` to be **True**

This PR contains no functional changes and sets up future changes to define the check and update functions required for the above MRC reconciliation loops.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI
- unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

5. Is this a breaking change? No

6. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No