### PR TITLE
feat(healthprobes): Allow multiple containers to use health probes

### DIFF
--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -353,7 +353,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 	for containerName, probes := range b.OriginalHealthProbes {
 		// Liveness probe listener + cluster
 		livenessClusterName := fmt.Sprintf("%s_%s", containerName, livenessCluster)
-		livenessListenerBuilder.AddProbe(containerName, livenessClusterName, constants.LivenessProbePath, probes.Liveness, probes.Liveness.IsHTTP)
+		livenessListenerBuilder.AddProbe(containerName, livenessClusterName, constants.LivenessProbePath, probes.Liveness)
 		livenessCluster := buildProbeCluster(livenessClusterName, probes.Liveness)
 		if livenessCluster != nil {
 			clusters = append(clusters, livenessCluster)
@@ -361,7 +361,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 
 		// Readiness probe listener + cluster
 		readinessClusterName := fmt.Sprintf("%s_%s", containerName, readinessCluster)
-		readinessListenerBuilder.AddProbe(containerName, readinessClusterName, constants.ReadinessProbePath, probes.Readiness, probes.Readiness.IsHTTP)
+		readinessListenerBuilder.AddProbe(containerName, readinessClusterName, constants.ReadinessProbePath, probes.Readiness)
 		readinessCluster := buildProbeCluster(readinessClusterName, probes.Readiness)
 		if readinessCluster != nil {
 			clusters = append(clusters, readinessCluster)
@@ -369,7 +369,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 
 		// Startup probe listener + cluster
 		startupClusterName := fmt.Sprintf("%s_%s", containerName, startupCluster)
-		startupListenerBuilder.AddProbe(containerName, startupClusterName, constants.StartupProbePath, probes.Startup, probes.Startup.IsHTTP)
+		startupListenerBuilder.AddProbe(containerName, startupClusterName, constants.StartupProbePath, probes.Startup)
 		startupCluster := buildProbeCluster(startupClusterName, probes.Startup)
 		if startupCluster != nil {
 			clusters = append(clusters, startupCluster)

--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -367,7 +367,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 				// Therefore, the last declared HTTPS probe will be the only one receiving traffic
 				livenessListenerBuilder.httpsClusterName = clusterName
 			}
-			clusters = append(clusters, getLivenessCluster(clusterName, probes.Liveness))
+			clusters = append(clusters, buildLivenessCluster(clusterName, probes.Liveness))
 		}
 
 		// Is there a readiness probe in the Pod Spec?
@@ -383,7 +383,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 			} else {
 				readinessListenerBuilder.httpsClusterName = clusterName
 			}
-			clusters = append(clusters, getReadinessCluster(clusterName, probes.Readiness))
+			clusters = append(clusters, buildReadinessCluster(clusterName, probes.Readiness))
 		}
 
 		// Is there a startup probe in the Pod Spec?
@@ -399,7 +399,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 			} else {
 				startupListenerBuilder.httpsClusterName = clusterName
 			}
-			clusters = append(clusters, getStartupCluster(clusterName, probes.Startup))
+			clusters = append(clusters, buildStartupCluster(clusterName, probes.Startup))
 		}
 	}
 

--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -368,7 +368,6 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 				livenessListenerBuilder.httpsClusterName = clusterName
 			}
 			clusters = append(clusters, getLivenessCluster(clusterName, probes.Liveness))
-
 		}
 
 		// Is there a readiness probe in the Pod Spec?
@@ -384,7 +383,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 			} else {
 				readinessListenerBuilder.httpsClusterName = clusterName
 			}
-			clusters = append(clusters, getReadinessCluster(containerName, probes.Readiness))
+			clusters = append(clusters, getReadinessCluster(clusterName, probes.Readiness))
 		}
 
 		// Is there a startup probe in the Pod Spec?
@@ -400,7 +399,7 @@ func (b *Builder) getProbeResources() ([]*xds_listener.Listener, []*xds_cluster.
 			} else {
 				startupListenerBuilder.httpsClusterName = clusterName
 			}
-			clusters = append(clusters, getStartupCluster(containerName, probes.Startup))
+			clusters = append(clusters, getStartupCluster(clusterName, probes.Startup))
 		}
 	}
 

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -21,10 +21,17 @@ func TestBuild(t *testing.T) {
 		TLSMaxProtocolVersion: "TLSv1_2",
 		CipherSuites:          []string{"abc", "xyz"},
 		ECDHCurves:            []string{"ABC", "XYZ"},
-		OriginalHealthProbes: models.HealthProbes{
-			Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true},
-			Readiness: &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true},
-			Startup:   &models.HealthProbe{Path: "/startup", Port: 83, IsHTTP: true},
+		OriginalHealthProbes: map[string]models.HealthProbes{
+			"my-container": {
+				Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true},
+				Readiness: &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true},
+				Startup:   &models.HealthProbe{Path: "/startup", Port: 83, IsHTTP: true},
+			},
+			"my-container-2": {
+				Liveness:  &models.HealthProbe{Path: "/liveness", Port: 84, IsHTTP: true},
+				Readiness: &models.HealthProbe{Path: "/readiness", Port: 85, IsHTTP: true},
+				Startup:   &models.HealthProbe{Path: "/startup", Port: 86, IsHTTP: true},
+			},
 		},
 	}
 

--- a/pkg/envoy/bootstrap/config_test.go
+++ b/pkg/envoy/bootstrap/config_test.go
@@ -110,7 +110,7 @@ static_resources:
         explicit_http_config:
           http2_protocol_options: {}
   - load_assignment:
-      cluster_name: liveness_cluster
+      cluster_name: my-container_liveness_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -118,10 +118,10 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 81
-    name: liveness_cluster
+    name: my-container_liveness_cluster
     type: STATIC
   - load_assignment:
-      cluster_name: readiness_cluster
+      cluster_name: my-container_readiness_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -129,10 +129,10 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 82
-    name: readiness_cluster
+    name: my-container_readiness_cluster
     type: STATIC
   - load_assignment:
-      cluster_name: startup_cluster
+      cluster_name: my-container_startup_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -140,7 +140,40 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 83
-    name: startup_cluster
+    name: my-container_startup_cluster
+    type: STATIC
+  - load_assignment:
+      cluster_name: my-container-2_liveness_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 84
+    name: my-container-2_liveness_cluster
+    type: STATIC
+  - load_assignment:
+      cluster_name: my-container-2_readiness_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 85
+    name: my-container-2_readiness_cluster
+    type: STATIC
+  - load_assignment:
+      cluster_name: my-container-2_startup_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 86
+    name: my-container-2_startup_cluster
     type: STATIC
   listeners:
   - address:
@@ -189,9 +222,15 @@ static_resources:
               name: local_service
               routes:
               - match:
-                  prefix: /osm-liveness-probe
+                  prefix: /osm-liveness-probe/my-container
                 route:
-                  cluster: liveness_cluster
+                  cluster: my-container_liveness_cluster
+                  prefix_rewrite: /liveness
+                  timeout: 1s
+              - match:
+                  prefix: /osm-liveness-probe/my-container-2
+                route:
+                  cluster: my-container-2_liveness_cluster
                   prefix_rewrite: /liveness
                   timeout: 1s
           stat_prefix: health_probes_http
@@ -242,9 +281,15 @@ static_resources:
               name: local_service
               routes:
               - match:
-                  prefix: /osm-readiness-probe
+                  prefix: /osm-readiness-probe/my-container
                 route:
-                  cluster: readiness_cluster
+                  cluster: my-container_readiness_cluster
+                  prefix_rewrite: /readiness
+                  timeout: 1s
+              - match:
+                  prefix: /osm-readiness-probe/my-container-2
+                route:
+                  cluster: my-container-2_readiness_cluster
                   prefix_rewrite: /readiness
                   timeout: 1s
           stat_prefix: health_probes_http
@@ -295,9 +340,15 @@ static_resources:
               name: local_service
               routes:
               - match:
-                  prefix: /osm-startup-probe
+                  prefix: /osm-startup-probe/my-container
                 route:
-                  cluster: startup_cluster
+                  cluster: my-container_startup_cluster
+                  prefix_rewrite: /startup
+                  timeout: 1s
+              - match:
+                  prefix: /osm-startup-probe/my-container-2
+                route:
+                  cluster: my-container-2_startup_cluster
                   prefix_rewrite: /startup
                   timeout: 1s
           stat_prefix: health_probes_http

--- a/pkg/envoy/bootstrap/envoy_config_benchmark_test.go
+++ b/pkg/envoy/bootstrap/envoy_config_benchmark_test.go
@@ -25,10 +25,12 @@ func BenchmarkBuildEnvoyBootstrapConfig(b *testing.B) {
 		TLSMaxProtocolVersion: "TLSv1_2",
 		CipherSuites:          []string{"abc", "xyz"},
 		ECDHCurves:            []string{"ABC", "XYZ"},
-		OriginalHealthProbes: models.HealthProbes{
-			Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true},
-			Readiness: &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true},
-			Startup:   &models.HealthProbe{Path: "/startup", Port: 83, IsHTTP: true},
+		OriginalHealthProbes: map[string]models.HealthProbes{
+			"my-container": {
+				Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true},
+				Readiness: &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true},
+				Startup:   &models.HealthProbe{Path: "/startup", Port: 83, IsHTTP: true},
+			},
 		},
 	}
 

--- a/pkg/envoy/bootstrap/envoy_config_health_probes.go
+++ b/pkg/envoy/bootstrap/envoy_config_health_probes.go
@@ -87,12 +87,12 @@ type probeListenerBuilder struct {
 	httpsClusterName  string
 }
 
-func (plb *probeListenerBuilder) AddProbe(containerName, clusterName, newProbePath string, probe *models.HealthProbe, isHTTP bool) {
+func (plb *probeListenerBuilder) AddProbe(containerName, clusterName, newProbePath string, probe *models.HealthProbe) {
 	if probe == nil || probe.IsTCPSocket {
 		return
 	}
 
-	if isHTTP {
+	if probe.IsHTTP {
 		plb.virtualHostRoutes = append(plb.virtualHostRoutes, probeListenerRoute{
 			pathPrefixMatch:   fmt.Sprintf("%s/%s", newProbePath, containerName),
 			clusterName:       clusterName,

--- a/pkg/envoy/bootstrap/envoy_config_health_probes.go
+++ b/pkg/envoy/bootstrap/envoy_config_health_probes.go
@@ -33,21 +33,21 @@ const (
 	startupListener   = "startup_listener"
 )
 
-func getLivenessCluster(clusterName string, originalProbe *models.HealthProbe) *xds_cluster.Cluster {
+func buildLivenessCluster(clusterName string, originalProbe *models.HealthProbe) *xds_cluster.Cluster {
 	if originalProbe == nil {
 		return nil
 	}
 	return getProbeCluster(clusterName, originalProbe.Port)
 }
 
-func getReadinessCluster(clusterName string, originalProbe *models.HealthProbe) *xds_cluster.Cluster {
+func buildReadinessCluster(clusterName string, originalProbe *models.HealthProbe) *xds_cluster.Cluster {
 	if originalProbe == nil {
 		return nil
 	}
 	return getProbeCluster(clusterName, originalProbe.Port)
 }
 
-func getStartupCluster(clusterName string, originalProbe *models.HealthProbe) *xds_cluster.Cluster {
+func buildStartupCluster(clusterName string, originalProbe *models.HealthProbe) *xds_cluster.Cluster {
 	if originalProbe == nil {
 		return nil
 	}
@@ -105,7 +105,8 @@ type probeListenerBuilder struct {
 }
 
 func (plb *probeListenerBuilder) Build() (*xds_listener.Listener, error) {
-	if plb.listenerName == "" || (plb.isHTTP && len(plb.virtualHostRoutes) == 0) {
+	// listenerName should be populated and one of (httpsClusterName, []virtualHostRoutes) should be set
+	if plb.listenerName == "" || (plb.httpsClusterName == "" && len(plb.virtualHostRoutes) == 0) {
 		return nil, nil
 	}
 

--- a/pkg/envoy/bootstrap/envoy_config_health_probes_test.go
+++ b/pkg/envoy/bootstrap/envoy_config_health_probes_test.go
@@ -66,9 +66,9 @@ var _ = ginkgo.Describe("Test functions creating Envoy config and rewriting the 
 			return getVirtualHost(allRoutes)
 		},
 		"getProbeCluster":     func() protoreflect.ProtoMessage { return getProbeCluster("cluster-name", 12341234) },
-		"getLivenessCluster":  func() protoreflect.ProtoMessage { return getLivenessCluster("my-container", liveness) },
-		"getReadinessCluster": func() protoreflect.ProtoMessage { return getReadinessCluster("my-container", readiness) },
-		"getStartupCluster":   func() protoreflect.ProtoMessage { return getStartupCluster("my-container", startup) },
+		"getLivenessCluster":  func() protoreflect.ProtoMessage { return buildLivenessCluster("my-container", liveness) },
+		"getReadinessCluster": func() protoreflect.ProtoMessage { return buildReadinessCluster("my-container", readiness) },
+		"getStartupCluster":   func() protoreflect.ProtoMessage { return buildStartupCluster("my-container", startup) },
 	}
 
 	listenerFunctionsToTest := map[string]func() (protoreflect.ProtoMessage, error){
@@ -110,7 +110,7 @@ func TestGetProbeCluster(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				assert.Equal(t, test.expected, getLivenessCluster(test.conainerName, test.probe))
+				assert.Equal(t, test.expected, buildLivenessCluster(test.conainerName, test.probe))
 			})
 		}
 	})
@@ -123,7 +123,7 @@ func TestGetProbeCluster(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				assert.Equal(t, test.expected, getReadinessCluster(test.conainerName, test.probe))
+				assert.Equal(t, test.expected, buildReadinessCluster(test.conainerName, test.probe))
 			})
 		}
 	})
@@ -136,7 +136,7 @@ func TestGetProbeCluster(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				assert.Equal(t, test.expected, getStartupCluster(test.conainerName, test.probe))
+				assert.Equal(t, test.expected, buildStartupCluster(test.conainerName, test.probe))
 			})
 		}
 	})

--- a/pkg/envoy/bootstrap/envoy_config_health_probes_test.go
+++ b/pkg/envoy/bootstrap/envoy_config_health_probes_test.go
@@ -14,15 +14,16 @@ import (
 	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/onsi/ginkgo"
-	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/envoy"
-	"github.com/openservicemesh/osm/pkg/envoy/bootstrap/test"
-	"github.com/openservicemesh/osm/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
+	"github.com/openservicemesh/osm/pkg/envoy/bootstrap/test"
+	"github.com/openservicemesh/osm/pkg/models"
 )
 
 var _ = ginkgo.Describe("Test functions creating Envoy config and rewriting the Pod's health probes to pass through Envoy", func() {
@@ -464,9 +465,9 @@ func Test_probeListenerBuilder_Build(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
-			} else {
-				assert.NoError(t, err)
 			}
+
+			assert.NoError(t, err)
 
 			wantJSON, err := marshalOptions.Marshal(tt.want)
 			if err != nil {

--- a/pkg/envoy/bootstrap/envoy_config_health_probes_test.go
+++ b/pkg/envoy/bootstrap/envoy_config_health_probes_test.go
@@ -1,51 +1,78 @@
 package bootstrap
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
+	xds_accesslog_filter "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	xds_cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	xds_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	xds_listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	xds_route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	xds_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	xds_tcp_proxy "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/onsi/ginkgo"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/reflect/protoreflect"
-
+	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/envoy"
 	"github.com/openservicemesh/osm/pkg/envoy/bootstrap/test"
 	"github.com/openservicemesh/osm/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 var _ = ginkgo.Describe("Test functions creating Envoy config and rewriting the Pod's health probes to pass through Envoy", func() {
 
 	timeout := 42 * time.Second
 	liveness := &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true, IsTCPSocket: false, Timeout: timeout}
-	livenessNonHTTP := &models.HealthProbe{Port: 81, IsHTTP: false, IsTCPSocket: false, Timeout: timeout}
 	readiness := &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true, IsTCPSocket: false, Timeout: timeout}
 	startup := &models.HealthProbe{Path: "/startup", Port: 83, IsHTTP: true, IsTCPSocket: false, Timeout: timeout}
 
+	var routes []probeListenerRoute
+	var defaultTimeoutRoutes []probeListenerRoute
+	routes = append(routes, probeListenerRoute{
+		pathPrefixRewrite: "/original/probe/path",
+		clusterName:       "-cluster-name-",
+		pathPrefixMatch:   "/some/path",
+		timeout:           timeout,
+	})
+
+	defaultTimeoutRoutes = append(routes, probeListenerRoute{
+		pathPrefixRewrite: "/original/probe/path",
+		clusterName:       "-cluster-name-2-",
+		pathPrefixMatch:   "/some/path2",
+		timeout:           0 * time.Second,
+	})
+
+	var allRoutes []probeListenerRoute
+	allRoutes = append(allRoutes, routes...)
+	allRoutes = append(allRoutes, defaultTimeoutRoutes...)
 	// Listed below are the functions we are going to test.
 	// The key in the map is the name of the function -- must match what's in the value of the map.
 	// The key (function name) is used to locate and load the YAML file with the expected return for this function.
 	clusterFunctionsToTest := map[string]func() protoreflect.ProtoMessage{
 		"getVirtualHosts": func() protoreflect.ProtoMessage {
-			return getVirtualHost("/some/path", "-cluster-name-", "/original/probe/path", timeout)
+			return getVirtualHost(routes)
 		},
 		"getVirtualHostsDefault": func() protoreflect.ProtoMessage {
-			return getVirtualHost("/some/path", "-cluster-name-", "/original/probe/path", 0*time.Second)
+			return getVirtualHost(defaultTimeoutRoutes)
+		},
+		"getVirtualHostsMultiple": func() protoreflect.ProtoMessage {
+			return getVirtualHost(allRoutes)
 		},
 		"getProbeCluster":     func() protoreflect.ProtoMessage { return getProbeCluster("cluster-name", 12341234) },
-		"getLivenessCluster":  func() protoreflect.ProtoMessage { return getLivenessCluster(liveness) },
-		"getReadinessCluster": func() protoreflect.ProtoMessage { return getReadinessCluster(readiness) },
-		"getStartupCluster":   func() protoreflect.ProtoMessage { return getStartupCluster(startup) },
+		"getLivenessCluster":  func() protoreflect.ProtoMessage { return getLivenessCluster("my-container", liveness) },
+		"getReadinessCluster": func() protoreflect.ProtoMessage { return getReadinessCluster("my-container", readiness) },
+		"getStartupCluster":   func() protoreflect.ProtoMessage { return getStartupCluster("my-container", startup) },
 	}
 
 	listenerFunctionsToTest := map[string]func() (protoreflect.ProtoMessage, error){
-		"getHTTPAccessLog":           func() (protoreflect.ProtoMessage, error) { return getHTTPAccessLog() },
-		"getTCPAccessLog":            func() (protoreflect.ProtoMessage, error) { return getTCPAccessLog() },
-		"getProbeListener":           func() (protoreflect.ProtoMessage, error) { return getProbeListener("a", "b", "c", 9, liveness) },
-		"getLivenessListener":        func() (protoreflect.ProtoMessage, error) { return getLivenessListener(liveness) },
-		"getLivenessListenerNonHTTP": func() (protoreflect.ProtoMessage, error) { return getLivenessListener(livenessNonHTTP) },
-		"getReadinessListener":       func() (protoreflect.ProtoMessage, error) { return getReadinessListener(readiness) },
-		"getStartupListener":         func() (protoreflect.ProtoMessage, error) { return getStartupListener(startup) },
+		"getHTTPAccessLog": func() (protoreflect.ProtoMessage, error) { return getHTTPAccessLog() },
+		"getTCPAccessLog":  func() (protoreflect.ProtoMessage, error) { return getTCPAccessLog() },
 	}
 
 	for fnName, fn := range clusterFunctionsToTest {
@@ -68,9 +95,10 @@ var _ = ginkgo.Describe("Test functions creating Envoy config and rewriting the 
 
 func TestGetProbeCluster(t *testing.T) {
 	type probeClusterTest struct {
-		name     string
-		probe    *models.HealthProbe
-		expected *xds_cluster.Cluster
+		conainerName string
+		name         string
+		probe        *models.HealthProbe
+		expected     *xds_cluster.Cluster
 	}
 
 	t.Run("liveness", func(t *testing.T) {
@@ -81,7 +109,7 @@ func TestGetProbeCluster(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				assert.Equal(t, test.expected, getLivenessCluster(test.probe))
+				assert.Equal(t, test.expected, getLivenessCluster(test.conainerName, test.probe))
 			})
 		}
 	})
@@ -94,7 +122,7 @@ func TestGetProbeCluster(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				assert.Equal(t, test.expected, getReadinessCluster(test.probe))
+				assert.Equal(t, test.expected, getReadinessCluster(test.conainerName, test.probe))
 			})
 		}
 	})
@@ -107,62 +135,333 @@ func TestGetProbeCluster(t *testing.T) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				assert.Equal(t, test.expected, getStartupCluster(test.probe))
+				assert.Equal(t, test.expected, getStartupCluster(test.conainerName, test.probe))
 			})
 		}
 	})
 }
 
-func TestGetProbeListener(t *testing.T) {
-	type probeListenerTest struct {
-		name     string
-		probe    *models.HealthProbe
-		expected *xds_listener.Listener
-		err      error
+func Test_probeListenerBuilder_Build(t *testing.T) {
+	timeout := 42 * time.Second
+	liveness := &models.HealthProbe{Path: "/liveness", Port: 81, IsHTTP: true, IsTCPSocket: false, Timeout: timeout}
+	readiness := &models.HealthProbe{Path: "/readiness", Port: 82, IsHTTP: true, IsTCPSocket: false, Timeout: timeout}
+	httpAccessLog, err := getHTTPAccessLog()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	t.Run("liveness", func(t *testing.T) {
-		tests := []probeListenerTest{
-			{
-				name: "nil",
-			},
-		}
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				actual, err := getLivenessListener(test.probe)
-				assert.Equal(t, test.expected, actual)
-				assert.Equal(t, test.err, err)
-			})
-		}
-	})
+	tcpAccessLog, err := getTCPAccessLog()
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	t.Run("readiness", func(t *testing.T) {
-		tests := []probeListenerTest{
-			{
-				name: "nil",
+	testLivenessListenerHTTPConnManager := &xds_http_connection_manager.HttpConnectionManager{
+		CodecType:  xds_http_connection_manager.HttpConnectionManager_AUTO,
+		StatPrefix: "health_probes_http",
+		AccessLog: []*xds_accesslog_filter.AccessLog{
+			httpAccessLog,
+		},
+		RouteSpecifier: &xds_http_connection_manager.HttpConnectionManager_RouteConfig{
+			RouteConfig: &xds_route.RouteConfiguration{
+				Name: "local_route",
+				VirtualHosts: []*xds_route.VirtualHost{
+					{
+						Name: "local_service",
+						Domains: []string{
+							"*",
+						},
+						Routes: []*xds_route.Route{
+							{
+								Match: &xds_route.RouteMatch{
+									PathSpecifier: &xds_route.RouteMatch_Prefix{
+										Prefix: "/osm-liveness-probe/my-container",
+									},
+								},
+								Action: &xds_route.Route_Route{
+									Route: &xds_route.RouteAction{
+										ClusterSpecifier: &xds_route.RouteAction_Cluster{
+											Cluster: "my-container_liveness_cluster",
+										},
+										PrefixRewrite: "/liveness",
+										Timeout:       durationpb.New(timeout),
+									},
+								},
+							},
+						},
+					},
+				},
 			},
-		}
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				actual, err := getReadinessListener(test.probe)
-				assert.Equal(t, test.expected, actual)
-				assert.Equal(t, test.err, err)
-			})
-		}
-	})
+		},
+		HttpFilters: []*xds_http_connection_manager.HttpFilter{
+			{
+				Name: envoy.HTTPRouterFilterName,
+				ConfigType: &xds_http_connection_manager.HttpFilter_TypedConfig{
+					TypedConfig: &any.Any{
+						TypeUrl: envoy.HTTPRouterFilterTypeURL,
+					},
+				},
+			},
+		},
+	}
 
-	t.Run("startup", func(t *testing.T) {
-		tests := []probeListenerTest{
-			{
-				name: "nil",
+	pbHTTPConnectionManager, err := anypb.New(testLivenessListenerHTTPConnManager)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testLivenessListener := &xds_listener.Listener{
+		Name: "liveness_listener",
+		Address: &xds_core.Address{
+			Address: &xds_core.Address_SocketAddress{
+				SocketAddress: &xds_core.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &xds_core.SocketAddress_PortValue{
+						PortValue: 15901,
+					},
+				},
 			},
-		}
-		for _, test := range tests {
-			t.Run(test.name, func(t *testing.T) {
-				actual, err := getStartupListener(test.probe)
-				assert.Equal(t, test.expected, actual)
-				assert.Equal(t, test.err, err)
-			})
-		}
-	})
+		},
+		FilterChains: []*xds_listener.FilterChain{
+			{
+				Filters: []*xds_listener.Filter{
+					{
+						Name: envoy.HTTPConnectionManagerFilterName,
+						ConfigType: &xds_listener.Filter_TypedConfig{
+							TypedConfig: pbHTTPConnectionManager,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testReadinessListenerHTTPConnManager := &xds_http_connection_manager.HttpConnectionManager{
+		CodecType:  xds_http_connection_manager.HttpConnectionManager_AUTO,
+		StatPrefix: "health_probes_http",
+		AccessLog: []*xds_accesslog_filter.AccessLog{
+			httpAccessLog,
+		},
+		RouteSpecifier: &xds_http_connection_manager.HttpConnectionManager_RouteConfig{
+			RouteConfig: &xds_route.RouteConfiguration{
+				Name: "local_route",
+				VirtualHosts: []*xds_route.VirtualHost{
+					{
+						Name: "local_service",
+						Domains: []string{
+							"*",
+						},
+						Routes: []*xds_route.Route{
+							{
+								Match: &xds_route.RouteMatch{
+									PathSpecifier: &xds_route.RouteMatch_Prefix{
+										Prefix: "/osm-readiness-probe/my-container",
+									},
+								},
+								Action: &xds_route.Route_Route{
+									Route: &xds_route.RouteAction{
+										ClusterSpecifier: &xds_route.RouteAction_Cluster{
+											Cluster: "my-container_readiness_cluster",
+										},
+										PrefixRewrite: "/readiness",
+										Timeout:       durationpb.New(timeout),
+									},
+								},
+							},
+							{
+								Match: &xds_route.RouteMatch{
+									PathSpecifier: &xds_route.RouteMatch_Prefix{
+										Prefix: "/osm-readiness-probe/my-sidecar",
+									},
+								},
+								Action: &xds_route.Route_Route{
+									Route: &xds_route.RouteAction{
+										ClusterSpecifier: &xds_route.RouteAction_Cluster{
+											Cluster: "my-sidecar_readiness_cluster",
+										},
+										PrefixRewrite: "/readiness",
+										Timeout:       durationpb.New(1 * time.Second),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		HttpFilters: []*xds_http_connection_manager.HttpFilter{
+			{
+				Name: envoy.HTTPRouterFilterName,
+				ConfigType: &xds_http_connection_manager.HttpFilter_TypedConfig{
+					TypedConfig: &any.Any{
+						TypeUrl: envoy.HTTPRouterFilterTypeURL,
+					},
+				},
+			},
+		},
+	}
+
+	pbHTTPConnectionManagerReadiness, err := anypb.New(testReadinessListenerHTTPConnManager)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testReadinessListener := &xds_listener.Listener{
+		Name: "readiness_listener",
+		Address: &xds_core.Address{
+			Address: &xds_core.Address_SocketAddress{
+				SocketAddress: &xds_core.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &xds_core.SocketAddress_PortValue{
+						PortValue: 15901,
+					},
+				},
+			},
+		},
+		FilterChains: []*xds_listener.FilterChain{
+			{
+				Filters: []*xds_listener.Filter{
+					{
+						Name: envoy.HTTPConnectionManagerFilterName,
+						ConfigType: &xds_listener.Filter_TypedConfig{
+							TypedConfig: pbHTTPConnectionManagerReadiness,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	httpsProbeTCPProxy := &xds_tcp_proxy.TcpProxy{
+		StatPrefix: "health_probes",
+		AccessLog: []*xds_accesslog_filter.AccessLog{
+			tcpAccessLog,
+		},
+		ClusterSpecifier: &xds_tcp_proxy.TcpProxy_Cluster{
+			Cluster: "my-sidecar_startup_cluster",
+		},
+	}
+	pbTCPProxy, err := anypb.New(httpsProbeTCPProxy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	httpsListener := &xds_listener.Listener{
+		Name: "startup_listener",
+		Address: &xds_core.Address{
+			Address: &xds_core.Address_SocketAddress{
+				SocketAddress: &xds_core.SocketAddress{
+					Address: "0.0.0.0",
+					PortSpecifier: &xds_core.SocketAddress_PortValue{
+						PortValue: 15903,
+					},
+				},
+			},
+		},
+		FilterChains: []*xds_listener.FilterChain{
+			{
+				Filters: []*xds_listener.Filter{
+					{
+						Name: envoy.TCPProxyFilterName,
+						ConfigType: &xds_listener.Filter_TypedConfig{
+							TypedConfig: pbTCPProxy,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	type fields struct {
+		listenerName      string
+		inboundPort       int32
+		virtualHostRoutes []probeListenerRoute
+		isHTTP            bool
+		httpsClusterName  string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *xds_listener.Listener
+		wantErr string
+	}{
+		{
+			name: "livenessListener",
+			fields: fields{
+				listenerName: livenessListener,
+				inboundPort:  constants.LivenessProbePort,
+				isHTTP:       true,
+				virtualHostRoutes: []probeListenerRoute{
+					{
+						clusterName:       fmt.Sprintf("my-container_%s", livenessCluster),
+						pathPrefixMatch:   fmt.Sprintf("%s/my-container", constants.LivenessProbePath),
+						pathPrefixRewrite: liveness.Path,
+						timeout:           timeout,
+					},
+				},
+			},
+			want: testLivenessListener,
+		},
+		{
+			name: "readinessListener (multiple routes, default timeout)",
+			fields: fields{
+				listenerName: readinessListener,
+				inboundPort:  constants.ReadinessProbePort,
+				isHTTP:       true,
+				virtualHostRoutes: []probeListenerRoute{
+					{
+						clusterName:       fmt.Sprintf("my-container_%s", readinessCluster),
+						pathPrefixMatch:   fmt.Sprintf("%s/my-container", constants.ReadinessProbePath),
+						pathPrefixRewrite: readiness.Path,
+						timeout:           timeout,
+					},
+					{
+						clusterName:       fmt.Sprintf("my-extra-sidecar-container_%s", readinessCluster),
+						pathPrefixMatch:   fmt.Sprintf("%s/my-extra-sidecar-container", constants.ReadinessProbePath),
+						pathPrefixRewrite: readiness.Path,
+						timeout:           0 * time.Second, // Build() should change 0s to 1s
+					},
+				},
+			},
+			want: testReadinessListener,
+		},
+
+		{
+			name: "HTTPS probe",
+			fields: fields{
+				listenerName:     "error",
+				httpsClusterName: fmt.Sprintf("my-sidecar_%s", startupCluster),
+			},
+			want: httpsListener,
+		},
+		{
+			name: "no virtualHosts (should return nil and no error)",
+			fields: fields{
+				listenerName: "my-listener",
+			},
+		},
+		{
+			name: "no listener name (should return nil and no error)",
+			fields: fields{
+				virtualHostRoutes: []probeListenerRoute{
+					{},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plb := &probeListenerBuilder{
+				listenerName:      tt.fields.listenerName,
+				inboundPort:       tt.fields.inboundPort,
+				virtualHostRoutes: tt.fields.virtualHostRoutes,
+				isHTTP:            tt.fields.isHTTP,
+			}
+			got, err := plb.Build()
+			if err.Error() != tt.wantErr {
+				t.Errorf("probeListenerBuilder.Build() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("probeListenerBuilder.Build() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/envoy/bootstrap/types.go
+++ b/pkg/envoy/bootstrap/types.go
@@ -28,5 +28,6 @@ type Builder struct {
 	// ECDHCurves is the list of ECDH curves it supports
 	ECDHCurves []string
 
-	OriginalHealthProbes models.HealthProbes
+	// A map of container -> health probe structs
+	OriginalHealthProbes map[string]models.HealthProbes
 }

--- a/pkg/injector/bootstrap.go
+++ b/pkg/injector/bootstrap.go
@@ -36,7 +36,7 @@ func (wh *mutatingWebhook) createEnvoyBootstrapFromExisting(proxyUUID uuid.UUID,
 	return wh.marshalAndSaveBootstrap(bootstrapConfigName(proxyUUID), namespace, config, cert)
 }
 
-func (wh *mutatingWebhook) createEnvoyBootstrapConfig(proxyUUID uuid.UUID, namespace string, cert *certificate.Certificate, originalHealthProbes models.HealthProbes) (*corev1.Secret, error) {
+func (wh *mutatingWebhook) createEnvoyBootstrapConfig(proxyUUID uuid.UUID, namespace string, cert *certificate.Certificate, originalHealthProbes map[string]models.HealthProbes) (*corev1.Secret, error) {
 	builder := bootstrap.Builder{
 		NodeID: proxyUUID.String(),
 

--- a/pkg/injector/bootstrap_test.go
+++ b/pkg/injector/bootstrap_test.go
@@ -65,10 +65,17 @@ var _ = Describe("Test functions creating Envoy bootstrap configuration", func()
 		},
 	}
 
-	originalHealthProbes := models.HealthProbes{
-		Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81},
-		Readiness: &models.HealthProbe{Path: "/readiness", Port: 82},
-		Startup:   &models.HealthProbe{Path: "/startup", Port: 83},
+	originalHealthProbes := map[string]models.HealthProbes{
+		"my-container": {
+			Liveness:  &models.HealthProbe{Path: "/liveness", Port: 81},
+			Readiness: &models.HealthProbe{Path: "/readiness", Port: 82},
+			Startup:   &models.HealthProbe{Path: "/startup", Port: 83},
+		},
+		"my-sidecar": {
+			Liveness:  &models.HealthProbe{Path: "/liveness", Port: 84},
+			Readiness: &models.HealthProbe{Path: "/readiness", Port: 85},
+			Startup:   &models.HealthProbe{Path: "/startup", Port: 86},
+		},
 	}
 
 	expectedRewrittenContainerPorts := []corev1.ContainerPort{

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -122,7 +122,15 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 		return nil, err
 	}
 
-	if originalHealthProbes.UsesTCP() {
+	var usesTCP bool
+	for _, probes := range originalHealthProbes {
+		if probes.UsesTCP() {
+			usesTCP = true
+			break
+		}
+	}
+
+	if usesTCP {
 		healthcheckContainer := corev1.Container{
 			Name:            "osm-healthcheck",
 			Image:           os.Getenv("OSM_DEFAULT_HEALTHCHECK_CONTAINER_IMAGE"),

--- a/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
+++ b/pkg/injector/test_fixtures/expected_envoy_bootstrap_config.yaml
@@ -60,7 +60,7 @@ static_resources:
         explicit_http_config:
           http2_protocol_options: {}
   - load_assignment:
-      cluster_name: liveness_cluster
+      cluster_name: my-container_liveness_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -68,10 +68,10 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 81
-    name: liveness_cluster
+    name: my-container_liveness_cluster
     type: STATIC
   - load_assignment:
-      cluster_name: readiness_cluster
+      cluster_name: my-container_readiness_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -79,10 +79,10 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 82
-    name: readiness_cluster
+    name: my-container_readiness_cluster
     type: STATIC
   - load_assignment:
-      cluster_name: startup_cluster
+      cluster_name: my-container_startup_cluster
       endpoints:
       - lb_endpoints:
         - endpoint:
@@ -90,7 +90,40 @@ static_resources:
               socket_address:
                 address: 127.0.0.1
                 port_value: 83
-    name: startup_cluster
+    name: my-container_startup_cluster
+    type: STATIC
+- load_assignment:
+      cluster_name: my-sidecar_liveness_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 84
+    name: my-sidecar_liveness_cluster
+    type: STATIC
+  - load_assignment:
+      cluster_name: my-sidecar_readiness_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 85
+    name: my-sidecar_readiness_cluster
+    type: STATIC
+  - load_assignment:
+      cluster_name: my-sidecar_startup_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 86
+    name: my-sidecar_startup_cluster
     type: STATIC
   listeners:
   - address:
@@ -139,9 +172,15 @@ static_resources:
               name: local_service
               routes:
               - match:
-                  prefix: /osm-liveness-probe
+                  prefix: /osm-liveness-probe/my-container
                 route:
-                  cluster: liveness_cluster
+                  cluster: my-container_liveness_cluster
+                  prefix_rewrite: /liveness
+                  timeout: 1s
+              - match:
+                  prefix: /osm-liveness-probe/my-sidecar
+                route:
+                  cluster: my-sidecar_liveness_cluster
                   prefix_rewrite: /liveness
                   timeout: 1s
           stat_prefix: health_probes_http
@@ -192,9 +231,15 @@ static_resources:
               name: local_service
               routes:
               - match:
-                  prefix: /osm-readiness-probe
+                  prefix: /osm-readiness-probe/my-container
                 route:
-                  cluster: readiness_cluster
+                  cluster: my-container_readiness_cluster
+                  prefix_rewrite: /readiness
+                  timeout: 1s
+              - match:
+                  prefix: /osm-readiness-probe/my-sidecar
+                route:
+                  cluster: my-sidecar_readiness_cluster
                   prefix_rewrite: /readiness
                   timeout: 1s
           stat_prefix: health_probes_http
@@ -245,9 +290,15 @@ static_resources:
               name: local_service
               routes:
               - match:
-                  prefix: /osm-startup-probe
+                  prefix: /osm-startup-probe/my-container
                 route:
-                  cluster: startup_cluster
+                  cluster: my-container_startup_cluster
+                  prefix_rewrite: /startup
+                  timeout: 1s
+              - match:
+                  prefix: /osm-startup-probe/my-sidecar
+                route:
+                  cluster: my-sidecar_startup_cluster
                   prefix_rewrite: /startup
                   timeout: 1s
           stat_prefix: health_probes_http

--- a/pkg/models/healthprobe.go
+++ b/pkg/models/healthprobe.go
@@ -10,7 +10,8 @@ type HealthProbe struct {
 	Timeout time.Duration
 
 	// isHTTP corresponds to an httpGet probe with a scheme of HTTP or undefined.
-	// This helps inform what kind of Envoy config to add to the pod.
+	// This helps inform what kind of Envoy config to add to the pod. A HealthProbe
+	// that is neither HTTP nor TCPSocket is assumed to be HTTPS
 	IsHTTP bool
 
 	// isTCPSocket indicates if the probe defines a TCPSocketAction.

--- a/tests/envoy_xds_expectations/expected_output_getLivenessCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessCluster.yaml
@@ -1,5 +1,5 @@
 load_assignment:
-  cluster_name: liveness_cluster
+  cluster_name: my-container_liveness_cluster
   endpoints:
   - lb_endpoints:
     - endpoint:
@@ -7,5 +7,5 @@ load_assignment:
           socket_address:
             address: 127.0.0.1
             port_value: 81
-name: liveness_cluster
+name: my-container_liveness_cluster
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListener.yaml
@@ -44,9 +44,9 @@ filter_chains:
           name: local_service
           routes:
           - match:
-              prefix: /osm-liveness-probe
+              prefix: /osm-liveness-probe/my-cluster
             route:
-              cluster: liveness_cluster
+              cluster: my-container_liveness_cluster
               prefix_rewrite: /liveness
               timeout: 42s
       stat_prefix: health_probes_http

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
@@ -22,5 +22,5 @@ filter_chains:
               upstream_cluster: '%UPSTREAM_CLUSTER%'
               upstream_host: '%UPSTREAM_HOST%'
       cluster: my-container_liveness_cluster
-      stat_prefix: health_probes
+      stat_prefix: health_probes_https
 name: liveness_listener

--- a/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getLivenessListenerNonHTTP.yaml
@@ -21,6 +21,6 @@ filter_chains:
               start_time: '%START_TIME%'
               upstream_cluster: '%UPSTREAM_CLUSTER%'
               upstream_host: '%UPSTREAM_HOST%'
-      cluster: liveness_cluster
+      cluster: my-container_liveness_cluster
       stat_prefix: health_probes
 name: liveness_listener

--- a/tests/envoy_xds_expectations/expected_output_getReadinessCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessCluster.yaml
@@ -1,5 +1,5 @@
 load_assignment:
-  cluster_name: readiness_cluster
+  cluster_name: my-container_readiness_cluster
   endpoints:
   - lb_endpoints:
     - endpoint:
@@ -7,5 +7,5 @@ load_assignment:
           socket_address:
             address: 127.0.0.1
             port_value: 82
-name: readiness_cluster
+name: my-container_readiness_cluster
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getReadinessListener.yaml
@@ -44,9 +44,9 @@ filter_chains:
           name: local_service
           routes:
           - match:
-              prefix: /osm-readiness-probe
+              prefix: /osm-readiness-probe/my-container
             route:
-              cluster: readiness_cluster
+              cluster: my-container/readiness_cluster
               prefix_rewrite: /readiness
               timeout: 42s
       stat_prefix: health_probes_http

--- a/tests/envoy_xds_expectations/expected_output_getStartupCluster.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupCluster.yaml
@@ -1,5 +1,5 @@
 load_assignment:
-  cluster_name: startup_cluster
+  cluster_name: my-container_startup_cluster
   endpoints:
   - lb_endpoints:
     - endpoint:
@@ -7,5 +7,5 @@ load_assignment:
           socket_address:
             address: 127.0.0.1
             port_value: 83
-name: startup_cluster
+name: my-container_startup_cluster
 type: STATIC

--- a/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getStartupListener.yaml
@@ -44,9 +44,9 @@ filter_chains:
           name: local_service
           routes:
           - match:
-              prefix: /osm-startup-probe
+              prefix: /osm-startup-probe/my-container
             route:
-              cluster: startup_cluster
+              cluster: my-container_startup_cluster
               prefix_rewrite: /startup
               timeout: 42s
       stat_prefix: health_probes_http

--- a/tests/envoy_xds_expectations/expected_output_getVirtualHostsMultiple.yaml
+++ b/tests/envoy_xds_expectations/expected_output_getVirtualHostsMultiple.yaml
@@ -3,6 +3,12 @@ domains:
 name: local_service
 routes:
 - match:
+    prefix: /some/path
+  route:
+    cluster: -cluster-name-
+    prefix_rewrite: /original/probe/path
+    timeout: 42s
+- match:
     prefix: /some/path2
   route:
     cluster: -cluster-name-2-


### PR DESCRIPTION
Create an Envoy cluster per (container, health probe) tuple and inject the container name into the path prefix so that OSM supports health probes from multiple containers

Fixes #4948

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Instead of having a single Envoy cluster for each type of probe (liveness, startup, readiness), we now create an Envoy cluster per container probe. The probe rewrite results in the following containerSpec:
```yaml
- name: nginx
  image: nginx:1.19-alpine
  livenessProbe:
    httpGet:
      path: /osm-liveness-probe/nginx
      port: 15901
      scheme: HTTP
- name: httpbin
  image: kennethreitz/httpbin
  livenessProbe:
    httpGet:
      path: /osm-liveness-probe/httpbin
      port: 15901
      scheme: HTTP
```

The generated Envoy config looks like this:
```json
{
   "clusters":[
      {
         "name":"httpbin_liveness_cluster",
         "type":"STATIC",
         "load_assignment":{
            "cluster_name":"httpbin_liveness_cluster",
            "endpoints":[
               {
                  "lb_endpoints":[
                     {
                        "endpoint":{
                           "address":{
                              "socket_address":{
                                 "address":"127.0.0.1",
                                 "port_value":14001
                              }
                           }
                        }
                     }
                  ]
               }
            ]
         }
      },
      {
         "name":"nginx_liveness_cluster",
         "type":"STATIC",
         "load_assignment":{
            "cluster_name":"nginx_liveness_cluster",
            "endpoints":[
               {
                  "lb_endpoints":[
                     {
                        "endpoint":{
                           "address":{
                              "socket_address":{
                                 "address":"127.0.0.1",
                                 "port_value":80
                              }
                           }
                        }
                     }
                  ]
               }
            ]
         }
      }
   ],
   "listeners":[
      {
         "name":"liveness_listener",
         "address":{
            "socket_address":{
               "address":"0.0.0.0",
               "port_value":15901
            }
         },
         "filter_chains":[
            {
               "filters":[
                  {
                     "name":"envoy.filters.network.http_connection_manager",
                     "typed_config":{
                        "@type":"type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
                        "stat_prefix":"health_probes_http",
                        "route_config":{
                           "name":"local_route",
                           "virtual_hosts":[
                              {
                                 "name":"local_service",
                                 "domains":[
                                    "*"
                                 ],
                                 "routes":[
                                    {
                                       "match":{
                                          "prefix":"/osm-liveness-probe/httpbin"
                                       },
                                       "route":{
                                          "cluster":"httpbin_liveness_cluster",
                                          "prefix_rewrite":"/",
                                          "timeout":"1s"
                                       }
                                    },
                                    {
                                       "match":{
                                          "prefix":"/osm-liveness-probe/nginx"
                                       },
                                       "route":{
                                          "cluster":"nginx_liveness_cluster",
                                          "prefix_rewrite":"/",
                                          "timeout":"1s"
                                       }
                                    }
                                 ]
                              }
                           ]
                        }
                     }
                  }
               ]
            }
         ]
      }
   ]
}
```
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Updated Unit tests
Updated E2E tests
Manual test
<!--

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? N/A

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? not yet