### PR TITLE
k8s: update app protocol detection for k8s service port

### DIFF
--- a/pkg/compute/kube/client.go
+++ b/pkg/compute/kube/client.go
@@ -661,7 +661,7 @@ func (c *client) serviceToMeshServices(svc corev1.Service) []service.MeshService
 		// Order of Preference is:
 		// 1. port.appProtocol field
 		// 2. protocol prefixed to port name (e.g. tcp-my-port)
-		// 3. default to http for for TCP ports
+		// 3. default to http for TCP ports
 		var protocol string
 		for _, p := range constants.SupportedProtocolsInMesh {
 			if strings.HasPrefix(portSpec.Name, p+"-") {

--- a/pkg/compute/kube/client.go
+++ b/pkg/compute/kube/client.go
@@ -661,8 +661,8 @@ func (c *client) serviceToMeshServices(svc corev1.Service) []service.MeshService
 		// Order of Preference is:
 		// 1. port.appProtocol field
 		// 2. protocol prefixed to port name (e.g. tcp-my-port)
-		// 3. default to http
-		protocol := constants.ProtocolHTTP
+		// 3. default to http for for TCP ports
+		var protocol string
 		for _, p := range constants.SupportedProtocolsInMesh {
 			if strings.HasPrefix(portSpec.Name, p+"-") {
 				protocol = p
@@ -672,6 +672,22 @@ func (c *client) serviceToMeshServices(svc corev1.Service) []service.MeshService
 
 		// use port.appProtocol if specified, else use port protocol
 		meshSvc.Protocol = pointer.StringDeref(portSpec.AppProtocol, protocol)
+
+		// If app protocol was not detected and the protocol is TCP, use HTTP
+		// as the default app protocol.
+		// This is required for backward compatibility where users may be relying
+		// on implicit HTTP protocol selection.
+		//
+		// Note: it's possible for MeshService.Protocol to be unset for
+		// non TCP ports (eg. UDP) if we could not infer the corresponding
+		// app protocol via the appProtocol field or the port name.
+		// This will result in an error log for the specific port when the
+		// Envoy config is built for that port.
+		if meshSvc.Protocol == "" && portSpec.Protocol == corev1.ProtocolTCP {
+			log.Warn().Msgf("Did not detect app protocol for TCP port name=%s number=%d for service %s/%s, defaulting to http",
+				portSpec.Name, portSpec.Port, svc.Namespace, svc.Name)
+			meshSvc.Protocol = constants.ProtocolHTTP
+		}
 
 		// The endpoints for the kubernetes service carry information that allows
 		// us to retrieve the TargetPort for the MeshService.

--- a/pkg/compute/kube/client_test.go
+++ b/pkg/compute/kube/client_test.go
@@ -2220,7 +2220,7 @@ func TestServiceToMeshServices(t *testing.T) {
 			name: "k8s service with single port and endpoint, no appProtocol set",
 			// Single port on the service maps to a single MeshService.
 			// Since no appProtocol is specified, MeshService.Protocol should default
-			// to http.
+			// to http since Port.Protocol=TCP.
 			svc: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1",
@@ -2319,7 +2319,7 @@ func TestServiceToMeshServices(t *testing.T) {
 			name: "k8s headless service with single port and endpoint, no appProtocol set",
 			// Single port on the service maps to a single MeshService.
 			// Since no appProtocol is specified, MeshService.Protocol should default
-			// to http.
+			// to http because Port.Protocol=TCP
 			svc: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1",


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This change updates the app protocol detection for a service port to eliminate a misleading error scenario that results from using the same port for multiple protocols.

It does the following:

1. Only uses http implicitly for TCP based ports that do not have appProtocol or a valid protocol prefix in the port name.

2. Adds a warn log when implicitly using http as the app protocol for TCP based ports.

The result is that duplicate filter chain matches
are eliminated with the same port is used for different protocols, eg. port 8080 being used for TCP and UDP.

Resolves #5223

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Unit tests

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Control Plane              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `TBD`