### PR TITLE
fix(): resolve lint error from unchecked AddEventHandler return values

### DIFF
--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -24,7 +24,7 @@ type MRCComposer struct {
 // to be ordered for any particular resources, but NOT across different resources.
 func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
 	eventChan := make(chan certificate.MRCEvent)
-	m.AddMeshRootCertificateEventHandler(cache.ResourceEventHandlerFuncs{
+	err := m.AddMeshRootCertificateEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			mrc := obj.(*v1alpha2.MeshRootCertificate)
 			log.Debug().Msgf("received MRC add event for MRC %s/%s", mrc.GetNamespace(), mrc.GetName())
@@ -47,7 +47,7 @@ func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, e
 		DeleteFunc: func(obj interface{}) {},
 	})
 
-	return eventChan, nil
+	return eventChan, err
 }
 
 // UpdateMeshRootCertificate updates the given mesh root certificate.

--- a/pkg/compute/mock_compute_client_generated.go
+++ b/pkg/compute/mock_compute_client_generated.go
@@ -48,9 +48,11 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // AddMeshRootCertificateEventHandler mocks base method.
-func (m *MockInterface) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) {
+func (m *MockInterface) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
+	ret := m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AddMeshRootCertificateEventHandler indicates an expected call of AddMeshRootCertificateEventHandler.

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -487,7 +487,12 @@ func (c *Client) ListServiceExports() []*mcs.ServiceExport {
 	return serviceExports
 }
 
-// AddMeshRootCertificateEventHandler adds an event handler specific to mesh root certificiates.
-func (c *Client) AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler) {
-	_, _ = c.informers[informerKeyMeshRootCertificate].AddEventHandler(handler)
+// AddMeshRootCertificateEventHandler adds an event handler specific to mesh root certificates.
+// Returns an error if it fails to add the event handler.
+func (c *Client) AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler) error {
+	if _, err := c.informers[informerKeyMeshRootCertificate].AddEventHandler(handler); err != nil {
+		log.Error().Err(err).Msgf("Error adding event handler for %s", informerKeyMeshRootCertificate)
+		return err
+	}
+	return nil
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -489,5 +489,5 @@ func (c *Client) ListServiceExports() []*mcs.ServiceExport {
 
 // AddMeshRootCertificateEventHandler adds an event handler specific to mesh root certificiates.
 func (c *Client) AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler) {
-	c.informers[informerKeyMeshRootCertificate].AddEventHandler(handler)
+	_, _ = c.informers[informerKeyMeshRootCertificate].AddEventHandler(handler)
 }

--- a/pkg/k8s/mock_controller_generated.go
+++ b/pkg/k8s/mock_controller_generated.go
@@ -45,9 +45,11 @@ func (m *MockController) EXPECT() *MockControllerMockRecorder {
 }
 
 // AddMeshRootCertificateEventHandler mocks base method.
-func (m *MockController) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) {
+func (m *MockController) AddMeshRootCertificateEventHandler(arg0 cache.ResourceEventHandler) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
+	ret := m.ctrl.Call(m, "AddMeshRootCertificateEventHandler", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AddMeshRootCertificateEventHandler indicates an expected call of AddMeshRootCertificateEventHandler.

--- a/pkg/k8s/types.go
+++ b/pkg/k8s/types.go
@@ -115,7 +115,7 @@ type PassthroughInterface interface {
 
 	GetMeshConfig() configv1alpha2.MeshConfig
 	GetMeshRootCertificate(mrcName string) *configv1alpha2.MeshRootCertificate
-	AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler)
+	AddMeshRootCertificateEventHandler(handler cache.ResourceEventHandler) error
 
 	ListMeshRootCertificates() ([]*configv1alpha2.MeshRootCertificate, error)
 	UpdateMeshRootCertificate(obj *configv1alpha2.MeshRootCertificate) (*configv1alpha2.MeshRootCertificate, error)

--- a/pkg/reconciler/client.go
+++ b/pkg/reconciler/client.go
@@ -64,7 +64,7 @@ func (c *client) initCustomResourceDefinitionMonitor() {
 	c.informers[CrdInformerKey] = informerFactory
 
 	// Add event handler to informer
-	c.informers[CrdInformerKey].AddEventHandler(c.crdEventHandler())
+	_, _ = c.informers[CrdInformerKey].AddEventHandler(c.crdEventHandler())
 }
 
 // Initializes mutating webhook monitoring
@@ -81,7 +81,7 @@ func (c *client) initMutatingWebhookConfigurationMonitor() {
 	c.informers[MutatingWebhookInformerKey] = informerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 
 	// Add event handler to informer
-	c.informers[MutatingWebhookInformerKey].AddEventHandler(c.mutatingWebhookEventHandler())
+	_, _ = c.informers[MutatingWebhookInformerKey].AddEventHandler(c.mutatingWebhookEventHandler())
 }
 
 // Initializes validating webhook monitoring
@@ -98,7 +98,7 @@ func (c *client) initValidatingWebhookConfigurationMonitor() {
 	c.informers[ValidatingWebhookInformerKey] = informerFactory.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer()
 
 	// Add event handler to informer
-	c.informers[ValidatingWebhookInformerKey].AddEventHandler(c.validatingWebhookEventHandler())
+	_, _ = c.informers[ValidatingWebhookInformerKey].AddEventHandler(c.validatingWebhookEventHandler())
 }
 
 func (c *client) run(stop <-chan struct{}) error {

--- a/pkg/reconciler/client.go
+++ b/pkg/reconciler/client.go
@@ -29,14 +29,17 @@ func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient client
 	}
 
 	// Initialize informers
-	informerInitHandlerMap := map[InformerKey]func(){
+	informerInitHandlerMap := map[InformerKey]func() error{
 		CrdInformerKey:               c.initCustomResourceDefinitionMonitor,
 		MutatingWebhookInformerKey:   c.initMutatingWebhookConfigurationMonitor,
 		ValidatingWebhookInformerKey: c.initValidatingWebhookConfigurationMonitor,
 	}
 
 	for _, informer := range selectInformers {
-		informerInitHandlerMap[informer]()
+		if err := informerInitHandlerMap[informer](); err != nil {
+			log.Error().Err(err).Msgf("Failed to initialize informer for %s", informer)
+			return err
+		}
 	}
 
 	if err := c.run(stop); err != nil {
@@ -49,7 +52,8 @@ func NewReconcilerClient(kubeClient kubernetes.Interface, apiServerClient client
 }
 
 // Initializes CustomResourceDefinition monitoring
-func (c *client) initCustomResourceDefinitionMonitor() {
+// Returns an error if the informer could not be initialized
+func (c *client) initCustomResourceDefinitionMonitor() error {
 	// Use the OSM version as the selector for reconciliation
 	osmCrdsLabel := map[string]string{constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue, constants.ReconcileLabel: c.osmVersion}
 
@@ -64,11 +68,16 @@ func (c *client) initCustomResourceDefinitionMonitor() {
 	c.informers[CrdInformerKey] = informerFactory
 
 	// Add event handler to informer
-	_, _ = c.informers[CrdInformerKey].AddEventHandler(c.crdEventHandler())
+	if _, err := c.informers[CrdInformerKey].AddEventHandler(c.crdEventHandler()); err != nil {
+		log.Error().Err(err).Msgf("Failed to add event handler to informer %s", CrdInformerKey)
+		return err
+	}
+	return nil
 }
 
 // Initializes mutating webhook monitoring
-func (c *client) initMutatingWebhookConfigurationMonitor() {
+// Returns an error if the informer could not be initialized
+func (c *client) initMutatingWebhookConfigurationMonitor() error {
 	osmMwhcLabel := map[string]string{constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue, constants.OSMAppInstanceLabelKey: c.meshName, constants.ReconcileLabel: strconv.FormatBool(true)}
 	labelSelector := fields.SelectorFromSet(osmMwhcLabel).String()
 	option := informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
@@ -81,11 +90,16 @@ func (c *client) initMutatingWebhookConfigurationMonitor() {
 	c.informers[MutatingWebhookInformerKey] = informerFactory.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
 
 	// Add event handler to informer
-	_, _ = c.informers[MutatingWebhookInformerKey].AddEventHandler(c.mutatingWebhookEventHandler())
+	if _, err := c.informers[MutatingWebhookInformerKey].AddEventHandler(c.mutatingWebhookEventHandler()); err != nil {
+		log.Error().Err(err).Msgf("Failed to add event handler to informer %s", MutatingWebhookInformerKey)
+		return err
+	}
+	return nil
 }
 
 // Initializes validating webhook monitoring
-func (c *client) initValidatingWebhookConfigurationMonitor() {
+// Returns an error if the informer could not be initialized
+func (c *client) initValidatingWebhookConfigurationMonitor() error {
 	osmVwhcLabel := map[string]string{constants.OSMAppNameLabelKey: constants.OSMAppNameLabelValue, constants.OSMAppInstanceLabelKey: c.meshName, constants.ReconcileLabel: strconv.FormatBool(true)}
 	labelSelector := fields.SelectorFromSet(osmVwhcLabel).String()
 	option := informers.WithTweakListOptions(func(opt *metav1.ListOptions) {
@@ -98,7 +112,11 @@ func (c *client) initValidatingWebhookConfigurationMonitor() {
 	c.informers[ValidatingWebhookInformerKey] = informerFactory.Admissionregistration().V1().ValidatingWebhookConfigurations().Informer()
 
 	// Add event handler to informer
-	_, _ = c.informers[ValidatingWebhookInformerKey].AddEventHandler(c.validatingWebhookEventHandler())
+	if _, err := c.informers[ValidatingWebhookInformerKey].AddEventHandler(c.validatingWebhookEventHandler()); err != nil {
+		log.Error().Err(err).Msgf("Failed to add event handler to informer %s", ValidatingWebhookInformerKey)
+		return err
+	}
+	return nil
 }
 
 func (c *client) run(stop <-chan struct{}) error {


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Fixes lint error introduced in #5283

When upgrading helm to 3.11.1, the k8.io client-go package was also updated to v0.26.3. In v0.26 the API for [`AddEventHandler`](https://pkg.go.dev/k8s.io/client-go@v0.26.3/tools/cache#SharedInformer) was updated to return an error and registration handle to enable individual handler cancelation. 

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? No