### PR TITLE
fix(): Missing name in tracing

### DIFF
--- a/pkg/injector/bootstrap_test.go
+++ b/pkg/injector/bootstrap_test.go
@@ -43,6 +43,8 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		},
 	}
 
+	namespace := "namespace"
+
 	meshConfig := v1alpha2.MeshConfig{
 		Spec: v1alpha2.MeshConfigSpec{
 			Sidecar: v1alpha2.SidecarSpec{
@@ -87,7 +89,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 	Context("test unix getEnvoySidecarContainerSpec()", func() {
 		It("creates Envoy sidecar spec", func() {
-			actual := getEnvoySidecarContainerSpec(pod, meshConfig, originalHealthProbes, constants.OSLinux)
+			actual := getEnvoySidecarContainerSpec(pod, namespace, meshConfig, originalHealthProbes, constants.OSLinux)
 
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,
@@ -200,7 +202,7 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 
 	Context("test Windows getEnvoySidecarContainerSpec()", func() {
 		It("creates Envoy sidecar spec", func() {
-			actual := getEnvoySidecarContainerSpec(pod, meshConfig, originalHealthProbes, constants.OSWindows)
+			actual := getEnvoySidecarContainerSpec(pod, namespace, meshConfig, originalHealthProbes, constants.OSWindows)
 
 			expected := corev1.Container{
 				Name:            constants.EnvoyContainerName,

--- a/pkg/injector/envoy_container.go
+++ b/pkg/injector/envoy_container.go
@@ -38,9 +38,10 @@ func getPlatformSpecificSpecComponents(meshConfig v1alpha2.MeshConfig, podOS str
 	return
 }
 
-func getEnvoySidecarContainerSpec(pod *corev1.Pod, meshConfig v1alpha2.MeshConfig, originalHealthProbes models.HealthProbes, podOS string) corev1.Container {
+func getEnvoySidecarContainerSpec(pod *corev1.Pod, namespace string, meshConfig v1alpha2.MeshConfig, originalHealthProbes models.HealthProbes, podOS string) corev1.Container {
 	// cluster ID will be used as an identifier to the tracing sink
-	clusterID := fmt.Sprintf("%s.%s", pod.Spec.ServiceAccountName, pod.Namespace)
+	// pod.Namespace is unset in the API request to the webhook so namespace is derived from req.Namespace
+	clusterID := fmt.Sprintf("%s.%s", pod.Spec.ServiceAccountName, namespace)
 	securityContext, containerImage := getPlatformSpecificSpecComponents(meshConfig, podOS)
 
 	logLevel := meshConfig.Spec.Sidecar.LogLevel

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -25,6 +25,7 @@ import (
 )
 
 func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.AdmissionRequest, proxyUUID uuid.UUID) ([]byte, error) {
+	// pod.Namespace is unset in the API request to the webhook so namespace is derived from req.Namespace
 	namespace := req.Namespace
 
 	// Issue a certificate for the proxy sidecar - used for Envoy to connect to XDS (not Envoy-to-Envoy connections)
@@ -142,7 +143,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	}
 
 	// Add the Envoy sidecar
-	sidecar := getEnvoySidecarContainerSpec(pod, wh.kubeController.GetMeshConfig(), originalHealthProbes, podOS)
+	sidecar := getEnvoySidecarContainerSpec(pod, namespace, wh.kubeController.GetMeshConfig(), originalHealthProbes, podOS)
 	pod.Spec.Containers = append(pod.Spec.Containers, sidecar)
 
 	return json.Marshal(makePatches(req, pod))


### PR DESCRIPTION
Resolved missing namespace component of ClusterID

Part of #5048

Signed-off-by: Whitney Griffith <whitney.griffith16@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

[Envoy Sidecar Container Spec](https://github.com/openservicemesh/osm/blob/main/pkg/injector/envoy_container.go#L43) sets the [--service-cluster](https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-service-cluster) parameter based on ServiceAccount and pod.Namespace. Namespace component is always missing, even in [example tracing documentation](https://release-v1-2.docs.openservicemesh.io/docs/guides/observability/tracing/).


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

- [x]  Test in AKS environment
- [x] Test in Kind environment 

**Additional Work**:

- [x] Update [example tracing documentation](https://release-v1-2.docs.openservicemesh.io/docs/guides/observability/tracing/) [PR](https://github.com/openservicemesh/osm-docs/pull/440)

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [X] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [X] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?