### PR TITLE
docs(pkg/certificate/README.md): fix broken document link

### DIFF
--- a/pkg/certificate/README.md
+++ b/pkg/certificate/README.md
@@ -2,7 +2,7 @@
 
 This package contains tools for issuing and renewing certificates for the service mesh.
 
-For design and details on mTLS and certificate issuance please see [docs/patterns/certificates.md](../../docs/patterns/certificates.md).
+For design and details on mTLS and certificate issuance please see [docs/patterns/certificates.md](../../docs/certificate_management.md).
 
 
 ## Interfaces


### PR DESCRIPTION
Signed-off-by: Wen Lin <linwen1991@gmail.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Link to the [Certificate Management](https://github.com/openservicemesh/osm/blob/main/docs/certificate_management.md) is broken. Fixed by using the correct link.
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Test manually in local. 
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ X] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution? No

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No