### PR TITLE
Move the required truncation of certificate expiration time to the GetExpiration method

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -51,7 +51,10 @@ func (c *Certificate) GetSerialNumber() SerialNumber {
 
 // GetExpiration returns the expiration time of the certificate
 func (c *Certificate) GetExpiration() time.Time {
-	return c.Expiration
+	// Round is called to truncate monotonic clock to the nearest second. This is done to avoid environments where the
+	// CPU clock may stop, resulting in a time measurement that differs significantly from the x509 timestamp.
+	// See https://github.com/openservicemesh/osm/issues/5000#issuecomment-1218539412 for more details.
+	return c.Expiration.Round(0)
 }
 
 // GetCertificateChain returns the certificate chain of the certificate

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -148,10 +148,7 @@ func (m *Manager) ShouldRotate(c *Certificate) bool {
 	minRotateBeforeExpireTime := time.Duration(MinRotateBeforeExpireMinutes) * time.Minute
 	fractionOfValidityDuration := m.getValidityDurationForCertType(c.certType) / fractionValidityDuration
 	renewBefore := maxDuration(fractionOfValidityDuration, minRotateBeforeExpireTime) + secondsNoise
-	// Round is called to truncate monotonic clock to the nearest second. This is done to avoid environments where the
-	// CPU clock may stop, resulting in a time measurement that differs significantly from the x509 timestamp.
-	// See https://github.com/openservicemesh/osm/issues/5000#issuecomment-1218539412 for more details.
-	expiration := c.GetExpiration().Round(0)
+	expiration := c.GetExpiration()
 	if time.Until(expiration) <= renewBefore {
 		log.Info().Msgf("Cert %s should be rotated; expires in %+v; renewBefore is %+v",
 			c.GetCommonName(),

--- a/pkg/debugger/certificate.go
+++ b/pkg/debugger/certificate.go
@@ -34,7 +34,7 @@ func (ds DebugConfig) getCertHandler() http.Handler {
 
 			_, _ = fmt.Fprintf(w, "---[ %d ]---\n", idx)
 			_, _ = fmt.Fprintf(w, "\t Common Name: %q\n", cert.GetCommonName())
-			_, _ = fmt.Fprintf(w, "\t Valid Until: %+v (%+v remaining)\n", cert.GetExpiration(), time.Until(cert.GetExpiration().Round(0)))
+			_, _ = fmt.Fprintf(w, "\t Valid Until: %+v (%+v remaining)\n", cert.GetExpiration(), time.Until(cert.GetExpiration()))
 			_, _ = fmt.Fprintf(w, "\t Issuing CA (SHA256): %x\n", sha256.Sum256(ca))
 			_, _ = fmt.Fprintf(w, "\t Trusted CAs (SHA256): %x\n", sha256.Sum256(trustedCAs))
 			_, _ = fmt.Fprintf(w, "\t Cert Chain (SHA256): %x\n", sha256.Sum256(chain))


### PR DESCRIPTION
Move truncation into GetExpiration so GetExpiration correctly returns the time with monotonic clock truncated