### PR TITLE
Appended version check

### DIFF
--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -74,6 +74,15 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 				return err
 			}
 
+			if !settings.IsManaged() && !versionCmd.versionOnly {
+				latestReleaseVersion, err := getLatestReleaseVersion()
+				if err != nil {
+					multiError = multierror.Append(multiError, fmt.Errorf("Failed to get latest release information: %w", err))
+				} else if err := outputLatestReleaseVersion(versionCmd.out, latestReleaseVersion, cliVersionInfo.Version); err != nil {
+					multiError = multierror.Append(multiError, fmt.Errorf("Failed to output latest release information: %w", err))
+				}
+			}
+
 			meshInfoList, err := getMeshInfoList(versionCmd.config, versionCmd.clientset)
 			if err != nil {
 				return fmt.Errorf("unable to list meshes within the cluster: %w", err)
@@ -91,15 +100,6 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 			w := newTabWriter(versionCmd.out)
 			fmt.Fprint(w, versionCmd.outputPrettyVersionInfo(verInfo.remoteVersionInfoList))
 			_ = w.Flush()
-
-			if !settings.IsManaged() && !versionCmd.versionOnly {
-				latestReleaseVersion, err := getLatestReleaseVersion()
-				if err != nil {
-					multiError = multierror.Append(multiError, fmt.Errorf("Failed to get latest release information: %w", err))
-				} else if err := outputLatestReleaseVersion(versionCmd.out, latestReleaseVersion, cliVersionInfo.Version); err != nil {
-					multiError = multierror.Append(multiError, fmt.Errorf("Failed to output latest release information: %w", err))
-				}
-			}
 
 			return multiError.ErrorOrNil()
 		},

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -77,9 +77,9 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 			if !settings.IsManaged() && !versionCmd.versionOnly {
 				latestReleaseVersion, err := getLatestReleaseVersion()
 				if err != nil {
-					multiError = multierror.Append(multiError, fmt.Errorf("Failed to get latest release information: %w", err))
+					multiError = multierror.Append(multiError, fmt.Errorf("failed to get latest release information: %w", err))
 				} else if err := outputLatestReleaseVersion(versionCmd.out, latestReleaseVersion, cliVersionInfo.Version); err != nil {
-					multiError = multierror.Append(multiError, fmt.Errorf("Failed to output latest release information: %w", err))
+					multiError = multierror.Append(multiError, fmt.Errorf("failed to output latest release information: %w", err))
 				}
 			}
 
@@ -92,7 +92,7 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 				versionCmd.namespace = m.namespace
 				meshVer, err := versionCmd.getMeshVersion()
 				if err != nil {
-					multiError = multierror.Append(multiError, fmt.Errorf("Failed to get mesh version for mesh %s in namespace %s: %w", m.name, m.namespace, err))
+					multiError = multierror.Append(multiError, fmt.Errorf("failed to get mesh version for mesh %s in namespace %s: %w", m.name, m.namespace, err))
 				}
 				verInfo.remoteVersionInfoList = append(verInfo.remoteVersionInfoList, meshVer)
 			}
@@ -115,12 +115,12 @@ func newVersionCmd(out io.Writer) *cobra.Command {
 func (v *versionCmd) setKubeClientset() error {
 	config, err := settings.RESTClientGetter().ToRESTConfig()
 	if err != nil {
-		return fmt.Errorf("Error fetching kubeconfig")
+		return fmt.Errorf("error fetching kubeconfig")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return fmt.Errorf("Could not access Kubernetes cluster, check kubeconfig")
+		return fmt.Errorf("could not access Kubernetes cluster, check kubeconfig")
 	}
 	v.clientset = clientset
 	return nil
@@ -154,16 +154,16 @@ func (v *versionCmd) getMeshVersion() (*remoteVersionInfo, error) {
 func (r *remoteVersion) proxyGetMeshVersion(pod string, namespace string, clientset kubernetes.Interface) (*version.Info, error) {
 	resp, err := clientset.CoreV1().Pods(namespace).ProxyGet("", pod, strconv.Itoa(constants.OSMHTTPServerPort), constants.VersionPath, nil).DoRaw(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving mesh version from pod [%s] in namespace [%s]: %w", pod, namespace, err)
+		return nil, fmt.Errorf("error retrieving mesh version from pod [%s] in namespace [%s]: %w", pod, namespace, err)
 	}
 	if len(resp) == 0 {
-		return nil, fmt.Errorf("Empty response received from pod [%s] in namespace [%s]: %w", pod, namespace, err)
+		return nil, fmt.Errorf("empty response received from pod [%s] in namespace [%s]: %w", pod, namespace, err)
 	}
 
 	versionInfo := &version.Info{}
 	err = json.Unmarshal(resp, versionInfo)
 	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling retrieved mesh version from pod [%s] in namespace [%s]: %w", pod, namespace, err)
+		return nil, fmt.Errorf("error unmarshalling retrieved mesh version from pod [%s] in namespace [%s]: %w", pod, namespace, err)
 	}
 
 	return versionInfo, nil


### PR DESCRIPTION
Now OSM CLI version check will happen regardless of any K8s cluster

Signed-off-by: mudit singh <mudit.singh@india.nec.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Earlier the OSM CLI version check only happened when there is K8s cluster present as below
![ss1](https://user-images.githubusercontent.com/53465654/207572039-c734a7a6-a696-4306-b211-06cee8900195.png)
If no K8s cluster is present below is the output
![ss2](https://user-images.githubusercontent.com/53465654/207572120-4618afca-4442-42b2-b489-ae751d365213.png)



<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Yes Manual testing done below are the screenshots
With K8s cluster
![ss3](https://user-images.githubusercontent.com/53465654/207572875-4dfb8131-66f5-4712-a4b7-a1d33d257169.png)

Without K8s cluster
![ss4](https://user-images.githubusercontent.com/53465654/207573362-17b64087-f58a-40fb-b1fb-6fea9f81eb9f.png)


<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ X] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?
No
2. Is this a breaking change?
No
3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?