### PR TITLE
ref(informers): Remove duplicate InformerKey definitions

### DIFF
--- a/cmd/osm-injector/osm-injector.go
+++ b/cmd/osm-injector/osm-injector.go
@@ -198,7 +198,7 @@ func main() {
 	}
 
 	// Initialize kubernetes.Controller to watch kubernetes resources
-	kubeController := k8s.NewClient(osmNamespace, osmMeshConfigName, informerCollection, kubeClient, policyClient, configClient, msgBroker, k8s.Namespaces)
+	kubeController := k8s.NewClient(osmNamespace, osmMeshConfigName, informerCollection, kubeClient, policyClient, configClient, msgBroker, informers.InformerKeyNamespace)
 	computeClient := kube.NewClient(kubeController)
 
 	certOpts, err := getCertOptions()

--- a/pkg/compute/kube/client_test.go
+++ b/pkg/compute/kube/client_test.go
@@ -2422,7 +2422,7 @@ func TestGetMeshService(t *testing.T) {
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
 			_ = ic.Add(informers.InformerKeyService, tc.svc, t)
-			_ = ic.Add(informers.InformerKeyEndpoints, tc.endpoints, t)
+			_ = ic.Add(informers.InformerKeyEndpoint, tc.endpoints, t)
 
 			controller := k8s.NewClient(osmNamespace, "", ic, nil, nil, nil, messaging.NewBroker(make(chan struct{})))
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NewClient returns a new kubernetes.Controller which means to provide access to locally-cached k8s resources
-func NewClient(osmNamespace, meshConfigName string, informerCollection *informers.InformerCollection, kubeClient kubernetes.Interface, policyClient policyv1alpha1Client.Interface, configClient configv1alpha2Client.Interface, msgBroker *messaging.Broker, selectInformers ...InformerKey) *Client {
+func NewClient(osmNamespace, meshConfigName string, informerCollection *informers.InformerCollection, kubeClient kubernetes.Interface, policyClient policyv1alpha1Client.Interface, configClient configv1alpha2Client.Interface, msgBroker *messaging.Broker, selectInformers ...informers.InformerKey) *Client {
 	// Initialize client object
 	c := &Client{
 		informers:      informerCollection,
@@ -39,32 +39,32 @@ func NewClient(osmNamespace, meshConfigName string, informerCollection *informer
 	}
 
 	// Initialize informers
-	informerInitHandlerMap := map[InformerKey]func(){
-		Namespaces:             c.initNamespaceMonitor,
-		Services:               c.initServicesMonitor,
-		ServiceAccounts:        c.initServiceAccountsMonitor,
-		Pods:                   c.initPodMonitor,
-		Endpoints:              c.initEndpointMonitor,
-		MeshConfig:             c.initMeshConfigMonitor,
-		MeshRootCertificate:    c.initMRCMonitor,
-		ExtensionService:       c.initExtensionServiceMonitor,
-		Egress:                 c.initEgressMonitor,
-		IngressBackend:         c.initIngressBackendMonitor,
-		Retry:                  c.initRetryMonitor,
-		UpstreamTrafficSetting: c.initUpstreamTrafficSettingMonitor,
-		Telemetry:              c.initTelemetryMonitor,
-		TrafficSplit:           c.initTrafficSplitMonitor,
-		HTTPRouteGroup:         c.initHTTPRouteGroupMonitor,
-		TCPRoute:               c.initTCPRouteMonitor,
-		TrafficTarget:          c.initTrafficTargetMonitor,
+	informerInitHandlerMap := map[informers.InformerKey]func(){
+		informers.InformerKeyNamespace:              c.initNamespaceMonitor,
+		informers.InformerKeyService:                c.initServicesMonitor,
+		informers.InformerKeyServiceAccount:         c.initServiceAccountsMonitor,
+		informers.InformerKeyPod:                    c.initPodMonitor,
+		informers.InformerKeyEndpoint:               c.initEndpointMonitor,
+		informers.InformerKeyMeshConfig:             c.initMeshConfigMonitor,
+		informers.InformerKeyMeshRootCertificate:    c.initMRCMonitor,
+		informers.InformerKeyExtensionService:       c.initExtensionServiceMonitor,
+		informers.InformerKeyEgress:                 c.initEgressMonitor,
+		informers.InformerKeyIngressBackend:         c.initIngressBackendMonitor,
+		informers.InformerKeyRetry:                  c.initRetryMonitor,
+		informers.InformerKeyUpstreamTrafficSetting: c.initUpstreamTrafficSettingMonitor,
+		informers.InformerKeyTelemetry:              c.initTelemetryMonitor,
+		informers.InformerKeyTrafficSplit:           c.initTrafficSplitMonitor,
+		informers.InformerKeyHTTPRouteGroup:         c.initHTTPRouteGroupMonitor,
+		informers.InformerKeyTCPRoute:               c.initTCPRouteMonitor,
+		informers.InformerKeyTrafficTarget:          c.initTrafficTargetMonitor,
 	}
 
 	// If specific informers are not selected to be initialized, initialize all informers
 	if len(selectInformers) == 0 {
-		selectInformers = []InformerKey{
-			Namespaces, Services, ServiceAccounts, Pods, Endpoints, MeshConfig, MeshRootCertificate, ExtensionService,
-			Egress, IngressBackend, Retry, UpstreamTrafficSetting, Telemetry, TrafficSplit, HTTPRouteGroup, TCPRoute,
-			TrafficTarget}
+		selectInformers = []informers.InformerKey{
+			informers.InformerKeyNamespace, informers.InformerKeyService, informers.InformerKeyServiceAccount, informers.InformerKeyPod, informers.InformerKeyEndpoint, informers.InformerKeyMeshConfig, informers.InformerKeyMeshRootCertificate, informers.InformerKeyExtensionService,
+			informers.InformerKeyEgress, informers.InformerKeyIngressBackend, informers.InformerKeyRetry, informers.InformerKeyUpstreamTrafficSetting, informers.InformerKeyTelemetry, informers.InformerKeyTrafficSplit, informers.InformerKeyHTTPRouteGroup, informers.InformerKeyTCPRoute,
+			informers.InformerKeyTrafficTarget}
 	}
 
 	for _, informer := range selectInformers {
@@ -137,7 +137,7 @@ func (c *Client) initPodMonitor() {
 }
 
 func (c *Client) initEndpointMonitor() {
-	c.informers.AddEventHandler(informers.InformerKeyEndpoints, GetEventHandlerFuncs(c.shouldObserve, c.msgBroker))
+	c.informers.AddEventHandler(informers.InformerKeyEndpoint, GetEventHandlerFuncs(c.shouldObserve, c.msgBroker))
 }
 
 func (c *Client) initTrafficSplitMonitor() {
@@ -301,7 +301,7 @@ func (c *Client) ListPods() []*corev1.Pod {
 // GetEndpoints returns the endpoint for a given service, otherwise returns nil if not found
 // or error if the API errored out.
 func (c *Client) GetEndpoints(name, namespace string) (*corev1.Endpoints, error) {
-	ep, exists, err := c.informers.GetByKey(informers.InformerKeyEndpoints, key(name, namespace))
+	ep, exists, err := c.informers.GetByKey(informers.InformerKeyEndpoint, key(name, namespace))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -636,7 +636,7 @@ func TestGetEndpoints(t *testing.T) {
 			ic, err := informers.NewInformerCollection(testMeshName, nil, informers.WithKubeClient(testclient.NewSimpleClientset()))
 			a.Nil(err)
 			c := NewClient("osm", tests.OsmMeshConfigName, ic, nil, nil, nil, nil)
-			_ = ic.Add(informers.InformerKeyEndpoints, tc.endpoints, t)
+			_ = ic.Add(informers.InformerKeyEndpoint, tc.endpoints, t)
 
 			actual, err := c.GetEndpoints(tc.svcName, tc.svcNamespace)
 			a.Nil(err)

--- a/pkg/k8s/informers/informers.go
+++ b/pkg/k8s/informers/informers.go
@@ -78,7 +78,7 @@ func WithKubeClient(kubeClient kubernetes.Interface) InformerCollectionOption {
 		ic.informers[InformerKeyService] = v1api.Services().Informer()
 		ic.informers[InformerKeyServiceAccount] = v1api.ServiceAccounts().Informer()
 		ic.informers[InformerKeyPod] = v1api.Pods().Informer()
-		ic.informers[InformerKeyEndpoints] = v1api.Endpoints().Informer()
+		ic.informers[InformerKeyEndpoint] = v1api.Endpoints().Informer()
 		ic.informers[InformerKeySecret] = secretInformerFactory.Core().V1().Secrets().Informer()
 	}
 }

--- a/pkg/k8s/informers/types.go
+++ b/pkg/k8s/informers/types.go
@@ -17,8 +17,8 @@ const (
 	InformerKeyService InformerKey = "Service"
 	// InformerKeyPod is the InformerKey for a Pod informer
 	InformerKeyPod InformerKey = "Pod"
-	// InformerKeyEndpoints is the InformerKey for a Endpoints informer
-	InformerKeyEndpoints InformerKey = "Endpoints"
+	// InformerKeyEndpoint is the InformerKey for a Endpoint informer
+	InformerKeyEndpoint InformerKey = "Endpoint"
 	// InformerKeyServiceAccount is the InformerKey for a ServiceAccount informer
 	InformerKeyServiceAccount InformerKey = "ServiceAccount"
 	// InformerKeySecret is the InformerKey for a Secret informer

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -54,46 +54,6 @@ const (
 	DefaultKubeEventResyncInterval = 0 * time.Second
 )
 
-// InformerKey stores the different Informers we keep for K8s resources
-type InformerKey string
-
-const (
-	// Namespaces lookup identifier
-	Namespaces InformerKey = "Namespaces"
-	// Services lookup identifier
-	Services InformerKey = "Services"
-	// Pods lookup identifier
-	Pods InformerKey = "Pods"
-	// Endpoints lookup identifier
-	Endpoints InformerKey = "Endpoints"
-	// ServiceAccounts lookup identifier
-	ServiceAccounts InformerKey = "ServiceAccounts"
-	// MeshConfig lookup identifier
-	MeshConfig InformerKey = "MeshConfig"
-	// MeshRootCertificate lookup identifier
-	MeshRootCertificate InformerKey = "MeshRootCertificate"
-	// ExtensionService lookup identifier
-	ExtensionService InformerKey = "ExtensionService"
-	// Egress lookup identifier
-	Egress InformerKey = "Egress"
-	// IngressBackend lookup identifier
-	IngressBackend InformerKey = "IngressBackend"
-	// Retry lookup identifier
-	Retry InformerKey = "Retry"
-	// UpstreamTrafficSetting lookup identifier
-	UpstreamTrafficSetting InformerKey = "UpstreamTrafficSetting"
-	// Telemetry lookup identifier
-	Telemetry InformerKey = "Telemetry"
-	// TrafficSplit lookup identifier
-	TrafficSplit InformerKey = "TrafficSplit"
-	// HTTPRouteGroup lookup identifier
-	HTTPRouteGroup InformerKey = "HTTPRouteGroup"
-	// TCPRoute lookup identifier
-	TCPRoute InformerKey = "TCPRoute"
-	// TrafficTarget lookup identifier
-	TrafficTarget InformerKey = "TrafficTarget"
-)
-
 // Client is the type used to represent the k8s client for the native k8s resources
 type Client struct {
 	policyClient   policyv1alpha1Client.Interface

--- a/pkg/reconciler/client.go
+++ b/pkg/reconciler/client.go
@@ -15,10 +15,11 @@ import (
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/errcode"
 	"github.com/openservicemesh/osm/pkg/k8s"
+	k8sinformers "github.com/openservicemesh/osm/pkg/k8s/informers"
 )
 
 // NewReconcilerClient implements a client to reconcile osm managed resources
-func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient clientset.Interface, meshName, osmVersion string, stop chan struct{}, selectInformers ...k8s.InformerKey) error {
+func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient clientset.Interface, meshName, osmVersion string, stop chan struct{}, selectInformers ...k8sinformers.InformerKey) error {
 	// Initialize client object
 	c := client{
 		kubeClient:      kubeClient,
@@ -29,7 +30,7 @@ func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient client
 	}
 
 	// Initialize informers
-	informerInitHandlerMap := map[k8s.InformerKey]func(){
+	informerInitHandlerMap := map[k8sinformers.InformerKey]func(){
 		CrdInformerKey:               c.initCustomResourceDefinitionMonitor,
 		MutatingWebhookInformerKey:   c.initMutatingWebhookConfigurationMonitor,
 		ValidatingWebhookInformerKey: c.initValidatingWebhookConfigurationMonitor,
@@ -37,7 +38,7 @@ func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient client
 
 	// If specific informers are not selected to be initialized, initialize all informers
 	if len(selectInformers) == 0 {
-		informers := []k8s.InformerKey{MutatingWebhookInformerKey, ValidatingWebhookInformerKey}
+		informers := []k8sinformers.InformerKey{MutatingWebhookInformerKey, ValidatingWebhookInformerKey}
 		// initialize informer for CRDs only if the apiServerClient is not nil
 		if apiServerClient != nil {
 			informers = append(informers, CrdInformerKey)

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/openservicemesh/osm/pkg/k8s"
+	"github.com/openservicemesh/osm/pkg/k8s/informers"
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
@@ -16,20 +16,20 @@ var log = logger.New("reconciler")
 
 const (
 	// CrdInformerKey lookup identifier
-	CrdInformerKey k8s.InformerKey = "CRDInformerKey"
+	CrdInformerKey informers.InformerKey = "CRDInformerKey"
 
 	// MutatingWebhookInformerKey lookup identifier
-	MutatingWebhookInformerKey k8s.InformerKey = "MutatingWebhookConfigInformerKey"
+	MutatingWebhookInformerKey informers.InformerKey = "MutatingWebhookConfigInformerKey"
 
 	// ValidatingWebhookInformerKey lookup identifier
-	ValidatingWebhookInformerKey k8s.InformerKey = "ValidatingWebhookConfigInformerKey"
+	ValidatingWebhookInformerKey informers.InformerKey = "ValidatingWebhookConfigInformerKey"
 
 	// nameIndex is the lookup name for the most comment index function, which is to index by the name field
 	nameIndex string = "name"
 )
 
 // informerCollection is the type holding the collection of informers we keep
-type informerCollection map[k8s.InformerKey]cache.SharedIndexInformer
+type informerCollection map[informers.InformerKey]cache.SharedIndexInformer
 
 // client is a struct for all components necessary to connect to and maintain state of a Kubernetes cluster
 type client struct {


### PR DESCRIPTION
Signed-off-by: Kalya Subramanian <kasubra@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Removes duplicate definition of InformerKey names. Fixes #5152 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ X ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
N/A
2. Is this a breaking change?
No
3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
N/A