### PR TITLE
Add @shalier as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # ref: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-* @shashankram @nojnhuh @jaellio @trstringer @keithmattix @steeling
+* @shashankram @nojnhuh @jaellio @trstringer @keithmattix @steeling @shalier
 
 # Emeritus maintainers
 # @michelleN @eduser25 @snehachhabria @draychev


### PR DESCRIPTION
Signed-off-by: Keith Mattix II <keithmattix2@gmail.com>

The last PR (#5261) added @shalier in the OWNERS file but not the CODEOWNERS file which is why she is not being requested on reviews.