### PR TITLE
change Envoy node ID to the UUID

### DIFF
--- a/pkg/envoy/xdsutil.go
+++ b/pkg/envoy/xdsutil.go
@@ -1,9 +1,7 @@
 package envoy
 
 import (
-	"fmt"
 	"net"
-	"strings"
 
 	xds_accesslog_filter "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -17,7 +15,6 @@ import (
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 
-	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy/secrets"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -212,47 +209,6 @@ func GetADSConfigSource() *xds_core.ConfigSource {
 		},
 		ResourceApiVersion: xds_core.ApiVersion_V3,
 	}
-}
-
-// GetEnvoyServiceNodeID creates the string for Envoy's "--service-node" CLI argument for the Kubernetes sidecar container Command/Args
-func GetEnvoyServiceNodeID(nodeID, workloadKind, workloadName string) string {
-	items := []string{
-		"$(POD_UID)",
-		"$(POD_NAMESPACE)",
-		"$(POD_IP)",
-		"$(SERVICE_ACCOUNT)",
-		nodeID,
-		"$(POD_NAME)",
-		workloadKind,
-		workloadName,
-	}
-
-	return strings.Join(items, constants.EnvoyServiceNodeSeparator)
-}
-
-// ParseEnvoyServiceNodeID parses the given Envoy service node ID and returns the encoded metadata
-func ParseEnvoyServiceNodeID(serviceNodeID string) (*PodMetadata, error) {
-	chunks := strings.Split(serviceNodeID, constants.EnvoyServiceNodeSeparator)
-
-	if len(chunks) < 5 {
-		return nil, fmt.Errorf("invalid envoy service node id format")
-	}
-
-	meta := &PodMetadata{
-		UID:            chunks[0],
-		Namespace:      chunks[1],
-		IP:             chunks[2],
-		ServiceAccount: identity.K8sServiceAccount{Name: chunks[3], Namespace: chunks[1]},
-		EnvoyNodeID:    chunks[4],
-	}
-
-	if len(chunks) >= 8 {
-		meta.Name = chunks[5]
-		meta.WorkloadKind = chunks[6]
-		meta.WorkloadName = chunks[7]
-	}
-
-	return meta, nil
 }
 
 // GetCIDRRangeFromStr converts the given CIDR as a string to an XDS CidrRange object

--- a/pkg/envoy/xdsutil_test.go
+++ b/pkg/envoy/xdsutil_test.go
@@ -284,53 +284,6 @@ var _ = Describe("Test Envoy tools", func() {
 			Expect(actual).To(Equal(expected))
 		})
 	})
-
-	Context("Test GetEnvoyServiceNodeID()", func() {
-		It("", func() {
-			actual := GetEnvoyServiceNodeID("-nodeID-", "-workload-kind-", "-workload-name-")
-			expected := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-/$(POD_NAME)/-workload-kind-/-workload-name-"
-			Expect(actual).To(Equal(expected))
-		})
-	})
-
-	Context("Test ParseEnvoyServiceNodeID()", func() {
-		It("", func() {
-			serviceNodeID := GetEnvoyServiceNodeID("-nodeID-", "-workload-kind-", "-workload-name-")
-			meta, err := ParseEnvoyServiceNodeID(serviceNodeID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(meta.UID).To(Equal("$(POD_UID)"))
-			Expect(meta.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.IP).To(Equal("$(POD_IP)"))
-			Expect(meta.ServiceAccount.Name).To(Equal("$(SERVICE_ACCOUNT)"))
-			Expect(meta.ServiceAccount.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.EnvoyNodeID).To(Equal("-nodeID-"))
-			Expect(meta.Name).To(Equal("$(POD_NAME)"))
-			Expect(meta.WorkloadKind).To(Equal("-workload-kind-"))
-			Expect(meta.WorkloadName).To(Equal("-workload-name-"))
-		})
-
-		It("handles when not all fields are defined", func() {
-			serviceNodeID := "$(POD_UID)/$(POD_NAMESPACE)/$(POD_IP)/$(SERVICE_ACCOUNT)/-nodeID-"
-			meta, err := ParseEnvoyServiceNodeID(serviceNodeID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(meta.UID).To(Equal("$(POD_UID)"))
-			Expect(meta.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.IP).To(Equal("$(POD_IP)"))
-			Expect(meta.ServiceAccount.Name).To(Equal("$(SERVICE_ACCOUNT)"))
-			Expect(meta.ServiceAccount.Namespace).To(Equal("$(POD_NAMESPACE)"))
-			Expect(meta.EnvoyNodeID).To(Equal("-nodeID-"))
-			Expect(meta.Name).To(Equal(""))
-			Expect(meta.WorkloadKind).To(Equal(""))
-			Expect(meta.WorkloadName).To(Equal(""))
-		})
-
-		It("should error when there are less than 5 chunks in the serviceNodeID string", func() {
-			// this 'serviceNodeID' will yield 2 chunks
-			serviceNodeID := "$(POD_UID)/$(POD_NAMESPACE)"
-			_, err := ParseEnvoyServiceNodeID(serviceNodeID)
-			Expect(err).To(HaveOccurred())
-		})
-	})
 })
 
 func TestGetCIDRRangeFromStr(t *testing.T) {

--- a/pkg/injector/bootstrap.go
+++ b/pkg/injector/bootstrap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	xds_bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -18,7 +19,7 @@ import (
 )
 
 // This will read an existing envoy bootstrap config, and create a new copy by changing the NodeID, and certificates.
-func (wh *mutatingWebhook) createEnvoyBootstrapFromExisting(newBootstrapSecretName, oldBootstrapSecretName, namespace string, cert *certificate.Certificate) (*corev1.Secret, error) {
+func (wh *mutatingWebhook) createEnvoyBootstrapFromExisting(proxyUUID uuid.UUID, oldBootstrapSecretName, namespace string, cert *certificate.Certificate) (*corev1.Secret, error) {
 	existing, err := wh.kubeClient.CoreV1().Secrets(namespace).Get(context.Background(), oldBootstrapSecretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -30,16 +31,16 @@ func (wh *mutatingWebhook) createEnvoyBootstrapFromExisting(newBootstrapSecretNa
 		return nil, fmt.Errorf("error unmarshalling envoy bootstrap config: %w", err)
 	}
 
-	config.Node.Id = cert.GetCommonName().String()
+	config.Node.Id = proxyUUID.String()
 
-	return wh.marshalAndSaveBootstrap(newBootstrapSecretName, namespace, config, cert)
+	return wh.marshalAndSaveBootstrap(bootstrapConfigName(proxyUUID), namespace, config, cert)
 }
 
-func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamespace string, cert *certificate.Certificate, originalHealthProbes models.HealthProbes) (*corev1.Secret, error) {
+func (wh *mutatingWebhook) createEnvoyBootstrapConfig(proxyUUID uuid.UUID, namespace string, cert *certificate.Certificate, originalHealthProbes models.HealthProbes) (*corev1.Secret, error) {
 	builder := bootstrap.Builder{
-		NodeID: cert.GetCommonName().String(),
+		NodeID: proxyUUID.String(),
 
-		XDSHost: fmt.Sprintf("%s.%s.svc.cluster.local", constants.OSMControllerName, osmNamespace),
+		XDSHost: fmt.Sprintf("%s.%s.svc.cluster.local", constants.OSMControllerName, wh.osmNamespace),
 
 		// OriginalHealthProbes stores the path and port for liveness, readiness, and startup health probes as initially
 		// defined on the Pod Spec.
@@ -55,7 +56,7 @@ func (wh *mutatingWebhook) createEnvoyBootstrapConfig(name, namespace, osmNamesp
 		return nil, err
 	}
 
-	return wh.marshalAndSaveBootstrap(name, namespace, bootstrapConfig, cert)
+	return wh.marshalAndSaveBootstrap(bootstrapConfigName(proxyUUID), namespace, bootstrapConfig, cert)
 }
 
 func (wh *mutatingWebhook) marshalAndSaveBootstrap(name, namespace string, config *xds_bootstrap.Bootstrap, cert *certificate.Certificate) (*corev1.Secret, error) {

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -61,12 +61,12 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 		// with the same UUID, so instead we change the UUID, and create a new bootstrap config, copied from the original,
 		// with the proxy UUID changed.
 		oldConfigName := bootstrapSecretPrefix + originalUUID
-		if _, err := wh.createEnvoyBootstrapFromExisting(envoyBootstrapConfigName, oldConfigName, namespace, bootstrapCertificate); err != nil {
+		if _, err := wh.createEnvoyBootstrapFromExisting(proxyUUID, oldConfigName, namespace, bootstrapCertificate); err != nil {
 			log.Error().Err(err).Msgf("Failed to create Envoy bootstrap config for already-injected pod: service-account=%s, namespace=%s, certificate CN prefix=%s", pod.Spec.ServiceAccountName, namespace, cnPrefix)
 			return nil, err
 		}
 	default:
-		if _, err = wh.createEnvoyBootstrapConfig(envoyBootstrapConfigName, namespace, wh.osmNamespace, bootstrapCertificate, originalHealthProbes); err != nil {
+		if _, err = wh.createEnvoyBootstrapConfig(proxyUUID, namespace, bootstrapCertificate, originalHealthProbes); err != nil {
 			log.Error().Err(err).Msgf("Failed to create Envoy bootstrap config for pod: service-account=%s, namespace=%s, certificate CN prefix=%s", pod.Spec.ServiceAccountName, namespace, cnPrefix)
 			return nil, err
 		}
@@ -168,6 +168,10 @@ func (wh *mutatingWebhook) verifyPrerequisites(podOS string) error {
 	}
 
 	return nil
+}
+
+func bootstrapConfigName(proxyUUID uuid.UUID) string {
+	return bootstrapSecretPrefix + proxyUUID.String()
 }
 
 func (wh *mutatingWebhook) configurePodInit(podOS string, pod *corev1.Pod, namespace string) error {


### PR DESCRIPTION
This is considered more stable due to trust domains being able to rotate.

This is in preparation for the switch to the envoy snapshot cache, so we don't have to parse the uuid from the cert, which is considered more fragile