### PR TITLE
fix(): reduce minimum tls version for control plane

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          only-new-issues: true
           skip-pkg-cache: true
 
   codegen:

--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -99,7 +99,7 @@ spec:
                         - TLSv1_3
                       default: TLSv1_2
                     tlsMaxProtocolVersion:
-                      description: The maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+                      description: The maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0 (deprecated), TLSv1_1 (deprecated), TLSv1_2 and TLSv1_3.
                       type: string
                       enum:
                         - TLS_AUTO

--- a/dockerfiles/Dockerfile.init
+++ b/dockerfiles/Dockerfile.init
@@ -1,2 +1,2 @@
-FROM alpine:3
+FROM alpine:3.17.3
 RUN apk add --no-cache iptables

--- a/pkg/apis/config/v1alpha2/mesh_config.go
+++ b/pkg/apis/config/v1alpha2/mesh_config.go
@@ -79,7 +79,7 @@ type SidecarSpec struct {
 	// TLSMinProtocolVersion defines the minimum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
 	TLSMinProtocolVersion string `json:"tlsMinProtocolVersion,omitempty"`
 
-	// TLSMaxProtocolVersion defines the maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+	// TLSMaxProtocolVersion defines the maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0 (deprecated), TLSv1_1 (deprecated), TLSv1_2 and TLSv1_3.
 	TLSMaxProtocolVersion string `json:"tlsMaxProtocolVersion,omitempty"`
 
 	// CipherSuites defines a list of ciphers that listener supports when negotiating TLS 1.0-1.2. This setting has no effect when negotiating TLS 1.3. For valid cipher names, see the latest OpenSSL ciphers manual page. E.g. https://www.openssl.org/docs/man1.1.1/apps/ciphers.html.

--- a/pkg/compute/kube/envoy.go
+++ b/pkg/compute/kube/envoy.go
@@ -51,6 +51,7 @@ func (c *client) getEnvoyConfig(pod *v1.Pod, envoyURL string, kubeConfig *rest.C
 		}
 
 		//nolint: errcheck
+		//#nosec G307
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {

--- a/pkg/constants/tls.go
+++ b/pkg/constants/tls.go
@@ -5,4 +5,4 @@ package constants
 import "crypto/tls"
 
 // MinTLSVersion is the minimum TLS version specified for control plane servers
-const MinTLSVersion = tls.VersionTLS13
+const MinTLSVersion = tls.VersionTLS12

--- a/tests/e2e/e2e_envoy_max_mtls_version_test.go
+++ b/tests/e2e/e2e_envoy_max_mtls_version_test.go
@@ -1,0 +1,162 @@
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+
+	. "github.com/openservicemesh/osm/tests/framework"
+)
+
+// Prior iterations of OSM supported a wide range of min and max MTLS versions for the envoy sidecar (TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3)
+// even though the OSM Control Plane's minimum version has been upgraded to TLSv1_2
+// This test verifies that the envoy sidecar maxTLSVersion is compatible with the current OSM control plane's minTLSVersion
+var _ = OSMDescribe("Test envoy maxTLSVersion is compatible with OSM control plane's minTLSVersion",
+	OSMDescribeInfo{
+		Tier:   1,
+		Bucket: 12,
+	},
+	func() {
+		Context("Envoy maxTLSVersion equals control planes's minTLSVersion, tls.VersionTLS12", func() {
+			// Is compatible
+			envoyMaxTLSVersion := "TLSv1_2"
+			testEnvoyMaxMtlsVersionIsCompatibileWithOSMControlPlane(envoyMaxTLSVersion)
+		})
+
+		Context("envoy maxTLSVersion is greater than the control planes's minTLSVersion, tls.VersionTLS13", func() {
+			// Is compatible
+			envoyMaxTLSVersion := "TLSv1_3"
+			testEnvoyMaxMtlsVersionIsCompatibileWithOSMControlPlane(envoyMaxTLSVersion)
+		})
+
+		Context("envoy maxTLSVersion is less than the control planes's minTLSVersion, tls.VersionTLS11", func() {
+			// Is not compatible
+			envoyMaxTLSVersion := "TLSv1_1"
+			testEnvoyMaxMtlsVersionIsNotCompatibileWithOSMControlPlane(envoyMaxTLSVersion)
+		})
+	})
+
+func testEnvoyMaxMtlsVersionIsCompatibileWithOSMControlPlane(envoyMaxTLSVersion string) {
+	const clientName = "client"
+	const serverName = "server"
+	var ns = []string{clientName, serverName}
+
+	It("Tests HTTP traffic for client pod -> server pod", func() {
+		// Set up meshed client and server pods
+		clientPod, dstSvc := setUpTestApps(envoyMaxTLSVersion, clientName, serverName, ns)
+
+		By("Sending a request from client to server")
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        clientName,
+			SourcePod:       clientPod.Name,
+			SourceContainer: clientName,
+
+			Destination: fmt.Sprintf("%s.%s.svc.cluster.local", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", clientName, clientPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+			if result.Err != nil || result.StatusCode != 200 {
+				Td.T.Logf("> (%s) HTTP Req failed %d %v",
+					srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> (%s) HTTP Req succeeded: %d", srcToDestStr, result.StatusCode)
+			return true
+		}, 5, Td.ReqSuccessTimeout)
+		Expect(cond).To(BeTrue(), "envoy maxTLSVersion %s is compatible with OSM control plane", envoyMaxTLSVersion)
+	})
+}
+
+func testEnvoyMaxMtlsVersionIsNotCompatibileWithOSMControlPlane(envoyMaxTLSVersion string) {
+	const clientName = "client"
+	const serverName = "server"
+	var ns = []string{clientName, serverName}
+
+	It("Tests HTTP traffic for client pod -> server pod", func() {
+		// Set up meshed client and server pods
+		clientPod, dstSvc := setUpTestApps(envoyMaxTLSVersion, clientName, serverName, ns)
+
+		By("Sending a request from client to server")
+		// All ready. Expect client to reach server
+		clientToServer := HTTPRequestDef{
+			SourceNs:        clientName,
+			SourcePod:       clientPod.Name,
+			SourceContainer: clientName,
+
+			Destination: fmt.Sprintf("%s.%s.svc.cluster.local", dstSvc.Name, dstSvc.Namespace),
+		}
+
+		srcToDestStr := fmt.Sprintf("%s -> %s",
+			fmt.Sprintf("%s/%s", clientName, clientPod.Name),
+			clientToServer.Destination)
+
+		cond := Td.WaitForRepeatedSuccess(func() bool {
+			result := Td.HTTPRequest(clientToServer)
+			// Curl exit code 7 == Conn refused
+			if result.Err == nil || !strings.Contains(result.Err.Error(), "command terminated with exit code 7 ") {
+				Td.T.Logf("> (%s) HTTP Req failed, incorrect expected result: %d, %v", srcToDestStr, result.StatusCode, result.Err)
+				return false
+			}
+			Td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
+			return true
+		}, 5, 150*time.Second)
+		Expect(cond).To(BeTrue(), "envoy maxTLSVersion %s is not compatible with OSM control plane", envoyMaxTLSVersion)
+	})
+}
+
+// setUpTestApps creates a curl client pod, http server pod and kubernetes service for server pod
+func setUpTestApps(envoyMaxTLSVersion string, clientName string, serverName string, ns []string) (*v1.Pod, *v1.Service) {
+	// Install OSM
+	installOpts := Td.GetOSMInstallOpts()
+	installOpts.EnablePermissiveMode = true
+	Expect(Td.InstallOSM(installOpts)).To(Succeed())
+	Expect(Td.WaitForPodsRunningReady(Td.OsmNamespace, 60*time.Second, 3 /* 1 controller, 1 injector, 1 bootstrap */, nil)).To(Succeed())
+
+	// Get the meshConfig CRD
+	meshConfig, err := Td.GetMeshConfig(Td.OsmNamespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Update envoy maxTLSVersion
+	By(fmt.Sprintf("Patching envoy maxTLSVersion to be %s", envoyMaxTLSVersion))
+	meshConfig.Spec.Sidecar.TLSMaxProtocolVersion = envoyMaxTLSVersion
+	_, err = Td.UpdateOSMConfig(meshConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create Meshed Test NS
+	for _, n := range ns {
+		Expect(Td.CreateNs(n, nil)).To(Succeed())
+		Expect(Td.AddNsToMesh(true, n)).To(Succeed())
+	}
+
+	// Get simple pod definitions for the HTTP server
+	svcAccDef, podDef, svcDef, err := Td.GetOSSpecificHTTPBinPod(serverName, serverName, PodCommandDefault...)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create Server Pod
+	_, err = Td.CreateServiceAccount(serverName, &svcAccDef)
+	Expect(err).NotTo(HaveOccurred())
+	_, err = Td.CreatePod(serverName, podDef)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create Server Service
+	dstSvc, err := Td.CreateService(serverName, svcDef)
+	Expect(err).NotTo(HaveOccurred())
+	// Expect it to be up and running in it's receiver namespace
+	Expect(Td.WaitForPodsRunningReady(serverName, 90*time.Second, 1, nil)).To(Succeed())
+
+	// Create Client Pod
+	withSourceKubernetesService := true
+	// setupSource sets up a curl source service and returns the pod object
+	clientPod := setupSource(clientName, withSourceKubernetesService)
+	return clientPod, dstSvc
+}


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Envoy proxy fails if tlsMaxProtocolVersion is set to TLSv1_2 because the minimum tls version for control plane was set to TLSv1_3

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [x] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?