### PR TITLE
feat(certs): handle MRCUpdated event when intent set passive

### DIFF
--- a/cmd/osm-controller/osm-controller.go
+++ b/cmd/osm-controller/osm-controller.go
@@ -197,6 +197,8 @@ func main() {
 
 	meshSpec := smi.NewSMIClient(informerCollection, osmNamespace, k8sClient, msgBroker)
 
+	computeClient := kube.NewClient(k8sClient)
+
 	certOpts, err := getCertOptions()
 	if err != nil {
 		log.Fatal().Err(err).Msg("Error getting certificate options")
@@ -206,21 +208,19 @@ func main() {
 	var certManager *certificate.Manager
 	if enableMeshRootCertificate {
 		certManager, err = providers.NewCertificateManagerFromMRC(ctx, kubeClient, kubeConfig, osmNamespace,
-			certOpts, k8sClient, informerCollection, 5*time.Second)
+			certOpts, computeClient, informerCollection, 5*time.Second)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error fetching certificate manager of kind %s from MRC", certProviderKind)
 		}
 	} else {
 		certManager, err = providers.NewCertificateManager(ctx, kubeClient, kubeConfig, osmNamespace,
-			certOpts, k8sClient, 5*time.Second, trustDomain)
+			certOpts, computeClient, 5*time.Second, trustDomain)
 		if err != nil {
 			events.GenericEventRecorder().FatalEvent(err, events.InvalidCertificateManager,
 				"Error fetching certificate manager of kind %s", certProviderKind)
 		}
 	}
-
-	computeClient := kube.NewClient(k8sClient)
 
 	ingress.Initialize(kubeClient, k8sClient, stop, certManager, msgBroker)
 

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -19,6 +19,7 @@ import (
 	v1alpha4 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
 	v1alpha20 "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	types "k8s.io/apimachinery/pkg/types"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // MockMeshCataloger is a mock of MeshCataloger interface.
@@ -42,6 +43,18 @@ func NewMockMeshCataloger(ctrl *gomock.Controller) *MockMeshCataloger {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMeshCataloger) EXPECT() *MockMeshCatalogerMockRecorder {
 	return m.recorder
+}
+
+// AddMRCEventsHandler mocks base method.
+func (m *MockMeshCataloger) AddMRCEventsHandler(arg0 cache.ResourceEventHandlerFuncs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMRCEventsHandler", arg0)
+}
+
+// AddMRCEventsHandler indicates an expected call of AddMRCEventsHandler.
+func (mr *MockMeshCatalogerMockRecorder) AddMRCEventsHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMRCEventsHandler", reflect.TypeOf((*MockMeshCataloger)(nil).AddMRCEventsHandler), arg0)
 }
 
 // GetEgressTrafficPolicy mocks base method.

--- a/pkg/certificate/components.go
+++ b/pkg/certificate/components.go
@@ -1,0 +1,24 @@
+package certificate
+
+import (
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+// componentsAreIssuing returns true if all certificate component statuses are `issuing`
+func componentsAreIssuing(mrc *v1alpha2.MeshRootCertificate) bool {
+	return mrc.Status.ComponentStatuses.Bootstrap == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.Gateway == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.Sidecar == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.Webhooks == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.XDSControlPlane == constants.MRCComponentStatusIssuing
+}
+
+// componentsHaveError returns true if any certificate component statuses are `error`
+func componentsHaveError(mrc *v1alpha2.MeshRootCertificate) bool {
+	return mrc.Status.ComponentStatuses.Bootstrap == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.Gateway == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.Sidecar == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.Webhooks == constants.MRCComponentStatusIssuing &&
+		mrc.Status.ComponentStatuses.XDSControlPlane == constants.MRCComponentStatusIssuing
+}

--- a/pkg/certificate/components.go
+++ b/pkg/certificate/components.go
@@ -16,9 +16,9 @@ func componentsAreIssuing(mrc *v1alpha2.MeshRootCertificate) bool {
 
 // componentsHaveError returns true if any certificate component statuses are `error`
 func componentsHaveError(mrc *v1alpha2.MeshRootCertificate) bool {
-	return mrc.Status.ComponentStatuses.Bootstrap == constants.MRCComponentStatusIssuing &&
-		mrc.Status.ComponentStatuses.Gateway == constants.MRCComponentStatusIssuing &&
-		mrc.Status.ComponentStatuses.Sidecar == constants.MRCComponentStatusIssuing &&
-		mrc.Status.ComponentStatuses.Webhooks == constants.MRCComponentStatusIssuing &&
-		mrc.Status.ComponentStatuses.XDSControlPlane == constants.MRCComponentStatusIssuing
+	return mrc.Status.ComponentStatuses.Bootstrap == constants.MRCComponentStatusError &&
+		mrc.Status.ComponentStatuses.Gateway == constants.MRCComponentStatusError &&
+		mrc.Status.ComponentStatuses.Sidecar == constants.MRCComponentStatusError &&
+		mrc.Status.ComponentStatuses.Webhooks == constants.MRCComponentStatusError &&
+		mrc.Status.ComponentStatuses.XDSControlPlane == constants.MRCComponentStatusError
 }

--- a/pkg/certificate/conditions.go
+++ b/pkg/certificate/conditions.go
@@ -1,0 +1,110 @@
+package certificate
+
+import (
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	ready              v1alpha2.MeshRootCertificateConditionType = "Ready"
+	accepted           v1alpha2.MeshRootCertificateConditionType = "Accepted"
+	issuingRollout     v1alpha2.MeshRootCertificateConditionType = "IssuingRollout"
+	validatingRollout  v1alpha2.MeshRootCertificateConditionType = "ValidatingRollout"
+	issuingRollback    v1alpha2.MeshRootCertificateConditionType = "IssuingRollback"
+	validatingRollback v1alpha2.MeshRootCertificateConditionType = "ValidatingRollback"
+)
+
+const (
+	trueStatus    v1alpha2.MeshRootCertificateConditionStatus = "True"
+	falseStatus   v1alpha2.MeshRootCertificateConditionStatus = "False"
+	unknownStatus v1alpha2.MeshRootCertificateConditionStatus = "Unknown"
+)
+
+type mrcConditionReason string
+
+const (
+	pendingReason mrcConditionReason = "Pending"
+
+	// Accepted type
+	certificateAcceptedReason mrcConditionReason = "CertificateAccepted"
+
+	// ValidatingRollout type
+	passiveStateValidatingReason      mrcConditionReason = "PassiveState"
+	passivelyInUseForValidationReason mrcConditionReason = "CertificatePassivelyInUseForValidation"
+
+	// IssuingRollout type
+	passiveStateIssuingReason      mrcConditionReason = "PassiveState"
+	passivelyInUseForIssuingReason mrcConditionReason = "CertificatePassivelyInUseForIssuing"
+
+	// IssuingRollback type
+	isNotReadyIssuingReason      mrcConditionReason = "IsNotReady"
+	passiveStateCertIssuedReason mrcConditionReason = "PassiveStateAndCertIsBeingIssued"
+	noLongerIssuingReason        mrcConditionReason = "NoLongerIssuing"
+
+	// ValidatingRollback type
+	isNotReadyValidatingReason    mrcConditionReason = "IsNotReady"
+	passiveStateCertTrustedReason mrcConditionReason = "PassiveStateAndCertIsTrusted"
+	noLongerValidatingReason      mrcConditionReason = "NoLongerValidating"
+
+	// Ready type
+	rotationCompleteReason mrcConditionReason = "RotationComplete"
+)
+
+func setMRCCondition(mrc *v1alpha2.MeshRootCertificate, conditionType v1alpha2.MeshRootCertificateConditionType, conditionStatus v1alpha2.MeshRootCertificateConditionStatus, conditionReason mrcConditionReason, message string) {
+	newCondition := v1alpha2.MeshRootCertificateCondition{
+		Type:    conditionType,
+		Status:  conditionStatus,
+		Reason:  string(conditionReason),
+		Message: message,
+	}
+
+	now := metav1.NewTime(time.Now())
+	newCondition.LastTransitionTime = &now
+
+	for i, condition := range mrc.Status.Conditions {
+		if condition.Type != newCondition.Type {
+			continue
+		}
+
+		// only update transition time on status change
+		if condition.Status == newCondition.Status {
+			newCondition.LastTransitionTime = condition.LastTransitionTime
+		} else {
+			log.Debug().Str("mrc", mrc.Name).Msgf("updating last transition time for condition type %s", condition.Type)
+		}
+
+		// update condition
+		mrc.Status.Conditions[i] = newCondition
+		log.Debug().Str("mrc", mrc.Name).Msgf("updated existing condition of type %s", condition.Type)
+		return
+	}
+
+	// condition type not found, append it to condition list
+	mrc.Status.Conditions = append(mrc.Status.Conditions, newCondition)
+	log.Debug().Str("mrc", mrc.Name).Msgf("added new condition of type %s", conditionType)
+}
+
+func getMRCCondition(mrc *v1alpha2.MeshRootCertificate, conditionType v1alpha2.MeshRootCertificateConditionType) *v1alpha2.MeshRootCertificateCondition {
+	for _, condition := range mrc.Status.Conditions {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+	return nil
+}
+
+// mrcHasCondition returns true if the given MRC has a condition matching the specified condition
+// Only the type, status, and reason are used in comparison
+func mrcHasCondition(mrc *v1alpha2.MeshRootCertificate, condition v1alpha2.MeshRootCertificateCondition) bool {
+	for _, cond := range mrc.Status.Conditions {
+		if cond.Type == condition.Type &&
+			cond.Status == condition.Status &&
+			cond.Reason == condition.Reason {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/certificate/conditions.go
+++ b/pkg/certificate/conditions.go
@@ -23,37 +23,35 @@ const (
 	unknownStatus v1alpha2.MeshRootCertificateConditionStatus = "Unknown"
 )
 
-type mrcConditionReason string
-
 const (
-	pendingReason mrcConditionReason = "Pending"
+	pendingReason = "Pending"
 
 	// Accepted type
-	certificateAcceptedReason mrcConditionReason = "CertificateAccepted"
+	certificateAcceptedReason = "CertificateAccepted"
 
 	// ValidatingRollout type
-	passiveStateValidatingReason      mrcConditionReason = "PassiveState"
-	passivelyInUseForValidationReason mrcConditionReason = "CertificatePassivelyInUseForValidation"
+	passiveStateValidatingReason      = "PassiveState"
+	passivelyInUseForValidationReason = "CertificatePassivelyInUseForValidation"
 
 	// IssuingRollout type
-	passiveStateIssuingReason      mrcConditionReason = "PassiveState"
-	passivelyInUseForIssuingReason mrcConditionReason = "CertificatePassivelyInUseForIssuing"
+	passiveStateIssuingReason      = "PassiveState"
+	passivelyInUseForIssuingReason = "CertificatePassivelyInUseForIssuing"
 
 	// IssuingRollback type
-	isNotReadyIssuingReason      mrcConditionReason = "IsNotReady"
-	passiveStateCertIssuedReason mrcConditionReason = "PassiveStateAndCertIsBeingIssued"
-	noLongerIssuingReason        mrcConditionReason = "NoLongerIssuing"
+	isNotReadyIssuingReason      = "IsNotReady"
+	passiveStateCertIssuedReason = "PassiveStateAndCertIsBeingIssued"
+	noLongerIssuingReason        = "NoLongerIssuing"
 
 	// ValidatingRollback type
-	isNotReadyValidatingReason    mrcConditionReason = "IsNotReady"
-	passiveStateCertTrustedReason mrcConditionReason = "PassiveStateAndCertIsTrusted"
-	noLongerValidatingReason      mrcConditionReason = "NoLongerValidating"
+	isNotReadyValidatingReason    = "IsNotReady"
+	passiveStateCertTrustedReason = "PassiveStateAndCertIsTrusted"
+	noLongerValidatingReason      = "NoLongerValidating"
 
 	// Ready type
-	rotationCompleteReason mrcConditionReason = "RotationComplete"
+	rotationCompleteReason = "RotationComplete"
 )
 
-func setMRCCondition(mrc *v1alpha2.MeshRootCertificate, conditionType v1alpha2.MeshRootCertificateConditionType, conditionStatus v1alpha2.MeshRootCertificateConditionStatus, conditionReason mrcConditionReason, message string) {
+func setMRCCondition(mrc *v1alpha2.MeshRootCertificate, conditionType v1alpha2.MeshRootCertificateConditionType, conditionStatus v1alpha2.MeshRootCertificateConditionStatus, conditionReason string, message string) {
 	newCondition := v1alpha2.MeshRootCertificateCondition{
 		Type:    conditionType,
 		Status:  conditionStatus,

--- a/pkg/certificate/conditions_test.go
+++ b/pkg/certificate/conditions_test.go
@@ -1,0 +1,1 @@
+package certificate

--- a/pkg/certificate/conditions_test.go
+++ b/pkg/certificate/conditions_test.go
@@ -1,1 +1,382 @@
 package certificate
+
+import (
+	"testing"
+	time "time"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+	tassert "github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetMRCCondition(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+
+	testCases := []struct {
+		name                       string
+		mrc                        *v1alpha2.MeshRootCertificate
+		expectedConditionsLen      int
+		expectedLastTransitionTime *metav1.Time
+		newCondition               v1alpha2.MeshRootCertificateCondition
+	}{
+		{
+			name: "set new condition",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+			},
+			expectedConditionsLen: 1,
+			newCondition: v1alpha2.MeshRootCertificateCondition{
+				Type:    accepted,
+				Status:  trueStatus,
+				Reason:  certificateAcceptedReason,
+				Message: "test",
+			},
+		},
+		{
+			name: "update existing condition, no status change",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:               validatingRollback,
+							Status:             falseStatus,
+							Reason:             isNotReadyValidatingReason,
+							Message:            "test",
+							LastTransitionTime: &now,
+						},
+					},
+				},
+			},
+			expectedConditionsLen:      1,
+			expectedLastTransitionTime: &now,
+			newCondition: v1alpha2.MeshRootCertificateCondition{
+				Type:    validatingRollback,
+				Status:  falseStatus,
+				Reason:  noLongerValidatingReason,
+				Message: "test",
+			},
+		},
+		{
+			name: "update status of existing condition",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:    validatingRollout,
+							Status:  falseStatus,
+							Reason:  passiveStateValidatingReason,
+							Message: "test",
+						},
+					},
+				},
+			},
+			expectedConditionsLen: 1,
+			newCondition: v1alpha2.MeshRootCertificateCondition{
+				Type:    validatingRollout,
+				Status:  trueStatus,
+				Reason:  passivelyInUseForValidationReason,
+				Message: "test",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+			setMRCCondition(tc.mrc, tc.newCondition.Type, tc.newCondition.Status, tc.newCondition.Reason, tc.newCondition.Message)
+
+			a.Equal(tc.expectedConditionsLen, len(tc.mrc.Status.Conditions))
+			for _, cond := range tc.mrc.Status.Conditions {
+				if cond.Type != tc.newCondition.Type {
+					continue
+				}
+
+				a.Equal(tc.newCondition.Status, cond.Status)
+				a.Equal(tc.newCondition.Reason, cond.Reason)
+				a.Equal(tc.newCondition.Message, cond.Message)
+
+				if tc.expectedLastTransitionTime != nil {
+					a.Equal(tc.expectedLastTransitionTime, cond.LastTransitionTime)
+				}
+			}
+		})
+	}
+}
+
+func TestGetMRCCondition(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		mrc                  *v1alpha2.MeshRootCertificate
+		desiredConditionType v1alpha2.MeshRootCertificateConditionType
+		expectedCondition    *v1alpha2.MeshRootCertificateCondition
+	}{
+		{
+			name: "condition not found",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:    validatingRollout,
+							Status:  falseStatus,
+							Reason:  pendingReason,
+							Message: "test2",
+						},
+					},
+				},
+			},
+			desiredConditionType: accepted,
+			expectedCondition:    nil,
+		},
+		{
+			name: "condition found",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:    validatingRollout,
+							Status:  falseStatus,
+							Reason:  pendingReason,
+							Message: "test2",
+						},
+					},
+				},
+			},
+			desiredConditionType: validatingRollout,
+			expectedCondition: &v1alpha2.MeshRootCertificateCondition{
+				Type:    validatingRollout,
+				Status:  falseStatus,
+				Reason:  pendingReason,
+				Message: "test2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+			cond := getMRCCondition(tc.mrc, tc.desiredConditionType)
+			a.Equal(tc.expectedCondition, cond)
+		})
+	}
+}
+
+func TestMRCHasCondition(t *testing.T) {
+	testCases := []struct {
+		name             string
+		mrc              *v1alpha2.MeshRootCertificate
+		desiredCondition v1alpha2.MeshRootCertificateCondition
+		expectedReturn   bool
+	}{
+		{
+			name: "has condition",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:    validatingRollout,
+							Status:  falseStatus,
+							Reason:  pendingReason,
+							Message: "test",
+						},
+					},
+				},
+			},
+			desiredCondition: v1alpha2.MeshRootCertificateCondition{
+				Type:    validatingRollout,
+				Status:  falseStatus,
+				Reason:  pendingReason,
+				Message: "test2",
+			},
+			expectedReturn: true,
+		},
+		{
+			name: "has condition type, but not desired status",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:    validatingRollout,
+							Status:  falseStatus,
+							Reason:  pendingReason,
+							Message: "test",
+						},
+					},
+				},
+			},
+			desiredCondition: v1alpha2.MeshRootCertificateCondition{
+				Type:    validatingRollout,
+				Status:  trueStatus,
+				Reason:  passivelyInUseForValidationReason,
+				Message: "test",
+			},
+			expectedReturn: false,
+		},
+		{
+			name: "does not have desired condition",
+			mrc: &v1alpha2.MeshRootCertificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "osm-mesh-root-certificate",
+					Namespace: "osm-system",
+				},
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Provider: v1alpha2.ProviderSpec{
+						Tresor: &v1alpha2.TresorProviderSpec{
+							CA: v1alpha2.TresorCASpec{
+								SecretRef: v1.SecretReference{
+									Name:      "osm-ca-bundle",
+									Namespace: "osm-system",
+								},
+							},
+						},
+					},
+				},
+				Intent: constants.MRCIntentPassive,
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:    validatingRollout,
+							Status:  falseStatus,
+							Reason:  pendingReason,
+							Message: "test",
+						},
+					},
+				},
+			},
+			desiredCondition: v1alpha2.MeshRootCertificateCondition{
+				Type:    accepted,
+				Status:  trueStatus,
+				Reason:  certificateAcceptedReason,
+				Message: "test",
+			},
+			expectedReturn: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := tassert.New(t)
+			hasCond := mrcHasCondition(tc.mrc, tc.desiredCondition)
+			a.Equal(tc.expectedReturn, hasCond)
+		})
+	}
+}

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -9,7 +9,7 @@ var errEncodeCert = errors.New("encode cert")
 var errMarshalPrivateKey = errors.New("marshal private key")
 var errNoPrivateKeyInPEM = errors.New("no private Key in PEM")
 
-// ErrNoCertificateInPEM is the errror for no certificate in PEM
+// ErrNoCertificateInPEM is the error for no certificate in PEM
 var ErrNoCertificateInPEM = errors.New("no certificate in PEM")
 
 // All of the below errors should be returned by the StorageEngine for each described scenario. The errors may be
@@ -20,3 +20,6 @@ var ErrInvalidCertSecret = errors.New("invalid secret for certificate")
 
 // ErrSecretNotFound should be returned if the secret isn't present in the underlying infra, on a Get
 var ErrSecretNotFound = errors.New("secret not found")
+
+// ErrMRCNotFound should be returned if a MRC cannot be found in the control plane namespace
+var ErrMRCNotFound = errors.New("mrc not found")

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -168,6 +168,7 @@ func (m *Manager) handleMRCEvent(ctx context.Context, mrcClient MRCClient, event
 			}
 
 			// define reconciler
+			// TODO(jaellio): Maybe it would make more sense for this to be the MRCController
 			mrcReconciler := MRCReconciler{
 				mrcName:      newMRC.Name,
 				updateStatus: nil,
@@ -220,8 +221,8 @@ func handleActiveToPassiveMRCStatusChange(mrcClient MRCClient, event MRCEvent) e
 		}
 
 		// set new conditions
-		setMRCCondition(mrc, newIssuingRollbackCond.Type, newIssuingRollbackCond.Status, mrcConditionReason(newIssuingRollbackCond.Reason), "")
-		setMRCCondition(mrc, newValidatingRollbackCond.Type, newValidatingRollbackCond.Status, mrcConditionReason(newIssuingRollbackCond.Reason), "")
+		setMRCCondition(mrc, newIssuingRollbackCond.Type, newIssuingRollbackCond.Status, newIssuingRollbackCond.Reason, "")
+		setMRCCondition(mrc, newValidatingRollbackCond.Type, newValidatingRollbackCond.Status, newIssuingRollbackCond.Reason, "")
 
 		_, err := mrcClient.UpdateMeshRootCertificateStatus(mrc)
 		return err

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -331,7 +331,7 @@ func TestHandleMRCEvent(t *testing.T) {
 			mrcClient: &fakeMRCClient{},
 			mrcEvent: MRCEvent{
 				Type: MRCEventAdded,
-				MRC: &v1alpha2.MeshRootCertificate{
+				NewMRC: &v1alpha2.MeshRootCertificate{
 					ObjectMeta: v1.ObjectMeta{
 						Name: "my-mrc",
 					},
@@ -386,7 +386,7 @@ func TestHandleMRCEvent(t *testing.T) {
 			assert := tassert.New(t)
 			m := &Manager{}
 
-			err := m.handleMRCEvent(tt.mrcClient, tt.mrcEvent)
+			err := m.handleMRCEvent(context.Background(), tt.mrcClient, tt.mrcEvent)
 			if !tt.wantErr {
 				assert.NoError(err)
 			} else {

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -19,8 +19,8 @@ func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEven
 	ch := make(chan certificate.MRCEvent)
 	go func() {
 		ch <- certificate.MRCEvent{
-			Type: certificate.MRCEventAdded,
-			MRC:  c.mrc,
+			Type:   certificate.MRCEventAdded,
+			NewMRC: c.mrc,
 		}
 		close(ch)
 	}()

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -20,8 +20,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate/providers/certmanager"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/vault"
+	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/constants"
-	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/k8s/informers"
 	"github.com/openservicemesh/osm/pkg/utils"
 )
@@ -45,7 +45,7 @@ var getCA = func(i certificate.Issuer) (pem.RootCertificate, error) {
 // NewCertificateManager returns a new certificate manager with a MRC compat client.
 // TODO(4713): Remove and use NewCertificateManagerFromMRC
 func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface, kubeConfig *rest.Config,
-	providerNamespace string, option Options, kubeController k8s.Controller, checkInterval time.Duration, trustDomain string) (*certificate.Manager, error) {
+	providerNamespace string, option Options, computeClient compute.Interface, checkInterval time.Duration, trustDomain string) (*certificate.Manager, error) {
 	if err := option.Validate(); err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 		MRCProviderGenerator: MRCProviderGenerator{
 			kubeClient:      kubeClient,
 			kubeConfig:      kubeConfig,
-			KeyBitSize:      utils.GetCertKeyBitSize(kubeController.GetMeshConfig()),
+			KeyBitSize:      utils.GetCertKeyBitSize(computeClient.GetMeshConfig()),
 			caExtractorFunc: getCA,
 		},
 		mrc: &v1alpha2.MeshRootCertificate{
@@ -104,6 +104,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 				},
 			},
 		},
+		Interface: computeClient,
 	}
 	// TODO(#4745): Remove after deprecating the osm.vault.token option.
 	if vaultOption, ok := option.(VaultOptions); ok {
@@ -113,15 +114,15 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 	return certificate.NewManager(
 		ctx,
 		mrcClient,
-		func() time.Duration { return utils.GetServiceCertValidityPeriod(kubeController.GetMeshConfig()) },
-		func() time.Duration { return utils.GetIngressGatewayCertValidityPeriod(kubeController.GetMeshConfig()) },
+		func() time.Duration { return utils.GetServiceCertValidityPeriod(computeClient.GetMeshConfig()) },
+		func() time.Duration { return utils.GetIngressGatewayCertValidityPeriod(computeClient.GetMeshConfig()) },
 		checkInterval,
 	)
 }
 
 // NewCertificateManagerFromMRC returns a new certificate manager.
 func NewCertificateManagerFromMRC(ctx context.Context, kubeClient kubernetes.Interface, kubeConfig *rest.Config,
-	providerNamespace string, option Options, kubeController k8s.Controller, ic *informers.InformerCollection, checkInterval time.Duration) (*certificate.Manager, error) {
+	providerNamespace string, option Options, computeClient compute.Interface, ic *informers.InformerCollection, checkInterval time.Duration) (*certificate.Manager, error) {
 	if err := option.Validate(); err != nil {
 		return nil, err
 	}
@@ -130,10 +131,10 @@ func NewCertificateManagerFromMRC(ctx context.Context, kubeClient kubernetes.Int
 		MRCProviderGenerator: MRCProviderGenerator{
 			kubeClient:      kubeClient,
 			kubeConfig:      kubeConfig,
-			KeyBitSize:      utils.GetCertKeyBitSize(kubeController.GetMeshConfig()),
+			KeyBitSize:      utils.GetCertKeyBitSize(computeClient.GetMeshConfig()),
 			caExtractorFunc: getCA,
 		},
-		informerCollection: ic,
+		Interface: computeClient,
 	}
 	// TODO(#4745): Remove after deprecating the osm.vault.token option.
 	if vaultOption, ok := option.(VaultOptions); ok {
@@ -143,8 +144,8 @@ func NewCertificateManagerFromMRC(ctx context.Context, kubeClient kubernetes.Int
 	return certificate.NewManager(
 		ctx,
 		mrcClient,
-		func() time.Duration { return utils.GetServiceCertValidityPeriod(kubeController.GetMeshConfig()) },
-		func() time.Duration { return utils.GetIngressGatewayCertValidityPeriod(kubeController.GetMeshConfig()) },
+		func() time.Duration { return utils.GetServiceCertValidityPeriod(computeClient.GetMeshConfig()) },
+		func() time.Duration { return utils.GetIngressGatewayCertValidityPeriod(computeClient.GetMeshConfig()) },
 		checkInterval,
 	)
 }

--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -7,34 +7,15 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
-	"github.com/openservicemesh/osm/pkg/k8s/informers"
+	"github.com/openservicemesh/osm/pkg/compute"
 )
 
 // MRCComposer is a composer object that allows consumers
 // to observe MRCs (via List() and Watch()) as well as generate
 // `certificate.Provider`s from those MRCs
 type MRCComposer struct {
-	informerCollection *informers.InformerCollection
+	compute.Interface
 	MRCProviderGenerator
-}
-
-// List returns the MRCs stored in the informerCollection's store
-func (m *MRCComposer) List() ([]*v1alpha2.MeshRootCertificate, error) {
-	// informers return slice of pointers so we'll convert them to value types before returning
-	mrcPtrs := m.informerCollection.List(informers.InformerKeyMeshRootCertificate)
-	var mrcs []*v1alpha2.MeshRootCertificate
-	for _, mrcPtr := range mrcPtrs {
-		if mrcPtr == nil {
-			continue
-		}
-		mrc, ok := mrcPtr.(*v1alpha2.MeshRootCertificate)
-		if !ok {
-			continue
-		}
-		mrcs = append(mrcs, mrc)
-	}
-
-	return mrcs, nil
 }
 
 // Watch returns a channel that receives events whenever MRCs are added, updated, and deleted
@@ -43,23 +24,23 @@ func (m *MRCComposer) List() ([]*v1alpha2.MeshRootCertificate, error) {
 // to be ordered for any particular resources, but NOT across different resources.
 func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	eventChan := make(chan certificate.MRCEvent)
-	m.informerCollection.AddEventHandler(informers.InformerKeyMeshRootCertificate, cache.ResourceEventHandlerFuncs{
+	m.AddMRCEventsHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			mrc := obj.(*v1alpha2.MeshRootCertificate)
 			log.Debug().Msgf("received MRC add event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
 			eventChan <- certificate.MRCEvent{
-				Type: certificate.MRCEventAdded,
-				MRC:  mrc,
+				Type:   certificate.MRCEventAdded,
+				NewMRC: mrc,
 			}
 		},
-		// We don't really care about the previous version
-		// since the "state machine" of the MRC is well defined
-		UpdateFunc: func(_, newObj interface{}) {
-			mrc := newObj.(*v1alpha2.MeshRootCertificate)
-			log.Debug().Msgf("received MRC update event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldMRC := oldObj.(*v1alpha2.MeshRootCertificate)
+			newMRC := newObj.(*v1alpha2.MeshRootCertificate)
+			log.Debug().Msgf("received MRC update event for MRC %s/%s", newMRC.GetNamespace(), newMRC.GetName())
 			eventChan <- certificate.MRCEvent{
-				Type: certificate.MRCEventUpdated,
-				MRC:  mrc,
+				Type:   certificate.MRCEventUpdated,
+				OldMRC: oldMRC,
+				NewMRC: newMRC,
 			}
 		},
 		// We don't care about deletes because the only deletes that should

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
+	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/constants"
 )
 
@@ -22,6 +23,7 @@ const (
 )
 
 type fakeMRCClient struct {
+	compute.Interface
 	mrcChannel chan certificate.MRCEvent
 }
 
@@ -38,7 +40,7 @@ func NewFakeMRC() *fakeMRCClient { //nolint: revive // unexported-return
 func (c *fakeMRCClient) NewCertEvent(name, state string) {
 	c.mrcChannel <- certificate.MRCEvent{
 		Type: certificate.MRCEventAdded,
-		MRC: &v1alpha2.MeshRootCertificate{
+		NewMRC: &v1alpha2.MeshRootCertificate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "osm-system",
@@ -117,12 +119,6 @@ func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (
 	}
 
 	return issuer, cert.GetTrustedCAs(), nil
-}
-
-// List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
-func (c *fakeMRCClient) List() ([]*v1alpha2.MeshRootCertificate, error) {
-	// return single empty object in the list.
-	return []*v1alpha2.MeshRootCertificate{{Spec: v1alpha2.MeshRootCertificateSpec{TrustDomain: "fake.example.com"}}}, nil
 }
 
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {

--- a/pkg/certificate/providers/types.go
+++ b/pkg/certificate/providers/types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
+	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -75,6 +76,7 @@ type CertManagerOptions struct {
 // It's intent is to match the custom interface that will wrap the MRC k8s informer.
 // TODO(#4502): Remove this entirely once we are fully onboarded to MRC informers.
 type MRCCompatClient struct {
+	compute.Interface
 	MRCProviderGenerator
 	mrc *v1alpha2.MeshRootCertificate
 }

--- a/pkg/certificate/reconciler.go
+++ b/pkg/certificate/reconciler.go
@@ -1,0 +1,10 @@
+package certificate
+
+import (
+	"context"
+	"time"
+)
+
+func (r *MRCReconciler) CheckAndUpdate(ctx context.Context, mrcClient MRCClient, checkInterval time.Duration) {
+	// Not implemented
+}

--- a/pkg/compute/mock_compute_client_generated.go
+++ b/pkg/compute/mock_compute_client_generated.go
@@ -15,6 +15,7 @@ import (
 	identity "github.com/openservicemesh/osm/pkg/identity"
 	service "github.com/openservicemesh/osm/pkg/service"
 	types "k8s.io/apimachinery/pkg/types"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -38,6 +39,18 @@ func NewMockInterface(ctrl *gomock.Controller) *MockInterface {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
+}
+
+// AddMRCEventsHandler mocks base method.
+func (m *MockInterface) AddMRCEventsHandler(arg0 cache.ResourceEventHandlerFuncs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMRCEventsHandler", arg0)
+}
+
+// AddMRCEventsHandler indicates an expected call of AddMRCEventsHandler.
+func (mr *MockInterfaceMockRecorder) AddMRCEventsHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMRCEventsHandler", reflect.TypeOf((*MockInterface)(nil).AddMRCEventsHandler), arg0)
 }
 
 // GetHostnamesForService mocks base method.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -220,6 +220,9 @@ const (
 	// MRCComponentStatusUnknown is the unknown status option for the component status of the MeshRootCertificate
 	MRCComponentStatusUnknown = "Unknown"
 
+	// MRCComponentStatusIssuing is the issuing status option for the component status of the MeshRootCertificate
+	MRCComponentStatusIssuing = "Issuing"
+
 	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
 	MRCConditionStatusUnknown = "Unknown"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -220,6 +220,9 @@ const (
 	// MRCComponentStatusUnknown is the unknown status option for the component status of the MeshRootCertificate
 	MRCComponentStatusUnknown = "Unknown"
 
+	// MRCComponentStatusError is the error status option for the component status of the MeshRootCertificate
+	MRCComponentStatusError = "Error"
+
 	// MRCComponentStatusIssuing is the issuing status option for the component status of the MeshRootCertificate
 	MRCComponentStatusIssuing = "Issuing"
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
@@ -428,4 +429,9 @@ func (c *Client) ListMeshRootCertificates() ([]*configv1alpha2.MeshRootCertifica
 	}
 
 	return mrcs, nil
+}
+
+// AddMRCEventsHandler adds the event handler for MRCEvents
+func (c *Client) AddMRCEventsHandler(handlerFuncs cache.ResourceEventHandlerFuncs) {
+	c.informers.AddEventHandler(osminformers.InformerKeyMeshRootCertificate, handlerFuncs)
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -627,9 +627,8 @@ func TestConfigUpdateStatus(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := tassert.New(t)
-			kubeClient := testclient.NewSimpleClientset()
 			configClient := fakeConfigClient.NewSimpleClientset(tc.existingResource.(runtime.Object))
-			ic, err := informers.NewInformerCollection(tests.MeshName, nil, informers.WithKubeClient(kubeClient))
+			ic, err := informers.NewInformerCollection(tests.MeshName, nil)
 			a.Nil(err)
 			c := NewClient(tests.OsmNamespace, tests.OsmMeshConfigName, ic, nil, configClient, nil)
 			switch v := tc.updatedResource.(type) {

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -13,6 +13,7 @@ import (
 	envoy "github.com/openservicemesh/osm/pkg/envoy"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
+	cache "k8s.io/client-go/tools/cache"
 )
 
 // MockController is a mock of Controller interface.
@@ -36,6 +37,18 @@ func NewMockController(ctrl *gomock.Controller) *MockController {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockController) EXPECT() *MockControllerMockRecorder {
 	return m.recorder
+}
+
+// AddMRCEventsHandler mocks base method.
+func (m *MockController) AddMRCEventsHandler(arg0 cache.ResourceEventHandlerFuncs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMRCEventsHandler", arg0)
+}
+
+// AddMRCEventsHandler indicates an expected call of AddMRCEventsHandler.
+func (mr *MockControllerMockRecorder) AddMRCEventsHandler(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMRCEventsHandler", reflect.TypeOf((*MockController)(nil).AddMRCEventsHandler), arg0)
 }
 
 // GetEndpoints mocks base method.

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
@@ -149,4 +150,7 @@ type PassthroughInterface interface {
 
 	// GetUpstreamTrafficSetting returns the UpstreamTrafficSetting resources with namespaced name
 	GetUpstreamTrafficSetting(*types.NamespacedName) *policyv1alpha1.UpstreamTrafficSetting
+
+	// AddMRCEventsHandler adds event handlers to create MRCEvents
+	AddMRCEventsHandler(cache.ResourceEventHandlerFuncs)
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Adds logic to update MRC conditions and components. Handles MRCUpdated event when intent set to passive.

Part of #5091 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?