### PR TITLE
feat(cert): use intent to set issuers during root cert rotation

### DIFF
--- a/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
+++ b/cmd/osm-bootstrap/crds/config_mesh_root_certificate.yaml
@@ -37,9 +37,9 @@ spec:
       served: true
       storage: true
       additionalPrinterColumns:
-        - description: Current state of the MeshRootCertificate config
-          jsonPath: .status.state
-          name: State
+        - description: Intent for the MeshRootCertificate
+          jsonPath: .spec.intent
+          name: Intent
           type: string
       schema:
         openAPIV3Schema:
@@ -48,6 +48,7 @@ spec:
             spec:
               type: object
               required:
+                - intent
                 - provider
               properties:
                 trustDomain:
@@ -55,12 +56,12 @@ spec:
                   type: string
                   default: cluster.local
                 intent:
-                  description: Intent specifies the role of the MeshRootCertificate, can be active or passive
+                  description: Intent specifies the role of the MeshRootCertificate, can be active, passive
                   type: string
                   enum:
                     - passive
                     - active
-                  default: passive
+                    - inactive
                 spiffeEnabled:
                   description: Adds a SPIFFE ID to the certificates, creating a SPIFFE compatible x509 SVID document
                   type: boolean

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -423,20 +423,11 @@ func (b *bootstrap) createMeshRootCertificate() error {
 	if err != nil {
 		return err
 	}
-	createdMRC, err := b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Create(context.TODO(), defaultMeshRootCertificate, metav1.CreateOptions{})
+	_, err = b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Create(context.TODO(), defaultMeshRootCertificate, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		log.Info().Msgf("MeshRootCertificate already exists in %s. Skip creating.", b.namespace)
 		return nil
 	}
-	if err != nil {
-		return err
-	}
-
-	_, err = b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).UpdateStatus(context.Background(), createdMRC, metav1.UpdateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		log.Info().Msgf("MeshRootCertificate status already exists in %s. Skip creating.", b.namespace)
-	}
-
 	if err != nil {
 		return err
 	}

--- a/cmd/osm-bootstrap/osm-bootstrap.go
+++ b/cmd/osm-bootstrap/osm-bootstrap.go
@@ -49,7 +49,6 @@ const (
 	meshConfigName                   = "osm-mesh-config"
 	presetMeshConfigName             = "preset-mesh-config"
 	presetMeshConfigJSONKey          = "preset-mesh-config.json"
-	meshRootCertificateName          = "osm-mesh-root-certificate"
 	presetMeshRootCertificateName    = "preset-mesh-root-certificate"
 	presetMeshRootCertificateJSONKey = "preset-mesh-root-certificate.json"
 )
@@ -168,7 +167,7 @@ func main() {
 	if enableMeshRootCertificate {
 		err = bootstrap.ensureMeshRootCertificate()
 		if err != nil {
-			log.Fatal().Err(err).Msgf("Error setting up default MeshRootCertificate %s from ConfigMap %s", meshRootCertificateName, presetMeshRootCertificateName)
+			log.Fatal().Err(err).Msgf("Error setting up default MeshRootCertificate %s from ConfigMap %s", constants.DefaultMeshRootCertificateName, presetMeshRootCertificateName)
 			return
 		}
 	}
@@ -433,36 +432,6 @@ func (b *bootstrap) createMeshRootCertificate() error {
 		return err
 	}
 
-	createdMRC.Status = configv1alpha2.MeshRootCertificateStatus{
-		State: constants.MRCStatePending,
-		Conditions: []configv1alpha2.MeshRootCertificateCondition{
-			{
-				Type:   constants.MRCConditionTypeReady,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeAccepted,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeIssuingRollout,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeValidatingRollout,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeIssuingRollback,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeValidatingRollback,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-		},
-	}
-
 	_, err = b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).UpdateStatus(context.Background(), createdMRC, metav1.UpdateOptions{})
 	if apierrors.IsAlreadyExists(err) {
 		log.Info().Msgf("MeshRootCertificate status already exists in %s. Skip creating.", b.namespace)
@@ -472,7 +441,7 @@ func (b *bootstrap) createMeshRootCertificate() error {
 		return err
 	}
 
-	log.Info().Msgf("Successfully created MeshRootCertificate %s in %s.", meshRootCertificateName, b.namespace)
+	log.Info().Msgf("Successfully created MeshRootCertificate %s in %s.", constants.DefaultMeshRootCertificateName, b.namespace)
 	return nil
 }
 
@@ -490,7 +459,7 @@ func buildMeshRootCertificate(presetMeshRootCertificateConfigMap *corev1.ConfigM
 			APIVersion: "config.openservicemesh.io/configv1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: meshRootCertificateName,
+			Name: constants.DefaultMeshRootCertificateName,
 		},
 		Spec: presetMeshRootCertificateSpec,
 	}

--- a/cmd/osm-bootstrap/osm-bootstrap_test.go
+++ b/cmd/osm-bootstrap/osm-bootstrap_test.go
@@ -91,38 +91,9 @@ var testPresetMeshConfigMap = &corev1.ConfigMap{
 var testMeshRootCertificate = &configv1alpha2.MeshRootCertificate{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: testNamespace,
-		Name:      meshRootCertificateName,
+		Name:      constants.DefaultMeshRootCertificateName,
 	},
 	Spec: configv1alpha2.MeshRootCertificateSpec{},
-	Status: configv1alpha2.MeshRootCertificateStatus{
-		State: constants.MRCStatePending,
-		Conditions: []configv1alpha2.MeshRootCertificateCondition{
-			{
-				Type:   constants.MRCConditionTypeReady,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeAccepted,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeIssuingRollout,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeValidatingRollout,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeIssuingRollback,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-			{
-				Type:   constants.MRCConditionTypeValidatingRollback,
-				Status: constants.MRCConditionStatusUnknown,
-			},
-		},
-	},
 }
 
 var testPresetMeshRootCertificate = &corev1.ConfigMap{
@@ -136,6 +107,7 @@ var testPresetMeshRootCertificate = &corev1.ConfigMap{
 	},
 	Data: map[string]string{
 		presetMeshRootCertificateJSONKey: `{
+"intent": "Active",
 "provider": {
 	"tresor": {
 	 "ca": {
@@ -176,7 +148,7 @@ func TestBuildMeshRootCertificate(t *testing.T) {
 	meshRootCertificate, err := buildMeshRootCertificate(testPresetMeshRootCertificate)
 	assert.Contains(meshRootCertificate.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
 	assert.NoError(err)
-	assert.Equal(meshRootCertificate.Name, meshRootCertificateName)
+	assert.Equal(meshRootCertificate.Name, constants.DefaultMeshRootCertificateName)
 	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.CA.SecretRef.Name, "osm-ca-bundle")
 	assert.Equal(meshRootCertificate.Spec.Provider.Tresor.CA.SecretRef.Namespace, testNamespace)
 	assert.Nil(meshRootCertificate.Spec.Provider.Vault)
@@ -388,10 +360,9 @@ func TestCreateMeshRootCertificate(t *testing.T) {
 				assert.Error(err)
 			}
 
-			mrc, err := b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Get(context.TODO(), meshRootCertificateName, metav1.GetOptions{})
+			_, err = b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Get(context.TODO(), constants.DefaultMeshRootCertificateName, metav1.GetOptions{})
 			if tc.expectDefaultMeshRootCertificate {
 				assert.NoError(err)
-				assert.Equal(constants.MRCStatePending, mrc.Status.State)
 			} else {
 				assert.Error(err)
 			}
@@ -442,7 +413,7 @@ func TestEnsureMeshRootCertificate(t *testing.T) {
 			err := b.ensureMeshRootCertificate()
 			assert.Equal(tc.expectErr, err != nil)
 
-			_, err = b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Get(context.TODO(), meshRootCertificateName, metav1.GetOptions{})
+			_, err = b.configClient.ConfigV1alpha2().MeshRootCertificates(b.namespace).Get(context.TODO(), constants.DefaultMeshRootCertificateName, metav1.GetOptions{})
 			assert.Equal(tc.expectErr, err != nil)
 		})
 	}

--- a/pkg/apis/config/v1alpha2/meshrootcertificate.go
+++ b/pkg/apis/config/v1alpha2/meshrootcertificate.go
@@ -122,6 +122,19 @@ type TresorCASpec struct {
 // can be (Active, Passive).
 type MeshRootCertificateIntent string
 
+const (
+	// ActiveIntent means the settings and certificate provider in this MRC are used for signing and
+	// validating certificates.
+	ActiveIntent MeshRootCertificateIntent = "active"
+
+	// PassiveIntent means the settings and certificate provider in this MRC are used for validating
+	// certificates.
+	PassiveIntent MeshRootCertificateIntent = "passive"
+
+	// InactiveIntent means the settings and certificate provider in this MRC no longer in use.
+	InactiveIntent MeshRootCertificateIntent = "inactive"
+)
+
 // MeshRootCertificateComponentStatus specifies the status of the certificate component,
 // can be (`Issuing`, `Validating`, `Unknown`).
 type MeshRootCertificateComponentStatus string

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -23,8 +23,10 @@ var ErrNumMRCExceedsMaxSupported = errors.New("found more than the max number of
 // have an active intent.
 var ErrExpectedActiveMRC = errors.New("found single MRC with non active intent")
 
-// ErrUnknownMRCIntent is the error that should be returned if the intent value is not passive, active, or inactive.
-var ErrUnknownMRCIntent = errors.New("found single MRC with non active intent")
+// ErrUnexpectedMRCIntent is the error that should be returned if the intent value is not passive or active.
+// The MRC reconciler should only consider MRCs with passive or active intents for the validating and signing
+// issuers.
+var ErrUnexpectedMRCIntent = errors.New("found unexpected MRC intent. Expected passive or active")
 
 // ErrUnexpectedNilMRC is the the error that should be returned if the MRC is nil.
 var ErrUnexpectedNilMRC = errors.New("received nil MRC")

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -19,9 +19,8 @@ var ErrInvalidMRCIntentCombination = errors.New("invalid mrc intent combination"
 // and/or passive intent in the mesh.
 var ErrNumMRCExceedsMaxSupported = errors.New("found more than the max number of MRCs supported in the control plane namespace")
 
-// ErrExpectedActiveMRC is the error that should be returned when there is only 1 MRC in the mesh and it does not
-// have an active intent.
-var ErrExpectedActiveMRC = errors.New("found single MRC with non active intent")
+// ErrExpectedActiveMRC is the error that should be returned when no active MRCs are present in the mesh.
+var ErrExpectedActiveMRC = errors.New("found no active MRCs")
 
 // ErrUnexpectedMRCIntent is the error that should be returned if the intent value is not passive or active.
 // The MRC reconciler should only consider MRCs with passive or active intents for the validating and signing

--- a/pkg/certificate/errors.go
+++ b/pkg/certificate/errors.go
@@ -9,8 +9,28 @@ var errEncodeCert = errors.New("encode cert")
 var errMarshalPrivateKey = errors.New("marshal private key")
 var errNoPrivateKeyInPEM = errors.New("no private Key in PEM")
 
-// ErrNoCertificateInPEM is the errror for no certificate in PEM
+// ErrNoCertificateInPEM is the error for no certificate in PEM
 var ErrNoCertificateInPEM = errors.New("no certificate in PEM")
+
+// ErrInvalidMRCIntentCombination is the error that should be returned if the combination of MRC intents is invalid.
+var ErrInvalidMRCIntentCombination = errors.New("invalid mrc intent combination")
+
+// ErrNumMRCExceedsMaxSupported is the error that should be returned if there are more than 2 MRCs with active
+// and/or passive intent in the mesh.
+var ErrNumMRCExceedsMaxSupported = errors.New("found more than the max number of MRCs supported in the control plane namespace")
+
+// ErrExpectedActiveMRC is the error that should be returned when there is only 1 MRC in the mesh and it does not
+// have an active intent.
+var ErrExpectedActiveMRC = errors.New("found single MRC with non active intent")
+
+// ErrUnknownMRCIntent is the error that should be returned if the intent value is not passive, active, or inactive.
+var ErrUnknownMRCIntent = errors.New("found single MRC with non active intent")
+
+// ErrUnexpectedNilMRC is the the error that should be returned if the MRC is nil.
+var ErrUnexpectedNilMRC = errors.New("received nil MRC")
+
+// ErrNoMRCsFound is the the error that should be returned if no MRCs were found in the control plane.
+var ErrNoMRCsFound = errors.New("found no MRCs")
 
 // All of the below errors should be returned by the StorageEngine for each described scenario. The errors may be
 // wrapped

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -5,18 +5,16 @@ import (
 	"fmt"
 	"time"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
-
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
-)
-
-var (
-	validity = time.Hour
+	osmConfigClient "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 )
 
 // fakeMRCClient implements the MRCClient interface
 type fakeMRCClient struct {
-	mrcList []*v1alpha2.MeshRootCertificate
+	configClient osmConfigClient.Interface
 }
 
 // GetCertIssuerForMRC returns a fakeIssuer and pre-generated RootCertificate. It is intended to implement the certificate.MRCClient interface.
@@ -27,17 +25,26 @@ func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (
 // ListMeshRootCertificates returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
 	// return single empty object in the list.
-	return c.mrcList, nil
+	mrcList, err := c.configClient.ConfigV1alpha2().MeshRootCertificates("osm-system").List(context.Background(), v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var mrcListPointers []*v1alpha2.MeshRootCertificate
+	for i := range mrcList.Items {
+		mrcListPointers = append(mrcListPointers, &mrcList.Items[i])
+	}
+	return mrcListPointers, nil
 }
 
 // UpdateMeshRootCertificate updates the given mesh root certificate.
 func (c *fakeMRCClient) UpdateMeshRootCertificate(mrc *v1alpha2.MeshRootCertificate) error {
-	// TODO(5046): implement this.
-	return nil
+	_, err := c.configClient.ConfigV1alpha2().MeshRootCertificates("osm-system").Update(context.Background(), mrc, v1.UpdateOptions{})
+	return err
 }
 
 // Watch returns a channel that has one MRCEventAdded. It is intended to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan MRCEvent, error) {
+	// send event for first CA created
 	ch := make(chan MRCEvent)
 	go func() {
 		ch <- MRCEvent{
@@ -67,21 +74,4 @@ func (i *fakeIssuer) IssueCertificate(options IssueOptions) (*Certificate, error
 		TrustedCAs: pem.RootCertificate(i.id),
 		PrivateKey: pem.PrivateKey(i.id),
 	}, nil
-}
-
-// FakeCertManager is a testing helper that returns a *certificate.Manager
-func FakeCertManager() (*Manager, error) {
-	getCertValidityDuration := func() time.Duration { return validity }
-	cm, err := NewManager(
-		context.Background(),
-		&fakeMRCClient{},
-		getCertValidityDuration,
-		getCertValidityDuration,
-		1*time.Hour,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error creating fakeCertManager, err: %w", err)
-	}
-
-	return cm, nil
 }

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -14,11 +14,13 @@ import (
 
 // fakeMRCClient implements the MRCClient interface
 type fakeMRCClient struct {
-	configClient osmConfigClient.Interface
+	configClient             osmConfigClient.Interface
+	countGetCertIssuerForMRC int
 }
 
 // GetCertIssuerForMRC returns a fakeIssuer and pre-generated RootCertificate. It is intended to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (Issuer, pem.RootCertificate, error) {
+	c.countGetCertIssuerForMRC++
 	return &fakeIssuer{id: mrc.Name}, pem.RootCertificate("rootCA"), nil
 }
 

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -101,6 +101,7 @@ func (m *Manager) start(ctx context.Context, mrcClient MRCClient) error {
 			}
 
 			if m.signingIssuer != nil && m.validatingIssuer != nil {
+				log.Debug().Msg("successfully initialized certificate manager")
 				once.Do(func() {
 					wg.Done()
 				})

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -14,17 +14,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/logger"
 )
 
-const (
-	// mrcDurationPerStage is the amount of time we leave each MRC in a stage before moving to the next stage. This is
-	// intended to accommodate the rotation of *all* rotations across all injector and controller pods for:
-	// 1. Bootstrap Cert rotation for each live proxy
-	// 2. Service Cert rotation and xDS push for each connected proxy
-	// 3. xDS server cert rotation on the controller
-	// 4. Mutating and Validating Webhook rotation for the servers and for the webhook configuration objects.
-	// 5. Ingress Gateway Certificate.
-	mrcDurationPerStage = 5 * time.Minute
-)
-
 var (
 	log = logger.New("certificate")
 )

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -10,6 +10,7 @@ import (
 	tassert "github.com/stretchr/testify/assert"
 	trequire "github.com/stretchr/testify/require"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/constants"
 	"github.com/openservicemesh/osm/pkg/identity"
@@ -84,7 +85,8 @@ func TestRotor(t *testing.T) {
 
 	stop := make(chan struct{})
 	defer close(stop)
-	certManager, err := NewManager(context.Background(), &fakeMRCClient{}, getServiceCertValidityPeriod, getIngressGatewayCertValidityPeriod, 5*time.Second)
+	certManager, err := NewManager(context.Background(), &fakeMRCClient{mrcList: []*v1alpha2.MeshRootCertificate{activeMRC1}},
+		getServiceCertValidityPeriod, getIngressGatewayCertValidityPeriod, 5*time.Second)
 	require.NoError(err)
 
 	certA, err := certManager.IssueCertificate(ForServiceIdentity(identity.ServiceIdentity(cnPrefix)))

--- a/pkg/certificate/manager_test.go
+++ b/pkg/certificate/manager_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/cskr/pubsub"
 	tassert "github.com/stretchr/testify/assert"
 	trequire "github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/constants"
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/identity"
 )
 
@@ -85,7 +86,8 @@ func TestRotor(t *testing.T) {
 
 	stop := make(chan struct{})
 	defer close(stop)
-	certManager, err := NewManager(context.Background(), &fakeMRCClient{mrcList: []*v1alpha2.MeshRootCertificate{activeMRC1}},
+	configClient := configFake.NewSimpleClientset([]runtime.Object{activeMRC1}...)
+	certManager, err := NewManager(context.Background(), &fakeMRCClient{configClient: configClient},
 		getServiceCertValidityPeriod, getIngressGatewayCertValidityPeriod, 5*time.Second)
 	require.NoError(err)
 

--- a/pkg/certificate/mrc_reconciler.go
+++ b/pkg/certificate/mrc_reconciler.go
@@ -129,11 +129,12 @@ func (m *Manager) getCertIssuers(desiredSigningMRC, desiredValidatingMRC *v1alph
 
 	if desiredSigningMRC == desiredValidatingMRC {
 		desiredValidatingIssuer = desiredSigningIssuer
-	} else {
-		desiredValidatingIssuer, err = m.getCertIssuer(desiredValidatingMRC)
-		if err != nil {
-			return nil, nil, err
-		}
+		return desiredSigningIssuer, desiredValidatingIssuer, nil
+	}
+
+	desiredValidatingIssuer, err = m.getCertIssuer(desiredValidatingMRC)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return desiredSigningIssuer, desiredValidatingIssuer, nil

--- a/pkg/certificate/mrc_reconciler.go
+++ b/pkg/certificate/mrc_reconciler.go
@@ -1,214 +1,217 @@
 package certificate
 
 import (
-	"time"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
-	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
-// UseCase is how the certificate is used. Each use case will have its own rotation mechanism, that is necessary to
-// determine if we can propagate the rotation forward.
-type UseCase string
-
-const (
-	// UseCaseValidatingWebhook maps to the certificate use case for the validating webhook.
-	UseCaseValidatingWebhook UseCase = "validatingWebhook"
-
-	// UseCaseMutatingWebhook maps to the certificate use case for the Mutating Webhook
-	UseCaseMutatingWebhook UseCase = "mutatingWebhook"
-
-	// UseCaseXDSControlPlane maps to the certificate use case for the XDS Control Plane
-	UseCaseXDSControlPlane UseCase = "xdsControlPlane"
-
-	// UseCaseSidecar maps to the certificate use case for the  sidecar service certs
-	UseCaseSidecar UseCase = "sidecar"
-
-	// UseCaseBootstrap maps to the certificate use case for the  Bootstrap secrets
-	UseCaseBootstrap UseCase = "bootstrap"
-
-	// UseCaseGateway maps to the certificate use case for the  Gateway ingress cert.
-	UseCaseGateway UseCase = "gateway"
-)
-
-var (
-	allUseCases = []UseCase{
-		UseCaseValidatingWebhook,
-		UseCaseMutatingWebhook,
-		UseCaseXDSControlPlane,
-		UseCaseSidecar,
-		UseCaseBootstrap,
-		UseCaseGateway,
-	}
-)
-
-func (uc UseCase) String() string {
-	return string(uc)
-}
 func (m *Manager) handleMRCEvent(event MRCEvent) error {
-	mrc := event.MRC
-	// TODO(5046): remove this first call to setIssuers.
-	err := m.setIssuers(event.MRC)
-	if err == nil {
-		return nil
-	}
-	log.Err(err).Msg("error setting issuers on mrc")
-	// TODO(5046): improve logging in this method.
-	if shouldUpdateMRCComponentStatus(mrc) {
-		if err := m.updateMRCComponentStatus(mrc); err != nil {
-			return err
-		}
-	} else if shouldUpdateState(mrc) {
-		if err := m.updateMRCState(mrc); err != nil {
-			return err
-		}
-	} else if m.shouldSetIssuers(mrc) {
-		log.Info().Msgf("setting new certificate issuers on the Certificate Manager for MRC %s in stage %s", mrc.GetName(), mrc.Status.State)
-		return m.setIssuers(mrc)
-	}
-	return nil
-}
-
-// Component statuses determine if we're ready to transition the mrc to the next state.
-// TODO(5046): add unit tests for this, and other methods in here.
-func shouldUpdateMRCComponentStatus(mrc *v1alpha2.MeshRootCertificate) bool {
-	if isTerminal(mrc) {
-		return false
-	}
-
-	if len(mrc.Status.Conditions) == 0 {
-		return false
-	}
-
-	transitionAfter := mrc.Status.TransitionAfter
-	if transitionAfter == nil {
-		return false
-	}
-
-	//The truncate is needed so we truncate the monotonic clock.
-	return transitionAfter.Truncate(0).After(time.Now())
-}
-
-// shouldUpdateState (and conditions).
-func shouldUpdateState(mrc *v1alpha2.MeshRootCertificate) bool {
-	// TODO(5046): determine the status to we need to be at to be able to move forward.
-	var status v1alpha2.MeshRootCertificateComponentStatus
-
-	for _, useCase := range allUseCases {
-		switch useCase {
-		case UseCaseValidatingWebhook:
-			if mrc.Status.ComponentStatuses.ValidatingWebhook != status {
-				return false
-			}
-		case UseCaseMutatingWebhook:
-			if mrc.Status.ComponentStatuses.MutatingWebhook != status {
-				return false
-			}
-		case UseCaseXDSControlPlane:
-			if mrc.Status.ComponentStatuses.XDSControlPlane != status {
-				return false
-			}
-		case UseCaseSidecar:
-			if mrc.Status.ComponentStatuses.Sidecar != status {
-				return false
-			}
-		case UseCaseBootstrap:
-			if mrc.Status.ComponentStatuses.Bootstrap != status {
-				return false
-			}
-		case UseCaseGateway:
-			if mrc.Status.ComponentStatuses.Gateway != status {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-// update the MRCComponentStatus
-func (m *Manager) updateMRCComponentStatus(mrc *v1alpha2.MeshRootCertificate) error {
-	// TODO(5046): determine the status to set the owned components to.
-	var status v1alpha2.MeshRootCertificateComponentStatus
-
-	for _, useCase := range m.ownedUseCases {
-		switch useCase {
-		case UseCaseValidatingWebhook:
-			// validating, issuing unknown.
-			mrc.Status.ComponentStatuses.ValidatingWebhook = status
-		case UseCaseMutatingWebhook:
-			mrc.Status.ComponentStatuses.MutatingWebhook = status
-		case UseCaseXDSControlPlane:
-			mrc.Status.ComponentStatuses.XDSControlPlane = status
-		case UseCaseSidecar:
-			mrc.Status.ComponentStatuses.Sidecar = status
-		case UseCaseBootstrap:
-			mrc.Status.ComponentStatuses.Bootstrap = status
-		case UseCaseGateway:
-			mrc.Status.ComponentStatuses.Gateway = status
-		}
-	}
-
-	return m.mrcClient.UpdateMeshRootCertificate(mrc)
-}
-
-// isTerminal checks if the MRC is in a terminal state.
-func isTerminal(mrc *v1alpha2.MeshRootCertificate) bool {
-	// TODO(5046): check if the mrc is in a terminal state.
-	return true
-}
-
-// state and condition get updated together.
-func (m *Manager) updateMRCState(mrc *v1alpha2.MeshRootCertificate) error {
-	// TODO(5046): update the MRC state & conditions, and issue the update via the MRCClient.
-
-	// If it's not in a terminal state, set the next transition time.
-	// NOTE: consider that this isTerminal check will need to apply against the updated mrc state which should happen
-	// above in this method.
-	if isTerminal(mrc) {
-		mrc.Status.TransitionAfter = nil
-	} else {
-		mrc.Status.TransitionAfter = &metav1.Time{Time: time.Now().Add(mrcDurationPerStage)}
-	}
-
-	// TODO(5046): add the retry loop.
-	return m.mrcClient.UpdateMeshRootCertificate(mrc)
-}
-
-func (m *Manager) shouldSetIssuers(mrc *v1alpha2.MeshRootCertificate) bool {
-	// TODO(5046): check the states, and if in some form of an active state, AND if the MRC is not already the existing
-	// then we should set MRC, so return true
-	return true
-}
-
-func (m *Manager) setIssuers(mrc *v1alpha2.MeshRootCertificate) error {
-	client, ca, err := m.mrcClient.GetCertIssuerForMRC(mrc)
+	log.Debug().Msgf("handling MRC event for MRC %s", event.MRCName)
+	mrcList, err := m.mrcClient.ListMeshRootCertificates()
 	if err != nil {
 		return err
 	}
 
-	c := &issuer{Issuer: client, ID: mrc.Name, CertificateAuthority: ca, TrustDomain: mrc.Spec.TrustDomain, SpiffeEnabled: mrc.Spec.SpiffeEnabled}
-	switch {
-	case mrc.Status.State == constants.MRCStateActive:
-		m.mu.Lock()
-		m.signingIssuer = c
-		m.validatingIssuer = c
-		m.mu.Unlock()
-	case mrc.Status.State == constants.MRCStateIssuingRollback || mrc.Status.State == constants.MRCStateIssuingRollout:
-		m.mu.Lock()
-		m.signingIssuer = c
-		m.mu.Unlock()
-	case mrc.Status.State == constants.MRCStateValidatingRollback || mrc.Status.State == constants.MRCStateValidatingRollout:
-		m.mu.Lock()
-		m.validatingIssuer = c
-		m.mu.Unlock()
-		// TODO(5046): let's not have a default case.. what are the explicit states that can result in this?
-	default:
-		m.mu.Lock()
-		m.signingIssuer = c
-		m.validatingIssuer = c
-		m.mu.Unlock()
+	filteredMRCList := filterOutInactiveMRCs(mrcList)
+
+	desiredSigningMRC, desiredValidatingMRC, err := getSigningAndValidatingMRCs(filteredMRCList)
+	if err != nil {
+		return err
 	}
+
+	m.mu.Lock()
+	signingIssuer := m.signingIssuer
+	validatingIssuer := m.validatingIssuer
+	m.mu.Unlock()
+
+	// if the issuers are already set to the desired value, return
+	if signingIssuer != nil && signingIssuer.ID == desiredSigningMRC.Name && validatingIssuer != nil && validatingIssuer.ID == desiredValidatingMRC.Name {
+		return nil
+	}
+
+	desiredSigningIssuer, desiredValidatingIssuer, err := m.getCertIssuers(desiredSigningMRC, desiredValidatingMRC)
+	if err != nil {
+		return err
+	}
+
+	return m.updateIssuers(desiredSigningIssuer, desiredValidatingIssuer)
+}
+
+var validMRCIntentCombinations = map[v1alpha2.MeshRootCertificateIntent][]v1alpha2.MeshRootCertificateIntent{
+	v1alpha2.ActiveIntent: {
+		v1alpha2.PassiveIntent,
+		v1alpha2.ActiveIntent,
+	},
+	v1alpha2.PassiveIntent: {
+		v1alpha2.ActiveIntent,
+	},
+}
+
+// ValidateMRCIntents validates the intent combination of MRCs
+func ValidateMRCIntents(mrc1, mrc2 *v1alpha2.MeshRootCertificate) error {
+	if mrc1 == nil || mrc2 == nil {
+		log.Error().Err(ErrUnexpectedNilMRC).Msg("unexpected nil MRC provided when validating MRC intents")
+		return ErrUnexpectedNilMRC
+	}
+	if mrc1 == mrc2 {
+		if mrc1.Spec.Intent != v1alpha2.ActiveIntent {
+			log.Error().Err(ErrExpectedActiveMRC).Msgf("expected single MRC with %s intent, found %s", v1alpha2.ActiveIntent, mrc1.Spec.Intent)
+			return ErrExpectedActiveMRC
+		}
+
+		return nil
+	}
+
+	intent1 := mrc1.Spec.Intent
+	intent2 := mrc2.Spec.Intent
+
+	validIntents, ok := validMRCIntentCombinations[intent1]
+	if !ok {
+		log.Error().Err(ErrUnknownMRCIntent).Msgf("unable to find %s intent in set of valid intents. Invalid combination of %s intent and %s intent", intent1, intent1, intent2)
+		return ErrUnknownMRCIntent
+	}
+
+	for _, intent := range validIntents {
+		if intent2 == intent {
+			log.Debug().Msgf("verified valid intent combination of %s intent and %s intent", intent1, intent2)
+			return nil
+		}
+	}
+
+	log.Error().Err(ErrInvalidMRCIntentCombination).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidMRCIntentCombination)).
+		Msgf("invalid combination of %s intent and %s intent", intent1, intent2)
+	return ErrInvalidMRCIntentCombination
+}
+
+// getSigningAndValidatingMRCs returns the signing and validating MRCs from a list of MRCs
+func getSigningAndValidatingMRCs(mrcList []*v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, *v1alpha2.MeshRootCertificate, error) {
+	if len(mrcList) == 0 {
+		log.Error().Err(ErrNoMRCsFound).Msg("when handling MRC event, found no MRCs in OSM control plane namespace")
+		return nil, nil, ErrNoMRCsFound
+	}
+	if len(mrcList) > 2 {
+		log.Error().Err(ErrNumMRCExceedsMaxSupported).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrNumMRCExceedsMaxSupported)).
+			Msgf("expected 2 or less MRCs in the OSM control plane namespace, found %d", len(mrcList))
+		return nil, nil, ErrNumMRCExceedsMaxSupported
+	}
+
+	var mrc1, mrc2 *v1alpha2.MeshRootCertificate
+	mrc1 = mrcList[0]
+	if len(mrcList) == 2 {
+		mrc2 = mrcList[1]
+	} else {
+		log.Trace().Msgf("found single MRC in the mesh when handling MRC event for MRC %s", mrc1.Name)
+		// if there is only one MRC, set mrc2 equal to mrc1
+		mrc2 = mrc1
+	}
+
+	log.Debug().Msg("validating MRC intent combination")
+	if err := ValidateMRCIntents(mrc1, mrc2); err != nil {
+		return nil, nil, err
+	}
+
+	if mrc1 == nil || mrc2 == nil {
+		log.Error().Err(ErrUnexpectedNilMRC).Msg("unexpected nil MRC provided when validating MRC intents")
+		return nil, nil, ErrUnexpectedNilMRC
+	}
+
+	intent1 := mrc1.Spec.Intent
+	intent2 := mrc2.Spec.Intent
+
+	switch intent1 {
+	case v1alpha2.ActiveIntent:
+		switch intent2 {
+		case v1alpha2.PassiveIntent:
+			return mrc1, mrc2, nil
+		case v1alpha2.ActiveIntent:
+			// If mrc1 != mrc2 and both MRCs have active intents, their state is non
+			// deterministic. To avoid continuously resetting the issuers, only update
+			// if the issuers have not already been set.
+			return mrc1, mrc2, nil
+		default:
+			log.Error().Err(ErrInvalidMRCIntentCombination).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidMRCIntentCombination)).
+				Msgf("invalid combination of %s intent and %s intent", intent1, intent2)
+			return nil, nil, ErrInvalidMRCIntentCombination
+		}
+	case v1alpha2.PassiveIntent:
+		switch intent2 {
+		case v1alpha2.ActiveIntent:
+			return mrc2, mrc1, nil
+		default:
+			log.Error().Err(ErrInvalidMRCIntentCombination).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidMRCIntentCombination)).
+				Msgf("invalid combination of %s intent and %s intent", intent1, intent2)
+			return nil, nil, ErrInvalidMRCIntentCombination
+		}
+	default:
+		log.Error().Err(ErrUnknownMRCIntent).Msgf("invalid combination of %s intent and %s intent", intent1, intent2)
+		return nil, nil, ErrUnknownMRCIntent
+	}
+}
+
+func (m *Manager) updateIssuers(signingIssuer, validatingIssuer *issuer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.signingIssuer = signingIssuer
+	m.validatingIssuer = validatingIssuer
+	log.Trace().Msgf("setting issuers for validating[%s] and signing[%s]", validatingIssuer.ID, signingIssuer.ID)
 	return nil
+}
+
+func (m *Manager) getCertIssuers(signingMRC, validatingMRC *v1alpha2.MeshRootCertificate) (*issuer, *issuer, error) {
+	if signingMRC == nil || validatingMRC == nil {
+		log.Error().Err(ErrUnexpectedNilMRC).Msg("unexpected nil MRC provided when getting cert issuers from MRCs")
+		return nil, nil, ErrUnexpectedNilMRC
+	}
+
+	var desiredSigningIssuer, desiredValidatingIssuer *issuer
+	desiredSigningIssuer, err := m.getCertIssuer(signingMRC)
+	if err != nil {
+		return nil, nil, err
+	}
+	// don't get the issuer again if there is a single MRC in the control plane
+	if signingMRC == validatingMRC {
+		desiredValidatingIssuer = desiredSigningIssuer
+	} else {
+		desiredValidatingIssuer, err = m.getCertIssuer(validatingMRC)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return desiredSigningIssuer, desiredValidatingIssuer, nil
+}
+
+func (m *Manager) getCertIssuer(mrc *v1alpha2.MeshRootCertificate) (*issuer, error) {
+	m.mu.Lock()
+	signingIssuer := m.signingIssuer
+	validatingIssuer := m.validatingIssuer
+	m.mu.Unlock()
+
+	// if the issuer has already been created for the specified mrc,
+	// return the existing issuer
+	if signingIssuer != nil && mrc.Name == signingIssuer.ID {
+		return signingIssuer, nil
+	}
+	if validatingIssuer != nil && mrc.Name == validatingIssuer.ID {
+		return validatingIssuer, nil
+	}
+
+	client, ca, err := m.mrcClient.GetCertIssuerForMRC(mrc)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &issuer{Issuer: client, ID: mrc.Name, CertificateAuthority: ca, TrustDomain: mrc.Spec.TrustDomain, SpiffeEnabled: mrc.Spec.SpiffeEnabled}
+	return c, nil
+}
+
+func filterOutInactiveMRCs(mrcList []*v1alpha2.MeshRootCertificate) []*v1alpha2.MeshRootCertificate {
+	n := 0
+	for _, mrc := range mrcList {
+		if mrc.Spec.Intent != v1alpha2.InactiveIntent {
+			mrcList[n] = mrc
+			n++
+		}
+	}
+	return mrcList[:n]
 }

--- a/pkg/certificate/mrc_reconciler.go
+++ b/pkg/certificate/mrc_reconciler.go
@@ -22,7 +22,7 @@ func (m *Manager) handleMRCEvent(event MRCEvent) error {
 
 	shouldUpdate, err := m.shouldUpdateIssuers(desiredSigningMRC, desiredValidatingMRC)
 	if err != nil {
-		return nil
+		return err
 	}
 	if !shouldUpdate {
 		return nil
@@ -36,124 +36,76 @@ func (m *Manager) handleMRCEvent(event MRCEvent) error {
 	return m.updateIssuers(desiredSigningIssuer, desiredValidatingIssuer)
 }
 
-var validMRCIntents = map[v1alpha2.MeshRootCertificateIntent]struct{}{
-	v1alpha2.ActiveIntent:  {},
-	v1alpha2.PassiveIntent: {},
-}
-
-// validateMRCIntents validates the inte MRCs
-func validateMRCIntent(intent v1alpha2.MeshRootCertificateIntent) error {
-	_, ok := validMRCIntents[intent]
-	if !ok {
-		log.Error().Err(ErrUnexpectedMRCIntent).Msgf("unable to find %s intent in set of valid intents", intent)
-		return ErrUnexpectedMRCIntent
-	}
-
-	log.Debug().Msgf("validated MRC intent %s", intent)
-	return nil
-}
-
 // getSigningAndValidatingMRCs returns the signing and validating MRCs from a list of MRCs
 func getSigningAndValidatingMRCs(mrcList []*v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, *v1alpha2.MeshRootCertificate, error) {
 	if len(mrcList) == 0 {
 		log.Error().Err(ErrNoMRCsFound).Msg("when handling MRC event, found no MRCs in OSM control plane namespace")
 		return nil, nil, ErrNoMRCsFound
 	}
+
 	if len(mrcList) > 2 {
 		log.Error().Err(ErrNumMRCExceedsMaxSupported).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrNumMRCExceedsMaxSupported)).
 			Msgf("expected 2 or less MRCs in the OSM control plane namespace, found %d", len(mrcList))
 		return nil, nil, ErrNumMRCExceedsMaxSupported
 	}
 
-	var mrc1, mrc2 *v1alpha2.MeshRootCertificate
-	mrc1 = mrcList[0]
-	if len(mrcList) == 2 {
-		mrc2 = mrcList[1]
-	} else {
-		log.Trace().Msgf("found single MRC in the mesh when handling MRC event for MRC %s", mrc1.Name)
-		// if there is only one MRC, set mrc2 equal to mrc1
-		mrc2 = mrc1
-	}
-
-	if mrc1 == nil || mrc2 == nil {
-		log.Error().Err(ErrUnexpectedNilMRC).Msg("unexpected nil MRC provided when validating MRC intents")
-		return nil, nil, ErrUnexpectedNilMRC
-	}
-
-	intent1 := mrc1.Spec.Intent
-	intent2 := mrc2.Spec.Intent
-
-	if err := validateMRCIntent(intent1); err != nil {
-		return nil, nil, err
-	}
-	if err := validateMRCIntent(intent2); err != nil {
-		return nil, nil, err
-	}
-
-	log.Debug().Msgf("validating intent combination of %s and %s", intent1, intent2)
-	if mrc1 == mrc2 {
-		// if the MRCs are equal then there is only 1 MRC in the mesh
-		// and it must have an active intent
-		if intent1 == v1alpha2.ActiveIntent {
-			// since there is only 1 MRC, it is the signing and validating MRC
-			return mrc1, mrc2, nil
-		}
-
-		log.Error().Err(ErrExpectedActiveMRC).Msgf("expected single MRC with %s intent, found %s", v1alpha2.ActiveIntent, mrc1.Spec.Intent)
+	if len(mrcList) == 1 && mrcList[0].Spec.Intent != v1alpha2.ActiveIntent {
+		log.Error().Err(ErrExpectedActiveMRC).Msgf("expected single MRC with %s intent, found %s", v1alpha2.ActiveIntent, mrcList[0].Spec.Intent)
 		return nil, nil, ErrExpectedActiveMRC
+	}
+
+	// check if there are 2 passive MRCs. This is not allowed, must have an active MRC
+	if len(mrcList) == 2 && mrcList[0].Spec.Intent == v1alpha2.PassiveIntent && mrcList[1].Spec.Intent == v1alpha2.PassiveIntent {
+		return nil, nil, ErrExpectedActiveMRC
+	}
+
+	// single active MRC
+	if len(mrcList) == 1 {
+		return mrcList[0], mrcList[0], nil
 	}
 
 	// the combination of active and passive intents is deterministic
 	// regardless of MRC ordering, the passive MRC is the validating MRC and
-	// the active MRC is the signing MRC
-	// the combination of active and active intents is non-deterministic
-	// depending on the MRC ordering, either MRC could be the validating or
-	// signing MRC
-	if intent1 == v1alpha2.ActiveIntent && (intent2 == v1alpha2.PassiveIntent || intent2 == v1alpha2.ActiveIntent) {
-		return mrc1, mrc2, nil
-	}
-	if intent1 == v1alpha2.PassiveIntent && intent2 == v1alpha2.ActiveIntent {
-		return mrc2, mrc1, nil
+	// the active MRC is the signing MRC this means that if the first one in
+	// the list is Passive and the second is active we can return this
+	// combination and any other is valid
+	if mrcList[0].Spec.Intent == v1alpha2.PassiveIntent && mrcList[1].Spec.Intent == v1alpha2.ActiveIntent {
+		return mrcList[1], mrcList[0], nil
 	}
 
-	log.Error().Err(ErrInvalidMRCIntentCombination).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrInvalidMRCIntentCombination)).
-		Msgf("invalid intent combination of %s and %s", intent1, intent2)
-	return nil, nil, ErrInvalidMRCIntentCombination
+	// note: the combination of active and active intents is non-deterministic
+	// depending on the MRC ordering, either MRC could be the validating or
+	// signing MRC. Not swapping them indefinitely if the list order changes
+	// on updates is handled later on
+	return mrcList[0], mrcList[1], nil
 }
 
 func (m *Manager) shouldUpdateIssuers(desiredSigningMRC, desiredValidatingMRC *v1alpha2.MeshRootCertificate) (bool, error) {
-	if desiredSigningMRC == nil || desiredValidatingMRC == nil {
-		log.Error().Err(ErrUnexpectedNilMRC).Msg("unexpected nil MRC provided when getting cert issuers from MRCs")
-		return false, ErrUnexpectedNilMRC
-	}
-
 	m.mu.Lock()
 	signingIssuer := m.signingIssuer
 	validatingIssuer := m.validatingIssuer
 	m.mu.Unlock()
 
-	// if the issuers are already set to the desired value, return
-	if signingIssuer != nil && signingIssuer.ID == desiredSigningMRC.Name && validatingIssuer != nil && validatingIssuer.ID == desiredValidatingMRC.Name {
+	if signingIssuer == nil || validatingIssuer == nil {
+		return true, nil
+	}
+
+	// no update required if the issuers are already set to the desired value
+	if signingIssuer.ID == desiredSigningMRC.Name && validatingIssuer.ID == desiredValidatingMRC.Name {
 		log.Debug().Msgf("issuers already set to the desired value. Will not update issuers: validating[%s] and signing[%s]", validatingIssuer.ID, signingIssuer.ID)
 		return false, nil
 	}
 
-	// if desiredSigningMRC != desiredValidatingMRC and both MRCs have active intents, their state is non
-	// deterministic. To avoid continuously resetting the issuers, only update
-	// if the issuers have not already been set
-	if desiredSigningMRC != desiredValidatingMRC && desiredSigningMRC.Spec.Intent == v1alpha2.ActiveIntent &&
-		desiredValidatingMRC.Spec.Intent == v1alpha2.ActiveIntent && signingIssuer != nil && validatingIssuer != nil {
-		log.Debug().Msgf("issuers already set and MRC intents are non deterministic; validating[%s] and signing[%s]", validatingIssuer.ID, signingIssuer.ID)
+	bothActive := desiredSigningMRC.Spec.Intent == v1alpha2.ActiveIntent && desiredValidatingMRC.Spec.Intent == v1alpha2.ActiveIntent
+	exist := (desiredSigningMRC.Name == signingIssuer.ID || desiredSigningMRC.Name == validatingIssuer.ID) &&
+		(desiredValidatingMRC.Name == signingIssuer.ID || desiredValidatingMRC.Name == validatingIssuer.ID)
 
-		// if the issuers match either desired MRC, don't update. Note: the issuers are not set to their
-		// desired values, but are in an acceptable state.
-		if (desiredSigningMRC.Name == signingIssuer.ID || desiredSigningMRC.Name == validatingIssuer.ID) &&
-			(desiredValidatingMRC.Name == signingIssuer.ID || desiredValidatingMRC.Name == validatingIssuer.ID) {
-			log.Debug().Msgf("Will not update issuers to avoid repeated updates; validating[%s] and signing[%s]", validatingIssuer.ID, signingIssuer.ID)
-			return false, nil
-		}
-		// update since the issuers do not match the desired MRCs
-		return true, nil
+	// if desiredSigningMRC != desiredValidatingMRC and both MRCs have active intents, their state is non
+	// deterministic. No update required if the current signing and validating issuers correspond to the
+	// existing MRCs. This check is necessary to avoid continuously resetting the issuers on start up
+	if desiredSigningMRC != desiredValidatingMRC && bothActive && exist {
+		log.Debug().Msgf("Will not update issuers to avoid repeated updates; validating[%s] and signing[%s]", validatingIssuer.ID, signingIssuer.ID)
+		return false, nil
 	}
 
 	return true, nil
@@ -169,24 +121,15 @@ func (m *Manager) updateIssuers(signingIssuer, validatingIssuer *issuer) error {
 }
 
 func (m *Manager) getCertIssuers(desiredSigningMRC, desiredValidatingMRC *v1alpha2.MeshRootCertificate) (*issuer, *issuer, error) {
-	if desiredSigningMRC == nil || desiredValidatingMRC == nil {
-		log.Error().Err(ErrUnexpectedNilMRC).Msg("unexpected nil MRC provided when getting cert issuers from MRCs")
-		return nil, nil, ErrUnexpectedNilMRC
-	}
-
 	var desiredSigningIssuer, desiredValidatingIssuer *issuer
 	desiredSigningIssuer, err := m.getCertIssuer(desiredSigningMRC)
 	if err != nil {
 		return nil, nil, err
 	}
-	// don't get the issuer again if there is a single MRC in the control plane
-	if desiredSigningMRC == desiredValidatingMRC {
-		desiredValidatingIssuer = desiredSigningIssuer
-	} else {
-		desiredValidatingIssuer, err = m.getCertIssuer(desiredValidatingMRC)
-		if err != nil {
-			return nil, nil, err
-		}
+
+	desiredValidatingIssuer, err = m.getCertIssuer(desiredValidatingMRC)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return desiredSigningIssuer, desiredValidatingIssuer, nil

--- a/pkg/certificate/mrc_reconciler.go
+++ b/pkg/certificate/mrc_reconciler.go
@@ -127,9 +127,13 @@ func (m *Manager) getCertIssuers(desiredSigningMRC, desiredValidatingMRC *v1alph
 		return nil, nil, err
 	}
 
-	desiredValidatingIssuer, err = m.getCertIssuer(desiredValidatingMRC)
-	if err != nil {
-		return nil, nil, err
+	if desiredSigningMRC == desiredValidatingMRC {
+		desiredValidatingIssuer = desiredSigningIssuer
+	} else {
+		desiredValidatingIssuer, err = m.getCertIssuer(desiredValidatingMRC)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	return desiredSigningIssuer, desiredValidatingIssuer, nil

--- a/pkg/certificate/mrc_reconciler_test.go
+++ b/pkg/certificate/mrc_reconciler_test.go
@@ -158,92 +158,35 @@ func TestHandleMRCEvent(t *testing.T) {
 	}
 }
 
-func TestValidateMRCIntents(t *testing.T) {
+func TestValidateMRCIntent(t *testing.T) {
 	tests := []struct {
 		name   string
-		mrc1   *v1alpha2.MeshRootCertificate
-		mrc2   *v1alpha2.MeshRootCertificate
+		intent v1alpha2.MeshRootCertificateIntent
 		result error
 	}{
 		{
-			name:   "two nil mrcs",
-			mrc1:   nil,
-			mrc2:   nil,
-			result: ErrUnexpectedNilMRC,
+			name:   "valid active intent",
+			intent: v1alpha2.ActiveIntent,
 		},
 		{
-			name:   "single invalid mrc intent passive",
-			mrc1:   passiveMRC1,
-			mrc2:   passiveMRC1,
-			result: ErrExpectedActiveMRC,
+			name:   "valid passive intent",
+			intent: v1alpha2.PassiveIntent,
 		},
 		{
-			name: "invalid mrc intent foo",
-			mrc1: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: "foo",
-				},
-			},
-			mrc2: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.ActiveIntent,
-				},
-			},
-			result: ErrUnknownMRCIntent,
+			name:   "invalid unknown intent",
+			intent: "foo",
+			result: ErrUnexpectedMRCIntent,
 		},
 		{
-			name: "invalid mrc intent combination of passive and passive",
-			mrc1: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.PassiveIntent,
-				},
-			},
-			mrc2: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.PassiveIntent,
-				},
-			},
-			result: ErrInvalidMRCIntentCombination,
-		},
-		{
-			name: "valid mrc intent combination of active and active",
-			mrc1: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.ActiveIntent,
-				},
-			},
-			mrc2: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.ActiveIntent,
-				},
-			},
-			result: nil,
-		},
-		{
-			name: "valid mrc intent combination of active and passive",
-			mrc1: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.ActiveIntent,
-				},
-			},
-			mrc2: &v1alpha2.MeshRootCertificate{
-				Spec: v1alpha2.MeshRootCertificateSpec{
-					Intent: v1alpha2.PassiveIntent,
-				},
-			},
-			result: nil,
-		},
-		{
-			name:   "single valid mrc intent active",
-			mrc1:   activeMRC1,
-			mrc2:   activeMRC1,
-			result: nil,
+			name:   "invalid empty intent",
+			intent: "",
+			result: ErrUnexpectedMRCIntent,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := tassert.New(t)
-			err := validateMRCIntents(tt.mrc1, tt.mrc2)
+			err := validateMRCIntent(tt.intent)
 			assert.Equal(tt.result, err)
 		})
 	}
@@ -263,7 +206,7 @@ func TestGetSigningAndValidatingMRCs(t *testing.T) {
 			expectedError: ErrNoMRCsFound,
 		},
 		{
-			name: "more than 2 active and passive MRCs",
+			name: "more than 2 active and passive mrcs",
 			mrcList: []*v1alpha2.MeshRootCertificate{
 				activeMRC1,
 				passiveMRC2,
@@ -280,7 +223,7 @@ func TestGetSigningAndValidatingMRCs(t *testing.T) {
 			expectedValidatingMRC: activeMRC1,
 		},
 		{
-			name: "single mrc is passive, expect err, validateMRCIntent fails",
+			name: "single mrc is passive, expect err",
 			mrcList: []*v1alpha2.MeshRootCertificate{
 				passiveMRC1,
 			},

--- a/pkg/certificate/mrc_reconciler_test.go
+++ b/pkg/certificate/mrc_reconciler_test.go
@@ -1,0 +1,525 @@
+package certificate
+
+import (
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/certificate/pem"
+)
+
+var activeMRC1 = &v1alpha2.MeshRootCertificate{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "mrc1",
+	},
+	Spec: v1alpha2.MeshRootCertificateSpec{
+		Intent: v1alpha2.ActiveIntent,
+	},
+}
+
+var passiveMRC1 = &v1alpha2.MeshRootCertificate{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "mrc1",
+	},
+	Spec: v1alpha2.MeshRootCertificateSpec{
+		Intent: v1alpha2.PassiveIntent,
+	},
+}
+
+var activeMRC2 = &v1alpha2.MeshRootCertificate{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "mrc2",
+	},
+	Spec: v1alpha2.MeshRootCertificateSpec{
+		Intent: v1alpha2.ActiveIntent,
+	},
+}
+
+var passiveMRC2 = &v1alpha2.MeshRootCertificate{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "mrc2",
+	},
+	Spec: v1alpha2.MeshRootCertificateSpec{
+		Intent: v1alpha2.PassiveIntent,
+	},
+}
+
+func TestHandleMRCEvent(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		mrcEvent             MRCEvent
+		mrcList              []*v1alpha2.MeshRootCertificate
+		expectedError        bool
+		wantSigningIssuer    *issuer
+		wantValidatingIssuer *issuer
+	}{
+		{
+			name: "no issuers set when no MRCs found",
+			mrcEvent: MRCEvent{
+				MRCName: "my-mrc",
+			},
+			expectedError:        true,
+			mrcList:              []*v1alpha2.MeshRootCertificate{},
+			wantSigningIssuer:    nil,
+			wantValidatingIssuer: nil,
+		},
+		{
+			name: "no issuers set when more than 2 MRCs found",
+			mrcEvent: MRCEvent{
+				MRCName: "my-mrc",
+			},
+			expectedError: true,
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-mrc",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						TrustDomain: "foo.bar.com",
+						Intent:      v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-mrc1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						TrustDomain: "foo.bar.com",
+						Intent:      v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-mrc2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						TrustDomain: "foo.bar.com",
+						Intent:      v1alpha2.PassiveIntent,
+					},
+				},
+			},
+			wantSigningIssuer:    nil,
+			wantValidatingIssuer: nil,
+		},
+		{
+			name: "set issuers for single MRC",
+			mrcEvent: MRCEvent{
+				MRCName: "my-mrc",
+			},
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "my-mrc",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						TrustDomain: "foo.bar.com",
+						Intent:      v1alpha2.ActiveIntent,
+					},
+				},
+			},
+			wantSigningIssuer:    &issuer{Issuer: &fakeIssuer{id: "my-mrc"}, ID: "my-mrc", TrustDomain: "foo.bar.com", CertificateAuthority: pem.RootCertificate("rootCA")},
+			wantValidatingIssuer: &issuer{Issuer: &fakeIssuer{id: "my-mrc"}, ID: "my-mrc", TrustDomain: "foo.bar.com", CertificateAuthority: pem.RootCertificate("rootCA")},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			m := &Manager{
+				mrcClient: &fakeMRCClient{
+					mrcList: tt.mrcList,
+				},
+			}
+
+			err := m.handleMRCEvent(tt.mrcEvent)
+			if !tt.expectedError {
+				assert.NoError(err)
+			} else {
+				assert.Error(err)
+			}
+
+			assert.Equal(tt.wantSigningIssuer, m.signingIssuer)
+			assert.Equal(tt.wantValidatingIssuer, m.validatingIssuer)
+		})
+	}
+}
+
+func TestValidateMRCIntents(t *testing.T) {
+	tests := []struct {
+		name   string
+		mrc1   *v1alpha2.MeshRootCertificate
+		mrc2   *v1alpha2.MeshRootCertificate
+		result error
+	}{
+		{
+			name:   "Two nil mrcs",
+			mrc1:   nil,
+			mrc2:   nil,
+			result: ErrUnexpectedNilMRC,
+		},
+		{
+			name:   "Single invalid mrc intent passive",
+			mrc1:   passiveMRC1,
+			mrc2:   passiveMRC1,
+			result: ErrExpectedActiveMRC,
+		},
+		{
+			name: "Invalid mrc intent foo",
+			mrc1: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: "foo",
+				},
+			},
+			mrc2: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
+				},
+			},
+			result: ErrUnknownMRCIntent,
+		},
+		{
+			name: "Invalid mrc intent combination of passive and passive",
+			mrc1: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.PassiveIntent,
+				},
+			},
+			mrc2: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.PassiveIntent,
+				},
+			},
+			result: ErrInvalidMRCIntentCombination,
+		},
+		{
+			name: "Valid mrc intent combination of active and active",
+			mrc1: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
+				},
+			},
+			mrc2: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
+				},
+			},
+			result: nil,
+		},
+		{
+			name: "Valid mrc intent combination of active and passive",
+			mrc1: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
+				},
+			},
+			mrc2: &v1alpha2.MeshRootCertificate{
+				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.PassiveIntent,
+				},
+			},
+			result: nil,
+		},
+		{
+			name:   "Single valid mrc intent active",
+			mrc1:   activeMRC1,
+			mrc2:   activeMRC1,
+			result: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			err := ValidateMRCIntents(tt.mrc1, tt.mrc2)
+			assert.Equal(tt.result, err)
+		})
+	}
+}
+
+func TestGetSigningAndValidatingMRCs(t *testing.T) {
+	tests := []struct {
+		name                  string
+		mrcList               []*v1alpha2.MeshRootCertificate
+		expectedError         error
+		expectedSigningMRC    *v1alpha2.MeshRootCertificate
+		expectedValidatingMRC *v1alpha2.MeshRootCertificate
+	}{
+		{
+			name:          "no mrcs",
+			mrcList:       []*v1alpha2.MeshRootCertificate{},
+			expectedError: ErrNoMRCsFound,
+		},
+		{
+			name: "more than 2 active and passive MRCs",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.PassiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc3",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.PassiveIntent,
+					},
+				},
+			},
+			expectedError: ErrNumMRCExceedsMaxSupported,
+		},
+		{
+			name: "single mrc is active",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				activeMRC1,
+			},
+			expectedSigningMRC:    activeMRC1,
+			expectedValidatingMRC: activeMRC1,
+		},
+		{
+			name: "single mrc is passive, expect err, validateMRCIntent fails",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				passiveMRC1,
+			},
+			expectedError: ErrExpectedActiveMRC,
+		},
+		{
+			name: "mrc1 is active and mrc2 is passive",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				activeMRC1,
+				passiveMRC2,
+			},
+			expectedSigningMRC:    activeMRC1,
+			expectedValidatingMRC: passiveMRC2,
+		},
+		{
+			name: "mrc1 is active and mrc2 is active",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				activeMRC1,
+				activeMRC2,
+			},
+			expectedSigningMRC:    activeMRC1,
+			expectedValidatingMRC: activeMRC2,
+		},
+		{
+			name: "mrc1 is passive and mrc2 is active",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				passiveMRC1,
+				activeMRC2,
+			},
+			expectedSigningMRC:    activeMRC2,
+			expectedValidatingMRC: passiveMRC1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			signingMRC, validatingMRC, err := getSigningAndValidatingMRCs(tt.mrcList)
+			if tt.expectedError != nil {
+				assert.ErrorIs(err, tt.expectedError)
+			} else {
+				assert.NoError(err)
+				assert.Equal(tt.expectedSigningMRC, signingMRC)
+				assert.Equal(tt.expectedValidatingMRC, validatingMRC)
+			}
+		})
+	}
+}
+
+func TestGetCertIssuers(t *testing.T) {
+	mrc1Name := "mrc1"
+	mrc2Name := "mrc2"
+	tests := []struct {
+		name                       string
+		signingMRC                 *v1alpha2.MeshRootCertificate
+		validatingMRC              *v1alpha2.MeshRootCertificate
+		expectedSigningIssuerID    string
+		expectedValidatingIssuerID string
+		currentSigningIssuerID     string
+		currentValidatingIssuerID  string
+		expectedError              error
+	}{
+		{
+			name:          "mrcs are nil",
+			signingMRC:    nil,
+			validatingMRC: nil,
+			expectedError: ErrUnexpectedNilMRC,
+		},
+		{
+			name:                       "same mrcs for signing and validating, issuer does not exist",
+			signingMRC:                 activeMRC1,
+			validatingMRC:              activeMRC1,
+			expectedSigningIssuerID:    mrc1Name,
+			expectedValidatingIssuerID: mrc1Name},
+		{
+			name:                       "same mrcs for signing and validating, issuer does exist as signingIsseur",
+			signingMRC:                 activeMRC1,
+			validatingMRC:              activeMRC1,
+			currentSigningIssuerID:     mrc1Name,
+			currentValidatingIssuerID:  mrc2Name,
+			expectedSigningIssuerID:    mrc1Name,
+			expectedValidatingIssuerID: mrc1Name,
+		},
+		{
+			name:                       "mrc1 is active and mrc2 is passive and issuer for mrc2 does not exist",
+			signingMRC:                 activeMRC1,
+			validatingMRC:              passiveMRC2,
+			currentSigningIssuerID:     mrc1Name,
+			currentValidatingIssuerID:  mrc1Name,
+			expectedSigningIssuerID:    mrc1Name,
+			expectedValidatingIssuerID: mrc2Name,
+		},
+		{
+			name:                       "mrc1 is active and mrc2 is passive and issuers exist",
+			signingMRC:                 activeMRC1,
+			validatingMRC:              passiveMRC2,
+			currentSigningIssuerID:     mrc2Name,
+			currentValidatingIssuerID:  mrc1Name,
+			expectedSigningIssuerID:    mrc1Name,
+			expectedValidatingIssuerID: mrc2Name,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			m := &Manager{}
+			if tt.currentSigningIssuerID != "" {
+				m.signingIssuer = &issuer{ID: tt.currentSigningIssuerID}
+			}
+			if tt.currentValidatingIssuerID != "" {
+				m.validatingIssuer = &issuer{ID: tt.currentValidatingIssuerID}
+			}
+
+			signingIssuer, validatingIssuer, err := m.getCertIssuers(tt.signingMRC, tt.validatingMRC)
+			if tt.expectedError != nil {
+				assert.ErrorIs(err, tt.expectedError)
+			} else {
+				assert.NoError(err)
+				assert.NotNil(signingIssuer)
+				assert.Equal(tt.expectedSigningIssuerID, signingIssuer.ID)
+				assert.NotNil(validatingIssuer)
+				assert.Equal(tt.expectedValidatingIssuerID, validatingIssuer.ID)
+			}
+		})
+	}
+}
+
+func TestFilterOutInactiveMRCs(t *testing.T) {
+	tests := []struct {
+		name            string
+		mrcList         []*v1alpha2.MeshRootCertificate
+		expectedMRCList []*v1alpha2.MeshRootCertificate
+	}{
+		{
+			name:            "empty mrc list",
+			mrcList:         []*v1alpha2.MeshRootCertificate{},
+			expectedMRCList: []*v1alpha2.MeshRootCertificate{},
+		},
+		{
+			name: "mrc list with only inactive mrcs",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.InactiveIntent,
+					},
+				},
+			},
+			expectedMRCList: []*v1alpha2.MeshRootCertificate{},
+		},
+		{
+			name: "mrc list with no inactive mrcs",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.PassiveIntent,
+					},
+				},
+			},
+			expectedMRCList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.PassiveIntent,
+					},
+				},
+			},
+		},
+		{
+			name: "mrc list with no inactive mrcs",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.InactiveIntent,
+					},
+				},
+			},
+			expectedMRCList: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "mrc1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := tassert.New(t)
+
+			returnedMRCList := filterOutInactiveMRCs(tt.mrcList)
+			assert.ElementsMatch(tt.expectedMRCList, returnedMRCList)
+		})
+	}
+}

--- a/pkg/certificate/mrc_reconciler_test.go
+++ b/pkg/certificate/mrc_reconciler_test.go
@@ -158,40 +158,6 @@ func TestHandleMRCEvent(t *testing.T) {
 	}
 }
 
-func TestValidateMRCIntent(t *testing.T) {
-	tests := []struct {
-		name   string
-		intent v1alpha2.MeshRootCertificateIntent
-		result error
-	}{
-		{
-			name:   "valid active intent",
-			intent: v1alpha2.ActiveIntent,
-		},
-		{
-			name:   "valid passive intent",
-			intent: v1alpha2.PassiveIntent,
-		},
-		{
-			name:   "invalid unknown intent",
-			intent: "foo",
-			result: ErrUnexpectedMRCIntent,
-		},
-		{
-			name:   "invalid empty intent",
-			intent: "",
-			result: ErrUnexpectedMRCIntent,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert := tassert.New(t)
-			err := validateMRCIntent(tt.intent)
-			assert.Equal(tt.result, err)
-		})
-	}
-}
-
 func TestGetSigningAndValidatingMRCs(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -226,6 +192,14 @@ func TestGetSigningAndValidatingMRCs(t *testing.T) {
 			name: "single mrc is passive, expect err",
 			mrcList: []*v1alpha2.MeshRootCertificate{
 				passiveMRC1,
+			},
+			expectedError: ErrExpectedActiveMRC,
+		},
+		{
+			name: "mrc1 is passive and mrc2 is passive, expect err",
+			mrcList: []*v1alpha2.MeshRootCertificate{
+				passiveMRC1,
+				passiveMRC2,
 			},
 			expectedError: ErrExpectedActiveMRC,
 		},
@@ -286,12 +260,6 @@ func TestGetCertIssuers(t *testing.T) {
 		currentValidatingIssuerID  string
 		expectedError              error
 	}{
-		{
-			name:          "mrcs are nil",
-			signingMRC:    nil,
-			validatingMRC: nil,
-			expectedError: ErrUnexpectedNilMRC,
-		},
 		{
 			name:                       "same mrcs for signing and validating, issuer does not exist",
 			signingMRC:                 activeMRC1,
@@ -415,12 +383,6 @@ func TestShouldUpdateIssuers(t *testing.T) {
 		currentSigningIssuerID    string
 		currentValidatingIssuerID string
 	}{
-		{
-			name:          "nil MRC, expect error",
-			expectedError: ErrUnexpectedNilMRC,
-			signingMRC:    nil,
-			validatingMRC: activeMRC1,
-		},
 		{
 			name:           "2 MRCs in with active intents and issuers are not already set",
 			expectedUpdate: true,

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -20,8 +20,7 @@ func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEven
 	ch := make(chan certificate.MRCEvent)
 	go func() {
 		ch <- certificate.MRCEvent{
-			Type: certificate.MRCEventAdded,
-			MRC:  c.mrc,
+			MRCName: c.mrc.Name,
 		}
 		close(ch)
 	}()

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -64,7 +64,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 			Spec: v1alpha2.MeshRootCertificateSpec{
 				Provider:    option.AsProviderSpec(),
 				TrustDomain: trustDomain,
-				Intent:      constants.MRCIntentActive,
+				Intent:      v1alpha2.ActiveIntent,
 			},
 		},
 	}

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -64,37 +64,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 			Spec: v1alpha2.MeshRootCertificateSpec{
 				Provider:    option.AsProviderSpec(),
 				TrustDomain: trustDomain,
-				Intent:      constants.MRCIntentPassive,
-			},
-			Status: v1alpha2.MeshRootCertificateStatus{
-				State: constants.MRCStateActive,
-				// Statuses unset will be marked unknown
-				Conditions: []v1alpha2.MeshRootCertificateCondition{
-					{
-						Type:   constants.MRCConditionTypeReady,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeAccepted,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeIssuingRollout,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeValidatingRollout,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeIssuingRollback,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeValidatingRollback,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-				},
+				Intent:      constants.MRCIntentActive,
 			},
 		},
 	}
@@ -181,20 +151,20 @@ func (c *MRCProviderGenerator) getTresorOSMCertificateManager(mrc *v1alpha2.Mesh
 	// Regardless of success or failure, all instances can proceed to load the same CA.
 	rootCert, err = tresor.NewCA(constants.CertificationAuthorityCommonName, constants.CertificationAuthorityRootValidityPeriod, rootCertCountry, rootCertLocality, rootCertOrganization)
 	if err != nil {
-		return nil, errors.New("Failed to create new Certificate Authority with cert issuer tresor")
+		return nil, errors.New("failed to create new Certificate Authority with cert issuer tresor")
 	}
 
 	if rootCert.GetPrivateKey() == nil {
-		return nil, errors.New("Root cert does not have a private key")
+		return nil, errors.New("root cert does not have a private key")
 	}
 
 	rootCert, err = k8storage.GetCertificateFromSecret(mrc.Namespace, mrc.Spec.Provider.Tresor.CA.SecretRef.Name, rootCert, c.kubeClient)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to synchronize certificate on Secrets API : %w", err)
+		return nil, fmt.Errorf("failed to synchronize certificate on Secrets API : %w", err)
 	}
 
 	if rootCert.GetPrivateKey() == nil {
-		return nil, fmt.Errorf("Root cert does not have a private key: %w", certificate.ErrInvalidCertSecret)
+		return nil, fmt.Errorf("root cert does not have a private key: %w", certificate.ErrInvalidCertSecret)
 	}
 
 	tresorClient, err := tresor.New(

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -176,7 +176,7 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      constants.MRCIntentActive,
 					Provider: v1alpha2.ProviderSpec{
 						Tresor: &v1alpha2.TresorProviderSpec{
 							CA: v1alpha2.TresorCASpec{
@@ -185,36 +185,6 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 									Namespace: "osm-system",
 								},
 							},
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -232,6 +202,7 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						Tresor: &v1alpha2.TresorProviderSpec{
 							CA: v1alpha2.TresorCASpec{
@@ -240,36 +211,6 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 									Namespace: "",
 								},
 							},
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -287,41 +228,12 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						CertManager: &v1alpha2.CertManagerProviderSpec{
 							IssuerName:  "test-name",
 							IssuerKind:  "ClusterIssuer",
 							IssuerGroup: "cert-manager.io",
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -338,42 +250,13 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						Vault: &v1alpha2.VaultProviderSpec{
 							Host:     "",
 							Port:     0,
 							Role:     "",
 							Protocol: "",
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -395,42 +278,13 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						Vault: &v1alpha2.VaultProviderSpec{
 							Host:     "vault.default.svs.cluster.local",
 							Port:     8200,
 							Role:     "role",
 							Protocol: "http",
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -462,6 +316,7 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						Vault: &v1alpha2.VaultProviderSpec{
 							Host:     "vault.default.svc.cluster.local",
@@ -475,36 +330,6 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 									Key:       "token",
 								},
 							},
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -527,42 +352,13 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						Vault: &v1alpha2.VaultProviderSpec{
 							Host:     "vault.default.svs.cluster.local",
 							Port:     8200,
 							Role:     "role",
 							Protocol: "hi",
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -581,41 +377,12 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
+					Intent: v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						CertManager: &v1alpha2.CertManagerProviderSpec{
 							IssuerName:  "",
 							IssuerKind:  "test-kind",
 							IssuerGroup: "cert-manager.io",
-						},
-					},
-				},
-				Status: v1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-					// unspecified component status will be unknown.
-					Conditions: []v1alpha2.MeshRootCertificateCondition{
-						{
-							Type:   constants.MRCConditionTypeReady,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeAccepted,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollout,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeIssuingRollback,
-							Status: constants.MRCConditionStatusUnknown,
-						},
-						{
-							Type:   constants.MRCConditionTypeValidatingRollback,
-							Status: constants.MRCConditionStatusUnknown,
 						},
 					},
 				},
@@ -648,10 +415,10 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 
 			manager, err := NewCertificateManagerFromMRC(context.Background(), tc.kubeClient, tc.restConfig, tc.providerNamespace, tc.options, computeClient, 1*time.Hour)
 			if tc.expectError {
-				assert.Empty(manager)
+				assert.Nil(manager)
 				assert.Error(err)
 			} else {
-				assert.NotEmpty(manager)
+				assert.NotNil(manager)
 				assert.NoError(err)
 			}
 

--- a/pkg/certificate/providers/config_test.go
+++ b/pkg/certificate/providers/config_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/compute/kube"
-	"github.com/openservicemesh/osm/pkg/constants"
 	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
 	fakeConfigClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 	"github.com/openservicemesh/osm/pkg/k8s"
@@ -176,7 +175,7 @@ func TestGetCertificateManagerFromMRC(t *testing.T) {
 				},
 				Spec: v1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentActive,
+					Intent:      v1alpha2.ActiveIntent,
 					Provider: v1alpha2.ProviderSpec{
 						Tresor: &v1alpha2.TresorProviderSpec{
 							CA: v1alpha2.TresorCASpec{

--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -29,8 +29,7 @@ func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, e
 			mrc := obj.(*v1alpha2.MeshRootCertificate)
 			log.Debug().Msgf("received MRC add event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
 			eventChan <- certificate.MRCEvent{
-				Type: certificate.MRCEventAdded,
-				MRC:  mrc,
+				MRCName: mrc.Name,
 			}
 		},
 		// We don't really care about the previous version
@@ -39,8 +38,7 @@ func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, e
 			mrc := newObj.(*v1alpha2.MeshRootCertificate)
 			log.Debug().Msgf("received MRC update event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
 			eventChan <- certificate.MRCEvent{
-				Type: certificate.MRCEventUpdated,
-				MRC:  mrc,
+				MRCName: mrc.Name,
 			}
 		},
 		// We don't care about deletes because the only deletes that should

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -69,10 +70,16 @@ func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (
 // List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
 	// return single empty object in the list.
-	return []*v1alpha2.MeshRootCertificate{{Spec: v1alpha2.MeshRootCertificateSpec{
-		TrustDomain: "fake.example.com",
-		Intent:      v1alpha2.ActiveIntent,
-	}}}, nil
+	return []*v1alpha2.MeshRootCertificate{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "osm-mesh-root-certificate",
+			},
+			Spec: v1alpha2.MeshRootCertificateSpec{
+				TrustDomain: "fake.example.com",
+				Intent:      v1alpha2.ActiveIntent,
+			},
+		}}, nil
 }
 
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -7,42 +7,72 @@ import (
 
 	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/certificate/pem"
 	"github.com/openservicemesh/osm/pkg/certificate/providers/tresor"
 	"github.com/openservicemesh/osm/pkg/constants"
+	osmConfigClient "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	configFake "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
 )
 
 const (
 	rootCertOrganization = "Open Service Mesh Tresor"
 	initialRootName      = constants.DefaultMeshRootCertificateName
+	defaultNamespace     = "osm-system"
 )
 
+var defaultMRC *v1alpha2.MeshRootCertificate = &v1alpha2.MeshRootCertificate{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      initialRootName,
+		Namespace: defaultNamespace,
+	},
+	Spec: v1alpha2.MeshRootCertificateSpec{
+		TrustDomain: "cluster.local",
+		Intent:      v1alpha2.ActiveIntent,
+	},
+}
+
 type fakeMRCClient struct {
-	mrcChannel chan certificate.MRCEvent
+	mrcChannel   chan certificate.MRCEvent
+	configClient osmConfigClient.Interface
 }
 
 // NewFakeMRC allows for publishing events on to the watch channel to generate MRC events
+// and a default MRC is created
 func NewFakeMRC() *fakeMRCClient { //nolint: revive // unexported-return
+	ch := make(chan certificate.MRCEvent)
+	configClient := configFake.NewSimpleClientset([]runtime.Object{defaultMRC}...)
+
+	return &fakeMRCClient{
+		mrcChannel:   ch,
+		configClient: configClient,
+	}
+}
+
+// NewFakeMRCWithConfig allows for publishing events on to the watch channel to generate MRC events
+func NewFakeMRCWithConfig(configClient osmConfigClient.Interface) *fakeMRCClient { //nolint: revive // unexported-return
 	ch := make(chan certificate.MRCEvent)
 
 	return &fakeMRCClient{
-		mrcChannel: ch,
+		mrcChannel:   ch,
+		configClient: configClient,
 	}
 }
 
 // NewCertEvent allows pushing MRC events which can trigger cert changes
-func (c *fakeMRCClient) NewCertEvent(name, state, trustDomain string) {
+func (c *fakeMRCClient) NewCertEvent(mrcName string) {
 	c.mrcChannel <- certificate.MRCEvent{
-		MRCName: name,
+		MRCName: mrcName,
 	}
 }
 
 // UpdateMeshRootCertificate is not implemented on the compat client and always returns an error
 func (c *fakeMRCClient) UpdateMeshRootCertificate(mrc *v1alpha2.MeshRootCertificate) error {
-	return nil
+	_, err := c.configClient.ConfigV1alpha2().MeshRootCertificates("osm-system").Update(context.Background(), mrc, metav1.UpdateOptions{})
+	return err
 }
 
 // GetCertIssuerForMRC will return a root cert for testing.
@@ -70,22 +100,21 @@ func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (
 // List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
 	// return single empty object in the list.
-	return []*v1alpha2.MeshRootCertificate{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "osm-mesh-root-certificate",
-			},
-			Spec: v1alpha2.MeshRootCertificateSpec{
-				TrustDomain: "fake.example.com",
-				Intent:      v1alpha2.ActiveIntent,
-			},
-		}}, nil
+	mrcList, err := c.configClient.ConfigV1alpha2().MeshRootCertificates("osm-system").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var mrcListPointers []*v1alpha2.MeshRootCertificate
+	for i := range mrcList.Items {
+		mrcListPointers = append(mrcListPointers, &mrcList.Items[i])
+	}
+	return mrcListPointers, nil
 }
 
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	// send event for first CA created
 	go func() {
-		c.NewCertEvent(initialRootName, constants.MRCStateActive, "cluster.local")
+		c.NewCertEvent(initialRootName)
 	}()
 
 	return c.mrcChannel, nil
@@ -107,8 +136,8 @@ func NewFakeWithValidityDuration(getCertValidityDuration func() time.Duration, c
 	return tresorCertManager
 }
 
-// NewFakeWithMRC constructs a fake certificate manager with specified cert validity duration and fake MRC client
-func NewFakeWithMRC(fakeMRCClient *fakeMRCClient, checkInterval time.Duration) *certificate.Manager {
+// NewFakeWithMRCClient constructs a fake certificate manager with specified cert validity duration and fake MRC client
+func NewFakeWithMRCClient(fakeMRCClient *fakeMRCClient, checkInterval time.Duration) *certificate.Manager {
 	getValidityDuration := func() time.Duration { return 1 * time.Hour }
 	tresorCertManager, err := certificate.NewManager(context.Background(), fakeMRCClient, getValidityDuration, getValidityDuration, checkInterval)
 	if err != nil {

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/certificate"
@@ -18,7 +16,7 @@ import (
 
 const (
 	rootCertOrganization = "Open Service Mesh Tresor"
-	initialRootName      = "osm-mesh-root-certificate"
+	initialRootName      = constants.DefaultMeshRootCertificateName
 )
 
 type fakeMRCClient struct {
@@ -37,55 +35,7 @@ func NewFakeMRC() *fakeMRCClient { //nolint: revive // unexported-return
 // NewCertEvent allows pushing MRC events which can trigger cert changes
 func (c *fakeMRCClient) NewCertEvent(name, state, trustDomain string) {
 	c.mrcChannel <- certificate.MRCEvent{
-		Type: certificate.MRCEventAdded,
-		MRC: &v1alpha2.MeshRootCertificate{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: "osm-system",
-			},
-			Spec: v1alpha2.MeshRootCertificateSpec{
-				TrustDomain: trustDomain,
-				Provider: v1alpha2.ProviderSpec{
-					Tresor: &v1alpha2.TresorProviderSpec{
-						CA: v1alpha2.TresorCASpec{
-							SecretRef: v1.SecretReference{
-								Name:      "osm-ca-bundle",
-								Namespace: "osm-system",
-							},
-						},
-					},
-				},
-			},
-			Status: v1alpha2.MeshRootCertificateStatus{
-				State: state,
-				Conditions: []v1alpha2.MeshRootCertificateCondition{
-					{
-						Type:   constants.MRCConditionTypeReady,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeAccepted,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeIssuingRollout,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeValidatingRollout,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeIssuingRollback,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-					{
-						Type:   constants.MRCConditionTypeValidatingRollback,
-						Status: constants.MRCConditionStatusUnknown,
-					},
-				},
-			},
-		},
+		MRCName: name,
 	}
 }
 
@@ -119,7 +69,10 @@ func (c *fakeMRCClient) GetCertIssuerForMRC(mrc *v1alpha2.MeshRootCertificate) (
 // List returns the single, pre-generated MRC. It is intended to implement the certificate.MRCClient interface.
 func (c *fakeMRCClient) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertificate, error) {
 	// return single empty object in the list.
-	return []*v1alpha2.MeshRootCertificate{{Spec: v1alpha2.MeshRootCertificateSpec{TrustDomain: "fake.example.com"}}}, nil
+	return []*v1alpha2.MeshRootCertificate{{Spec: v1alpha2.MeshRootCertificateSpec{
+		TrustDomain: "fake.example.com",
+		Intent:      v1alpha2.ActiveIntent,
+	}}}, nil
 }
 
 func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {

--- a/pkg/certificate/providers/vault/certificate_manager_test.go
+++ b/pkg/certificate/providers/vault/certificate_manager_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Test client helpers", func() {
 			actual := newCert(cn, secret, expiration)
 
 			expected := &certificate.Certificate{
-				IssuingCA:    pem.RootCertificate("zz"),
-				TrustedCAs:   pem.RootCertificate("zz"),
+				IssuingCA:    pem.RootCertificate("zz\n"),
+				TrustedCAs:   pem.RootCertificate("zz\n"),
 				PrivateKey:   pem.PrivateKey("yy"),
 				CertChain:    pem.Certificate("xx"),
 				Expiration:   expiration,

--- a/pkg/certificate/types.go
+++ b/pkg/certificate/types.go
@@ -105,8 +105,7 @@ type issuer struct {
 type Manager struct {
 	// cache for all the certificates issued
 	// Types: map[certificate.CommonName]*certificate.Certificate
-	cache         sync.Map
-	ownedUseCases []UseCase
+	cache sync.Map
 
 	mrcClient MRCClient
 
@@ -139,18 +138,9 @@ type MRCEventType string
 
 // MRCEvent describes a change event on a given MRC
 type MRCEvent struct {
-	Type MRCEventType
-	// The last observed version of the MRC as of the time of this event
-	MRC *v1alpha2.MeshRootCertificate
+	// The name of the MRC generating the event
+	MRCName string
 }
-
-var (
-	// MRCEventAdded is the type of announcement emitted when we observe an addition of a Kubernetes MeshRootCertificate
-	MRCEventAdded MRCEventType = "meshrootcertificate-added"
-
-	// MRCEventUpdated is the type of announcement emitted when we observe an update to a Kubernetes MeshRootCertificate
-	MRCEventUpdated MRCEventType = "meshrootcertificate-updated"
-)
 
 // MRCEventBroker describes any type that allows the caller to Watch() MRCEvents
 type MRCEventBroker interface {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -191,63 +191,6 @@ const (
 	MetricsAnnotation = "openservicemesh.io/metrics"
 )
 
-// Annotations and labels used by the MeshRootCertificate
-const (
-	// MRCStateValidatingRollout is the validating rollout status option for the State of the MeshRootCertificate
-	MRCStateValidatingRollout = "validatingRollout"
-
-	// MRCStateIssuingRollout is the issuing rollout status option for the State of the MeshRootCertificate
-	MRCStateIssuingRollout = "issuingRollout"
-
-	// MRCStatePending is the pending status option for the State of the MeshRootCertificate
-	MRCStatePending = "pending"
-
-	// MRCStateActive is the active status option for the State of the MeshRootCertificate
-	MRCStateActive = "active"
-
-	// MRCStateIssuingRollback is the issuing rollback status option for the State of the MeshRootCertificate
-	MRCStateIssuingRollback = "issuingRollback"
-
-	// MRCStateValidatingRollback is the validating rollback status option for the State of the MeshRootCertificate
-	MRCStateValidatingRollback = "validatingRollback"
-
-	// MRCStateInactive is the inactive status option for the State of the MeshRootCertificate
-	MRCStateInactive = "inactive"
-
-	// MRCStateError is the error status option for the State of the MeshRootCertificate
-	MRCStateError = "error"
-
-	// MRCIntentPassive is the passive option for the Intent of the MeshRootCertificate
-	MRCIntentPassive = "passive"
-
-	// MRCIntentActive is the active option for the Intent of the MeshRootCertificate
-	MRCIntentActive = "active"
-
-	// MRCComponentStatusUnknown is the unknown status option for the component status of the MeshRootCertificate
-	MRCComponentStatusUnknown = "Unknown"
-
-	// MRCConditionStatusUnknown is the unknown status option for the condition status of the MeshRootCertificate
-	MRCConditionStatusUnknown = "Unknown"
-
-	// MRCConditionTypeReady is the ready condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeReady = "Ready"
-
-	// MRCConditionTypeAccepted is the accepted condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeAccepted = "Accepted"
-
-	// MRCConditionTypeIssuingRollout is the issuing rollout condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeIssuingRollout = "IssuingRollout"
-
-	// MRCConditionTypeIssuingRollback is the issuing rollback condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeIssuingRollback = "IssuingRollback"
-
-	// MRCConditionTypeValidatingRollout is the validating rollout condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeValidatingRollout = "ValidatingRollout"
-
-	// MRCConditionTypeValidatingRollback is the validating rollback condition type for certificate condition of the MeshRootCertificate
-	MRCConditionTypeValidatingRollback = "ValidatingRollback"
-)
-
 // Labels used by the control plane
 const (
 	// IgnoreLabel is the label used to ignore a resource

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -150,6 +150,9 @@ const (
 
 	// OSMMeshConfig is the name of the OSM MeshConfig
 	OSMMeshConfig = "osm-mesh-config"
+
+	// DefaultMeshRootCertificateName is the default MeshRootCertificateName name
+	DefaultMeshRootCertificateName = "osm-mesh-root-certificate"
 )
 
 // HealthProbe constants

--- a/pkg/errcode/errcode.go
+++ b/pkg/errcode/errcode.go
@@ -150,6 +150,14 @@ const (
 
 	// ErrUpdatingBootstrapSecret indicates a bootstrap secret could not be updated
 	ErrUpdatingBootstrapSecret
+
+	// ErrInvalidMRCIntentCombination indicates the combination of MRC intent values during root certificate rotation
+	// is invalid
+	ErrInvalidMRCIntentCombination
+
+	// ErrNumMRCExceedsMaxSupported indicated there are more MRCs in the control plane namespace than the max
+	// supported value
+	ErrNumMRCExceedsMaxSupported
 )
 
 // Range 4100-4150 reserved for PubSub system
@@ -565,11 +573,19 @@ An error occurred when creating a certificate to issue from the certificate mana
 `,
 
 	ErrInvalidCA: `
-The certificate authority privided when issuing a certificate was invalid.
+The certificate authority provided when issuing a certificate was invalid.
 `,
 
 	ErrRotatingCert: `
 The specified certificate could not be rotated.
+`,
+
+	ErrUpdatingBootstrapSecret: `
+The specified bootstrap secret could not be updated.
+`,
+
+	ErrInvalidMRCIntentCombination: `
+The combination of MRC Intent values is invalid.
 `,
 
 	//

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -786,6 +786,7 @@ func TestConfigUpdateStatus(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
+					Intent: configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -804,6 +805,7 @@ func TestConfigUpdateStatus(t *testing.T) {
 					Namespace: "osm-system",
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
+					Intent: configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -1261,6 +1263,7 @@ func TestListMeshRootCertificates(t *testing.T) {
 			Namespace: "osm-system",
 		},
 		Spec: configv1alpha2.MeshRootCertificateSpec{
+			Intent: configv1alpha2.ActiveIntent,
 			Provider: configv1alpha2.ProviderSpec{
 				Tresor: &configv1alpha2.TresorProviderSpec{
 					CA: configv1alpha2.TresorCASpec{
@@ -1271,9 +1274,6 @@ func TestListMeshRootCertificates(t *testing.T) {
 					},
 				},
 			},
-		},
-		Status: configv1alpha2.MeshRootCertificateStatus{
-			State: constants.MRCStateActive,
 		},
 	}
 	mrcClient := fakeConfigClient.NewSimpleClientset(mrc)

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -818,7 +818,7 @@ func TestConfigUpdateStatus(t *testing.T) {
 					},
 				},
 				Status: configv1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
+					State: "Error",
 				},
 			},
 		},

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -16,6 +16,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	configv1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	policyv1alpha1 "github.com/openservicemesh/osm/pkg/apis/policy/v1alpha1"
 	"github.com/openservicemesh/osm/pkg/compute"
@@ -303,7 +304,7 @@ func (kc *validator) validateMRCOnCreate(mrc *configv1alpha2.MeshRootCertificate
 		return err
 	}
 
-	if mrc.Spec.Intent == constants.MRCIntentActive {
+	if mrc.Spec.Intent == v1alpha2.ActiveIntent {
 		foundActive, err := kc.checkForExistingActiveMRC(mrc)
 		if err != nil {
 			return err
@@ -368,7 +369,7 @@ func (kc *validator) checkForExistingActiveMRC(mrc *configv1alpha2.MeshRootCerti
 	}
 
 	for _, m := range mrcs {
-		if m.Spec.Intent == constants.MRCIntentActive && m.Name != mrc.Name {
+		if m.Spec.Intent == v1alpha2.ActiveIntent && m.Name != mrc.Name {
 			log.Error().Msgf("cannot create MRC %s with intent active. An MRC with active intent already exists in the control plane namespace", getNamespacedMRC(mrc))
 			return true, nil
 		}

--- a/pkg/validator/validators.go
+++ b/pkg/validator/validators.go
@@ -329,16 +329,7 @@ func (kc *validator) validateMRCOnUpdate(oldMRC *configv1alpha2.MeshRootCertific
 		return fmt.Errorf("cannot update SpiffeEnabled for MRC %s. Create a new MRC and initiate root certificate rotation to enable SPIFFE certificates", getNamespacedMRC(oldMRC))
 	}
 
-	if oldMRC.Spec.Intent != newMRC.Spec.Intent && newMRC.Spec.Intent == constants.MRCIntentActive {
-		foundActive, err := kc.checkForExistingActiveMRC(newMRC)
-		if err != nil {
-			return err
-		}
-		if foundActive {
-			return fmt.Errorf("cannot update MRC %s to intent active. An MRC with active intent already exists in the control plane namespace", getNamespacedMRC(newMRC))
-		}
-	}
-
+	// TODO(#5205): add validation for simplified root certificate rotation process
 	return nil
 }
 

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -1928,9 +1928,6 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 						},
 					},
 				},
-				Status: configv1alpha2.MeshRootCertificateStatus{
-					State: constants.MRCStateActive,
-				},
 			},
 			mrcList: []runtime.Object{
 				&configv1alpha2.MeshRootCertificate{

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -1623,7 +1623,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -1647,7 +1647,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -1671,7 +1671,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						CertManager: &configv1alpha2.CertManagerProviderSpec{
 							IssuerName:  "osm-ca",
@@ -1692,7 +1692,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						CertManager: &configv1alpha2.CertManagerProviderSpec{
 							IssuerName:  "",
@@ -1713,7 +1713,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Vault: &configv1alpha2.VaultProviderSpec{
 							Host:     "vault.contoso.com",
@@ -1742,7 +1742,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Vault: &configv1alpha2.VaultProviderSpec{
 							Host:     "",
@@ -1771,7 +1771,7 @@ func TestValidateMRCProvider(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentPassive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Vault: &configv1alpha2.VaultProviderSpec{
 							Host:     "vault.contoso.com",
@@ -1824,7 +1824,7 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentActive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -1845,7 +1845,7 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 					},
 					Spec: configv1alpha2.MeshRootCertificateSpec{
 						TrustDomain: "cluster.local",
-						Intent:      constants.MRCIntentPassive,
+						Intent:      configv1alpha2.PassiveIntent,
 						Provider: configv1alpha2.ProviderSpec{
 							Tresor: &configv1alpha2.TresorProviderSpec{
 								CA: configv1alpha2.TresorCASpec{
@@ -1870,7 +1870,7 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentActive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -1891,7 +1891,7 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 					},
 					Spec: configv1alpha2.MeshRootCertificateSpec{
 						TrustDomain: "cluster.local",
-						Intent:      constants.MRCIntentActive,
+						Intent:      configv1alpha2.ActiveIntent,
 						Provider: configv1alpha2.ProviderSpec{
 							Tresor: &configv1alpha2.TresorProviderSpec{
 								CA: configv1alpha2.TresorCASpec{
@@ -1916,7 +1916,7 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 				},
 				Spec: configv1alpha2.MeshRootCertificateSpec{
 					TrustDomain: "cluster.local",
-					Intent:      constants.MRCIntentActive,
+					Intent:      configv1alpha2.ActiveIntent,
 					Provider: configv1alpha2.ProviderSpec{
 						Tresor: &configv1alpha2.TresorProviderSpec{
 							CA: configv1alpha2.TresorCASpec{
@@ -1940,7 +1940,7 @@ func TestCheckForExistingActiveMRC(t *testing.T) {
 					},
 					Spec: configv1alpha2.MeshRootCertificateSpec{
 						TrustDomain: "cluster.local",
-						Intent:      constants.MRCIntentActive,
+						Intent:      configv1alpha2.ActiveIntent,
 						Provider: configv1alpha2.ProviderSpec{
 							Tresor: &configv1alpha2.TresorProviderSpec{
 								CA: configv1alpha2.TresorCASpec{

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -63,6 +63,7 @@ func NewServer(name, namespace string, port int, cm *certificate.Manager, handle
 // Run actually starts the server.
 func (s *Server) Run(ctx context.Context) error {
 	if err := s.configureCertificateRotation(ctx); err != nil {
+		log.Error().Err(err).Msg("failed to configure cert rotation")
 		return err
 	}
 

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -63,7 +63,6 @@ func NewServer(name, namespace string, port int, cm *certificate.Manager, handle
 // Run actually starts the server.
 func (s *Server) Run(ctx context.Context) error {
 	if err := s.configureCertificateRotation(ctx); err != nil {
-		log.Error().Err(err).Msg("failed to configure cert rotation")
 		return err
 	}
 

--- a/tests/e2e/e2e_meshrootcertificate_test.go
+++ b/tests/e2e/e2e_meshrootcertificate_test.go
@@ -121,8 +121,11 @@ func basicCertRotationScenario(installOptions ...InstallOsmOpt) {
 	By("deleting original certificate")
 	err = Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Delete(context.Background(), constants.DefaultMeshRootCertificateName, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	err = Td.Client.CoreV1().Secrets(Td.OsmNamespace).Delete(context.Background(), OsmCABundleName, metav1.DeleteOptions{})
-	Expect(err).NotTo(HaveOccurred())
+	if installOpts.CertManager != Vault {
+		// no secrets are created in Vault case
+		err = Td.Client.CoreV1().Secrets(Td.OsmNamespace).Delete(context.Background(), OsmCABundleName, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	}
 
 	By("checking HTTP traffic for client -> server pod after deleting original cert")
 	verifyCertRotation(clientPod, serverPod, newCertName, newCertName)

--- a/tests/e2e/e2e_meshrootcertificate_test.go
+++ b/tests/e2e/e2e_meshrootcertificate_test.go
@@ -16,12 +16,8 @@ import (
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
 	"github.com/openservicemesh/osm/pkg/constants"
+	"github.com/openservicemesh/osm/tests/framework"
 	. "github.com/openservicemesh/osm/tests/framework"
-)
-
-var (
-	ActiveIntent  = v1alpha2.MeshRootCertificateIntent("active")
-	PassiveIntent = v1alpha2.MeshRootCertificateIntent("passive")
 )
 
 var _ = OSMDescribe("MeshRootCertificate",
@@ -49,38 +45,103 @@ var _ = OSMDescribe("MeshRootCertificate",
 		})
 	})
 
+// basicCerRotationScenario rotates a new cert in through the follow pattern:
+// | Step  | MRC1 old   | MRC2 new     | signer    | validator |
+// | ----- | ---------- | ------------ | --------- | --------- |
+// | 1     | active     |              | mcr1      | mcr1      |
+// | 2     | active     | passive      | mcr1      | mcr2      |
+// | 3     | active     | active       | mcr2/mrc1 | mcr1/mrc2 |
+// | 4     | passive    | active       | mcr2      | mcr1      |
+// | 5     | inactive   | active       | mcr2      | mcr2 	   |
+// | 5     |            | active       | mcr2      | mcr2      |
 func basicCertRotationScenario(installOptions ...InstallOsmOpt) {
 	By("installing with MRC enabled")
 	installOptions = append(installOptions, WithMeshRootCertificateEnabled())
 	installOpts := Td.GetOSMInstallOpts(installOptions...)
 	Expect(Td.InstallOSM(installOpts)).To(Succeed())
 
-	// no secrets are created in Vault case
+	By("checking the certificate exists")
 	if installOpts.CertManager != Vault {
-		By("checking the certificate exists")
+		// no secrets are created in Vault case
 		err := Td.WaitForCABundleSecret(Td.OsmNamespace, OsmCABundleName, time.Second*5)
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	By("checking that an active cert cannot be created")
+	By("checking HTTP traffic for client -> server pod after initial MRC creation")
+	clientPod, serverPod, serverSvc := deployTestWorkload()
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	By("checking that another cert with active intent cannot be created")
 	time.Sleep(time.Second * 10)
 	activeNotAllowed := "not-allowed"
-	_, err := createMeshRootCertificate(activeNotAllowed, ActiveIntent, installOpts.CertManager)
+	_, err := createMeshRootCertificate(activeNotAllowed, v1alpha2.ActiveIntent, installOpts.CertManager)
 	Expect(err).Should(HaveOccurred())
 	Expect(err.Error()).Should(ContainSubstring("cannot create MRC %s/%s with intent active. An MRC with active intent already exists in the control plane namespace", Td.OsmNamespace, activeNotAllowed))
 
-	By("creating a second certificate in passive state")
+	By("creating a second certificate with passive intent")
 	newCertName := "osm-mrc-2"
-	_, err = createMeshRootCertificate(newCertName, PassiveIntent, installOpts.CertManager)
+	_, err = createMeshRootCertificate(newCertName, v1alpha2.PassiveIntent, installOpts.CertManager)
 	Expect(err).NotTo(HaveOccurred())
 
-	// no secrets are created in Vault case
+	By("ensuring the new CA secret exists")
 	if installOpts.CertManager != Vault {
-		By("ensuring the new CA secret exists")
+		// no secrets are created in Vault case
 		err = Td.WaitForCABundleSecret(Td.OsmNamespace, newCertName, time.Second*90)
 		Expect(err).NotTo(HaveOccurred())
 	}
-	// TODO(#4835) add checks for the correct statuses for the two certificates and complete cert rotation
+
+	By("checking HTTP traffic for client -> server pod after new cert is rotated in")
+	verifyCertRotation(clientPod, serverPod, constants.DefaultMeshRootCertificateName, newCertName)
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	By("moving new cert from Passive to Active")
+	updateCertificate(newCertName, v1alpha2.ActiveIntent)
+
+	By("checking HTTP traffic for client -> server pod after new cert is rotated in for validation")
+	// At this stage when they are both same intent it isn't deterministic which is validating and signing
+	// skip the verification for now. We check it again later.
+	// verifyCertRotation(clientPod, serverPod, newCertName, constants.DefaultMeshRootCertificateName)
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	By("moving original cert from Active to Passive")
+	updateCertificate(constants.DefaultMeshRootCertificateName, v1alpha2.PassiveIntent)
+
+	By("checking HTTP traffic for client -> server pod after new cert is rotated in for signing")
+	verifyCertRotation(clientPod, serverPod, newCertName, constants.DefaultMeshRootCertificateName)
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	By("moving original cert from passive to inactive")
+	updateCertificate(constants.DefaultMeshRootCertificateName, v1alpha2.InactiveIntent)
+
+	By("checking HTTP traffic for client -> server pod after removing original cert")
+	verifyCertRotation(clientPod, serverPod, newCertName, newCertName)
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	// Success! the new certificate is in use; lets go nuclear and make sure
+	By("deleting original certificate")
+	err = Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Delete(context.Background(), constants.DefaultMeshRootCertificateName, metav1.DeleteOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	err = Td.Client.CoreV1().Secrets(Td.OsmNamespace).Delete(context.Background(), OsmCABundleName, metav1.DeleteOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("checking HTTP traffic for client -> server pod after deleting original cert")
+	verifyCertRotation(clientPod, serverPod, newCertName, newCertName)
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	By("restarting osm controller")
+	// If anything got stuck in above rotation this will ensure things are indeed working
+	stdout, stderr, err := Td.RunLocal("kubectl", "rollout", "restart", "deployment", "osm-controller", "-n", Td.OsmNamespace)
+	Td.T.Logf("stderr:\n%s\n", stderr)
+	Td.T.Logf("stdout:\n%s\n", stdout)
+	Expect(err).NotTo(HaveOccurred())
+	time.Sleep(5 * time.Second)
+	Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+	By("checking HTTP traffic for client -> server pod after restarting")
+	verifyCertRotation(clientPod, serverPod, newCertName, newCertName)
+	verifySuccessfulPodConnection(clientPod, serverPod, serverSvc)
+
+	// todo maybe check that cert modules are different?
 }
 
 func createMeshRootCertificate(name string, intent v1alpha2.MeshRootCertificateIntent, certificateManagerType string) (*v1alpha2.MeshRootCertificate, error) {
@@ -118,6 +179,16 @@ func createTressorMRC(name string, intent v1alpha2.MeshRootCertificateIntent) (*
 				},
 			},
 		}, metav1.CreateOptions{})
+}
+
+func updateCertificate(name string, intent v1alpha2.MeshRootCertificateIntent) {
+	mrc, err := Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Get(context.Background(), name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	mrc.Spec.Intent = intent
+
+	_, err = Td.ConfigClient.ConfigV1alpha2().MeshRootCertificates(Td.OsmNamespace).Update(context.Background(), mrc, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func createCertManagerMRC(name string, intent v1alpha2.MeshRootCertificateIntent) (*v1alpha2.MeshRootCertificate, error) {
@@ -225,4 +296,156 @@ func createVaultMRC(name string, intent v1alpha2.MeshRootCertificateIntent) (*v1
 				},
 			},
 		}, metav1.CreateOptions{})
+}
+
+/*func verifiyUpdatedPodCert(pod *v1.Pod) {
+	By("Verifying pod has updated certificates")
+
+	// It can take a moment for envoy to load the certs
+	Eventually(func() (string, error) {
+		args := []string{"proxy", "get", "certs", pod.Name, fmt.Sprintf("-n=%s", pod.Namespace)}
+		stdout, _, err := Td.RunLocal(filepath.FromSlash("../../bin/osm"), args...)
+		Td.T.Logf("stdout:\n%s", stdout)
+		return stdout.String(), err
+	}, 10*time.Second).Should(ContainSubstring(fmt.Sprintf("\"uri\": \"spiffe://cluster.local/%s/%s", pod.Spec.ServiceAccountName, pod.Namespace)))
+}*/
+
+func verifySuccessfulPodConnection(srcPod, dstPod *v1.Pod, serverSvc *v1.Service) {
+	By("Waiting for repeated request success")
+	cond := Td.WaitForRepeatedSuccess(func() bool {
+		result :=
+			Td.FortioHTTPLoadTest(FortioHTTPLoadTestDef{
+				HTTPRequestDef: HTTPRequestDef{
+					SourceNs:        srcPod.Namespace,
+					SourcePod:       srcPod.Name,
+					SourceContainer: srcPod.Name,
+
+					Destination: fmt.Sprintf("%s.%s:%d", serverSvc.Name, dstPod.Namespace, fortioHTTPPort),
+				},
+			})
+
+		if result.Err != nil || result.HasFailedHTTPRequests() {
+			Td.T.Logf("> REST req has failed requests: %v", result.Err)
+			return false
+		}
+		Td.T.Logf("> REST req succeeded. Status codes: %v", result.AllReturnCodes())
+		return true
+	}, 2 /*runs the load test this many times successfully*/, 90*time.Second /*timeout*/)
+	Expect(cond).To(BeTrue())
+}
+
+// verifyCertRotation ensure the certificates have been rotated properly across all components:
+// 1. Verify service certs were updated (todo)
+// 2. Verify webhooks were updated (todo)
+// 3. Verify bootstrap certs updated (todo)
+// 4. verify xds cert updated (todo)
+func verifyCertRotation(clientPodDef, serverPodDef *v1.Pod, signingCertName, validatingCertName string) {
+	By("checking bootstrap secrets are updated after creating MRC with passive intent")
+	podSelector := constants.EnvoyUniqueIDLabelName
+	srvPod, err := Td.Client.CoreV1().Pods(serverPodDef.Namespace).Get(context.Background(), serverPodDef.Name, metav1.GetOptions{})
+	Expect(err).To(BeNil())
+
+	clientPod, err := Td.Client.CoreV1().Pods(clientPodDef.Namespace).Get(context.Background(), clientPodDef.Name, metav1.GetOptions{})
+	Expect(err).To(BeNil())
+
+	srvPodUUID := srvPod.GetLabels()[podSelector]
+	clientPodUUID := clientPod.GetLabels()[podSelector]
+
+	srvSecretName := fmt.Sprintf("envoy-bootstrap-config-%s", srvPodUUID)
+	clientSecretName := fmt.Sprintf("envoy-bootstrap-config-%s", clientPodUUID)
+
+	// TODO(jaellio): add a time.wait instead of waiting so long in call
+	err = Td.WaitForBootstrapSecretUpdate(serverPodDef.Namespace, srvSecretName, signingCertName, validatingCertName, time.Second*30)
+	Expect(err).NotTo(HaveOccurred())
+	err = Td.WaitForBootstrapSecretUpdate(clientPodDef.Namespace, clientSecretName, signingCertName, validatingCertName, time.Second*30)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// func getCertificateModulus(pod *v1.Pod) string {
+// 	// It can take a moment for envoy to load the certs
+// 	Eventually(func() (string, error) {
+// 		args := []string{"proxy", "get", "config_dump", pod.Name, fmt.Sprintf("-n=%s", pod.Namespace)}
+// 		stdout, _, err := Td.RunOsmCli(args...)
+
+// 		return stdout.String(), err
+// 	}, 10*time.Second).Should(ContainSubstring(fmt.Sprintf("\"uri\": \"spiffe://cluster.local/%s/%s", pod.Spec.ServiceAccountName, pod.Namespace)))
+// }
+
+func deployTestWorkload() (*v1.Pod, *v1.Pod, *v1.Service) {
+	var (
+		clientNamespace = framework.RandomNameWithPrefix("client")
+		serverNamespace = framework.RandomNameWithPrefix("server")
+		ns              = []string{clientNamespace, serverNamespace}
+	)
+
+	By("Deploying client -> server workload")
+	// Create namespaces
+	for _, n := range ns {
+		Expect(Td.CreateNs(n, nil)).To(Succeed())
+		Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+	}
+
+	// Get simple pod definitions for the HTTP server
+	serverSvcAccDef, serverPodDef, serverSvcDef, err := Td.SimplePodApp(
+		SimplePodAppDef{
+			PodName:   framework.RandomNameWithPrefix("pod"),
+			Namespace: serverNamespace,
+			Image:     fortioImageName,
+			Ports:     []int{fortioHTTPPort},
+			OS:        Td.ClusterOS,
+		})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = Td.CreateServiceAccount(serverNamespace, &serverSvcAccDef)
+	Expect(err).NotTo(HaveOccurred())
+	serverPod, err := Td.CreatePod(serverNamespace, serverPodDef)
+	Expect(err).NotTo(HaveOccurred())
+	serverSvc, err := Td.CreateService(serverNamespace, serverSvcDef)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Expect it to be up and running in it's receiver namespace
+	Expect(Td.WaitForPodsRunningReady(serverNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+	// Get simple Pod definitions for the client
+	podName := framework.RandomNameWithPrefix("pod")
+	clientSvcAccDef, clientPodDef, clientSvcDef, err := Td.SimplePodApp(SimplePodAppDef{
+		PodName:       podName,
+		Namespace:     clientNamespace,
+		ContainerName: podName,
+		Image:         fortioImageName,
+		Ports:         []int{fortioHTTPPort},
+		OS:            Td.ClusterOS,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = Td.CreateServiceAccount(clientNamespace, &clientSvcAccDef)
+	Expect(err).NotTo(HaveOccurred())
+	clientPod, err := Td.CreatePod(clientNamespace, clientPodDef)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = Td.CreateService(clientNamespace, clientSvcDef)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Expect it to be up and running in it's receiver namespace
+	Expect(Td.WaitForPodsRunningReady(clientNamespace, 60*time.Second, 1, nil)).To(Succeed())
+
+	// Deploy allow rule client->server
+	httpRG, trafficTarget := Td.CreateSimpleAllowPolicy(
+		SimpleAllowPolicy{
+			RouteGroupName:    "routes",
+			TrafficTargetName: "target",
+
+			SourceNamespace:      clientNamespace,
+			SourceSVCAccountName: clientSvcAccDef.Name,
+
+			DestinationNamespace:      serverNamespace,
+			DestinationSvcAccountName: serverSvcAccDef.Name,
+		})
+
+	// Configs have to be put into a monitored NS, and osm-system can't be by cli
+	_, err = Td.CreateHTTPRouteGroup(serverNamespace, httpRG)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = Td.CreateTrafficTarget(serverNamespace, trafficTarget)
+	Expect(err).NotTo(HaveOccurred())
+
+	return clientPod, serverPod, serverSvc
 }

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -552,7 +552,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 	}
 
 	if err := td.CreateNs(instOpts.ControlPlaneNS, nil); err != nil {
-		return fmt.Errorf("failed to create namespace " + instOpts.ControlPlaneNS)
+		return fmt.Errorf("failed to create namespace %s error:%v", instOpts.ControlPlaneNS, err)
 	}
 
 	var args []string

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1458,6 +1458,46 @@ func (td *OsmTestData) WaitForCABundleSecret(ns, name string, timeout time.Durat
 	return fmt.Errorf("CA bundle secret  [%s] not ready in NS %s after %s", name, ns, timeout)
 }
 
+const (
+	signingIssuerIDKey    = "signing_issuer_id"
+	validatingIssuerIDKey = "validating_issuer_id"
+)
+
+// WaitForBootstrapSecretUpdate waits for the CA bundle secret to be updated
+func (td *OsmTestData) WaitForBootstrapSecretUpdate(ns, name, expectedSigningIssuerID, expectedValidatingIssuerID string, timeout time.Duration) error {
+	td.T.Logf("Wait up to %s for %s secret to be ready in NS [%s]...", timeout, ns)
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
+		secret, err := td.Client.CoreV1().Secrets(ns).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			td.T.Logf("bootstrap secret [%s] not ready in NS [%s]", name, ns)
+			continue // retry
+		}
+		signingIssuerID, ok := secret.Data[signingIssuerIDKey]
+		if !ok {
+			td.T.Logf("bootstrap secret [%s] does not have field [%s] in NS [%s]", name, signingIssuerIDKey, ns)
+			continue
+		}
+		if string(signingIssuerID) != expectedSigningIssuerID {
+			td.T.Logf("bootstrap secret [%s] does not have expected signingIssuerID [%q] in NS [%s]", name, signingIssuerID, ns)
+			continue
+		}
+
+		validatingIssuerID, ok := secret.Data[validatingIssuerIDKey]
+		if !ok {
+			td.T.Logf("bootstrap secret [%s] does not have field [%s] in NS [%s]", name, validatingIssuerIDKey, ns)
+			continue
+		}
+		if string(validatingIssuerID) != expectedValidatingIssuerID {
+			td.T.Logf("bootstrap secret [%s] does not have expected validatingIssuerID [%q] in NS [%s]", name, signingIssuerID, ns)
+			continue
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("bootstrap secret [%s] not updated in NS %s after %s", name, ns, timeout)
+}
+
 // VerifyRestarts ensure no crashes on osm-namespace instances for OSM CTL processes
 func (td *OsmTestData) VerifyRestarts() bool {
 	restartsAtTestEnd := td.GetOsmCtlComponentRestarts()


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

The PR includes the changes required to support an MVP of manual root certificate rotation. With these changes, a user will be able to manually create and update the `intent` of the MRCs and rotate the root certificate without downtime. OSM utilizes a level-triggered approach to bring the state of the mesh to match the MRC intent.

There are 3 possible values for intent. Each describes the desired role of the provider and certificate settings specified in the MRC:
- **active**: the certificate provider issues and signs certificates and the ca_bundle for that provider is included in the validation context
- **passive**: the certificate provider is not used to issue or sign certificates and the ca_bundle for the provider is included in the validation context
- **inactive**: the certificate provider is not used to issue or sign certificates and it is not included in the validation context

To rotate the root certificate or update the certificate provider, the user must perform the following actions:
There is an existing MRC, MRC1 and a new MRC will be created, MRC2
1. create a new MRC with `inactive` intent -> MRC1.intent = active, MRC2.intent = inactive
2. update the intent of the new MRC to `passive`. Wait to allow the certificates to be rotated -> MRC1.intent = active, MRC2.intent = passive
3. update the intent of the new MRC to `active` -> MRC1.intent = active, MRC2.intent = active
4. update the intent of the old MRC to `passive`. Wait to allow the certificates to be rotated -> MRC1.intent = passive, MRC2.intent = active
5. update the intent of the old MRC to `inactive` -> MRC1.intent = inactive, MRC2.intent = active

Note: All combinations of intent are deterministic except for `active` and `active`. The order in which the MRCs are listed determines which will be the `signingIssuer` or the `validatingIssuer`. 

Initial proposal for root certificate rotation simplification: https://docs.google.com/document/d/1bh3Yfn5DXWjmzdKa4XHlk-9KepUNb_EgDDrzd1G_deY/edit?usp=sharing

Resolves #5198 
Part of #4998 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
- e2es testing rotation with tresor, cert-manager, and vault
- unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ x ] |
| Certificate Management     | [ x ] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

7. Is this a breaking change? No

8. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No