### PR TITLE
Move e2e tests to separate function and add OSM CLI helper function

### DIFF
--- a/tests/e2e/e2e_certmanager_test.go
+++ b/tests/e2e/e2e_certmanager_test.go
@@ -18,121 +18,125 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using cert-manager",
 	},
 	func() {
 		Context("CertManagerSimpleClientServer", func() {
-			var (
-				clientNamespace     = framework.RandomNameWithPrefix("client")
-				serverNamespace     = framework.RandomNameWithPrefix("server")
-				clientContainerName = framework.RandomNameWithPrefix("container")
-				ns                  = []string{clientNamespace, serverNamespace}
-			)
-
-			It("Tests HTTP traffic for client pod -> server pod", func() {
-				// Install OSM
-				installOpts := Td.GetOSMInstallOpts()
-				installOpts.CertManager = "cert-manager"
-				// Currently certs are rotated ~30-35s. This means we will rotate every other time we check, which is on a
-				// 5 second period. We just add the 10 5 extra seconds to make sure the http requests succeed.
-				installOpts.CertValidtyDuration = time.Second * 10
-				installOpts.SetOverrides = []string{
-					// increase timeout when using an external certificate provider due to
-					// potential slowness issuing certs
-					"osm.injector.webhookTimeoutSeconds=30",
-				}
-				Expect(Td.InstallOSM(installOpts)).To(Succeed())
-				Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 5 /* 3 cert-manager pods, 1 controller, 1 injector */, nil)).To(Succeed())
-
-				// Create namespaces
-				for _, n := range ns {
-					Expect(Td.CreateNs(n, nil)).To(Succeed())
-					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
-				}
-
-				// Get simple pod definitions for the HTTP server
-				destinationPort := fortioHTTPPort
-				serverSvcAccDef, serverPodDef, serverSvcDef, err := Td.SimplePodApp(
-					SimplePodAppDef{
-						PodName:   framework.RandomNameWithPrefix("pod"),
-						Namespace: serverNamespace,
-						Image:     fortioImageName,
-						Ports:     []int{destinationPort},
-						OS:        Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = Td.CreateServiceAccount(serverNamespace, &serverSvcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				dstPod, err := Td.CreatePod(serverNamespace, serverPodDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(serverNamespace, serverSvcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(serverNamespace, 60*time.Second, 1, nil)).To(Succeed())
-
-				// Get simple Pod definitions for the client
-				clientSvcAccDef, clientPodDef, clientSvcDef, err := Td.SimplePodApp(SimplePodAppDef{
-					PodName:       framework.RandomNameWithPrefix("pod"),
-					Namespace:     clientNamespace,
-					ContainerName: clientContainerName,
-					Image:         fortioImageName,
-					Ports:         []int{destinationPort},
-					OS:            Td.ClusterOS,
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = Td.CreateServiceAccount(clientNamespace, &clientSvcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := Td.CreatePod(clientNamespace, clientPodDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(clientNamespace, clientSvcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(clientNamespace, 60*time.Second, 1, nil)).To(Succeed())
-
-				// Deploy allow rule client->server
-				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-					SimpleAllowPolicy{
-						RouteGroupName:    "routes",
-						TrafficTargetName: "target",
-
-						SourceNamespace:      clientNamespace,
-						SourceSVCAccountName: clientSvcAccDef.Name,
-
-						DestinationNamespace:      serverNamespace,
-						DestinationSvcAccountName: serverSvcAccDef.Name,
-					})
-
-				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = Td.CreateHTTPRouteGroup(serverNamespace, httpRG)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(serverNamespace, trafficTarget)
-				Expect(err).NotTo(HaveOccurred())
-
-				// All ready. Expect client to reach server
-				// Need to get the pod though.
-				for i := 0; i < 2; i++ {
-					cond := Td.WaitForRepeatedSuccess(func() bool {
-						result :=
-							Td.FortioHTTPLoadTest(FortioHTTPLoadTestDef{
-								HTTPRequestDef: HTTPRequestDef{
-									SourceNs:        srcPod.Namespace,
-									SourcePod:       srcPod.Name,
-									SourceContainer: clientContainerName,
-
-									Destination: fmt.Sprintf("%s.%s:%d", serverSvcDef.Name, dstPod.Namespace, destinationPort),
-								},
-							})
-
-						if result.Err != nil || result.HasFailedHTTPRequests() {
-							Td.T.Logf("> REST req has failed requests: %v", result.Err)
-							return false
-						}
-						Td.T.Logf("> REST req succeeded. Status codes: %v", result.AllReturnCodes())
-						return true
-					}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
-					Expect(cond).To(BeTrue())
-					time.Sleep(time.Second * 6) // 6 seconds guarantee the certs are rotated.
-				}
-			})
+			testCertManager()
 		})
 	})
+
+func testCertManager(installOptions ...InstallOsmOpt) {
+	var (
+		clientNamespace     = framework.RandomNameWithPrefix("client")
+		serverNamespace     = framework.RandomNameWithPrefix("server")
+		clientContainerName = framework.RandomNameWithPrefix("container")
+		ns                  = []string{clientNamespace, serverNamespace}
+	)
+
+	It("Tests HTTP traffic for client pod -> server pod", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts(installOptions...)
+		installOpts.CertManager = "cert-manager"
+		// Currently certs are rotated ~30-35s. This means we will rotate every other time we check, which is on a
+		// 5 second period. We just add the 10 5 extra seconds to make sure the http requests succeed.
+		installOpts.CertValidtyDuration = time.Second * 10
+		installOpts.SetOverrides = []string{
+			// increase timeout when using an external certificate provider due to
+			// potential slowness issuing certs
+			"osm.injector.webhookTimeoutSeconds=30",
+		}
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
+		Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 5 /* 3 cert-manager pods, 1 controller, 1 injector */, nil)).To(Succeed())
+
+		// Create namespaces
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Get simple pod definitions for the HTTP server
+		destinationPort := fortioHTTPPort
+		serverSvcAccDef, serverPodDef, serverSvcDef, err := Td.SimplePodApp(
+			SimplePodAppDef{
+				PodName:   framework.RandomNameWithPrefix("pod"),
+				Namespace: serverNamespace,
+				Image:     fortioImageName,
+				Ports:     []int{destinationPort},
+				OS:        Td.ClusterOS,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = Td.CreateServiceAccount(serverNamespace, &serverSvcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		dstPod, err := Td.CreatePod(serverNamespace, serverPodDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateService(serverNamespace, serverSvcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(serverNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+		// Get simple Pod definitions for the client
+		clientSvcAccDef, clientPodDef, clientSvcDef, err := Td.SimplePodApp(SimplePodAppDef{
+			PodName:       framework.RandomNameWithPrefix("pod"),
+			Namespace:     clientNamespace,
+			ContainerName: clientContainerName,
+			Image:         fortioImageName,
+			Ports:         []int{destinationPort},
+			OS:            Td.ClusterOS,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = Td.CreateServiceAccount(clientNamespace, &clientSvcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		srcPod, err := Td.CreatePod(clientNamespace, clientPodDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateService(clientNamespace, clientSvcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(clientNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    "routes",
+				TrafficTargetName: "target",
+
+				SourceNamespace:      clientNamespace,
+				SourceSVCAccountName: clientSvcAccDef.Name,
+
+				DestinationNamespace:      serverNamespace,
+				DestinationSvcAccountName: serverSvcAccDef.Name,
+			})
+
+		// Configs have to be put into a monitored NS, and osm-system can't be by cli
+		_, err = Td.CreateHTTPRouteGroup(serverNamespace, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(serverNamespace, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		// All ready. Expect client to reach server
+		// Need to get the pod though.
+		for i := 0; i < 2; i++ {
+			cond := Td.WaitForRepeatedSuccess(func() bool {
+				result :=
+					Td.FortioHTTPLoadTest(FortioHTTPLoadTestDef{
+						HTTPRequestDef: HTTPRequestDef{
+							SourceNs:        srcPod.Namespace,
+							SourcePod:       srcPod.Name,
+							SourceContainer: clientContainerName,
+
+							Destination: fmt.Sprintf("%s.%s:%d", serverSvcDef.Name, dstPod.Namespace, destinationPort),
+						},
+					})
+
+				if result.Err != nil || result.HasFailedHTTPRequests() {
+					Td.T.Logf("> REST req has failed requests: %v", result.Err)
+					return false
+				}
+				Td.T.Logf("> REST req succeeded. Status codes: %v", result.AllReturnCodes())
+				return true
+			}, 5 /*consecutive success threshold*/, 90*time.Second /*timeout*/)
+			Expect(cond).To(BeTrue())
+			time.Sleep(time.Second * 6) // 6 seconds guarantee the certs are rotated.
+		}
+	})
+}

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -18,115 +18,119 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 	},
 	func() {
 		Context("HashivaultSimpleClientServer", func() {
-			var (
-				clientNamespace = framework.RandomNameWithPrefix("client")
-				serverNamespace = framework.RandomNameWithPrefix("server")
-				ns              = []string{clientNamespace, serverNamespace}
-
-				clientContainerName = "client-container"
-			)
-
-			It("Tests HTTP traffic for client pod -> server pod", func() {
-				// Install OSM
-				installOpts := Td.GetOSMInstallOpts()
-				installOpts.CertManager = "vault"
-				installOpts.SetOverrides = []string{
-					// increase timeout when using an external certificate provider due to
-					// potential slowness issuing certs
-					"osm.injector.webhookTimeoutSeconds=30",
-				}
-				Expect(Td.InstallOSM(installOpts)).To(Succeed())
-
-				// Create Test NS
-				for _, n := range ns {
-					Expect(Td.CreateNs(n, nil)).To(Succeed())
-					Expect(Td.AddNsToMesh(true, n)).To(Succeed())
-				}
-
-				// Get simple pod definitions for the HTTP server
-				serverSvcAccDef, serverPodDef, serverSvcDef, err := Td.SimplePodApp(
-					SimplePodAppDef{
-						PodName:   framework.RandomNameWithPrefix("serverpod"),
-						Namespace: serverNamespace,
-						Image:     "kennethreitz/httpbin",
-						Ports:     []int{80},
-						OS:        Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-
-				serverServiceAccount, err := Td.CreateServiceAccount(serverNamespace, &serverSvcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreatePod(serverNamespace, serverPodDef)
-				Expect(err).NotTo(HaveOccurred())
-				serverService, err := Td.CreateService(serverNamespace, serverSvcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(serverNamespace, 60*time.Second, 1, nil)).To(Succeed())
-
-				// Get simple Pod, Service, ServiceAccount definitions for the client
-				clientSvcAccDef, clientPodDef, clientSvcDef, err := Td.SimplePodApp(SimplePodAppDef{
-					PodName:       framework.RandomNameWithPrefix("clientpod"),
-					Namespace:     clientNamespace,
-					ContainerName: clientContainerName,
-					Command:       []string{"/bin/bash", "-c", "--"},
-					Args:          []string{"while true; do sleep 30; done;"},
-					Image:         "songrgg/alpine-debug",
-					Ports:         []int{80},
-					OS:            Td.ClusterOS,
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				clientServiceAccount, err := Td.CreateServiceAccount(clientNamespace, &clientSvcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				srcPod, err := Td.CreatePod(clientNamespace, clientPodDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateService(clientNamespace, clientSvcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Expect it to be up and running in it's receiver namespace
-				Expect(Td.WaitForPodsRunningReady(clientNamespace, 60*time.Second, 1, nil)).To(Succeed())
-
-				// Deploy allow rule client->server
-				httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-					SimpleAllowPolicy{
-						RouteGroupName:    "routes",
-						TrafficTargetName: "test-target",
-
-						SourceNamespace:      clientNamespace,
-						SourceSVCAccountName: clientServiceAccount.Name,
-
-						DestinationNamespace:      serverNamespace,
-						DestinationSvcAccountName: serverServiceAccount.Name,
-					})
-
-				// Configs have to be put into a monitored NS, and osm-system can't be by cli
-				_, err = Td.CreateHTTPRouteGroup(serverNamespace, httpRG)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateTrafficTarget(serverNamespace, trafficTarget)
-				Expect(err).NotTo(HaveOccurred())
-
-				// All ready. Expect client to reach server
-				// Need to get the pod though.
-				cond := Td.WaitForRepeatedSuccess(func() bool {
-					requestDef := HTTPRequestDef{
-						SourceNs:        srcPod.Namespace,
-						SourcePod:       srcPod.Name,
-						SourceContainer: clientContainerName,
-
-						Destination: fmt.Sprintf("%s.%s", serverService.Name, serverNamespace),
-					}
-					result :=
-						Td.HTTPRequest(requestDef)
-
-					if result.Err != nil || result.StatusCode != 200 {
-						Td.T.Logf("> REST req failed (status: %d) %v: request details: %#v", result.StatusCode, result.Err, requestDef)
-						return false
-					}
-					Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
-					return true
-				}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
-				Expect(cond).To(BeTrue())
-			})
+			testHashiCorpVault()
 		})
 	})
+
+func testHashiCorpVault(installOptions ...InstallOsmOpt) {
+	var (
+		clientNamespace = framework.RandomNameWithPrefix("client")
+		serverNamespace = framework.RandomNameWithPrefix("server")
+		ns              = []string{clientNamespace, serverNamespace}
+
+		clientContainerName = "client-container"
+	)
+
+	It("Tests HTTP traffic for client pod -> server pod", func() {
+		// Install OSM
+		installOpts := Td.GetOSMInstallOpts(installOptions...)
+		installOpts.CertManager = "vault"
+		installOpts.SetOverrides = []string{
+			// increase timeout when using an external certificate provider due to
+			// potential slowness issuing certs
+			"osm.injector.webhookTimeoutSeconds=30",
+		}
+		Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+		// Create Test NS
+		for _, n := range ns {
+			Expect(Td.CreateNs(n, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+		}
+
+		// Get simple pod definitions for the HTTP server
+		serverSvcAccDef, serverPodDef, serverSvcDef, err := Td.SimplePodApp(
+			SimplePodAppDef{
+				PodName:   framework.RandomNameWithPrefix("serverpod"),
+				Namespace: serverNamespace,
+				Image:     "kennethreitz/httpbin",
+				Ports:     []int{80},
+				OS:        Td.ClusterOS,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		serverServiceAccount, err := Td.CreateServiceAccount(serverNamespace, &serverSvcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreatePod(serverNamespace, serverPodDef)
+		Expect(err).NotTo(HaveOccurred())
+		serverService, err := Td.CreateService(serverNamespace, serverSvcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(serverNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+		// Get simple Pod, Service, ServiceAccount definitions for the client
+		clientSvcAccDef, clientPodDef, clientSvcDef, err := Td.SimplePodApp(SimplePodAppDef{
+			PodName:       framework.RandomNameWithPrefix("clientpod"),
+			Namespace:     clientNamespace,
+			ContainerName: clientContainerName,
+			Command:       []string{"/bin/bash", "-c", "--"},
+			Args:          []string{"while true; do sleep 30; done;"},
+			Image:         "songrgg/alpine-debug",
+			Ports:         []int{80},
+			OS:            Td.ClusterOS,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		clientServiceAccount, err := Td.CreateServiceAccount(clientNamespace, &clientSvcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		srcPod, err := Td.CreatePod(clientNamespace, clientPodDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateService(clientNamespace, clientSvcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Expect it to be up and running in it's receiver namespace
+		Expect(Td.WaitForPodsRunningReady(clientNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+		// Deploy allow rule client->server
+		httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+			SimpleAllowPolicy{
+				RouteGroupName:    "routes",
+				TrafficTargetName: "test-target",
+
+				SourceNamespace:      clientNamespace,
+				SourceSVCAccountName: clientServiceAccount.Name,
+
+				DestinationNamespace:      serverNamespace,
+				DestinationSvcAccountName: serverServiceAccount.Name,
+			})
+
+		// Configs have to be put into a monitored NS, and osm-system can't be by cli
+		_, err = Td.CreateHTTPRouteGroup(serverNamespace, httpRG)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateTrafficTarget(serverNamespace, trafficTarget)
+		Expect(err).NotTo(HaveOccurred())
+
+		// All ready. Expect client to reach server
+		// Need to get the pod though.
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			requestDef := HTTPRequestDef{
+				SourceNs:        srcPod.Namespace,
+				SourcePod:       srcPod.Name,
+				SourceContainer: clientContainerName,
+
+				Destination: fmt.Sprintf("%s.%s", serverService.Name, serverNamespace),
+			}
+			result :=
+				Td.HTTPRequest(requestDef)
+
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> REST req failed (status: %d) %v: request details: %#v", result.StatusCode, result.Err, requestDef)
+				return false
+			}
+			Td.T.Logf("> REST req succeeded: %d", result.StatusCode)
+			return true
+		}, 5 /*consecutive success threshold*/, 60*time.Second /*timeout*/)
+		Expect(cond).To(BeTrue())
+	})
+}

--- a/tests/e2e/e2e_metrics_test.go
+++ b/tests/e2e/e2e_metrics_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -50,7 +49,7 @@ var _ = OSMDescribe("Custom WASM metrics between one client pod and one server",
 				Expect(Td.CreateNs(n, nil)).To(Succeed())
 				Expect(Td.AddNsToMesh(true, n)).To(Succeed())
 			}
-			stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "metrics", "enable", "--namespace", strings.Join(ns, ","))
+			stdout, stderr, err := Td.RunOsmCli("metrics", "enable", "--namespace", strings.Join(ns, ","))
 			Td.T.Log(stdout)
 			if err != nil {
 				Td.T.Logf("stderr:\n%s", stderr)

--- a/tests/e2e/e2e_osm_reinstall_test.go
+++ b/tests/e2e/e2e_osm_reinstall_test.go
@@ -1,8 +1,6 @@
 package e2e
 
 import (
-	"path/filepath"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -20,7 +18,7 @@ var _ = OSMDescribe("Test reinstalling OSM in the same namespace with the same m
 			Expect(Td.InstallOSM(opts)).To(Succeed())
 
 			By("Uninstalling OSM")
-			stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "uninstall", "mesh", "-f", "--osm-namespace", opts.ControlPlaneNS)
+			stdout, stderr, err := Td.RunOsmCli("uninstall", "mesh", "-f", "--osm-namespace", opts.ControlPlaneNS)
 			Td.T.Log(stdout)
 			if err != nil {
 				Td.T.Logf("stderr:\n%s", stderr)
@@ -30,7 +28,7 @@ var _ = OSMDescribe("Test reinstalling OSM in the same namespace with the same m
 			By("Reinstalling OSM")
 			// Invoke the CLI directly because Td.InstallOSM unconditionally
 			// creates the namespace which fails when it already exists.
-			stdout, stderr, err = Td.RunLocal(filepath.FromSlash("../../bin/osm"), "install", "--verbose", "--timeout=5m", "--osm-namespace", opts.ControlPlaneNS, "--set", "osm.image.registry="+opts.ContainerRegistryLoc+",osm.image.tag="+opts.OsmImagetag)
+			stdout, stderr, err = Td.RunOsmCli("install", "--verbose", "--timeout=5m", "--osm-namespace", opts.ControlPlaneNS, "--set", "osm.image.registry="+opts.ContainerRegistryLoc+",osm.image.tag="+opts.OsmImagetag)
 			Td.T.Log(stdout)
 			if err != nil {
 				Td.T.Logf("stderr:\n%s", stderr)

--- a/tests/e2e/e2e_permissive_smi_switching_test.go
+++ b/tests/e2e/e2e_permissive_smi_switching_test.go
@@ -22,165 +22,169 @@ var _ = OSMDescribe("Test HTTP traffic from N deployment client -> 1 deployment 
 	},
 	func() {
 		Context("PermissiveToSmiSwitching", func() {
-			var (
-				destApp           = framework.RandomNameWithPrefix("server")
-				sourceAppBaseName = framework.RandomNameWithPrefix("client")
-				sourceNamespaces  = []string{}
-
-				// Total (numberOfClientApps x replicaSetPerApp) pods
-				numberOfClientServices = 2
-				replicaSetPerService   = 2
-			)
-
-			// Used across the test to wait for concurrent steps to finish
-			var wg sync.WaitGroup
-
-			for i := 0; i < numberOfClientServices; i++ {
-				// base names for each client service
-				sourceNamespaces = append(sourceNamespaces, fmt.Sprintf("%s%d", sourceAppBaseName, i))
-			}
-
-			It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
-				// Install OSM
-				Expect(Td.InstallOSM(Td.GetOSMInstallOpts())).To(Succeed())
-
-				// Server NS
-				Expect(Td.CreateNs(destApp, nil)).To(Succeed())
-				Expect(Td.AddNsToMesh(true, destApp)).To(Succeed())
-
-				// Client Applications
-				for _, srcClient := range sourceNamespaces {
-					Expect(Td.CreateNs(srcClient, nil)).To(Succeed())
-					Expect(Td.AddNsToMesh(true, srcClient)).To(Succeed())
-				}
-
-				// Use a deployment with multiple replicaset at serverside
-				svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
-					SimpleDeploymentAppDef{
-						DeploymentName:     destApp,
-						Namespace:          destApp,
-						ServiceAccountName: destApp,
-						ServiceName:        destApp,
-						ReplicaCount:       int32(replicaSetPerService),
-						Image:              "kennethreitz/httpbin",
-						Ports:              []int{DefaultUpstreamServicePort},
-						Command:            HttpbinCmd,
-						OS:                 Td.ClusterOS,
-					})
-				Expect(err).NotTo(HaveOccurred())
-
-				_, err = Td.CreateServiceAccount(destApp, &svcAccDef)
-				Expect(err).NotTo(HaveOccurred())
-				_, err = Td.CreateDeployment(destApp, deploymentDef)
-				Expect(err).NotTo(HaveOccurred())
-				serverService, err := Td.CreateService(destApp, svcDef)
-				Expect(err).NotTo(HaveOccurred())
-
-				wg.Add(1)
-				go func(wg *sync.WaitGroup, srcClient string) {
-					defer GinkgoRecover()
-					defer wg.Done()
-					Expect(Td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService, nil)).To(Succeed())
-				}(&wg, destApp)
-
-				// Create all client deployments, also with replicaset
-				for _, srcClient := range sourceNamespaces {
-					svcAccDef, deploymentDef, svcDef, err = Td.SimpleDeploymentApp(
-						SimpleDeploymentAppDef{
-							DeploymentName:     srcClient,
-							Namespace:          srcClient,
-							ServiceAccountName: srcClient,
-							ContainerName:      srcClient,
-							ReplicaCount:       int32(replicaSetPerService),
-							Command:            []string{"/bin/bash", "-c", "--"},
-							Args:               []string{"while true; do sleep 30; done;"},
-							Image:              "songrgg/alpine-debug",
-							Ports:              []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
-							OS:                 Td.ClusterOS,
-						})
-					Expect(err).NotTo(HaveOccurred())
-
-					_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateDeployment(srcClient, deploymentDef)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateService(srcClient, svcDef)
-					Expect(err).NotTo(HaveOccurred())
-
-					wg.Add(1)
-					go func(wg *sync.WaitGroup, srcClient string) {
-						defer GinkgoRecover()
-						defer wg.Done()
-						Expect(Td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService, nil)).To(Succeed())
-					}(&wg, srcClient)
-				}
-				wg.Wait()
-
-				// Create Multiple HTTP request structure and fill it with appropriate details
-				requests := HTTPMultipleRequest{
-					Sources: []HTTPRequestDef{},
-				}
-				for _, ns := range sourceNamespaces {
-					pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
-					Expect(err).To(BeNil())
-
-					for _, pod := range pods.Items {
-						requests.Sources = append(requests.Sources, HTTPRequestDef{
-							SourceNs:        ns,
-							SourcePod:       pod.Name,
-							SourceContainer: ns,
-
-							Destination: fmt.Sprintf("%s.%s:%d", serverService.Name, serverService.Namespace, DefaultUpstreamServicePort),
-						})
-					}
-				}
-
-				By("Fails traffic test with no permissive mode and no SMI rules")
-				Expect(trafficTest(false, requests)).To(BeTrue())
-
-				By("Succeeds traffic test when permissive mode is enabled between inmesh targets")
-				Expect(setPermissiveMode(true)).To(BeNil())
-				Expect(trafficTest(true, requests)).To(BeTrue())
-
-				// ---
-				// The following two steps are added to test, debug and make sure unsubscriptions happen at XDS level
-				// They may seem redundant; they are not.
-				By("Fails traffic test again again when permissive is disabled")
-				Expect(setPermissiveMode(false)).To(BeNil())
-				Expect(trafficTest(false, requests)).To(BeTrue())
-
-				By("Traffic succeeds again when re-enabled")
-				Expect(setPermissiveMode(true)).To(BeNil())
-				Expect(trafficTest(true, requests)).To(BeTrue())
-				// ---
-
-				By("Traffic succeeds again when re-enabled")
-				for _, srcClient := range sourceNamespaces {
-					httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
-						SimpleAllowPolicy{
-							RouteGroupName:    srcClient,
-							TrafficTargetName: srcClient,
-
-							SourceNamespace:      srcClient,
-							SourceSVCAccountName: srcClient,
-
-							DestinationNamespace:      destApp,
-							DestinationSvcAccountName: destApp,
-						})
-
-					_, err = Td.CreateHTTPRouteGroup(destApp, httpRG)
-					Expect(err).NotTo(HaveOccurred())
-					_, err = Td.CreateTrafficTarget(destApp, trafficTarget)
-					Expect(err).NotTo(HaveOccurred())
-				}
-				Expect(trafficTest(true, requests)).To(BeTrue())
-
-				By("Succeeds when disabling Permissive now that SMI rules are in place")
-				Expect(setPermissiveMode(false)).To(BeNil())
-				Expect(trafficTest(true, requests)).To(BeTrue())
-			})
+			testPermissiveToSmiSwitching()
 		})
 	})
+
+func testPermissiveToSmiSwitching(installOptions ...InstallOsmOpt) {
+	var (
+		destApp           = framework.RandomNameWithPrefix("server")
+		sourceAppBaseName = framework.RandomNameWithPrefix("client")
+		sourceNamespaces  = []string{}
+
+		// Total (numberOfClientApps x replicaSetPerApp) pods
+		numberOfClientServices = 2
+		replicaSetPerService   = 2
+	)
+
+	// Used across the test to wait for concurrent steps to finish
+	var wg sync.WaitGroup
+
+	for i := 0; i < numberOfClientServices; i++ {
+		// base names for each client service
+		sourceNamespaces = append(sourceNamespaces, fmt.Sprintf("%s%d", sourceAppBaseName, i))
+	}
+
+	It("Tests HTTP traffic from multiple client deployments to a server deployment", func() {
+		// Install OSM
+		Expect(Td.InstallOSM(Td.GetOSMInstallOpts(installOptions...))).To(Succeed())
+
+		// Server NS
+		Expect(Td.CreateNs(destApp, nil)).To(Succeed())
+		Expect(Td.AddNsToMesh(true, destApp)).To(Succeed())
+
+		// Client Applications
+		for _, srcClient := range sourceNamespaces {
+			Expect(Td.CreateNs(srcClient, nil)).To(Succeed())
+			Expect(Td.AddNsToMesh(true, srcClient)).To(Succeed())
+		}
+
+		// Use a deployment with multiple replicaset at serverside
+		svcAccDef, deploymentDef, svcDef, err := Td.SimpleDeploymentApp(
+			SimpleDeploymentAppDef{
+				DeploymentName:     destApp,
+				Namespace:          destApp,
+				ServiceAccountName: destApp,
+				ServiceName:        destApp,
+				ReplicaCount:       int32(replicaSetPerService),
+				Image:              "kennethreitz/httpbin",
+				Ports:              []int{DefaultUpstreamServicePort},
+				Command:            HttpbinCmd,
+				OS:                 Td.ClusterOS,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = Td.CreateServiceAccount(destApp, &svcAccDef)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = Td.CreateDeployment(destApp, deploymentDef)
+		Expect(err).NotTo(HaveOccurred())
+		serverService, err := Td.CreateService(destApp, svcDef)
+		Expect(err).NotTo(HaveOccurred())
+
+		wg.Add(1)
+		go func(wg *sync.WaitGroup, srcClient string) {
+			defer GinkgoRecover()
+			defer wg.Done()
+			Expect(Td.WaitForPodsRunningReady(destApp, 200*time.Second, replicaSetPerService, nil)).To(Succeed())
+		}(&wg, destApp)
+
+		// Create all client deployments, also with replicaset
+		for _, srcClient := range sourceNamespaces {
+			svcAccDef, deploymentDef, svcDef, err = Td.SimpleDeploymentApp(
+				SimpleDeploymentAppDef{
+					DeploymentName:     srcClient,
+					Namespace:          srcClient,
+					ServiceAccountName: srcClient,
+					ContainerName:      srcClient,
+					ReplicaCount:       int32(replicaSetPerService),
+					Command:            []string{"/bin/bash", "-c", "--"},
+					Args:               []string{"while true; do sleep 30; done;"},
+					Image:              "songrgg/alpine-debug",
+					Ports:              []int{DefaultUpstreamServicePort}, // Can't deploy services with empty/no ports
+					OS:                 Td.ClusterOS,
+				})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = Td.CreateServiceAccount(srcClient, &svcAccDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateDeployment(srcClient, deploymentDef)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateService(srcClient, svcDef)
+			Expect(err).NotTo(HaveOccurred())
+
+			wg.Add(1)
+			go func(wg *sync.WaitGroup, srcClient string) {
+				defer GinkgoRecover()
+				defer wg.Done()
+				Expect(Td.WaitForPodsRunningReady(srcClient, 200*time.Second, replicaSetPerService, nil)).To(Succeed())
+			}(&wg, srcClient)
+		}
+		wg.Wait()
+
+		// Create Multiple HTTP request structure and fill it with appropriate details
+		requests := HTTPMultipleRequest{
+			Sources: []HTTPRequestDef{},
+		}
+		for _, ns := range sourceNamespaces {
+			pods, err := Td.Client.CoreV1().Pods(ns).List(context.Background(), metav1.ListOptions{})
+			Expect(err).To(BeNil())
+
+			for _, pod := range pods.Items {
+				requests.Sources = append(requests.Sources, HTTPRequestDef{
+					SourceNs:        ns,
+					SourcePod:       pod.Name,
+					SourceContainer: ns,
+
+					Destination: fmt.Sprintf("%s.%s:%d", serverService.Name, serverService.Namespace, DefaultUpstreamServicePort),
+				})
+			}
+		}
+
+		By("Fails traffic test with no permissive mode and no SMI rules")
+		Expect(trafficTest(false, requests)).To(BeTrue())
+
+		By("Succeeds traffic test when permissive mode is enabled between inmesh targets")
+		Expect(setPermissiveMode(true)).To(BeNil())
+		Expect(trafficTest(true, requests)).To(BeTrue())
+
+		// ---
+		// The following two steps are added to test, debug and make sure unsubscriptions happen at XDS level
+		// They may seem redundant; they are not.
+		By("Fails traffic test again again when permissive is disabled")
+		Expect(setPermissiveMode(false)).To(BeNil())
+		Expect(trafficTest(false, requests)).To(BeTrue())
+
+		By("Traffic succeeds again when re-enabled")
+		Expect(setPermissiveMode(true)).To(BeNil())
+		Expect(trafficTest(true, requests)).To(BeTrue())
+		// ---
+
+		By("Traffic succeeds again when re-enabled")
+		for _, srcClient := range sourceNamespaces {
+			httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+				SimpleAllowPolicy{
+					RouteGroupName:    srcClient,
+					TrafficTargetName: srcClient,
+
+					SourceNamespace:      srcClient,
+					SourceSVCAccountName: srcClient,
+
+					DestinationNamespace:      destApp,
+					DestinationSvcAccountName: destApp,
+				})
+
+			_, err = Td.CreateHTTPRouteGroup(destApp, httpRG)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = Td.CreateTrafficTarget(destApp, trafficTarget)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		Expect(trafficTest(true, requests)).To(BeTrue())
+
+		By("Succeeds when disabling Permissive now that SMI rules are in place")
+		Expect(setPermissiveMode(false)).To(BeNil())
+		Expect(trafficTest(true, requests)).To(BeTrue())
+	})
+}
 
 func setPermissiveMode(b bool) error {
 	meshConfig, err := Td.GetMeshConfig(Td.OsmNamespace)

--- a/tests/e2e/e2e_retry_policy_test.go
+++ b/tests/e2e/e2e_retry_policy_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -128,7 +127,7 @@ var _ = OSMDescribe("Test Retry Policy",
 						defer GinkgoRecover()
 						result := Td.HTTPRequest(req)
 
-						stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "proxy", "get", "stats", clientPod.Name, "--namespace", client)
+						stdout, stderr, err := Td.RunOsmCli("proxy", "get", "stats", clientPod.Name, "--namespace", client)
 						if err != nil {
 							Td.T.Logf("Could not get client stats: %v", stderr)
 						}
@@ -244,7 +243,7 @@ var _ = OSMDescribe("Test Retry Policy",
 						defer GinkgoRecover()
 						result := Td.HTTPRequest(req)
 
-						stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "proxy", "get", "stats", clientPod.Name, "--namespace", client)
+						stdout, stderr, err := Td.RunOsmCli("proxy", "get", "stats", clientPod.Name, "--namespace", client)
 						if err != nil {
 							Td.T.Logf("Could not get client stats: %v", stderr)
 						}

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -208,7 +208,7 @@ var _ = OSMDescribe("Upgrade from latest",
 			}
 
 			setArgs := "--set=osm.image.tag=" + Td.OsmImageTag + ",osm.image.registry=" + Td.CtrRegistryServer + ",osm.image.pullPolicy=" + string(pullPolicy) + ",osm.deployPrometheus=true,osm.enablePrivilegedInitContainer=" + strconv.FormatBool(Td.DeployOnOpenShift) + ",osm.osmController.resource.requests.cpu=0.3,osm.injector.resource.requests.cpu=0.1,osm.prometheus.resources.requests.cpu=0.1,osm.prometheus.resources.requests.memory=256M"
-			stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "mesh", "upgrade", "--osm-namespace="+Td.OsmNamespace, setArgs)
+			stdout, stderr, err := Td.RunOsmCli("mesh", "upgrade", "--osm-namespace="+Td.OsmNamespace, setArgs)
 			Td.T.Log(stdout.String())
 			if err != nil {
 				Td.T.Log("stderr:\n" + stderr.String())

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -568,7 +568,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	}
 
 	td.T.Log("Installing OSM")
-	stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args...)
+	stdout, stderr, err := td.RunOsmCli(args...)
 	if err != nil {
 		td.T.Logf("error running osm install")
 		td.T.Logf("stdout:\n%s", stdout)
@@ -1063,6 +1063,11 @@ func (td *OsmTestData) RunLocal(path string, args ...string) (*bytes.Buffer, *by
 	return stdout, stderr, err
 }
 
+// RunOsmCli executes the local osm binary built for the test
+func (td *OsmTestData) RunOsmCli(args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+	return Td.RunLocal(filepath.FromSlash("../../bin/osm"), args...)
+}
+
 // RunRemote runs command in remote container
 func (td *OsmTestData) RunRemote(
 	ns string, podName string, containerName string,
@@ -1429,7 +1434,7 @@ func (td *OsmTestData) GetBugReport() error {
 
 	args := []string{"support", "bug-report", "--all", fmt.Sprintf("-o=%s/osm_bug_report.tar.gz", absTestDirPath)}
 
-	stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args...)
+	stdout, stderr, err := td.RunOsmCli(args...)
 
 	td.T.Logf("stdout:\n%s", stdout)
 

--- a/tests/framework/common_metrics.go
+++ b/tests/framework/common_metrics.go
@@ -210,7 +210,7 @@ func (g *Grafana) PanelPNGSnapshot(dashboard string, panelID int, fromMinutes in
 // `.*over_limit.*`: 5
 // `tls_inspector.*alpn_found.*`: 6
 func (td *OsmTestData) GetEnvoyMetric(pod types.NamespacedName, queryMatchers []string) ([]int, error) {
-	stdout, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "proxy", "get", "stats", pod.Name, "--namespace", pod.Namespace)
+	stdout, stderr, err := Td.RunOsmCli("proxy", "get", "stats", pod.Name, "--namespace", pod.Namespace)
 	if err != nil {
 		time.Sleep(1 * time.Minute)
 		return nil, fmt.Errorf("could not get client stats, stderr=%s, err=%w", stderr, err)
@@ -238,7 +238,7 @@ func (td *OsmTestData) GetEnvoyMetric(pod types.NamespacedName, queryMatchers []
 
 // ResetEnvoyStats resets the Envoy stats counters for the given pod
 func (td *OsmTestData) ResetEnvoyStats(pod types.NamespacedName) error {
-	_, stderr, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), "proxy", "set", "reset_counters", pod.Name, "--namespace", pod.Namespace)
+	_, stderr, err := Td.RunOsmCli("proxy", "set", "reset_counters", pod.Name, "--namespace", pod.Namespace)
 	if err != nil {
 		time.Sleep(1 * time.Minute)
 		return fmt.Errorf("could not get client stats, stderr=%s, err=%w", stderr, err)

--- a/tests/framework/namespace.go
+++ b/tests/framework/namespace.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -20,7 +19,7 @@ func (td *OsmTestData) AddNsToMesh(enableSidecarInjection bool, ns ...string) er
 			args = append(args, "--disable-sidecar-injection")
 		}
 
-		stdout, stderr, err := td.RunLocal(filepath.FromSlash("../../bin/osm"), args...)
+		stdout, stderr, err := td.RunOsmCli(args...)
 		if err != nil {
 			td.T.Logf("error running osm namespace add")
 			td.T.Logf("stdout:\n%s", stdout)
@@ -30,7 +29,7 @@ func (td *OsmTestData) AddNsToMesh(enableSidecarInjection bool, ns ...string) er
 
 		if Td.EnableNsMetricTag {
 			args = []string{"metrics", "enable", "--namespace", namespace}
-			stdout, stderr, err = td.RunLocal(filepath.FromSlash("../../bin/osm"), args...)
+			stdout, stderr, err = td.RunOsmCli(args...)
 			if err != nil {
 				td.T.Logf("error running osm namespace add")
 				td.T.Logf("stdout:\n%s", stdout)


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This is a small PR to refactor tests to:

-  add helper function for running OSM cli which centralizes the call and makes it easier to discover when writing tests.
- move the tests to a function which enables retesting similar functionality (see #5131 for example)

This separate PR to make it easier to review and make #5131 smaller diff.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [x] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
no
2. Is this a breaking change?
no
3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
n/a