### PR TITLE
Removed deprecated functionality

### DIFF
--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -477,7 +476,7 @@ func (td *OsmTestData) LoadImagesToKind(imageNames []string) error {
 		return fmt.Errorf("failed to get image data")
 	}
 
-	imageReader, err := ioutil.ReadAll(imageData)
+	imageReader, err := io.ReadAll(imageData)
 	if err != nil {
 		return fmt.Errorf("failed to read images")
 	}
@@ -1634,7 +1633,7 @@ func (td *OsmTestData) GrabLogs() error {
 		td.T.Logf("stdout:\n%s", stdout)
 		td.T.Logf("stderr:\n%s", stderr)
 	} else {
-		if err := ioutil.WriteFile(fmt.Sprintf("%s/%s", absTestDirPath, "events"), stdout.Bytes(), 0600); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("%s/%s", absTestDirPath, "events"), stdout.Bytes(), 0600); err != nil {
 			td.T.Logf("Failed to write file for events: %s", err)
 		}
 	}

--- a/tests/framework/common.go
+++ b/tests/framework/common.go
@@ -1752,7 +1752,7 @@ func (td *OsmTestData) AddOpenShiftSCC(scc, serviceAccount, namespace string) er
 
 	_, err = td.createRoleBinding(namespace, &roleBindingDefinition)
 	if err != nil {
-		return fmt.Errorf("Failed to create RoleBinding %s: %w", roleBindingName, err)
+		return fmt.Errorf("failed to create RoleBinding %s: %w", roleBindingName, err)
 	}
 
 	return nil


### PR DESCRIPTION
Removed Go 1.16 functionality of io/ioutil that is deprecated now.

Signed-off-by: mudit singh <mudit.singh@india.nec.com>

<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**: Yes

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [ ] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [ ] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [X ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project?
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change?

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)?