### PR TITLE
k8s/events: detect Secret kind

### DIFF
--- a/pkg/k8s/events/types.go
+++ b/pkg/k8s/events/types.go
@@ -113,6 +113,9 @@ const (
 	// ServiceAccount is the Kind for Kubernetes service account events.
 	ServiceAccount Kind = "serviceaccount"
 
+	// Secret is the Kind for Kubernetes secret events.
+	Secret Kind = "secret"
+
 	// TrafficSplit is the Kind for Kubernetes traffic split events.
 	TrafficSplit Kind = "trafficsplit"
 
@@ -166,6 +169,8 @@ func GetKind(obj interface{}) Kind {
 		return Service
 	case *corev1.ServiceAccount:
 		return ServiceAccount
+	case *corev1.Secret:
+		return Secret
 	case *networkingv1.Ingress:
 		return Ingress
 	case *smiSplit.TrafficSplit:


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Secret events were ignored, leading
to error logs when Secret events
are received. This allows the
controller to correctly process the event.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Without this change, the follow error logs are observed:
```
{"level":"error","component":"kube-events","time":"2022-10-12T18:36:13Z","file":"types.go:196","message":"Unknown kind: &Secret{ObjectMeta:{envoy-bootstrap-config-e18ceb59-6184-4215-9097-1e32ce86bfc6  httpbin  11b77a82-9cad-40e3-9903-c5b25e01f0f6 49248 0 2022-10-12 18:36:13 +0000 UTC <nil> <nil> map[app.kubernetes.io/instance:osm app.kubernetes.io/name:openservicemesh.io app.kubernetes.io/version:dev] map[] [] []  [{osm-injector Update v1 2022-10-12 18:36:13 +0000 UTC FieldsV1 {\"f:data\":{\".\":{},\"f:bootstrap.yaml\":{},\"f:cacert.pem\":{},\"f:sds_cert.pem\":{},\"f:sds_key.pem\":{},\"f:signing_issuer_id\":{},\"f:tls_certificate_sds_secret.yaml\":{},\"f:validating_issuer_id\":{},\"f:validation_context_sds_secret.yaml\":{}},\"f:metadata\":{\"f:labels\":{\".\":{},\"f:app.kubernetes.io/instance\":{},\"f:app.kubernetes.io/name\":{},\"f:app.kubernetes.io/version\":{}}},\"f:type\":{}} }]},Data:map[string][]byte{bootstrap.yaml: ...
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `n/a`