### PR TITLE
temporarily switch to a manual workflow for helm chart

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,8 +1,5 @@
 name: Release Helm Chart
-on:
-  push:
-    tags:
-      - "v*"
+on: workflow_dispatch
 
 jobs:
   release:


### PR DESCRIPTION
Steps:

1. Manually release helm chart v1.2.0 
2. Revert this PR
3. Re-release v1.2.1