### PR TITLE
fix(): remove support for incompatible tls versions for envoy TLSMaxProtocolVersion

### DIFF
--- a/cmd/osm-bootstrap/crds/config_meshconfig.yaml
+++ b/cmd/osm-bootstrap/crds/config_meshconfig.yaml
@@ -99,7 +99,7 @@ spec:
                         - TLSv1_3
                       default: TLSv1_2
                     tlsMaxProtocolVersion:
-                      description: The maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+                      description: The maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0 (deprecated), TLSv1_1 (deprecated), TLSv1_2 and TLSv1_3.
                       type: string
                       enum:
                         - TLS_AUTO

--- a/dockerfiles/Dockerfile.init
+++ b/dockerfiles/Dockerfile.init
@@ -1,2 +1,2 @@
-FROM alpine:3
+FROM alpine:3.17.3
 RUN apk add --no-cache iptables

--- a/pkg/apis/config/v1alpha2/mesh_config.go
+++ b/pkg/apis/config/v1alpha2/mesh_config.go
@@ -79,7 +79,7 @@ type SidecarSpec struct {
 	// TLSMinProtocolVersion defines the minimum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
 	TLSMinProtocolVersion string `json:"tlsMinProtocolVersion,omitempty"`
 
-	// TLSMaxProtocolVersion defines the maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3.
+	// TLSMaxProtocolVersion defines the maximum TLS protocol version that the sidecar supports. Valid TLS protocol versions are TLS_AUTO, TLSv1_0 (deprecated), TLSv1_1 (deprecated), TLSv1_2 and TLSv1_3.
 	TLSMaxProtocolVersion string `json:"tlsMaxProtocolVersion,omitempty"`
 
 	// CipherSuites defines a list of ciphers that listener supports when negotiating TLS 1.0-1.2. This setting has no effect when negotiating TLS 1.3. For valid cipher names, see the latest OpenSSL ciphers manual page. E.g. https://www.openssl.org/docs/man1.1.1/apps/ciphers.html.

--- a/tests/e2e/e2e_envoy_max_mtls_version_test.go
+++ b/tests/e2e/e2e_envoy_max_mtls_version_test.go
@@ -14,8 +14,8 @@ import (
 
 // Prior iterations of OSM supported a wide range of min and max MTLS versions for the envoy sidecar (TLS_AUTO, TLSv1_0, TLSv1_1, TLSv1_2 and TLSv1_3)
 // even though the OSM Control Plane's minimum version has been upgraded to TLSv1_2
-// This test verifies that the envoy sidecar maxTLSVersion is compatible with the current osm control plane's minTLSVersion
-var _ = OSMDescribe("Test envoy maxTLSVersion is compatible with osm control plane's minTLSVersion",
+// This test verifies that the envoy sidecar maxTLSVersion is compatible with the current OSM control plane's minTLSVersion
+var _ = OSMDescribe("Test envoy maxTLSVersion is compatible with OSM control plane's minTLSVersion",
 	OSMDescribeInfo{
 		Tier:   1,
 		Bucket: 12,
@@ -110,7 +110,7 @@ func testEnvoyMaxMtlsVersionIsNotCompatibileWithOSMControlPlane(envoyMaxTLSVersi
 			Td.T.Logf("> (%s) HTTP Req failed correctly: %v", srcToDestStr, result.Err)
 			return true
 		}, 5, 150*time.Second)
-		Expect(cond).To(BeTrue(), "envoy maxTLSVersion %s is not compatible with osm control plane", envoyMaxTLSVersion)
+		Expect(cond).To(BeTrue(), "envoy maxTLSVersion %s is not compatible with OSM control plane", envoyMaxTLSVersion)
 	})
 }
 


### PR DESCRIPTION


<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**: Part of #5282. This removes support for TLSv1_0 and TLSv1_1 from the envoy TLSMaxProtocolVersion options. 

<!--

Please describe how this change was tested. You could include supporting information
such as logs, snippets, and screenshots.

-->
**Testing done**:

<!--

Please mark with X for applicable areas.

-->
**Affected area**:
| Functional Area            |     |
| -------------------------- | --- |
| New Functionality          | [ ] |
| CI System                  | [ ] |
| CLI Tool                   | [ ] |
| Certificate Management     | [ ] |
| Control Plane              | [x] |
| Demo                       | [ ] |
| Documentation              | [ ] |
| Egress                     | [ ] |
| Ingress                    | [ ] |
| Install                    | [ ] |
| Networking                 | [x] |
| Observability              | [ ] |
| Performance                | [ ] |
| SMI Policy                 | [ ] |
| Security                   | [ ] |
| Sidecar Injection          | [ ] |
| Tests                      | [ ] |
| Upgrade                    | [ ] |
| Other                      | [ ] |
