### PR TITLE
Add the start of basic tests for MRC rotation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,7 +241,7 @@ jobs:
       matrix:
         k8s_version: [""]
         focus: [""]
-        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
         include:
           - k8s_version: v1.22.9
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"

--- a/demo/deploy-vault.sh
+++ b/demo/deploy-vault.sh
@@ -48,7 +48,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
       - name: vault
-        image: registry.hub.docker.com/library/vault:1.4.0
+        image: registry.hub.docker.com/library/vault:1.11.3
         imagePullPolicy: Always
         command: ["/bin/sh","-c"]
         args:

--- a/tests/e2e/e2e_hashivault_test.go
+++ b/tests/e2e/e2e_hashivault_test.go
@@ -24,6 +24,10 @@ var _ = OSMDescribe("1 Client pod -> 1 Server pod test using Vault",
 		Context("with SPIFFE Enabled", func() {
 			testHashCorpVault(WithSpiffeEnabled())
 		})
+
+		Context("with MeshRootCertificate Enabled", func() {
+			testHashCorpVault(WithSpiffeEnabled())
+		})
 	})
 
 func testHashCorpVault(installOptions ...InstallOsmOpt) {
@@ -37,13 +41,8 @@ func testHashCorpVault(installOptions ...InstallOsmOpt) {
 
 	It("Tests HTTP traffic for client pod -> server pod", func() {
 		// Install OSM
+		installOptions = append(installOptions, WithVault())
 		installOpts := Td.GetOSMInstallOpts(installOptions...)
-		installOpts.CertManager = "vault"
-		installOpts.SetOverrides = []string{
-			// increase timeout when using an external certificate provider due to
-			// potential slowness issuing certs
-			"osm.injector.webhookTimeoutSeconds=30",
-		}
 		Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
 		// Create Test NS

--- a/tests/e2e/e2e_meshrootcertificate_test.go
+++ b/tests/e2e/e2e_meshrootcertificate_test.go
@@ -1,0 +1,228 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	certman "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+var (
+	ActiveIntent  = v1alpha2.MeshRootCertificateIntent("active")
+	PassiveIntent = v1alpha2.MeshRootCertificateIntent("passive")
+)
+
+var _ = OSMDescribe("MeshRootCertificate",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 11,
+	},
+	func() {
+		Context("with Tressor", func() {
+			It("rotates certificates", func() {
+				basicCertRotationScenario()
+			})
+		})
+
+		Context("with CertManager", func() {
+			It("rotates certificates", func() {
+				basicCertRotationScenario(WithCertManagerEnabled())
+			})
+		})
+
+		Context("with Vault", func() {
+			It("rotates certificates", func() {
+				basicCertRotationScenario(WithVault())
+			})
+		})
+	})
+
+func basicCertRotationScenario(installOptions ...InstallOsmOpt) {
+	By("installing with MRC enabled")
+	installOptions = append(installOptions, WithMeshRootCertificateEnabled())
+	installOpts := Td.GetOSMInstallOpts(installOptions...)
+	Expect(Td.InstallOSM(installOpts)).To(Succeed())
+
+	// no secrets are created in Vault case
+	if installOpts.CertManager != Vault {
+		By("checking the certificate exists")
+		err := Td.WaitForCABundleSecret(Td.OsmNamespace, OsmCABundleName, time.Second*5)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	By("checking that an active cert cannot be created")
+	time.Sleep(time.Second * 10)
+	activeNotAllowed := "not-allowed"
+	_, err := createMeshRootCertificate(activeNotAllowed, ActiveIntent, installOpts.CertManager)
+	Expect(err).Should(HaveOccurred())
+	Expect(err.Error()).Should(ContainSubstring("cannot create MRC %s/%s with intent active. An MRC with active intent already exists in the control plane namespace", Td.OsmNamespace, activeNotAllowed))
+
+	By("creating a second certificate in passive state")
+	newCertName := "osm-mrc-2"
+	_, err = createMeshRootCertificate(newCertName, PassiveIntent, installOpts.CertManager)
+	Expect(err).NotTo(HaveOccurred())
+
+	// no secrets are created in Vault case
+	if installOpts.CertManager != Vault {
+		By("ensuring the new CA secret exists")
+		err = Td.WaitForCABundleSecret(Td.OsmNamespace, newCertName, time.Second*90)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	// TODO(#4835) add checks for the correct statuses for the two certificates and complete cert rotation
+}
+
+func createMeshRootCertificate(name string, intent v1alpha2.MeshRootCertificateIntent, certificateManagerType string) (*v1alpha2.MeshRootCertificate, error) {
+	switch certificateManagerType {
+	case DefaultCertManager:
+		return createTressorMRC(name, intent)
+	case CertManager:
+		return createCertManagerMRC(name, intent)
+	case Vault:
+		return createVaultMRC(name, intent)
+	default:
+		Fail("should not be able to create MRC of unknown type")
+		return nil, fmt.Errorf("should not be able to create MRC of unknown type")
+	}
+}
+
+func createTressorMRC(name string, intent v1alpha2.MeshRootCertificateIntent) (*v1alpha2.MeshRootCertificate, error) {
+	return Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Create(
+		context.Background(), &v1alpha2.MeshRootCertificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: Td.OsmNamespace,
+			},
+			Spec: v1alpha2.MeshRootCertificateSpec{
+				TrustDomain: "cluster.local",
+				Intent:      intent,
+				Provider: v1alpha2.ProviderSpec{
+					Tresor: &v1alpha2.TresorProviderSpec{
+						CA: v1alpha2.TresorCASpec{
+							SecretRef: v1.SecretReference{
+								Name:      name,
+								Namespace: Td.OsmNamespace,
+							},
+						}},
+				},
+			},
+		}, metav1.CreateOptions{})
+}
+
+func createCertManagerMRC(name string, intent v1alpha2.MeshRootCertificateIntent) (*v1alpha2.MeshRootCertificate, error) {
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: cmapi.CertificateSpec{
+			IsCA:       true,
+			Duration:   &metav1.Duration{Duration: 90 * 24 * time.Hour},
+			SecretName: name,
+			CommonName: "osm-system",
+			IssuerRef: cmmeta.ObjectReference{
+				Name:  "selfsigned",
+				Kind:  "Issuer",
+				Group: "cert-manager.io",
+			},
+		},
+	}
+
+	ca := &cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				CA: &cmapi.CAIssuer{
+					SecretName: name,
+				},
+			},
+		},
+	}
+
+	cmClient, err := certman.NewForConfig(Td.RestConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = cmClient.CertmanagerV1().Certificates(Td.OsmNamespace).Create(context.TODO(), cert, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = cmClient.CertmanagerV1().Issuers(Td.OsmNamespace).Create(context.TODO(), ca, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	return Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Create(
+		context.Background(), &v1alpha2.MeshRootCertificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: Td.OsmNamespace,
+			},
+			Spec: v1alpha2.MeshRootCertificateSpec{
+				TrustDomain: "cluster.local",
+				Intent:      intent,
+				Provider: v1alpha2.ProviderSpec{
+					CertManager: &v1alpha2.CertManagerProviderSpec{
+						IssuerName:  name,
+						IssuerKind:  "Issuer",
+						IssuerGroup: "cert-manager.io",
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+}
+
+func createVaultMRC(name string, intent v1alpha2.MeshRootCertificateIntent) (*v1alpha2.MeshRootCertificate, error) {
+	vaultPod, err := Td.GetPodsForLabel(Td.OsmNamespace, metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			constants.AppLabel: "vault",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(vaultPod)).Should(Equal(1))
+
+	command := []string{"vault", "write", "pki/root/rotate/internal", "common_name=osm.root", fmt.Sprintf("issuer_name=%s", name)}
+	stdout, stderr, err := Td.RunRemote(Td.OsmNamespace, vaultPod[0].Name, "vault", command)
+	Td.T.Logf("Vault create new root output: %s, stderr:%s", stdout, stderr)
+	Expect(err).NotTo(HaveOccurred())
+
+	command = []string{"vault", "write", fmt.Sprintf("pki/roles/%s", name), "allow_any_name=true", "allow_subdomains=true", "max_ttl=87700h", "allowed_uri_sans=spiffe://*"}
+	stdout, stderr, err = Td.RunRemote(Td.OsmNamespace, vaultPod[0].Name, "vault", command)
+	Td.T.Logf("Vault create new role output: %s, stderr:%s", stdout, stderr)
+	Expect(err).NotTo(HaveOccurred())
+
+	return Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Create(
+		context.Background(), &v1alpha2.MeshRootCertificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: Td.OsmNamespace,
+			},
+			Spec: v1alpha2.MeshRootCertificateSpec{
+				TrustDomain: "cluster.local",
+				Intent:      intent,
+				Provider: v1alpha2.ProviderSpec{
+					Vault: &v1alpha2.VaultProviderSpec{
+						Host:     "vault." + Td.OsmNamespace + ".svc.cluster.local",
+						Protocol: "http",
+						Port:     8200,
+						Role:     name,
+						Token: v1alpha2.VaultTokenSpec{
+							SecretKeyRef: v1alpha2.SecretKeyReferenceSpec{
+								Name:      "osm-vault-token",
+								Namespace: Td.OsmNamespace,
+								Key:       "notused",
+							}, // The test framework wires up the using default token right now so this isn't actually used
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+}

--- a/tests/framework/constants.go
+++ b/tests/framework/constants.go
@@ -4,8 +4,8 @@ const (
 	// test tag prefix, for NS labeling
 	osmTest = "osmTest"
 
-	// osmCABundleName is the name of the secret used to store the CA bundle
-	osmCABundleName = "osm-ca-bundle"
+	// OsmCABundleName is the name of the secret used to store the CA bundle
+	OsmCABundleName = "osm-ca-bundle"
 )
 
 const (
@@ -26,9 +26,6 @@ const (
 	// default image tag
 	defaultImageTag = "latest"
 
-	// default cert manager
-	defaultCertManager = "tresor"
-
 	// default envoy loglevel
 	defaultEnvoyLogLevel = "debug"
 
@@ -37,6 +34,17 @@ const (
 
 	// Test folder base default value
 	testFolderBase = "/tmp"
+)
+
+const (
+	// DefaultCertManager is Tressor
+	DefaultCertManager = "tresor"
+
+	// CertManager for cert-manager.io
+	CertManager = "cert-manager"
+
+	// Vault cert manager
+	Vault = "vault"
 )
 
 const (

--- a/tests/framework/types.go
+++ b/tests/framework/types.go
@@ -134,6 +134,7 @@ type InstallOSMOpts struct {
 	EnableIngressBackendPolicy    bool
 	EnableRetryPolicy             bool
 	EnableSPIFFE                  bool
+	EnableMRC                     bool
 }
 
 // InstallOsmOpt is a function type for setting install options


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Add the start of basic tests for MRC rotation:
- runs some basic tests with MRC turned on
- Starts testing the Rotation of Certificates for Tressor, CertManager, and Vault
~- Fixes a bug in the validator selection logic (see https://github.com/kubernetes/kubernetes/issues/92157#issuecomment-825160958)~ (fixed in https://github.com/openservicemesh/osm/pull/5191)
- upgrades vault version to 1.11 which has new Root Cert Rotation APIs (https://learn.hashicorp.com/tutorials/vault/pki-engine#step-7-rotate-root-ca)

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

e2e

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [x] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
    no

2. Is this a breaking change?
no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
n/a