### PR TITLE
Changes renewBefore to use cert validity duration

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -9,9 +9,6 @@ import (
 )
 
 const (
-	// RenewBeforeCertExpires signifies how much earlier (before expiration) should a certificate be renewed
-	RenewBeforeCertExpires = 30 * time.Second
-
 	// So that we do not renew all certs at the same time - add noise.
 	// These define the min and max of the seconds of noise to be added
 	// to the early certificate renewal.

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -9,6 +9,13 @@ import (
 )
 
 const (
+	// MinRotateBeforeExpireMinutes specifies the minimum number of minutes of how much earlier we can do a certificate renewal.
+	// This prevents us from rotating too frequently.
+	MinRotateBeforeExpireMinutes = 5
+
+	// Specifies what fraction of validity duration we want to renew before the certificate expires.
+	fractionValidityDuration = 3
+
 	// So that we do not renew all certs at the same time - add noise.
 	// These define the min and max of the seconds of noise to be added
 	// to the early certificate renewal.

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -139,12 +139,12 @@ func (m *Manager) GetTrustDomain() string {
 // ShouldRotate determines whether a certificate should be rotated.
 func (m *Manager) ShouldRotate(c *Certificate) bool {
 	// The certificate is going to expire at a timestamp T
-	// We want to renew earlier. How much earlier is defined in renewBeforeCertExpires.
+	// We want to renew earlier. How much earlier is defined as a third of the certificate's validity duration.
 	// We add a few seconds noise to the early renew period so that certificates that may have been
 	// created at the same time are not renewed at the exact same time.
 	intNoise := rand.Intn(noiseSeconds) // #nosec G404
 	secondsNoise := time.Duration(intNoise) * time.Second
-	renewBefore := RenewBeforeCertExpires + secondsNoise
+	renewBefore := m.getValidityDurationForCertType(c.certType)/3 + secondsNoise
 	// Round is called to truncate monotonic clock to the nearest second. This is done to avoid environments where the
 	// CPU clock may stop, resulting in a time measurement that differs significantly from the x509 timestamp.
 	// See https://github.com/openservicemesh/osm/issues/5000#issuecomment-1218539412 for more details.

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -139,12 +139,15 @@ func (m *Manager) GetTrustDomain() string {
 // ShouldRotate determines whether a certificate should be rotated.
 func (m *Manager) ShouldRotate(c *Certificate) bool {
 	// The certificate is going to expire at a timestamp T
-	// We want to renew earlier. How much earlier is defined as a third of the certificate's validity duration.
+	// We want to renew earlier. How much earlier is defined as the max between
+	// a fractionValidityDuration of the certificate's validity duration and the minimum allowed time defined in minRotateBeforeExpireTime.
 	// We add a few seconds noise to the early renew period so that certificates that may have been
 	// created at the same time are not renewed at the exact same time.
 	intNoise := rand.Intn(noiseSeconds) // #nosec G404
 	secondsNoise := time.Duration(intNoise) * time.Second
-	renewBefore := m.getValidityDurationForCertType(c.certType)/3 + secondsNoise
+	minRotateBeforeExpireTime := time.Duration(MinRotateBeforeExpireMinutes) * time.Minute
+	fractionOfValidityDuration := m.getValidityDurationForCertType(c.certType) / fractionValidityDuration
+	renewBefore := maxDuration(fractionOfValidityDuration, minRotateBeforeExpireTime) + secondsNoise
 	// Round is called to truncate monotonic clock to the nearest second. This is done to avoid environments where the
 	// CPU clock may stop, resulting in a time measurement that differs significantly from the x509 timestamp.
 	// See https://github.com/openservicemesh/osm/issues/5000#issuecomment-1218539412 for more details.
@@ -174,6 +177,13 @@ func (m *Manager) ShouldRotate(c *Certificate) bool {
 	}
 	log.Trace().Msgf("Cert %s should not be rotated with serial number %s and expiration %s", c.GetCommonName(), c.GetSerialNumber(), c.GetExpiration())
 	return false
+}
+
+func maxDuration(a time.Duration, b time.Duration) time.Duration {
+	if a >= b {
+		return a
+	}
+	return b
 }
 
 func (m *Manager) checkAndRotate() {

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -52,7 +52,7 @@ func TestShouldRotate(t *testing.T) {
 		{
 			name: "Valid certificate",
 			cert: &Certificate{
-				Expiration:         time.Now().Add(1 * time.Hour),
+				Expiration:         time.Now().Add(constants.OSMCertificateValidityPeriod),
 				signingIssuerID:    "1",
 				validatingIssuerID: "1",
 			},

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -179,7 +179,7 @@ func TestListIssuedCertificate(t *testing.T) {
 func TestIssueCertificate(t *testing.T) {
 	assert := tassert.New(t)
 	cnPrefix := "fake-cert-cn"
-	getServiceValidityDuration := func() time.Duration { return time.Minute }
+	getServiceValidityDuration := func() time.Duration { return time.Hour }
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/pkg/injector/bootstrap_test.go
+++ b/pkg/injector/bootstrap_test.go
@@ -401,7 +401,7 @@ func TestRotateBootstrapSecrets(t *testing.T) {
 	commonName2 := certificate.CommonName(proxyUUID2.String() + ".test.cert")
 
 	notBefore := time.Now()
-	notAfter := notBefore.Add(1 * time.Hour)
+	notAfter := notBefore.Add(constants.OSMCertificateValidityPeriod)
 	pemCert, pemKey, err := certificate.CreateValidCertAndKey(commonName1, notBefore, notAfter)
 	assert.Nil(err)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
change renewBefore to use a third of the certificate's validity duration plus some noise
and resolves #5150 

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x ] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?