### PR TITLE
fix: remove Automatic rebase mergify rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -116,18 +116,3 @@ pull_request_rules:
       merge:
         # Currently we merge PRs by creating a merge commit
         method: merge
-
-  - name: Automatic rebase
-    conditions:
-      # True if the PR has any of the following labels
-      - or:
-        - label=automerge
-        - label=autorebase
-        - label=automerge-squash
-      # True when the PR is not conflicting with the base branch
-      - -conflict
-      # True if the PR is not in draft state
-      - -draft
-    actions:
-      rebase:
-        # Mergify will use any OSM user that's logged into the Mergify dashboard for the rebasing

--- a/docs/automerge.md
+++ b/docs/automerge.md
@@ -4,7 +4,7 @@ description: "How to use labels and commands to automerge/autorebase your pull r
 type: docs
 ---
 
-OSM uses [Mergify](https://docs.mergify.io/) to automatically merge (automerge), automatically squash and merge (autosquash), and automatically rebase (autorebase) pull requests.
+OSM uses [Mergify](https://docs.mergify.io/) to automatically merge (automerge) and automatically squash and merge (autosquash) pull requests.
 
 # Automerge
 A pull request will be automerged via a merge commit if it meets the following criteria:
@@ -26,9 +26,6 @@ A pull request will be autosquashed (commits will be squashed then merged) if it
  - Base branch is main branch
  If the pull request has an `automerge-squash` label, the OSM-PR-bot will also autorebase the pull request if the PR branch goes out-of-date.
 > Note: Pull requests that are paths-ignore cannot be merged automatically.
-
-# Autorebase
-A pull request will be autorebased only and not automerged/autosquashed if it has the `autorebase` label, as long as there are no conflicts. The rebase action will be completed by OSM-PR-bot.
 
 # In Pull Request Comments
 Some Mergify commands can also be triggered via comments on the pull request.


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:

Removes the Automatic rebase mergify rule due to mergify's [deprecation](https://changelog.mergify.com/changelog/rebasing-pull-requests-with-a-random-user-is-deprecated) of using a random org user as the [`bot_account`](https://docs.mergify.com/actions/rebase/#options). Mergify instead uses the author of the PR. The action will fail if the user has not logged into the mergify dashboard. If a github application such a dependabot creates a PR and triggers the rebase mergify action, the action will fail.

Related mergify GH issue: https://github.com/Mergifyio/mergify/issues/5074
Example OSM failure:
![image](https://user-images.githubusercontent.com/64559656/228991791-56667d4d-5165-409e-aca1-c3c1806a80e7.png)


Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution? 

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? N/A