### PR TITLE
fix(envoy): add keep-alive time to detect sidecar disconnections

### DIFF
--- a/pkg/envoy/bootstrap/config.go
+++ b/pkg/envoy/bootstrap/config.go
@@ -16,6 +16,7 @@ import (
 	xds_discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/golang/protobuf/ptypes/any"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/envoy"
@@ -276,6 +277,13 @@ func (b *Builder) Build() (*xds_bootstrap.Bootstrap, error) {
 									},
 								},
 							},
+						},
+					},
+					UpstreamConnectionOptions: &xds_cluster.UpstreamConnectionOptions{
+						TcpKeepalive: &xds_core.TcpKeepalive{
+							KeepaliveProbes:   wrapperspb.UInt32(5),
+							KeepaliveTime:     wrapperspb.UInt32(60),
+							KeepaliveInterval: wrapperspb.UInt32(5),
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Sanya Kochhar <kochhars@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Defines a 60s keep-alive time after which probes will start being sent to check if a sidecar is still connected to the control plane. Previously this defaulted to 2 hours

Resolves #5149


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [x] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? no
    -   Did you notify the maintainers and provide attribution? no

2. Is this a breaking change? no

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? n/a