### PR TITLE
envoy/access-logs: allow removing HTTP query string

### DIFF
--- a/pkg/envoy/generator/lds/accesslog_test.go
+++ b/pkg/envoy/generator/lds/accesslog_test.go
@@ -26,8 +26,20 @@ func TestAccessLogBuild(t *testing.T) {
 			expectErr:             false,
 		},
 		{
-			name:                  "custom  stream access log JSON format",
+			name:                  "custom stream access log text format with query formatter",
+			ab:                    NewAccessLogBuilder().Name("foo").Format("[%START_TIME%] \"%REQ(:METHOD)% %REQ_WITHOUT_QUERY(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS%\n"),
+			numExpectedAccessLogs: 1, // STDOUT stream access log
+			expectErr:             false,
+		},
+		{
+			name:                  "custom stream access log JSON format",
 			ab:                    NewAccessLogBuilder().Name("foo").Format(`{"authority":"%REQ(:AUTHORITY)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%"}`),
+			numExpectedAccessLogs: 1, // STDOUT stream access log
+			expectErr:             false,
+		},
+		{
+			name:                  "custom stream access log JSON format with query formatter",
+			ab:                    NewAccessLogBuilder().Name("foo").Format(`{"authority":"%REQ_WITHOUT_QUERY(:AUTHORITY)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%"}`),
 			numExpectedAccessLogs: 1, // STDOUT stream access log
 			expectErr:             false,
 		},


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Allows specifying the removal of HTTP query strings from access logs as they may contain sensitive
info. If the %REQ_WITHOUT_QUERY command operator
is specified instead of the regular %REQ operator, then a query string formatter is used such that
the HTTP path without the query string is rendered in the access logs.

Resolves #5241

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:
Tested query string masking using the `%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%` 
for both JSON and text based access log formats.

E.g. for the query `http://httpbin.httpbin:14001/status/200?foo=bar`, the `foo=bar` query string is stripped off when using the `%REQ_WITHOUT_QUERY` instead of the `%REQ` operator. 

TEXT
```
apiVersion: policy.openservicemesh.io/v1alpha1
kind: Telemetry
metadata:
  name: httpbin-log
  namespace: httpbin
spec:
  accessLog:
    format: "[%START_TIME%] \"%REQ(:METHOD)% %REQ_WITHOUT_QUERY(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS%\n"
```
```
[2022-11-14T20:07:40.010Z] "HEAD /status/200 HTTP/1.1" 200 -
```

JSON 
```
apiVersion: policy.openservicemesh.io/v1alpha1
kind: Telemetry
metadata:
  name: httpbin-log
  namespace: httpbin
spec:
  accessLog:
    format: '{"path":"%REQ_WITHOUT_QUERY(X-ENVOY-ORIGINAL-PATH?:PATH)%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%"}'
```
```
{"path":"/status/200","bytes_received":0,"bytes_sent":0}
```

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [X] |
| Observability              | [X] |

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? `no`
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? `no`

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? `no`