### PR TITLE
Split e2es into more buckets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,7 +241,7 @@ jobs:
       matrix:
         k8s_version: [""]
         focus: [""]
-        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        bucket: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
         include:
           - k8s_version: v1.22.9
             focus: "Test traffic flowing from client to server with a Kubernetes Service for the Source: HTTP"

--- a/tests/e2e/e2e_meshrootcertificate_test.go
+++ b/tests/e2e/e2e_meshrootcertificate_test.go
@@ -40,7 +40,14 @@ var _ = OSMDescribe("MeshRootCertificate",
 				trustDomainRotation()
 			})
 		})
+	})
 
+var _ = OSMDescribe("MeshRootCertificate",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 13,
+	},
+	func() {
 		Context("with CertManager", func() {
 			It("rotates certificates", func() {
 				basicCertRotationScenario(WithCertManagerEnabled())
@@ -50,7 +57,14 @@ var _ = OSMDescribe("MeshRootCertificate",
 				enablingMRCAfterInstallScenario(WithCertManagerEnabled())
 			})
 		})
+	})
 
+var _ = OSMDescribe("MeshRootCertificate",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 14,
+	},
+	func() {
 		Context("with Vault", func() {
 			It("rotates certificates", func() {
 				basicCertRotationScenario(WithVault())
@@ -60,7 +74,14 @@ var _ = OSMDescribe("MeshRootCertificate",
 				enablingMRCAfterInstallScenario(WithVault(), WithVaultTokenSecretRef())
 			})
 		})
+	})
 
+var _ = OSMDescribe("MeshRootCertificate",
+	OSMDescribeInfo{
+		Tier:   2,
+		Bucket: 15,
+	},
+	func() {
 		Context("can switch providers", func() {
 			It("during rotation", func() {
 				providerChangeRotation()


### PR DESCRIPTION
Signed-off-by: James Sturtevant <jstur@microsoft.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Split e2es into more buckets so overall time for test completion is faster.
fixes: #5257

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?