### PR TITLE
fix(cmd/cli/version.go): fix 'osm version' command to make it compatible with local compiled version

### DIFF
--- a/cmd/cli/version_latest.go
+++ b/cmd/cli/version_latest.go
@@ -45,9 +45,8 @@ func outputLatestReleaseVersion(out io.Writer, latestRelease string, currentRele
 	}
 	current, err := version.ParseSemantic(currentRelease)
 	if err != nil {
-		return err
-	}
-	if current.LessThan(latest) {
+		fmt.Fprintf(out, "\nOSM in %s version. Latest available version is %s.\n\n", currentRelease, latestRelease)
+	} else if current.LessThan(latest) {
 		fmt.Fprintf(out, "\nOSM %s is now available. Please see https://github.com/openservicemesh/osm/releases/latest.\nWARNING: upgrading could introduce breaking changes. Please review the release notes.\n\n", latestRelease)
 	}
 	return nil

--- a/cmd/cli/version_latest_test.go
+++ b/cmd/cli/version_latest_test.go
@@ -17,11 +17,11 @@ func TestOutputLatestReleaseVersion(t *testing.T) {
 		output  string
 	}{
 		{
-			name:    "invalid current version",
-			current: "v1.0.0.0",
+			name:    "customized current version",
+			current: "dev",
 			latest:  "v1.0.0",
-			err:     fmt.Errorf("illegal version string \"v1.0.0.0\""),
-			output:  "",
+			err:     nil,
+			output:  "\nOSM in dev version. Latest available version is v1.0.0.\n\n",
 		},
 		{
 			name:    "invalid latest version",


### PR DESCRIPTION

Signed-off-by: Wen Lin <linwen1991@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fix `osm version` command to make it compatible with local compiled version. Fixing is for [this issue](https://github.com/openservicemesh/osm/issues/5007#issuecomment-1242172429). The issue occurs while compare the `dev` version with latest available version. However, the regex only parses numbered version. When we try to parse `dev` version, we will see error: `Failed to output latest release information: could not parse `dev` as version` . The fix here disabled the comparison of `dev` and latest available version. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

- Test by running the commands `./bin/osm version` and `osm version` locally. 
- Manually deployed the fixed version to an Azure K8s Service cluster and run the commands `./bin/osm version` and `osm version`.

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? N
    -   Did you notify the maintainers and provide attribution? N/A

2. Is this a breaking change? N

3. Has documentation corresponding to this change been updated in the [osm-docs] (https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A