### PR TITLE
feat(certs): adds check to move componentStatuses to Validating

### DIFF
--- a/pkg/apis/config/v1alpha2/meshrootcertificate.go
+++ b/pkg/apis/config/v1alpha2/meshrootcertificate.go
@@ -123,24 +123,8 @@ type TresorCASpec struct {
 type MeshRootCertificateIntent string
 
 // MeshRootCertificateComponentStatus specifies the status of the certificate component,
-// can be (`Issuing`, `Validating`, `Unknown`).
+// can be (`issuing`, `validating`, `unknown`, `unused`).
 type MeshRootCertificateComponentStatus string
-
-const (
-	// Issuing means that the root cert described by this MRC is now issuing certs for this component of OSM.
-	Issuing MeshRootCertificateComponentStatus = "issuing"
-
-	// Validating means that the root cert's cert chain, described by this MRC is now part of the CABundle used to
-	// validate requests for this component..
-	Validating MeshRootCertificateComponentStatus = "validating"
-
-	// Unused means that the root cert described by this MRC is unused.
-	Unused MeshRootCertificateComponentStatus = "unused"
-
-	// UnknownComponentStatus means that the use of the root cert described by this MRC is in an unknown state for this
-	// component.
-	UnknownComponentStatus MeshRootCertificateComponentStatus = "unknown"
-)
 
 // MeshRootCertificateConditionStatus specifies the status of the MeshRootCertificate condition,
 // one of (`True`, `False`, `Unknown`).

--- a/pkg/certificate/mrc_reconciler_test.go
+++ b/pkg/certificate/mrc_reconciler_test.go
@@ -1,0 +1,181 @@
+package certificate
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+)
+
+func TestShouldChangeStatusToValidating(t *testing.T) {
+	testCases := []struct {
+		name   string
+		mrc    *v1alpha2.MeshRootCertificate
+		expRes bool
+	}{
+		{
+			name:   "should change status to validating",
+			expRes: true,
+			mrc: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: constants.MRCIntentPassive,
+				},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeAccepted,
+							Status: constants.MRCConditionStatusTrue,
+						},
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: constants.MRCConditionStatusFalse,
+							Reason: constants.MRCConditionReasonPending,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "intent is not passive",
+			expRes: false,
+			mrc: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: "active",
+				},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeAccepted,
+							Status: constants.MRCConditionStatusTrue,
+						},
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: constants.MRCConditionStatusFalse,
+							Reason: constants.MRCConditionReasonPending,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "Accepted condition status is not true",
+			expRes: false,
+			mrc: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: constants.MRCIntentPassive,
+				},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeAccepted,
+							Status: "False",
+						},
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: constants.MRCConditionStatusFalse,
+							Reason: constants.MRCConditionReasonPending,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "ValidatingRollout status is not false",
+			expRes: false,
+			mrc: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: constants.MRCIntentPassive,
+				},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeAccepted,
+							Status: constants.MRCConditionStatusTrue,
+						},
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: "True",
+							Reason: constants.MRCConditionReasonPending,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:   "ValidatingRollout reason is not Pending",
+			expRes: false,
+			mrc: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: constants.MRCIntentPassive,
+				},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeAccepted,
+							Status: constants.MRCConditionStatusTrue,
+						},
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: constants.MRCConditionStatusFalse,
+							Reason: "PassiveIntent",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			res := shouldChangeStatusToValidating(tc.mrc)
+			assert.Equal(tc.expRes, res)
+		})
+	}
+}
+
+func TestGetNextStatus(t *testing.T) {
+	testCases := []struct {
+		name   string
+		mrc    *v1alpha2.MeshRootCertificate
+		expRes v1alpha2.MeshRootCertificateComponentStatus
+	}{
+		{
+			name:   "initial status not set",
+			expRes: constants.MRCComponentStatusUnknown,
+			mrc:    &v1alpha2.MeshRootCertificate{},
+		},
+		{
+			name:   "should change status to validating",
+			expRes: constants.MRCComponentStatusValidating,
+			mrc: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: constants.MRCIntentPassive,
+				},
+				Status: v1alpha2.MeshRootCertificateStatus{
+					Conditions: []v1alpha2.MeshRootCertificateCondition{
+						{
+							Type:   constants.MRCConditionTypeAccepted,
+							Status: constants.MRCConditionStatusTrue,
+						},
+						{
+							Type:   constants.MRCConditionTypeValidatingRollout,
+							Status: constants.MRCConditionStatusFalse,
+							Reason: constants.MRCConditionReasonPending,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			res := getNextStatus(tc.mrc)
+			assert.Equal(tc.expRes, res)
+		})
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,7 +1,11 @@
 // Package constants defines the constants that are used by multiple other packages within OSM.
 package constants
 
-import "time"
+import (
+	"time"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+)
 
 const (
 	// WildcardIPAddr is a string constant.
@@ -221,37 +225,43 @@ const (
 	MRCIntentActive = "active"
 
 	// MRCComponentStatusUnknown is the unknown status option for the component status of the MeshRootCertificate
-	MRCComponentStatusUnknown = "Unknown"
+	MRCComponentStatusUnknown v1alpha2.MeshRootCertificateComponentStatus = "unknown"
 
 	// MRCComponentStatusValidating is the validating status option for the component status of the MeshRootCertificate
-	MRCComponentStatusValidating = "Validating"
+	MRCComponentStatusValidating v1alpha2.MeshRootCertificateComponentStatus = "validating"
+
+	// MRCComponentStatusIssuing means that the root cert described by this MRC is now issuing certs for this component of OSM.
+	MRCComponentStatusIssuing v1alpha2.MeshRootCertificateComponentStatus = "issuing"
+
+	// MRCComponentStatusUnused means that the root cert described by this MRC is unused.
+	MRCComponentStatusUnused v1alpha2.MeshRootCertificateComponentStatus = "unused"
 
 	// MRCConditionTypeReady is the ready condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeReady = "Ready"
+	MRCConditionTypeReady v1alpha2.MeshRootCertificateConditionType = "Ready"
 
 	// MRCConditionTypeAccepted is the accepted condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeAccepted = "Accepted"
+	MRCConditionTypeAccepted v1alpha2.MeshRootCertificateConditionType = "Accepted"
 
 	// MRCConditionTypeIssuingRollout is the issuing rollout condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeIssuingRollout = "IssuingRollout"
+	MRCConditionTypeIssuingRollout v1alpha2.MeshRootCertificateConditionType = "IssuingRollout"
 
 	// MRCConditionTypeIssuingRollback is the issuing rollback condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeIssuingRollback = "IssuingRollback"
+	MRCConditionTypeIssuingRollback v1alpha2.MeshRootCertificateConditionType = "IssuingRollback"
 
 	// MRCConditionTypeValidatingRollout is the validating rollout condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeValidatingRollout = "ValidatingRollout"
+	MRCConditionTypeValidatingRollout v1alpha2.MeshRootCertificateConditionType = "ValidatingRollout"
 
 	// MRCConditionTypeValidatingRollback is the validating rollback condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeValidatingRollback = "ValidatingRollback"
+	MRCConditionTypeValidatingRollback v1alpha2.MeshRootCertificateConditionType = "ValidatingRollback"
 
 	// MRCConditionStatusTrue is the true status option for the condition status of the MeshRootCertificate
-	MRCConditionStatusTrue = "True"
+	MRCConditionStatusTrue v1alpha2.MeshRootCertificateConditionStatus = "True"
 
 	// MRCConditionStatusFalse is the false status option for the condition status of the MeshRootCertificate
-	MRCConditionStatusFalse = "False"
+	MRCConditionStatusFalse v1alpha2.MeshRootCertificateConditionStatus = "False"
 
 	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
-	MRCConditionStatusUnknown = "Unknown"
+	MRCConditionStatusUnknown v1alpha2.MeshRootCertificateConditionStatus = "Unknown"
 
 	// MRCConditionReasonPending is the Pending reason option for the condition reason of the MeshRootCertificate
 	MRCConditionReasonPending = "Pending"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -223,8 +223,8 @@ const (
 	// MRCComponentStatusUnknown is the unknown status option for the component status of the MeshRootCertificate
 	MRCComponentStatusUnknown = "Unknown"
 
-	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
-	MRCConditionStatusUnknown = "Unknown"
+	// MRCComponentStatusValidating is the validating status option for the component status of the MeshRootCertificate
+	MRCComponentStatusValidating = "Validating"
 
 	// MRCConditionTypeReady is the ready condition type for certificate condition of the MeshRootCertificate
 	MRCConditionTypeReady = "Ready"
@@ -243,6 +243,18 @@ const (
 
 	// MRCConditionTypeValidatingRollback is the validating rollback condition type for certificate condition of the MeshRootCertificate
 	MRCConditionTypeValidatingRollback = "ValidatingRollback"
+
+	// MRCConditionStatusTrue is the true status option for the condition status of the MeshRootCertificate
+	MRCConditionStatusTrue = "True"
+
+	// MRCConditionStatusFalse is the false status option for the condition status of the MeshRootCertificate
+	MRCConditionStatusFalse = "False"
+
+	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
+	MRCConditionStatusUnknown = "Unknown"
+
+	// MRCConditionReasonPending is the Pending reason option for the condition reason of the MeshRootCertificate
+	MRCConditionReasonPending = "Pending"
 )
 
 // Labels used by the control plane


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Adds check that the MRC meets the attribute required to move the component statuses to Validating and resolves #5181

Signed-off-by: Shalier Xia <shalierxia@microsoft.com>
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [x ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?