### PR TITLE
style(demo/cmd/bookbuyer/) update bookbuyer container names for clari…

### DIFF
--- a/demo/cmd/bookbuyer/bookbuyer.html.template
+++ b/demo/cmd/bookbuyer/bookbuyer.html.template
@@ -40,8 +40,8 @@
       <ul>
         <li>Total books bought: <strong>{{.BooksBought}}</strong>
           <ul>
-            <li>from bookstore V1: <strong>{{.BooksBoughtV1}}</strong>
-            <li>from bookstore V2: <strong>{{.BooksBoughtV2}}</strong>
+            <li>from bookstore-v1: <strong>{{.BooksBoughtV1}}</strong>
+            <li>from bookstore-v2: <strong>{{.BooksBoughtV2}}</strong>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
…ty in demo

Signed-off-by: Zach Rhoads <zachary.rhoads@microsoft.com>


**Description**:
Fixes feedback from https://github.com/openservicemesh/osm-docs/issues/105 citing confusion in how the different bookstore containers are referenced. Updated html to use the names of the bookstore containers/services as they are deployed in the demo.


**Testing done**:

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ x] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? none needed based on initial search. Would only need screenshot updates