### PR TITLE
Use custom trust domain with contour in helm chart

### DIFF
--- a/charts/osm/templates/preset-mesh-config.yaml
+++ b/charts/osm/templates/preset-mesh-config.yaml
@@ -38,7 +38,7 @@ data:
         "serviceCertValidityDuration": {{.Values.osm.certificateProvider.serviceCertValidityDuration | mustToJson}},
         {{- if .Values.contour.enabled }}
         "ingressGateway": {
-          "subjectAltNames": ["osm-contour-envoy.{{include "osm.namespace" .}}.cluster.local"],
+          "subjectAltNames": ["osm-contour-envoy.{{include "osm.namespace" .}}.{{.Values.osm.trustDomain}}"],
           "validityDuration": "24h",
           "secret": {
             "name": "osm-contour-envoy-client-cert",


### PR DESCRIPTION
With the introduction of Custom Trust domains the helm chart should use the trust domain when creating contour SAN configuration.

after the this patch:

```
❯ helm template osm charts/osm --set osm.trustDomain=something.com --set contour.enabled=true | grep something.com
          "subjectAltNames": ["osm-contour-envoy.osm-system.something.com"],
            "--trust-domain", "something.com",
            "--trust-domain", "something.com",
            "--trust-domain", "something.com",
```

before:

```
❯ helm template osm charts/osm --set osm.trustDomain=something.com --set contour.enabled=true | grep subjectAltNames
          "subjectAltNames": ["osm-contour-envoy.osm-system.cluster.local"],
```

Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?