### PR TITLE
telemetry: allow exporting access log to OTEL collector

### DIFF
--- a/pkg/envoy/generator/cds.go
+++ b/pkg/envoy/generator/cds.go
@@ -47,6 +47,8 @@ func (g *EnvoyConfigGenerator) generateCDS(ctx context.Context, proxy *models.Pr
 		cb.SetEnvoyTracingAddress(tracingAddress)
 	}
 
+	cb.SetOpenTelemetryExtSvc(g.catalog.GetTelemetryConfig(proxy).OpenTelemetryService)
+
 	// Build upstream, local, egress, outbound passthrough, inbound prometheus and outbound tracing clusters per mesh policies
 	clusters, err := cb.Build()
 	if err != nil {

--- a/pkg/envoy/generator/cds_test.go
+++ b/pkg/envoy/generator/cds_test.go
@@ -97,6 +97,7 @@ func TestGenerateCDS(t *testing.T) {
 	mockCatalog.EXPECT().IsMetricsEnabled(proxy).Return(true, nil).AnyTimes()
 	mockCatalog.EXPECT().GetMeshConfig().Return(meshConfig).AnyTimes()
 	mockCatalog.EXPECT().ListServicesForProxy(proxy).Return(nil, nil).AnyTimes()
+	mockCatalog.EXPECT().GetTelemetryConfig(proxy).Return(models.TelemetryConfig{}).AnyTimes()
 
 	podlabels := map[string]string{
 		constants.AppLabel:               testMeshSvc.Name,
@@ -429,6 +430,7 @@ func TestNewResponseGetEgressClusterConfigsError(t *testing.T) {
 	meshCatalog.EXPECT().IsMetricsEnabled(proxy).Return(false, nil).AnyTimes()
 	meshCatalog.EXPECT().GetMeshConfig().AnyTimes()
 	meshCatalog.EXPECT().ListServicesForProxy(proxy).Return(nil, nil).AnyTimes()
+	meshCatalog.EXPECT().GetTelemetryConfig(proxy).Return(models.TelemetryConfig{}).AnyTimes()
 
 	g := NewEnvoyConfigGenerator(meshCatalog, nil)
 
@@ -453,6 +455,7 @@ func TestNewResponseGetEgressTrafficPolicyNotEmpty(t *testing.T) {
 	}, nil).Times(1)
 	meshCatalog.EXPECT().GetMeshConfig().AnyTimes()
 	meshCatalog.EXPECT().ListServicesForProxy(proxy).Return(nil, nil).AnyTimes()
+	meshCatalog.EXPECT().GetTelemetryConfig(proxy).Return(models.TelemetryConfig{}).AnyTimes()
 
 	g := NewEnvoyConfigGenerator(meshCatalog, nil)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change allows exporting Envoy access logs to an OpenTelemetry collector using the OpenTelemetry
access log config.

The access log config has already been implemented. This change creates the cluster configuration for
the OpenTelemetry collector's ExtensionService.

Resolves #4999
Part of #5136

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Tested access logs being exported to an OpenTelemety collector using
config such as:
```
apiVersion: policy.openservicemesh.io/v1alpha1
kind: Telemetry
metadata:
  name: httpbin-log
  namespace: httpbin
spec:
  selector:
    app: httpbin

  accessLog:
    format: '{"authority":"%REQ(:AUTHORITY)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%"}'
    #format: "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS%\n"

    openTelemetry:
      extensionService:
        name: otel-collector
        namespace: otel
      attributes:
        someKey: "someValue"
---
apiVersion: config.openservicemesh.io/v1alpha2
kind: ExtensionService
metadata:
  name: otel-collector
  namespace: otel
spec:
  host: otel-collector.otel.svc.cluster.local
  port: 4317
  protocol: h2c
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Observability              | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `not yet`