### PR TITLE
feat(certs): MeshRootCertificate validation

### DIFF
--- a/pkg/certificate/mrc_reconciler.go
+++ b/pkg/certificate/mrc_reconciler.go
@@ -2,7 +2,6 @@ package certificate
 
 import (
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
-	"github.com/openservicemesh/osm/pkg/errcode"
 )
 
 func (m *Manager) handleMRCEvent(event MRCEvent) error {
@@ -64,21 +63,17 @@ func getSigningAndValidatingMRCs(mrcList []*v1alpha2.MeshRootCertificate) (*v1al
 	return mrcList[0], mrcList[1], nil
 }
 
-// ValidateMRCCombination takes a list of MRCs and ensures that the MRC combination is valid
+// ValidateMRCCombination expects a list of Active and Passive MRCs and ensures that the MRC combination is valid
 func ValidateMRCCombination(mrcList []*v1alpha2.MeshRootCertificate) error {
 	if len(mrcList) == 0 {
-		log.Error().Err(ErrNoMRCsFound).Msg("when handling MRC event, found no MRCs in OSM control plane namespace")
 		return ErrNoMRCsFound
 	}
 
 	if len(mrcList) > 2 {
-		log.Error().Err(ErrNumMRCExceedsMaxSupported).Str(errcode.Kind, errcode.GetErrCodeWithMetric(errcode.ErrNumMRCExceedsMaxSupported)).
-			Msgf("expected 2 or less MRCs in the OSM control plane namespace, found %d", len(mrcList))
 		return ErrNumMRCExceedsMaxSupported
 	}
 
 	if len(mrcList) == 1 && mrcList[0].Spec.Intent != v1alpha2.ActiveIntent {
-		log.Error().Err(ErrExpectedActiveMRC).Msgf("expected single MRC with %s intent, found %s", v1alpha2.ActiveIntent, mrcList[0].Spec.Intent)
 		return ErrExpectedActiveMRC
 	}
 

--- a/tests/e2e/e2e_meshrootcertificate_test.go
+++ b/tests/e2e/e2e_meshrootcertificate_test.go
@@ -89,7 +89,7 @@ func basicCertRotationScenario(installOptions ...InstallOsmOpt) {
 	activeNotAllowed := "not-allowed"
 	_, err := createMeshRootCertificate(activeNotAllowed, v1alpha2.ActiveIntent, installOpts.CertManager)
 	Expect(err).Should(HaveOccurred())
-	Expect(err.Error()).Should(ContainSubstring("cannot create MRC %s/%s with active intent . An MRC with intent already exists in the control plane namespace.", Td.OsmNamespace, activeNotAllowed))
+	Expect(err.Error()).Should(ContainSubstring("cannot create MRC %s/%s with active intent. An MRC with this intent already exists in the control plane namespace.", Td.OsmNamespace, activeNotAllowed))
 
 	By("creating a second certificate with passive intent")
 	newCertName := "osm-mrc-2"

--- a/tests/e2e/e2e_meshrootcertificate_test.go
+++ b/tests/e2e/e2e_meshrootcertificate_test.go
@@ -89,7 +89,7 @@ func basicCertRotationScenario(installOptions ...InstallOsmOpt) {
 	activeNotAllowed := "not-allowed"
 	_, err := createMeshRootCertificate(activeNotAllowed, v1alpha2.ActiveIntent, installOpts.CertManager)
 	Expect(err).Should(HaveOccurred())
-	Expect(err.Error()).Should(ContainSubstring("cannot create MRC %s/%s with intent active. An MRC with active intent already exists in the control plane namespace", Td.OsmNamespace, activeNotAllowed))
+	Expect(err.Error()).Should(ContainSubstring("cannot create MRC %s/%s with active intent . An MRC with intent already exists in the control plane namespace.", Td.OsmNamespace, activeNotAllowed))
 
 	By("creating a second certificate with passive intent")
 	newCertName := "osm-mrc-2"


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This builds on #5201 and validates creation of the MeshRootCertificates as well as updates to the MeshRootCertificates.  It only allows the valid combinations of Active and Passive certificates.

Fixes #5205

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
unit/e2e/manual
<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [x] |
| Certificate Management     | [x] |
| Tests                      | [x] |



Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
no
2. Is this a breaking change?
no
3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
