### PR TITLE
apis: add CRD + informer for Telemetry & ExtensionService

### DIFF
--- a/charts/osm/templates/osm-rbac.yaml
+++ b/charts/osm/templates/osm-rbac.yaml
@@ -41,7 +41,7 @@ rules:
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["config.openservicemesh.io"]
-    resources: ["meshconfigs", "meshrootcertificates"]
+    resources: ["meshconfigs", "meshrootcertificates", "extensionservices"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["config.openservicemesh.io"]
     resources: ["meshrootcertificates/status"]
@@ -58,10 +58,10 @@ rules:
 
   # OSM's custom policy API
   - apiGroups: ["policy.openservicemesh.io"]
-    resources: ["egresses", "ingressbackends", "retries", "upstreamtrafficsettings"]
+    resources: ["egresses", "ingressbackends", "retries", "upstreamtrafficsettings", "telemetries"]
     verbs: ["list", "get", "watch"]
   - apiGroups: ["policy.openservicemesh.io"]
-    resources: ["ingressbackends/status", "upstreamtrafficsettings/status"]
+    resources: ["ingressbackends/status", "upstreamtrafficsettings/status", "telemetry/status"]
     verbs: ["update"]
 
   # Used for interacting with cert-manager CertificateRequest resources.

--- a/cmd/osm-bootstrap/crds/config_extensionservice.yaml
+++ b/cmd/osm-bootstrap/crds/config_extensionservice.yaml
@@ -1,0 +1,63 @@
+# Custom Resource Definition (CRD) for OSM's ExtensionService specification.
+#
+# Copyright Open Service Mesh authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: extensionservices.config.openservicemesh.io
+  labels:
+    app.kubernetes.io/name : "openservicemesh.io"
+spec:
+  group: config.openservicemesh.io
+  scope: Namespaced
+  names:
+    kind: ExtensionService
+    listKind: ExtensionServiceList
+    shortNames:
+      - extsvc
+    singular: extensionservice
+    plural: extensionservices
+  conversion:
+    strategy: None
+  versions:
+    - name: v1alpha2
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - host
+                - port
+              properties:
+                host:
+                  description: Hostname of the service.
+                  type: string
+                  minLength: 1
+                port:
+                  description: Port of the service.
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                protocol:
+                  description: Protocol of the service.
+                  type: string
+                connectTimeout:
+                  description: Timeout for connecting to the service.
+                  type: string

--- a/cmd/osm-bootstrap/crds/policy_telemetry.yaml
+++ b/cmd/osm-bootstrap/crds/policy_telemetry.yaml
@@ -1,0 +1,101 @@
+# Custom Resource Definition (CRD) for OSM's Telemetry API.
+#
+# Copyright Open Service Mesh authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: telemetries.policy.openservicemesh.io
+  labels:
+    app.kubernetes.io/name : "openservicemesh.io"
+spec:
+  group: policy.openservicemesh.io
+  scope: Namespaced
+  names:
+    kind: Telemetry
+    listKind: TelemetryList
+    shortNames:
+      - telemetry
+    singular: telemetry
+    plural: telemetries
+  conversion:
+    strategy: None
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+      - description: Current status of the Telemetry policy.
+        jsonPath: .status.currentStatus
+        name: Status
+        type: string
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                selector:
+                  description: selector (optional) defines the pod label selector for pods the Telemetry
+                    configuration is applicable to. It selects pods with matching label keys
+                    and values. If not specified, the configuration applies to all pods
+                    in the Telemetry resource's namespace.
+                  type: object
+                  additionalProperties: true
+                accessLog:
+                  description: accessLog (optional) defines the Envoy access log configuration.
+                  type: object
+                  properties:
+                    format:
+                      description: format (optional) defines the Envoy access log format.
+                        The format can either be unstructured or structured (e.g. JSON).
+                        Refer to https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-strings
+                        regarding how a format string can be specified.
+                      type: string
+                      minLength: 1
+                    openTelemetry:
+                      description: openTelemetry (optional) defines the OpenTelemetry configuration used to export the
+                        Envoy access logs to an OpenTelemetry collector.
+                      type: object
+                      required:
+                        - extensionService
+                      properties:
+                        extensionService:
+                          description: extensionService defines the reference to ExtensionService resource
+                            corresponding to the OpenTelemetry collector the access log should be exported to.
+                          type: object
+                          required:
+                            - namespace
+                            - name
+                          properties:
+                            namespace:
+                              description: Namespace of the ExtensionService resource.
+                              type: string
+                              minLength: 1
+                            name:
+                              description: Name of the ExtensionService resource.
+                              type: string
+                              minLength: 1
+                        attributes:
+                          description: attributes (optional) defines key-value pairs as additional metadata corresponding access log record.
+                          type: object
+                          additionalProperties: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        # status enables the status subresource
+        status: {}

--- a/pkg/apis/policy/v1alpha1/telemetry.go
+++ b/pkg/apis/policy/v1alpha1/telemetry.go
@@ -45,7 +45,8 @@ type EnvoyAccessLogConfig struct {
 	// The format can either be unstructured or structured (e.g. JSON).
 	// Refer to https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-strings
 	// regarding how a format string can be specified.
-	Format string `json:"format"`
+	// +optional
+	Format string `json:"format,omitempty"`
 
 	// OpenTelemetry defines the OpenTelemetry configuration used to export the
 	// Envoy access logs to an OpenTelemetry collector.
@@ -56,8 +57,8 @@ type EnvoyAccessLogConfig struct {
 // EnvoyAccessLogOpenTelemetryConfig defines the Envoy access log OpenTelemetry
 // configuration.
 type EnvoyAccessLogOpenTelemetryConfig struct {
-	// ExtensionService defines the references to ExtensionService resource
-	// corresponding to the OpenTelemetry collector.
+	// ExtensionService defines the referenence to ExtensionService resource
+	// corresponding to the OpenTelemetry collector the access log should be exported to.
 	ExtensionService ExtensionServiceRef `json:"extensionService"`
 
 	// Attributes defines key-value pairs as additional metadata corresponding access log record.

--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -287,6 +287,20 @@ func (mr *MockMeshCatalogerMockRecorder) GetTCPRoute(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoute", reflect.TypeOf((*MockMeshCataloger)(nil).GetTCPRoute), arg0)
 }
 
+// GetTelemetryPolicy mocks base method.
+func (m *MockMeshCataloger) GetTelemetryPolicy(arg0 *models.Proxy) *v1alpha1.Telemetry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTelemetryPolicy", arg0)
+	ret0, _ := ret[0].(*v1alpha1.Telemetry)
+	return ret0
+}
+
+// GetTelemetryPolicy indicates an expected call of GetTelemetryPolicy.
+func (mr *MockMeshCatalogerMockRecorder) GetTelemetryPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetryPolicy", reflect.TypeOf((*MockMeshCataloger)(nil).GetTelemetryPolicy), arg0)
+}
+
 // GetUpstreamTrafficSetting mocks base method.
 func (m *MockMeshCataloger) GetUpstreamTrafficSetting(arg0 *types.NamespacedName) *v1alpha1.UpstreamTrafficSetting {
 	m.ctrl.T.Helper()

--- a/pkg/compute/mock_compute_client_generated.go
+++ b/pkg/compute/mock_compute_client_generated.go
@@ -214,6 +214,20 @@ func (mr *MockInterfaceMockRecorder) GetTCPRoute(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoute", reflect.TypeOf((*MockInterface)(nil).GetTCPRoute), arg0)
 }
 
+// GetTelemetryPolicy mocks base method.
+func (m *MockInterface) GetTelemetryPolicy(arg0 *models.Proxy) *v1alpha1.Telemetry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTelemetryPolicy", arg0)
+	ret0, _ := ret[0].(*v1alpha1.Telemetry)
+	return ret0
+}
+
+// GetTelemetryPolicy indicates an expected call of GetTelemetryPolicy.
+func (mr *MockInterfaceMockRecorder) GetTelemetryPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetryPolicy", reflect.TypeOf((*MockInterface)(nil).GetTelemetryPolicy), arg0)
+}
+
 // GetUpstreamTrafficSetting mocks base method.
 func (m *MockInterface) GetUpstreamTrafficSetting(arg0 *types.NamespacedName) *v1alpha1.UpstreamTrafficSetting {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/informers/informers.go
+++ b/pkg/k8s/informers/informers.go
@@ -105,9 +105,11 @@ func WithConfigClient(configClient configClientset.Interface, meshConfigName, os
 		})
 		meshConfiginformerFactory := configInformers.NewSharedInformerFactoryWithOptions(configClient, DefaultKubeEventResyncInterval, configInformers.WithNamespace(osmNamespace), listOption)
 		mrcInformerFactory := configInformers.NewSharedInformerFactoryWithOptions(configClient, DefaultKubeEventResyncInterval, configInformers.WithNamespace(osmNamespace))
+		extensionSvcInformerFactory := configInformers.NewSharedInformerFactoryWithOptions(configClient, DefaultKubeEventResyncInterval)
 
 		ic.informers[InformerKeyMeshConfig] = meshConfiginformerFactory.Config().V1alpha2().MeshConfigs().Informer()
 		ic.informers[InformerKeyMeshRootCertificate] = mrcInformerFactory.Config().V1alpha2().MeshRootCertificates().Informer()
+		ic.informers[InformerKeyExtensionService] = extensionSvcInformerFactory.Config().V1alpha2().ExtensionServices().Informer()
 	}
 }
 
@@ -120,6 +122,7 @@ func WithPolicyClient(policyClient policyClientset.Interface) InformerCollection
 		ic.informers[InformerKeyIngressBackend] = informerFactory.Policy().V1alpha1().IngressBackends().Informer()
 		ic.informers[InformerKeyUpstreamTrafficSetting] = informerFactory.Policy().V1alpha1().UpstreamTrafficSettings().Informer()
 		ic.informers[InformerKeyRetry] = informerFactory.Policy().V1alpha1().Retries().Informer()
+		ic.informers[InformerKeyTelemetry] = informerFactory.Policy().V1alpha1().Telemetries().Informer()
 	}
 }
 

--- a/pkg/k8s/informers/types.go
+++ b/pkg/k8s/informers/types.go
@@ -37,6 +37,8 @@ const (
 	InformerKeyMeshConfig InformerKey = "MeshConfig"
 	// InformerKeyMeshRootCertificate is the InformerKey for a MeshRootCertificate informer
 	InformerKeyMeshRootCertificate InformerKey = "MeshRootCertificate"
+	// InformerKeyExtensionService is the InformerKey for an ExtensionService informer
+	InformerKeyExtensionService InformerKey = "ExtensionService"
 
 	// InformerKeyEgress is the InformerKey for a Egress informer
 	InformerKeyEgress InformerKey = "Egress"
@@ -46,6 +48,8 @@ const (
 	InformerKeyUpstreamTrafficSetting InformerKey = "UpstreamTrafficSetting"
 	// InformerKeyRetry is the InformerKey for a Retry informer
 	InformerKeyRetry InformerKey = "Retry"
+	// InformerKeyTelemetry is the InformerKey for a Telemetry informer
+	InformerKeyTelemetry InformerKey = "Telemetry"
 )
 
 const (

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -184,6 +184,20 @@ func (mr *MockControllerMockRecorder) GetTCPRoute(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTCPRoute", reflect.TypeOf((*MockController)(nil).GetTCPRoute), arg0)
 }
 
+// GetTelemetryPolicy mocks base method.
+func (m *MockController) GetTelemetryPolicy(arg0 *models.Proxy) *v1alpha1.Telemetry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTelemetryPolicy", arg0)
+	ret0, _ := ret[0].(*v1alpha1.Telemetry)
+	return ret0
+}
+
+// GetTelemetryPolicy indicates an expected call of GetTelemetryPolicy.
+func (mr *MockControllerMockRecorder) GetTelemetryPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTelemetryPolicy", reflect.TypeOf((*MockController)(nil).GetTelemetryPolicy), arg0)
+}
+
 // GetUpstreamTrafficSetting mocks base method.
 func (m *MockController) GetUpstreamTrafficSetting(arg0 *types.NamespacedName) *v1alpha1.UpstreamTrafficSetting {
 	m.ctrl.T.Helper()

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -72,6 +72,8 @@ const (
 	MeshConfig InformerKey = "MeshConfig"
 	// MeshRootCertificate lookup identifier
 	MeshRootCertificate InformerKey = "MeshRootCertificate"
+	// ExtensionService lookup identifier
+	ExtensionService InformerKey = "ExtensionService"
 	// Egress lookup identifier
 	Egress InformerKey = "Egress"
 	// IngressBackend lookup identifier
@@ -80,6 +82,8 @@ const (
 	Retry InformerKey = "Retry"
 	// UpstreamTrafficSetting lookup identifier
 	UpstreamTrafficSetting InformerKey = "UpstreamTrafficSetting"
+	// Telemetry lookup identifier
+	Telemetry InformerKey = "Telemetry"
 	// TrafficSplit lookup identifier
 	TrafficSplit InformerKey = "TrafficSplit"
 	// HTTPRouteGroup lookup identifier
@@ -193,4 +197,9 @@ type PassthroughInterface interface {
 	// ListTrafficTargets lists SMI TrafficTarget resources. An optional filter can be applied to filter the
 	// returned list
 	ListTrafficTargets() []*access.TrafficTarget
+
+	// GetTelemetryPolicy returns the Telemetry policy for the given proxy instance.
+	// It returns the most specific match if multiple matching policies exist, in the following
+	// order of preference: 1. selector match, 2. namespace match, 3. global match
+	GetTelemetryPolicy(*models.Proxy) *policyv1alpha1.Telemetry
 }


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
- Adds CRD for Telemetry and ExtensionService APIs

- Adds informer clients

- Adds an API to lookup the Telemetry config for a proxy

- Minor changes to the API definition

Part of #5136

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests, e2e suite

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Observability              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `not yet`