### PR TITLE
Create new design doc submission process

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -17,6 +17,7 @@ numberOfReviewers: 2
 useReviewGroups: true
 
 # A list of reviewers, split into different groups, to be added to pull requests (GitHub user name)
+# Make sure to keep this in sync with the OWNERS file
 reviewGroups:
   maintainers:
     - shashankram
@@ -25,8 +26,6 @@ reviewGroups:
     - trstringer
     - keithmattix
     - steeling
-    - snehachhabria
-    - draychev
   contributors:
     - allenlsy
     - jsturtevant

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,49 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 2
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+# numberOfAssignees: 2
+
+# Set to true to add reviewers from different groups to pull requests
+useReviewGroups: true
+
+# A list of reviewers, split into different groups, to be added to pull requests (GitHub user name)
+reviewGroups:
+  maintainers:
+    - shashankram
+    - nojnhuh
+    - jaellio
+    - trstringer
+    - keithmattix
+    - steeling
+    - snehachhabria
+    - draychev
+  contributors:
+    - allenlsy
+    - jsturtevant
+    - ksubrmnn
+    - shalier
+    - whitneygriffith 
+    - nshankar13
+    - schristoff
+    - SanyaKochhar
+
+# Set to true to add assignees from different groups to pull requests
+useAssigneeGroups: false
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip
+
+filterLabels:
+  include:
+    - kind/design-doc

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.3
+        with:
+          # configuration-path: '.github/auto_assign.yml' # Only needed if you use something other than .github/auto_assign.yml

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.3
-        with:
+        # with:
           # configuration-path: '.github/auto_assign.yml' # Only needed if you use something other than .github/auto_assign.yml

--- a/docs/design_docs/README.md
+++ b/docs/design_docs/README.md
@@ -1,0 +1,19 @@
+# Design Docs
+
+The Open Service Mesh (OSM) project fully-embraces design docs as a vehicle for feature proposals and discussion. This document describes the process for submitting a design doc and getting it accepted.
+
+## Prerequisites
+
+Before creating a design doc, please check the project's [issues](https://github.com/openservicemesh/osm/issues) to see if there's already ongoing effort being done. If you wold like to validate your approach or get some early feedback before starting design doc, consider starting a GitHub [discussion](https://github.com/openservicemesh/osm/discussions) on the OSM repo or asking a question in the #openservicemesh Slack [channel](https://cloud-native.slack.com/archives/C018794NV1C).
+
+## Creating a design doc
+
+Though it's not required, feel free to use the [design doc template](https://docs.google.com/document/d/1qLibGd-s3vVNakQ4e97wjuLnK4L0vSLQKIRedrzVM_k/edit#). If you choose to forgo the design doc template, make sure the same general information is present in your design doc.
+
+## Submitting a design doc
+
+To submit a design doc, submit a PR to this repo [openservicemesh/osm](github.com/openservicemesh/osm) with the title and link to your design doc added to the [index.md](./index.md) file in this directory. When submitting your PR, add the `kind/design-doc` label to it.
+
+## Design doc approval process
+
+OSM uses the [auto-assign GitHub Action](https://github.com/marketplace/actions/auto-assign-action) to automatically assign reviewers to the design doc: 2 maintainers and 2 contributors (see the [Contributor ladder](../../CONTRIBUTOR_LADDER.md) for details). Those who are auto-assigned should prioritize the design doc review the same as any code PR view. Feel free to review the design doc and add yourself as a reviewer even if you aren't auto-assigned! Comments regarding the content of the design doc should be made inline on the design doc itself if the editor supports it (e.g. Google Docs). Once a reviewer finds the design doc to be satisfactory, they should approve the PR on GitHub. Upon the approval of 2 maintainers, the PR will be merged and that design doc will be considered "approved".

--- a/docs/design_docs/index.md
+++ b/docs/design_docs/index.md
@@ -1,0 +1,5 @@
+# Design Docs Index
+
+| Name                                        | Link                                                                                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Envoy Access Logging and Extension Services | [doc](https://docs.google.com/document/d/1CZo79XlSBgwr2dOrbR1YDYzPveuk6lr6cAIkl75rW3g/edit?usp=sharing) |


### PR DESCRIPTION
Add new process for reviewing design docs. Here are the high level changes:
- Design docs are now submitted and tracked as PRs
- Design doc reviewers are automatically assigned: 2 maintainers and 2 contributors
- Auto-assigned reviewers should aim for a turnaround time for ~1 week max on reviews (same as code PRs)