### PR TITLE
fix(): linter running on PR misses errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          only-new-issues: true
+          args: --new-from-rev=HEAD~
           skip-pkg-cache: true
 
   codegen:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
     - "zz_generated.deepcopy.go$"
 
 linters:
+  disable-all: true
   enable:
     - goconst
     - gocyclo
@@ -22,6 +23,12 @@ linters:
 linters-settings:
   goimports:
     local-prefixes: github.com/openservicemesh/osm
+  revive:
+    ignore-generated-header: false
+    severity: "warning"
+    confidence: 0.0
+    error-code: 2
+    warning-code: 1
 
 issues:
   exclude-rules:

--- a/demo/cmd/tcp-client/tcp-client.go
+++ b/demo/cmd/tcp-client/tcp-client.go
@@ -54,12 +54,12 @@ func main() {
 			requestMsg := fmt.Sprintf("%s #connection=%d, #msg-counter=%d, msg=client hello\n", requestPrefix, connectionCounter, msgCounter)
 
 			// write on the connection
-			if bytesWritten, writeErr := conn.Write([]byte(requestMsg)); err != nil {
+			bytesWritten, writeErr := conn.Write([]byte(requestMsg))
+			if writeErr != nil {
 				log.Error().Err(writeErr).Msg("Write error")
 				continue
-			} else {
-				log.Info().Msgf("Wrote %d bytes, msg written: [%s]\n", bytesWritten, requestMsg)
 			}
+			log.Info().Msgf("Wrote %d bytes, msg written: [%s]\n", bytesWritten, requestMsg)
 
 			// read response from server
 			responseMsg, err := response.ReadString(byte('\n'))

--- a/pkg/certificate/fake_manager.go
+++ b/pkg/certificate/fake_manager.go
@@ -45,7 +45,7 @@ func (c *fakeMRCClient) UpdateMeshRootCertificate(mrc *v1alpha2.MeshRootCertific
 }
 
 // Watch returns a channel that has one MRCEventAdded. It is intended to implement the certificate.MRCClient interface.
-func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan MRCEvent, error) {
+func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan MRCEvent, error) { //nolint: revive // unused-parameter
 	// send event for first CA created
 	ch := make(chan MRCEvent)
 	go func() {

--- a/pkg/certificate/manager.go
+++ b/pkg/certificate/manager.go
@@ -345,7 +345,7 @@ func (m *Manager) SubscribeRotations(key string) (chan interface{}, func()) {
 		go m.pubsub.Unsub(ch)
 		// must empty the channel to prevent deadlock
 		// https://github.com/openservicemesh/osm/issues/4847
-		for range ch {
+		for range ch { //nolint: revive // empty-block
 		}
 	}
 }

--- a/pkg/certificate/providers/compat.go
+++ b/pkg/certificate/providers/compat.go
@@ -16,7 +16,7 @@ func (c *MRCCompatClient) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertif
 }
 
 // Watch is a basic Watch implementation for the MRC attached to the compat client
-func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
+func (c *MRCCompatClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) { //nolint: revive // unused-parameter
 	ch := make(chan certificate.MRCEvent)
 	go func() {
 		ch <- certificate.MRCEvent{

--- a/pkg/certificate/providers/config.go
+++ b/pkg/certificate/providers/config.go
@@ -84,7 +84,7 @@ func NewCertificateManager(ctx context.Context, kubeClient kubernetes.Interface,
 
 // NewCertificateManagerFromMRC returns a new certificate manager.
 func NewCertificateManagerFromMRC(ctx context.Context, kubeClient kubernetes.Interface, kubeConfig *rest.Config,
-	providerNamespace string, option Options, computeClient compute.Interface, checkInterval time.Duration) (*certificate.Manager, error) {
+	providerNamespace string, option Options, computeClient compute.Interface, checkInterval time.Duration) (*certificate.Manager, error) { //nolint: revive // unused-parameter
 	if err := option.Validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/certificate/providers/mrc.go
+++ b/pkg/certificate/providers/mrc.go
@@ -22,7 +22,7 @@ type MRCComposer struct {
 // from the informerCollection's MRC store. Channels returned from multiple invocations of
 // Watch() are unique and have no coordination with each other. Events are guaranteed
 // to be ordered for any particular resources, but NOT across different resources.
-func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
+func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) { //nolint: revive // unused-parameter
 	eventChan := make(chan certificate.MRCEvent)
 	err := m.AddMeshRootCertificateEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -51,7 +51,7 @@ func (m *MRCComposer) Watch(ctx context.Context) (<-chan certificate.MRCEvent, e
 }
 
 // UpdateMeshRootCertificate updates the given mesh root certificate.
-func (m *MRCComposer) UpdateMeshRootCertificate(mrc *v1alpha2.MeshRootCertificate) error {
+func (m *MRCComposer) UpdateMeshRootCertificate(mrc *v1alpha2.MeshRootCertificate) error { //nolint: revive // unused-parameter
 	// TODO(5046): implement this.
 	return nil
 }

--- a/pkg/certificate/providers/tresor/fake/fake.go
+++ b/pkg/certificate/providers/tresor/fake/fake.go
@@ -111,7 +111,7 @@ func (c *fakeMRCClient) ListMeshRootCertificates() ([]*v1alpha2.MeshRootCertific
 	return mrcListPointers, nil
 }
 
-func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) {
+func (c *fakeMRCClient) Watch(ctx context.Context) (<-chan certificate.MRCEvent, error) { //nolint: revive // unused-parameter
 	// send event for first CA created
 	go func() {
 		c.NewCertEvent(initialRootName)

--- a/pkg/envoy/generator/cds/builder.go
+++ b/pkg/envoy/generator/cds/builder.go
@@ -521,7 +521,7 @@ func GetDefaultCircuitBreakerThreshold() *xds_cluster.CircuitBreakers_Thresholds
 // upstream traffic setting provided.
 // It applies the default circuit breaker thresholds to the upstream cluster.
 func applyUpstreamConnectionSettings(upstreamConnectionSettings *policyv1alpha1.ConnectionSettingsSpec, upstreamCluster *xds_cluster.Cluster,
-	httpProtocolOptions *extensions_upstream_http.HttpProtocolOptions) {
+	httpProtocolOptions *extensions_upstream_http.HttpProtocolOptions) { //nolint:revive // unused-parameter
 	// Apply Circuit Breaker threshold
 	threshold := GetDefaultCircuitBreakerThreshold()
 	upstreamCluster.CircuitBreakers = &xds_cluster.CircuitBreakers{

--- a/pkg/envoy/server/cache.go
+++ b/pkg/envoy/server/cache.go
@@ -22,13 +22,13 @@ func (s *Server) OnStreamClosed(streamID int64) {
 
 // OnStreamRequest is called when a request happens on an open connection
 func (s *Server) OnStreamRequest(streamID int64, req *discovery.DiscoveryRequest) error {
-	log.Debug().Msgf("OnStreamRequest node: %s, type: %s, v: %s, nonce: %s, resNames: %s", req.Node.Id, req.TypeUrl, req.VersionInfo, req.ResponseNonce, req.ResourceNames)
+	log.Debug().Msgf("OnStreamRequest node: %s, type: %s, v: %s, nonce: %s, resNames: %s, streamID: %d", req.Node.Id, req.TypeUrl, req.VersionInfo, req.ResponseNonce, req.ResourceNames, streamID)
 	return nil
 }
 
 // OnStreamResponse is called when a response is being sent to a request
 func (s *Server) OnStreamResponse(_ context.Context, streamID int64, req *discovery.DiscoveryRequest, resp *discovery.DiscoveryResponse) {
-	log.Debug().Msgf("OnStreamDeltaResponse node: %s type: %s, v: %s, nonce: %s, NumResources: %d", req.Node.Id, resp.TypeUrl, resp.VersionInfo, resp.Nonce, len(resp.Resources))
+	log.Debug().Msgf("OnStreamDeltaResponse node: %s type: %s, v: %s, nonce: %s, NumResources: %d, streamID: %d", req.Node.Id, resp.TypeUrl, resp.VersionInfo, resp.Nonce, len(resp.Resources), streamID)
 }
 
 // --- Fetch request types. Callback interfaces still requires these to be defined

--- a/pkg/injector/exclusions.go
+++ b/pkg/injector/exclusions.go
@@ -33,7 +33,7 @@ const (
 // The kind of exclusion (inbound vs outbound) is determined by the specified annotation.
 //
 // The function returns an error when it is unable to determine whether ports need to be excluded from outbound sidecar interception.
-func getPortExclusionListForPod(pod *corev1.Pod, namespace string, annotation string) ([]int, error) {
+func getPortExclusionListForPod(pod *corev1.Pod, namespace string, annotation string) ([]int, error) { //nolint: revive // unused-parameter
 	var ports []int
 
 	portsToExcludeStr, ok := pod.Annotations[annotation]
@@ -87,7 +87,7 @@ func mergePortExclusionLists(podSpecificPortExclusionList, globalPortExclusionLi
 // The kind of exclusion (inclusion vs exclusion) is determined by the specified annotation.
 //
 // The function returns an error when it is unable to determine whether IP ranges need to be excluded from outbound sidecar interception.
-func getOutboundIPRangeListForPod(pod *corev1.Pod, namespace string, annotation string) ([]string, error) {
+func getOutboundIPRangeListForPod(pod *corev1.Pod, namespace string, annotation string) ([]string, error) { //nolint: revive // unused-parameter
 	ipRangeExclusionsStr, ok := pod.Annotations[annotation]
 	if !ok {
 		// No port exclusion annotation specified

--- a/pkg/injector/webhook.go
+++ b/pkg/injector/webhook.go
@@ -60,10 +60,7 @@ func NewMutatingWebhook(ctx context.Context, kubeClient kubernetes.Interface, ce
 		webhookCreatePod: http.HandlerFunc(wh.podCreationHandler),
 	},
 		func(cert *certificate.Certificate) error {
-			if err := createOrUpdateMutatingWebhook(kubeClient, cert, webhookTimeout, webhookConfigName, meshName, osmNamespace, osmVersion, enableReconciler); err != nil {
-				return err
-			}
-			return nil
+			return createOrUpdateMutatingWebhook(kubeClient, cert, webhookTimeout, webhookConfigName, meshName, osmNamespace, osmVersion, enableReconciler)
 		})
 
 	return srv.Run(ctx)

--- a/pkg/k8s/informers.go
+++ b/pkg/k8s/informers.go
@@ -195,7 +195,10 @@ func (c *Client) run(stop <-chan struct{}) error {
 			continue
 		}
 
-		informer.AddEventHandler(handler)
+		if _, err := informer.AddEventHandler(handler); err != nil {
+			log.Error().Err(err).Msgf("Error adding event handler for %s informer", name)
+			return err
+		}
 
 		go informer.Run(stop)
 		names = append(names, string(name))

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -22,7 +22,7 @@ func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, e
 
 type noopConnection struct{}
 
-func (*noopConnection) CreateStream(headers http.Header) (httpstream.Stream, error) { //nolint: revive // unused-parameter
+func (*noopConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
 	return nil, nil
 }
 func (*noopConnection) RemoveStreams(streams ...httpstream.Stream) {} //nolint: revive // unused-parameter

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -16,16 +16,16 @@ type fakeDialer struct {
 	dialErr error
 }
 
-func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) {
+func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) { //notlint: revive // unused-parameter
 	return d.conn, "", d.dialErr
 }
 
 type noopConnection struct{}
 
-func (*noopConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+func (*noopConnection) CreateStream(headers http.Header) (httpstream.Stream, error) { //nolint: revive // unused-parameter
 	return nil, nil
 }
-func (*noopConnection) RemoveStreams(streams ...httpstream.Stream) {}
+func (*noopConnection) RemoveStreams(streams ...httpstream.Stream) {} //nolint: revive // unused-parameter
 func (*noopConnection) CloseChan() <-chan bool                     { return nil }
 func (*noopConnection) Close() error                               { return nil }
 func (*noopConnection) SetIdleTimeout(time.Duration)               {}

--- a/pkg/k8s/portforward_test.go
+++ b/pkg/k8s/portforward_test.go
@@ -16,7 +16,7 @@ type fakeDialer struct {
 	dialErr error
 }
 
-func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) { //notlint: revive // unused-parameter
+func (d *fakeDialer) Dial(protocols ...string) (httpstream.Connection, string, error) { //nolint: revive // unused-parameter
 	return d.conn, "", d.dialErr
 }
 

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -103,7 +103,7 @@ func (b *Broker) runWorkqueueProcessor() {
 	// if 'processNextItems()' returns false.
 	go wait.Until(
 		func() {
-			for b.processNextItem() {
+			for b.processNextItem() { //nolint: revive // empty-block
 			}
 		},
 		time.Second,
@@ -267,7 +267,7 @@ func (b *Broker) Unsub(pubSub *pubsub.PubSub, ch chan interface{}) {
 	// existing messages on the subscribed channel must be drained as noted
 	// in https://github.com/cskr/pubsub/blob/v1.0.2/pubsub.go#L95.
 	go pubSub.Unsub(ch)
-	for range ch {
+	for range ch { //nolint: revive // empty-block
 		// Drain channel until 'Unsub' results in a close on the subscribed channel
 	}
 }

--- a/pkg/osm/control_plane_test.go
+++ b/pkg/osm/control_plane_test.go
@@ -38,7 +38,7 @@ func (g *fakeGenerator) getCallCount(uuid string) int {
 	return g.callCount[uuid]
 }
 
-func (g *fakeGenerator) GenerateConfig(ctx context.Context, proxy *models.Proxy) (fakeConfig, error) {
+func (g *fakeGenerator) GenerateConfig(ctx context.Context, proxy *models.Proxy) (fakeConfig, error) { //nolint: revive // unused-parameter
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.callCount[proxy.UUID.String()]++
@@ -64,7 +64,7 @@ func (s *fakeServer) getCallCount(uuid string) int {
 	return s.callCount[uuid]
 }
 
-func (s *fakeServer) UpdateProxy(ctx context.Context, proxy *models.Proxy, config fakeConfig) error {
+func (s *fakeServer) UpdateProxy(ctx context.Context, proxy *models.Proxy, config fakeConfig) error { //nolint: revive // unused-parameter
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.callCount[proxy.UUID.String()]++

--- a/pkg/validator/server.go
+++ b/pkg/validator/server.go
@@ -51,10 +51,7 @@ func NewValidatingWebhook(ctx context.Context, webhookConfigName, osmNamespace, 
 	srv := webhook.NewServer(ValidatorWebhookSvc, osmNamespace, constants.ValidatorWebhookPort, certManager, map[string]http.HandlerFunc{
 		validationAPIPath: v.doValidation,
 	}, func(cert *certificate.Certificate) error {
-		if err := createOrUpdateValidatingWebhook(kubeClient, cert, webhookConfigName, meshName, osmNamespace, osmVersion, validateTrafficTarget, enableReconciler); err != nil {
-			return err
-		}
-		return nil
+		return createOrUpdateValidatingWebhook(kubeClient, cert, webhookConfigName, meshName, osmNamespace, osmVersion, validateTrafficTarget, enableReconciler)
 	})
 
 	return srv.Run(ctx)

--- a/pkg/validator/validators_test.go
+++ b/pkg/validator/validators_test.go
@@ -2064,12 +2064,12 @@ func TestValidateMRCOnUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := tassert.New(t)
-			old := createTestMrc(tt.mrcName, tt.oldRole)
-			new := createTestMrc(tt.mrcName, tt.newRole)
+			oldMrc := createTestMrc(tt.mrcName, tt.oldRole)
+			newMrc := createTestMrc(tt.mrcName, tt.newRole)
 			// add the old to the list
-			tt.otherMrcs = append(tt.otherMrcs, old)
+			tt.otherMrcs = append(tt.otherMrcs, oldMrc)
 			v := createValidator(tt.otherMrcs)
-			err := v.validateMRCOnUpdate(old, new)
+			err := v.validateMRCOnUpdate(oldMrc, newMrc)
 			if tt.wantErr {
 				a.Error(err)
 			} else {

--- a/pkg/workerpool/workerpool_test.go
+++ b/pkg/workerpool/workerpool_test.go
@@ -20,7 +20,7 @@ func TestNewWorkerPool(t *testing.T) {
 }
 
 // Uses AddJob, which relies on job hash for queue assignment
-func TestAddJob(t *testing.T) {
+func TestAddJob(t *testing.T) { //nolint:revive // unused-parameter
 	njobs := 10 // also worker routines
 	wp := NewWorkerPool(njobs)
 


### PR DESCRIPTION
<!--

Please describe the motivation for this PR and provide enough
information so that others can review it.

-->
**Description**:
Replaces `only-new-issues` with new command line argument

[`only-new-issues`](https://github.com/marketplace/actions/run-golangci-lint#how-to-use) was added in a recent PR to the linter github action. This condition only applies when making a pull request, not on merging/pushing. Therefore, on pull request the linter was run with the additional command line options: `--new-from-patch=/tmp/tmp-1758-4jITrYvTb07C/pull.patch --new=false --new-from-rev=`. When the linter is run on main once the PR is merged, no command line options are added.

Setting the `--new-from-rev` option to `HEAD~" does not resolve the unrelated lint errors that surface. It is unclear if the addition of the option is beneficial.

Please answer the following questions with yes/no.

1. Does this change contain code from or inspired by another project? No
    -   Did you notify the maintainers and provide attribution?

2. Is this a breaking change? No

3. Has documentation corresponding to this change been updated in the [osm-docs](https://github.com/openservicemesh/osm-docs) repo (if applicable)? NA