### PR TITLE
fix(debug): update nil check for proxy

### DIFF
--- a/pkg/debugger/proxy.go
+++ b/pkg/debugger/proxy.go
@@ -68,7 +68,7 @@ func (ds DebugConfig) printProxies(w http.ResponseWriter) {
 
 func (ds DebugConfig) getConfigDump(streamID int64, w http.ResponseWriter) {
 	proxy := ds.proxyRegistry.GetConnectedProxy(streamID)
-	if proxy != nil {
+	if proxy == nil {
 		msg := fmt.Sprintf("Proxy for Stream ID %d not found, may have been disconnected", streamID)
 		log.Error().Msg(msg)
 		http.Error(w, msg, http.StatusNotFound)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Fixes incorrect nil check logic on proxy, preventing access to the envoy config dump via the debug server.

Resolves #5102 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- verified access to config dump via debug server by running demo with debug server enabled and port forwarding the server

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs] (https://github.com/openservicemesh/osm-docs) repo (if applicable)? No