### PR TITLE
feat(certs): add basic MRC validation

### DIFF
--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -60,6 +60,7 @@ spec:
                   enum:
                     - passive
                     - active
+                  default: passive
                 provider:
                   description: Certificate provider used by the mesh control plane
                   type: object

--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -109,6 +109,9 @@ spec:
                         protocol:
                           description: Protocol for the Vault connection
                           type: string
+                          enum:
+                            - http
+                            - https
                         token:
                           description: Token used by the mesh control plane
                           type: object

--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -54,6 +54,12 @@ spec:
                   description: Trust Domain to use in common name for certificates, e.g. "example.com"
                   type: string
                   default: cluster.local
+                intent:
+                  description: Intent specifies the role of the MeshRootCertificate, can be active or passive
+                  type: string
+                  enum:
+                    - passive
+                    - active
                 provider:
                   description: Certificate provider used by the mesh control plane
                   type: object
@@ -154,9 +160,6 @@ spec:
                     - required: ["certManager"]
                     - required: ["vault"]
                     - required: ["tresor"]
-            intent:
-              description: Intent specifies the role of the MeshRootCertificate, can be active or passive
-              type: string
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true

--- a/pkg/apis/config/v1alpha2/meshrootcertificate.go
+++ b/pkg/apis/config/v1alpha2/meshrootcertificate.go
@@ -17,7 +17,7 @@ type MeshRootCertificate struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec is the MeshRootCertifte config specification
+	// Spec is the MeshRootCertificate config specification
 	// +optional
 	Spec MeshRootCertificateSpec `json:"spec,omitempty"`
 

--- a/pkg/apis/config/v1alpha2/meshrootcertificate.go
+++ b/pkg/apis/config/v1alpha2/meshrootcertificate.go
@@ -17,13 +17,9 @@ type MeshRootCertificate struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Spec is the MeshRootCertificate config specification
+	// Spec is the MeshRootCertifte config specification
 	// +optional
 	Spec MeshRootCertificateSpec `json:"spec,omitempty"`
-
-	// Intent of the MeshRootCertificate resource
-	// +optional
-	Intent MeshRootCertificateIntent `json:"intent,omitempty"`
 
 	// Status of the MeshRootCertificate resource
 	// +optional
@@ -37,6 +33,9 @@ type MeshRootCertificateSpec struct {
 
 	// TrustDomain is the trust domain to use as a suffix in Common Names for new certificates.
 	TrustDomain string `json:"trustDomain"`
+
+	// Intent of the MeshRootCertificate resource
+	Intent MeshRootCertificateIntent `json:"intent"`
 }
 
 // ProviderSpec defines the certificate provider used by the mesh control plane

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -65,8 +65,8 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 			Spec: v1alpha2.MeshRootCertificateSpec{
 				Provider:    option.AsProviderSpec(),
 				TrustDomain: trustDomain,
+				Intent:      constants.MRCIntentPassive,
 			},
-			Intent: constants.MRCIntentPassive,
 			Status: v1alpha2.MeshRootCertificateStatus{
 				State: constants.MRCStateActive,
 				ComponentStatuses: v1alpha2.MeshRootCertificateComponentStatuses{

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -177,6 +177,8 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					TrustDomain: "cluster.local",
+					Intent:      constants.MRCIntentPassive,
 					Provider: v1alpha2.ProviderSpec{
 						Tresor: &v1alpha2.TresorProviderSpec{
 							CA: v1alpha2.TresorCASpec{
@@ -188,7 +190,6 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 						},
 					},
 				},
-				Intent: constants.MRCIntentPassive,
 				Status: v1alpha2.MeshRootCertificateStatus{
 					State: constants.MRCStateActive,
 					ComponentStatuses: v1alpha2.MeshRootCertificateComponentStatuses{

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1161,9 +1161,8 @@ func TestListMeshRootCertificates(t *testing.T) {
 
 	mrcClient := fakeConfigClient.NewSimpleClientset()
 	stop := make(chan struct{})
-	osmMeshRootCertificateName := "osm-mesh-root-certificate"
 
-	ic, err := informers.NewInformerCollection(tests.MeshName, stop, informers.WithConfigClient(mrcClient, osmMeshRootCertificateName, tests.OsmNamespace))
+	ic, err := informers.NewInformerCollection(tests.MeshName, stop, informers.WithConfigClient(mrcClient, tests.OsmMeshConfigName, tests.OsmNamespace))
 	a.Nil(err)
 
 	c := NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, nil, nil)

--- a/pkg/validator/patch.go
+++ b/pkg/validator/patch.go
@@ -18,6 +18,9 @@ const (
 	// ValidatingWebhookName is the name of the validating webhook.
 	ValidatingWebhookName = "osm-validator.k8s.io"
 
+	// ControlPlaneValidatingWebhookName is the name of the validating webhook for control plane resource.
+	ControlPlaneValidatingWebhookName = "osm-control-plane-validator.k8s.io"
+
 	// ValidatorWebhookSvc is the name of the validator service.
 	ValidatorWebhookSvc = "osm-validator"
 )
@@ -48,6 +51,17 @@ func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert *certi
 				Resources:   []string{"traffictargets"},
 			},
 		})
+	}
+
+	controlPlaneRules := []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{"config.openservicemesh.io"},
+				APIVersions: []string{"v1alpha2"},
+				Resources:   []string{"meshrootcertificates"},
+			},
+		},
 	}
 
 	vwhcLabels := map[string]string{
@@ -104,7 +118,37 @@ func createOrUpdateValidatingWebhook(clientSet kubernetes.Interface, cert *certi
 					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
 					return &sideEffect
 				}(),
-				AdmissionReviewVersions: []string{"v1"}}},
+				AdmissionReviewVersions: []string{"v1"},
+			},
+			{
+				Name: ControlPlaneValidatingWebhookName,
+				ClientConfig: admissionregv1.WebhookClientConfig{
+					Service: &admissionregv1.ServiceReference{
+						Namespace: osmNamespace,
+						Name:      ValidatorWebhookSvc,
+						Path:      &webhookPath,
+						Port:      &webhookPort,
+					},
+					CABundle: cert.GetTrustedCAs()},
+				FailurePolicy: &failurePolicy,
+				MatchPolicy:   &matchPolicy,
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "name",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{osmNamespace},
+						},
+					},
+				},
+				Rules: controlPlaneRules,
+				SideEffects: func() *admissionregv1.SideEffectClass {
+					sideEffect := admissionregv1.SideEffectClassNoneOnDryRun
+					return &sideEffect
+				}(),
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
 	}
 
 	if _, err := clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Create(context.Background(), &vwhc, metav1.CreateOptions{}); err != nil {

--- a/pkg/validator/patch_test.go
+++ b/pkg/validator/patch_test.go
@@ -130,6 +130,8 @@ func TestCreateValidatingWebhook(t *testing.T) {
 						},
 					})
 					assert.ElementsMatch(webhook.Rules, tc.expectedControlPlaneRules)
+				} else {
+					assert.Fail("unknown webhook %s in validating webhook configuration", webhook.Name)
 				}
 			}
 		})

--- a/pkg/validator/patch_test.go
+++ b/pkg/validator/patch_test.go
@@ -32,6 +32,15 @@ var (
 			Resources:   []string{"traffictargets"},
 		},
 	}
+
+	configRule = admissionregv1.RuleWithOperations{
+		Operations: []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update},
+		Rule: admissionregv1.Rule{
+			APIGroups:   []string{"config.openservicemesh.io"},
+			APIVersions: []string{"v1alpha2"},
+			Resources:   []string{"meshrootcertificates"},
+		},
+	}
 )
 
 func TestCreateValidatingWebhook(t *testing.T) {
@@ -44,19 +53,22 @@ func TestCreateValidatingWebhook(t *testing.T) {
 	enableReconciler := true
 
 	testCases := []struct {
-		name                  string
-		validateTrafficTarget bool
-		expectedRules         []admissionregv1.RuleWithOperations
+		name                      string
+		validateTrafficTarget     bool
+		expectedRules             []admissionregv1.RuleWithOperations
+		expectedControlPlaneRules []admissionregv1.RuleWithOperations
 	}{
 		{
-			name:                  "with smi validation enabled",
-			validateTrafficTarget: true,
-			expectedRules:         []admissionregv1.RuleWithOperations{ingressRule, trafficTargetRule},
+			name:                      "with smi validation enabled",
+			validateTrafficTarget:     true,
+			expectedRules:             []admissionregv1.RuleWithOperations{ingressRule, trafficTargetRule},
+			expectedControlPlaneRules: []admissionregv1.RuleWithOperations{configRule},
 		},
 		{
-			name:                  "with smi validation disabled",
-			validateTrafficTarget: false,
-			expectedRules:         []admissionregv1.RuleWithOperations{ingressRule},
+			name:                      "with smi validation disabled",
+			validateTrafficTarget:     false,
+			expectedRules:             []admissionregv1.RuleWithOperations{ingressRule},
+			expectedControlPlaneRules: []admissionregv1.RuleWithOperations{configRule},
 		},
 	}
 
@@ -74,7 +86,7 @@ func TestCreateValidatingWebhook(t *testing.T) {
 			assert.Len(webhooks.Items, 1)
 
 			wh := webhooks.Items[0]
-			assert.Len(wh.Webhooks, 1)
+			assert.Len(wh.Webhooks, 2)
 			assert.Equal(wh.ObjectMeta.Name, webhookName)
 			assert.EqualValues(wh.ObjectMeta.Labels, map[string]string{
 				constants.OSMAppNameLabelKey:     constants.OSMAppNameLabelValue,
@@ -83,30 +95,43 @@ func TestCreateValidatingWebhook(t *testing.T) {
 				constants.AppLabel:               constants.OSMControllerName,
 				constants.ReconcileLabel:         strconv.FormatBool(true),
 			})
-			assert.Equal(wh.Webhooks[0].ClientConfig.Service.Namespace, osmNamespace)
-			assert.Equal(wh.Webhooks[0].ClientConfig.Service.Name, ValidatorWebhookSvc)
-			assert.Equal(wh.Webhooks[0].ClientConfig.Service.Path, &webhookPath)
-			assert.Equal(wh.Webhooks[0].ClientConfig.Service.Port, &webhookPort)
 
-			assert.Equal(wh.Webhooks[0].NamespaceSelector.MatchLabels[constants.OSMKubeResourceMonitorAnnotation], meshName)
-			assert.EqualValues(wh.Webhooks[0].NamespaceSelector.MatchExpressions, []metav1.LabelSelectorRequirement{
-				{
-					Key:      constants.IgnoreLabel,
-					Operator: metav1.LabelSelectorOpDoesNotExist,
-				},
-				{
-					Key:      "name",
-					Operator: metav1.LabelSelectorOpNotIn,
-					Values:   []string{osmNamespace},
-				},
-				{
-					Key:      "control-plane",
-					Operator: metav1.LabelSelectorOpDoesNotExist,
-				},
-			})
+			for _, webhook := range wh.Webhooks {
+				assert.Equal(webhook.ClientConfig.Service.Namespace, osmNamespace)
+				assert.Equal(webhook.ClientConfig.Service.Name, ValidatorWebhookSvc)
+				assert.Equal(webhook.ClientConfig.Service.Path, &webhookPath)
+				assert.Equal(webhook.ClientConfig.Service.Port, &webhookPort)
+				assert.Equal(webhook.AdmissionReviewVersions, []string{"v1"})
 
-			assert.ElementsMatch(wh.Webhooks[0].Rules, tc.expectedRules)
-			assert.Equal(wh.Webhooks[0].AdmissionReviewVersions, []string{"v1"})
+				if webhook.Name == ValidatingWebhookName {
+					assert.Equal(webhook.NamespaceSelector.MatchLabels[constants.OSMKubeResourceMonitorAnnotation], meshName)
+					assert.EqualValues(webhook.NamespaceSelector.MatchExpressions, []metav1.LabelSelectorRequirement{
+						{
+							Key:      constants.IgnoreLabel,
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+						{
+							Key:      "name",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{osmNamespace},
+						},
+						{
+							Key:      "control-plane",
+							Operator: metav1.LabelSelectorOpDoesNotExist,
+						},
+					})
+					assert.ElementsMatch(webhook.Rules, tc.expectedRules)
+				} else if webhook.Name == ControlPlaneValidatingWebhookName {
+					assert.EqualValues(webhook.NamespaceSelector.MatchExpressions, []metav1.LabelSelectorRequirement{
+						{
+							Key:      "name",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{osmNamespace},
+						},
+					})
+					assert.ElementsMatch(webhook.Rules, tc.expectedControlPlaneRules)
+				}
+			}
 		})
 	}
 }

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -11,6 +11,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/client-go/kubernetes"
 
+	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/constants"
@@ -43,6 +44,7 @@ func NewValidatingWebhook(ctx context.Context, webhookConfigName, osmNamespace, 
 			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():                 egressValidator,
 			policyv1alpha1.SchemeGroupVersion.WithKind("UpstreamTrafficSetting").String(): kv.upstreamTrafficSettingValidator,
 			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():               trafficTargetValidator,
+			configv1alpha2.SchemeGroupVersion.WithKind("MeshRootCertificate").String():    meshRootCertificateValidator,
 		},
 	}
 

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -33,9 +33,9 @@ type validatingWebhookServer struct {
 }
 
 // NewValidatingWebhook returns a validatingWebhookServer with the defaultValidators that were previously registered.
-func NewValidatingWebhook(ctx context.Context, webhookConfigName, osmNamespace, osmVersion, meshName string, enableReconciler, validateTrafficTarget bool, certManager *certificate.Manager, kubeClient kubernetes.Interface, policyClient compute.Interface) error {
-	kv := &policyValidator{
-		policyClient: policyClient,
+func NewValidatingWebhook(ctx context.Context, webhookConfigName, osmNamespace, osmVersion, meshName string, enableReconciler, validateTrafficTarget bool, certManager *certificate.Manager, kubeClient kubernetes.Interface, computeClient compute.Interface) error {
+	kv := &validator{
+		computeClient: computeClient,
 	}
 
 	v := &validatingWebhookServer{
@@ -44,7 +44,7 @@ func NewValidatingWebhook(ctx context.Context, webhookConfigName, osmNamespace, 
 			policyv1alpha1.SchemeGroupVersion.WithKind("Egress").String():                 egressValidator,
 			policyv1alpha1.SchemeGroupVersion.WithKind("UpstreamTrafficSetting").String(): kv.upstreamTrafficSettingValidator,
 			smiAccess.SchemeGroupVersion.WithKind("TrafficTarget").String():               trafficTargetValidator,
-			configv1alpha2.SchemeGroupVersion.WithKind("MeshRootCertificate").String():    meshRootCertificateValidator,
+			configv1alpha2.SchemeGroupVersion.WithKind("MeshRootCertificate").String():    kv.meshRootCertificateValidator,
 		},
 	}
 

--- a/pkg/validator/server_benchmark_test.go
+++ b/pkg/validator/server_benchmark_test.go
@@ -53,8 +53,8 @@ func BenchmarkDoValidation(b *testing.B) {
 	}
 	k8sClient := k8s.NewClient("osm-ns", tests.OsmMeshConfigName, informerCollection, policyClient, configClient, msgBroker)
 	compute := kube.NewClient(k8sClient)
-	kv := &policyValidator{
-		policyClient: compute,
+	kv := &validator{
+		computeClient: compute,
 	}
 
 	w := httptest.NewRecorder()

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -173,7 +173,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 		cancel()
 	})
 
-	t.Run("successful startup with reconciler enabled and traffic target validation enabled", func(t *testing.T) {
+	t.Run("successful startup with reconciler enabled, traffic target validation enabled, and mrc validation enabled", func(t *testing.T) {
 		certManager := tresorFake.NewFake(1 * time.Hour)
 		enableReconciler = true
 
@@ -192,7 +192,7 @@ func TestNewValidatingWebhook(t *testing.T) {
 		tassert.NoError(t, err)
 	})
 
-	t.Run("successful startup with reconciler enabled and validation for traffic target disabled", func(t *testing.T) {
+	t.Run("successful startup with reconciler enabled and validation for traffic target disabled, and mrc validation enabled", func(t *testing.T) {
 		certManager := tresorFake.NewFake(1 * time.Hour)
 		enableReconciler = true
 		validateTrafficTarget = false

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -299,7 +299,7 @@ func validateMRCOnCreate(mrc *configv1alpha2.MeshRootCertificate) error {
 		return fmt.Errorf("trustDomain must be non empty for MRC %s", getNamespacedMRC(mrc))
 	}
 
-	if err := validateProvider(mrc); err != nil {
+	if err := validateMRCProvider(mrc); err != nil {
 		return err
 	}
 
@@ -318,7 +318,7 @@ func validateMRCOnUpdate(oldMRC *configv1alpha2.MeshRootCertificate, newMRC *con
 	return nil
 }
 
-func validateProvider(mrc *configv1alpha2.MeshRootCertificate) error {
+func validateMRCProvider(mrc *configv1alpha2.MeshRootCertificate) error {
 	p := mrc.Spec.Provider
 	switch {
 	case p.Tresor != nil:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

- adds BASIC validation of the MRC on add and update to the validating webhook
  - on add, checks for valid trust domain
  - on update, verifies trust domain and provider were not updated
- moves `Intent` field to MRC spec
- adds enum on the `Intent` field to limit possible values to `active` and `passive`

Part of #4723 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- [x] CI
- [x] manual MRC creation and updates

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No