### PR TITLE
Revert "feat(cerst): Adds MRCResyncInterval (#5195)"

### DIFF
--- a/pkg/catalog/mock_catalog_generated.go
+++ b/pkg/catalog/mock_catalog_generated.go
@@ -7,7 +7,6 @@ package catalog
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	v1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
@@ -50,15 +49,15 @@ func (m *MockMeshCataloger) EXPECT() *MockMeshCatalogerMockRecorder {
 }
 
 // AddMeshRootCertificateEventHandler mocks base method.
-func (m *MockMeshCataloger) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler, arg1 time.Duration) {
+func (m *MockMeshCataloger) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0, arg1)
+	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
 }
 
 // AddMeshRootCertificateEventHandler indicates an expected call of AddMeshRootCertificateEventHandler.
-func (mr *MockMeshCatalogerMockRecorder) AddMeshRootCertificateEventHandler(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockMeshCatalogerMockRecorder) AddMeshRootCertificateEventHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeshRootCertificateEventHandler", reflect.TypeOf((*MockMeshCataloger)(nil).AddMeshRootCertificateEventHandler), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeshRootCertificateEventHandler", reflect.TypeOf((*MockMeshCataloger)(nil).AddMeshRootCertificateEventHandler), arg0)
 }
 
 // GetEgressClusterConfigs mocks base method.

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -15,14 +15,14 @@ import (
 )
 
 const (
-	// MrcDurationPerStage is the amount of time we leave each MRC in a stage before moving to the next stage. This is
+	// mrcDurationPerStage is the amount of time we leave each MRC in a stage before moving to the next stage. This is
 	// intended to accommodate the rotation of *all* rotations across all injector and controller pods for:
 	// 1. Bootstrap Cert rotation for each live proxy
 	// 2. Service Cert rotation and xDS push for each connected proxy
 	// 3. xDS server cert rotation on the controller
 	// 4. Mutating and Validating Webhook rotation for the servers and for the webhook configuration objects.
 	// 5. Ingress Gateway Certificate.
-	MrcDurationPerStage = 5 * time.Minute
+	mrcDurationPerStage = 5 * time.Minute
 )
 
 var (

--- a/pkg/certificate/mrc_reconciler.go
+++ b/pkg/certificate/mrc_reconciler.go
@@ -169,7 +169,7 @@ func (m *Manager) updateMRCState(mrc *v1alpha2.MeshRootCertificate) error {
 	if isTerminal(mrc) {
 		mrc.Status.TransitionAfter = nil
 	} else {
-		mrc.Status.TransitionAfter = &metav1.Time{Time: time.Now().Add(MrcDurationPerStage)}
+		mrc.Status.TransitionAfter = &metav1.Time{Time: time.Now().Add(mrcDurationPerStage)}
 	}
 
 	// TODO(5046): add the retry loop.

--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -10,10 +10,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/compute"
 )
 
-// MRCResyncInterval is the resync interval to provide a retry mechanism for MRC event handlers
-// It is half of the MrcDurationPerStage (the amount of time we leave each MRC in a stage before moving to the next stage)
-const MRCResyncInterval = certificate.MrcDurationPerStage / 2
-
 // MRCComposer is a composer object that allows consumers
 // to observe MRCs (via List() and Watch()) as well as generate
 // `certificate.Provider`s from those MRCs
@@ -51,7 +47,7 @@ func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, e
 		// happen come from the control plane cleaning up an old MRC. Our
 		// ValdatingWebhookConfiguration should prevent deletes from users
 		DeleteFunc: func(obj interface{}) {},
-	}, MRCResyncInterval)
+	})
 
 	return eventChan, nil
 }

--- a/pkg/compute/mock_compute_client_generated.go
+++ b/pkg/compute/mock_compute_client_generated.go
@@ -7,7 +7,6 @@ package compute
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	v1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
@@ -49,15 +48,15 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AddMeshRootCertificateEventHandler mocks base method.
-func (m *MockInterface) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler, arg1 time.Duration) {
+func (m *MockInterface) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0, arg1)
+	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
 }
 
 // AddMeshRootCertificateEventHandler indicates an expected call of AddMeshRootCertificateEventHandler.
-func (mr *MockInterfaceMockRecorder) AddMeshRootCertificateEventHandler(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) AddMeshRootCertificateEventHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeshRootCertificateEventHandler", reflect.TypeOf((*MockInterface)(nil).AddMeshRootCertificateEventHandler), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeshRootCertificateEventHandler", reflect.TypeOf((*MockInterface)(nil).AddMeshRootCertificateEventHandler), arg0)
 }
 
 // GetHTTPRouteGroup mocks base method.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"time"
 
 	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 	smiSpecs "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/specs/v1alpha4"
@@ -489,6 +488,6 @@ func (c *Client) ListServiceExports() []*mcs.ServiceExport {
 }
 
 // AddMeshRootCertificateEventHandler adds an event handler specific to mesh root certificiates.
-func (c *Client) AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler, resyncInterval time.Duration) {
-	c.informers[informerKeyMeshRootCertificate].AddEventHandlerWithResyncPeriod(handler, resyncInterval)
+func (c *Client) AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler) {
+	c.informers[informerKeyMeshRootCertificate].AddEventHandler(handler)
 }

--- a/pkg/k8s/informers.go
+++ b/pkg/k8s/informers.go
@@ -77,8 +77,8 @@ const (
 
 const (
 	// DefaultKubeEventResyncInterval is the default resync interval for k8s events
-	// This is set to 0 because we do not need resyncs from k8s client.
-	// For the MeshConfig resource, we have our own Ticker to turn on periodic resyncs.
+	// This is set to 0 because we do not need resyncs from k8s client, and have our
+	// own Ticker to turn on periodic resyncs.
 	DefaultKubeEventResyncInterval = 0 * time.Second
 )
 

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -7,7 +7,6 @@ package k8s
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	v1alpha2 "github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
@@ -46,15 +45,15 @@ func (m *MockController) EXPECT() *MockControllerMockRecorder {
 }
 
 // AddMeshRootCertificateEventHandler mocks base method.
-func (m *MockController) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler, arg1 time.Duration) {
+func (m *MockController) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0, arg1)
+	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
 }
 
 // AddMeshRootCertificateEventHandler indicates an expected call of AddMeshRootCertificateEventHandler.
-func (mr *MockControllerMockRecorder) AddMeshRootCertificateEventHandler(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockControllerMockRecorder) AddMeshRootCertificateEventHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeshRootCertificateEventHandler", reflect.TypeOf((*MockController)(nil).AddMeshRootCertificateEventHandler), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeshRootCertificateEventHandler", reflect.TypeOf((*MockController)(nil).AddMeshRootCertificateEventHandler), arg0)
 }
 
 // GetEndpoints mocks base method.

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -4,7 +4,6 @@ package k8s
 
 import (
 	"context"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -116,7 +115,7 @@ type PassthroughInterface interface {
 
 	GetMeshConfig() configv1alpha2.MeshConfig
 	GetMeshRootCertificate(mrcName string) *configv1alpha2.MeshRootCertificate
-	AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler, resyncInterval time.Duration)
+	AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler)
 
 	ListMeshRootCertificates() ([]*configv1alpha2.MeshRootCertificate, error)
 	UpdateMeshRootCertificate(obj *configv1alpha2.MeshRootCertificate) (*configv1alpha2.MeshRootCertificate, error)


### PR DESCRIPTION
This reverts commit 6fc993bec81dc172f0c34763882f19780e8a4744.

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Reverts: https://github.com/openservicemesh/osm/pull/5195 based on https://github.com/openservicemesh/osm/pull/5195#discussion_r999775665 


This change ends up resulting in the log message `the specified resyncPeriod 2m30s is invalid because this shared informer doesn't support resyncing.`

I tested it out and the base informer needs to have a resync enabled (aka a value > 1s) otherwise it resync is disabled. https://github.com/kubernetes/client-go/blob/c81636cd4415f0858a99c2cc18023740df7aa15f/tools/cache/shared_informer.go#L516-L524

We've been running without resyncs in https://github.com/openservicemesh/osm/pull/5201 without resync and this was initially needed for time based changes, which is a different direction then we ended up with.

Can revisit later if required.


<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?