### PR TITLE
Self-nominate Mudit as a Maintainer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@
 - @keithmattix
 - @steeling
 - @shalier
+- @mudit-01
 
 # Non-code maintainers
 - @phillipgibson


### PR DESCRIPTION
Hi Maintainers
I've been contributing to OSM for a year now. CLI, documentation, and other areas are where I have contributed. I accept each and every prerequisite for becoming a Maintainer. Hence self-nominating myself for the role of a Maintainer.
Thanks!
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: NA

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [X ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?