### PR TITLE
Builder pattern for inbound mesh trafficpolicy

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/messaging"

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -3,9 +3,12 @@ package catalog
 import (
 	"time"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/messaging"
+	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/ticker"
 )
 
@@ -25,4 +28,37 @@ func NewMeshCatalog(computeInterface compute.Interface, certManager *certificate
 	resyncTicker.Start(stop)
 
 	return mc
+}
+
+// GetUpstreamServicesIncludeApex returns a list of all upstream services associated with the given list
+// of services. An upstream service is associated with another service if it is a backend for an apex/root service
+// in a TrafficSplit config. This function returns a list consisting of the given upstream services and all apex
+// services associated with each of those services.
+func (mc *MeshCatalog) GetUpstreamServicesIncludeApex(upstreamServices []service.MeshService) []service.MeshService {
+	svcSet := mapset.NewSet()
+	var allServices []service.MeshService
+
+	// Each service could be a backend in a traffic split config. Construct a list
+	// of all possible services the given list of services is associated with.
+	for _, svc := range upstreamServices {
+		if newlyAdded := svcSet.Add(svc); newlyAdded {
+			allServices = append(allServices, svc)
+		}
+
+		for _, split := range mc.ListTrafficSplitsByOptions(smi.WithTrafficSplitBackendService(svc)) {
+			apexMeshService := service.MeshService{
+				Namespace:  svc.Namespace,
+				Name:       split.Spec.Service,
+				Port:       svc.Port,
+				TargetPort: svc.TargetPort,
+				Protocol:   svc.Protocol,
+			}
+
+			if newlyAdded := svcSet.Add(apexMeshService); newlyAdded {
+				allServices = append(allServices, apexMeshService)
+			}
+		}
+	}
+
+	return allServices
 }

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -2453,13 +2453,13 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 
 			allUpstreamSvcIncludeApex := mc.GetUpstreamServicesIncludeApex(tc.upstreamServices)
 
-			upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
-			hostnamesPerService := make(map[*service.MeshService][]string)
+			upstreamTrafficSettingsPerService := make(map[service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
+			hostnamesPerService := make(map[service.MeshService][]string)
 
 			for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 				upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop
-				upstreamTrafficSettingsPerService[&upstreamSvc] = mc.GetUpstreamTrafficSettingByService(&upstreamSvc)
-				hostnamesPerService[&upstreamSvc] = mc.GetHostnamesForService(upstreamSvc, true /* local namespace FQDN should always be allowed for inbound routes*/)
+				upstreamTrafficSettingsPerService[upstreamSvc] = mc.GetUpstreamTrafficSettingByService(&upstreamSvc)
+				hostnamesPerService[upstreamSvc] = mc.GetHostnamesForService(upstreamSvc, true /* local namespace FQDN should always be allowed for inbound routes*/)
 			}
 
 			inboundTPBuilder.UpstreamServices(tc.upstreamServices)
@@ -2470,7 +2470,7 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 			inboundTPBuilder.TrafficTargetsByOptions(mc.ListTrafficTargetsByOptions(destinationFilter))
 			inboundTPBuilder.EnablePermissiveTrafficPolicyMode(tc.permissiveMode)
 			inboundTPBuilder.TrustDomain(mc.certManager.GetTrustDomains())
-			inboundTPBuilder.HttpTrafficSpecsList(mc.ListHTTPTrafficSpecs())
+			inboundTPBuilder.HTTPTrafficSpecsList(mc.ListHTTPTrafficSpecs())
 
 			actualClusterConfigs := inboundTPBuilder.GetInboundMeshClusterConfigs()
 			actualHTTPRouteConfigsPerPort := inboundTPBuilder.GetInboundMeshHTTPRouteConfigsPerPort()
@@ -2537,7 +2537,7 @@ func TestRoutesFromRules(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(fmt.Sprintf("Testing routesFromRules where %s", tc.name), func(t *testing.T) {
 			inboundTPBuilder := trafficpolicy.InboundTrafficPolicyBuilder()
-			inboundTPBuilder.HttpTrafficSpecsList(mc.ListHTTPTrafficSpecs())
+			inboundTPBuilder.HTTPTrafficSpecsList(mc.ListHTTPTrafficSpecs())
 			routes, err := inboundTPBuilder.RoutesFromRules(tc.rules, tc.namespace)
 			assert.Nil(err)
 			assert.EqualValues(tc.expectedRoutes, routes)
@@ -2719,7 +2719,7 @@ func TestGetHTTPPathsPerRoute(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			inboundTPBuilder := trafficpolicy.InboundTrafficPolicyBuilder()
-			inboundTPBuilder.HttpTrafficSpecsList([]*spec.HTTPRouteGroup{&tc.trafficSpec})
+			inboundTPBuilder.HTTPTrafficSpecsList([]*spec.HTTPRouteGroup{&tc.trafficSpec})
 			actual, err := inboundTPBuilder.GetHTTPPathsPerRoute()
 			assert.Nil(err)
 			assert.True(reflect.DeepEqual(actual, tc.expectedHTTPPathsPerRoute))

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -2453,8 +2453,8 @@ func TestGetInboundMeshTrafficPolicy(t *testing.T) {
 
 			allUpstreamSvcIncludeApex := mc.GetUpstreamServicesIncludeApex(tc.upstreamServices)
 
-			var upstreamTrafficSettingsPerService map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting
-			var hostnamesPerService map[*service.MeshService][]string
+			upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
+			hostnamesPerService := make(map[*service.MeshService][]string)
 
 			for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 				upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop

--- a/pkg/catalog/inbound_traffic_policies_test.go
+++ b/pkg/catalog/inbound_traffic_policies_test.go
@@ -14,7 +14,6 @@ import (
 	split "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/split/v1alpha2"
 	tassert "github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/openservicemesh/osm/pkg/apis/config/v1alpha2"
@@ -26,6 +25,8 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/k8s"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
+	"github.com/openservicemesh/osm/pkg/tests"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
 )
 

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -11,7 +11,9 @@ import (
 	"github.com/openservicemesh/osm/pkg/identity"
 	"github.com/openservicemesh/osm/pkg/logger"
 	"github.com/openservicemesh/osm/pkg/service"
+	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 )
 
 var (
@@ -44,15 +46,6 @@ type MeshCataloger interface {
 	// ListInboundTrafficTargetsWithRoutes returns a list traffic target objects composed of its routes for the given destination service identity
 	ListInboundTrafficTargetsWithRoutes(identity.ServiceIdentity) ([]trafficpolicy.TrafficTargetWithRoutes, error)
 
-	// GetInboundMeshClusterConfigs returns the cluster configs for the inbound mesh traffic policy for the given upstream services
-	GetInboundMeshClusterConfigs([]service.MeshService) []*trafficpolicy.MeshClusterConfig
-
-	// GetInboundMeshTrafficMatches returns the traffic matches for the inbound mesh traffic policy for the given upstream services
-	GetInboundMeshTrafficMatches([]service.MeshService) []*trafficpolicy.TrafficMatch
-
-	// GetInboundMeshHTTPRouteConfigsPerPort returns a map of the given inbound traffic policy per port for the given upstream identity and services
-	GetInboundMeshHTTPRouteConfigsPerPort(identity.ServiceIdentity, []service.MeshService) map[int][]*trafficpolicy.InboundTrafficPolicy
-
 	// GetOutboundMeshClusterConfigs returns the cluster configs for the outbound mesh traffic policy for the given downstream identity
 	GetOutboundMeshClusterConfigs(identity.ServiceIdentity) []*trafficpolicy.MeshClusterConfig
 
@@ -82,6 +75,17 @@ type MeshCataloger interface {
 
 	// GetIngressHTTPRoutePolicies returns the ingress traffic matches for the ingress traffic policy for the given mesh service
 	GetIngressTrafficMatches([]service.MeshService) [][]*trafficpolicy.IngressTrafficMatch
+
+	ListServiceAccountsFromTrafficTargets() []identity.K8sServiceAccount
+
+	// GetUpstreamServicesIncludeApex returns a list of all upstream services associated with the given list
+	// of services. An upstream service is associated with another service if it is a backend for an apex/root service
+	// in a TrafficSplit config. This function returns a list consisting of the given upstream services and all apex
+	// services associated with each of those services.
+	GetUpstreamServicesIncludeApex(upstreamServices []service.MeshService) []service.MeshService
+
+	// ListTrafficTargetsByOptions returns a list of traffic targets that match the given options.
+	ListTrafficTargetsByOptions(options ...smi.TrafficTargetListOption) []*smiAccess.TrafficTarget
 }
 
 type trafficDirection string

--- a/pkg/catalog/types.go
+++ b/pkg/catalog/types.go
@@ -5,6 +5,8 @@
 package catalog
 
 import (
+	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
+
 	"github.com/openservicemesh/osm/pkg/certificate"
 	"github.com/openservicemesh/osm/pkg/compute"
 	"github.com/openservicemesh/osm/pkg/endpoint"
@@ -13,7 +15,6 @@ import (
 	"github.com/openservicemesh/osm/pkg/service"
 	"github.com/openservicemesh/osm/pkg/smi"
 	"github.com/openservicemesh/osm/pkg/trafficpolicy"
-	smiAccess "github.com/servicemeshinterface/smi-sdk-go/pkg/apis/access/v1alpha3"
 )
 
 var (
@@ -75,8 +76,6 @@ type MeshCataloger interface {
 
 	// GetIngressHTTPRoutePolicies returns the ingress traffic matches for the ingress traffic policy for the given mesh service
 	GetIngressTrafficMatches([]service.MeshService) [][]*trafficpolicy.IngressTrafficMatch
-
-	ListServiceAccountsFromTrafficTargets() []identity.K8sServiceAccount
 
 	// GetUpstreamServicesIncludeApex returns a list of all upstream services associated with the given list
 	// of services. An upstream service is associated with another service if it is a backend for an apex/root service

--- a/pkg/envoy/generator/cds.go
+++ b/pkg/envoy/generator/cds.go
@@ -34,7 +34,7 @@ func (g *EnvoyConfigGenerator) generateCDS(ctx context.Context, proxy *models.Pr
 	inboundTPBuilder.UpstreamServices(proxyServices)
 	allUpstreamSvcIncludeApex := g.catalog.GetUpstreamServicesIncludeApex(proxyServices)
 	inboundTPBuilder.UpstreamServicesIncludeApex(allUpstreamSvcIncludeApex)
-	var upstreamTrafficSettingsPerService map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting
+	upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
 
 	for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop

--- a/pkg/envoy/generator/cds.go
+++ b/pkg/envoy/generator/cds.go
@@ -34,11 +34,11 @@ func (g *EnvoyConfigGenerator) generateCDS(ctx context.Context, proxy *models.Pr
 	inboundTPBuilder.UpstreamServices(proxyServices)
 	allUpstreamSvcIncludeApex := g.catalog.GetUpstreamServicesIncludeApex(proxyServices)
 	inboundTPBuilder.UpstreamServicesIncludeApex(allUpstreamSvcIncludeApex)
-	upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
+	upstreamTrafficSettingsPerService := make(map[service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
 
 	for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop
-		upstreamTrafficSettingsPerService[&upstreamSvc] = g.catalog.GetUpstreamTrafficSettingByService(&upstreamSvc)
+		upstreamTrafficSettingsPerService[upstreamSvc] = g.catalog.GetUpstreamTrafficSettingByService(&upstreamSvc)
 	}
 
 	inboundTPBuilder.UpstreamTrafficSettingsPerService(upstreamTrafficSettingsPerService)

--- a/pkg/envoy/generator/generator_test.go
+++ b/pkg/envoy/generator/generator_test.go
@@ -48,6 +48,7 @@ func TestGenerateConfig(t *testing.T) {
 	provider.EXPECT().ListServices().Return([]service.MeshService{tests.BookstoreApexService, tests.BookbuyerService}).AnyTimes()
 	provider.EXPECT().ListServicesForProxy(proxy).Return([]service.MeshService{tests.BookbuyerService}, nil).AnyTimes()
 	provider.EXPECT().ListHTTPTrafficSpecs().Return(nil).AnyTimes()
+	provider.EXPECT().ListTrafficTargets().Return(nil).AnyTimes()
 	provider.EXPECT().GetHostnamesForService(gomock.Any(), gomock.Any()).Return([]string{"fake.hostname.cluster.local"}).AnyTimes()
 	provider.EXPECT().GetServicesForServiceIdentity(tests.BookstoreServiceIdentity).Return([]service.MeshService{tests.BookstoreApexService}).AnyTimes()
 	provider.EXPECT().GetServicesForServiceIdentity(tests.BookbuyerServiceIdentity).Return([]service.MeshService{tests.BookbuyerService}).AnyTimes()

--- a/pkg/envoy/generator/generator_test.go
+++ b/pkg/envoy/generator/generator_test.go
@@ -47,6 +47,7 @@ func TestGenerateConfig(t *testing.T) {
 	provider.EXPECT().ListServiceIdentitiesForService(gomock.Any(), gomock.Any()).Return([]identity.ServiceIdentity{tests.BookstoreServiceIdentity}, nil).AnyTimes()
 	provider.EXPECT().ListServices().Return([]service.MeshService{tests.BookstoreApexService, tests.BookbuyerService}).AnyTimes()
 	provider.EXPECT().ListServicesForProxy(proxy).Return([]service.MeshService{tests.BookbuyerService}, nil).AnyTimes()
+	provider.EXPECT().ListHTTPTrafficSpecs().Return(nil).AnyTimes()
 	provider.EXPECT().GetHostnamesForService(gomock.Any(), gomock.Any()).Return([]string{"fake.hostname.cluster.local"}).AnyTimes()
 	provider.EXPECT().GetServicesForServiceIdentity(tests.BookstoreServiceIdentity).Return([]service.MeshService{tests.BookstoreApexService}).AnyTimes()
 	provider.EXPECT().GetServicesForServiceIdentity(tests.BookbuyerServiceIdentity).Return([]service.MeshService{tests.BookbuyerService}).AnyTimes()

--- a/pkg/envoy/generator/lds.go
+++ b/pkg/envoy/generator/lds.go
@@ -91,11 +91,11 @@ func (g *EnvoyConfigGenerator) generateLDS(ctx context.Context, proxy *models.Pr
 	inboundTPBuilder.UpstreamServices(svcList)
 	allUpstreamSvcIncludeApex := g.catalog.GetUpstreamServicesIncludeApex(svcList)
 	inboundTPBuilder.UpstreamServicesIncludeApex(allUpstreamSvcIncludeApex)
-	upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
+	upstreamTrafficSettingsPerService := make(map[service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
 
 	for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop
-		upstreamTrafficSettingsPerService[&upstreamSvc] = g.catalog.GetUpstreamTrafficSettingByService(&upstreamSvc)
+		upstreamTrafficSettingsPerService[upstreamSvc] = g.catalog.GetUpstreamTrafficSettingByService(&upstreamSvc)
 	}
 
 	inboundTPBuilder.UpstreamTrafficSettingsPerService(upstreamTrafficSettingsPerService)

--- a/pkg/envoy/generator/lds.go
+++ b/pkg/envoy/generator/lds.go
@@ -91,7 +91,7 @@ func (g *EnvoyConfigGenerator) generateLDS(ctx context.Context, proxy *models.Pr
 	inboundTPBuilder.UpstreamServices(svcList)
 	allUpstreamSvcIncludeApex := g.catalog.GetUpstreamServicesIncludeApex(svcList)
 	inboundTPBuilder.UpstreamServicesIncludeApex(allUpstreamSvcIncludeApex)
-	var upstreamTrafficSettingsPerService map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting
+	upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
 
 	for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop

--- a/pkg/envoy/generator/rds.go
+++ b/pkg/envoy/generator/rds.go
@@ -40,7 +40,7 @@ func (g *EnvoyConfigGenerator) generateRDS(ctx context.Context, proxy *models.Pr
 	inboundTPBuilder.UpstreamIdentity(proxy.Identity)
 	inboundTPBuilder.EnablePermissiveTrafficPolicyMode(g.catalog.GetMeshConfig().Spec.Traffic.EnablePermissiveTrafficPolicyMode)
 	inboundTPBuilder.TrustDomain(g.certManager.GetTrustDomains())
-	inboundTPBuilder.HttpTrafficSpecsList(g.catalog.ListHTTPTrafficSpecs())
+	inboundTPBuilder.HTTPTrafficSpecsList(g.catalog.ListHTTPTrafficSpecs())
 
 	destinationFilter := smi.WithTrafficTargetDestination(proxy.Identity.ToK8sServiceAccount())
 	inboundTPBuilder.TrafficTargetsByOptions(g.catalog.ListTrafficTargetsByOptions(destinationFilter))
@@ -48,13 +48,13 @@ func (g *EnvoyConfigGenerator) generateRDS(ctx context.Context, proxy *models.Pr
 	allUpstreamSvcIncludeApex := g.catalog.GetUpstreamServicesIncludeApex(proxyServices)
 	inboundTPBuilder.UpstreamServicesIncludeApex(allUpstreamSvcIncludeApex)
 
-	upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
-	hostnamesPerService := make(map[*service.MeshService][]string)
+	upstreamTrafficSettingsPerService := make(map[service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
+	hostnamesPerService := make(map[service.MeshService][]string)
 
 	for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop
-		upstreamTrafficSettingsPerService[&upstreamSvc] = g.catalog.GetUpstreamTrafficSettingByService(&upstreamSvc)
-		hostnamesPerService[&upstreamSvc] = g.catalog.GetHostnamesForService(upstreamSvc, true /* local namespace FQDN should always be allowed for inbound routes*/)
+		upstreamTrafficSettingsPerService[upstreamSvc] = g.catalog.GetUpstreamTrafficSettingByService(&upstreamSvc)
+		hostnamesPerService[upstreamSvc] = g.catalog.GetHostnamesForService(upstreamSvc, true /* local namespace FQDN should always be allowed for inbound routes*/)
 	}
 
 	inboundTPBuilder.UpstreamTrafficSettingsPerService(upstreamTrafficSettingsPerService)

--- a/pkg/envoy/generator/rds.go
+++ b/pkg/envoy/generator/rds.go
@@ -48,8 +48,8 @@ func (g *EnvoyConfigGenerator) generateRDS(ctx context.Context, proxy *models.Pr
 	allUpstreamSvcIncludeApex := g.catalog.GetUpstreamServicesIncludeApex(proxyServices)
 	inboundTPBuilder.UpstreamServicesIncludeApex(allUpstreamSvcIncludeApex)
 
-	var upstreamTrafficSettingsPerService map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting
-	var hostnamesPerService map[*service.MeshService][]string
+	upstreamTrafficSettingsPerService := make(map[*service.MeshService]*policyv1alpha1.UpstreamTrafficSetting)
+	hostnamesPerService := make(map[*service.MeshService][]string)
 
 	for _, upstreamSvc := range allUpstreamSvcIncludeApex {
 		upstreamSvc := upstreamSvc // To prevent loop variable memory aliasing in for loop

--- a/pkg/envoy/generator/rds_test.go
+++ b/pkg/envoy/generator/rds_test.go
@@ -244,7 +244,7 @@ func TestGenerateRDSWithTrafficSplit(t *testing.T) {
 	mockComputeInterface.EXPECT().ListServicesForProxy(gomock.Any()).Return(nil, nil).AnyTimes()
 	mockComputeInterface.EXPECT().ListTrafficTargets().Return([]*access.TrafficTarget{&tests.TrafficTarget, &tests.BookstoreV2TrafficTarget}).AnyTimes()
 	mockComputeInterface.EXPECT().ListTrafficSplits().Return([]*split.TrafficSplit{&tests.TrafficSplit}).AnyTimes()
-
+	mockComputeInterface.EXPECT().ListHTTPTrafficSpecs().Return(nil).AnyTimes()
 	mockComputeInterface.EXPECT().ListEgressPoliciesForServiceAccount(gomock.Any()).Return(nil).AnyTimes()
 	mockComputeInterface.EXPECT().GetIngressBackendPolicyForService(gomock.Any()).Return(nil).AnyTimes()
 	mockComputeInterface.EXPECT().GetUpstreamTrafficSettingByService(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/envoy/server/server_test.go
+++ b/pkg/envoy/server/server_test.go
@@ -34,6 +34,7 @@ func TestADSResponse(t *testing.T) {
 	provider := compute.NewMockInterface(mockCtrl)
 	provider.EXPECT().IsMetricsEnabled(gomock.Any()).Return(true, nil).AnyTimes()
 	provider.EXPECT().ListEgressPoliciesForServiceAccount(gomock.Any()).Return(nil).AnyTimes()
+	provider.EXPECT().ListHTTPTrafficSpecs().Return(nil).AnyTimes()
 	provider.EXPECT().GetIngressBackendPolicyForService(gomock.Any()).Return(nil).AnyTimes()
 	provider.EXPECT().GetUpstreamTrafficSettingByService(gomock.Any()).Return(nil).AnyTimes()
 	provider.EXPECT().GetUpstreamTrafficSettingByNamespace(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/trafficpolicy/inbound_traffic_policy_builder.go
+++ b/pkg/trafficpolicy/inbound_traffic_policy_builder.go
@@ -337,7 +337,7 @@ func (b *inboundTrafficPolicyBuilder) GetHTTPPathsPerRoute() (map[TrafficSpecNam
 	return routePolicies, nil
 }
 
-// GetTrafficSpectName returns the formatted TrafficSpecName from the Traffic Spec kind, namespace, name.
+// GetTrafficSpecName returns the formatted TrafficSpecName from the Traffic Spec kind, namespace, name.
 func GetTrafficSpecName(trafficSpecKind string, trafficSpecNamespace string, trafficSpecName string) TrafficSpecName {
 	specKey := fmt.Sprintf("%s/%s/%s", trafficSpecKind, trafficSpecNamespace, trafficSpecName)
 	return TrafficSpecName(specKey)


### PR DESCRIPTION
Signed-off-by: nshankar13 <nshankar@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Leverage the builder pattern for the inbound mesh traffic policy. 

A minor issue here is that the inbound_traffic_policies test still needs to live in pkg/catalog even though the builder itself is in /pkg/trafficpolicy. This is because the tests depend on the `catalog` and `tests` package, which cannot be imported in `pkg/trafficpolicy` due to an import cycle error. Thus, with the current implementation, some methods in inbound_traffic_policy_builder.go need to be exported just for the sake of being able to test them from `pkg/catalog`. 

Resolves: https://github.com/openservicemesh/osm/issues/5059



<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?