### PR TITLE
Add @shalier as a codeowner maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # ref: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @shashankram @snehachhabria @nojnhuh @draychev @jaellio @trstringer @keithmattix @steeling
+* @shashankram @snehachhabria @nojnhuh @draychev @jaellio @trstringer @keithmattix @steeling @shalier
 
 # Emeritus maintainers
 # @michelleN @eduser25

--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@
 - @trstringer
 - @keithmattix
 - @steeling
+- @shalier
 
 # Non-code maintainers
 - @phillipgibson


### PR DESCRIPTION
@shalier has been contributing to the project at the level that is expected of a maintainer.

**Maintainers**, if you agree with this nomination, leave a "+1" comment and approve the PR (do not merge it).

Signed-off-by: Thomas Stringer <thomas@trstringer.com>

**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| Other                      | [X] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No.

2. Is this a breaking change? No.

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A