### PR TITLE
feat(certs): add MRC methods to k8s client

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -193,7 +193,7 @@ func main() {
 		events.GenericEventRecorder().FatalEvent(err, events.InitializationError, "Error creating informer collection")
 	}
 
-	k8sClient := k8s.NewClient(osmNamespace, osmMeshConfigName, informerCollection, policyClient, msgBroker)
+	k8sClient := k8s.NewClient(osmNamespace, osmMeshConfigName, informerCollection, policyClient, configClient, msgBroker)
 
 	meshSpec := smi.NewSMIClient(informerCollection, osmNamespace, k8sClient, msgBroker)
 

--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -198,7 +198,7 @@ func main() {
 	}
 
 	// Initialize kubernetes.Controller to watch kubernetes resources
-	kubeController := k8s.NewClient(osmNamespace, osmMeshConfigName, informerCollection, policyClient, msgBroker, k8s.Namespaces)
+	kubeController := k8s.NewClient(osmNamespace, osmMeshConfigName, informerCollection, policyClient, configClient, msgBroker, k8s.Namespaces)
 
 	certOpts, err := getCertOptions()
 	if err != nil {

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -144,6 +144,20 @@ func (mr *MockMeshCatalogerMockRecorder) GetMeshConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshConfig", reflect.TypeOf((*MockMeshCataloger)(nil).GetMeshConfig))
 }
 
+// GetMeshRootCertificate mocks base method.
+func (m *MockMeshCataloger) GetMeshRootCertificate(arg0 string) *v1alpha2.MeshRootCertificate {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeshRootCertificate", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	return ret0
+}
+
+// GetMeshRootCertificate indicates an expected call of GetMeshRootCertificate.
+func (mr *MockMeshCatalogerMockRecorder) GetMeshRootCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshRootCertificate", reflect.TypeOf((*MockMeshCataloger)(nil).GetMeshRootCertificate), arg0)
+}
+
 // GetMeshService mocks base method.
 func (m *MockMeshCataloger) GetMeshService(arg0, arg1 string, arg2 uint16) (service.MeshService, error) {
 	m.ctrl.T.Helper()
@@ -414,6 +428,21 @@ func (mr *MockMeshCatalogerMockRecorder) ListIngressBackendPolicies() *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIngressBackendPolicies", reflect.TypeOf((*MockMeshCataloger)(nil).ListIngressBackendPolicies))
 }
 
+// ListMeshRootCertificates mocks base method.
+func (m *MockMeshCataloger) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMeshRootCertificates")
+	ret0, _ := ret[0].([]*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMeshRootCertificates indicates an expected call of ListMeshRootCertificates.
+func (mr *MockMeshCatalogerMockRecorder) ListMeshRootCertificates() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMeshRootCertificates", reflect.TypeOf((*MockMeshCataloger)(nil).ListMeshRootCertificates))
+}
+
 // ListNamespaces mocks base method.
 func (m *MockMeshCataloger) ListNamespaces() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -573,6 +602,36 @@ func (m *MockMeshCataloger) UpdateIngressBackendStatus(arg0 *v1alpha1.IngressBac
 func (mr *MockMeshCatalogerMockRecorder) UpdateIngressBackendStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressBackendStatus", reflect.TypeOf((*MockMeshCataloger)(nil).UpdateIngressBackendStatus), arg0)
+}
+
+// UpdateMeshRootCertificate mocks base method.
+func (m *MockMeshCataloger) UpdateMeshRootCertificate(arg0 *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeshRootCertificate", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMeshRootCertificate indicates an expected call of UpdateMeshRootCertificate.
+func (mr *MockMeshCatalogerMockRecorder) UpdateMeshRootCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeshRootCertificate", reflect.TypeOf((*MockMeshCataloger)(nil).UpdateMeshRootCertificate), arg0)
+}
+
+// UpdateMeshRootCertificateStatus mocks base method.
+func (m *MockMeshCataloger) UpdateMeshRootCertificateStatus(arg0 *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeshRootCertificateStatus", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMeshRootCertificateStatus indicates an expected call of UpdateMeshRootCertificateStatus.
+func (mr *MockMeshCatalogerMockRecorder) UpdateMeshRootCertificateStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeshRootCertificateStatus", reflect.TypeOf((*MockMeshCataloger)(nil).UpdateMeshRootCertificateStatus), arg0)
 }
 
 // UpdateUpstreamTrafficSettingStatus mocks base method.

--- a/pkg/compute/kube/client_test.go
+++ b/pkg/compute/kube/client_test.go
@@ -489,7 +489,7 @@ func TestGetServicesForServiceIdentity(t *testing.T) {
 			ic, err := informers.NewInformerCollection("test-mesh", stop, informers.WithKubeClient(testClient))
 			assert.NoError(err)
 			c := &client{
-				kubeController: k8s.NewClient("osm-ns", tests.OsmMeshConfigName, ic, nil, messaging.NewBroker(stop)),
+				kubeController: k8s.NewClient("osm-ns", tests.OsmMeshConfigName, ic, nil, nil, messaging.NewBroker(stop)),
 			}
 			actual := c.GetServicesForServiceIdentity(tc.svcIdentity)
 			assert.ElementsMatch(tc.expected, actual)
@@ -823,7 +823,7 @@ func TestListServicesForProxy(t *testing.T) {
 			ic, err := informers.NewInformerCollection("test-mesh", stop, informers.WithKubeClient(testClient))
 			assert.NoError(err)
 			c := &client{
-				kubeController: k8s.NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, messaging.NewBroker(stop)),
+				kubeController: k8s.NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, nil, messaging.NewBroker(stop)),
 			}
 			actual, err := c.ListServicesForProxy(tc.proxy)
 			assert.ElementsMatch(tc.expected, actual)
@@ -1694,7 +1694,7 @@ func TestGetProxyStatsHeaders(t *testing.T) {
 				informers.WithKubeClient(fakeClient),
 			)
 			assert.NoError(err)
-			controller := k8s.NewClient("ns", "", informer, nil, messaging.NewBroker(stop))
+			controller := k8s.NewClient("ns", "", informer, nil, nil, messaging.NewBroker(stop))
 			c := NewClient(controller)
 			actual, err := c.GetProxyStatsHeaders(test.proxy)
 			if test.expectErr {
@@ -2287,7 +2287,7 @@ func TestK8sServicesToMeshServices(t *testing.T) {
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(fakeClient))
 			assert.Nil(err)
 
-			kubecontroller := k8s.NewClient("", "", ic, nil, messaging.NewBroker(make(<-chan struct{})))
+			kubecontroller := k8s.NewClient("", "", ic, nil, nil, messaging.NewBroker(make(<-chan struct{})))
 
 			c := NewClient(kubecontroller)
 
@@ -2424,7 +2424,7 @@ func TestGetMeshService(t *testing.T) {
 			_ = ic.Add(informers.InformerKeyService, tc.svc, t)
 			_ = ic.Add(informers.InformerKeyEndpoints, tc.endpoints, t)
 
-			controller := k8s.NewClient(osmNamespace, "", ic, nil, messaging.NewBroker(make(chan struct{})))
+			controller := k8s.NewClient(osmNamespace, "", ic, nil, nil, messaging.NewBroker(make(chan struct{})))
 
 			c := NewClient(controller)
 

--- a/pkg/compute/mock_compute_client_generated.go
+++ b/pkg/compute/mock_compute_client_generated.go
@@ -82,6 +82,20 @@ func (mr *MockInterfaceMockRecorder) GetMeshConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshConfig", reflect.TypeOf((*MockInterface)(nil).GetMeshConfig))
 }
 
+// GetMeshRootCertificate mocks base method.
+func (m *MockInterface) GetMeshRootCertificate(arg0 string) *v1alpha2.MeshRootCertificate {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeshRootCertificate", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	return ret0
+}
+
+// GetMeshRootCertificate indicates an expected call of GetMeshRootCertificate.
+func (mr *MockInterfaceMockRecorder) GetMeshRootCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshRootCertificate", reflect.TypeOf((*MockInterface)(nil).GetMeshRootCertificate), arg0)
+}
+
 // GetMeshService mocks base method.
 func (m *MockInterface) GetMeshService(arg0, arg1 string, arg2 uint16) (service.MeshService, error) {
 	m.ctrl.T.Helper()
@@ -295,6 +309,21 @@ func (mr *MockInterfaceMockRecorder) ListIngressBackendPolicies() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIngressBackendPolicies", reflect.TypeOf((*MockInterface)(nil).ListIngressBackendPolicies))
 }
 
+// ListMeshRootCertificates mocks base method.
+func (m *MockInterface) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMeshRootCertificates")
+	ret0, _ := ret[0].([]*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMeshRootCertificates indicates an expected call of ListMeshRootCertificates.
+func (mr *MockInterfaceMockRecorder) ListMeshRootCertificates() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMeshRootCertificates", reflect.TypeOf((*MockInterface)(nil).ListMeshRootCertificates))
+}
+
 // ListNamespaces mocks base method.
 func (m *MockInterface) ListNamespaces() ([]string, error) {
 	m.ctrl.T.Helper()
@@ -409,6 +438,36 @@ func (m *MockInterface) UpdateIngressBackendStatus(arg0 *v1alpha1.IngressBackend
 func (mr *MockInterfaceMockRecorder) UpdateIngressBackendStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressBackendStatus", reflect.TypeOf((*MockInterface)(nil).UpdateIngressBackendStatus), arg0)
+}
+
+// UpdateMeshRootCertificate mocks base method.
+func (m *MockInterface) UpdateMeshRootCertificate(arg0 *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeshRootCertificate", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMeshRootCertificate indicates an expected call of UpdateMeshRootCertificate.
+func (mr *MockInterfaceMockRecorder) UpdateMeshRootCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeshRootCertificate", reflect.TypeOf((*MockInterface)(nil).UpdateMeshRootCertificate), arg0)
+}
+
+// UpdateMeshRootCertificateStatus mocks base method.
+func (m *MockInterface) UpdateMeshRootCertificateStatus(arg0 *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeshRootCertificateStatus", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMeshRootCertificateStatus indicates an expected call of UpdateMeshRootCertificateStatus.
+func (mr *MockInterfaceMockRecorder) UpdateMeshRootCertificateStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeshRootCertificateStatus", reflect.TypeOf((*MockInterface)(nil).UpdateMeshRootCertificateStatus), arg0)
 }
 
 // UpdateUpstreamTrafficSettingStatus mocks base method.

--- a/pkg/envoy/ads/response_benchmark_test.go
+++ b/pkg/envoy/ads/response_benchmark_test.go
@@ -50,7 +50,7 @@ func setupTestServer(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create informer collection: %s", err)
 	}
-	kubeController := k8s.NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, informerCollection, policyClient, msgBroker)
+	kubeController := k8s.NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, informerCollection, policyClient, configClient, msgBroker)
 	kubeProvider := kube.NewClient(kubeController)
 
 	meshConfig := configv1alpha2.MeshConfig{

--- a/pkg/injector/webhook_benchmark_test.go
+++ b/pkg/injector/webhook_benchmark_test.go
@@ -84,7 +84,7 @@ func BenchmarkPodCreationHandler(b *testing.B) {
 		informers.WithKubeClient(kubeClient),
 		informers.WithConfigClient(configClient, tests.OsmMeshConfigName, tests.OsmNamespace),
 	)
-	kubeController := k8s.NewClient("osm-system", tests.OsmMeshConfigName, informerCollection, policyClient, msgBroker)
+	kubeController := k8s.NewClient("osm-system", tests.OsmMeshConfigName, informerCollection, policyClient, configClient, msgBroker)
 	if err != nil {
 		b.Fatalf("Failed to create kubeController: %s", err.Error())
 	}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -19,7 +19,7 @@ import (
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/envoy"
-	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+	fakeConfigClient "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	fakePolicyClient "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/messaging"
@@ -70,7 +70,7 @@ func TestIsMonitoredNamespace(t *testing.T) {
 
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyNamespace, tc.namespace, t)
 
 			actual := c.IsMonitoredNamespace(tc.ns)
@@ -113,7 +113,7 @@ func TestGetNamespace(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyNamespace, tc.namespace, t)
 
 			actual := c.GetNamespace(tc.ns)
@@ -160,7 +160,7 @@ func TestListNamespaces(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			for _, ns := range tc.namespaces {
 				_ = ic.Add(informers.InformerKeyNamespace, ns, t)
 			}
@@ -227,7 +227,7 @@ func TestGetService(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyService, tc.service, t)
 
 			actual := c.GetService(tc.svcName, tc.svcNamespace)
@@ -284,7 +284,7 @@ func TestListServices(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyNamespace, tc.namespace, t)
 
 			for _, s := range tc.services {
@@ -341,7 +341,7 @@ func TestListServiceAccounts(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyNamespace, tc.namespace, t)
 
 			for _, s := range tc.sa {
@@ -398,7 +398,7 @@ func TestListPods(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyNamespace, tc.namespace, t)
 
 			for _, p := range tc.pods {
@@ -455,7 +455,7 @@ func TestGetEndpoints(t *testing.T) {
 			a := tassert.New(t)
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil)
 			_ = ic.Add(informers.InformerKeyEndpoints, tc.endpoints, t)
 
 			actual, err := c.GetEndpoints(tc.svcName, tc.svcNamespace)
@@ -465,7 +465,7 @@ func TestGetEndpoints(t *testing.T) {
 	}
 }
 
-func TestUpdateStatus(t *testing.T) {
+func TestPolicyUpdateStatus(t *testing.T) {
 	testCases := []struct {
 		name             string
 		existingResource interface{}
@@ -561,7 +561,7 @@ func TestUpdateStatus(t *testing.T) {
 			policyClient := fakePolicyClient.NewSimpleClientset(tc.existingResource.(runtime.Object))
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(kubeClient), informers.WithPolicyClient(policyClient))
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, ic, policyClient, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, ic, policyClient, nil, nil)
 			switch v := tc.updatedResource.(type) {
 			case *policyv1alpha1.IngressBackend:
 				_, err = c.UpdateIngressBackendStatus(v)
@@ -569,6 +569,73 @@ func TestUpdateStatus(t *testing.T) {
 			case *policyv1alpha1.UpstreamTrafficSetting:
 				_, err = c.UpdateUpstreamTrafficSettingStatus(v)
 				a.Equal(tc.expectErr, err != nil)
+			}
+		})
+	}
+}
+
+func TestConfigUpdateStatus(t *testing.T) {
+	testCases := []struct {
+		name             string
+		existingResource interface{}
+		updatedResource  interface{}
+	}{
+		{
+			name: "valid MeshRootCertificate resource",
+			existingResource: &configv1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: configv1alpha2.MeshRootCertificateSpec{
+					Provider: configv1alpha2.ProviderSpec{
+						Tresor: &configv1alpha2.TresorProviderSpec{
+							CA: configv1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+			},
+			updatedResource: &configv1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: configv1alpha2.MeshRootCertificateSpec{
+					Provider: configv1alpha2.ProviderSpec{
+						Tresor: &configv1alpha2.TresorProviderSpec{
+							CA: configv1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Status: configv1alpha2.MeshRootCertificateStatus{
+					State: constants.MRCStateActive,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+			kubeClient := testclient.NewSimpleClientset()
+			configClient := fakeConfigClient.NewSimpleClientset(tc.existingResource.(runtime.Object))
+			ic, err := informers.NewInformerCollection(tests.MeshName, nil, informers.WithKubeClient(kubeClient))
+			a.Nil(err)
+			c := NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, configClient, nil)
+			switch v := tc.updatedResource.(type) {
+			case *configv1alpha2.MeshRootCertificate:
+				_, err = c.UpdateMeshRootCertificateStatus(v)
+				a.NoError(err)
 			}
 		})
 	}
@@ -603,7 +670,7 @@ func TestGetPodForProxy(t *testing.T) {
 	ic, err := informers.NewInformerCollection(testMeshName, stop, informers.WithKubeClient(kubeClient))
 	assert.Nil(err)
 
-	kubeController := NewClient("osm", tests.OsmMeshConfigName, ic, nil, messaging.NewBroker(nil))
+	kubeController := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, messaging.NewBroker(nil))
 
 	testCases := []struct {
 		name  string
@@ -663,7 +730,7 @@ func monitoredNS(name string) *v1.Namespace {
 func TestGetMeshConfig(t *testing.T) {
 	a := assert.New(t)
 
-	meshConfigClient := fakeConfig.NewSimpleClientset()
+	meshConfigClient := fakeConfigClient.NewSimpleClientset()
 	stop := make(chan struct{})
 	osmNamespace := "osm"
 	osmMeshConfigName := "osm-mesh-config"
@@ -671,7 +738,7 @@ func TestGetMeshConfig(t *testing.T) {
 	ic, err := informers.NewInformerCollection("osm", stop, informers.WithConfigClient(meshConfigClient, osmMeshConfigName, osmNamespace))
 	a.Nil(err)
 
-	c := NewClient(osmNamespace, tests.OsmMeshConfigName, ic, nil, nil)
+	c := NewClient(osmNamespace, tests.OsmMeshConfigName, ic, nil, nil, nil)
 
 	// Returns empty MeshConfig if informer cache is empty
 	a.Equal(configv1alpha2.MeshConfig{}, c.GetMeshConfig())
@@ -828,7 +895,7 @@ func TestListEgressPolicies(t *testing.T) {
 				informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
 
-			c := NewClient("osm", tests.OsmMeshConfigName, informerCollection, fakeClient, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, informerCollection, fakeClient, nil, nil)
 			a.Nil(err)
 			a.NotNil(c)
 
@@ -949,7 +1016,7 @@ func TestListRetryPolicy(t *testing.T) {
 				informers.WithKubeClient(testclient.NewSimpleClientset()),
 			)
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, informerCollection, fakeClient, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, informerCollection, fakeClient, nil, nil)
 			a.Nil(err)
 			a.NotNil(c)
 
@@ -1016,7 +1083,7 @@ func TestListUpstreamTrafficSetting(t *testing.T) {
 				informers.WithKubeClient(testclient.NewSimpleClientset()),
 			)
 			a.Nil(err)
-			c := NewClient("osm", tests.OsmMeshConfigName, informerCollection, fakeClient, nil)
+			c := NewClient("osm", tests.OsmMeshConfigName, informerCollection, fakeClient, nil, nil)
 			a.Nil(err)
 			a.NotNil(c)
 
@@ -1033,4 +1100,100 @@ func TestListUpstreamTrafficSetting(t *testing.T) {
 			a.Equal(tc.expected, actual)
 		})
 	}
+}
+
+func TestGetMeshRootCertificate(t *testing.T) {
+	testCases := []struct {
+		name                string
+		meshRootCertificate *configv1alpha2.MeshRootCertificate
+		mrcName             string
+		expected            bool
+	}{
+		{
+			name: "gets the MRC from the cache given its key",
+			meshRootCertificate: &configv1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mrc",
+					Namespace: "osm-system",
+				},
+			},
+			mrcName:  "mrc",
+			expected: true,
+		},
+		{
+			name: "returns nil if the MRC is not found in the cache",
+			meshRootCertificate: &configv1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "mrc",
+					Namespace: "osm-system",
+				},
+			},
+			mrcName:  "mrc2",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithConfigClient(fakeConfigClient.NewSimpleClientset(), tests.OsmMeshConfigName, tests.OsmNamespace))
+			a.Nil(err)
+			c := NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, nil, nil)
+			_ = ic.Add(informers.InformerKeyMeshRootCertificate, tc.meshRootCertificate, t)
+
+			actual := c.GetMeshRootCertificate(tc.mrcName)
+			if tc.expected {
+				a.Equal(tc.meshRootCertificate, actual)
+			} else {
+				a.Nil(actual)
+			}
+		})
+	}
+}
+
+func TestListMeshRootCertificates(t *testing.T) {
+	a := assert.New(t)
+
+	mrcClient := fakeConfigClient.NewSimpleClientset()
+	stop := make(chan struct{})
+	osmMeshRootCertificateName := "osm-mesh-root-certificate"
+
+	ic, err := informers.NewInformerCollection(tests.MeshName, stop, informers.WithConfigClient(mrcClient, osmMeshRootCertificateName, tests.OsmNamespace))
+	a.Nil(err)
+
+	c := NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, nil, nil)
+
+	mrcList, err := c.ListMeshRootCertificates()
+	a.NoError(err)
+	a.Empty(mrcList)
+
+	newList := []*configv1alpha2.MeshRootCertificate{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "osm-mesh-root-certificate",
+				Namespace: "osm-system",
+			},
+			Spec: configv1alpha2.MeshRootCertificateSpec{
+				Provider: configv1alpha2.ProviderSpec{
+					Tresor: &configv1alpha2.TresorProviderSpec{
+						CA: configv1alpha2.TresorCASpec{
+							SecretRef: v1.SecretReference{
+								Name:      "osm-ca-bundle",
+								Namespace: "osm-system",
+							},
+						},
+					},
+				},
+			},
+			Status: configv1alpha2.MeshRootCertificateStatus{
+				State: constants.MRCStateActive,
+			},
+		},
+	}
+	err = c.informers.Add(informers.InformerKeyMeshRootCertificate, newList[0], t)
+	a.Nil(err)
+
+	mrcList, err = c.ListMeshRootCertificates()
+	a.NoError(err)
+	a.ElementsMatch(newList, mrcList)
 }

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -67,6 +67,20 @@ func (mr *MockControllerMockRecorder) GetMeshConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshConfig", reflect.TypeOf((*MockController)(nil).GetMeshConfig))
 }
 
+// GetMeshRootCertificate mocks base method.
+func (m *MockController) GetMeshRootCertificate(arg0 string) *v1alpha2.MeshRootCertificate {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeshRootCertificate", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	return ret0
+}
+
+// GetMeshRootCertificate indicates an expected call of GetMeshRootCertificate.
+func (mr *MockControllerMockRecorder) GetMeshRootCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeshRootCertificate", reflect.TypeOf((*MockController)(nil).GetMeshRootCertificate), arg0)
+}
+
 // GetNamespace mocks base method.
 func (m *MockController) GetNamespace(arg0 string) *v1.Namespace {
 	m.ctrl.T.Helper()
@@ -180,6 +194,21 @@ func (mr *MockControllerMockRecorder) ListIngressBackendPolicies() *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIngressBackendPolicies", reflect.TypeOf((*MockController)(nil).ListIngressBackendPolicies))
 }
 
+// ListMeshRootCertificates mocks base method.
+func (m *MockController) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListMeshRootCertificates")
+	ret0, _ := ret[0].([]*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListMeshRootCertificates indicates an expected call of ListMeshRootCertificates.
+func (mr *MockControllerMockRecorder) ListMeshRootCertificates() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMeshRootCertificates", reflect.TypeOf((*MockController)(nil).ListMeshRootCertificates))
+}
+
 // ListNamespaces mocks base method.
 func (m *MockController) ListNamespaces() ([]*v1.Namespace, error) {
 	m.ctrl.T.Helper()
@@ -278,6 +307,36 @@ func (m *MockController) UpdateIngressBackendStatus(arg0 *v1alpha1.IngressBacken
 func (mr *MockControllerMockRecorder) UpdateIngressBackendStatus(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIngressBackendStatus", reflect.TypeOf((*MockController)(nil).UpdateIngressBackendStatus), arg0)
+}
+
+// UpdateMeshRootCertificate mocks base method.
+func (m *MockController) UpdateMeshRootCertificate(arg0 *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeshRootCertificate", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMeshRootCertificate indicates an expected call of UpdateMeshRootCertificate.
+func (mr *MockControllerMockRecorder) UpdateMeshRootCertificate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeshRootCertificate", reflect.TypeOf((*MockController)(nil).UpdateMeshRootCertificate), arg0)
+}
+
+// UpdateMeshRootCertificateStatus mocks base method.
+func (m *MockController) UpdateMeshRootCertificateStatus(arg0 *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeshRootCertificateStatus", arg0)
+	ret0, _ := ret[0].(*v1alpha2.MeshRootCertificate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMeshRootCertificateStatus indicates an expected call of UpdateMeshRootCertificateStatus.
+func (mr *MockControllerMockRecorder) UpdateMeshRootCertificateStatus(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeshRootCertificateStatus", reflect.TypeOf((*MockController)(nil).UpdateMeshRootCertificateStatus), arg0)
 }
 
 // UpdateUpstreamTrafficSettingStatus mocks base method.

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -11,6 +11,7 @@ import (
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/envoy"
+	configv1alpha2Client "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	policyv1alpha1Client "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned"
 
 	"github.com/openservicemesh/osm/pkg/k8s/informers"
@@ -78,6 +79,7 @@ const (
 // Client is the type used to represent the k8s client for the native k8s resources
 type Client struct {
 	policyClient   policyv1alpha1Client.Interface
+	configClient   configv1alpha2Client.Interface
 	informers      *informers.InformerCollection
 	msgBroker      *messaging.Broker
 	osmNamespace   string
@@ -125,6 +127,10 @@ type Controller interface {
 // well.
 type PassthroughInterface interface {
 	GetMeshConfig() configv1alpha2.MeshConfig
+	GetMeshRootCertificate(mrcName string) *configv1alpha2.MeshRootCertificate
+	ListMeshRootCertificates() ([]*configv1alpha2.MeshRootCertificate, error)
+	UpdateMeshRootCertificate(obj *configv1alpha2.MeshRootCertificate) (*configv1alpha2.MeshRootCertificate, error)
+	UpdateMeshRootCertificateStatus(obj *configv1alpha2.MeshRootCertificate) (*configv1alpha2.MeshRootCertificate, error)
 	GetOSMNamespace() string
 	UpdateIngressBackendStatus(obj *policyv1alpha1.IngressBackend) (*policyv1alpha1.IngressBackend, error)
 	UpdateUpstreamTrafficSettingStatus(obj *policyv1alpha1.UpstreamTrafficSetting) (*policyv1alpha1.UpstreamTrafficSetting, error)

--- a/pkg/smi/client_test.go
+++ b/pkg/smi/client_test.go
@@ -58,7 +58,7 @@ func bootstrapClient(stop chan struct{}, t *testing.T) (*Client, *fakeKubeClient
 		return nil, nil, err
 	}
 
-	kubernetesClient := k8s.NewClient("osm-ns", tests.OsmMeshConfigName, informerCollection, nil, msgBroker)
+	kubernetesClient := k8s.NewClient("osm-ns", tests.OsmMeshConfigName, informerCollection, nil, nil, msgBroker)
 
 	fakeClientSet := &fakeKubeClientSet{
 		kubeClient:                kubeClient,

--- a/pkg/validator/server_benchmark_test.go
+++ b/pkg/validator/server_benchmark_test.go
@@ -51,7 +51,7 @@ func BenchmarkDoValidation(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Failed to create informer collection: %s", err)
 	}
-	k8sClient := k8s.NewClient("osm-ns", tests.OsmMeshConfigName, informerCollection, policyClient, msgBroker)
+	k8sClient := k8s.NewClient("osm-ns", tests.OsmMeshConfigName, informerCollection, policyClient, configClient, msgBroker)
 	compute := kube.NewClient(k8sClient)
 	kv := &policyValidator{
 		policyClient: compute,

--- a/pkg/validator/server_test.go
+++ b/pkg/validator/server_test.go
@@ -20,6 +20,7 @@ import (
 
 	tresorFake "github.com/openservicemesh/osm/pkg/certificate/providers/tresor/fake"
 	computekube "github.com/openservicemesh/osm/pkg/compute/kube"
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	policyFake "github.com/openservicemesh/osm/pkg/gen/client/policy/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/k8s/informers"
@@ -163,7 +164,8 @@ func TestNewValidatingWebhook(t *testing.T) {
 		informerCollection, err := informers.NewInformerCollection("osm", stop, informers.WithKubeClient(kube))
 		tassert.NoError(t, err)
 		policyClient := policyFake.NewSimpleClientset()
-		k8sClient := k8s.NewClient(testNamespace, testMeshConfigName, informerCollection, policyClient, broker)
+		configClient := configFake.NewSimpleClientset()
+		k8sClient := k8s.NewClient(testNamespace, testMeshConfigName, informerCollection, policyClient, configClient, broker)
 		compute := computekube.NewClient(k8sClient)
 		ctx, cancel := context.WithCancel(context.Background())
 		err = NewValidatingWebhook(ctx, webhook.Name, testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, certManager, kube, compute)
@@ -182,7 +184,8 @@ func TestNewValidatingWebhook(t *testing.T) {
 		informerCollection, err := informers.NewInformerCollection("osm", stop, informers.WithKubeClient(kube))
 		tassert.NoError(t, err)
 		policyClient := policyFake.NewSimpleClientset()
-		k8sClient := k8s.NewClient(testNamespace, testMeshConfigName, informerCollection, policyClient, broker)
+		configClient := configFake.NewSimpleClientset()
+		k8sClient := k8s.NewClient(testNamespace, testMeshConfigName, informerCollection, policyClient, configClient, broker)
 
 		compute := computekube.NewClient(k8sClient)
 		err = NewValidatingWebhook(context.Background(), "my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, certManager, kube, compute)
@@ -202,7 +205,8 @@ func TestNewValidatingWebhook(t *testing.T) {
 		informerCollection, err := informers.NewInformerCollection("osm", stop, informers.WithKubeClient(kube))
 		tassert.NoError(t, err)
 		policyClient := policyFake.NewSimpleClientset()
-		k8sClient := k8s.NewClient(testNamespace, testMeshConfigName, informerCollection, policyClient, broker)
+		configClient := configFake.NewSimpleClientset()
+		k8sClient := k8s.NewClient(testNamespace, testMeshConfigName, informerCollection, policyClient, configClient, broker)
 		compute := computekube.NewClient(k8sClient)
 
 		err = NewValidatingWebhook(context.Background(), "my-webhook", testNamespace, testVersion, testMeshName, enableReconciler, validateTrafficTarget, certManager, kube, compute)

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -780,7 +780,7 @@ func TestIngressBackendValidator(t *testing.T) {
 			)
 			assert.NoError(err)
 
-			k8sClient := k8s.NewClient("osm-namespace", "osm-mesh-config", informerCollection, fakeClient, broker)
+			k8sClient := k8s.NewClient("osm-namespace", "osm-mesh-config", informerCollection, fakeClient, nil, broker)
 			policyClient := kube.NewClient(k8sClient)
 			pv := &policyValidator{
 				policyClient: policyClient,
@@ -1305,7 +1305,7 @@ func TestUpstreamTrafficSettingValidator(t *testing.T) {
 			)
 			assert.NoError(err)
 
-			k8sClient := k8s.NewClient("test-namespace", "test-mesh-config", informerCollection, fakeClient, broker)
+			k8sClient := k8s.NewClient("test-namespace", "test-mesh-config", informerCollection, fakeClient, nil, broker)
 			policyClient := kube.NewClient(k8sClient)
 
 			pv := &policyValidator{


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds the configClient to the k8s client definition and adds methods to support getting, updating, and listing the MRC resource. These methods will be used to update the MRC during root certificate rotation.

Part of #5046 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- CI

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No