### PR TITLE
Remove pre-povisioned ADS certificate 

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -54,10 +54,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/version"
 )
 
-const (
-	xdsServerCertificateCommonName = "ads"
-)
-
 var (
 	verbosity                  string
 	meshName                   string // An ID that uniquely identifies an OSM instance
@@ -238,14 +234,9 @@ func main() {
 
 	proxyRegistry := registry.NewProxyRegistry()
 
-	adsCert, err := certManager.IssueCertificate(xdsServerCertificateCommonName, certificate.Internal)
-	if err != nil {
-		events.GenericEventRecorder().FatalEvent(err, events.CertificateIssuanceFailure, "Error issuing XDS certificate to ADS server")
-	}
-
 	// Create and start the ADS gRPC service
 	xdsServer := ads.NewADSServer(meshCatalog, proxyRegistry, k8sClient.GetMeshConfig().Spec.Observability.EnableDebugServer, osmNamespace, certManager, k8sClient, msgBroker)
-	if err := xdsServer.Start(ctx, cancel, constants.ADSServerPort, adsCert); err != nil {
+	if err := xdsServer.Start(ctx, cancel, constants.ADSServerPort); err != nil {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error initializing ADS server")
 	}
 

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -87,8 +87,7 @@ func (s *GRPCServer) GetServer() *grpc.Server {
 func (s *GRPCServer) updateConfig() error {
 	grpcCert, err := s.cm.IssueCertificate(
 		s.certCommonName,
-		certificate.Internal,
-		certificate.FullCNProvided())
+		certificate.Internal)
 	if err != nil {
 		return err
 	}

--- a/pkg/envoy/ads/server.go
+++ b/pkg/envoy/ads/server.go
@@ -72,7 +72,7 @@ func (s *Server) withXdsLogMutex(f func()) {
 }
 
 // Start starts the ADS server
-func (s *Server) Start(ctx context.Context, cancel context.CancelFunc, port int, adsCert *certificate.Certificate) error {
+func (s *Server) Start(ctx context.Context, cancel context.CancelFunc, port int) error {
 	grpcServer, lis, err := NewGrpc(ServerType, port, xdsServerCertificateCommonName, s.certManager)
 	if err != nil {
 		return fmt.Errorf("error starting ADS server: %w", err)

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -90,6 +90,7 @@ func (s *Server) setCert() error {
 	// This is a certificate issued for the webhook handler
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned.
+	// Kubernetes requires webhooks to have format of 'servicename.namespace.svc' without trust domain
 	webhookCert, err := s.cm.IssueCertificate(
 		s.certCommonName(),
 		certificate.Internal,


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

This PR:

-  removes the pre-provisioning of the ADS cert that is provisioned.  When it was pre-provisioned it ended up with the `ads.cluster.local` trust domain appended.  When rotating it would end up using this even though it was requested that the provisioned cert already included the `FullCNProvided` which would have given a cert with CN `ads`.  It was an implementation detail that the cert that was pre-provisioned ended up being re-used because our cache mechanism looks up the certs by "prefix" which was `ads`.
- ~Sets up all the internal certificates to have the trust domain as part of the CN.  Prior ADS ended up with trust domain (due to issue explained above) but webhooks didn't. I've chosen to include the Trust Domain as part of the all the certs to be consistent in naming our CN and will be necessary as we add spiffe support which requires a TrustDomain.~  Webhooks in k8s need to be in format of `service.namespace.svc` (https://github.com/openservicemesh/osm/pull/5101#discussion_r966251904)

 
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Manual, unit, e2e

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?