### PR TITLE
Pins the JaegerTracing image to latest version

### DIFF
--- a/charts/osm/README.md
+++ b/charts/osm/README.md
@@ -262,7 +262,7 @@ The following table lists the configurable parameters of the osm chart and their
 | osm.tracing.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[1].values[3] | string | `"s390x"` |  |
 | osm.tracing.enable | bool | `false` | Toggles Envoy's tracing functionality on/off for all sidecar proxies in the mesh |
 | osm.tracing.endpoint | string | `"/api/v2/spans"` | Tracing collector's API path where the spans will be sent to |
-| osm.tracing.image | string | `"jaegertracing/all-in-one"` | Image used for tracing |
+| osm.tracing.image | string | `"jaegertracing/all-in-one:1.39"` | Image used for tracing |
 | osm.tracing.nodeSelector | object | `{}` |  |
 | osm.tracing.port | int | `9411` | Port of the tracing collector service |
 | osm.tracing.tolerations | list | `[]` | Node tolerations applied to control plane pods. The specified tolerations allow pods to schedule onto nodes with matching taints. |

--- a/charts/osm/values.yaml
+++ b/charts/osm/values.yaml
@@ -344,7 +344,7 @@ osm:
     # -- Tracing collector's API path where the spans will be sent to
     endpoint: "/api/v2/spans"
     # -- Image used for tracing
-    image: jaegertracing/all-in-one
+    image: jaegertracing/all-in-one:1.39
 
     ## Node labels for pod assignment
     ## Ref: https://kubernetes.io/docs/user-guide/node-selection/


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
This pins the jaeger deployment to the latest version. We do this we all the other tools we include in the helm chart and this ensures we know what version of jaeger we are supporting.

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [x] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
no
2. Is this a breaking change?
no
3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?
no