### PR TITLE
Update IssueCertificate Provider Interface to be more easily extended

### DIFF
--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -107,13 +107,13 @@ type fakeIssuer struct {
 }
 
 // IssueCertificate is a testing helper to satisfy the certificate client interface
-func (i *fakeIssuer) IssueCertificate(cn CommonName, validityPeriod time.Duration) (*Certificate, error) {
+func (i *fakeIssuer) IssueCertificate(options IssueOptions) (*Certificate, error) {
 	if i.err {
 		return nil, fmt.Errorf("%s failed", i.id)
 	}
 	return &Certificate{
-		CommonName: cn,
-		Expiration: time.Now().Add(validityPeriod),
+		CommonName: options.CommonName(),
+		Expiration: time.Now().Add(options.ValidityDuration),
 		// simply used to distinguish the private/public key from other issuers
 		IssuingCA:  pem.RootCertificate(i.id),
 		TrustedCAs: pem.RootCertificate(i.id),

--- a/pkg/certificate/options.go
+++ b/pkg/certificate/options.go
@@ -2,26 +2,112 @@ package certificate
 
 import (
 	"fmt"
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/identity"
 )
 
-// IssueOption is an option that can be passed to IssueCertificate.
-type IssueOption func(*issueOptions)
+// IssueOption is an option that can be passed to IssueCertificate on the CertificateManager
+type IssueOption func(*IssueOptions)
 
-type issueOptions struct {
-	fullCNProvided bool
+// IssueOptions is passed to the Certificate Providers when creating certificates
+type IssueOptions struct {
+	fullCNProvided   bool
+	trustDomain      string
+	commonNamePrefix string
+	certType         certType
+	ValidityDuration time.Duration
 }
 
-func (o *issueOptions) formatCN(prefix, trustDomain string) CommonName {
+func (o IssueOptions) cacheKey() string {
+	return o.commonNamePrefix
+}
+
+// CommonName constructs the CommonName for the certificate.
+// If the FullCommonName option is set it will use configured name.
+// Otherwise it uses the name configured and appends the trustdomain
+func (o IssueOptions) CommonName() CommonName {
 	if o.fullCNProvided {
-		return CommonName(prefix)
+		return CommonName(o.commonNamePrefix)
 	}
-	return CommonName(fmt.Sprintf("%s.%s", prefix, trustDomain))
+
+	if o.commonNamePrefix == "" {
+		return CommonName(o.trustDomain)
+	}
+
+	return CommonName(fmt.Sprintf("%s.%s", o.commonNamePrefix, o.trustDomain))
 }
 
-// FullCNProvided tells IssueCertificate that the provided prefix is actually the full trust domain, and not to append
-// the issuer's trust domain.
-func FullCNProvided() IssueOption {
-	return func(opts *issueOptions) {
+func withCommonNamePrefix(prefix string) IssueOption {
+	return func(opts *IssueOptions) {
+		opts.commonNamePrefix = prefix
+	}
+}
+
+func withFullCommonName() IssueOption {
+	return func(opts *IssueOptions) {
 		opts.fullCNProvided = true
 	}
+}
+
+func withCertType(certType certType) IssueOption {
+	return func(opts *IssueOptions) {
+		opts.certType = certType
+	}
+}
+
+// ForServiceIdentity creates a service certificate with the given prefix for the common name
+// The trust domain will be appended to the Common Name
+func ForServiceIdentity(identity identity.ServiceIdentity) IssueOption {
+	return func(opts *IssueOptions) {
+		opts.commonNamePrefix = identity.String()
+		opts.certType = service
+	}
+}
+
+// ForIngressGateway creates a certificate which is given a full common name
+func ForIngressGateway(fullCommonName string) IssueOption {
+	return func(opts *IssueOptions) {
+		opts.commonNamePrefix = fullCommonName
+		opts.fullCNProvided = true
+		opts.certType = ingressGateway
+	}
+}
+
+// ForCommonNamePrefix creates an internal certificate with a prefix for the common name.
+// The trust domain will be appended to the Common Name
+func ForCommonNamePrefix(prefix string) IssueOption {
+	return func(opts *IssueOptions) {
+		opts.commonNamePrefix = prefix
+		opts.certType = internal
+	}
+}
+
+// ForCommonName creates an internal certificate with a given full common name
+func ForCommonName(fullCommonName string) IssueOption {
+	return func(opts *IssueOptions) {
+		opts.commonNamePrefix = fullCommonName
+		opts.certType = internal
+		opts.fullCNProvided = true
+	}
+}
+
+// NewCertOptions creates the IssueOptions for issuing a certificate
+func NewCertOptions(options ...IssueOption) IssueOptions {
+	opts := &IssueOptions{}
+	for _, o := range options {
+		o(opts)
+	}
+
+	return *opts
+}
+
+// NewCertOptionsWithFullName creates the IssueOptions for the issuing a certificate with a given full common name
+func NewCertOptionsWithFullName(fullCommonName string, validity time.Duration) IssueOptions {
+	opts := &IssueOptions{
+		ValidityDuration: validity,
+		fullCNProvided:   true,
+		commonNamePrefix: fullCommonName,
+	}
+	return *opts
 }

--- a/pkg/certificate/options_test.go
+++ b/pkg/certificate/options_test.go
@@ -1,0 +1,89 @@
+package certificate
+
+import (
+	"testing"
+)
+
+func TestIssueOptions_CommonName(t *testing.T) {
+	tests := []struct {
+		name         string
+		trustDomain  string
+		issueOption  []IssueOption
+		want         CommonName
+		wantCertType certType
+	}{
+		{
+			name:         "ForServiceIdentity appends trust domain",
+			trustDomain:  "cluster.local",
+			issueOption:  []IssueOption{ForServiceIdentity("sa.ns")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: service,
+		},
+		{
+			name:         "ForCommonName uses common name passed without appending trust domain",
+			issueOption:  []IssueOption{ForCommonName("sa.ns.cluster.local")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: internal,
+		},
+		{
+			name:         "ForCommonName uses common name passed without appending trust domain when trust domain is present",
+			trustDomain:  "dont.use.com",
+			issueOption:  []IssueOption{ForCommonName("sa.ns.cluster.local")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: internal,
+		},
+		{
+			name:         "ForIngressGateway uses commonname passed without appending trust domain",
+			trustDomain:  "dont.use.com",
+			issueOption:  []IssueOption{ForIngressGateway("sa.ns.cluster.local")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: ingressGateway,
+		},
+		{
+			name:         "ForIngressGateway uses commonname passed without appending trust domain",
+			issueOption:  []IssueOption{ForIngressGateway("sa.ns.cluster.local")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: ingressGateway,
+		},
+		{
+			name:         "ForCommonNamePrefix appends trust domain",
+			trustDomain:  "cluster.local",
+			issueOption:  []IssueOption{ForCommonNamePrefix("sa.ns")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: internal,
+		},
+		{
+			name:         "withCommonNamePrefix appends trust domain",
+			trustDomain:  "cluster.local",
+			issueOption:  []IssueOption{withCommonNamePrefix("sa.ns")},
+			want:         CommonName("sa.ns.cluster.local"),
+			wantCertType: "",
+		},
+		{
+			name:         "withFullCommonName uses name passed",
+			trustDomain:  "cluster.local",
+			issueOption:  []IssueOption{withFullCommonName(), withCommonNamePrefix("sa.ns.example.com")},
+			want:         CommonName("sa.ns.example.com"),
+			wantCertType: "",
+		},
+		{
+			name:         "withCertType uses name passed",
+			issueOption:  []IssueOption{withCertType(service)},
+			want:         CommonName(""),
+			wantCertType: service,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := NewCertOptions(tt.issueOption...)
+			o.trustDomain = tt.trustDomain
+			if got := o.CommonName(); got != tt.want {
+				t.Errorf("IssueOptions.CommonName() = %v, want %v", got, tt.want)
+			}
+
+			if got := o.certType; got != tt.wantCertType {
+				t.Errorf("IssueOptions.certType = %v, want %v", got, tt.wantCertType)
+			}
+		})
+	}
+}

--- a/pkg/certificate/providers/certmanager/certificate_manager.go
+++ b/pkg/certificate/providers/certmanager/certificate_manager.go
@@ -79,24 +79,24 @@ func (cm *CertManager) certificateFromCertificateRequest(cr *cmapi.CertificateRe
 }
 
 // IssueCertificate will request a new signed certificate from the configured cert-manager issuer.
-func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPeriod time.Duration) (*certificate.Certificate, error) {
+func (cm *CertManager) IssueCertificate(options certificate.IssueOptions) (*certificate.Certificate, error) {
 	duration := &metav1.Duration{
-		Duration: validityPeriod,
+		Duration: options.ValidityDuration,
 	}
 
 	certPrivKey, err := rsa.GenerateKey(rand.Reader, cm.keySize)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrGeneratingPrivateKey)).
-			Msgf("Error generating private key for certificate with CN=%s", cn)
-		return nil, fmt.Errorf("failed to generate private key for certificate with CN=%s: %w", cn, err)
+			Msgf("Error generating private key for certificate with CN=%s", options.CommonName())
+		return nil, fmt.Errorf("failed to generate private key for certificate with CN=%s: %w", options.CommonName(), err)
 	}
 
 	privKeyPEM, err := certificate.EncodeKeyDERtoPEM(certPrivKey)
 	if err != nil {
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingKeyDERtoPEM)).
-			Msgf("Error encoding private key for certificate with CN=%s", cn)
+			Msgf("Error encoding private key for certificate with CN=%s", options.CommonName())
 		return nil, err
 	}
 
@@ -105,9 +105,9 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 		SignatureAlgorithm: x509.SHA512WithRSA,
 		PublicKeyAlgorithm: x509.RSA,
 		Subject: pkix.Name{
-			CommonName: cn.String(),
+			CommonName: options.CommonName().String(),
 		},
-		DNSNames: []string{cn.String()},
+		DNSNames: []string{options.CommonName().String()},
 	}
 
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csr, certPrivKey)
@@ -123,7 +123,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 		// TODO(#3962): metric might not be scraped before process restart resulting from this error
 		log.Error().Err(err).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrEncodingCertDERtoPEM)).
 			Msg("error encoding cert request DER to PEM")
-		return nil, fmt.Errorf("failed to encode certificate request DER to PEM CN=%s: %w", cn, err)
+		return nil, fmt.Errorf("failed to encode certificate request DER to PEM CN=%s: %w", options.CommonName(), err)
 	}
 
 	cr := &cmapi.CertificateRequest{
@@ -147,7 +147,7 @@ func (cm *CertManager) IssueCertificate(cn certificate.CommonName, validityPerio
 		return nil, err
 	}
 
-	log.Debug().Msgf("Created CertificateRequest %s/%s for CN=%s", cm.namespace, cr.Name, cn)
+	log.Debug().Msgf("Created CertificateRequest %s/%s for CN=%s", cm.namespace, cr.Name, options.CommonName())
 
 	// TODO: add timeout option instead of 60s hard coded.
 	cr, err = cm.waitForCertificateReady(cr.Name, time.Second*60)

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -34,7 +34,7 @@ const (
 )
 
 var getCA = func(i certificate.Issuer) (pem.RootCertificate, error) {
-	cert, err := i.IssueCertificate("init-cert", 1*time.Second)
+	cert, err := i.IssueCertificate(certificate.NewCertOptionsWithFullName("init-cert", 1*time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/certificate/providers/tresor/certificate_manager_benchmark_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_benchmark_test.go
@@ -15,7 +15,7 @@ func BenchmarkIssueCertificate(b *testing.B) {
 		b.Logf("Failed to set log level to error: %s", err)
 	}
 
-	serviceFQDN := certificate.CommonName("a.b.c")
+	serviceFQDN := "a.b.c"
 	validity := 3 * time.Second
 	cn := certificate.CommonName("Test CA")
 	rootCertCountry := "US"
@@ -39,7 +39,7 @@ func BenchmarkIssueCertificate(b *testing.B) {
 	b.ResetTimer()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		bmCert, _ = m.IssueCertificate(serviceFQDN, validity)
+		bmCert, _ = m.IssueCertificate(certificate.NewCertOptionsWithFullName(serviceFQDN, validity))
 	}
 	b.StopTimer()
 }

--- a/pkg/certificate/providers/tresor/certificate_manager_test.go
+++ b/pkg/certificate/providers/tresor/certificate_manager_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Test Certificate Manager", func() {
 		)
 		It("should issue a certificate", func() {
 			Expect(newCertError).ToNot(HaveOccurred())
-			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)
+			cert, issueCertificateError := m.IssueCertificate(certificate.NewCertOptionsWithFullName(serviceFQDN, validity))
 			Expect(issueCertificateError).ToNot(HaveOccurred())
 			Expect(cert.GetCommonName()).To(Equal(certificate.CommonName(serviceFQDN)))
 
@@ -77,7 +77,7 @@ var _ = Describe("Test Certificate Manager", func() {
 
 		m := &CertManager{}
 		It("should return errNoIssuingCA error", func() {
-			cert, issueCertificateError := m.IssueCertificate(serviceFQDN, validity)
+			cert, issueCertificateError := m.IssueCertificate(certificate.NewCertOptionsWithFullName(serviceFQDN, validity))
 			Expect(cert).To(BeNil())
 			Expect(issueCertificateError).To(Equal(errNoIssuingCA))
 		})

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -114,7 +114,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestIssueCertificate(t *testing.T) {
-	var commonName certificate.CommonName = "localhost"
+	var commonName = "localhost"
 	var validityPeriod = time.Hour
 
 	token, addr := mockVault(t)
@@ -127,7 +127,7 @@ func TestIssueCertificate(t *testing.T) {
 
 	testCases := []struct {
 		description string
-		cn          certificate.CommonName
+		cn          string
 		vP          time.Duration
 		wantErr     bool
 	}{
@@ -139,7 +139,7 @@ func TestIssueCertificate(t *testing.T) {
 		},
 		{
 			description: "error with invalid common name",
-			cn:          certificate.CommonName(" "),
+			cn:          " ",
 			vP:          time.Duration(-1),
 			wantErr:     true,
 		},
@@ -147,7 +147,7 @@ func TestIssueCertificate(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tassert := assert.New(t)
-			_, err = cm.IssueCertificate(tc.cn, tc.vP)
+			_, err = cm.IssueCertificate(certificate.NewCertOptionsWithFullName(tc.cn, tc.vP))
 			if tc.wantErr {
 				tassert.Error(err, "expected error, got nil")
 			} else {

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -41,25 +41,27 @@ func (cn CommonName) String() string {
 	return string(cn)
 }
 
-// CertType is the type of certificate. This is only used by OSM.
-type CertType string
+// certTypeInternal is the type of certificate. This is only used by OSM.
+type certType string
 
 const (
-	// Internal is the CertType representing all certs issued for use by the OSM
+	// internal is the CertType representing all certs issued for use by the OSM
 	// control plane.
-	Internal CertType = "internal"
+	internal certType = "internal"
 
-	// IngressGateway is the CertType for certs issued for use by ingress gateways.
-	IngressGateway CertType = "ingressGateway"
+	// ingressGateway is the CertType for certs issued for use by ingress gateways.
+	ingressGateway certType = "ingressGateway"
 
-	// Service is the CertType for certs issued for use by the data plane.
-	Service CertType = "service"
+	// service is the CertType for certs issued for use by the data plane.
+	service certType = "service"
 )
 
 // Certificate represents an x509 certificate.
 type Certificate struct {
 	// The CommonName of the certificate
 	CommonName CommonName
+
+	cacheKey string
 
 	// The serial number of the certificate
 	SerialNumber SerialNumber
@@ -82,13 +84,13 @@ type Certificate struct {
 	signingIssuerID    string
 	validatingIssuerID string
 
-	certType CertType
+	certType certType
 }
 
 // Issuer is the interface for a certificate authority that can issue certificates from a given root certificate.
 type Issuer interface {
 	// IssueCertificate issues a new certificate.
-	IssueCertificate(CommonName, time.Duration) (*Certificate, error)
+	IssueCertificate(IssueOptions) (*Certificate, error)
 }
 
 type issuer struct {

--- a/pkg/debugger/certificate_test.go
+++ b/pkg/debugger/certificate_test.go
@@ -20,7 +20,7 @@ func TestGetCertHandler(t *testing.T) {
 		certDebugger: tresorFake.NewFake(time.Hour),
 	}
 
-	_, err := ds.certDebugger.IssueCertificate("commonName", certificate.Service)
+	_, err := ds.certDebugger.IssueCertificate(certificate.ForServiceIdentity("commonName"))
 	assert.Nil(err)
 
 	handler := ds.getCertHandler()

--- a/pkg/envoy/ads/grpc.go
+++ b/pkg/envoy/ads/grpc.go
@@ -85,9 +85,7 @@ func (s *GRPCServer) GetServer() *grpc.Server {
 }
 
 func (s *GRPCServer) updateConfig() error {
-	grpcCert, err := s.cm.IssueCertificate(
-		s.certCommonName,
-		certificate.Internal)
+	grpcCert, err := s.cm.IssueCertificate(certificate.ForCommonNamePrefix(s.certCommonName))
 	if err != nil {
 		return err
 	}

--- a/pkg/envoy/ads/response_benchmark_test.go
+++ b/pkg/envoy/ads/response_benchmark_test.go
@@ -95,7 +95,7 @@ func setupTestServer(b *testing.B) {
 	namespace := tests.Namespace
 	proxySvcAccount := tests.BookstoreServiceAccount
 
-	certPEM, _ := certManager.IssueCertificate(proxySvcAccount.ToServiceIdentity().String(), certificate.Service)
+	certPEM, _ := certManager.IssueCertificate(certificate.ForServiceIdentity(proxySvcAccount.ToServiceIdentity()))
 	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 	server, _ = tests.NewFakeXDSServer(cert, nil, nil)
 

--- a/pkg/envoy/sds/response.go
+++ b/pkg/envoy/sds/response.go
@@ -19,7 +19,7 @@ func NewResponse(meshCatalog catalog.MeshCataloger, proxy *envoy.Proxy, certMana
 	builder := NewBuilder().SetProxy(proxy).SetTrustDomain(certManager.GetTrustDomain())
 
 	// 1. Issue a service certificate for this proxy
-	cert, err := certManager.IssueCertificate(proxy.Identity.String(), certificate.Service)
+	cert, err := certManager.IssueCertificate(certificate.ForServiceIdentity(proxy.Identity))
 	if err != nil {
 		log.Error().Err(err).Str("proxy", proxy.String()).Msgf("Error issuing a certificate for proxy")
 		return nil, err

--- a/pkg/ingress/gateway.go
+++ b/pkg/ingress/gateway.go
@@ -128,7 +128,7 @@ func (c *client) handleCertChanges(cn string, secret corev1.SecretReference) fun
 	// must subscribe prior to issuing the cert to guarantee we get all rotations.
 	certRotateChan, unsub := c.certProvider.SubscribeRotations(cn)
 
-	cert, err := c.certProvider.IssueCertificate(cn, certificate.IngressGateway, certificate.FullCNProvided())
+	cert, err := c.certProvider.IssueCertificate(certificate.ForIngressGateway(cn))
 	if err != nil {
 		log.Err(err).Msg("error issuing a certificate for ingress gateway")
 	}

--- a/pkg/injector/patch.go
+++ b/pkg/injector/patch.go
@@ -31,7 +31,7 @@ func (wh *mutatingWebhook) createPatch(pod *corev1.Pod, req *admissionv1.Admissi
 	cnPrefix := envoy.NewXDSCertCNPrefix(proxyUUID, envoy.KindSidecar, identity.New(pod.Spec.ServiceAccountName, namespace))
 	log.Debug().Msgf("Patching POD spec: service-account=%s, namespace=%s with certificate CN prefix=%s", pod.Spec.ServiceAccountName, namespace, cnPrefix)
 	startTime := time.Now()
-	bootstrapCertificate, err := wh.certManager.IssueCertificate(cnPrefix, certificate.Internal)
+	bootstrapCertificate, err := wh.certManager.IssueCertificate(certificate.ForCommonNamePrefix(cnPrefix))
 	if err != nil {
 		log.Error().Err(err).Msgf("Error issuing bootstrap certificate for Envoy with CN prefix=%s", cnPrefix)
 		return nil, err

--- a/pkg/utils/mtls_test.go
+++ b/pkg/utils/mtls_test.go
@@ -30,7 +30,7 @@ func TestValidateClient(t *testing.T) {
 
 	certManager := tresorFake.NewFake(1 * time.Hour)
 	cnPrefix := fmt.Sprintf("%s.%s.%s", uuid.New(), tests.BookstoreServiceAccountName, tests.Namespace)
-	certPEM, _ := certManager.IssueCertificate(cnPrefix, certificate.Internal)
+	certPEM, _ := certManager.IssueCertificate(certificate.ForCommonNamePrefix(cnPrefix))
 	cert, _ := certificate.DecodePEMCertificate(certPEM.GetCertificateChain())
 
 	validateClientTests := []validateClientTest{

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -91,10 +91,7 @@ func (s *Server) setCert() error {
 	// This cert does not have to be related to the Envoy certs, but it does have to match
 	// the cert provisioned.
 	// Kubernetes requires webhooks to have format of 'servicename.namespace.svc' without trust domain
-	webhookCert, err := s.cm.IssueCertificate(
-		s.certCommonName(),
-		certificate.Internal,
-		certificate.FullCNProvided())
+	webhookCert, err := s.cm.IssueCertificate(certificate.ForCommonName(s.certCommonName()))
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -76,10 +76,7 @@ func TestCertRotation(t *testing.T) {
 
 			// create a cert before we start the server
 			// Allows us to test there was a change in certs
-			firstCert, _ := cm.IssueCertificate(
-				"testhook.ns.svc",
-				certificate.Internal,
-				certificate.FullCNProvided())
+			firstCert, _ := cm.IssueCertificate(certificate.ForCommonName("testhook.ns.svc"))
 
 			server := NewServer("testhook", "ns", 6000, cm, nil, onCertChange)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This refactors the IssueCertificate API to use the Options pattern throughout the code base. This does a few things:

- make it possible to add additional information in the Providers IssueCertificate. For instance, we re-use the information to generate a SpiffeID, where as prior we needed guess the trust domain and deconstruct the CN to figure it out
- Simplifies the calls to the Managers IssueCertificate API.  
  - In the case of `prefix` it was sometimes the prefix, sometimes not. In all cases it was the cache key and we can hide that detial further.
  - The `certtype` is internal to manager and will be removed in future when the information is stored on the MRC so this is a step in that direction by only using it in cert package and unexporting it.


fixes: #5095, https://github.com/openservicemesh/osm/issues/5002#issuecomment-1225010079


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
no
2. Is this a breaking change?
no

4. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
no