### PR TITLE
Move snehachhabria and draychev to emeritus status

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # ref: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @shashankram @snehachhabria @nojnhuh @draychev @jaellio @trstringer @keithmattix @steeling
+* @shashankram @nojnhuh @jaellio @trstringer @keithmattix @steeling
 
 # Emeritus maintainers
-# @michelleN @eduser25
+# @michelleN @eduser25 @snehachhabria @draychev

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,7 @@
 # Code maintainers (borrowed from https://github.com/openservicemesh/osm/blob/main/CODEOWNERS)
 
 - @shashankram
-- @snehachhabria
 - @nojnhuh
-- @draychev
 - @jaellio
 - @trstringer
 - @keithmattix
@@ -15,3 +13,5 @@
 # Emeritus maintainers
 - @michelleN
 - @eduser25
+- @snehachhabria
+- @draychev


### PR DESCRIPTION
Due to the project guidelines on [inactivity](https://github.com/openservicemesh/osm/blob/main/CONTRIBUTOR_LADDER.md#inactivity), this PR proposes moving @snehachhabria and @draychev to emeritus status. Thank you for your contributions to this project!

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A