### PR TITLE
Support for root certificate rotation via CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ endif
 LDFLAGS ?= "-X $(BUILD_DATE_VAR)=$(BUILD_DATE) -X $(BUILD_VERSION_VAR)=$(VERSION) -X $(BUILD_GITCOMMIT_VAR)=$(GIT_SHA) -s -w"
 
 # These two values are combined and passed to go test
+GO_TEST_FLAGS ?= 
 E2E_FLAGS ?= -installType=KindCluster
 E2E_FLAGS_DEFAULT := -test.v -ginkgo.v -ginkgo.progress -ctrRegistry $(CTR_REGISTRY) -osmImageTag $(CTR_TAG)
 
@@ -152,7 +153,7 @@ kind-reset:
 .PHONY: test-e2e
 test-e2e: DOCKER_BUILDX_OUTPUT=type=docker
 test-e2e: docker-build-osm build-osm docker-build-tcp-echo-server
-	go test ./tests/e2e $(E2E_FLAGS_DEFAULT) $(E2E_FLAGS)
+	go test $(GO_TEST_FLAGS) ./tests/e2e $(E2E_FLAGS_DEFAULT) $(E2E_FLAGS)
 
 .env:
 	cp .env.example .env

--- a/cmd/cli/alpha.go
+++ b/cmd/cli/alpha.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const alphaDescription = `
+This command consists of multiple subcommands related that are in alpha.
+`
+
+func newAlphaCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alpha",
+		Short: "commands that are in alpha",
+		Long:  alphaDescription,
+		Args:  cobra.NoArgs,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(out, "*** This command is in Preview.  Only run in dev/test environments ***\n")
+		},
+	}
+	cmd.AddCommand(newCertificateCmd(out))
+	return cmd
+}

--- a/cmd/cli/certificate.go
+++ b/cmd/cli/certificate.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+const certificateDescription = `
+This command consists of multiple subcommands related to managing certificates
+associated with osm installations.
+`
+
+func newCertificateCmd(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "certificate",
+		Short:   "commands for managing MeshRootCertificates",
+		Aliases: []string{"mrc"},
+		Long:    certificateDescription,
+		Args:    cobra.NoArgs,
+	}
+	cmd.AddCommand(newCertificateRotateCmd(out))
+	return cmd
+}

--- a/cmd/cli/certificate_rotate.go
+++ b/cmd/cli/certificate_rotate.go
@@ -181,7 +181,7 @@ func (r *rotateCmd) run() error {
 		}
 
 		if oldMrc.Spec.Provider.Tresor != nil {
-			r.deleteTresorSecret(oldMrc.Spec.Provider.Tresor.CA, newMrc.Spec.Provider.Tresor.CA)
+			err := r.deleteTresorSecret(oldMrc.Spec.Provider.Tresor.CA, newMrc.Spec.Provider.Tresor.CA)
 			if err != nil {
 				fmt.Printf("warning: unable to delete secret [%s]", oldMrc.Spec.Provider.Tresor.CA.SecretRef.Name)
 			}

--- a/cmd/cli/certificate_rotate.go
+++ b/cmd/cli/certificate_rotate.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	"github.com/openservicemesh/osm/pkg/constants"
+	configClientset "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	osmConfigClient "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned"
+	"github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/scheme"
+)
+
+const rotateDesc = `
+This command rotates the OSM Root Certificate
+`
+
+const meshRotateExample = `
+# Rotate the mesh root certificate that is Active in the osm-system namespace
+osm alpha certificate rotate -d -y
+`
+
+type rotateCmd struct {
+	out io.Writer
+
+	meshName        string
+	newTrustDomain  string
+	clientSet       kubernetes.Interface
+	configClient    osmConfigClient.Interface
+	prompt          bool
+	deleteOld       bool
+	waitForRotation time.Duration
+	mrcFilePath     string
+	mrcName         string
+	prompter        func(a ...any) (int, error)
+}
+
+func newCertificateRotateCmd(out io.Writer) *cobra.Command {
+	rotate := &rotateCmd{
+		out: out,
+	}
+
+	cmd := &cobra.Command{
+		Use:     "rotate",
+		Short:   "rotate the MeshRootCertificate",
+		Long:    rotateDesc,
+		Example: meshRotateExample,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			config, err := settings.RESTClientGetter().ToRESTConfig()
+			if err != nil {
+				return fmt.Errorf("error fetching kubeconfig: %w", err)
+			}
+
+			configClient, err := configClientset.NewForConfig(config)
+			if err != nil {
+				return fmt.Errorf("could not access Kubernetes cluster, check kubeconfig: %w", err)
+			}
+			rotate.configClient = configClient
+
+			clientset, err := kubernetes.NewForConfig(config)
+			if err != nil {
+				return fmt.Errorf("could not access Kubernetes cluster, check kubeconfig: %w", err)
+			}
+			rotate.clientSet = clientset
+			rotate.prompter = fmt.Scanln
+
+			return rotate.run()
+		},
+	}
+
+	f := cmd.Flags()
+
+	f.StringVar(&rotate.meshName, "mesh-name", defaultMeshName, "Name of the service mesh")
+	f.StringVarP(&rotate.newTrustDomain, "trust-domain", "t", "", "If specified the new cert will use this trust domain. Works with certificate provider tresor")
+	f.BoolVarP(&rotate.prompt, "accept", "y", false, "when specified it will not prompt for user input")
+	f.BoolVarP(&rotate.deleteOld, "delete", "d", false, "when specified it will delete the old MeshRootCertificate, otherwise the MeshRootCertificate will remain as inactive")
+	f.DurationVarP(&rotate.waitForRotation, "wait", "w", 60*time.Second, "Time to wait for certificate to propagate to all components at each step")
+	f.StringVarP(&rotate.mrcFilePath, "file", "f", "", "File to use for the new MRC. When not supplied the settings from the existing MRC are copied")
+	f.StringVarP(&rotate.mrcName, "meshrootcertificate", "c", "", "Existing MeshRootCertificate to rotate to active role using the name in currently configured namespace")
+	return cmd
+}
+
+func (r *rotateCmd) promptForContinue(msg string) bool {
+	if !r.prompt {
+		var rotate string
+		fmt.Fprintf(r.out, msg+" y/n:")
+		_, err := r.prompter(rotate)
+		if err != nil {
+			fmt.Printf("warning: error reading value from user: %s\n", err)
+			return true
+		}
+
+		if rotate != "y" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (r *rotateCmd) run() error {
+	// TODO(#5204): check if MRC feature is enabled
+	// TODO(#4891): check cert rotations or metrics instead of using time
+	if !r.promptForContinue("Are you sure you want to initiate rotation?") {
+		return nil
+	}
+
+	oldMrc, err := r.findCurrentInUse()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(r.out, "Found MeshRootCertificate [%s] for mesh [%s] in namespace [%s]\n\n", oldMrc.Name, r.meshName, settings.Namespace())
+
+	newMrc, err := r.createOrFindNewMRC(oldMrc)
+	if err != nil {
+		return fmt.Errorf("unable to create or find new MeshRootCertificate: %s", err)
+	}
+	fmt.Fprintf(r.out, "Created new MeshRootCertificate [%s] in Inactive role\n", newMrc.Name)
+
+	fmt.Fprintf(r.out, "Moving MeshRootCertificate [%s] to Passive role\n", newMrc.Name)
+	if !r.promptForContinue("Are you sure you want to initiate rotation?") {
+		return nil
+	}
+	err = r.updateCertificate(newMrc.Name, v1alpha2.PassiveIntent)
+	if err != nil {
+		return fmt.Errorf("unable to update MeshRootCertificate [%s] with role [%s]: %s", newMrc.Name, v1alpha2.PassiveIntent, err)
+	}
+	fmt.Fprintf(r.out, "waiting for propagation...\n\n")
+	time.Sleep(r.waitForRotation)
+
+	fmt.Fprintf(r.out, "Moving MeshRootCertificate [%s] to Active role\n", newMrc.Name)
+	if !r.promptForContinue("Are you sure you want to initiate rotation?") {
+		return nil
+	}
+	err = r.updateCertificate(newMrc.Name, v1alpha2.ActiveIntent)
+	if err != nil {
+		return fmt.Errorf("unable to update MeshRootCertificate [%s] with role [%s]: %s", newMrc.Name, v1alpha2.ActiveIntent, err)
+	}
+	fmt.Fprintf(r.out, "waiting for propagation...\n\n")
+
+	time.Sleep(r.waitForRotation)
+
+	fmt.Fprintf(r.out, "Moving MeshRootCertificate [%s] to Passive role\n", oldMrc.Name)
+	if !r.promptForContinue("Are you sure you want to initiate rotation?") {
+		return nil
+	}
+	err = r.updateCertificate(oldMrc.Name, v1alpha2.PassiveIntent)
+	if err != nil {
+		return fmt.Errorf("unable to update MeshRootCertificate [%s] with role [%s]: %s", oldMrc.Name, v1alpha2.PassiveIntent, err)
+	}
+	fmt.Fprintf(r.out, "waiting for propagation...\n\n")
+	time.Sleep(r.waitForRotation)
+
+	fmt.Fprintf(r.out, "Moving MeshRootCertificate [%s] to Inactive role\n", oldMrc.Name)
+	if !r.promptForContinue("Are you sure you to move the old MeshRootCertificate to Inactive?") {
+		return nil
+	}
+	err = r.updateCertificate(oldMrc.Name, v1alpha2.InactiveIntent)
+	if err != nil {
+		return fmt.Errorf("unable to update MeshRootCertificate [%s] with role [%s]: %s", oldMrc.Name, v1alpha2.InactiveIntent, err)
+	}
+	fmt.Fprintf(r.out, "waiting for propagation...\n\n")
+	time.Sleep(r.waitForRotation)
+
+	if r.deleteOld {
+		if !r.promptForContinue("Are you sure you want to delete the old MeshRootCertificate?") {
+			return nil
+		}
+		err = r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Delete(context.Background(), oldMrc.Name, metav1.DeleteOptions{})
+		if err != nil {
+			fmt.Printf("warning: unable to delete MeshRootCertificate [%s]", oldMrc.Name)
+		}
+		if oldMrc.Spec.Provider.Tresor != nil {
+			err = r.clientSet.CoreV1().Secrets(oldMrc.Spec.Provider.Tresor.CA.SecretRef.Namespace).Delete(context.Background(), oldMrc.Spec.Provider.Tresor.CA.SecretRef.Name, metav1.DeleteOptions{})
+			if err != nil {
+				fmt.Printf("warning: unable to delete secret [%s]", oldMrc.Spec.Provider.Tresor.CA.SecretRef.Name)
+			}
+		}
+	}
+
+	fmt.Fprintf(r.out, "\nOSM successfully rotated root certificate for mesh [%s] in namespace [%s]\n", r.meshName, settings.Namespace())
+	fmt.Fprintf(r.out, "\nThe new MeshRootCertificate [%s] is now active\n", newMrc.Name)
+	return nil
+}
+
+func (r *rotateCmd) findCurrentInUse() (*v1alpha2.MeshRootCertificate, error) {
+	mrcs, err := r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("not able to find MeshRootCertificates: %w", err)
+	}
+
+	var activeMrc *v1alpha2.MeshRootCertificate
+	for _, mrc := range mrcs.Items {
+		if mrc.Spec.Intent == v1alpha2.ActiveIntent {
+			if activeMrc != nil {
+				return nil, fmt.Errorf("can only rotate when there is only one active MRC. Found two: %s and %s", mrc.Name, activeMrc.Name)
+			}
+			m := mrc
+			activeMrc = &m
+		}
+
+		if mrc.Spec.Intent == v1alpha2.PassiveIntent {
+			return nil, fmt.Errorf("it appears a rotation is in progress. \n\nFound MRC %s in state %s", mrc.Name, mrc.Spec.Intent)
+		}
+	}
+
+	if activeMrc == nil {
+		return nil, fmt.Errorf("not able to find MeshRootCertificate in active state")
+	}
+
+	return activeMrc, nil
+}
+
+func (r *rotateCmd) updateCertificate(name string, intent v1alpha2.MeshRootCertificateIntent) error {
+	mrc, err := r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	mrc.Spec.Intent = intent
+	_, err = r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Update(context.Background(), mrc, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *rotateCmd) createOrFindNewMRC(mrc *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	if r.mrcName != "" {
+		fmt.Fprintf(r.out, "using existing MeshRootCertificate %s\n", r.mrcName)
+
+		existing, err := r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Get(context.Background(), r.mrcName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to verify that MeshRootCertificate [%s]. Error: %v", existing.Name, err)
+		}
+
+		if existing.Spec.Intent != v1alpha2.InactiveIntent {
+			return nil, fmt.Errorf("MRC provided must be in Inactive role")
+		}
+
+		return existing, nil
+	}
+
+	if r.mrcFilePath != "" {
+		fmt.Fprintf(r.out, "using file %s\n", r.mrcFilePath)
+		decode := scheme.Codecs.UniversalDeserializer().Decode
+		file, err := os.ReadFile(r.mrcFilePath)
+		if err != nil {
+			return nil, err
+		}
+		obj, _, err := decode([]byte(file), nil, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		newMRC, ok := obj.(*v1alpha2.MeshRootCertificate)
+		if !ok {
+			return nil, fmt.Errorf("file provided is not recognized as MeshRootCertificate")
+		}
+		if newMRC.Spec.Intent != v1alpha2.InactiveIntent {
+			return nil, fmt.Errorf("file provided must be a MeshRootCertificate in the Inactive role")
+		}
+
+		existing, err := r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Get(context.Background(), newMRC.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to verify that MeshRootCertificate [%s] doesn't already exist. Error: %v", newMRC.Name, err)
+		}
+		if existing != nil {
+			return nil, fmt.Errorf("cannot use MeshRootCertificate [%s] as it already exists in cluster", newMRC.Name)
+		}
+
+		return r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Create(context.Background(), newMRC, metav1.CreateOptions{})
+	}
+
+	return r.createFromExisting(mrc)
+}
+
+func (r *rotateCmd) createFromExisting(mrc *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	switch {
+	case mrc.Spec.Provider.Tresor != nil:
+		return r.createTresorFromExisting(mrc)
+	case mrc.Spec.Provider.Vault != nil:
+		// since we can't create the secrets in vault we require them to create a file
+		return nil, fmt.Errorf("please use -file or -meshrootcertificate option to provide a MeshRootCertificate Vault provider")
+	case mrc.Spec.Provider.CertManager != nil:
+		// since we require them to set up cert-manager.io ahead of time we can create it for them
+		return nil, fmt.Errorf("please use -file or -meshrootcertificate option to provide a MeshRootCertificate for CertManager provider")
+	default:
+		return nil, fmt.Errorf("unknown certificate provider: %+v", mrc.Spec.Provider)
+	}
+}
+
+func generateName() (string, string) {
+	var chars = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+
+	s := make([]rune, 8)
+	for i := range s {
+		num, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		s[i] = chars[num.Int64()]
+	}
+	return fmt.Sprintf("%s-%x", constants.DefaultMeshRootCertificateName, string(s)), string(s)
+}
+
+func (r *rotateCmd) createTresorFromExisting(mrc *v1alpha2.MeshRootCertificate) (*v1alpha2.MeshRootCertificate, error) {
+	newName, nameSuffix := generateName()
+	trustDomain := mrc.Spec.TrustDomain
+	if r.newTrustDomain != "" {
+		trustDomain = r.newTrustDomain
+	}
+	return r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Create(
+		context.Background(), &v1alpha2.MeshRootCertificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      newName,
+				Namespace: settings.Namespace(),
+			},
+			Spec: v1alpha2.MeshRootCertificateSpec{
+				TrustDomain: trustDomain,
+				Intent:      v1alpha2.InactiveIntent,
+				Provider: v1alpha2.ProviderSpec{
+					Tresor: &v1alpha2.TresorProviderSpec{
+						CA: v1alpha2.TresorCASpec{
+							SecretRef: v1.SecretReference{
+								Name:      fmt.Sprintf("%s-%x", "osm-ca-bundle-", nameSuffix),
+								Namespace: settings.Namespace(),
+							},
+						}},
+				},
+			},
+		}, metav1.CreateOptions{})
+}
+
+// uncomment once https://github.com/openservicemesh/osm/pull/5204 merges
+// func (cmd *rotateCmd) isMRCEnabled() (bool, error) {
+// 	osmNamespace := settings.Namespace()
+
+// 	meshConfig, err := cmd.meshConfigClient.ConfigV1alpha2().MeshConfigs(osmNamespace).Get(context.TODO(), defaultOsmMeshConfigName, metav1.GetOptions{})
+
+// 	if err != nil {
+// 		return false, fmt.Errorf("Error fetching MeshConfig %s: %w", defaultOsmMeshConfigName, err)
+// 	}
+// 	return meshConfig.Spec.FeatureFlags.enableMeshRootCertificate, nil
+// }

--- a/cmd/cli/certificate_rotate_test.go
+++ b/cmd/cli/certificate_rotate_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	tassert "github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
+	fakeConfig "github.com/openservicemesh/osm/pkg/gen/client/config/clientset/versioned/fake"
+)
+
+func Test_rotateCmd_findCurrentActive(t *testing.T) {
+	tests := []struct {
+		name        string
+		existingMrc []*v1alpha2.MeshRootCertificate
+		wantErr     bool
+	}{
+		{
+			name:    "no mrcs returns error",
+			wantErr: true,
+		},
+		{
+			name:    "mrcs in bad state returns error",
+			wantErr: true,
+			existingMrc: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "badstate",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.PassiveIntent,
+					},
+				},
+			},
+		},
+		{
+			name:    "rotation in progress",
+			wantErr: true,
+			existingMrc: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "passive",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.PassiveIntent,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+			},
+		},
+		{
+			name:    "two active should error",
+			wantErr: true,
+			existingMrc: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+			},
+		},
+		{
+			name:    "only one active should return name",
+			wantErr: false,
+			existingMrc: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+			},
+		},
+		{
+			name:    "only one active should return name with some inactive",
+			wantErr: false,
+			existingMrc: []*v1alpha2.MeshRootCertificate{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.ActiveIntent,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "inactive1",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.InactiveIntent,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "inactive2",
+					},
+					Spec: v1alpha2.MeshRootCertificateSpec{
+						Intent: v1alpha2.InactiveIntent,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := tassert.New(t)
+			r := &rotateCmd{
+				clientSet:    fake.NewSimpleClientset(),
+				configClient: fakeConfig.NewSimpleClientset(),
+			}
+
+			for _, mrc := range tt.existingMrc {
+				_, err := r.configClient.ConfigV1alpha2().MeshRootCertificates(settings.Namespace()).Create(context.Background(), mrc, v1.CreateOptions{})
+				assert.NoError(err)
+			}
+			mrc, err := r.findCurrentInUse()
+
+			if tt.wantErr {
+				assert.Nil(mrc)
+				assert.NotNil(err)
+			} else {
+				assert.Equal("active", mrc.Name)
+				assert.Equal(v1alpha2.ActiveIntent, mrc.Spec.Intent)
+			}
+		})
+	}
+}

--- a/cmd/cli/osm.go
+++ b/cmd/cli/osm.go
@@ -47,6 +47,7 @@ func newRootCmd(config *action.Configuration, stdin io.Reader, stdout io.Writer,
 		newSupportCmd(config, stdout, stderr),
 		newUninstallCmd(config, stdin, stdout),
 		newVerifyCmd(stdout, stderr),
+		newAlphaCmd(stdout),
 	)
 
 	// Add subcommands related to unmanaged environments

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -186,20 +186,20 @@ func (c *MRCProviderGenerator) getHashiVaultOSMCertificateManager(mrc *v1alpha2.
 	// A Vault address would have the following shape: "http://vault.default.svc.cluster.local:8200"
 	vaultAddr := fmt.Sprintf("%s://%s:%d", provider.Protocol, provider.Host, provider.Port)
 
-	// If the DefaultVaultToken is empty, query Vault token secret
-	var err error
-	vaultToken := c.DefaultVaultToken
-	if vaultToken == "" {
+	// If provider has secret ref filled, query Vault token secret
+	token := c.DefaultVaultToken
+	if provider.Token.SecretKeyRef.Name != "" && provider.Token.SecretKeyRef.Namespace != "" && provider.Token.SecretKeyRef.Key != "" {
 		log.Debug().Msgf("Attempting to get Vault token from secret %s", provider.Token.SecretKeyRef.Name)
-		vaultToken, err = getHashiVaultOSMToken(&provider.Token.SecretKeyRef, c.kubeClient)
+		vaultToken, err := getHashiVaultOSMToken(&provider.Token.SecretKeyRef, c.kubeClient)
 		if err != nil {
 			return nil, err
 		}
+		token = vaultToken
 	}
 
 	vaultClient, err := vault.New(
 		vaultAddr,
-		vaultToken,
+		token,
 		provider.Role,
 	)
 	if err != nil {

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -393,7 +393,7 @@ func WithVaultTokenSecretRef() InstallOsmOpt {
 	return func(opts *InstallOSMOpts) {
 		opts.SetOverrides = []string{
 			"osm.vault.secret.name=osm-vault-token",
-			"osm.vault.secret.key=token-key",
+			"osm.vault.secret.key=vault_token",
 		}
 	}
 }
@@ -430,7 +430,7 @@ func (td *OsmTestData) GetOSMInstallOpts(options ...InstallOsmOpt) InstallOSMOpt
 		VaultRole:            "openservicemesh",
 		VaultToken:           "token",
 		VaultTokenSecretName: "osm-vault-token",
-		VaultTokenSecretKey:  "token-key",
+		VaultTokenSecretKey:  "vault_token",
 
 		CertmanagerIssuerGroup: "cert-manager.io",
 		CertmanagerIssuerKind:  "Issuer",
@@ -893,13 +893,13 @@ tail /dev/random;
 
 	vaultSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "osm-vault-token",
+			Name: instOpts.VaultTokenSecretName,
 			Labels: map[string]string{
 				constants.AppLabel: appName,
 			},
 		},
 		StringData: map[string]string{
-			"vault_token": instOpts.VaultToken,
+			instOpts.VaultTokenSecretKey: instOpts.VaultToken,
 		},
 	}
 	_, err = td.Client.CoreV1().Secrets(instOpts.ControlPlaneNS).Create(context.TODO(), vaultSecret, metav1.CreateOptions{})

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -607,7 +607,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 
 	switch instOpts.CertManager {
 	case Vault:
-		if err := td.installVault(instOpts); err != nil {
+		if err := td.InstallVault(instOpts); err != nil {
 			return err
 		}
 		instOpts.SetOverrides = append(instOpts.SetOverrides,
@@ -622,7 +622,7 @@ func (td *OsmTestData) InstallOSM(instOpts InstallOSMOpts) error {
 			return fmt.Errorf("failed waiting for vault pod to become ready")
 		}
 	case CertManager:
-		if err := td.installCertManager(instOpts); err != nil {
+		if err := td.InstallCertManager(); err != nil {
 			return err
 		}
 		instOpts.SetOverrides = append(instOpts.SetOverrides,
@@ -756,7 +756,8 @@ func (td *OsmTestData) LoadOSMImagesIntoKind() error {
 	return td.LoadImagesToKind(imageNames)
 }
 
-func (td *OsmTestData) installVault(instOpts InstallOSMOpts) error {
+// InstallVault installs HashiCorp Vault on the cluster and creates an initial certificate
+func (td *OsmTestData) InstallVault(instOpts InstallOSMOpts) error {
 	td.T.Log("Installing Vault")
 
 	appName := "vault"
@@ -890,6 +891,22 @@ tail /dev/random;
 		return fmt.Errorf("failed to create vault deployment")
 	}
 
+	vaultSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "osm-vault-token",
+			Labels: map[string]string{
+				constants.AppLabel: appName,
+			},
+		},
+		StringData: map[string]string{
+			"vault_token": instOpts.VaultToken,
+		},
+	}
+	_, err = td.Client.CoreV1().Secrets(instOpts.ControlPlaneNS).Create(context.TODO(), vaultSecret, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to create vault secret")
+	}
+
 	vaultSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: appName,
@@ -919,7 +936,8 @@ tail /dev/random;
 	return nil
 }
 
-func (td *OsmTestData) installCertManager(instOpts InstallOSMOpts) error {
+// InstallCertManager installs cert-manager.io on the cluster and creates an initial certificate
+func (td *OsmTestData) InstallCertManager() error {
 	By("Installing cert-manager")
 	helm := &action.Configuration{}
 	if err := helm.Init(td.Env.RESTClientGetter(), td.OsmNamespace, "secret", td.T.Logf); err != nil {

--- a/tests/framework/common_traffic_fortio.go
+++ b/tests/framework/common_traffic_fortio.go
@@ -104,6 +104,8 @@ func (td *OsmTestData) FortioHTTPLoadTest(ht FortioHTTPLoadTestDef) FortioLoadRe
 		command = append(command, ht.Destination)
 	}
 
+	Td.T.Logf("command: %s", command)
+	Td.T.Logf("source pod: %s", ht.SourcePod)
 	stdout, stderr, err := td.RunRemote(ht.SourceNs, ht.SourcePod, ht.SourceContainer, command)
 	if err != nil {
 		// Error codes from the execution come through err

--- a/tests/framework/constants.go
+++ b/tests/framework/constants.go
@@ -37,8 +37,11 @@ const (
 )
 
 const (
-	// DefaultCertManager is Tressor
-	DefaultCertManager = "tresor"
+	// DefaultCertManager is Tresor
+	DefaultCertManager = TresorCertManager
+
+	// TresorCertManager for Tresor
+	TresorCertManager = "tresor"
 
 	// CertManager for cert-manager.io
 	CertManager = "cert-manager"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This build on #5201 (required before this) to provide alpha support for rotation in the CLI. This is a proposal for adding a command to ease the burden of managing the MRCs and adds several tests for trust domain and switching between providers.

example usage would be:



```
./bin/osm alpha certificate rotate -d -y
```

Resolves #4835 
<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?