### PR TITLE
Revert "temporarily switch to a manual workflow for helm chart (#5076)"

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,5 +1,8 @@
 name: Release Helm Chart
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   release:


### PR DESCRIPTION
Revert prior commit that enabled manually pushing helm chart instead of pushing automatically based on tag.